### PR TITLE
fix(ci): remove spurious release trigger on PRs & standardize PR workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,7 +46,6 @@ on:
     secrets:
       HOMEBREW_TAP_TOKEN:
         required: false
-  pull_request:
   push:
     tags:
       - '**[0-9]+.[0-9]+.[0-9]+*'
@@ -58,9 +57,9 @@ jobs:
     runs-on: "ubuntu-latest"
     outputs:
       val: ${{ steps.plan.outputs.manifest }}
-      tag: ${{ inputs.tag || (!github.event.pull_request && github.ref_name || '') }}
-      tag-flag: ${{ inputs.tag && format('--tag={0}', inputs.tag) || (!github.event.pull_request && format('--tag={0}', github.ref_name) || '') }}
-      publishing: ${{ inputs.tag != '' || !github.event.pull_request }}
+      tag: ${{ inputs.tag || github.ref_name }}
+      tag-flag: ${{ format('--tag={0}', inputs.tag || github.ref_name) }}
+      publishing: "true"
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
@@ -77,14 +76,9 @@ jobs:
         with:
           name: cargo-dist-cache
           path: ~/.cargo/bin/cargo-dist
-      # sure would be cool if github gave us proper conditionals...
-      # so here's a doubly-nested ternary-via-truthiness to try to provide the best possible
-      # functionality based true whether this is a pull_request, and whether it's from a fork.
-      # (PRs run true the *source* but secrets are usually true the *target* -- that's *good*
-      # but also really annoying to build CI around when it needs secrets to work right.)
       - id: plan
         run: |
-          cargo dist ${{ (!github.event.pull_request && format('host --steps=create --tag={0}', github.ref_name)) || 'plan' }} --output-format=json > plan-dist-manifest.json
+          cargo dist host --steps=create --tag=${{ inputs.tag || github.ref_name }} --output-format=json > plan-dist-manifest.json
           echo "cargo dist ran successfully"
           cat plan-dist-manifest.json
           echo "manifest=$(jq -c "." plan-dist-manifest.json)" >> "$GITHUB_OUTPUT"

