### PR TITLE
refactor(symphony): use snafu context selectors instead of manual error construction

### DIFF
--- a/crates/symphony/src/agent.rs
+++ b/crates/symphony/src/agent.rs
@@ -175,10 +175,10 @@ impl RalphAgent {
             format!("ralph doctor exited with {}", output.status)
         };
 
-        Err(crate::error::SymphonyError::Workspace {
-            message:  format!("failed to validate Ralph workspace config: {details}"),
-            location: std::panic::Location::caller(),
-        })
+        crate::error::WorkspaceSnafu {
+            message: format!("failed to validate Ralph workspace config: {details}"),
+        }
+        .fail()
     }
 
     async fn init_workspace_config<P: AsRef<Path>>(&self, workspace: P) -> Result<()> {
@@ -221,10 +221,10 @@ impl RalphAgent {
             format!("ralph init exited with {}", output.status)
         };
 
-        Err(crate::error::SymphonyError::Workspace {
-            message:  format!("failed to initialize Ralph workspace config: {details}"),
-            location: std::panic::Location::caller(),
-        })
+        crate::error::WorkspaceSnafu {
+            message: format!("failed to initialize Ralph workspace config: {details}"),
+        }
+        .fail()
     }
 
     pub fn build_prompt(&self, task: &AgentTask) -> String {

--- a/crates/symphony/src/service.rs
+++ b/crates/symphony/src/service.rs
@@ -481,11 +481,7 @@ impl IssueRuntime {
 
         let mut resolved = repo;
         if resolved.repo_path.is_none() {
-            let cwd =
-                std::env::current_dir().map_err(|source| crate::error::SymphonyError::Io {
-                    source,
-                    location: std::panic::Location::caller(),
-                })?;
+            let cwd = std::env::current_dir().context(crate::error::IoSnafu)?;
             resolved.repo_path = Some(cwd.clone());
         }
         Ok(resolved)
@@ -563,13 +559,12 @@ struct IssueLogWriter {
 impl IssueLogWriter {
     async fn record(&self, stream_name: &'static str, line: &str) -> Result<()> {
         let entry = format!("{} [{}] {}\n", Utc::now().to_rfc3339(), stream_name, line);
-        self.sender
-            .send(entry)
-            .await
-            .map_err(|_| crate::error::SymphonyError::Workspace {
-                message:  String::from("issue log writer closed unexpectedly"),
-                location: std::panic::Location::caller(),
-            })
+        self.sender.send(entry).await.map_err(|_| {
+            crate::error::WorkspaceSnafu {
+                message: String::from("issue log writer closed unexpectedly"),
+            }
+            .build()
+        })
     }
 }
 
@@ -579,24 +574,22 @@ async fn spawn_issue_log_writer(
     issue: &TrackedIssue,
     workspace: &WorkspaceInfo,
 ) -> Result<IssueLogWriter> {
-    let parent = log_path
-        .parent()
-        .ok_or_else(|| crate::error::SymphonyError::Workspace {
-            message:  format!("issue log path has no parent: {}", log_path.display()),
-            location: std::panic::Location::caller(),
-        })?;
-    tokio::fs::create_dir_all(parent).await.map_err(|source| {
-        crate::error::SymphonyError::WorkspaceIo {
+    let parent = log_path.parent().ok_or_else(|| {
+        crate::error::WorkspaceSnafu {
+            message: format!("issue log path has no parent: {}", log_path.display()),
+        }
+        .build()
+    })?;
+    tokio::fs::create_dir_all(parent)
+        .await
+        .context(crate::error::WorkspaceIoSnafu {
             message: format!(
                 "failed to create issue log directory {} for issue {} in repo {}",
                 parent.display(),
                 issue.identifier,
                 issue.repo
             ),
-            source,
-            location: std::panic::Location::caller(),
-        }
-    })?;
+        })?;
 
     let mut file = OpenOptions::new()
         .create(true)
@@ -604,15 +597,13 @@ async fn spawn_issue_log_writer(
         .truncate(true)
         .open(log_path)
         .await
-        .map_err(|source| crate::error::SymphonyError::WorkspaceIo {
+        .context(crate::error::WorkspaceIoSnafu {
             message: format!(
                 "failed to open issue log file {} for issue {} in repo {}",
                 log_path.display(),
                 issue.identifier,
                 issue.repo
             ),
-            source,
-            location: std::panic::Location::caller(),
         })?;
     let header = format!(
         "{} [meta] issue={} repo={} branch={} workspace={}\n",
@@ -622,18 +613,16 @@ async fn spawn_issue_log_writer(
         workspace.branch,
         workspace.path.display(),
     );
-    file.write_all(header.as_bytes()).await.map_err(|source| {
-        crate::error::SymphonyError::WorkspaceIo {
+    file.write_all(header.as_bytes())
+        .await
+        .context(crate::error::WorkspaceIoSnafu {
             message: format!(
                 "failed to write issue log header to {} for issue {} in repo {}",
                 log_path.display(),
                 issue.identifier,
                 issue.repo
             ),
-            source,
-            location: std::panic::Location::caller(),
-        }
-    })?;
+        })?;
 
     let (sender, mut receiver) = mpsc::channel::<String>(256);
     let log_path = log_path.to_path_buf();

--- a/crates/symphony/src/workspace.rs
+++ b/crates/symphony/src/workspace.rs
@@ -17,12 +17,12 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use snafu::ensure;
+use snafu::{ResultExt, ensure};
 use tracing::{info, warn};
 
 use crate::{
     config::RepoConfig,
-    error::{Result, SymphonyError},
+    error::{GitSnafu, IoSnafu, Result, WorkspaceIoSnafu},
 };
 
 #[derive(Debug, Clone)]
@@ -46,19 +46,12 @@ impl WorkspaceManager {
         let repo_path = repo.repo_path.clone().expect("checked repo_path above");
 
         if repo_path.exists() {
-            let checkout =
-                git2::Repository::open(&repo_path).map_err(|source| SymphonyError::Git {
-                    source,
-                    location: std::panic::Location::caller(),
-                })?;
+            let checkout = git2::Repository::open(&repo_path).context(GitSnafu)?;
             return Ok((checkout, repo_path));
         }
 
         if let Some(parent) = repo_path.parent() {
-            fs::create_dir_all(parent).map_err(|source| SymphonyError::Io {
-                source,
-                location: std::panic::Location::caller(),
-            })?;
+            fs::create_dir_all(parent).context(IoSnafu)?;
         }
 
         info!(
@@ -68,12 +61,7 @@ impl WorkspaceManager {
             "cloning missing repository checkout for symphony"
         );
 
-        let checkout = git2::Repository::clone(&repo.url, &repo_path).map_err(|source| {
-            SymphonyError::Git {
-                source,
-                location: std::panic::Location::caller(),
-            }
-        })?;
+        let checkout = git2::Repository::clone(&repo.url, &repo_path).context(GitSnafu)?;
 
         Ok((checkout, repo_path))
     }
@@ -116,15 +104,13 @@ impl WorkspaceManager {
                     branch = %branch,
                     "removing invalid existing symphony worktree before recreation"
                 );
-                fs::remove_dir_all(&path).map_err(|source| SymphonyError::WorkspaceIo {
+                fs::remove_dir_all(&path).context(WorkspaceIoSnafu {
                     message: format!(
                         "failed to remove invalid worktree {} for repo {} branch {}",
                         path.display(),
                         repo.name,
                         branch
                     ),
-                    source,
-                    location: std::panic::Location::caller(),
                 })?;
                 if let Ok(wt) = checkout.find_worktree(&branch) {
                     let _ = wt.prune(Some(
@@ -140,34 +126,17 @@ impl WorkspaceManager {
             }
         }
 
-        fs::create_dir_all(&workspace_root).map_err(|source| SymphonyError::Io {
-            source,
-            location: std::panic::Location::caller(),
-        })?;
-        let head_ref = checkout.head().map_err(|source| SymphonyError::Git {
-            source,
-            location: std::panic::Location::caller(),
-        })?;
-        let head = head_ref
-            .peel_to_commit()
-            .map_err(|source| SymphonyError::Git {
-                source,
-                location: std::panic::Location::caller(),
-            })?;
+        fs::create_dir_all(&workspace_root).context(IoSnafu)?;
+        let head_ref = checkout.head().context(GitSnafu)?;
+        let head = head_ref.peel_to_commit().context(GitSnafu)?;
 
         let branch_ref = match checkout.branch(&branch, &head, false) {
             Ok(branch_ref) => branch_ref,
             Err(err) if err.code() == git2::ErrorCode::Exists => checkout
                 .find_branch(&branch, git2::BranchType::Local)
-                .map_err(|source| SymphonyError::Git {
-                    source,
-                    location: std::panic::Location::caller(),
-                })?,
+                .context(GitSnafu)?,
             Err(err) => {
-                return Err(SymphonyError::Git {
-                    source:   err,
-                    location: std::panic::Location::caller(),
-                });
+                return Err(err).context(GitSnafu);
             }
         };
 
@@ -176,10 +145,7 @@ impl WorkspaceManager {
         options.reference(Some(&reference));
         checkout
             .worktree(&branch, &path, Some(&options))
-            .map_err(|source| SymphonyError::Git {
-                source,
-                location: std::panic::Location::caller(),
-            })?;
+            .context(GitSnafu)?;
 
         Ok(WorkspaceInfo {
             path,
@@ -199,10 +165,7 @@ impl WorkspaceManager {
         let (repo, _) = self.ensure_repo_checkout(repo)?;
 
         if workspace.path.exists() {
-            fs::remove_dir_all(&workspace.path).map_err(|source| SymphonyError::Io {
-                source,
-                location: std::panic::Location::caller(),
-            })?;
+            fs::remove_dir_all(&workspace.path).context(IoSnafu)?;
         }
 
         if let Ok(wt) = repo.find_worktree(&workspace.branch) {
@@ -212,10 +175,7 @@ impl WorkspaceManager {
         }
 
         if let Ok(mut branch) = repo.find_branch(&workspace.branch, git2::BranchType::Local) {
-            branch.delete().map_err(|source| SymphonyError::Git {
-                source,
-                location: std::panic::Location::caller(),
-            })?;
+            branch.delete().context(GitSnafu)?;
         }
 
         Ok(())


### PR DESCRIPTION
## Summary
- Replace 18 manual snafu error constructions with idiomatic context selectors
- `workspace.rs` (12): `.map_err(|source| SymphonyError::Git{..})` → `.context(GitSnafu)`, `.context(IoSnafu)`, `.context(WorkspaceIoSnafu{..})`
- `agent.rs` (2): `Err(SymphonyError::Workspace{..})` → `WorkspaceSnafu{..}.fail()`
- `service.rs` (4): manual `map_err` / `ok_or_else` → `.context()` and `WorkspaceSnafu{..}.build()`

## Test plan
- [x] `cargo check -p rara-symphony` passes
- [x] All pre-commit hooks pass (cargo check, fmt, clippy)
- [ ] CI green

Closes #380

🤖 Generated with [Claude Code](https://claude.com/claude-code)