### PR TITLE
chore(rara-git): upgrade rand_core 0.6 → 0.10

### DIFF
--- a/crates/extensions/rara-git/Cargo.toml
+++ b/crates/extensions/rara-git/Cargo.toml
@@ -10,10 +10,11 @@ workspace = true
 
 [dependencies]
 git2 = { workspace = true }
-rand_core = { version = "0.6", features = ["getrandom"] }
+getrandom = { version = "0.4", features = ["sys_rng"] }
+rand_core = "0.10"
 rara-paths = { workspace = true }
 snafu.workspace = true
-ssh-key = { version = "0.6", features = ["ed25519", "rand_core"] }
+ssh-key = { version = "0.7.0-rc.9", features = ["ed25519", "rand_core"] }
 tokio = { workspace = true }
 tracing.workspace = true
 

--- a/crates/extensions/rara-git/src/ssh.rs
+++ b/crates/extensions/rara-git/src/ssh.rs
@@ -50,7 +50,7 @@ pub fn get_or_create_keypair(ssh_dir: &Path) -> Result<SshKeyPair, GitError> {
     })?;
 
     let private_key =
-        ssh_key::PrivateKey::random(&mut rand_core::OsRng, ssh_key::Algorithm::Ed25519).map_err(
+        ssh_key::PrivateKey::random(&mut rand_core::UnwrapErr(getrandom::SysRng), ssh_key::Algorithm::Ed25519).map_err(
             |e| GitError::SshKey {
                 message: format!("failed to generate key: {e}"),
             },


### PR DESCRIPTION
## Summary
- Upgraded rand_core from 0.6 to 0.10
- Upgraded ssh-key from 0.6 to 0.7.0-rc.9 for compatibility
- Added getrandom 0.4 with sys_rng feature
- Replaced removed `OsRng` with `UnwrapErr(getrandom::SysRng)`

Closes #287