### PR TITLE
chore(ci): remove unused Rust coverage job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,8 +53,6 @@ jobs:
     needs: changes
     if: ${{ needs.changes.outputs.code == 'true' || github.event_name == 'push' }}
     uses: ./.github/workflows/rust.yml
-    secrets:
-      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   release-pr:
     name: Release PR

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -2,9 +2,6 @@ name: Rust
 
 on:
   workflow_call:
-    secrets:
-      CODECOV_TOKEN:
-        required: false
 
 concurrency:
   group: rust-${{ github.event.pull_request.number || github.sha }}
@@ -83,38 +80,6 @@ jobs:
 
       - name: Run tests
         run: cargo nextest run --workspace
-
-  coverage:
-    name: Coverage
-    runs-on: arc-runner-set
-    if: github.ref == 'refs/heads/main'
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
-        with:
-          persist-credentials: false
-
-      - name: Start sccache
-        run: sccache --start-server || true
-
-      - name: Generate coverage report
-        run: |
-          cargo tarpaulin \
-            --engine llvm \
-            --workspace \
-            --no-dead-code \
-            --skip-clean \
-            --out xml \
-            --output-dir ./coverage
-
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          files: ./coverage/cobertura.xml
-          flags: rust
-          fail_ci_if_error: false
-          verbose: true
 
   rust-success:
     name: Rust Success


### PR DESCRIPTION
Remove the `coverage` job from `rust.yml` and clean up the `CODECOV_TOKEN` secret that was only used by it.

Closes #390