### PR TITLE
feat(memory): add structured user profile template for distillation

### DIFF
--- a/crates/agents/src/lib.rs
+++ b/crates/agents/src/lib.rs
@@ -311,6 +311,29 @@ Use `distill-user-notes` to condense accumulated user notes when a user's tape h
 3. Combine the existing distilled summary (if any) with recent notes into a new compact summary
 4. Call `distill-user-notes` with the condensed summary
 
+The distilled summary must follow a structured profile template:
+
+## Identity
+Name, role, background, timezone
+
+## Communication Style
+Language preference, verbosity, tone, interaction patterns
+
+## Expertise & Interests
+Technical domains, skill levels, current learning areas
+
+## Key Facts
+Projects, relationships, important context
+
+## Active Context
+Current goals, pending tasks, recent focus areas
+
+Rules:
+- Always preserve valid information from the existing distilled summary
+- When a note contradicts previous knowledge, prefer the newer information
+- Remove completed TODOs and clearly outdated information
+- Omit sections with no information — don't fill in placeholders
+
 Good distillation preserves all important facts while removing redundancy and outdated information.
 
 ## Soul Evolution

--- a/crates/app/src/tools/mita_distill_user_notes.rs
+++ b/crates/app/src/tools/mita_distill_user_notes.rs
@@ -45,10 +45,16 @@ impl AgentTool for DistillUserNotesTool {
     fn name(&self) -> &str { Self::NAME }
 
     fn description(&self) -> &str {
-        "Distill accumulated user notes into a compact summary anchor. Use this when a user's tape \
-         has accumulated many notes that should be condensed. The summary should capture all \
-         important knowledge from previous notes plus the existing distilled summary. After \
-         distillation, only the summary and newer notes will appear in the user's context."
+        "Distill accumulated user notes into a compact summary anchor using the structured profile \
+         template below. Use this when a user's tape has accumulated many notes that should be \
+         condensed.\n\nThe summary MUST follow this template (omit empty sections):\n\n## \
+         Identity\nName, role, background, timezone\n\n## Communication Style\nLanguage \
+         preference, verbosity, tone, interaction patterns\n\n## Expertise & Interests\nTechnical \
+         domains, skill levels, current learning areas\n\n## Key Facts\nProjects, relationships, \
+         important context\n\n## Active Context\nCurrent goals, pending tasks, recent focus \
+         areas\n\nRules:\n- Preserve all valid information from the previous anchor summary\n- \
+         When information conflicts, prefer the most recent note and note the change\n- Remove \
+         completed TODOs and outdated information\n- Omit sections with no information"
     }
 
     fn parameters_schema(&self) -> serde_json::Value {


### PR DESCRIPTION
## Summary
- Add a structured profile template (Identity, Communication Style, Expertise & Interests, Key Facts, Active Context) to the `distill-user-notes` tool description so the LLM receives the template as part of the tool schema
- Add the same template and rules to the Mita system prompt's Knowledge Distillation section for reinforcement
- Ensures consistent, structured output across distillation cycles

Closes #402

## Test plan
- [x] `cargo check -p rara-app` passes
- [x] `cargo check -p rara-agents` passes
- [x] Pre-commit hooks (check, fmt, clippy) all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)