### PR TITLE
chore: remove unused llmfit-core dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -170,7 +170,6 @@ lettre = { version = "0.11", default-features = false, features = [
     "hostname",
 ] }
 lineark-sdk = "1.1"
-llmfit-core = { git = "https://github.com/AlexsJones/llmfit" }
 md5 = "0.7"
 moka = { version = "0.12", features = ["future"] }
 notify = "7"

--- a/crates/extensions/backend-admin/Cargo.toml
+++ b/crates/extensions/backend-admin/Cargo.toml
@@ -19,7 +19,6 @@ futures = { workspace = true }
 git2 = { workspace = true }
 jiff = { workspace = true }
 
-llmfit-core = { workspace = true }
 opentelemetry = { version = "0.31.0", default-features = false, features = ["trace"] }
 rara-channels = { workspace = true }
 rara-codex-oauth = { workspace = true }

--- a/deny.toml
+++ b/deny.toml
@@ -91,6 +91,4 @@ unknown-registry = "deny"
 unknown-git = "deny"
 allow-registry = ["https://github.com/rust-lang/crates.io-index"]
 allow-git = [
-    "https://github.com/AlexsJones/llmfit",
-
 ]


### PR DESCRIPTION
## Summary
- Remove `llmfit-core` from workspace `Cargo.toml`, `backend-admin/Cargo.toml`, and `deny.toml`
- Dependency was declared but never used in any source code

Closes #345

🤖 Generated with [Claude Code](https://claude.com/claude-code)