### PR TITLE
chore(mcp): upgrade rmcp 0.16 → 1.2

### DIFF
--- a/crates/integrations/mcp/Cargo.toml
+++ b/crates/integrations/mcp/Cargo.toml
@@ -22,7 +22,7 @@ rara-kernel.workspace = true
 rara-keyring-store.workspace = true
 rara-paths.workspace = true
 reqwest.workspace = true
-rmcp = { version = "^0.16", default-features = false, features = [
+rmcp = { version = "^1.2", default-features = false, features = [
     "auth",
     "base64",
     "client",

--- a/crates/integrations/mcp/src/client.rs
+++ b/crates/integrations/mcp/src/client.rs
@@ -482,17 +482,13 @@ impl RmcpClient {
             None => None,
         };
 
-        let result = run_with_timeout(
-            service.call_tool(CallToolRequestParams {
-                meta: None,
-                name: name.into(),
-                arguments,
-                task: None,
-            }),
-            timeout,
-            "tools/call",
-        )
-        .await?;
+        let mut params = CallToolRequestParams::new(name);
+        if let Some(args) = arguments {
+            params = params.with_arguments(args);
+        }
+
+        let result =
+            run_with_timeout(service.call_tool(params), timeout, "tools/call").await?;
 
         self.persist_oauth_tokens().await;
         Ok(result)

--- a/crates/integrations/mcp/src/manager/managed_client.rs
+++ b/crates/integrations/mcp/src/manager/managed_client.rs
@@ -64,10 +64,7 @@ use futures::{
     future::{BoxFuture, Shared},
 };
 use rara_keyring_store::KeyringStoreRef;
-use rmcp::model::{
-    ClientCapabilities, ElicitationCapability, FormElicitationCapability, Implementation,
-    InitializeRequestParams, ProtocolVersion, Tool,
-};
+use rmcp::model::{ClientCapabilities, Implementation, InitializeRequestParams, ProtocolVersion, Tool};
 use tokio_util::sync::CancellationToken;
 use tracing::info;
 
@@ -446,33 +443,17 @@ impl ManagedClient {
     ) -> Result<Self, StartupOutcomeError> {
         // Declare our client capabilities per the MCP specification.
         // https://modelcontextprotocol.io/specification/2025-06-18/basic/lifecycle
-        let params = InitializeRequestParams {
-            meta:             None,
-            capabilities:     ClientCapabilities {
-                experimental: None,
-                extensions:   None,
-                roots:        None,
-                sampling:     None,
-                // Elicitation: server can ask the user for input via forms.
-                // https://modelcontextprotocol.io/specification/2025-06-18/client/elicitation
-                elicitation:  Some(ElicitationCapability {
-                    form: Some(FormElicitationCapability {
-                        schema_validation: None,
-                    }),
-                    url:  None,
-                }),
-                tasks:        None,
-            },
-            client_info:      Implementation {
-                name:        "rara-mcp-client".to_owned(),
-                version:     env!("CARGO_PKG_VERSION").to_owned(),
-                title:       Some("rara".into()),
-                description: None,
-                icons:       None,
-                website_url: None,
-            },
-            protocol_version: ProtocolVersion::LATEST,
-        };
+        // Elicitation: server can ask the user for input via forms.
+        // https://modelcontextprotocol.io/specification/2025-06-18/client/elicitation
+        let capabilities = ClientCapabilities::builder()
+            .enable_elicitation()
+            .build();
+
+        let client_info = Implementation::new("rara-mcp-client", env!("CARGO_PKG_VERSION"))
+            .with_title("rara");
+
+        let params = InitializeRequestParams::new(capabilities, client_info)
+            .with_protocol_version(ProtocolVersion::LATEST);
 
         // Build the elicitation callback that bridges server-initiated
         // elicitation requests back to the UI via ElicitationRequestManager.

--- a/crates/integrations/mcp/src/oauth.rs
+++ b/crates/integrations/mcp/src/oauth.rs
@@ -20,11 +20,9 @@ use std::{
 };
 
 use anyhow::{Context, Result};
-use oauth2::{
-    AccessToken, EmptyExtraTokenFields, RefreshToken, Scope, TokenResponse, basic::BasicTokenType,
-};
+use oauth2::{AccessToken, RefreshToken, Scope, TokenResponse, basic::BasicTokenType};
 use rara_keyring_store::{KeyringStore, KeyringStoreRef};
-use rmcp::transport::auth::{AuthorizationManager, OAuthTokenResponse};
+use rmcp::transport::auth::{AuthorizationManager, OAuthTokenResponse, VendorExtraTokenFields};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use tokio::sync::Mutex;
@@ -557,7 +555,7 @@ impl From<FileTokenEntry> for StoredOAuthTokens {
         let mut response = OAuthTokenResponse::new(
             AccessToken::new(entry.access_token),
             BasicTokenType::Bearer,
-            EmptyExtraTokenFields {},
+            VendorExtraTokenFields::default(),
         );
 
         if let Some(refresh) = entry.refresh_token {


### PR DESCRIPTION
## Summary
- Upgraded rmcp from 0.16 to 1.2 (major version bump)
- Adapted to new builder APIs: `CallToolRequestParams`, `ClientCapabilities`, `Implementation`, `InitializeRequestParams`
- Replaced `EmptyExtraTokenFields` with `VendorExtraTokenFields`

Closes #284