### PR TITLE
chore: unify all crate versions to 0.0.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "0.0.17"
+version = "0.0.1"
 edition = "2024"
 license = "Apache-2.0"
 authors = ["crrow"]

--- a/crates/common/yunara-store/Cargo.toml
+++ b/crates/common/yunara-store/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yunara-store"
-version = "0.1.0"
+version = "0.0.1"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true


### PR DESCRIPTION
## Summary
- Workspace root version: `0.0.17` → `0.0.1`
- `yunara-store` version: `0.1.0` → `0.0.1`

Closes #388