### PR TITLE
fix(deps): upgrade testcontainers-modules to 0.15

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -226,7 +226,7 @@ validator = "^0.20"
 git2 = "0.20"
 tempfile = "3"
 testcontainers = "0.27"
-testcontainers-modules = { version = "0.14", features = ["postgres", "k3s"] }
+testcontainers-modules = { version = "0.15", features = ["postgres", "k3s"] }
 
 # Internal workspace crates (use =version to keep in sync with workspace version)
 base = { path = "crates/common/base" }

--- a/crates/integrations/keyring-store/src/lib.rs
+++ b/crates/integrations/keyring-store/src/lib.rs
@@ -30,7 +30,7 @@ pub enum Error {
     },
 
     /// Database error from the PostgreSQL credential store.
-    #[snafu(display("database error: {source}"))]
+    #[snafu(display("database error: {source}"), visibility(pub))]
     Pg {
         source:   sqlx::Error,
         #[snafu(implicit)]

--- a/crates/integrations/pg-credential-store/src/lib.rs
+++ b/crates/integrations/pg-credential-store/src/lib.rs
@@ -15,7 +15,8 @@
 use std::fmt::Debug;
 
 use async_trait::async_trait;
-use rara_keyring_store::{KeyringStore, Result};
+use rara_keyring_store::{KeyringStore, PgSnafu, Result};
+use snafu::ResultExt;
 use sqlx::SqlitePool;
 
 #[derive(Clone)]
@@ -44,10 +45,7 @@ impl KeyringStore for PgKeyringStore {
         .bind(account)
         .fetch_optional(&self.pool)
         .await
-        .map_err(|e| rara_keyring_store::Error::Pg {
-            source:   e,
-            location: snafu::Location::default(),
-        })?;
+        .context(PgSnafu)?;
         Ok(row.map(|(v,)| v))
     }
 
@@ -63,10 +61,7 @@ impl KeyringStore for PgKeyringStore {
         .bind(value)
         .execute(&self.pool)
         .await
-        .map_err(|e| rara_keyring_store::Error::Pg {
-            source:   e,
-            location: snafu::Location::default(),
-        })?;
+        .context(PgSnafu)?;
         Ok(())
     }
 
@@ -78,10 +73,7 @@ impl KeyringStore for PgKeyringStore {
                 .bind(account)
                 .execute(&self.pool)
                 .await
-                .map_err(|e| rara_keyring_store::Error::Pg {
-                    source:   e,
-                    location: snafu::Location::default(),
-                })?;
+                .context(PgSnafu)?;
         Ok(result.rows_affected() > 0)
     }
 }

--- a/crates/symphony/src/agent.rs
+++ b/crates/symphony/src/agent.rs
@@ -177,7 +177,7 @@ impl RalphAgent {
 
         Err(crate::error::SymphonyError::Workspace {
             message:  format!("failed to validate Ralph workspace config: {details}"),
-            location: snafu::Location::new(file!(), line!(), column!()),
+            location: std::panic::Location::caller(),
         })
     }
 
@@ -223,7 +223,7 @@ impl RalphAgent {
 
         Err(crate::error::SymphonyError::Workspace {
             message:  format!("failed to initialize Ralph workspace config: {details}"),
-            location: snafu::Location::new(file!(), line!(), column!()),
+            location: std::panic::Location::caller(),
         })
     }
 

--- a/crates/symphony/src/service.rs
+++ b/crates/symphony/src/service.rs
@@ -484,7 +484,7 @@ impl IssueRuntime {
             let cwd =
                 std::env::current_dir().map_err(|source| crate::error::SymphonyError::Io {
                     source,
-                    location: snafu::Location::new(file!(), line!(), column!()),
+                    location: std::panic::Location::caller(),
                 })?;
             resolved.repo_path = Some(cwd.clone());
         }
@@ -568,7 +568,7 @@ impl IssueLogWriter {
             .await
             .map_err(|_| crate::error::SymphonyError::Workspace {
                 message:  String::from("issue log writer closed unexpectedly"),
-                location: snafu::Location::new(file!(), line!(), column!()),
+                location: std::panic::Location::caller(),
             })
     }
 }
@@ -583,7 +583,7 @@ async fn spawn_issue_log_writer(
         .parent()
         .ok_or_else(|| crate::error::SymphonyError::Workspace {
             message:  format!("issue log path has no parent: {}", log_path.display()),
-            location: snafu::Location::new(file!(), line!(), column!()),
+            location: std::panic::Location::caller(),
         })?;
     tokio::fs::create_dir_all(parent).await.map_err(|source| {
         crate::error::SymphonyError::WorkspaceIo {
@@ -594,7 +594,7 @@ async fn spawn_issue_log_writer(
                 issue.repo
             ),
             source,
-            location: snafu::Location::new(file!(), line!(), column!()),
+            location: std::panic::Location::caller(),
         }
     })?;
 
@@ -612,7 +612,7 @@ async fn spawn_issue_log_writer(
                 issue.repo
             ),
             source,
-            location: snafu::Location::new(file!(), line!(), column!()),
+            location: std::panic::Location::caller(),
         })?;
     let header = format!(
         "{} [meta] issue={} repo={} branch={} workspace={}\n",
@@ -631,7 +631,7 @@ async fn spawn_issue_log_writer(
                 issue.repo
             ),
             source,
-            location: snafu::Location::new(file!(), line!(), column!()),
+            location: std::panic::Location::caller(),
         }
     })?;
 

