### PR TITLE
ci: remove redundant protoc installation from rust.yml

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -42,9 +42,6 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Install protoc
-        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
-
       - name: Start sccache
         run: sccache --start-server || true
 
@@ -64,9 +61,6 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Install protoc
-        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
-
       - name: Start sccache
         run: sccache --start-server || true
 
@@ -84,9 +78,6 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Install protoc
-        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
-
       - name: Start sccache
         run: sccache --start-server || true
 
@@ -102,9 +93,6 @@ jobs:
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
         with:
           persist-credentials: false
-
-      - name: Install protoc
-        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
 
       - name: Start sccache
         run: sccache --start-server || true


### PR DESCRIPTION
## Summary
- CI runner 镜像已预装 protoc（`/usr/local/bin/protoc`），但 `rust.yml` 的 4 个 job（clippy, docs, test, coverage）都在跑 `apt-get update && apt-get install -y protobuf-compiler`
- 删除这 4 个冗余步骤，每个 job 省掉一次 apt-get update + install

Closes #367