### PR TITLE
test(symphony): isolate worktree fixtures

### DIFF
--- a/crates/symphony/src/workspace.rs
+++ b/crates/symphony/src/workspace.rs
@@ -250,6 +250,7 @@ mod tests {
     #[test]
     fn creates_and_cleans_up_worktree() {
         let repo_dir = TempDir::new().unwrap();
+        let workspace_root = TempDir::new().unwrap();
         let repo = git2::Repository::init(repo_dir.path()).unwrap();
         let mut index = repo.index().unwrap();
         let tree_oid = index.write_tree().unwrap();
@@ -262,6 +263,7 @@ mod tests {
             .name("rararulab/rara".to_owned())
             .url("https://github.com/rararulab/rara".to_owned())
             .repo_path(repo_dir.path().to_path_buf())
+            .workspace_root(workspace_root.path().to_path_buf())
             .active_labels(vec!["symphony:ready".to_owned()])
             .build();
 
@@ -277,6 +279,7 @@ mod tests {
     #[test]
     fn clones_missing_repo_before_creating_worktree() {
         let source_dir = TempDir::new().unwrap();
+        let workspace_root = TempDir::new().unwrap();
         let source_repo = git2::Repository::init(source_dir.path()).unwrap();
         let mut index = source_repo.index().unwrap();
         let tree_oid = index.write_tree().unwrap();
@@ -292,6 +295,7 @@ mod tests {
             .name("crrowbot/rara-notes".to_owned())
             .url(source_dir.path().display().to_string())
             .repo_path(repo_path.clone())
+            .workspace_root(workspace_root.path().to_path_buf())
             .active_labels(vec!["symphony:ready".to_owned()])
             .build();
 


### PR DESCRIPTION
## Summary
- use temporary workspace roots in symphony workspace tests
- avoid writing test worktrees into the real ~/.config/rara directory
- prevent tests from leaving behind broken .git pointers to deleted temp repos

## Testing
- cargo test -p rara-symphony creates_and_cleans_up_worktree
- cargo test -p rara-symphony clones_missing_repo_before_creating_worktree
- cargo test -p rara-symphony replaces_invalid_existing_worktree_directory

## Context
The previous tests used the default workspace_root, which resolves into the real user config directory. That polluted live Symphony worktree paths with test-only .git files pointing at temporary repositories that no longer existed.