### PR TITLE
fix(symphony): recreate invalid worktrees

### DIFF
--- a/crates/symphony/src/workspace.rs
+++ b/crates/symphony/src/workspace.rs
@@ -17,12 +17,12 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use snafu::{Location, ensure};
+use snafu::{Location, ResultExt, ensure};
 use tracing::{info, warn};
 
 use crate::{
     config::RepoConfig,
-    error::{Result, SymphonyError},
+    error::{IoSnafu, Result, SymphonyError},
 };
 
 #[derive(Debug, Clone)]
@@ -116,10 +116,7 @@ impl WorkspaceManager {
                     branch = %branch,
                     "removing invalid existing symphony worktree before recreation"
                 );
-                fs::remove_dir_all(&path).map_err(|source| SymphonyError::Io {
-                    source,
-                    location: Location::new(file!(), line!(), column!()),
-                })?;
+                fs::remove_dir_all(&path).context(IoSnafu)?;
                 if let Ok(wt) = repo.find_worktree(&branch) {
                     let _ = wt.prune(Some(
                         git2::WorktreePruneOptions::new().valid(false).locked(false),


### PR DESCRIPTION
## Summary
- validate an existing Symphony worktree before reusing it
- remove and recreate stale worktree directories whose .git points to a missing gitdir
- add a regression test for broken worktree recovery

## Testing
- cargo test -p rara-symphony replaces_invalid_existing_worktree_directory

## Context
After PR #153, Symphony could still fail with `IO error: No such file or directory (os error 2)` when it encountered an old broken worktree directory left behind by a previous failed run. This change makes worktree reuse self-healing.