### PR TITLE
feat(kernel): default execution mode to plan (v2)

### DIFF
--- a/crates/kernel/src/agent/mod.rs
+++ b/crates/kernel/src/agent/mod.rs
@@ -137,10 +137,10 @@ pub struct SandboxConfig {
 pub enum ExecutionMode {
     /// Standard reactive agent loop (v1). The agent processes each message
     /// through the normal LLM → tool → LLM cycle.
-    #[default]
     Reactive,
     /// Plan-execute mode (v2). The agent first generates a plan, then
     /// executes each step with verification.
+    #[default]
     Plan,
 }
 


### PR DESCRIPTION
Change the default `ExecutionMode` from `Reactive` (v1) to `Plan` (v2), so all sessions use plan-execute mode by default. Users can still switch back via `/msg_version 1`.

Closes #479