### PR TITLE
feat(symphony): add Codex as alternative agent backend (RAR-7)

### DIFF
--- a/crates/symphony/src/agent.rs
+++ b/crates/symphony/src/agent.rs
@@ -85,15 +85,20 @@ Issue #{number}: {title}
     }
 
     /// Write `PROMPT.md` into the issue worktree and spawn a non-interactive
-    /// `ralph run` subprocess whose output is consumed by symphony.
+    /// agent subprocess whose output is consumed by symphony.
+    ///
+    /// The subprocess command depends on the configured backend:
+    /// - **Ralph**: `ralph run -c <config> --no-tui` (reads `PROMPT.md` from cwd)
+    /// - **Codex**: `codex --quiet --approval-mode full-auto "<prompt>"` (prompt as arg)
     pub async fn start<P: AsRef<Path>>(&self, task: &AgentTask, workspace: P) -> Result<AgentHandle> {
+        let prompt = self.build_prompt(task);
         let prompt_path = workspace.as_ref().join("PROMPT.md");
-        tokio::fs::write(&prompt_path, self.build_prompt(task))
+        tokio::fs::write(&prompt_path, &prompt)
             .await
             .context(IoSnafu)?;
 
-        let mut cmd = Command::new(&self.config.command);
-        for arg in self.config.command_args() {
+        let mut cmd = Command::new(self.config.effective_command());
+        for arg in self.config.command_args(Some(&prompt)) {
             cmd.arg(arg);
         }
 

--- a/crates/symphony/src/config.rs
+++ b/crates/symphony/src/config.rs
@@ -16,6 +16,17 @@ fn default_command() -> String {
     "ralph".to_owned()
 }
 
+/// Execution backend for the coding agent subprocess.
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum AgentBackend {
+    /// Ralph CLI (`ralph run`) — the default backend.
+    #[default]
+    Ralph,
+    /// OpenAI Codex CLI (`codex --approval-mode full-auto`).
+    Codex,
+}
+
 fn default_max_concurrent_agents() -> usize {
     2
 }
@@ -136,16 +147,23 @@ pub struct SymphonyConfig {
 
 #[derive(Debug, Clone, Builder, Serialize, Deserialize)]
 pub struct AgentConfig {
-    /// The command to invoke ralph.
-    #[serde(default = "default_command")]
-    pub command: String,
+    /// Which execution backend to use.
+    #[serde(default)]
+    #[builder(default)]
+    pub backend: AgentBackend,
 
-    /// Optional path to a ralph config file.
+    /// Override the command binary. When absent, derived from `backend`
+    /// (`"ralph"` for Ralph, `"codex"` for Codex).
+    #[serde(default)]
+    pub command: Option<String>,
+
+    /// Optional path to a ralph config file (Ralph backend only).
     #[serde(default)]
     pub config_file: Option<PathBuf>,
 
-    /// Extra args to pass to `ralph run`.
+    /// Extra args appended to the generated command line.
     #[serde(default)]
+    #[builder(default)]
     pub extra_args: Vec<String>,
 
     /// Timeout for a single agent run.
@@ -161,7 +179,8 @@ pub struct AgentConfig {
 impl Default for AgentConfig {
     fn default() -> Self {
         Self {
-            command: default_command(),
+            backend: AgentBackend::default(),
+            command: None,
             config_file: None,
             extra_args: Vec::new(),
             run_timeout: None,
@@ -170,16 +189,45 @@ impl Default for AgentConfig {
 }
 
 impl AgentConfig {
+    /// The binary to invoke, derived from `backend` unless explicitly overridden.
     #[must_use]
-    pub fn command_args(&self) -> Vec<String> {
-        let mut args = vec!["run".to_owned()];
-        if let Some(path) = &self.config_file {
-            args.push("-c".to_owned());
-            args.push(path.display().to_string());
+    pub fn effective_command(&self) -> &str {
+        self.command.as_deref().unwrap_or(match self.backend {
+            AgentBackend::Ralph => "ralph",
+            AgentBackend::Codex => "codex",
+        })
+    }
+
+    /// Build the argument list for the agent subprocess.
+    ///
+    /// `prompt` is required for the Codex backend (passed as a positional arg)
+    /// and ignored for Ralph (which reads `PROMPT.md` from the working directory).
+    #[must_use]
+    pub fn command_args(&self, prompt: Option<&str>) -> Vec<String> {
+        match self.backend {
+            AgentBackend::Ralph => {
+                let mut args = vec!["run".to_owned()];
+                if let Some(path) = &self.config_file {
+                    args.push("-c".to_owned());
+                    args.push(path.display().to_string());
+                }
+                args.push("--no-tui".to_owned());
+                args.extend(self.extra_args.iter().cloned());
+                args
+            }
+            AgentBackend::Codex => {
+                let mut args = vec![
+                    "--quiet".to_owned(),
+                    "--approval-mode".to_owned(),
+                    "full-auto".to_owned(),
+                ];
+                args.extend(self.extra_args.iter().cloned());
+                if let Some(p) = prompt {
+                    args.push(p.to_owned());
+                }
+                args
+            }
         }
-        args.push("--no-tui".to_owned());
-        args.extend(self.extra_args.iter().cloned());
-        args
     }
 }
 

--- a/crates/symphony/tests/ralph_run_runtime.rs
+++ b/crates/symphony/tests/ralph_run_runtime.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 
 use chrono::Utc;
-use rara_symphony::config::{AgentConfig, RepoConfig};
+use rara_symphony::config::{AgentBackend, AgentConfig, RepoConfig};
 use rara_symphony::tracker::{IssueState, TrackedIssue};
 use rara_symphony::agent::AgentTask;
 use rara_symphony::agent::RalphAgent;
@@ -41,7 +41,7 @@ fn agent_config_builds_ralph_run_command() {
         .extra_args(vec!["--autonomous".to_owned()])
         .build();
 
-    let args = agent.command_args();
+    let args = agent.command_args(None);
 
     assert_eq!(
         args,
@@ -51,6 +51,46 @@ fn agent_config_builds_ralph_run_command() {
             "/tmp/ralph.yml".to_owned(),
             "--no-tui".to_owned(),
             "--autonomous".to_owned(),
+        ]
+    );
+}
+
+#[test]
+fn agent_config_defaults_command_from_backend() {
+    let ralph = AgentConfig::default();
+    assert_eq!(ralph.effective_command(), "ralph");
+
+    let codex = AgentConfig::builder()
+        .backend(AgentBackend::Codex)
+        .build();
+    assert_eq!(codex.effective_command(), "codex");
+
+    // Explicit command overrides backend default.
+    let custom = AgentConfig::builder()
+        .backend(AgentBackend::Codex)
+        .command("/usr/local/bin/codex-nightly".to_owned())
+        .build();
+    assert_eq!(custom.effective_command(), "/usr/local/bin/codex-nightly");
+}
+
+#[test]
+fn codex_backend_builds_full_auto_command() {
+    let agent = AgentConfig::builder()
+        .backend(AgentBackend::Codex)
+        .extra_args(vec!["--model".to_owned(), "o3".to_owned()])
+        .build();
+
+    let args = agent.command_args(Some("Fix the bug"));
+
+    assert_eq!(
+        args,
+        vec![
+            "--quiet".to_owned(),
+            "--approval-mode".to_owned(),
+            "full-auto".to_owned(),
+            "--model".to_owned(),
+            "o3".to_owned(),
+            "Fix the bug".to_owned(),
         ]
     );
 }


### PR DESCRIPTION
## Summary

- Introduce `AgentBackend` enum (`Ralph` | `Codex`) in symphony config to select the coding agent execution backend
- Symphony can now spawn `codex --quiet --approval-mode full-auto` as an alternative to `ralph run`
- Command binary auto-derives from backend (`ralph` or `codex`), with explicit override support via `agent.command`
- Adds tests for backend selection, command derivation, and Codex argument construction

Closes #7 / RAR-7

## Configuration

```yaml
# symphony config
agent:
  backend: codex                    # or "ralph" (default)
  extra_args: ["--model", "o3"]     # optional
```

## Test plan

- [x] All 22 existing + new symphony tests pass
- [x] Full workspace `cargo check` passes
- [ ] Manual: configure `backend: codex` and verify codex subprocess spawns correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)