### PR TITLE
feat(ci): add Ollama integration test job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,10 @@ jobs:
     needs: changes
     if: ${{ needs.changes.outputs.code == 'true' || github.event_name == 'push' }}
     uses: ./.github/workflows/rust.yml
+    secrets:
+      OLLAMA_BASE_URL: ${{ secrets.OLLAMA_BASE_URL }}
+      OLLAMA_MODEL: ${{ secrets.OLLAMA_MODEL }}
+      OLLAMA_EMBEDDING_MODEL: ${{ secrets.OLLAMA_EMBEDDING_MODEL }}
 
   release-pr:
     name: Release PR

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -9,6 +9,10 @@ on:
         required: false
       OLLAMA_EMBEDDING_MODEL:
         required: false
+      OLLAMA_BASE_URL:
+        required: false
+      OLLAMA_MODEL:
+        required: false
 
 concurrency:
   group: rust-${{ github.event.pull_request.number || github.sha }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -2,6 +2,13 @@ name: Rust
 
 on:
   workflow_call:
+    secrets:
+      OLLAMA_BASE_URL:
+        required: false
+      OLLAMA_MODEL:
+        required: false
+      OLLAMA_EMBEDDING_MODEL:
+        required: false
 
 concurrency:
   group: rust-${{ github.event.pull_request.number || github.sha }}
@@ -80,6 +87,38 @@ jobs:
 
       - name: Run tests
         run: cargo nextest run --workspace
+
+  integration:
+    name: Integration (Ollama)
+    runs-on: arc-runner-set
+    if: github.ref == 'refs/heads/main'
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
+        with:
+          persist-credentials: false
+
+      - name: Start sccache
+        run: sccache --start-server || true
+
+      - name: Verify Ollama connectivity
+        run: curl -sf "${OLLAMA_BASE_URL}/api/tags" | head -c 200
+        env:
+          OLLAMA_BASE_URL: ${{ secrets.OLLAMA_BASE_URL }}
+
+      - name: Prepare CI config
+        run: envsubst < config.ci.yaml > config.yaml
+        env:
+          OLLAMA_BASE_URL: ${{ secrets.OLLAMA_BASE_URL }}
+          OLLAMA_MODEL: ${{ secrets.OLLAMA_MODEL }}
+          OLLAMA_EMBEDDING_MODEL: ${{ secrets.OLLAMA_EMBEDDING_MODEL }}
+
+      - name: Run integration tests
+        run: cargo nextest run --workspace --all-features --run-ignored ignored-only
+        env:
+          RARA_REAL_TAPE_SOAK_SECS: "120"
+          RARA_REAL_TAPE_TURN_TIMEOUT_SECS: "300"
+        timeout-minutes: 15
 
   rust-success:
     name: Rust Success

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -9,12 +9,6 @@ on:
         required: false
       OLLAMA_EMBEDDING_MODEL:
         required: false
-      OLLAMA_BASE_URL:
-        required: false
-      OLLAMA_MODEL:
-        required: false
-      OLLAMA_EMBEDDING_MODEL:
-        required: false
 
 concurrency:
   group: rust-${{ github.event.pull_request.number || github.sha }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -13,6 +13,8 @@ on:
         required: false
       OLLAMA_MODEL:
         required: false
+      OLLAMA_EMBEDDING_MODEL:
+        required: false
 
 concurrency:
   group: rust-${{ github.event.pull_request.number || github.sha }}

--- a/config.ci.yaml
+++ b/config.ci.yaml
@@ -21,6 +21,6 @@ llm:
       api_key: ollama
       default_model: ${OLLAMA_MODEL}
 users:
-- name: ryan
+- name: ci-bot
   role: root
   platforms: []

--- a/config.ci.yaml
+++ b/config.ci.yaml
@@ -17,9 +17,9 @@ llm:
   default_provider: ollama
   providers:
     ollama:
-      base_url: http://10.0.0.167:11434/v1
+      base_url: ${OLLAMA_BASE_URL}
       api_key: ollama
-      default_model: qwen2.5:32b
+      default_model: ${OLLAMA_MODEL}
 users:
 - name: ryan
   role: root

--- a/config.ci.yaml
+++ b/config.ci.yaml
@@ -17,10 +17,18 @@ llm:
   default_provider: ollama
   providers:
     ollama:
-      base_url: ${OLLAMA_BASE_URL}
+      base_url: ${OLLAMA_BASE_URL}/v1
       api_key: ollama
       default_model: ${OLLAMA_MODEL}
+knowledge:
+  embedding_model: ${OLLAMA_EMBEDDING_MODEL}
+  embedding_dimensions: 768
+  search_top_k: 10
+  similarity_threshold: 0.85
+  extractor_model: ${OLLAMA_MODEL}
+mita:
+  heartbeat_interval: "30m"
 users:
-- name: ci-bot
+- name: ryan
   role: root
   platforms: []

--- a/config.ci.yaml
+++ b/config.ci.yaml
@@ -1,0 +1,26 @@
+database:
+  max_connections: 5
+http:
+  bind_address: 127.0.0.1:0
+  max_body_size: 100MiB
+  enable_cors: false
+  request_timeout: 60
+grpc:
+  bind_address: 127.0.0.1:0
+  server_address: 127.0.0.1:0
+  max_recv_message_size: 512MiB
+  max_send_message_size: 512MiB
+telemetry:
+  otlp_endpoint: null
+  otlp_protocol: null
+llm:
+  default_provider: ollama
+  providers:
+    ollama:
+      base_url: http://10.0.0.167:11434/v1
+      api_key: ollama
+      default_model: qwen2.5:32b
+users:
+- name: ryan
+  role: root
+  platforms: []


### PR DESCRIPTION
## Summary
- 新增 `config.ci.yaml`，LLM 指向 self-hosted Ollama（`10.0.0.167:11434`，`qwen2.5:32b`）
- 在 `rust.yml` 新增 `integration` job，仅 main 分支触发，跑 `#[ignore]` 的集成测试
- Soak 120s / turn timeout 300s / job 限时 15min

## Test plan
- [ ] 合并后观察 main 分支 CI 中 `Integration (Ollama)` job 是否成功启动
- [ ] 确认 Ollama connectivity check 通过
- [ ] 确认 `real_model_soak_test_survives_long_tape_pressure` 在 CI 中通过

Closes #308