### PR TITLE
feat(gateway): add process resource monitoring with persistent alerts

### DIFF
--- a/crates/app/src/gateway/mod.rs
+++ b/crates/app/src/gateway/mod.rs
@@ -25,7 +25,7 @@ pub mod telegram;
 
 pub use detector::{UpdateDetector, UpdateState};
 pub use executor::{ExecutorError, UpdateExecutor, UpdateResult};
-pub use monitor::{AlertThresholds, ProcessMonitor, ProcessSnapshot, SnapshotHandle, ThresholdsHandle};
+pub use monitor::{AlertThresholds, GatewayState, ProcessMonitor, ProcessSnapshot, SnapshotHandle, ThresholdsHandle, load_gateway_state, save_gateway_state};
 pub use notifier::UpdateNotifier;
 pub use pipeline::run_update_pipeline;
 pub use supervisor::{SupervisorCommand, SupervisorHandle, SupervisorService, SupervisorStatus};

--- a/crates/app/src/gateway/monitor.rs
+++ b/crates/app/src/gateway/monitor.rs
@@ -16,7 +16,7 @@
 
 use std::sync::Arc;
 
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use sysinfo::{Pid, ProcessesToUpdate, System};
 use tokio::sync::RwLock;
 
@@ -54,7 +54,7 @@ pub struct ProcessSnapshot {
 // ---------------------------------------------------------------------------
 
 /// Thresholds for resource alerts. `None` = alert disabled.
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct AlertThresholds {
     /// CPU usage percentage threshold.
     pub cpu_percent: Option<f32>,
@@ -82,6 +82,49 @@ pub type SnapshotHandle = Arc<RwLock<ProcessSnapshot>>;
 
 /// Shared handle to alert thresholds.
 pub type ThresholdsHandle = Arc<RwLock<AlertThresholds>>;
+
+// ---------------------------------------------------------------------------
+// GatewayState — persisted runtime state
+// ---------------------------------------------------------------------------
+
+/// Persisted gateway runtime state (survives restarts).
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct GatewayState {
+    #[serde(default)]
+    pub alert_thresholds: AlertThresholds,
+}
+
+/// Path to the gateway runtime state file.
+fn state_file_path() -> std::path::PathBuf {
+    rara_paths::config_dir().join("gateway-state.yaml")
+}
+
+/// Load gateway state from disk. Returns default if file doesn't exist or is invalid.
+pub fn load_gateway_state() -> GatewayState {
+    let path = state_file_path();
+    match std::fs::read_to_string(&path) {
+        Ok(content) => serde_yaml::from_str(&content).unwrap_or_default(),
+        Err(_) => GatewayState::default(),
+    }
+}
+
+/// Save gateway state to disk. Errors are logged but not propagated.
+pub fn save_gateway_state(state: &GatewayState) {
+    let path = state_file_path();
+    if let Some(parent) = path.parent() {
+        let _ = std::fs::create_dir_all(parent);
+    }
+    match serde_yaml::to_string(state) {
+        Ok(yaml) => {
+            if let Err(e) = std::fs::write(&path, yaml) {
+                tracing::warn!(error = %e, "Failed to save gateway state");
+            }
+        }
+        Err(e) => {
+            tracing::warn!(error = %e, "Failed to serialize gateway state");
+        }
+    }
+}
 
 // ---------------------------------------------------------------------------
 // ProcessMonitor — collects metrics each tick

--- a/crates/app/src/gateway/telegram.rs
+++ b/crates/app/src/gateway/telegram.rs
@@ -365,6 +365,10 @@ impl GatewayTelegramListener {
                     return "Usage: /threshold cpu <percent>".to_owned();
                 };
                 self.alert_thresholds.write().await.cpu_percent = Some(val);
+                let state = super::monitor::GatewayState {
+                    alert_thresholds: self.alert_thresholds.read().await.clone(),
+                };
+                super::monitor::save_gateway_state(&state);
                 format!("CPU threshold set to {val}%")
             }
             "mem" => {
@@ -372,10 +376,18 @@ impl GatewayTelegramListener {
                     return "Usage: /threshold mem <MB>".to_owned();
                 };
                 self.alert_thresholds.write().await.mem_mb = Some(val);
+                let state = super::monitor::GatewayState {
+                    alert_thresholds: self.alert_thresholds.read().await.clone(),
+                };
+                super::monitor::save_gateway_state(&state);
                 format!("Memory threshold set to {val} MB")
             }
             "clear" => {
                 *self.alert_thresholds.write().await = Default::default();
+                let state = super::monitor::GatewayState {
+                    alert_thresholds: self.alert_thresholds.read().await.clone(),
+                };
+                super::monitor::save_gateway_state(&state);
                 "All thresholds cleared.".to_owned()
             }
             _ => "Usage: /threshold [cpu <percent> | mem <MB> | clear]".to_owned(),

--- a/crates/cmd/src/main.rs
+++ b/crates/cmd/src/main.rs
@@ -189,6 +189,12 @@ impl GatewayArgs {
         let process_snapshot: rara_app::gateway::SnapshotHandle = Default::default();
         let alert_thresholds: rara_app::gateway::ThresholdsHandle = Default::default();
 
+        // Load persisted thresholds from gateway-state.yaml.
+        {
+            let state = rara_app::gateway::load_gateway_state();
+            *alert_thresholds.write().await = state.alert_thresholds;
+        }
+
         {
             let snapshot = process_snapshot.clone();
             let thresholds = alert_thresholds.clone();


### PR DESCRIPTION
## Summary

- 新增 `ProcessMonitor` 模块，使用 `sysinfo` crate 按 PID 采集 rara server 子进程资源指标（CPU%、RSS、虚拟内存、线程数、FD 数、磁盘 IO、uptime）
- `/gateway/status` 端点扩展，返回实时进程资源快照
- 新增 Telegram `/stats` 命令查看当前资源状态
- 新增 Telegram `/threshold` 命令动态配置告警阈值（CPU%、内存 MB），超阈值自动 Telegram 告警
- 60 秒告警冷却机制防止刷屏
- 阈值持久化到 `~/.config/job/gateway-state.yaml`，重启不丢失

## Test plan

- [ ] `cargo check` 通过
- [ ] 本地启动 `rara gateway`，访问 `/gateway/status` 确认返回 `process` 字段
- [ ] Telegram `/stats` 返回资源数据
- [ ] `/threshold cpu 80` 设置阈值，重启后 `/threshold` 确认仍在
- [ ] `/threshold clear` 清除阈值

Closes #252
Closes #266

🤖 Generated with [Claude Code](https://claude.com/claude-code)