### PR TITLE
feat(telegram): register all command handlers and add slash menu

### DIFF
--- a/crates/app/src/lib.rs
+++ b/crates/app/src/lib.rs
@@ -453,16 +453,38 @@ pub async fn start_with_options(
     // Build command handlers shared across all channels.
     let command_handlers: Vec<std::sync::Arc<dyn rara_kernel::channel::command::CommandHandler>> = {
         use rara_channels::telegram::commands::{
-            KernelBotServiceClient, SessionCommandHandler, StopCommandHandler,
+            BasicCommandHandler, KernelBotServiceClient, McpCommandHandler, SessionCommandHandler,
+            StopCommandHandler, TapeCommandHandler,
         };
         let bot_client: std::sync::Arc<dyn rara_channels::telegram::commands::BotServiceClient> =
             std::sync::Arc::new(KernelBotServiceClient::new(
                 rara.session_index.clone(),
                 rara.tape_service.clone(),
             ));
+        let session_handler =
+            std::sync::Arc::new(SessionCommandHandler::new(bot_client.clone()));
+        let stop_handler =
+            std::sync::Arc::new(StopCommandHandler::new(bot_client.clone(), kernel_handle.clone()));
+        let tape_handler =
+            std::sync::Arc::new(TapeCommandHandler::new(bot_client));
+        // Collect all command definitions so /help can list them.
+        use rara_kernel::channel::command::CommandHandler as _;
+        let all_commands: Vec<rara_kernel::channel::command::CommandDefinition> = [
+            session_handler.commands(),
+            stop_handler.commands(),
+            tape_handler.commands(),
+        ]
+        .into_iter()
+        .flatten()
+        .collect();
+        let basic_handler = std::sync::Arc::new(BasicCommandHandler::new(all_commands));
+        let mcp_handler = std::sync::Arc::new(McpCommandHandler::new(bot_client));
         vec![
-            std::sync::Arc::new(SessionCommandHandler::new(bot_client.clone())),
-            std::sync::Arc::new(StopCommandHandler::new(bot_client, kernel_handle.clone())),
+            basic_handler,
+            session_handler,
+            stop_handler,
+            tape_handler,
+            mcp_handler,
         ]
     };
 

--- a/crates/channels/src/telegram/adapter.rs
+++ b/crates/channels/src/telegram/adapter.rs
@@ -1119,6 +1119,25 @@ impl ChannelAdapter for TelegramAdapter {
             .clone()
             .into();
 
+        // Register slash-menu with Telegram so '/' shows available commands.
+        {
+            let all_cmds: Vec<teloxide::types::BotCommand> = command_handlers
+                .iter()
+                .flat_map(|h| h.commands())
+                .map(|def| teloxide::types::BotCommand::new(&def.name, &def.description))
+                .collect();
+            if !all_cmds.is_empty() {
+                if let Err(e) = bot.set_my_commands(all_cmds).await {
+                    warn!(error = %e, "telegram: failed to register bot commands");
+                } else {
+                    info!(
+                        "telegram: registered {} bot command(s)",
+                        command_handlers.iter().flat_map(|h| h.commands()).count()
+                    );
+                }
+            }
+        }
+
         // Spawn approval request listener — sends inline keyboard to primary chat.
         {
             let approval_rx = handle.security().approval().subscribe_requests();


### PR DESCRIPTION
合并 #322 和 #327 的修复，统一处理。

## Summary

- 注册 `BasicCommandHandler`（/start, /help）、`TapeCommandHandler`（/anchors, /checkout）、`McpCommandHandler`（/mcp）
- 在 `TelegramAdapter::start()` 中调用 `bot.set_my_commands()`，用户输入 `/` 时弹出完整命令菜单

## 完整命令菜单

| 命令 | 说明 |
|------|------|
| `/start` | 启动机器人 |
| `/help` | 显示可用命令 |
| `/new` | 创建新会话 |
| `/clear` | 清除当前会话历史 |
| `/sessions` | 列出并切换会话 |
| `/usage` | 显示当前会话信息 |
| `/model` | 显示或切换 AI 模型 |
| `/stop` | 中断当前操作 |
| `/anchors` | 显示锚点树 |
| `/checkout` | 从锚点 fork 会话 |
| `/mcp` | 管理 MCP 服务器 |

Closes #322
Closes #327