### PR TITLE
feat(telegram): register McpCommandHandler and call set_my_commands

### DIFF
--- a/crates/app/src/lib.rs
+++ b/crates/app/src/lib.rs
@@ -453,7 +453,7 @@ pub async fn start_with_options(
     // Build command handlers shared across all channels.
     let command_handlers: Vec<std::sync::Arc<dyn rara_kernel::channel::command::CommandHandler>> = {
         use rara_channels::telegram::commands::{
-            KernelBotServiceClient, SessionCommandHandler, StopCommandHandler,
+            KernelBotServiceClient, McpCommandHandler, SessionCommandHandler, StopCommandHandler,
         };
         let bot_client: std::sync::Arc<dyn rara_channels::telegram::commands::BotServiceClient> =
             std::sync::Arc::new(KernelBotServiceClient::new(
@@ -462,7 +462,8 @@ pub async fn start_with_options(
             ));
         vec![
             std::sync::Arc::new(SessionCommandHandler::new(bot_client.clone())),
-            std::sync::Arc::new(StopCommandHandler::new(bot_client, kernel_handle.clone())),
+            std::sync::Arc::new(StopCommandHandler::new(bot_client.clone(), kernel_handle.clone())),
+            std::sync::Arc::new(McpCommandHandler::new(bot_client)),
         ]
     };
 

--- a/crates/channels/src/telegram/adapter.rs
+++ b/crates/channels/src/telegram/adapter.rs
@@ -1119,6 +1119,25 @@ impl ChannelAdapter for TelegramAdapter {
             .clone()
             .into();
 
+        // Register slash-menu with Telegram so '/' shows available commands.
+        {
+            let all_cmds: Vec<teloxide::types::BotCommand> = command_handlers
+                .iter()
+                .flat_map(|h| h.commands())
+                .map(|def| teloxide::types::BotCommand::new(&def.name, &def.description))
+                .collect();
+            if !all_cmds.is_empty() {
+                if let Err(e) = bot.set_my_commands(all_cmds).await {
+                    warn!(error = %e, "telegram: failed to register bot commands");
+                } else {
+                    info!(
+                        "telegram: registered {} bot command(s)",
+                        command_handlers.iter().flat_map(|h| h.commands()).count()
+                    );
+                }
+            }
+        }
+
         // Spawn approval request listener — sends inline keyboard to primary chat.
         {
             let approval_rx = handle.security().approval().subscribe_requests();


### PR DESCRIPTION
## Summary

- 在 `crates/app/src/lib.rs` 注册 `McpCommandHandler`（`/mcp`）
- 在 `TelegramAdapter::start()` 中调用 `bot.set_my_commands()`，将所有注册的命令同步到 Telegram，用户输入 `/` 时即弹出命令菜单

## 完整命令菜单（合并 PR #324 后）

| 命令 | 说明 |
|------|------|
| `/start` | 启动机器人 |
| `/help` | 显示可用命令 |
| `/new` | 创建新会话 |
| `/clear` | 清除当前会话历史 |
| `/sessions` | 列出并切换会话 |
| `/usage` | 显示当前会话信息 |
| `/model` | 显示或切换 AI 模型 |
| `/stop` | 中断当前操作 |
| `/anchors` | 显示锚点树 |
| `/checkout` | 从锚点 fork 会话 |
| `/mcp` | 管理 MCP 服务器 |

Closes #327