### PR TITLE
ci: fix paths-filter auth failure in Detect Changes job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
         with:
-          persist-credentials: false
+          fetch-depth: 0
 
       - name: Filter paths
         uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3


### PR DESCRIPTION
## Summary

- Remove `persist-credentials: false` from the `changes` (Detect Changes) checkout step
- Add `fetch-depth: 0` so the full history is available locally

## Root cause

`dorny/paths-filter` needs to compare against a base commit to produce the diff. With `fetch-depth: 1` (shallow) and `persist-credentials: false`, it tried to `git fetch` the missing base commit but had no credentials, resulting in:

```
fatal: could not read Username for 'https://github.com': No such device or address
```

## Fix

`fetch-depth: 0` (full clone) means paths-filter never needs to do an extra fetch. Removing `persist-credentials: false` also allows it to authenticate if it ever does. The `changes` job is read-only so keeping the default token is safe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)