### PR TITLE
feat(kernel): agent loop auto-fold with hierarchical summarization

### DIFF
--- a/crates/kernel/src/agent/fold.rs
+++ b/crates/kernel/src/agent/fold.rs
@@ -1,0 +1,188 @@
+// Copyright 2025 Rararulab
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Context folding — automatic hierarchical summarization of agent context.
+//!
+//! When context pressure exceeds a configurable threshold, the
+//! [`ContextFolder`] uses an independent LLM call to produce a compact
+//! [`FoldSummary`] that replaces the accumulated messages via a tape
+//! handoff anchor.
+
+use crate::{
+    llm::{self, LlmDriverRef},
+    memory::HandoffState,
+};
+
+/// Result of a context fold operation.
+pub struct FoldSummary {
+    /// Condensed summary of folded messages.
+    pub summary:    String,
+    /// Actionable next steps extracted from the folded context.
+    pub next_steps: String,
+}
+
+/// Performs context folding via an independent LLM summarization call.
+pub struct ContextFolder {
+    driver: LlmDriverRef,
+    model:  String,
+}
+
+impl ContextFolder {
+    /// Create a new folder using the given LLM driver and model.
+    pub fn new(driver: LlmDriverRef, model: String) -> Self { Self { driver, model } }
+
+    /// Summarize messages into a compact fold summary.
+    ///
+    /// If `prior_summary` is provided, it is included as additional context
+    /// so the fold can build on previous summarization layers
+    /// (hierarchical folding).
+    ///
+    /// `source_token_estimate` is the approximate token count of the source
+    /// messages, used to size the summarization output dynamically:
+    /// `max_tokens = (source_token_estimate / 10).clamp(256, 2048)`.
+    pub async fn fold_with_prior(
+        &self,
+        prior_summary: Option<&str>,
+        messages: &[llm::Message],
+        source_token_estimate: usize,
+    ) -> anyhow::Result<FoldSummary> {
+        let max_tokens = (source_token_estimate / 10).clamp(256, 2048) as u32;
+
+        // Build the summarization prompt.
+        let mut system_parts = vec![
+            "You are a context summarizer. Produce a concise summary of the conversation and a \
+             bullet list of next steps. Output EXACTLY two sections:\n\n## Summary\n<summary \
+             text>\n\n## Next Steps\n<bullet list>"
+                .to_owned(),
+        ];
+        if let Some(prior) = prior_summary {
+            system_parts.push(format!(
+                "\n\nPrior context summary (build upon this):\n{prior}"
+            ));
+        }
+        let system_prompt = system_parts.join("");
+
+        // Collect the conversation content into a single user message.
+        let conversation_text: String = messages
+            .iter()
+            .map(|m| {
+                let role_label = match m.role {
+                    llm::Role::System => "system",
+                    llm::Role::User => "user",
+                    llm::Role::Assistant => "assistant",
+                    llm::Role::Tool => "tool",
+                };
+                format!("[{}] {}", role_label, m.content.as_text())
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        let request = llm::CompletionRequest {
+            model:               self.model.clone(),
+            messages:            vec![
+                llm::Message::system(system_prompt),
+                llm::Message::user(format!(
+                    "Summarize the following conversation:\n\n{conversation_text}"
+                )),
+            ],
+            tools:               vec![],
+            temperature:         Some(0.0),
+            max_tokens:          Some(max_tokens),
+            thinking:            None,
+            tool_choice:         llm::ToolChoice::None,
+            parallel_tool_calls: false,
+            frequency_penalty:   None,
+        };
+
+        let response = self
+            .driver
+            .complete(request)
+            .await
+            .map_err(|e| anyhow::anyhow!("fold LLM call failed: {e}"))?;
+
+        let text = response
+            .content
+            .ok_or_else(|| anyhow::anyhow!("fold LLM returned empty content"))?;
+
+        // Parse the two sections from the response.
+        let (summary, next_steps) = parse_fold_response(&text);
+
+        Ok(FoldSummary {
+            summary,
+            next_steps,
+        })
+    }
+
+    /// Convert a [`FoldSummary`] into a [`HandoffState`] suitable for tape
+    /// anchoring, with `phase` set to `"auto-fold"`.
+    pub fn to_handoff_state(summary: &FoldSummary, _pressure: f64) -> HandoffState {
+        HandoffState {
+            phase:      Some("auto-fold".to_owned()),
+            summary:    Some(summary.summary.clone()),
+            next_steps: Some(summary.next_steps.clone()),
+            source_ids: vec![],
+            owner:      Some("system".to_owned()),
+            extra:      None,
+        }
+    }
+}
+
+/// Parse the LLM fold response into (summary, next_steps).
+///
+/// Expects `## Summary` and `## Next Steps` headers. Falls back to
+/// splitting on the first blank-line boundary if headers are absent.
+fn parse_fold_response(text: &str) -> (String, String) {
+    // Try header-based split first.
+    if let Some(summary_start) = text.find("## Summary") {
+        let after_summary = &text[summary_start + "## Summary".len()..];
+        let summary_end = after_summary
+            .find("## Next Steps")
+            .unwrap_or(after_summary.len());
+        let summary = after_summary[..summary_end].trim().to_owned();
+
+        let next_steps = if let Some(ns_start) = after_summary.find("## Next Steps") {
+            after_summary[ns_start + "## Next Steps".len()..]
+                .trim()
+                .to_owned()
+        } else {
+            String::new()
+        };
+
+        return (summary, next_steps);
+    }
+
+    // Fallback: entire text as summary.
+    (text.trim().to_owned(), String::new())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_fold_response_with_headers() {
+        let text = "## Summary\nDid A and B.\n\n## Next Steps\n- Do C\n- Do D";
+        let (summary, next_steps) = parse_fold_response(text);
+        assert_eq!(summary, "Did A and B.");
+        assert_eq!(next_steps, "- Do C\n- Do D");
+    }
+
+    #[test]
+    fn parse_fold_response_fallback() {
+        let text = "Just a plain summary without headers.";
+        let (summary, next_steps) = parse_fold_response(text);
+        assert_eq!(summary, "Just a plain summary without headers.");
+        assert!(next_steps.is_empty());
+    }
+}

--- a/crates/kernel/src/agent/mod.rs
+++ b/crates/kernel/src/agent/mod.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+pub mod fold;
+
 use std::{
     collections::HashMap,
     path::{Path, PathBuf},
@@ -820,6 +822,19 @@ pub(crate) async fn run_agent_loop(
     let mut consecutive_silent_iters: usize = 0;
     let mut needs_anchor_reminder = false;
     let mut context_pressure_warning: Option<String> = None;
+    // Auto-fold: track last fold anchor for cooldown calculation.
+    let mut last_fold_entry_id: Option<u64> = None;
+    let context_folder = if handle.config().context_folding.enabled {
+        let fold_model = handle
+            .config()
+            .context_folding
+            .fold_model
+            .clone()
+            .unwrap_or_else(|| model.clone());
+        Some(fold::ContextFolder::new(driver.clone(), fold_model))
+    } else {
+        None
+    };
     let mut llm_error_recovery_message: Option<String> = None;
     // ── Token & thinking metrics for UsageUpdate (#303) ──────────────
     // These are *cumulative* across all iterations within the turn.
@@ -1648,6 +1663,106 @@ pub(crate) async fn run_agent_loop(
                 },
                 tool_calls: tool_call_traces,
             });
+        }
+
+        // ── Auto-fold: hierarchical summarization ─────────────────────
+        // When context pressure exceeds the fold threshold and enough
+        // entries have accumulated, perform an automatic fold via an
+        // independent LLM summarization call. On failure we simply log
+        // and fall through to the existing 0.70/0.85 pressure warnings.
+        if let Some(ref folder) = context_folder {
+            if let Ok(tape_info) = tape.info(tape_name).await {
+                let pressure = tape_info.estimated_context_tokens as f64
+                    / capabilities.context_window_tokens as f64;
+                let fold_cfg = &handle.config().context_folding;
+
+                if pressure > fold_cfg.fold_threshold {
+                    let entries_since_fold = match last_fold_entry_id {
+                        Some(_) => tape_info.entries_since_last_anchor,
+                        None => tape_info.entries,
+                    };
+
+                    if entries_since_fold >= fold_cfg.min_entries_between_folds {
+                        info!(
+                            pressure = format!("{:.2}", pressure),
+                            entries_since_fold,
+                            "auto-fold: context pressure exceeded threshold, folding"
+                        );
+
+                        // Retrieve prior anchor summary for hierarchical folding.
+                        let prior_summary = match tape.anchors(tape_name, 1).await {
+                            Ok(anchors) => anchors.into_iter().next().and_then(|a| {
+                                serde_json::from_value::<crate::memory::HandoffState>(a.state)
+                                    .ok()
+                                    .and_then(|hs| hs.summary)
+                            }),
+                            Err(_) => None,
+                        };
+
+                        // Build messages for the fold input.
+                        let fold_messages = tape
+                            .rebuild_messages_for_llm(tape_name, user_id, &effective_prompt)
+                            .await;
+
+                        match fold_messages {
+                            Ok(msgs) => {
+                                let timeout =
+                                    std::time::Duration::from_secs(fold_cfg.branch_timeout_secs);
+                                let fold_result = tokio::time::timeout(
+                                    timeout,
+                                    folder.fold_with_prior(
+                                        prior_summary.as_deref(),
+                                        &msgs,
+                                        tape_info.estimated_context_tokens as usize,
+                                    ),
+                                )
+                                .await;
+
+                                match fold_result {
+                                    Ok(Ok(fold_summary)) => {
+                                        let handoff_state = fold::ContextFolder::to_handoff_state(
+                                            &fold_summary,
+                                            pressure,
+                                        );
+                                        match tape
+                                            .handoff(tape_name, "auto-fold", handoff_state)
+                                            .await
+                                        {
+                                            Ok(entries) => {
+                                                let anchor_id =
+                                                    entries.last().map(|e| e.id).unwrap_or(0);
+                                                last_fold_entry_id = Some(anchor_id);
+                                                info!(anchor_id, "auto-fold: tape handoff created");
+                                            }
+                                            Err(e) => {
+                                                warn!(
+                                                    error = %e,
+                                                    "auto-fold: tape handoff failed, skipping"
+                                                );
+                                            }
+                                        }
+                                    }
+                                    Ok(Err(e)) => {
+                                        warn!(
+                                            error = %e,
+                                            "auto-fold: summarization failed, skipping"
+                                        );
+                                    }
+                                    Err(_) => {
+                                        warn!("auto-fold: summarization timed out, skipping");
+                                    }
+                                }
+                            }
+                            Err(e) => {
+                                warn!(
+                                    error = %e,
+                                    "auto-fold: failed to rebuild messages for fold, skipping"
+                                );
+                            }
+                        }
+                    }
+                }
+            }
         }
 
         // ── Runtime context guard ──────────────────────────────────────

--- a/crates/kernel/src/kernel.rs
+++ b/crates/kernel/src/kernel.rs
@@ -104,6 +104,28 @@ pub struct KernelConfig {
     // Event queue configuration. Controls whether the kernel uses a single
     // global queue (`num_shards = 0`) or sharded parallel processing.
     pub event_queue:             ShardedEventQueueConfig,
+    /// Context folding (auto-summarization) configuration.
+    pub context_folding:         ContextFoldingConfig,
+}
+
+/// Configuration for automatic context folding (hierarchical summarization).
+#[derive(Debug, Clone, smart_default::SmartDefault)]
+pub struct ContextFoldingConfig {
+    /// Whether auto-fold is enabled.
+    #[default = true]
+    pub enabled:                   bool,
+    /// Context pressure fraction at which auto-fold triggers.
+    #[default = 0.60]
+    pub fold_threshold:            f64,
+    /// Minimum tape entries since last fold before another fold is allowed.
+    #[default = 15]
+    pub min_entries_between_folds: usize,
+    /// Override model for fold summarization calls. If `None`, the agent's
+    /// own model is used.
+    pub fold_model:                Option<String>,
+    /// Timeout in seconds for the fold LLM call.
+    #[default = 120]
+    pub branch_timeout_secs:       u64,
 }
 
 /// Shared reference to a


### PR DESCRIPTION
## Summary

- Add `ContextFolder` struct in `agent/fold.rs` that performs hierarchical context summarization via independent LLM calls, with dynamic `max_tokens` sizing and prior-summary chaining
- Add `ContextFoldingConfig` to `KernelConfig` with configurable threshold (0.60), cooldown (15 entries), optional fold model override, and timeout (120s)
- Integrate auto-fold check in `run_agent_loop` before the existing 0.70/0.85 context pressure warnings — fold failures are fault-tolerant (log + skip)
- Convert `agent.rs` → `agent/mod.rs` + `agent/fold.rs` module structure

## Test plan

- [ ] Verify `cargo check -p rara-kernel` passes
- [ ] Verify `cargo clippy` passes with no warnings
- [ ] Verify `cargo +nightly fmt --check` passes
- [ ] Unit tests for `parse_fold_response` in `fold.rs` pass
- [ ] Manual: confirm agent loop still works normally with `context_folding.enabled = false`
- [ ] Manual: confirm auto-fold triggers when context pressure > 0.60 with sufficient entries

Closes #372

🤖 Generated with [Claude Code](https://claude.com/claude-code)