### PR TITLE
fix(kernel): emit ToolCallStart before ToolCallArgumentsDelta

### DIFF
--- a/crates/kernel/src/llm/openai.rs
+++ b/crates/kernel/src/llm/openai.rs
@@ -417,6 +417,24 @@ impl StreamAccumulator {
                                 entry.name = name.clone();
                             }
                         }
+                    }
+
+                    // Emit ToolCallStart BEFORE any argument deltas so the
+                    // receiver creates the PendingToolCall entry first.
+                    // Otherwise ToolCallArgumentsDelta arrives for an index
+                    // that doesn't exist yet and arguments are silently dropped.
+                    if !entry.started && !entry.id.is_empty() && !entry.name.is_empty() {
+                        entry.started = true;
+                        let _ = tx
+                            .send(StreamDelta::ToolCallStart {
+                                index: tc.index,
+                                id:    entry.id.clone(),
+                                name:  entry.name.clone(),
+                            })
+                            .await;
+                    }
+
+                    if let Some(ref func) = tc.function {
                         if let Some(ref args) = func.arguments {
                             if !args.is_empty() {
                                 entry.arguments.push_str(args);
@@ -428,18 +446,6 @@ impl StreamAccumulator {
                                     .await;
                             }
                         }
-                    }
-
-                    // Emit ToolCallStart exactly once when we first get both id and name
-                    if !entry.started && !entry.id.is_empty() && !entry.name.is_empty() {
-                        entry.started = true;
-                        let _ = tx
-                            .send(StreamDelta::ToolCallStart {
-                                index: tc.index,
-                                id:    entry.id.clone(),
-                                name:  entry.name.clone(),
-                            })
-                            .await;
                     }
                 }
             }


### PR DESCRIPTION
## Summary

- OpenAI streaming parser 在同一个 chunk 中先发送 `ToolCallArgumentsDelta`，后发送 `ToolCallStart`
- Agent loop 接收端在 `ToolCallStart` 时才创建 entry，所以先到的 argument delta 被 `get_mut` 静默丢弃
- 对于短参数（一个 chunk 发完），所有参数丢失 → `arguments_buf = ""` → 标准化为 `{}` → `missing required parameter: command` 循环报错
- 修复：将 `ToolCallStart` 发送移到参数处理之前

## Test plan

- [ ] `cargo check -p rara-kernel` 通过
- [ ] 发送简单 bash 命令（如 `uv tool install xiaohongshu-cli`）验证不再报 missing parameter
- [ ] 验证多工具并行调用（parallel_tool_calls）场景正常

🤖 Generated with [Claude Code](https://claude.com/claude-code)