### PR TITLE
fix(ci): correct mergify check names for reusable workflows

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -2,8 +2,8 @@ pull_request_rules:
   - name: Automatic merge for Dependabot pull requests
     conditions:
       - author=dependabot[bot]
-      - check-success=Lint Success
-      - check-success=Rust Success
+      - check-success=Lint / Lint Success
+      - check-success=Rust / Rust Success
     actions:
       merge:
         method: squash


### PR DESCRIPTION
## Summary
- Mergify 的 `check-success` 条件写的是 `Lint Success` / `Rust Success`，但 reusable workflow 实际产生的 check 名称带有调用者前缀：`Lint / Lint Success` / `Rust / Rust Success`
- 条件永远不匹配，导致 Dependabot PR 无法自动 merge

## Test plan
- [ ] 确认 PR CI 通过后 Mergify 能正确识别 check 状态
- [ ] 观察下一个 Dependabot PR 是否自动 merge

Closes #269

🤖 Generated with [Claude Code](https://claude.com/claude-code)