### PR TITLE
fix(symphony): default dynamic repos to ssh

### DIFF
--- a/crates/symphony/src/config.rs
+++ b/crates/symphony/src/config.rs
@@ -328,7 +328,7 @@ impl RepoConfig {
 }
 
 pub(crate) fn default_repo_url(repo_name: &str) -> String {
-    format!("https://github.com/{repo_name}")
+    format!("git@github.com:{repo_name}.git")
 }
 
 pub(crate) fn default_repo_checkout_root(repo_name: &str) -> PathBuf {

--- a/crates/symphony/src/service.rs
+++ b/crates/symphony/src/service.rs
@@ -706,7 +706,7 @@ mod tests {
         .expect("fallback repo config should resolve");
 
         assert_eq!(repo.name, "crrowbot/rara-notes");
-        assert_eq!(repo.url, "https://github.com/crrowbot/rara-notes");
+        assert_eq!(repo.url, "git@github.com:crrowbot/rara-notes.git");
         assert_eq!(
             repo.repo_path,
             Some(

--- a/docs/src/symphony.md
+++ b/docs/src/symphony.md
@@ -148,6 +148,7 @@ symphony:
 
 - `repo_path` 是主仓库 checkout
 - `workspace_root` 可选；不填时默认落到 `~/.config/rara/ralpha/worktress/<repo>/worktrees`
+- 对于只通过 `repo:<owner>/<repo>` label 动态发现、但未显式写在 `symphony.repos` 里的仓库，Symphony 会默认使用 `git@github.com:<owner>/<repo>.git` 作为 clone URL
 - `workflow_file` 默认为 `WORKFLOW.md`
 - `tracker.started_issue_state` 控制 Ralph 成功启动后 issue 要切到哪个 tracker 状态，默认是 `In Progress`
 - `tracker.completed_issue_state` 控制 Ralph 成功完成后 issue 要切到哪个 tracker 状态，默认是 `ToVerify`


### PR DESCRIPTION
## Summary
- switch dynamically derived Symphony repo URLs from HTTPS to SSH
- keep explicit repo configuration unchanged
- document the default clone behavior for label-discovered repos

## Testing
- cargo test -p rara-symphony repo_config_derives_unknown_repo
- cargo test -p rara-symphony repo_config_prefers_explicit_repo_settings

## Context
This avoids the macOS libgit2 SecureTransport HTTPS clone failure seen when Symphony derives repo config from repo labels.