### PR TITLE
fix(kernel): agent loop 达到 max_iterations 时正确标记失败并生成兜底文本

### DIFF
--- a/crates/kernel/src/agent.rs
+++ b/crates/kernel/src/agent.rs
@@ -1632,11 +1632,29 @@ pub(crate) async fn run_agent_loop(
         }
     }
 
-    // Max iterations exhausted — return partial results
+    // Max iterations exhausted — return partial results with failure markers
     warn!(
         max_iterations,
         tool_calls_made, "inline agent loop hit max iterations limit, returning partial results"
     );
+    let exhaustion_error = format!(
+        "max iterations exhausted ({max_iterations} iterations, {tool_calls_made} tool calls)"
+    );
+    // Emit a stream warning so adapters (Telegram, SSE) can surface it to the
+    // user immediately.
+    stream_handle.emit(StreamEvent::Progress {
+        stage: format!(
+            "[警告] 已达到最大迭代次数（{max_iterations}），任务可能未完成。"
+        ),
+    });
+    // If the agent spent the entire turn doing tool calls and produced no
+    // visible text, synthesise a fallback message so the user is not left with
+    // a blank response.
+    if last_accumulated_text.is_empty() {
+        last_accumulated_text = format!(
+            "[已达到最大迭代次数，任务未完成。已执行 {tool_calls_made} 次工具调用。]"
+        );
+    }
     let trace = TurnTrace {
         duration_ms:      turn_start.elapsed().as_millis() as u64,
         model:            model.clone(),
@@ -1644,8 +1662,8 @@ pub(crate) async fn run_agent_loop(
         iterations:       iteration_traces,
         final_text_len:   last_accumulated_text.len(),
         total_tool_calls: tool_calls_made,
-        success:          true,
-        error:            None,
+        success:          false,
+        error:            Some(exhaustion_error),
     };
     // Best-effort mood update — failure is silently logged, never blocks the
     // response.


### PR DESCRIPTION
## Summary

修复 `run_agent_loop` 在 `max_iterations` 耗尽时的错误行为：

- **`success: false`** — 迭代耗尽标记为失败，而非误报成功
- **`error` 填充** — `TurnTrace.error` 填入 `"max iterations exhausted (N iterations, M tool calls)"`，调用者可区分正常完成与迭代截断
- **兜底文本** — `last_accumulated_text` 为空时（agent 全程做 tool calls）生成兜底消息，避免用户看到空响应
- **StreamEvent 通知** — 通过 `stream_handle.emit(StreamEvent::Progress { ... })` 告知用户迭代耗尽

## Affected Files

- `crates/kernel/src/agent.rs` — `run_agent_loop` max_iterations 退出分支

Closes #319