### PR TITLE
fix(kernel): ensure ToolCallStart emitted before ToolCallArgumentsDelta

### DIFF
--- a/crates/kernel/AGENT.md
+++ b/crates/kernel/AGENT.md
@@ -1,0 +1,33 @@
+# rara-kernel — Agent Guidelines
+
+## Critical: StreamDelta Event Ordering in `openai.rs`
+
+### The Invariant
+
+In `StreamAccumulator::process_chunk()`, **`ToolCallStart` MUST be sent before `ToolCallArgumentsDelta`** for the same tool call index.
+
+The receiver in `agent.rs` uses a `HashMap<u32, PendingToolCall>` keyed by index. The entry is only created when `ToolCallStart` arrives. If `ToolCallArgumentsDelta` arrives first, `get_mut(&index)` returns `None` and **the arguments are silently dropped**.
+
+### Why This Matters
+
+Some LLM providers (notably OpenRouter) deliver the tool call name and arguments in a **single SSE chunk**. If the code emits `ToolCallArgumentsDelta` before `ToolCallStart`, the arguments are lost. This causes:
+
+- Tool calls with empty `{}` arguments
+- Bash tool fails with `missing required parameter: command`
+- Agent enters a retry loop (67+ failed calls observed in production)
+
+### The Pattern (DO NOT CHANGE)
+
+```
+1. Set entry.id    (from tc.id)
+2. Set entry.name  (from tc.function.name)
+3. Collect args into local variable (DO NOT send yet)
+4. Emit ToolCallStart  (if !started && id + name are set)
+5. Emit ToolCallArgumentsDelta  (now the receiver entry exists)
+```
+
+### What NOT To Do
+
+- Do NOT move `ToolCallArgumentsDelta` emission before `ToolCallStart`
+- Do NOT inline the argument send back into the `if let Some(ref func)` block before the start check
+- Do NOT assume providers send tool call parts in separate chunks — single-chunk delivery is common

--- a/crates/kernel/src/llm/openai.rs
+++ b/crates/kernel/src/llm/openai.rs
@@ -411,6 +411,14 @@ impl StreamAccumulator {
                         }
                     }
 
+                    // Collect new arguments but defer sending the delta until
+                    // after ToolCallStart has been emitted.  Some providers
+                    // (e.g. OpenRouter) deliver name + arguments in a single
+                    // SSE chunk; if we send ToolCallArgumentsDelta first the
+                    // receiver has no pending entry yet and silently drops
+                    // the arguments.
+                    let mut new_args: Option<String> = None;
+
                     if let Some(ref func) = tc.function {
                         if let Some(ref name) = func.name {
                             if !name.is_empty() {
@@ -420,17 +428,15 @@ impl StreamAccumulator {
                         if let Some(ref args) = func.arguments {
                             if !args.is_empty() {
                                 entry.arguments.push_str(args);
-                                let _ = tx
-                                    .send(StreamDelta::ToolCallArgumentsDelta {
-                                        index:     tc.index,
-                                        arguments: args.clone(),
-                                    })
-                                    .await;
+                                new_args = Some(args.clone());
                             }
                         }
                     }
 
-                    // Emit ToolCallStart exactly once when we first get both id and name
+                    // Emit ToolCallStart exactly once when we first get both id and name.
+                    // This MUST happen before ToolCallArgumentsDelta so the
+                    // receiver registers the pending entry before accumulating
+                    // arguments.
                     if !entry.started && !entry.id.is_empty() && !entry.name.is_empty() {
                         entry.started = true;
                         let _ = tx
@@ -438,6 +444,17 @@ impl StreamAccumulator {
                                 index: tc.index,
                                 id:    entry.id.clone(),
                                 name:  entry.name.clone(),
+                            })
+                            .await;
+                    }
+
+                    // Now send the argument delta (receiver entry is guaranteed
+                    // to exist if ToolCallStart was emitted above).
+                    if let Some(args) = new_args {
+                        let _ = tx
+                            .send(StreamDelta::ToolCallArgumentsDelta {
+                                index:     tc.index,
+                                arguments: args,
                             })
                             .await;
                     }


### PR DESCRIPTION
## Summary

- **根因**: `StreamAccumulator::process_chunk()` 中 `ToolCallArgumentsDelta` 在 `ToolCallStart` **之前**发送到 channel。当 LLM provider（如 OpenRouter）在同一个 SSE chunk 中同时发送 tool call 的 name 和 arguments 时，agent.rs 收到 `ToolCallArgumentsDelta` 时 `pending_tool_calls` 里还没有对应 entry，`get_mut(&index)` 返回 `None`，**arguments 被静默丢弃**
- **现象**: 所有 bash 工具调用收到空参数 `{}`，报错 `missing required parameter: command`，agent 进入 67+ 次重试循环
- **修复**: 将 arguments 暂存到局部变量，确保 `ToolCallStart` 先发送（创建 receiver entry），再发送 `ToolCallArgumentsDelta`
- **新增 `crates/kernel/AGENT.md`**: 文档化此不变量，防止后续修改破坏事件顺序

## 事件顺序（修复后）

```
1. 设置 entry.id    (from tc.id)
2. 设置 entry.name  (from tc.function.name)
3. 暂存 args 到局部变量 (不立即发送)
4. 发送 ToolCallStart  (receiver 创建 pending entry)
5. 发送 ToolCallArgumentsDelta  (receiver entry 已存在，可正常累积)
```

## Test plan

- [x] `cargo check -p rara-kernel` 编译通过
- [x] `cargo build -p rara-cli` 构建成功
- [x] 在 chat 模式下测试 bash 工具 — `echo test123` 成功返回 `exit_code: 0`
- [x] 在 chat 模式下测试 ctx_execute 工具 — 正常工作
- [x] 对比修复前日志：67 次 bash 空参数失败 → 修复后首次调用即成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)