### PR TITLE
chore(ci): disable crates.io publishing

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -39,7 +39,6 @@ jobs:
           command: release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
 
       - name: Get workspace version
         id: get-version

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ homepage = "https://github.com/rararulab/rara"
 readme = "README.md"
 keywords = ["rust", "agent", "proactive", "developer-tools", "ai"]
 categories = ["command-line-utilities"]
+publish = false
 
 [workspace.lints.rust]
 unsafe_code = "deny"


### PR DESCRIPTION
## Summary

- 去掉 `release-plz.yml` 中的 `CARGO_REGISTRY_TOKEN`，不再 publish 到 crates.io
- 在 `workspace.package` 中设置 `publish = false`，防止误发

rara 是二进制应用不是库，没必要发到 crates.io。

Closes #281

🤖 Generated with [Claude Code](https://claude.com/claude-code)