### PR TITLE
feat(tool-macro): migrate kernel tools to ToolDef

### DIFF
--- a/crates/kernel/src/plan.rs
+++ b/crates/kernel/src/plan.rs
@@ -524,7 +524,7 @@ async fn create_plan_via_llm(
     if let Some(tool_call) = response
         .tool_calls
         .iter()
-        .find(|tc| tc.name == crate::tool::create_plan::CreatePlanTool::NAME)
+        .find(|tc| tc.name == crate::tool::create_plan::CreatePlanTool::TOOL_NAME)
     {
         let params: serde_json::Value =
             serde_json::from_str(&tool_call.arguments).map_err(|e| {
@@ -653,7 +653,7 @@ async fn replan_via_llm(
     if let Some(tool_call) = response
         .tool_calls
         .iter()
-        .find(|tc| tc.name == crate::tool::create_plan::CreatePlanTool::NAME)
+        .find(|tc| tc.name == crate::tool::create_plan::CreatePlanTool::TOOL_NAME)
     {
         let params: serde_json::Value =
             serde_json::from_str(&tool_call.arguments).map_err(|e| {

--- a/crates/kernel/src/tool/cancel_background.rs
+++ b/crates/kernel/src/tool/cancel_background.rs
@@ -13,25 +13,30 @@
 // limitations under the License.
 
 use async_trait::async_trait;
-use serde_json::Value;
+use rara_tool_macro::ToolDef;
+use schemars::JsonSchema;
+use serde::Deserialize;
 use tracing::info;
 
 use crate::{
     handle::KernelHandle,
     io::{BackgroundTaskStatus, StreamEvent},
     session::{SessionKey, Signal},
-    tool::{AgentTool, ToolContext, ToolOutput},
+    tool::{ToolContext, ToolExecute, ToolOutput},
 };
 
 /// Builtin tool that cancels a running background agent.
+#[derive(ToolDef)]
+#[tool(
+    name = "cancel-background",
+    description = "Cancel a running background task by task_id."
+)]
 pub struct CancelBackgroundTool {
     handle:      KernelHandle,
     session_key: SessionKey,
 }
 
 impl CancelBackgroundTool {
-    pub const NAME: &str = crate::tool_names::CANCEL_BACKGROUND;
-
     pub fn new(handle: KernelHandle, session_key: SessionKey) -> Self {
         Self {
             handle,
@@ -40,35 +45,31 @@ impl CancelBackgroundTool {
     }
 }
 
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct CancelBackgroundParams {
+    /// The task_id returned by spawn_background
+    task_id: String,
+    /// Optional reason for cancellation
+    reason:  Option<String>,
+}
+
 #[async_trait]
-impl AgentTool for CancelBackgroundTool {
-    fn name(&self) -> &str { Self::NAME }
+impl ToolExecute for CancelBackgroundTool {
+    type Params = CancelBackgroundParams;
 
-    fn description(&self) -> &str { "Cancel a running background task by task_id." }
-
-    fn parameters_schema(&self) -> Value {
-        serde_json::json!({
-            "type": "object",
-            "required": ["task_id"],
-            "properties": {
-                "task_id": { "type": "string", "description": "The task_id returned by spawn_background" },
-                "reason": { "type": "string", "description": "Optional reason for cancellation" }
-            }
-        })
-    }
-
-    async fn execute(&self, params: Value, _context: &ToolContext) -> anyhow::Result<ToolOutput> {
-        let task_id_str = params["task_id"]
-            .as_str()
-            .ok_or_else(|| anyhow::anyhow!("missing required field: task_id"))?;
-        let task_id = SessionKey::try_from_raw(task_id_str)
-            .map_err(|_| anyhow::anyhow!("invalid task_id: {task_id_str}"))?;
-        let reason = params["reason"].as_str().unwrap_or("cancelled by parent");
+    async fn run(
+        &self,
+        p: CancelBackgroundParams,
+        _context: &ToolContext,
+    ) -> anyhow::Result<ToolOutput> {
+        let task_id = SessionKey::try_from_raw(&p.task_id)
+            .map_err(|_| anyhow::anyhow!("invalid task_id: {}", p.task_id))?;
+        let reason = p.reason.as_deref().unwrap_or("cancelled by parent");
 
         if !self.handle.is_background_task(&self.session_key, &task_id) {
             return Ok(serde_json::json!({
                 "error": "task not found or not a background task of this session",
-                "task_id": task_id_str,
+                "task_id": p.task_id,
             })
             .into());
         }
@@ -85,7 +86,7 @@ impl AgentTool for CancelBackgroundTool {
         if let Err(e) = self.handle.send_signal(task_id, Signal::Terminate) {
             return Ok(serde_json::json!({
                 "error": format!("failed to send terminate signal: {e}"),
-                "task_id": task_id_str,
+                "task_id": p.task_id,
             })
             .into());
         }
@@ -105,7 +106,7 @@ impl AgentTool for CancelBackgroundTool {
         );
 
         Ok(serde_json::json!({
-            "task_id": task_id_str,
+            "task_id": p.task_id,
             "status": "cancelled",
             "reason": reason,
         })

--- a/crates/kernel/src/tool/create_plan.rs
+++ b/crates/kernel/src/tool/create_plan.rs
@@ -20,93 +20,68 @@
 //! plan executor (kernel loop).
 
 use async_trait::async_trait;
+use rara_tool_macro::ToolDef;
+use schemars::JsonSchema;
 use serde::Deserialize;
-use serde_json::json;
 
 use crate::plan::{ExecutionMode, Plan, PlanStatus, PlanStep};
 
 /// LLM-callable tool that creates a structured execution plan.
+#[derive(ToolDef)]
+#[tool(
+    name = "create-plan",
+    description = "Create a structured execution plan for complex tasks. The plan will be \
+                   executed step by step with independent context per step."
+)]
 pub struct CreatePlanTool;
-
-impl CreatePlanTool {
-    pub const NAME: &str = crate::tool_names::CREATE_PLAN;
-}
 
 // ============================================================================
 // Parameter types
 // ============================================================================
 
-#[derive(Debug, Deserialize)]
-struct StepInput {
+/// Execution mode for a plan step.
+#[derive(Debug, Default, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum StepMode {
+    /// Execute in the main agent context.
+    #[default]
+    Inline,
+    /// Execute in an independent worker session.
+    Worker,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct StepInput {
+    /// Natural language description of what this step should accomplish
     task:       String,
+    /// Execution mode: inline (main agent) or worker (independent session)
     #[serde(default)]
-    mode:       Option<String>,
+    mode:       StepMode,
+    /// Criteria for considering this step complete
     acceptance: String,
 }
 
-#[derive(Debug, Deserialize)]
-struct CreatePlanParams {
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct CreatePlanParams {
+    /// The overall goal of the plan
     goal:  String,
+    /// The steps to execute
     steps: Vec<StepInput>,
 }
 
 // ============================================================================
-// AgentTool impl
+// ToolExecute impl
 // ============================================================================
 
 #[async_trait]
-impl super::AgentTool for CreatePlanTool {
-    fn name(&self) -> &str { Self::NAME }
+impl super::ToolExecute for CreatePlanTool {
+    type Params = CreatePlanParams;
 
-    fn description(&self) -> &str {
-        "Create a structured execution plan for complex tasks. The plan will be executed step by \
-         step with independent context per step."
-    }
-
-    fn parameters_schema(&self) -> serde_json::Value {
-        json!({
-            "type": "object",
-            "required": ["goal", "steps"],
-            "properties": {
-                "goal": {
-                    "type": "string",
-                    "description": "The overall goal of the plan"
-                },
-                "steps": {
-                    "type": "array",
-                    "items": {
-                        "type": "object",
-                        "required": ["task", "acceptance"],
-                        "properties": {
-                            "task": {
-                                "type": "string",
-                                "description": "Natural language description of what this step should accomplish"
-                            },
-                            "mode": {
-                                "type": "string",
-                                "enum": ["inline", "worker"],
-                                "default": "inline",
-                                "description": "Execution mode: inline (main agent) or worker (independent session)"
-                            },
-                            "acceptance": {
-                                "type": "string",
-                                "description": "Criteria for considering this step complete"
-                            }
-                        }
-                    }
-                }
-            }
-        })
-    }
-
-    async fn execute(
+    async fn run(
         &self,
-        params: serde_json::Value,
+        input: CreatePlanParams,
         _context: &super::ToolContext,
     ) -> anyhow::Result<super::ToolOutput> {
-        let input: CreatePlanParams = serde_json::from_value(params)
-            .map_err(|e| anyhow::anyhow!("invalid create_plan params: {e}"))?;
-
         if input.steps.is_empty() {
             return Err(anyhow::anyhow!("plan must have at least one step"));
         }
@@ -116,9 +91,9 @@ impl super::AgentTool for CreatePlanTool {
             .into_iter()
             .enumerate()
             .map(|(index, s)| {
-                let mode = match s.mode.as_deref() {
-                    Some("worker") => ExecutionMode::Worker,
-                    _ => ExecutionMode::Inline,
+                let mode = match s.mode {
+                    StepMode::Worker => ExecutionMode::Worker,
+                    StepMode::Inline => ExecutionMode::Inline,
                 };
                 PlanStep {
                     index,

--- a/crates/kernel/src/tool/fold_branch.rs
+++ b/crates/kernel/src/tool/fold_branch.rs
@@ -43,7 +43,7 @@
 
 use std::sync::Arc;
 
-use async_trait::async_trait;
+use rara_tool_macro::ToolDef;
 use serde_json::Value;
 use tracing::{info, warn};
 
@@ -52,7 +52,7 @@ use crate::{
     handle::KernelHandle,
     io::AgentEvent,
     session::{SessionKey, Signal},
-    tool::{AgentTool, ToolContext, ToolOutput},
+    tool::{ToolContext, ToolOutput},
 };
 
 /// Maximum character length for the compressed result returned to the caller.
@@ -76,6 +76,15 @@ pub(crate) const FOLD_BRANCH_NAME_PREFIX: &str = "fold-branch-";
 /// completion the raw output is compressed via [`ContextFolder::fold_text`]
 /// (if it exceeds [`COMPACT_TARGET_CHARS`]) and returned as a JSON
 /// `ToolResult` to the parent's agent loop.
+#[derive(ToolDef)]
+#[tool(
+    name = "fold-branch",
+    description = "Spawn a child agent for a focused sub-task, wait for completion, and return a \
+                   compressed result. Use this when you need the result inline (synchronous). For \
+                   fire-and-forget tasks, use spawn-background instead.",
+    params_schema = "Self::schema()",
+    execute_fn = "self.exec"
+)]
 pub struct FoldBranchTool {
     handle:         KernelHandle,
     session_key:    SessionKey,
@@ -83,8 +92,6 @@ pub struct FoldBranchTool {
 }
 
 impl FoldBranchTool {
-    pub const NAME: &str = crate::tool_names::FOLD_BRANCH;
-
     pub fn new(
         handle: KernelHandle,
         session_key: SessionKey,
@@ -96,19 +103,8 @@ impl FoldBranchTool {
             context_folder,
         }
     }
-}
 
-#[async_trait]
-impl AgentTool for FoldBranchTool {
-    fn name(&self) -> &str { Self::NAME }
-
-    fn description(&self) -> &str {
-        "Spawn a child agent for a focused sub-task, wait for completion, and return a compressed \
-         result. Use this when you need the result inline (synchronous). For fire-and-forget \
-         tasks, use spawn-background instead."
-    }
-
-    fn parameters_schema(&self) -> Value {
+    fn schema() -> Value {
         serde_json::json!({
             "type": "object",
             "required": ["task", "instruction"],
@@ -138,7 +134,7 @@ impl AgentTool for FoldBranchTool {
         })
     }
 
-    async fn execute(&self, params: Value, _context: &ToolContext) -> anyhow::Result<ToolOutput> {
+    async fn exec(&self, params: Value, _context: &ToolContext) -> anyhow::Result<ToolOutput> {
         let task = params["task"]
             .as_str()
             .ok_or_else(|| anyhow::anyhow!("missing required field: task"))?

--- a/crates/kernel/src/tool/schedule.rs
+++ b/crates/kernel/src/tool/schedule.rs
@@ -22,6 +22,8 @@
 //! - `schedule-list` — list all scheduled jobs across sessions
 
 use async_trait::async_trait;
+use rara_tool_macro::ToolDef;
+use schemars::JsonSchema;
 use serde::Deserialize;
 use tokio::sync::oneshot;
 use tracing::debug;
@@ -29,7 +31,7 @@ use tracing::debug;
 use crate::{
     event::{KernelEventEnvelope, Syscall},
     schedule::{JobId, Trigger},
-    tool::{AgentTool, ToolContext, ToolOutput},
+    tool::{EmptyParams, ToolContext, ToolExecute, ToolOutput},
 };
 
 // -- shared helper ------------------------------------------------------------
@@ -74,60 +76,39 @@ async fn register_job(
 // ScheduleOnceTool
 // ============================================================================
 
+/// Tool for scheduling a one-shot future agent turn.
+#[derive(ToolDef)]
+#[tool(
+    name = "schedule-once",
+    description = "Schedule a one-shot future agent turn. `message` is the prompt that will be \
+                   sent to the LLM when the job fires, so write it like a user instruction and \
+                   name any required skills explicitly."
+)]
 pub struct ScheduleOnceTool;
 
-impl ScheduleOnceTool {
-    pub const NAME: &str = crate::tool_names::SCHEDULE_ONCE;
-}
-
-#[derive(Debug, Deserialize)]
-struct ScheduleOnceParams {
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct ScheduleOnceParams {
+    /// Fire once after this many seconds
     after_seconds: u64,
+    /// Prompt for the future scheduled agent. This is sent to the LLM when the
+    /// job fires, so write it like a user instruction; if a skill should be
+    /// used, name it explicitly.
     message:       String,
+    /// Routing tags for task report notification matching
+    /// (e.g. `["pr_review", "repo:rararulab/rara"]`)
     #[serde(default)]
     tags:          Vec<String>,
 }
 
 #[async_trait]
-impl AgentTool for ScheduleOnceTool {
-    fn name(&self) -> &str { Self::NAME }
+impl ToolExecute for ScheduleOnceTool {
+    type Params = ScheduleOnceParams;
 
-    fn description(&self) -> &str {
-        "Schedule a one-shot future agent turn. `message` is the prompt that will be sent to the \
-         LLM when the job fires, so write it like a user instruction and name any required skills \
-         explicitly."
-    }
-
-    fn parameters_schema(&self) -> serde_json::Value {
-        serde_json::json!({
-            "type": "object",
-            "required": ["after_seconds", "message"],
-            "properties": {
-                "after_seconds": {
-                    "type": "integer",
-                    "description": "Fire once after this many seconds"
-                },
-                "message": {
-                    "type": "string",
-                    "description": "Prompt for the future scheduled agent. This is sent to the LLM when the job fires, so write it like a user instruction; if a skill should be used, name it explicitly."
-                },
-                "tags": {
-                    "type": "array",
-                    "items": { "type": "string" },
-                    "description": "Routing tags for task report notification matching (e.g. [\"pr_review\", \"repo:rararulab/rara\"])"
-                }
-            }
-        })
-    }
-
-    async fn execute(
+    async fn run(
         &self,
-        params: serde_json::Value,
+        p: ScheduleOnceParams,
         context: &ToolContext,
     ) -> anyhow::Result<ToolOutput> {
-        let p: ScheduleOnceParams =
-            serde_json::from_value(params).map_err(|e| anyhow::anyhow!("invalid params: {e}"))?;
-
         if p.after_seconds == 0 {
             return Err(anyhow::anyhow!("after_seconds must be > 0"));
         }
@@ -145,60 +126,39 @@ impl AgentTool for ScheduleOnceTool {
 // ScheduleIntervalTool
 // ============================================================================
 
+/// Tool for scheduling a repeating future agent turn.
+#[derive(ToolDef)]
+#[tool(
+    name = "schedule-interval",
+    description = "Schedule a repeating future agent turn. `message` is the prompt that will be \
+                   sent to the LLM each time the job fires, so write it like a user instruction \
+                   and name any required skills explicitly."
+)]
 pub struct ScheduleIntervalTool;
 
-impl ScheduleIntervalTool {
-    pub const NAME: &str = crate::tool_names::SCHEDULE_INTERVAL;
-}
-
-#[derive(Debug, Deserialize)]
-struct ScheduleIntervalParams {
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct ScheduleIntervalParams {
+    /// Fire every N seconds (repeating)
     interval_seconds: u64,
+    /// Prompt for the future scheduled agent. This is sent to the LLM every
+    /// time the job fires, so write it like a user instruction; if a skill
+    /// should be used, name it explicitly.
     message:          String,
+    /// Routing tags for task report notification matching
+    /// (e.g. `["pr_review", "repo:rararulab/rara"]`)
     #[serde(default)]
     tags:             Vec<String>,
 }
 
 #[async_trait]
-impl AgentTool for ScheduleIntervalTool {
-    fn name(&self) -> &str { Self::NAME }
+impl ToolExecute for ScheduleIntervalTool {
+    type Params = ScheduleIntervalParams;
 
-    fn description(&self) -> &str {
-        "Schedule a repeating future agent turn. `message` is the prompt that will be sent to the \
-         LLM each time the job fires, so write it like a user instruction and name any required \
-         skills explicitly."
-    }
-
-    fn parameters_schema(&self) -> serde_json::Value {
-        serde_json::json!({
-            "type": "object",
-            "required": ["interval_seconds", "message"],
-            "properties": {
-                "interval_seconds": {
-                    "type": "integer",
-                    "description": "Fire every N seconds (repeating)"
-                },
-                "message": {
-                    "type": "string",
-                    "description": "Prompt for the future scheduled agent. This is sent to the LLM every time the job fires, so write it like a user instruction; if a skill should be used, name it explicitly."
-                },
-                "tags": {
-                    "type": "array",
-                    "items": { "type": "string" },
-                    "description": "Routing tags for task report notification matching (e.g. [\"pr_review\", \"repo:rararulab/rara\"])"
-                }
-            }
-        })
-    }
-
-    async fn execute(
+    async fn run(
         &self,
-        params: serde_json::Value,
+        p: ScheduleIntervalParams,
         context: &ToolContext,
     ) -> anyhow::Result<ToolOutput> {
-        let p: ScheduleIntervalParams =
-            serde_json::from_value(params).map_err(|e| anyhow::anyhow!("invalid params: {e}"))?;
-
         if p.interval_seconds == 0 {
             return Err(anyhow::anyhow!("interval_seconds must be > 0"));
         }
@@ -225,60 +185,41 @@ impl AgentTool for ScheduleIntervalTool {
 // ScheduleCronTool
 // ============================================================================
 
+/// Tool for scheduling a future agent turn using a cron expression.
+#[derive(ToolDef)]
+#[tool(
+    name = "schedule-cron",
+    description = "Schedule a future agent turn using a 6-field cron expression: 'sec min hour \
+                   day month weekday'. `message` is the prompt that will be sent to the LLM \
+                   whenever the job fires, so write it like a user instruction and name any \
+                   required skills explicitly."
+)]
 pub struct ScheduleCronTool;
 
-impl ScheduleCronTool {
-    pub const NAME: &str = crate::tool_names::SCHEDULE_CRON;
-}
-
-#[derive(Debug, Deserialize)]
-struct ScheduleCronParams {
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct ScheduleCronParams {
+    /// 6-field cron expression: 'sec min hour day month weekday' (e.g. '0 0 9 *
+    /// * *' for daily at 9am UTC, '0 */5 * * * *' for every 5 minutes)
     cron:    String,
+    /// Prompt for the future scheduled agent. This is sent to the LLM whenever
+    /// the cron job fires, so write it like a user instruction; if a skill
+    /// should be used, name it explicitly.
     message: String,
+    /// Routing tags for task report notification matching
+    /// (e.g. `["pr_review", "repo:rararulab/rara"]`)
     #[serde(default)]
     tags:    Vec<String>,
 }
 
 #[async_trait]
-impl AgentTool for ScheduleCronTool {
-    fn name(&self) -> &str { Self::NAME }
+impl ToolExecute for ScheduleCronTool {
+    type Params = ScheduleCronParams;
 
-    fn description(&self) -> &str {
-        "Schedule a future agent turn using a 6-field cron expression: 'sec min hour day month \
-         weekday'. `message` is the prompt that will be sent to the LLM whenever the job fires, so \
-         write it like a user instruction and name any required skills explicitly."
-    }
-
-    fn parameters_schema(&self) -> serde_json::Value {
-        serde_json::json!({
-            "type": "object",
-            "required": ["cron", "message"],
-            "properties": {
-                "cron": {
-                    "type": "string",
-                    "description": "6-field cron expression: 'sec min hour day month weekday' (e.g. '0 0 9 * * *' for daily at 9am UTC, '0 */5 * * * *' for every 5 minutes)"
-                },
-                "message": {
-                    "type": "string",
-                    "description": "Prompt for the future scheduled agent. This is sent to the LLM whenever the cron job fires, so write it like a user instruction; if a skill should be used, name it explicitly."
-                },
-                "tags": {
-                    "type": "array",
-                    "items": { "type": "string" },
-                    "description": "Routing tags for task report notification matching (e.g. [\"pr_review\", \"repo:rararulab/rara\"])"
-                }
-            }
-        })
-    }
-
-    async fn execute(
+    async fn run(
         &self,
-        params: serde_json::Value,
+        p: ScheduleCronParams,
         context: &ToolContext,
     ) -> anyhow::Result<ToolOutput> {
-        let p: ScheduleCronParams =
-            serde_json::from_value(params).map_err(|e| anyhow::anyhow!("invalid params: {e}"))?;
-
         if p.cron.is_empty() {
             return Err(anyhow::anyhow!("cron expression must not be empty"));
         }
@@ -320,44 +261,28 @@ impl AgentTool for ScheduleCronTool {
 // ============================================================================
 
 /// Tool for removing a scheduled task by ID.
+#[derive(ToolDef)]
+#[tool(
+    name = "schedule-remove",
+    description = "Remove a previously scheduled task by its job ID."
+)]
 pub struct ScheduleRemoveTool;
 
-impl ScheduleRemoveTool {
-    pub const NAME: &str = crate::tool_names::SCHEDULE_REMOVE;
-}
-
-#[derive(Debug, Deserialize)]
-struct ScheduleRemoveParams {
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct ScheduleRemoveParams {
+    /// The ID of the job to remove
     job_id: String,
 }
 
 #[async_trait]
-impl AgentTool for ScheduleRemoveTool {
-    fn name(&self) -> &str { Self::NAME }
+impl ToolExecute for ScheduleRemoveTool {
+    type Params = ScheduleRemoveParams;
 
-    fn description(&self) -> &str { "Remove a previously scheduled task by its job ID." }
-
-    fn parameters_schema(&self) -> serde_json::Value {
-        serde_json::json!({
-            "type": "object",
-            "required": ["job_id"],
-            "properties": {
-                "job_id": {
-                    "type": "string",
-                    "description": "The ID of the job to remove"
-                }
-            }
-        })
-    }
-
-    async fn execute(
+    async fn run(
         &self,
-        params: serde_json::Value,
+        p: ScheduleRemoveParams,
         context: &ToolContext,
     ) -> anyhow::Result<ToolOutput> {
-        let p: ScheduleRemoveParams = serde_json::from_value(params)
-            .map_err(|e| anyhow::anyhow!("invalid schedule-remove params: {e}"))?;
-
         let event_queue = &context.event_queue;
         let session_key = context.session_key;
 
@@ -386,30 +311,18 @@ impl AgentTool for ScheduleRemoveTool {
 // ============================================================================
 
 /// Tool for listing all scheduled tasks across sessions.
+#[derive(ToolDef)]
+#[tool(
+    name = "schedule-list",
+    description = "List all scheduled tasks across sessions."
+)]
 pub struct ScheduleListTool;
 
-impl ScheduleListTool {
-    pub const NAME: &str = crate::tool_names::SCHEDULE_LIST;
-}
-
 #[async_trait]
-impl AgentTool for ScheduleListTool {
-    fn name(&self) -> &str { Self::NAME }
+impl ToolExecute for ScheduleListTool {
+    type Params = EmptyParams;
 
-    fn description(&self) -> &str { "List all scheduled tasks across sessions." }
-
-    fn parameters_schema(&self) -> serde_json::Value {
-        serde_json::json!({
-            "type": "object",
-            "properties": {}
-        })
-    }
-
-    async fn execute(
-        &self,
-        _params: serde_json::Value,
-        context: &ToolContext,
-    ) -> anyhow::Result<ToolOutput> {
+    async fn run(&self, _p: EmptyParams, context: &ToolContext) -> anyhow::Result<ToolOutput> {
         let event_queue = &context.event_queue;
         let session_key = context.session_key;
 

--- a/crates/kernel/src/tool/spawn_background.rs
+++ b/crates/kernel/src/tool/spawn_background.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use async_trait::async_trait;
+use rara_tool_macro::ToolDef;
 use serde_json::Value;
 use tracing::info;
 
@@ -21,7 +21,7 @@ use crate::{
     handle::KernelHandle,
     io::{AgentEvent, StreamEvent},
     session::{BackgroundTaskEntry, SessionKey},
-    tool::{AgentTool, ToolContext, ToolOutput},
+    tool::{ToolContext, ToolOutput},
 };
 
 /// Builtin tool that spawns a background agent for long-running tasks.
@@ -29,33 +29,29 @@ use crate::{
 /// The agent runs independently — the parent's turn continues and completes
 /// normally. When the background agent finishes, the kernel triggers a
 /// proactive turn on the parent to deliver the result.
+#[derive(ToolDef)]
+#[tool(
+    name = "spawn-background",
+    description = "Spawn a background agent to handle a long-running task. The agent runs \
+                   independently and results are delivered when complete. You cannot interact \
+                   with the background agent after spawning it.",
+    params_schema = "Self::schema()",
+    execute_fn = "self.exec"
+)]
 pub struct SpawnBackgroundTool {
     handle:      KernelHandle,
     session_key: SessionKey,
 }
 
 impl SpawnBackgroundTool {
-    pub const NAME: &str = crate::tool_names::SPAWN_BACKGROUND;
-
     pub fn new(handle: KernelHandle, session_key: SessionKey) -> Self {
         Self {
             handle,
             session_key,
         }
     }
-}
 
-#[async_trait]
-impl AgentTool for SpawnBackgroundTool {
-    fn name(&self) -> &str { Self::NAME }
-
-    fn description(&self) -> &str {
-        "Spawn a background agent to handle a long-running task. The agent runs independently and \
-         results are delivered when complete. You cannot interact with the background agent after \
-         spawning it."
-    }
-
-    fn parameters_schema(&self) -> Value {
+    fn schema() -> Value {
         serde_json::json!({
             "type": "object",
             "required": ["manifest", "input", "description"],
@@ -79,7 +75,7 @@ impl AgentTool for SpawnBackgroundTool {
         })
     }
 
-    async fn execute(&self, params: Value, context: &ToolContext) -> anyhow::Result<ToolOutput> {
+    async fn exec(&self, params: Value, context: &ToolContext) -> anyhow::Result<ToolOutput> {
         let input = params["input"]
             .as_str()
             .ok_or_else(|| anyhow::anyhow!("missing required field: input"))?

--- a/crates/kernel/src/tool/tape.rs
+++ b/crates/kernel/src/tool/tape.rs
@@ -22,7 +22,7 @@
 use std::sync::Arc;
 
 use anyhow::Context;
-use async_trait::async_trait;
+use rara_tool_macro::ToolDef;
 use serde::Deserialize;
 
 use crate::{
@@ -36,6 +36,62 @@ use crate::{
 /// and its description teaches the LLM how the tape memory model works so it
 /// can reason about its own context window, search past conversations, and
 /// create anchors to manage memory.
+#[derive(ToolDef)]
+#[tool(
+    name = "tape",
+    description = "Your memory is a tape — an append-only timeline that records every message, \
+                   tool call, and tool result in this session as sequential entries.\n\n## How \
+                   your context window works\n\nYou do NOT see the entire tape. Your LLM context \
+                   window only contains entries since the last anchor (checkpoint). Everything \
+                   before that anchor still exists on the tape and is fully searchable, but it is \
+                   not in your current context.\n\n## When to anchor\n\nCreate anchors based on \
+                   **topic/task transitions**, not context size:\n- The user switches to a \
+                   different topic or task\n- A task or conversation thread reaches a natural \
+                   conclusion\n- The user explicitly asks to move on\n\nUse `info` to check \
+                   `estimated_context_tokens` as a health indicator — if context is growing large \
+                   after recalling old data, that is a good time to anchor and \
+                   consolidate.\n\nWhen creating an anchor, use a descriptive name (e.g. \
+                   `topic/immich-setup`, `task/debug-lifetime`) and always provide a `summary` \
+                   and `next_steps`. These are injected into your context after the anchor so you \
+                   retain key information.\n\n## Recall: accessing past context\n\nWhen the user \
+                   refers to something from a previous topic or earlier conversation:\n1. Use \
+                   `anchors` to see your memory structure and find the relevant anchor\n2. Use \
+                   `between_anchors` to load the full context of that topic segment\n3. Or use \
+                   `search` to find specific information by keyword across the entire \
+                   tape\n\nData before an anchor is NOT deleted — it is always available for \
+                   recall. Your anchors are like bookmarks in a book: you read from the current \
+                   bookmark forward, but you can always flip back.\n\n## Entry kinds\n\nEach tape \
+                   entry has a kind: `message` (user/assistant chat), `tool_call` (your tool \
+                   invocations), `tool_result` (tool outputs), `event` (lifecycle telemetry), \
+                   `system` (system prompts), `anchor` (checkpoints).\n\n## Actions\n\n- `info` — \
+                   inspect tape state (entries, anchors, `estimated_context_tokens`)\n- `search` \
+                   — recall past information by keyword, works across all anchors\n- `anchor` — \
+                   create a named checkpoint when transitioning topics\n- `anchors` — list \
+                   checkpoints to find relevant past context\n- `entries` — read raw tape entries \
+                   in your current context window or after a specific anchor\n- `between_anchors` \
+                   — recall the full context of a specific past topic segment\n- `checkout` — \
+                   fork from a named anchor, creating a new session with context up to that \
+                   point\n- `checkout_root` — find and return to the root (original) session by \
+                   walking the fork chain. Use this when you or the user want to go back to the \
+                   main conversation after working in a forked session.\n\n### checkout in \
+                   detail\n\n**When to use**: The user wants to return to a past topic's state \
+                   and continue from there, or explore a different direction from a previous \
+                   checkpoint. For example, the user says \"let's go back to where we were \
+                   debugging that lifetime issue and try a different approach.\"\n\n**What \
+                   happens**: A new session is created containing all tape entries up to and \
+                   including the named anchor. The original session is untouched — nothing is \
+                   lost or overwritten. Your context window in the new session starts from that \
+                   anchor's state, so you can continue working as if you were back at that point \
+                   in time.\n\n**checkout vs between_anchors**: `between_anchors` is read-only \
+                   recall — you see past entries but stay in the current session and context. \
+                   `checkout` forks a new session where you actually continue working from that \
+                   earlier point. Use `between_anchors` when you just need to reference old \
+                   information; use `checkout` when the user wants to resume or diverge from a \
+                   past state. To return to the original session after checking out, use \
+                   `checkout_root`.",
+    params_schema = "Self::schema()",
+    execute_fn = "self.exec"
+)]
 pub(crate) struct TapeTool {
     tape_service: TapeService,
     tape_name:    String,
@@ -43,8 +99,6 @@ pub(crate) struct TapeTool {
 }
 
 impl TapeTool {
-    pub const NAME: &str = crate::tool_names::TAPE;
-
     pub fn new(
         tape_service: TapeService,
         tape_name: String,
@@ -55,6 +109,98 @@ impl TapeTool {
             tape_name,
             sessions,
         }
+    }
+
+    fn schema() -> serde_json::Value {
+        serde_json::json!({
+            "type": "object",
+            "required": ["action"],
+            "properties": {
+                "action": {
+                    "type": "string",
+                    "enum": ["info", "search", "anchor", "anchors", "entries", "between_anchors", "checkout", "checkout_root"],
+                    "description": "The tape operation to perform."
+                },
+                "query": {
+                    "type": "string",
+                    "description": "[search] Text to search for in past conversations. Uses ranked Unicode-aware matching across message payloads and metadata."
+                },
+                "name": {
+                    "type": "string",
+                    "description": "[anchor, checkout] Name for the checkpoint or anchor to fork from."
+                },
+                "summary": {
+                    "type": "string",
+                    "description": "[anchor] Summary of the conversation up to this point. Always provide this so you retain context after the anchor trims your window."
+                },
+                "next_steps": {
+                    "type": "string",
+                    "description": "[anchor] What should happen next. Helps you pick up where you left off after context is trimmed."
+                },
+                "state": {
+                    "description": "[anchor] Optional additional JSON state to attach to the checkpoint."
+                },
+                "limit": {
+                    "type": "integer",
+                    "description": "[search, anchors] Maximum number of results to return. Default: 10."
+                },
+                "after_anchor": {
+                    "type": "string",
+                    "description": "[entries] Read entries after this named anchor instead of the most recent one."
+                },
+                "start": {
+                    "type": "string",
+                    "description": "[between_anchors] Starting anchor name."
+                },
+                "end": {
+                    "type": "string",
+                    "description": "[between_anchors] Ending anchor name."
+                },
+                "kinds": {
+                    "type": "array",
+                    "items": {
+                        "type": "string",
+                        "enum": ["message", "tool_call", "tool_result", "event", "system", "anchor"]
+                    },
+                    "description": "[entries, between_anchors] Filter entries by kind."
+                }
+            }
+        })
+    }
+
+    async fn exec(
+        &self,
+        params: serde_json::Value,
+        _context: &super::ToolContext,
+    ) -> anyhow::Result<super::ToolOutput> {
+        let action: TapeParams = serde_json::from_value(params)
+            .map_err(|e| anyhow::anyhow!("invalid tape tool params: {e}"))?;
+
+        let json = match action {
+            TapeParams::Info => self.exec_info().await,
+            TapeParams::Search { query, limit } => self.exec_search(&query, limit).await,
+            TapeParams::Anchor {
+                name,
+                summary,
+                next_steps,
+                state,
+            } => {
+                self.exec_anchor(&name, summary.as_deref(), next_steps.as_deref(), state)
+                    .await
+            }
+            TapeParams::Anchors { limit } => self.exec_anchors(limit).await,
+            TapeParams::Entries {
+                after_anchor,
+                kinds,
+            } => self.exec_entries(after_anchor.as_deref(), kinds).await,
+            TapeParams::BetweenAnchors { start, end, kinds } => {
+                self.exec_between_anchors(&start, &end, kinds).await
+            }
+            TapeParams::Checkout { name } => self.exec_checkout(&name).await,
+            TapeParams::CheckoutRoot => self.exec_checkout_root().await,
+        }?;
+
+        Ok(json.into())
     }
 
     async fn exec_info(&self) -> anyhow::Result<serde_json::Value> {
@@ -294,151 +440,4 @@ enum TapeParams {
         name: String,
     },
     CheckoutRoot,
-}
-
-// ============================================================================
-// AgentTool impl
-// ============================================================================
-
-#[async_trait]
-impl super::AgentTool for TapeTool {
-    fn name(&self) -> &str { Self::NAME }
-
-    fn description(&self) -> &str {
-        "Your memory is a tape — an append-only timeline that records every message, tool call, \
-         and tool result in this session as sequential entries.\n\n## How your context window \
-         works\n\nYou do NOT see the entire tape. Your LLM context window only contains entries \
-         since the last anchor (checkpoint). Everything before that anchor still exists on the \
-         tape and is fully searchable, but it is not in your current context.\n\n## When to \
-         anchor\n\nCreate anchors based on **topic/task transitions**, not context size:\n- The \
-         user switches to a different topic or task\n- A task or conversation thread reaches a \
-         natural conclusion\n- The user explicitly asks to move on\n\nUse `info` to check \
-         `estimated_context_tokens` as a health indicator — if context is growing large after \
-         recalling old data, that is a good time to anchor and consolidate.\n\nWhen creating an \
-         anchor, use a descriptive name (e.g. `topic/immich-setup`, `task/debug-lifetime`) and \
-         always provide a `summary` and `next_steps`. These are injected into your context after \
-         the anchor so you retain key information.\n\n## Recall: accessing past context\n\nWhen \
-         the user refers to something from a previous topic or earlier conversation:\n1. Use \
-         `anchors` to see your memory structure and find the relevant anchor\n2. Use \
-         `between_anchors` to load the full context of that topic segment\n3. Or use `search` to \
-         find specific information by keyword across the entire tape\n\nData before an anchor is \
-         NOT deleted — it is always available for recall. Your anchors are like bookmarks in a \
-         book: you read from the current bookmark forward, but you can always flip back.\n\n## \
-         Entry kinds\n\nEach tape entry has a kind: `message` (user/assistant chat), `tool_call` \
-         (your tool invocations), `tool_result` (tool outputs), `event` (lifecycle telemetry), \
-         `system` (system prompts), `anchor` (checkpoints).\n\n## Actions\n\n- `info` — inspect \
-         tape state (entries, anchors, `estimated_context_tokens`)\n- `search` — recall past \
-         information by keyword, works across all anchors\n- `anchor` — create a named checkpoint \
-         when transitioning topics\n- `anchors` — list checkpoints to find relevant past \
-         context\n- `entries` — read raw tape entries in your current context window or after a \
-         specific anchor\n- `between_anchors` — recall the full context of a specific past topic \
-         segment\n- `checkout` — fork from a named anchor, creating a new session with context up \
-         to that point\n- `checkout_root` — find and return to the root (original) session by \
-         walking the fork chain. Use this when you or the user want to go back to the main \
-         conversation after working in a forked session.\n\n### checkout in detail\n\n**When to \
-         use**: The user wants to return to a past topic's state and continue from there, or \
-         explore a different direction from a previous checkpoint. For example, the user says \
-         \"let's go back to where we were debugging that lifetime issue and try a different \
-         approach.\"\n\n**What happens**: A new session is created containing all tape entries up \
-         to and including the named anchor. The original session is untouched — nothing is lost or \
-         overwritten. Your context window in the new session starts from that anchor's state, so \
-         you can continue working as if you were back at that point in time.\n\n**checkout vs \
-         between_anchors**: `between_anchors` is read-only recall — you see past entries but stay \
-         in the current session and context. `checkout` forks a new session where you actually \
-         continue working from that earlier point. Use `between_anchors` when you just need to \
-         reference old information; use `checkout` when the user wants to resume or diverge from a \
-         past state. To return to the original session after checking out, use `checkout_root`."
-    }
-
-    fn parameters_schema(&self) -> serde_json::Value {
-        serde_json::json!({
-            "type": "object",
-            "required": ["action"],
-            "properties": {
-                "action": {
-                    "type": "string",
-                    "enum": ["info", "search", "anchor", "anchors", "entries", "between_anchors", "checkout", "checkout_root"],
-                    "description": "The tape operation to perform."
-                },
-                "query": {
-                    "type": "string",
-                    "description": "[search] Text to search for in past conversations. Uses ranked Unicode-aware matching across message payloads and metadata."
-                },
-                "name": {
-                    "type": "string",
-                    "description": "[anchor, checkout] Name for the checkpoint or anchor to fork from."
-                },
-                "summary": {
-                    "type": "string",
-                    "description": "[anchor] Summary of the conversation up to this point. Always provide this so you retain context after the anchor trims your window."
-                },
-                "next_steps": {
-                    "type": "string",
-                    "description": "[anchor] What should happen next. Helps you pick up where you left off after context is trimmed."
-                },
-                "state": {
-                    "description": "[anchor] Optional additional JSON state to attach to the checkpoint."
-                },
-                "limit": {
-                    "type": "integer",
-                    "description": "[search, anchors] Maximum number of results to return. Default: 10."
-                },
-                "after_anchor": {
-                    "type": "string",
-                    "description": "[entries] Read entries after this named anchor instead of the most recent one."
-                },
-                "start": {
-                    "type": "string",
-                    "description": "[between_anchors] Starting anchor name."
-                },
-                "end": {
-                    "type": "string",
-                    "description": "[between_anchors] Ending anchor name."
-                },
-                "kinds": {
-                    "type": "array",
-                    "items": {
-                        "type": "string",
-                        "enum": ["message", "tool_call", "tool_result", "event", "system", "anchor"]
-                    },
-                    "description": "[entries, between_anchors] Filter entries by kind."
-                }
-            }
-        })
-    }
-
-    async fn execute(
-        &self,
-        params: serde_json::Value,
-        _context: &super::ToolContext,
-    ) -> anyhow::Result<super::ToolOutput> {
-        let action: TapeParams = serde_json::from_value(params)
-            .map_err(|e| anyhow::anyhow!("invalid tape tool params: {e}"))?;
-
-        let json = match action {
-            TapeParams::Info => self.exec_info().await,
-            TapeParams::Search { query, limit } => self.exec_search(&query, limit).await,
-            TapeParams::Anchor {
-                name,
-                summary,
-                next_steps,
-                state,
-            } => {
-                self.exec_anchor(&name, summary.as_deref(), next_steps.as_deref(), state)
-                    .await
-            }
-            TapeParams::Anchors { limit } => self.exec_anchors(limit).await,
-            TapeParams::Entries {
-                after_anchor,
-                kinds,
-            } => self.exec_entries(after_anchor.as_deref(), kinds).await,
-            TapeParams::BetweenAnchors { start, end, kinds } => {
-                self.exec_between_anchors(&start, &end, kinds).await
-            }
-            TapeParams::Checkout { name } => self.exec_checkout(&name).await,
-            TapeParams::CheckoutRoot => self.exec_checkout_root().await,
-        }?;
-
-        Ok(json.into())
-    }
 }


### PR DESCRIPTION
## Summary
- Migrate 10 kernel tools to `#[derive(ToolDef)]`
- **Full auto mode** (ToolDef + ToolExecute): schedule.rs (5), cancel_background.rs, create_plan.rs
- **Override mode** (params_schema + execute_fn): spawn_background.rs, fold_branch.rs, tape.rs
- Net -120 lines: eliminated hand-written JSON Schema and boilerplate `impl AgentTool`

**PR 2 of 4** in the tool derive macro stacked PR series. Base: `issue-509-tool-macro-infra` (PR #514).

Closes #510

## Test plan
- [x] `cargo check -p rara-kernel` passes
- [x] `cargo test -p rara-kernel` — all 125+ tests pass
- [x] `cargo clippy` clean
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)