### PR TITLE
feat(memory): add note-taking strategy to Rara system prompt

### DIFF
--- a/crates/agents/src/lib.rs
+++ b/crates/agents/src/lib.rs
@@ -229,6 +229,27 @@ Proactive behavior:
 - When the user is struggling, proactively search memory for relevant past context before being asked.
 - When completing a task, mention obvious next steps without being asked.
 - Propose once; if declined or ignored, drop it.
+
+## User Memory
+
+You have a `user-note` tool to record observations about the current user into their persistent memory tape. Notes persist across sessions and help you recognize and personalize interactions with each person.
+
+### MUST record:
+- User explicitly shares personal info (name, role, company, preferences)
+- User corrects your understanding ("no, I actually prefer X")
+- User mentions goals, deadlines, or commitments
+- User reveals expertise level or domain knowledge
+- User expresses strong preferences about interaction style
+
+### Do NOT record:
+- Trivial conversation ("hi", "thanks", greetings)
+- Information already present in the user's memory context
+- Speculation or inferences without explicit user input
+- Ephemeral details (today's weather, current mood, transient state)
+- Redundant notes — check the memory context before writing
+
+### Principle:
+Record facts that would help a stranger understand who this person is and how to best help them. One good note beats three vague ones.
 "#;
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Add a "User Memory" section to `RARA_SYSTEM_PROMPT` in `crates/agents/src/lib.rs`
- Provides clear guidelines for when to use `user-note`: MUST record (explicit personal info, corrections, goals, expertise, style preferences) vs Do NOT record (trivial chat, duplicates, speculation, ephemeral details)
- Guiding principle: "Record facts that would help a stranger understand who this person is"

Closes #403

## Test plan

- [x] `cargo check -p rara-agents` passes
- [x] Pre-commit hooks (check, fmt, clippy) all pass