### PR TITLE
fix(symphony): allow missing Ralph core config

### DIFF
--- a/crates/symphony/src/agent.rs
+++ b/crates/symphony/src/agent.rs
@@ -99,6 +99,9 @@ impl RalphAgent {
         let core = match tokio::fs::read_to_string(&core_path).await {
             Ok(core) => core,
             Err(source) if source.kind() == std::io::ErrorKind::NotFound => {
+                // Dynamically discovered repos are not required to carry a
+                // repo-local `ralph.core.yml`; in that case the generated
+                // worktree-local `ralph.yml` is the best available config.
                 info!(
                     path = %core_path.display(),
                     "Ralph core config missing in worktree; using generated ralph.yml as-is"


### PR DESCRIPTION
## Summary
- skip core-config merge when a dynamic repo worktree does not contain `ralph.core.yml`
- keep using the generated `ralph.yml` from `ralph init` in that case
- add regression tests for both merge and missing-core behavior

## Testing
- cargo test -p rara-symphony missing_core_config_keeps_generated_ralph_config
- cargo test -p rara-symphony merge_core_config_overrides_generated_values

## Context
Dynamically discovered repos do not necessarily carry a repo-local `ralph.core.yml`. Symphony should not fail startup for those repos when the generated `ralph.yml` is sufficient.