### PR TITLE
fix(channels): remove stale message count from session detail/switch display

### DIFF
--- a/crates/channels/src/telegram/commands/callbacks.rs
+++ b/crates/channels/src/telegram/commands/callbacks.rs
@@ -97,12 +97,10 @@ impl CallbackHandler for SessionDetailCallbackHandler {
                 let title = detail.title.as_deref().unwrap_or("Untitled");
                 let model = detail.model.as_deref().unwrap_or("(default)");
                 let text = format!(
-                    "<b>{}</b>\nKey: <code>{}</code>\nModel: {}\nMessages: {}\nCreated: {}\nLast \
-                     active: {}",
+                    "<b>{}</b>\nKey: <code>{}</code>\nModel: {}\nCreated: {}\nLast active: {}",
                     html_escape(title),
                     html_escape(&detail.key),
                     html_escape(model),
-                    detail.message_count,
                     format_timestamp(&detail.created_at),
                     format_timestamp(&detail.updated_at),
                 );

--- a/crates/channels/src/telegram/commands/session.rs
+++ b/crates/channels/src/telegram/commands/session.rs
@@ -230,7 +230,6 @@ impl SessionCommandHandler {
                     "<b>Key:</b> <code>{}</code>",
                     html_escape(&detail.key)
                 );
-                let _ = writeln!(text, "<b>Messages:</b> {}", detail.message_count);
                 if let Some(ref model) = detail.model {
                     let _ = writeln!(text, "<b>Model:</b> {}", html_escape(model));
                 }


### PR DESCRIPTION
## Summary
- Remove `Messages` field from session detail callback (`callbacks.rs`)
- Remove `Messages` field from session info command (`session.rs`)
- Follows up on #441 which removed it from `/sessions` list but missed these two locations

Closes #448