### PR TITLE
fix(llm): add frequency_penalty to prevent repetition loops

### DIFF
--- a/crates/kernel/src/agent.rs
+++ b/crates/kernel/src/agent.rs
@@ -903,6 +903,11 @@ pub(crate) async fn run_agent_loop(
                 llm::ToolChoice::Auto
             },
             parallel_tool_calls: !tool_defs.is_empty() && capabilities.supports_parallel_tool_calls,
+            // Prevent LLM repetition loops — small models (e.g. step-3.5-flash) are
+            // especially prone to generating the same paragraph 3-4 times without
+            // a penalty. 0.3 is a conservative value that curbs repetition without
+            // degrading output quality. See #317.
+            frequency_penalty:   Some(0.3),
         };
 
         // Start streaming via LlmDriver

--- a/crates/kernel/src/llm/openai.rs
+++ b/crates/kernel/src/llm/openai.rs
@@ -548,6 +548,8 @@ struct ChatRequest<'a> {
     thinking:            Option<serde_json::Value>,
     #[serde(skip_serializing_if = "Option::is_none")]
     stream_options:      Option<WireStreamOptions>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    frequency_penalty:   Option<f32>,
 }
 
 #[derive(Serialize)]
@@ -685,6 +687,7 @@ impl<'a> ChatRequest<'a> {
             parallel_tool_calls,
             thinking,
             stream_options,
+            frequency_penalty: request.frequency_penalty,
         }
     }
 }

--- a/crates/kernel/src/llm/types.rs
+++ b/crates/kernel/src/llm/types.rs
@@ -261,6 +261,7 @@ pub struct CompletionRequest {
     pub thinking:            Option<ThinkingConfig>,
     pub tool_choice:         ToolChoice,
     pub parallel_tool_calls: bool,
+    pub frequency_penalty:   Option<f32>,
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/kernel/src/memory/knowledge/extractor.rs
+++ b/crates/kernel/src/memory/knowledge/extractor.rs
@@ -183,6 +183,7 @@ Output ONLY the JSON array, no markdown fences or explanation."#;
         thinking:            None,
         tool_choice:         ToolChoice::None,
         parallel_tool_calls: false,
+        frequency_penalty:   None,
     };
 
     let response = driver
@@ -254,6 +255,7 @@ async fn update_category_files(
             thinking:            None,
             tool_choice:         ToolChoice::None,
             parallel_tool_calls: false,
+            frequency_penalty:   None,
         };
 
         let response = driver

--- a/crates/kernel/src/plan.rs
+++ b/crates/kernel/src/plan.rs
@@ -491,6 +491,7 @@ async fn create_plan_via_llm(
         thinking: None,
         tool_choice: llm::ToolChoice::Required,
         parallel_tool_calls: false,
+        frequency_penalty: None,
     };
 
     info!(session_key = %session_key, "plan executor: calling LLM for plan creation");
@@ -618,6 +619,7 @@ async fn replan_via_llm(
         thinking: None,
         tool_choice: llm::ToolChoice::Required,
         parallel_tool_calls: false,
+        frequency_penalty: None,
     };
 
     info!(session_key = %session_key, "plan executor: calling LLM for replan");

--- a/crates/kernel/src/proactive.rs
+++ b/crates/kernel/src/proactive.rs
@@ -129,6 +129,7 @@ pub async fn should_reply(
         thinking:            None,
         tool_choice:         ToolChoice::None,
         parallel_tool_calls: false,
+        frequency_penalty:   None,
     };
 
     let response = match driver.complete(request).await {


### PR DESCRIPTION
## Summary
- `CompletionRequest` 和 `ChatRequest` 新增 `frequency_penalty` 字段
- Agent 循环中默认设置 `0.3` 防止 LLM 重复生成（小模型如 step-3.5-flash 尤其容易重复）
- 其他构造点（plan, proactive, extractor）设为 `None` 保持原有行为

Closes #317

## Test plan
- [x] `cargo check -p rara-kernel` 编译通过
- [ ] 用 step-3.5-flash 测试长回复是否还有重复
- [ ] 验证 deepseek/其他 OpenAI-compatible API 支持此参数

🤖 Generated with [Claude Code](https://claude.com/claude-code)