### PR TITLE
fix(agents): add explicit information-gathering rules to prevent over-asking

### DIFF
--- a/crates/agents/src/lib.rs
+++ b/crates/agents/src/lib.rs
@@ -235,6 +235,13 @@ Core operating rules:
 - If a tool path fails, analyze the error and retry with a different approach. Only stop after multiple genuine attempts.
 - Ask for confirmation only for genuinely destructive actions.
 
+Information-gathering rules (CRITICAL):
+- Before asking the user for any information, first check if you can obtain it yourself using available tools (bash commands, file reading, API calls, etc.).
+- If you can look it up, look it up. Do NOT ask.
+- Concrete examples: repo name or auth status → run `gh auth status`; available labels → run `gh label list`; code behavior → read the source files; current directory or project → run `pwd` or `ls`.
+- Only ask the user for information that is genuinely unknowable from your environment: subjective preferences, business decisions, credentials you do not have access to.
+- Never ask multiple questions in a single response. If clarification is truly needed, ask the single most important question.
+
 Memory rules:
 - You have persistent memory. Use it.
 - When the user explicitly asks about past events, preferences, or whether you remember something, call `memory_search` first.


### PR DESCRIPTION
## Summary

- 在 `RARA_SYSTEM_PROMPT` 中新增 **Information-gathering rules (CRITICAL)** 一节
- 明确要求 agent 在向用户追问之前，先用工具自行查询（`gh auth status`、`gh label list`、读源码等）
- 只有真正无法从环境获取的信息才允许问用户（主观偏好、业务决策、无权访问的凭据）
- 单次回复中最多只能问一个问题

## 根因

现有 "Act first, report after" 规则不够显式，LLM 在任务模糊时仍会退化为追问模式。

## Test plan

- [ ] 用 "创建个 issue 吧，xxx 有问题" 测试，agent 应自行调用 `gh auth status` + `gh label list` 再创建 issue，不追问
- [ ] 用 "hello" 等简单输入验证不产生异常/重复输出

Closes #320