### PR TITLE
feat(ci): upload release artifacts to MinIO S3

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -163,9 +163,6 @@ jobs:
             ${{ env.BUILD_MANIFEST_NAME }}
       - name: Upload artifacts to MinIO
         shell: bash
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         run: |
           for f in ${{ steps.cargo-dist.outputs.paths }}; do
             aws s3 cp "$f" "s3://artifacts/releases/${{ needs.plan.outputs.tag }}/" \


### PR DESCRIPTION
## Summary

- 在 `release.yml` 的 `build-local-artifacts` job 末尾添加 MinIO upload step
- 使用 `aws s3 cp --endpoint-url` 上传 binary + checksum 到 `s3://artifacts/releases/{tag}/`
- 凭证通过 GitHub Secrets（`AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY`）注入

Closes #301