### PR TITLE
fix(ci): remove package-lock.json from .gitignore to unblock release-plz

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,7 +63,6 @@ public/
 
 # Node (Playwright screenshot script)
 node_modules/
-package-lock.json
 desktop/build/
 desktop/artifacts/
 desktop/.electrobun/


### PR DESCRIPTION
## Summary
- `web/package-lock.json` is tracked by git but also listed in `.gitignore`, causing release-plz to detect a dirty working directory and fail with "uncommitted changes"
- Remove `package-lock.json` from `.gitignore` — it should be committed anyway (Node.js best practice for reproducible builds)

Closes #373

## Test plan
- [ ] Verify release-plz PR workflow succeeds after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)