### PR TITLE
RAR-11 support dynamic symphony repo labels

### DIFF
--- a/crates/symphony/src/config.rs
+++ b/crates/symphony/src/config.rs
@@ -17,23 +17,41 @@ use std::{path::PathBuf, time::Duration};
 use bon::Builder;
 use serde::{Deserialize, Serialize};
 
-fn default_active_labels() -> Vec<String> { vec!["symphony:ready".to_owned()] }
+pub(crate) fn default_active_labels() -> Vec<String> {
+    vec!["symphony:ready".to_owned()]
+}
 
-fn default_workflow_file() -> String { "WORKFLOW.md".to_owned() }
+fn default_workflow_file() -> String {
+    "WORKFLOW.md".to_owned()
+}
 
-fn default_command() -> String { "ralph".to_owned() }
+fn default_command() -> String {
+    "ralph".to_owned()
+}
 
-fn default_backend() -> String { "codex".to_owned() }
+fn default_backend() -> String {
+    "codex".to_owned()
+}
 
-fn default_core_config_file() -> PathBuf { PathBuf::from("ralph.core.yml") }
+fn default_core_config_file() -> PathBuf {
+    PathBuf::from("ralph.core.yml")
+}
 
-fn default_max_concurrent_agents() -> usize { 2 }
+fn default_max_concurrent_agents() -> usize {
+    2
+}
 
-fn default_stall_timeout() -> Duration { Duration::from_secs(30 * 60) }
+fn default_stall_timeout() -> Duration {
+    Duration::from_secs(30 * 60)
+}
 
-fn default_max_retry_backoff() -> Duration { Duration::from_secs(60 * 60) }
+fn default_max_retry_backoff() -> Duration {
+    Duration::from_secs(60 * 60)
+}
 
-fn default_active_states() -> Vec<String> { vec!["Todo".to_owned()] }
+fn default_active_states() -> Vec<String> {
+    vec!["Todo".to_owned()]
+}
 
 fn default_terminal_states() -> Vec<String> {
     vec![
@@ -45,13 +63,21 @@ fn default_terminal_states() -> Vec<String> {
     ]
 }
 
-fn default_repo_label_prefix() -> String { "repo:".to_owned() }
+fn default_repo_label_prefix() -> String {
+    "repo:".to_owned()
+}
 
-fn default_linear_endpoint() -> String { "https://api.linear.app/graphql".to_owned() }
+fn default_linear_endpoint() -> String {
+    "https://api.linear.app/graphql".to_owned()
+}
 
-fn default_started_issue_state() -> String { "In Progress".to_owned() }
+fn default_started_issue_state() -> String {
+    "In Progress".to_owned()
+}
 
-fn default_completed_issue_state() -> String { "ToVerify".to_owned() }
+fn default_completed_issue_state() -> String {
+    "ToVerify".to_owned()
+}
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "kind", rename_all = "snake_case")]
@@ -222,11 +248,11 @@ pub struct AgentConfig {
 impl Default for AgentConfig {
     fn default() -> Self {
         Self {
-            command:          default_command(),
-            backend:          default_backend(),
+            command: default_command(),
+            backend: default_backend(),
             core_config_file: default_core_config_file(),
-            extra_args:       Vec::new(),
-            run_timeout:      None,
+            extra_args: Vec::new(),
+            run_timeout: None,
         }
     }
 }
@@ -259,7 +285,9 @@ impl AgentConfig {
     }
 
     #[must_use]
-    pub fn doctor_args(&self) -> Vec<String> { vec!["doctor".to_owned()] }
+    pub fn doctor_args(&self) -> Vec<String> {
+        vec!["doctor".to_owned()]
+    }
 }
 
 #[derive(Debug, Clone, Builder, Serialize, Deserialize)]
@@ -297,6 +325,16 @@ impl RepoConfig {
             .clone()
             .or_else(|| Some(default_workspace_root(&self.name)))
     }
