### PR TITLE
fix(kernel): drop PublishEvent with missing/blank payload.message

### DIFF
--- a/crates/kernel/src/syscall.rs
+++ b/crates/kernel/src/syscall.rs
@@ -310,8 +310,8 @@ impl SyscallDispatcher {
                 if message.is_empty() {
                     tracing::warn!(
                         event_type = %event_type,
-                        ?payload,
                         sender = %syscall_sender,
+                        payload_keys = ?payload.as_object().map(|o| o.keys().collect::<Vec<_>>()),
                         "PublishEvent dropped: payload.message is missing or blank"
                     );
                 } else {


### PR DESCRIPTION
## Summary

- `Syscall::PublishEvent` 在 `payload.message` 缺失/空白/非 string 时，不再发送 `(empty notification)` 到 Telegram，改为 `tracing::warn!` 记录并丢弃事件

## Root Cause

`syscall.rs` 中 `unwrap_or("(empty notification)")` 将异常 payload 静默转为用户可见通知。当 scheduled job agent 未正确生成 `payload.message` 时，用户在 Telegram 收到无意义的 `(empty notification)` 消息。

## Changes

- `crates/kernel/src/syscall.rs`: PublishEvent handler 增加 message 校验，空白时 warn + drop

Closes #349

🤖 Generated with [Claude Code](https://claude.com/claude-code)