--- a/crates/symphony/src/workspace.rs
+++ b/crates/symphony/src/workspace.rs
@@ -17,7 +17,7 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use snafu::{Location, ensure};
+use snafu::ensure;
 use tracing::{info, warn};
 
 use crate::{
@@ -49,7 +49,7 @@ impl WorkspaceManager {
             let checkout =
                 git2::Repository::open(&repo_path).map_err(|source| SymphonyError::Git {
                     source,
-                    location: Location::new(file!(), line!(), column!()),
+                    location: std::panic::Location::caller(),
                 })?;
             return Ok((checkout, repo_path));
         }
@@ -57,7 +57,7 @@ impl WorkspaceManager {
         if let Some(parent) = repo_path.parent() {
             fs::create_dir_all(parent).map_err(|source| SymphonyError::Io {
                 source,
-                location: Location::new(file!(), line!(), column!()),
+                location: std::panic::Location::caller(),
             })?;
         }
 
@@ -71,7 +71,7 @@ impl WorkspaceManager {
         let checkout = git2::Repository::clone(&repo.url, &repo_path).map_err(|source| {
             SymphonyError::Git {
                 source,
-                location: Location::new(file!(), line!(), column!()),
+                location: std::panic::Location::caller(),
             }
         })?;
 
@@ -124,7 +124,7 @@ impl WorkspaceManager {
                         branch
                     ),
                     source,
-                    location: Location::new(file!(), line!(), column!()),
+                    location: std::panic::Location::caller(),
                 })?;
                 if let Ok(wt) = checkout.find_worktree(&branch) {
                     let _ = wt.prune(Some(
@@ -142,17 +142,17 @@ impl WorkspaceManager {
 
         fs::create_dir_all(&workspace_root).map_err(|source| SymphonyError::Io {
             source,
-            location: Location::new(file!(), line!(), column!()),
+            location: std::panic::Location::caller(),
         })?;
         let head_ref = checkout.head().map_err(|source| SymphonyError::Git {
             source,
-            location: Location::new(file!(), line!(), column!()),
+            location: std::panic::Location::caller(),
         })?;
         let head = head_ref
             .peel_to_commit()
             .map_err(|source| SymphonyError::Git {
                 source,
-                location: Location::new(file!(), line!(), column!()),
+                location: std::panic::Location::caller(),
             })?;
 
         let branch_ref = match checkout.branch(&branch, &head, false) {
@@ -161,12 +161,12 @@ impl WorkspaceManager {
                 .find_branch(&branch, git2::BranchType::Local)
                 .map_err(|source| SymphonyError::Git {
                     source,
-                    location: Location::new(file!(), line!(), column!()),
+                    location: std::panic::Location::caller(),
                 })?,
             Err(err) => {
                 return Err(SymphonyError::Git {
                     source:   err,
-                    location: Location::new(file!(), line!(), column!()),
+                    location: std::panic::Location::caller(),
                 });
             }
         };
@@ -178,7 +178,7 @@ impl WorkspaceManager {
             .worktree(&branch, &path, Some(&options))
             .map_err(|source| SymphonyError::Git {
                 source,
-                location: Location::new(file!(), line!(), column!()),
+                location: std::panic::Location::caller(),
             })?;
 
         Ok(WorkspaceInfo {
@@ -201,7 +201,7 @@ impl WorkspaceManager {
         if workspace.path.exists() {
             fs::remove_dir_all(&workspace.path).map_err(|source| SymphonyError::Io {
                 source,
-                location: Location::new(file!(), line!(), column!()),
+                location: std::panic::Location::caller(),
             })?;
         }
 
@@ -214,7 +214,7 @@ impl WorkspaceManager {
         if let Ok(mut branch) = repo.find_branch(&workspace.branch, git2::BranchType::Local) {
             branch.delete().map_err(|source| SymphonyError::Git {
                 source,
-                location: Location::new(file!(), line!(), column!()),
+                location: std::panic::Location::caller(),
             })?;
         }
 


### PR DESCRIPTION
## Summary
- Upgrade testcontainers-modules from 0.14 to 0.15 for testcontainers 0.27 compatibility
- Fix snafu 0.9 `Location` API changes: replace `Location::new()` / `Location::default()` with `std::panic::Location::caller()` or snafu context selectors
- Make `PgSnafu` public in keyring-store for downstream usage

Closes #378

🤖 Generated with [Claude Code](https://claude.com/claude-code)