--- a/AGENT.md
+++ b/AGENT.md
@@ -504,19 +504,14 @@ for item in items {
   * 基础设施（Docker/Compose/Env/Telemetry）要可维护。
 * 模块组织：尽量按业务域拆分为多个 workspace crate，以降低耦合并改善编译体验。
 
-### 10.2 Git 工作流（从初始化之后开始执行）
+### 10.2 Git 工作流（PR-based）
 
-* 除“仓库刚初始化、尚无协作历史”的特殊阶段外，不允许直接在 `main` 上开发业务改动。
-* 后续所有工作都走 worktree 流程：
-  * 由 subagent 创建 worktree；
-  * 在 worktree 中完成开发与验证；
-  * 提交 commit；
-  * 合并回 `main`；
-  * push 到 remote 的 `main`。
-
-建议命令（示例，按需调整 branch 名称）：
-
-```sh
-git worktree add ../job-wt-<topic> -b codex/<topic>
-cd ../job-wt-<topic>
-```
+* 禁止直接在 `main` 上开发或合并。
+* 所有变更必须通过 GitHub PR 合并，流程如下：
+  1. 创建 issue（`gh issue create`，必须带 `created-by:claude` label）；
+  2. 创建 worktree + 分支（`git worktree add .worktrees/issue-{N}-{name} -b issue-{N}-{name}`）；
+  3. 在 worktree 中完成开发、验证并 commit；
+  4. push 分支到 remote（`git push -u origin issue-{N}-{name}`）；
+  5. 创建 PR（`gh pr create`，body 中包含 `Closes #N`）；
+  6. PR 合并后清理 worktree 和本地分支。
+* 禁止本地 `git merge` 到 `main` — 所有合并通过 GitHub PR 完成。

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,17 +9,17 @@ Rara is a self-evolving, developer-first personal proactive agent built in Rust.
 
 ## Development Workflow
 
-### Issue → Worktree → Subagent → Merge
+### Issue → Worktree → PR → Merge
 
-This is the standard workflow for all feature/refactor work:
+This is the standard workflow for all feature/refactor work. All changes go through GitHub PRs — never merge locally on main.
 
 ```
 1. CREATE ISSUE    →  gh issue create + labels
 2. CREATE WORKTREE →  git worktree add .worktrees/issue-{N}-{name} -b issue-{N}-{name}
 3. DISPATCH        →  Task subagent works in the worktree
 4. VERIFY          →  cargo check + npm run build on worktree
-5. MERGE           →  git merge issue-{N}-{name} (resolve conflicts if needed)
-6. CLEANUP         →  git worktree remove + git branch -d + gh issue close
+5. PUSH & PR       →  git push -u origin + gh pr create
+6. CLEANUP         →  git worktree remove + git branch -d (after PR merged)
 ```
 
 #### Step 1: Create Issue
@@ -46,28 +46,25 @@ cargo check -p {crate-name}   # Rust backend
 cd web && npm run build        # Frontend (if touched)
 ```
 
-#### Step 5: Merge to Main
+#### Step 5: Push & Create PR
 ```bash
-git checkout main
-git merge issue-{N}-{short-name}
-# If conflicts: resolve → git add → git commit --no-edit
+git push -u origin issue-{N}-{short-name}
+gh pr create --title "fix(scope): description" --body "Closes #{N}"
 ```
+- Commit message must include `Closes #N` so the issue is auto-closed when PR merges
+- Never merge locally — all merges happen through GitHub PR
 
-#### Step 6: Cleanup
+#### Step 6: Cleanup (after PR merged)
 ```bash
 git worktree remove .worktrees/issue-{N}-{short-name}
 git branch -d issue-{N}-{short-name}
-gh issue close {N} --comment "Completed in {commit-hash} — {summary}."
 ```
-
-**Important**: `Closes #N` in commit messages only works when pushed to remote. For local-only workflows, always close issues explicitly with `gh issue close`.
 
 ### Parallel Execution
 
 When user requests involve multiple independent changes, split into separate issues and dispatch subagents in parallel:
-- Each subagent gets its own worktree and branch
-- Merge sequentially to main, resolving conflicts as they arise
-- The second merge may need conflict resolution where both branches touched the same files
+- Each subagent gets its own worktree, branch, and PR
+- PRs are reviewed and merged independently on GitHub
 
 ### Database Migrations
 
@@ -90,9 +87,9 @@ When user requests involve multiple independent changes, split into separate iss
 - Do NOT use manual `impl Display` + `impl Error` — use `snafu`
 - Do NOT use mock repositories in tests — use `testcontainers`
 - Do NOT work directly on `main` — always use worktrees for subagent work
+- Do NOT merge locally on `main` — all merges go through GitHub PRs
 - Do NOT create issues without `created-by:claude` label
-- Do NOT forget to close issues after merge — `gh issue close` explicitly
-- Do NOT leave stale worktrees — clean up after every merge
+- Do NOT leave stale worktrees — clean up after PR is merged
 - Do NOT modify already-applied migration files — create a new migration instead
 - Do NOT hardcode database URLs or config defaults in Rust code — use the YAML config file
 - Do NOT use noop/hollow trait implementations to糊弄编译器 — trait method 有真正实现时不允许默认空体（silently return `Ok(())` / `Ok(None)` / `vec![]`）；可选 UX hook（`typing_indicator`, lifecycle hooks）是唯一例外


### PR DESCRIPTION
## Summary
- `release.yml` 的 `on: pull_request:` 没有任何过滤条件，导致每个 PR 都触发 `cargo dist plan`（并失败）
- 移除该触发器，简化 plan job 中不再需要的 PR 条件判断
- 更新 CLAUDE.md 和 AGENT.md，将工作流从本地 merge 改为 GitHub PR-based

## Test plan
- [ ] 新 PR 不再出现 release workflow 的 plan/announce 等 job
- [ ] CI 只在 tag push 或 workflow_call 时触发 release 流程

Closes #271

🤖 Generated with [Claude Code](https://claude.com/claude-code)