### PR TITLE
RAR-21 fix schedule-cron 5-field parsing

### DIFF
--- a/crates/kernel/Cargo.toml
+++ b/crates/kernel/Cargo.toml
@@ -23,7 +23,7 @@ base.workspace = true
 base64.workspace = true
 bon.workspace = true
 chrono.workspace = true
-cron = "0.15"
+croner.workspace = true
 crossbeam-queue.workspace = true
 dashmap = "6"
 derive_more = { workspace = true }

--- a/crates/kernel/src/schedule.rs
+++ b/crates/kernel/src/schedule.rs
@@ -18,7 +18,7 @@
 //! and [`JobWheel`] (the scheduling data structure backed by a `BTreeMap`).
 //! Jobs are persisted as JSON and restored on startup.
 
-use std::{collections::BTreeMap, path::PathBuf};
+use std::{collections::BTreeMap, path::PathBuf, str::FromStr};
 
 use jiff::Timestamp;
 use serde::{Deserialize, Serialize};
@@ -47,12 +47,12 @@ pub enum Trigger {
         /// Interval in seconds.
         every_secs: u64,
         /// Next scheduled fire time.
-        next_at:    Timestamp,
+        next_at: Timestamp,
     },
     /// Fire according to a cron expression.
     Cron {
         /// The cron expression string (e.g. `"0 9 * * *"`).
-        expr:    String,
+        expr: String,
         /// Next scheduled fire time.
         next_at: Timestamp,
     },