+}
+
+pub(crate) fn default_repo_url(repo_name: &str) -> String {
+    format!("https://github.com/{repo_name}")
+}
+
+pub(crate) fn default_repo_checkout_root(repo_name: &str) -> PathBuf {
+    rara_paths::config_dir()
+        .join("ralpha/repos")
+        .join(repo_name)
 }
 
 fn default_workspace_root(repo_name: &str) -> PathBuf {

--- a/crates/symphony/src/service.rs
+++ b/crates/symphony/src/service.rs
@@ -31,31 +31,34 @@ use tracing::{error, info, warn};
 
 use crate::{
     agent::{AgentTask, RalphAgent},
-    config::{RepoConfig, SymphonyConfig, TrackerConfig},
-    error::{ConfigSnafu, IoSnafu, Result},
+    config::{
+        RepoConfig, SymphonyConfig, TrackerConfig, default_active_labels,
+        default_repo_checkout_root, default_repo_url,
+    },
+    error::{IoSnafu, Result},
     tracker::{GitHubIssueTracker, IssueState, IssueTracker, LinearIssueTracker, TrackedIssue},
     workspace::{WorkspaceInfo, WorkspaceManager, workflow_file},
 };
 
 struct RunningIssue {
-    issue:      TrackedIssue,
-    workspace:  WorkspaceInfo,
-    child:      Child,
+    issue: TrackedIssue,
+    workspace: WorkspaceInfo,
+    child: Child,
     started_at: Instant,
-    log_path:   PathBuf,
-    output:     ProcessOutputSummaryHandle,
+    log_path: PathBuf,
+    output: ProcessOutputSummaryHandle,
 }
 
 struct FinishedIssue {
-    issue:     TrackedIssue,
+    issue: TrackedIssue,
     workspace: WorkspaceInfo,
 }
 
 /// Top-level service that polls issue trackers, manages per-issue `ralph run`
 /// subprocesses, and advances issue state in the external tracker.
 pub struct SymphonyService {
-    config:       SymphonyConfig,
-    shutdown:     CancellationToken,
+    config: SymphonyConfig,
+    shutdown: CancellationToken,
     github_token: Option<String>,
 }
 
@@ -113,7 +116,6 @@ impl SymphonyService {
                 ..
             }) => {
                 let resolved_key = resolve_env_var(api_key)?;
-                let repo_names = self.config.repos.iter().map(|r| r.name.clone()).collect();
                 Ok(Box::new(LinearIssueTracker::new(
                     &resolved_key,
                     endpoint,
@@ -122,7 +124,6 @@ impl SymphonyService {
                     active_states.clone(),
                     terminal_states.clone(),
                     repo_label_prefix.clone(),
-                    repo_names,
                 )?))
             }
             Some(TrackerConfig::Github { api_key, .. }) => {
@@ -144,11 +145,11 @@ impl SymphonyService {
 }
 
 struct IssueRuntime {
-    config:            SymphonyConfig,
+    config: SymphonyConfig,
     workspace_manager: WorkspaceManager,
-    agent:             RalphAgent,
-    running:           HashMap<String, RunningIssue>,
-    failed:            HashMap<String, FinishedIssue>,
+    agent: RalphAgent,
+    running: HashMap<String, RunningIssue>,
+    failed: HashMap<String, FinishedIssue>,
 }
 
 impl IssueRuntime {
@@ -250,7 +251,7 @@ impl IssueRuntime {
                     self.failed.insert(
                         issue_id,
                         FinishedIssue {
-                            issue:     run.issue,
+                            issue: run.issue,
                             workspace: run.workspace,
                         },
                     );
@@ -271,7 +272,7 @@ impl IssueRuntime {
                 self.failed.insert(
                     issue_id,
                     FinishedIssue {
-                        issue:     run.issue,
+                        issue: run.issue,
                         workspace: run.workspace,
                     },
                 );
@@ -410,12 +411,7 @@ impl IssueRuntime {
             .iter()
             .find(|repo| repo.name == repo_name)
             .cloned()
-            .ok_or_else(|| {
-                ConfigSnafu {
-                    message: format!("unknown repo: {repo_name}"),
-                }
-                .build()
-            })?;
+            .unwrap_or_else(|| self.derived_repo_config(repo_name));
 
         let mut resolved = repo;
         if resolved.repo_path.is_none() {
@@ -427,6 +423,15 @@ impl IssueRuntime {
             resolved.repo_path = Some(cwd.clone());
         }
         Ok(resolved)
+    }
+
+    fn derived_repo_config(&self, repo_name: &str) -> RepoConfig {
+        RepoConfig::builder()
+            .name(repo_name.to_owned())
+            .url(default_repo_url(repo_name))
+            .repo_path(default_repo_checkout_root(repo_name))
+            .active_labels(default_active_labels())
+            .build()
     }
 
     fn max_concurrent_for_repo(&self, repo_name: &str) -> usize {
@@ -496,7 +501,7 @@ impl IssueLogWriter {
             .send(entry)
             .await
             .map_err(|_| crate::error::SymphonyError::Workspace {
-                message:  String::from("issue log writer closed unexpectedly"),
+                message: String::from("issue log writer closed unexpectedly"),
                 location: snafu::Location::new(file!(), line!(), column!()),
             })
     }
@@ -511,7 +516,7 @@ async fn spawn_issue_log_writer(
     let parent = log_path
         .parent()
         .ok_or_else(|| crate::error::SymphonyError::Workspace {
-            message:  format!("issue log path has no parent: {}", log_path.display()),
+            message: format!("issue log path has no parent: {}", log_path.display()),
             location: snafu::Location::new(file!(), line!(), column!()),
         })?;
     tokio::fs::create_dir_all(parent).await.context(IoSnafu)?;
@@ -575,14 +580,16 @@ impl ProcessOutputSummaryHandle {
         self.0.lock().await.record(stream_name, line);
     }
 
-    async fn snapshot(&self) -> ProcessOutputSummary { self.0.lock().await.clone() }
+    async fn snapshot(&self) -> ProcessOutputSummary {
+        self.0.lock().await.clone()
+    }
 }
 
 #[derive(Debug, Clone, Default)]
 struct ProcessOutputSummary {
     stdout_line_count: usize,
     stderr_line_count: usize,
-    stderr_tail:       VecDeque<String>,
+    stderr_tail: VecDeque<String>,
 }
 
 impl ProcessOutputSummary {
@@ -633,7 +640,12 @@ fn resolve_env_var(value: &str) -> crate::error::Result<String> {
 
 #[cfg(test)]
 mod tests {
-    use super::{ProcessOutputSummary, issue_log_path, lnav_hint};
+    use std::time::Duration;
+
+    use tokio_util::sync::CancellationToken;
+
+    use super::{IssueRuntime, ProcessOutputSummary, SymphonyService, issue_log_path, lnav_hint};
+    use crate::config::{AgentConfig, RepoConfig, SymphonyConfig};
 
     #[test]
     fn process_output_summary_keeps_only_recent_stderr_lines() {
@@ -667,5 +679,69 @@ mod tests {
         let hint = lnav_hint();
         assert!(hint.contains("lnav"));
         assert!(hint.contains("/ralpha/logs"));
+    }
+
+    #[test]
+    fn repo_config_derives_unknown_repo() {
+        let service = SymphonyService::new(
+            SymphonyConfig::builder()
+                .enabled(true)
+                .poll_interval(Duration::from_secs(30))
+                .max_concurrent_agents(2)
+                .stall_timeout(Duration::from_secs(30 * 60))
+                .max_retry_backoff(Duration::from_secs(60 * 60))
+                .workflow_file("WORKFLOW.md".to_owned())
+                .agent(AgentConfig::default())
+                .repos(vec![])
+                .build(),
+            CancellationToken::new(),
+            None,
+        );
+
+        let repo = IssueRuntime::new(
+            service.config.clone(),
+            crate::agent::RalphAgent::new(AgentConfig::default()),
+        )
+        .repo_config("crrowbot/rara-notes")
+        .expect("fallback repo config should resolve");
+
+        assert_eq!(repo.name, "crrowbot/rara-notes");
+        assert_eq!(repo.url, "https://github.com/crrowbot/rara-notes");
+        assert_eq!(
+            repo.repo_path,
+            Some(
+                rara_paths::config_dir()
+                    .join("ralpha/repos")
+                    .join("crrowbot/rara-notes")
+            )
+        );
+    }
+
+    #[test]
+    fn repo_config_prefers_explicit_repo_settings() {
+        let configured = RepoConfig::builder()
+            .name("rararulab/rara".to_owned())
+            .url("https://example.com/custom.git".to_owned())
+            .active_labels(vec!["symphony:ready".to_owned()])
+            .build();
+        let runtime = IssueRuntime::new(
+            SymphonyConfig::builder()
+                .enabled(true)
+                .poll_interval(Duration::from_secs(30))
+                .max_concurrent_agents(2)
+                .stall_timeout(Duration::from_secs(30 * 60))
+                .max_retry_backoff(Duration::from_secs(60 * 60))
+                .workflow_file("WORKFLOW.md".to_owned())
+                .agent(AgentConfig::default())
+                .repos(vec![configured])
+                .build(),
+            crate::agent::RalphAgent::new(AgentConfig::default()),
+        );
+
+        let repo = runtime
+            .repo_config("rararulab/rara")
+            .expect("configured repo should resolve");
+
+        assert_eq!(repo.url, "https://example.com/custom.git");
     }
 }

--- a/crates/symphony/src/tracker.rs
+++ b/crates/symphony/src/tracker.rs
@@ -36,23 +36,23 @@ pub enum IssueState {
 #[derive(Debug, Clone)]
 pub struct TrackedIssue {
     /// Unique identifier (owner/repo#number).
-    pub id:         String,
+    pub id: String,
     /// Human-readable identifier. GitHub: "42", Linear: "RAR-42".
     pub identifier: String,
     /// Repository name (owner/repo).
-    pub repo:       String,
+    pub repo: String,
     /// Issue number.
-    pub number:     u64,
+    pub number: u64,
     /// Issue title.
-    pub title:      String,
+    pub title: String,
     /// Issue body/description.
-    pub body:       Option<String>,
+    pub body: Option<String>,
     /// Labels attached to the issue.
-    pub labels:     Vec<String>,
+    pub labels: Vec<String>,
     /// Priority (lower = higher priority).
-    pub priority:   u32,
+    pub priority: u32,
     /// Current lifecycle state.
-    pub state:      IssueState,
+    pub state: IssueState,
     /// When the issue was created.
     pub created_at: DateTime<Utc>,
 }
@@ -75,9 +75,9 @@ pub trait IssueTracker: Send + Sync {
 
 /// GitHub-backed issue tracker using the REST API.
 pub struct GitHubIssueTracker {
-    repos:  Vec<RepoConfig>,
+    repos: Vec<RepoConfig>,
     client: reqwest::Client,
-    token:  Option<String>,
+    token: Option<String>,
 }
 
 impl GitHubIssueTracker {
@@ -127,7 +127,7 @@ impl GitHubIssueTracker {
         ensure!(
             resp.status().is_success(),
             GitHubStatusSnafu {
-                repo:   repo.name.clone(),
+                repo: repo.name.clone(),
                 status: resp.status(),
             }
         );
@@ -198,7 +198,7 @@ impl IssueTracker for GitHubIssueTracker {
         ensure!(
             resp.status().is_success(),
             GitHubStatusSnafu {
-                repo:   repo.clone(),
+                repo: repo.clone(),
                 status: resp.status(),
             }
         );
@@ -229,7 +229,9 @@ impl IssueTracker for GitHubIssueTracker {
 /// Parse an `"owner/repo"` slug into `(owner, repo)`.
 ///
 /// If no slash is present, treats the whole string as repo with empty owner.
-fn parse_repo_slug(slug: &str) -> (&str, &str) { slug.split_once('/').unwrap_or(("", slug)) }
+fn parse_repo_slug(slug: &str) -> (&str, &str) {
+    slug.split_once('/').unwrap_or(("", slug))
+}
 
 /// Derive a numeric priority from issue labels.
 ///
@@ -274,12 +276,12 @@ fn sort_issues(issues: &mut [TrackedIssue]) {
 
 #[derive(Debug, Deserialize)]
 struct GitHubIssue {
-    number:       u64,
-    title:        String,
-    body:         Option<String>,
-    state:        String,
-    labels:       Vec<GitHubLabel>,
-    created_at:   DateTime<Utc>,
+    number: u64,
+    title: String,
+    body: Option<String>,
+    state: String,
+    labels: Vec<GitHubLabel>,
+    created_at: DateTime<Utc>,
     pull_request: Option<serde_json::Value>,
 }
 
@@ -292,13 +294,12 @@ struct GitHubLabel {
 
 /// Linear-backed issue tracker using the GraphQL API.
 pub struct LinearIssueTracker {
-    client:            lineark_sdk::Client,
-    team_key:          String,
-    project_slug:      Option<String>,
-    active_states:     Vec<String>,
-    terminal_states:   Vec<String>,
+    client: lineark_sdk::Client,
+    team_key: String,
+    project_slug: Option<String>,
+    active_states: Vec<String>,
+    terminal_states: Vec<String>,
     repo_label_prefix: String,
-    repos:             Vec<String>,
 }
 
 impl LinearIssueTracker {
@@ -311,7 +312,6 @@ impl LinearIssueTracker {
         active_states: Vec<String>,
         terminal_states: Vec<String>,
         repo_label_prefix: String,
-        repos: Vec<String>,
     ) -> Result<Self> {
         let mut client = lineark_sdk::Client::from_token(api_key).context(LinearSnafu {
             message: "failed to create client",
@@ -324,7 +324,6 @@ impl LinearIssueTracker {
             active_states,
             terminal_states,
             repo_label_prefix,
-            repos,
         })
     }
 
@@ -334,7 +333,7 @@ impl LinearIssueTracker {
         for label in labels {
             let lower = label.to_lowercase();
             if let Some(repo) = lower.strip_prefix(&prefix) {
-                if self.repos.iter().any(|r| r == repo) {
+                if !repo.is_empty() {
                     return Some(repo.to_owned());
                 }
             }
@@ -476,7 +475,6 @@ impl IssueTracker for LinearIssueTracker {
                             identifier = ident,
                             labels = ?labels,
                             prefix = %self.repo_label_prefix,
-                            configured_repos = ?self.repos,
                             "linear: no matching repo label, skipping issue"
                         );
                         continue;
@@ -749,9 +747,13 @@ mod tests {
         assert_eq!(ids, vec!["b", "a", "e", "c", "d"]);
     }
 
-    fn s(v: &str) -> String { v.to_owned() }
+    fn s(v: &str) -> String {
+        v.to_owned()
+    }
 
-    fn dt(rfc3339: &str) -> DateTime<Utc> { rfc3339.parse().unwrap() }
+    fn dt(rfc3339: &str) -> DateTime<Utc> {
+        rfc3339.parse().unwrap()
+    }
 
     fn issue(id: &str, number: u64, priority: u32, created_at: DateTime<Utc>) -> TrackedIssue {
         TrackedIssue {
@@ -783,5 +785,25 @@ mod tests {
         assert_eq!(LinearIssueTracker::map_priority(2), 2);
         assert_eq!(LinearIssueTracker::map_priority(3), 3);
         assert_eq!(LinearIssueTracker::map_priority(4), 4);
+    }
+
+    #[test]
+    fn linear_extract_repo_accepts_any_repo_label_with_prefix() {
+        let tracker = LinearIssueTracker::new(
+            "token",
+            "https://api.linear.app/graphql",
+            "RAR".to_owned(),
+            None,
+            vec!["Todo".to_owned()],
+            vec!["Done".to_owned()],
+            "repo:".to_owned(),
+        )
+        .expect("tracker should build");
+
+        assert_eq!(
+            tracker.extract_repo(&[s("bug"), s("Repo:Crrowbot/Rara-Notes")]),
+            Some("crrowbot/rara-notes".to_owned())
+        );
+        assert_eq!(tracker.extract_repo(&[s("repo:")]), None);
     }
 }

--- a/crates/symphony/src/workspace.rs
+++ b/crates/symphony/src/workspace.rs
@@ -18,6 +18,7 @@ use std::{
 };
 
 use snafu::{Location, ensure};
+use tracing::info;
 
 use crate::{
     config::RepoConfig,
@@ -26,8 +27,8 @@ use crate::{
 
 #[derive(Debug, Clone)]
 pub struct WorkspaceInfo {
-    pub path:        PathBuf,
-    pub branch:      String,
+    pub path: PathBuf,
+    pub branch: String,
     pub created_now: bool,
 }
 
@@ -35,6 +36,48 @@ pub struct WorkspaceInfo {
 pub struct WorkspaceManager;
 
 impl WorkspaceManager {
+    fn ensure_repo_checkout(&self, repo: &RepoConfig) -> Result<(git2::Repository, PathBuf)> {
+        ensure!(
+            repo.repo_path.is_some(),
+            crate::error::WorkspaceSnafu {
+                message: format!("repo {} is missing repo_path", repo.name),
+            }
+        );
+        let repo_path = repo.repo_path.clone().expect("checked repo_path above");
+
+        if repo_path.exists() {
+            let checkout =
+                git2::Repository::open(&repo_path).map_err(|source| SymphonyError::Git {
+                    source,
+                    location: Location::new(file!(), line!(), column!()),
+                })?;
+            return Ok((checkout, repo_path));
+        }
+
+        if let Some(parent) = repo_path.parent() {
+            fs::create_dir_all(parent).map_err(|source| SymphonyError::Io {
+                source,
+                location: Location::new(file!(), line!(), column!()),
+            })?;
+        }
+
+        info!(
+            repo = %repo.name,
+            url = %repo.url,
+            path = %repo_path.display(),
+            "cloning missing repository checkout for symphony"
+        );
+
+        let checkout = git2::Repository::clone(&repo.url, &repo_path).map_err(|source| {
+            SymphonyError::Git {
+                source,
+                location: Location::new(file!(), line!(), column!()),
+            }
+        })?;
+
+        Ok((checkout, repo_path))
+    }
+
     /// Ensure the issue branch is checked out in a dedicated worktree under the
     /// configured workspace root. Existing worktrees are reused.
     pub fn ensure_worktree(
@@ -55,7 +98,6 @@ impl WorkspaceManager {
                 message: format!("repo {} is missing workspace_root", repo.name),
             }
         );
-        let repo_path = repo.repo_path.clone().expect("checked repo_path above");
         let workspace_root = repo
             .effective_workspace_root()
             .expect("checked workspace_root above");
@@ -75,10 +117,7 @@ impl WorkspaceManager {
             location: Location::new(file!(), line!(), column!()),
         })?;
 
-        let repo = git2::Repository::open(&repo_path).map_err(|source| SymphonyError::Git {
-            source,
-            location: Location::new(file!(), line!(), column!()),
-        })?;
+        let (repo, _) = self.ensure_repo_checkout(repo)?;
         let head_ref = repo.head().map_err(|source| SymphonyError::Git {
             source,
             location: Location::new(file!(), line!(), column!()),
@@ -100,7 +139,7 @@ impl WorkspaceManager {
                 })?,
             Err(err) => {
                 return Err(SymphonyError::Git {
-                    source:   err,
+                    source: err,
                     location: Location::new(file!(), line!(), column!()),
                 });
             }
@@ -130,11 +169,7 @@ impl WorkspaceManager {
                 message: format!("repo {} is missing repo_path", repo.name),
             }
         );
-        let repo_path = repo.repo_path.clone().expect("checked repo_path above");
-        let repo = git2::Repository::open(repo_path).map_err(|source| SymphonyError::Git {
-            source,
-            location: Location::new(file!(), line!(), column!()),
-        })?;
+        let (repo, _) = self.ensure_repo_checkout(repo)?;
 
         if workspace.path.exists() {
             fs::remove_dir_all(&workspace.path).map_err(|source| SymphonyError::Io {
@@ -220,5 +255,33 @@ mod tests {
 
         manager.cleanup_worktree(&repo, &workspace).unwrap();
         assert!(!workspace.path.exists());
+    }
+
+    #[test]
+    fn clones_missing_repo_before_creating_worktree() {
+        let source_dir = TempDir::new().unwrap();
+        let source_repo = git2::Repository::init(source_dir.path()).unwrap();
+        let mut index = source_repo.index().unwrap();
+        let tree_oid = index.write_tree().unwrap();
+        let tree = source_repo.find_tree(tree_oid).unwrap();
+        let sig = git2::Signature::now("test", "test@example.com").unwrap();
+        source_repo
+            .commit(Some("HEAD"), &sig, &sig, "initial", &tree, &[])
+            .unwrap();
+
+        let checkout_root = TempDir::new().unwrap();
+        let repo_path = checkout_root.path().join("clones/repo");
+        let repo = RepoConfig::builder()
+            .name("crrowbot/rara-notes".to_owned())
+            .url(source_dir.path().display().to_string())
+            .repo_path(repo_path.clone())
+            .active_labels(vec!["symphony:ready".to_owned()])
+            .build();
+
+        let manager = WorkspaceManager;
+        let workspace = manager.ensure_worktree(&repo, 11, "Dynamic repo").unwrap();
+
+        assert!(repo_path.exists());
+        assert!(workspace.path.exists());
     }
 }


### PR DESCRIPTION
## Summary
- allow Linear repo label matching to accept any non-empty `repo:` label instead of only configured repos
- derive fallback repo config for unknown repos and map them to managed checkouts under `~/.config/rara/ralpha/repos`
- auto-clone missing repo checkouts before creating worktrees and cover the new behavior with unit tests

## Verification
- cargo test -p rara-symphony