### PR TITLE
fix(kernel): skip empty notifications instead of sending placeholder

### DIFF
--- a/crates/kernel/src/syscall.rs
+++ b/crates/kernel/src/syscall.rs
@@ -301,14 +301,32 @@ impl SyscallDispatcher {
                 event_type: _,
                 payload,
             } => {
-                let message = payload
-                    .get("message")
-                    .and_then(|v| v.as_str())
-                    .unwrap_or("(empty notification)")
-                    .to_string();
-                let _ = kernel_handle.event_queue().try_push(
-                    crate::event::KernelEventEnvelope::send_notification(message),
-                );
+                // Try common field names in priority order.
+                let message = ["message", "text", "content", "body"]
+                    .iter()
+                    .find_map(|&field| {
+                        payload
+                            .get(field)
+                            .and_then(|v| v.as_str())
+                            .filter(|s| !s.trim().is_empty())
+                    });
+
+                match message {
+                    Some(msg) => {
+                        let _ = kernel_handle.event_queue().try_push(
+                            crate::event::KernelEventEnvelope::send_notification(
+                                msg.to_string(),
+                            ),
+                        );
+                    }
+                    None => {
+                        warn!(
+                            payload = ?payload,
+                            "PublishEvent: no usable message field found in payload, \
+                             dropping notification"
+                        );
+                    }
+                }
             }
             Syscall::RegisterJob {
                 trigger,
@@ -978,7 +996,7 @@ impl crate::tool::AgentTool for SyscallTool {
                     "description": "Event type string for publish"
                 },
                 "payload": {
-                    "description": "Event payload (any JSON) for publish"
+                    "description": "Event payload for publish. For user-visible notifications, include a non-empty 'message' field (e.g. {\"message\": \"Task completed\"})."
                 }
             }
         })


### PR DESCRIPTION
## Summary

- `PublishEvent` syscall now tries field names `message`, `text`, `content`, `body` in order instead of always falling back to a hardcoded `"(empty notification)"` string
- When no usable message field is found (or the value is blank), the notification is silently dropped and a `tracing::warn!` with the full payload is emitted for debugging
- Tool schema description for `payload` updated to explicitly tell agents to include a `message` field for user-visible notifications

## Test plan

- [ ] Run `cargo check -p rara-kernel` — passes cleanly
- [ ] Trigger a scheduled task that calls `kernel.publish` without a `message` field and confirm no notification is delivered to Telegram
- [ ] Trigger a scheduled task with `payload: { "message": "done" }` and confirm the notification arrives correctly

Closes #334