### PR TITLE
fix(release): filter noisy commits from changelog

### DIFF
--- a/cliff.toml
+++ b/cliff.toml
@@ -53,18 +53,18 @@ commit_parsers = [
     { message = "^refactor", group = "Refactor" },
     { message = "^style", group = "Styling" },
     { message = "^test", group = "Testing" },
-    # { message = "^chore\\(release\\): prepare for", skip = true },
-    # { message = "^chore\\(deps\\)", skip = true },
-    # { message = "^chore\\(pr\\)", skip = true },
-    # { message = "^chore\\(pull\\)", skip = true },
-    # { message = "^chore|^ci", group = "Miscellaneous Tasks" },
+    { message = "^chore\\(release\\): prepare for", skip = true },
+    { message = "^chore\\(deps\\)", skip = true },
+    { message = "^chore\\(pr\\)", skip = true },
+    { message = "^chore\\(pull\\)", skip = true },
+    { message = "^chore|^ci", group = "Miscellaneous Tasks" },
     { body = ".*security", group = "Security" },
     { message = "^revert", group = "Revert" },
 ]
 # protect breaking changes from being skipped due to matching a skipping commit_parser
 protect_breaking_commits = false
 # filter out the commits that are not matched by commit parsers
-filter_commits = false
+filter_commits = true
 # glob pattern for matching git tags
 tag_pattern = "v[0-9]*"
 # regex for skipping tags


### PR DESCRIPTION
## Summary
- Enable chore(deps/release/pr/pull) skip rules in cliff.toml to exclude dependency bump commits from changelog
- Set `filter_commits = true` to only include commits matching commit_parsers
- Fixes release PR body exceeding GitHub's 65536 character limit

Closes #384

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>