### PR TITLE
fix(keyring-store): fix build failure caused by secret-service missing runtime feature

### DIFF
--- a/crates/app/src/lib.rs
+++ b/crates/app/src/lib.rs
@@ -466,7 +466,7 @@ pub async fn start_with_options(
         let stop_handler =
             std::sync::Arc::new(StopCommandHandler::new(bot_client.clone(), kernel_handle.clone()));
         let tape_handler =
-            std::sync::Arc::new(TapeCommandHandler::new(bot_client));
+            std::sync::Arc::new(TapeCommandHandler::new(bot_client.clone()));
         // Collect all command definitions so /help can list them.
         use rara_kernel::channel::command::CommandHandler as _;
         let all_commands: Vec<rara_kernel::channel::command::CommandDefinition> = [

--- a/crates/integrations/keyring-store/Cargo.toml
+++ b/crates/integrations/keyring-store/Cargo.toml
@@ -21,8 +21,7 @@ sqlx.workspace = true
 tracing.workspace = true
 
 [target.'cfg(target_os = "linux")'.dependencies]
-keyring = { version = "^3.6", default-features = false, features = ["linux-native-async-persistent"] }
-secret-service = { version = "5", default-features = false, features = ["rt-tokio-crypto-rust"] }
+keyring = { version = "^3.6", default-features = false, features = ["linux-native-async-persistent", "tokio", "crypto-rust"] }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 keyring = { version = "^3.6", default-features = false, features = ["apple-native"] }


### PR DESCRIPTION
## 问题

合并 #331 后 `cargo check` 报错：

```
error: Please enable a feature to pick a runtime (such as rt-async-io-crypto-rust or rt-tokio-crypto-rust) for the secret-service crate
```

以及：

```
error[E0382]: use of moved value: `bot_client`
```

## 修复

**`crates/integrations/keyring-store/Cargo.toml`**

- Linux target 的 `keyring` dependency 新增 `"tokio"` 和 `"crypto-rust"` features，让 keyring 正确向 `secret-service v4` 转发运行时配置
- 删除多余的独立 `secret-service = "5"` 声明

**`crates/app/src/lib.rs`**

- `TapeCommandHandler::new(bot_client)` → `TapeCommandHandler::new(bot_client.clone())`，修复 `bot_client` 被 move 后 `McpCommandHandler` 无法使用的问题

Closes #332