### PR TITLE
fix(ci): harden Ollama integration job

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -111,13 +111,15 @@ jobs:
           tool: cargo-nextest
 
       - name: Verify Ollama connectivity
-        run: curl -sf ${{ secrets.OLLAMA_BASE_URL }}/models | head -c 200
+        run: curl -sf "${OLLAMA_BASE_URL}/api/tags" | head -c 200
+        env:
+          OLLAMA_BASE_URL: ${{ secrets.OLLAMA_BASE_URL }}
 
       - name: Prepare CI config
-        run: |
-          export OLLAMA_BASE_URL="${{ secrets.OLLAMA_BASE_URL }}"
-          export OLLAMA_MODEL="${{ secrets.OLLAMA_MODEL }}"
-          envsubst < config.ci.yaml > config.yaml
+        run: envsubst < config.ci.yaml > config.yaml
+        env:
+          OLLAMA_BASE_URL: ${{ secrets.OLLAMA_BASE_URL }}
+          OLLAMA_MODEL: ${{ secrets.OLLAMA_MODEL }}
 
       - name: Run integration tests
         run: cargo nextest run --workspace --all-features --run-ignored ignored-only

--- a/config.ci.yaml
+++ b/config.ci.yaml
@@ -21,6 +21,6 @@ llm:
       api_key: ollama
       default_model: ${OLLAMA_MODEL}
 users:
-- name: ryan
+- name: ci-bot
   role: root
   platforms: []


### PR DESCRIPTION
## Summary
- Use env: block instead of inline export for secret injection in Prepare CI config step
- Fix Ollama connectivity check endpoint from /models to /api/tags (standard Ollama API)
- Quote secret references via env vars to prevent shell injection
- Rename hardcoded user 'ryan' to 'ci-bot' for CI environment

## Test plan
- [ ] Verify CI workflow YAML is valid
- [ ] Confirm Ollama connectivity check hits correct endpoint after merge

Closes #381

🤖 Generated with [Claude Code](https://claude.com/claude-code)