@@ -94,17 +94,17 @@ impl Trigger {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct JobEntry {
     /// Unique job identifier.
-    pub id:          JobId,
+    pub id: JobId,
     /// When/how this job fires.
-    pub trigger:     Trigger,
+    pub trigger: Trigger,
     /// Text injected as a `UserMessage` when the job fires.
-    pub message:     String,
+    pub message: String,
     /// Session this job is bound to.
     pub session_key: SessionKey,
     /// The principal who created the job.
-    pub principal:   Principal,
+    pub principal: Principal,
     /// When this job was created.
-    pub created_at:  Timestamp,
+    pub created_at: Timestamp,
 }
 
 // ---------------------------------------------------------------------------
@@ -130,7 +130,9 @@ pub struct JobWheel {
 
 impl JobWheel {
     /// Build a wheel key from a job entry.
-    fn key(entry: &JobEntry) -> WheelKey { (entry.trigger.next_at().as_second(), entry.id.0) }
+    fn key(entry: &JobEntry) -> WheelKey {
+        (entry.trigger.next_at().as_second(), entry.id.0)
+    }
 
     /// Load jobs from the JSON persistence file, or create an empty wheel.
     pub fn load(path: PathBuf) -> Self {
@@ -202,8 +204,8 @@ impl JobWheel {
                         };
                         self.jobs.insert(Self::key(&rescheduled), rescheduled);
                     }
-                    Trigger::Cron { expr, .. } => match Self::next_cron_time(&expr, now) {
-                        Some(next) => {
+                    Trigger::Cron { expr, .. } => match next_cron_time(&expr, now) {
+                        Ok(next) => {
                             let mut rescheduled = entry;
                             rescheduled.trigger = Trigger::Cron {
                                 expr,
@@ -211,7 +213,7 @@ impl JobWheel {
                             };
                             self.jobs.insert(Self::key(&rescheduled), rescheduled);
                         }
-                        None => {
+                        Err(_) => {
                             warn!(job_id = %entry.id, expr = expr, "cron expression yields no future time, removing job");
                         }
                     },
@@ -260,19 +262,65 @@ impl JobWheel {
             }
         }
     }
+}
 
-    /// Compute the next fire time for a cron expression after `after`.
-    fn next_cron_time(expr: &str, after: Timestamp) -> Option<Timestamp> {
-        use std::str::FromStr;
+#[derive(Debug)]
+pub(crate) enum CronNextError {
+    Invalid(croner::errors::CronError),
+    NoFutureTime,
+}
 
-        let schedule = cron::Schedule::from_str(expr).ok()?;
-        // Convert jiff::Timestamp to chrono::DateTime<Utc>.
-        let after_chrono = chrono::DateTime::<chrono::Utc>::from_timestamp(
-            after.as_second(),
-            after.subsec_nanosecond() as u32,
-        )?;
-        let next_chrono = schedule.upcoming(chrono::Utc).find(|t| *t > after_chrono)?;
-        let next_ts = Timestamp::from_second(next_chrono.timestamp()).ok()?;
-        Some(next_ts)
+impl std::fmt::Display for CronNextError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Invalid(err) => write!(f, "{err}"),
+            Self::NoFutureTime => write!(f, "expression yields no future time"),
+        }
+    }
+}
+
+impl std::error::Error for CronNextError {}
+
+/// Compute the next fire time for a 5-field cron expression after `after`.
+pub(crate) fn next_cron_time(expr: &str, after: Timestamp) -> Result<Timestamp, CronNextError> {
+    let cron = croner::Cron::from_str(expr).map_err(CronNextError::Invalid)?;
+    let after_chrono = chrono::DateTime::<chrono::Utc>::from_timestamp(
+        after.as_second(),
+        after.subsec_nanosecond() as u32,
+    )
+    .ok_or(CronNextError::NoFutureTime)?;
+    let next = cron
+        .find_next_occurrence(&after_chrono, false)
+        .map_err(|_| CronNextError::NoFutureTime)?;
+    Timestamp::from_second(next.timestamp()).map_err(|_| CronNextError::NoFutureTime)
+}
+
+#[cfg(test)]
+mod tests {
+    use chrono::Timelike;
+
+    use super::*;
+
+    #[test]
+    fn next_cron_time_accepts_standard_five_field_expression() {
+        let after = Timestamp::from_second(1_763_254_800).expect("valid timestamp");
+
+        let next = next_cron_time("0 23 * * *", after).expect("valid cron expression");
+        let next_chrono = chrono::DateTime::<chrono::Utc>::from_timestamp(next.as_second(), 0)
+            .expect("timestamp converts to chrono");
+
+        assert!(next > after);
+        assert_eq!(next_chrono.minute(), 0);
+        assert_eq!(next_chrono.hour(), 23);
+    }
+
+    #[test]
+    fn next_cron_time_rejects_invalid_expression() {
+        let after = Timestamp::from_second(1_763_254_800).expect("valid timestamp");
+
+        assert!(matches!(
+            next_cron_time("not-a-cron", after),
+            Err(CronNextError::Invalid(_))
+        ));
     }
 }

--- a/crates/kernel/src/schedule_tool.rs
+++ b/crates/kernel/src/schedule_tool.rs
@@ -28,7 +28,7 @@ use tracing::debug;
 
 use crate::{
     event::{KernelEventEnvelope, Syscall},
-    schedule::{JobId, Trigger},
+    schedule::{CronNextError, JobId, Trigger, next_cron_time},
     tool::{AgentTool, ToolContext, ToolOutput},
 };
 
@@ -82,12 +82,14 @@ pub struct ScheduleOnceTool;
 #[derive(Debug, Deserialize)]
 struct ScheduleOnceParams {
     after_seconds: u64,
-    message:       String,
+    message: String,
 }
 
 #[async_trait]
 impl AgentTool for ScheduleOnceTool {
-    fn name(&self) -> &str { "schedule-once" }
+    fn name(&self) -> &str {
+        "schedule-once"
+    }
 
     fn description(&self) -> &str {
         "Schedule a one-shot task. It fires once after the specified delay in seconds."
@@ -140,14 +142,18 @@ pub struct ScheduleIntervalTool;
 #[derive(Debug, Deserialize)]
 struct ScheduleIntervalParams {
     interval_seconds: u64,
-    message:          String,
+    message: String,
 }
 
 #[async_trait]
 impl AgentTool for ScheduleIntervalTool {
-    fn name(&self) -> &str { "schedule-interval" }
+    fn name(&self) -> &str {
+        "schedule-interval"
+    }
 
-    fn description(&self) -> &str { "Schedule a repeating task. It fires every N seconds." }
+    fn description(&self) -> &str {
+        "Schedule a repeating task. It fires every N seconds."
+    }
 
     fn parameters_schema(&self) -> serde_json::Value {
         serde_json::json!({
@@ -203,13 +209,15 @@ pub struct ScheduleCronTool;
 
 #[derive(Debug, Deserialize)]
 struct ScheduleCronParams {
-    cron:    String,
+    cron: String,
     message: String,
 }
 
 #[async_trait]
 impl AgentTool for ScheduleCronTool {
-    fn name(&self) -> &str { "schedule-cron" }
+    fn name(&self) -> &str {
+        "schedule-cron"
+    }
 
     fn description(&self) -> &str {
         "Schedule a task using a cron expression (e.g. '0 9 * * *' for daily at 9am UTC)."
@@ -244,24 +252,19 @@ impl AgentTool for ScheduleCronTool {
             return Err(anyhow::anyhow!("cron expression must not be empty"));
         }
 
-        use std::str::FromStr;
-        let schedule = cron::Schedule::from_str(&p.cron)
-            .map_err(|e| anyhow::anyhow!("invalid cron expression '{}': {e}", p.cron))?;
-
         let now = jiff::Timestamp::now();
-        let now_chrono = chrono::DateTime::<chrono::Utc>::from_timestamp(
-            now.as_second(),
-            now.subsec_nanosecond() as u32,
-        )
-        .ok_or_else(|| anyhow::anyhow!("failed to convert timestamp"))?;
-
-        let next_chrono = schedule
-            .upcoming(chrono::Utc)
-            .find(|t| *t > now_chrono)
-            .ok_or_else(|| anyhow::anyhow!("cron expression '{}' yields no future time", p.cron))?;
-
-        let next_at = jiff::Timestamp::from_second(next_chrono.timestamp())
-            .map_err(|e| anyhow::anyhow!("timestamp conversion error: {e}"))?;
+        let next_at = match next_cron_time(&p.cron, now) {
+            Ok(next) => next,
+            Err(CronNextError::Invalid(e)) => {
+                return Err(anyhow::anyhow!("invalid cron expression '{}': {e}", p.cron));
+            }
+            Err(CronNextError::NoFutureTime) => {
+                return Err(anyhow::anyhow!(
+                    "cron expression '{}' yields no future time",
+                    p.cron
+                ));
+            }
+        };
 
         register_job(
             Trigger::Cron {
@@ -289,9 +292,13 @@ struct ScheduleRemoveParams {
 
 #[async_trait]
 impl AgentTool for ScheduleRemoveTool {
-    fn name(&self) -> &str { "schedule-remove" }
+    fn name(&self) -> &str {
+        "schedule-remove"
+    }
 
-    fn description(&self) -> &str { "Remove a previously scheduled task by its job ID." }
+    fn description(&self) -> &str {
+        "Remove a previously scheduled task by its job ID."
+    }
 
     fn parameters_schema(&self) -> serde_json::Value {
         serde_json::json!({
@@ -351,9 +358,13 @@ pub struct ScheduleListTool;
 
 #[async_trait]
 impl AgentTool for ScheduleListTool {
-    fn name(&self) -> &str { "schedule-list" }
+    fn name(&self) -> &str {
+        "schedule-list"
+    }
 
-    fn description(&self) -> &str { "List all scheduled tasks for the current session." }
+    fn description(&self) -> &str {
+        "List all scheduled tasks for the current session."
+    }
 
     fn parameters_schema(&self) -> serde_json::Value {
         serde_json::json!({
@@ -403,5 +414,46 @@ impl AgentTool for ScheduleListTool {
             "count": list.len(),
         })
         .into())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn schedule_cron_accepts_valid_five_field_expression() {
+        let tool = ScheduleCronTool;
+        let err = tool
+            .execute(
+                json!({
+                    "cron": "0 23 * * *",
+                    "message": "nightly task"
+                }),
+                &ToolContext::default(),
+            )
+            .await
+            .expect_err("missing event queue should fail after cron validation");
+
+        assert!(err.to_string().contains("no event queue in tool context"));
+    }
+
+    #[tokio::test]
+    async fn schedule_cron_rejects_invalid_expression() {
+        let tool = ScheduleCronTool;
+        let err = tool
+            .execute(
+                json!({
+                    "cron": "not-a-cron",
+                    "message": "nightly task"
+                }),
+                &ToolContext::default(),
+            )
+            .await
+            .expect_err("invalid cron expression should fail");
+
+        assert!(err.to_string().contains("invalid cron expression"));
     }
 }


### PR DESCRIPTION
## Summary
- switch kernel cron parsing from `cron` to shared `croner`-based helpers so standard 5-field expressions are accepted
- use the same next-occurrence logic in runtime rescheduling to keep accepted cron jobs firing after the first run
- add regression coverage for valid 5-field expressions and invalid cron input

## Verification
- `cargo test -p rara-kernel next_cron_time_ -- --nocapture`
- `cargo test -p rara-kernel schedule_cron_ -- --nocapture`
- `cargo check -p rara-kernel --tests`

## Notes
- `cargo clippy -p rara-kernel --tests -- -D warnings` currently trips a pre-existing workspace lint in `crates/soul/src/file.rs` unrelated to this change.