### PR TITLE
feat(kernel): agent knowledge directory with index + on-demand loading (#466)

### DIFF
--- a/crates/agents/src/lib.rs
+++ b/crates/agents/src/lib.rs
@@ -252,7 +252,16 @@ You have a `user-note` tool to record observations about the current user into t
 ### Principle:
 Record facts that would help a stranger understand who this person is and how to best help them. One good note beats three vague ones.
 
-You have an external knowledge file at `~/.config/rara/agents/rara/agent.md`. This file contains your operational notes about tools, CLIs, and workflows. When the owner installs a new tool or teaches you how to use something, update this file using the `edit-file` tool so you remember it in future sessions. If the file doesn't exist yet, create it with `write-file`.
+You have an external knowledge system at `~/.config/rara/agents/rara/`:
+
+- `agent.md` — Your tool index. Each line: `- {name}: {one-sentence purpose} → knowledge/{name}.md`. This file is loaded into your prompt every session, so keep it minimal (one line per tool).
+- `knowledge/{name}.md` — Detailed notes for each tool. One file per CLI tool. Soft limit: 300 lines. Use `read-file` to load details when needed for a task.
+
+When you learn a new tool:
+1. Write detailed notes to `knowledge/{name}.md` using `write-file`
+2. Add one index line to `agent.md` using `edit-file`
+
+When you use a known tool and need to recall details, `read-file` the corresponding knowledge file.
 "#;
 
 // ---------------------------------------------------------------------------

--- a/crates/kernel/src/agent/mod.rs
+++ b/crates/kernel/src/agent/mod.rs
@@ -669,12 +669,17 @@ fn load_agent_md(agent_name: &str) -> Option<String> {
     None
 }
 
-/// Create the agent.md file with seed content if it doesn't exist.
+/// Create the agent.md file and knowledge directory if they don't exist.
 fn ensure_agent_md(path: &Path, agent_name: &str) {
     if let Some(parent) = path.parent() {
         if let Err(e) = std::fs::create_dir_all(parent) {
             warn!(agent = agent_name, error = %e, "failed to create agent.md parent directory");
             return;
+        }
+        // Create knowledge/ subdirectory for per-tool knowledge files
+        let knowledge_dir = parent.join("knowledge");
+        if let Err(e) = std::fs::create_dir_all(&knowledge_dir) {
+            warn!(agent = agent_name, error = %e, "failed to create knowledge directory");
         }
     }
     match std::fs::write(path, "") {


### PR DESCRIPTION
## Summary

- Split monolithic `agent.md` into minimal index (always in prompt) + per-tool `knowledge/{name}.md` files (read on demand)
- `ensure_agent_md()` now creates `knowledge/` subdirectory alongside `agent.md`
- Updated system prompt to guide Rara on the new index + knowledge structure

## Design

See `docs/plans/2026-03-17-agent-knowledge-directory-design.md`

Closes #466