### PR TITLE
refactor(kernel): migrate browser tools to ToolDef derive macro (#511)

### DIFF
--- a/crates/kernel/src/tool/browser/click.rs
+++ b/crates/kernel/src/tool/browser/click.rs
@@ -14,42 +14,31 @@
 
 //! Click an element in the active browser page.
 
-use async_trait::async_trait;
+use rara_tool_macro::ToolDef;
 use serde::Deserialize;
 
 use crate::{
     browser::BrowserManagerRef,
-    tool::{AgentTool, ToolContext, ToolOutput},
+    tool::{ToolContext, ToolOutput},
 };
 
 /// Click an element identified by its ref ID from the accessibility snapshot.
+#[derive(ToolDef)]
+#[tool(
+    name = "browser-click",
+    description = "Click an element on the page using its ref ID from the accessibility snapshot. \
+                   Returns a fresh snapshot after clicking.",
+    params_schema = "Self::schema()",
+    execute_fn = "self.exec"
+)]
 pub struct BrowserClickTool {
     manager: BrowserManagerRef,
 }
 
 impl BrowserClickTool {
-    pub const NAME: &str = crate::tool_names::BROWSER_CLICK;
-
     pub fn new(manager: BrowserManagerRef) -> Self { Self { manager } }
-}
 
-#[derive(Debug, Deserialize)]
-struct Params {
-    r#ref:   String,
-    #[serde(default)]
-    element: Option<String>,
-}
-
-#[async_trait]
-impl AgentTool for BrowserClickTool {
-    fn name(&self) -> &str { Self::NAME }
-
-    fn description(&self) -> &str {
-        "Click an element on the page using its ref ID from the accessibility snapshot. Returns a \
-         fresh snapshot after clicking."
-    }
-
-    fn parameters_schema(&self) -> serde_json::Value {
+    fn schema() -> serde_json::Value {
         serde_json::json!({
             "type": "object",
             "required": ["ref"],
@@ -66,7 +55,7 @@ impl AgentTool for BrowserClickTool {
         })
     }
 
-    async fn execute(
+    async fn exec(
         &self,
         params: serde_json::Value,
         _context: &ToolContext,
@@ -82,4 +71,11 @@ impl AgentTool for BrowserClickTool {
 
         Ok(serde_json::json!({ "snapshot": snapshot }).into())
     }
+}
+
+#[derive(Debug, Deserialize)]
+struct Params {
+    r#ref:   String,
+    #[serde(default)]
+    element: Option<String>,
 }

--- a/crates/kernel/src/tool/browser/close.rs
+++ b/crates/kernel/src/tool/browser/close.rs
@@ -14,38 +14,36 @@
 
 //! Close all browser tabs.
 
-use async_trait::async_trait;
+use rara_tool_macro::ToolDef;
 
 use crate::{
     browser::BrowserManagerRef,
-    tool::{AgentTool, ToolContext, ToolOutput},
+    tool::{ToolContext, ToolOutput},
 };
 
 /// Close all browser tabs and reset the browser state.
+#[derive(ToolDef)]
+#[tool(
+    name = "browser-close",
+    description = "Close all browser tabs and reset the browser state.",
+    params_schema = "Self::schema()",
+    execute_fn = "self.exec"
+)]
 pub struct BrowserCloseTool {
     manager: BrowserManagerRef,
 }
 
 impl BrowserCloseTool {
-    pub const NAME: &str = crate::tool_names::BROWSER_CLOSE;
-
     pub fn new(manager: BrowserManagerRef) -> Self { Self { manager } }
-}
 
-#[async_trait]
-impl AgentTool for BrowserCloseTool {
-    fn name(&self) -> &str { Self::NAME }
-
-    fn description(&self) -> &str { "Close all browser tabs and reset the browser state." }
-
-    fn parameters_schema(&self) -> serde_json::Value {
+    fn schema() -> serde_json::Value {
         serde_json::json!({
             "type": "object",
             "properties": {}
         })
     }
 
-    async fn execute(
+    async fn exec(
         &self,
         _params: serde_json::Value,
         _context: &ToolContext,

--- a/crates/kernel/src/tool/browser/console.rs
+++ b/crates/kernel/src/tool/browser/console.rs
@@ -14,34 +14,30 @@
 
 //! Retrieve browser console messages (stub — not yet implemented).
 
-use async_trait::async_trait;
+use rara_tool_macro::ToolDef;
 
-use crate::tool::{AgentTool, ToolContext, ToolOutput};
+use crate::tool::{ToolContext, ToolOutput};
 
 /// Retrieve console.log/warn/error messages from the browser. Stub — pending
 /// Lightpanda support.
+#[derive(ToolDef)]
+#[tool(
+    name = "browser-console-messages",
+    description = "Retrieve console messages (log, warn, error) from the browser page.",
+    params_schema = "Self::schema()",
+    execute_fn = "self.exec"
+)]
 pub struct BrowserConsoleMessagesTool;
 
 impl BrowserConsoleMessagesTool {
-    pub const NAME: &str = crate::tool_names::BROWSER_CONSOLE_MESSAGES;
-}
-
-#[async_trait]
-impl AgentTool for BrowserConsoleMessagesTool {
-    fn name(&self) -> &str { Self::NAME }
-
-    fn description(&self) -> &str {
-        "Retrieve console messages (log, warn, error) from the browser page."
-    }
-
-    fn parameters_schema(&self) -> serde_json::Value {
+    fn schema() -> serde_json::Value {
         serde_json::json!({
             "type": "object",
             "properties": {}
         })
     }
 
-    async fn execute(
+    async fn exec(
         &self,
         _params: serde_json::Value,
         _context: &ToolContext,

--- a/crates/kernel/src/tool/browser/drag.rs
+++ b/crates/kernel/src/tool/browser/drag.rs
@@ -14,25 +14,23 @@
 
 //! Drag an element (stub — not yet implemented).
 
-use async_trait::async_trait;
+use rara_tool_macro::ToolDef;
 
-use crate::tool::{AgentTool, ToolContext, ToolOutput};
+use crate::tool::{ToolContext, ToolOutput};
 
 /// Drag an element from one position to another. Stub — pending Lightpanda
 /// support.
+#[derive(ToolDef)]
+#[tool(
+    name = "browser-drag",
+    description = "Drag an element from one position to another on the page.",
+    params_schema = "Self::schema()",
+    execute_fn = "self.exec"
+)]
 pub struct BrowserDragTool;
 
 impl BrowserDragTool {
-    pub const NAME: &str = crate::tool_names::BROWSER_DRAG;
-}
-
-#[async_trait]
-impl AgentTool for BrowserDragTool {
-    fn name(&self) -> &str { Self::NAME }
-
-    fn description(&self) -> &str { "Drag an element from one position to another on the page." }
-
-    fn parameters_schema(&self) -> serde_json::Value {
+    fn schema() -> serde_json::Value {
         serde_json::json!({
             "type": "object",
             "required": ["startRef", "endRef"],
@@ -49,7 +47,7 @@ impl AgentTool for BrowserDragTool {
         })
     }
 
-    async fn execute(
+    async fn exec(
         &self,
         _params: serde_json::Value,
         _context: &ToolContext,

--- a/crates/kernel/src/tool/browser/evaluate.rs
+++ b/crates/kernel/src/tool/browser/evaluate.rs
@@ -14,39 +14,31 @@
 
 //! Evaluate a JavaScript expression in the active browser page.
 
-use async_trait::async_trait;
+use rara_tool_macro::ToolDef;
 use serde::Deserialize;
 
 use crate::{
     browser::BrowserManagerRef,
-    tool::{AgentTool, ToolContext, ToolOutput},
+    tool::{ToolContext, ToolOutput},
 };
 
 /// Evaluate a JavaScript expression and return the result.
+#[derive(ToolDef)]
+#[tool(
+    name = "browser-evaluate",
+    description = "Evaluate a JavaScript expression in the active browser page and return the \
+                   result.",
+    params_schema = "Self::schema()",
+    execute_fn = "self.exec"
+)]
 pub struct BrowserEvaluateTool {
     manager: BrowserManagerRef,
 }
 
 impl BrowserEvaluateTool {
-    pub const NAME: &str = crate::tool_names::BROWSER_EVALUATE;
-
     pub fn new(manager: BrowserManagerRef) -> Self { Self { manager } }
-}
 
-#[derive(Debug, Deserialize)]
-struct Params {
-    expression: String,
-}
-
-#[async_trait]
-impl AgentTool for BrowserEvaluateTool {
-    fn name(&self) -> &str { Self::NAME }
-
-    fn description(&self) -> &str {
-        "Evaluate a JavaScript expression in the active browser page and return the result."
-    }
-
-    fn parameters_schema(&self) -> serde_json::Value {
+    fn schema() -> serde_json::Value {
         serde_json::json!({
             "type": "object",
             "required": ["expression"],
@@ -59,7 +51,7 @@ impl AgentTool for BrowserEvaluateTool {
         })
     }
 
-    async fn execute(
+    async fn exec(
         &self,
         params: serde_json::Value,
         _context: &ToolContext,
@@ -75,4 +67,9 @@ impl AgentTool for BrowserEvaluateTool {
 
         Ok(serde_json::json!({ "result": result }).into())
     }
+}
+
+#[derive(Debug, Deserialize)]
+struct Params {
+    expression: String,
 }

--- a/crates/kernel/src/tool/browser/fill_form.rs
+++ b/crates/kernel/src/tool/browser/fill_form.rs
@@ -14,26 +14,22 @@
 
 //! Fill a form with multiple values (stub — not yet implemented).
 
-use async_trait::async_trait;
+use rara_tool_macro::ToolDef;
 
-use crate::tool::{AgentTool, ToolContext, ToolOutput};
+use crate::tool::{ToolContext, ToolOutput};
 
 /// Fill multiple form fields at once. Stub — pending Lightpanda support.
+#[derive(ToolDef)]
+#[tool(
+    name = "browser-fill-form",
+    description = "Fill multiple form fields at once by providing a mapping of ref IDs to values.",
+    params_schema = "Self::schema()",
+    execute_fn = "self.exec"
+)]
 pub struct BrowserFillFormTool;
 
 impl BrowserFillFormTool {
-    pub const NAME: &str = crate::tool_names::BROWSER_FILL_FORM;
-}
-
-#[async_trait]
-impl AgentTool for BrowserFillFormTool {
-    fn name(&self) -> &str { Self::NAME }
-
-    fn description(&self) -> &str {
-        "Fill multiple form fields at once by providing a mapping of ref IDs to values."
-    }
-
-    fn parameters_schema(&self) -> serde_json::Value {
+    fn schema() -> serde_json::Value {
         serde_json::json!({
             "type": "object",
             "required": ["fields"],
@@ -50,7 +46,7 @@ impl AgentTool for BrowserFillFormTool {
         })
     }
 
-    async fn execute(
+    async fn exec(
         &self,
         _params: serde_json::Value,
         _context: &ToolContext,

--- a/crates/kernel/src/tool/browser/handle_dialog.rs
+++ b/crates/kernel/src/tool/browser/handle_dialog.rs
@@ -14,27 +14,24 @@
 
 //! Handle a browser dialog (stub — not yet implemented).
 
-use async_trait::async_trait;
+use rara_tool_macro::ToolDef;
 
-use crate::tool::{AgentTool, ToolContext, ToolOutput};
+use crate::tool::{ToolContext, ToolOutput};
 
 /// Handle a browser dialog (alert, confirm, prompt). Stub — pending Lightpanda
 /// support.
+#[derive(ToolDef)]
+#[tool(
+    name = "browser-handle-dialog",
+    description = "Handle a JavaScript dialog (alert, confirm, prompt) by accepting or dismissing \
+                   it.",
+    params_schema = "Self::schema()",
+    execute_fn = "self.exec"
+)]
 pub struct BrowserHandleDialogTool;
 
 impl BrowserHandleDialogTool {
-    pub const NAME: &str = crate::tool_names::BROWSER_HANDLE_DIALOG;
-}
-
-#[async_trait]
-impl AgentTool for BrowserHandleDialogTool {
-    fn name(&self) -> &str { Self::NAME }
-
-    fn description(&self) -> &str {
-        "Handle a JavaScript dialog (alert, confirm, prompt) by accepting or dismissing it."
-    }
-
-    fn parameters_schema(&self) -> serde_json::Value {
+    fn schema() -> serde_json::Value {
         serde_json::json!({
             "type": "object",
             "required": ["action"],
@@ -52,7 +49,7 @@ impl AgentTool for BrowserHandleDialogTool {
         })
     }
 
-    async fn execute(
+    async fn exec(
         &self,
         _params: serde_json::Value,
         _context: &ToolContext,

--- a/crates/kernel/src/tool/browser/hover.rs
+++ b/crates/kernel/src/tool/browser/hover.rs
@@ -14,24 +14,22 @@
 
 //! Hover over an element (stub — not yet implemented).
 
-use async_trait::async_trait;
+use rara_tool_macro::ToolDef;
 
-use crate::tool::{AgentTool, ToolContext, ToolOutput};
+use crate::tool::{ToolContext, ToolOutput};
 
 /// Hover over an element by ref ID. Stub — pending Lightpanda support.
+#[derive(ToolDef)]
+#[tool(
+    name = "browser-hover",
+    description = "Hover over an element on the page using its ref ID.",
+    params_schema = "Self::schema()",
+    execute_fn = "self.exec"
+)]
 pub struct BrowserHoverTool;
 
 impl BrowserHoverTool {
-    pub const NAME: &str = crate::tool_names::BROWSER_HOVER;
-}
-
-#[async_trait]
-impl AgentTool for BrowserHoverTool {
-    fn name(&self) -> &str { Self::NAME }
-
-    fn description(&self) -> &str { "Hover over an element on the page using its ref ID." }
-
-    fn parameters_schema(&self) -> serde_json::Value {
+    fn schema() -> serde_json::Value {
         serde_json::json!({
             "type": "object",
             "required": ["ref"],
@@ -48,7 +46,7 @@ impl AgentTool for BrowserHoverTool {
         })
     }
 
-    async fn execute(
+    async fn exec(
         &self,
         _params: serde_json::Value,
         _context: &ToolContext,

--- a/crates/kernel/src/tool/browser/navigate.rs
+++ b/crates/kernel/src/tool/browser/navigate.rs
@@ -14,40 +14,31 @@
 
 //! Navigate to a URL in the browser.
 
-use async_trait::async_trait;
+use rara_tool_macro::ToolDef;
 use serde::Deserialize;
 
 use crate::{
     browser::BrowserManagerRef,
-    tool::{AgentTool, ToolContext, ToolOutput},
+    tool::{ToolContext, ToolOutput},
 };
 
 /// Navigate to a URL, returning the page title and accessibility snapshot.
+#[derive(ToolDef)]
+#[tool(
+    name = "browser-navigate",
+    description = "Navigate to a URL in the browser. Returns the page title and an accessibility \
+                   snapshot of the page content.",
+    params_schema = "Self::schema()",
+    execute_fn = "self.exec"
+)]
 pub struct BrowserNavigateTool {
     manager: BrowserManagerRef,
 }
 
 impl BrowserNavigateTool {
-    pub const NAME: &str = crate::tool_names::BROWSER_NAVIGATE;
-
     pub fn new(manager: BrowserManagerRef) -> Self { Self { manager } }
-}
 
-#[derive(Debug, Deserialize)]
-struct Params {
-    url: String,
-}
-
-#[async_trait]
-impl AgentTool for BrowserNavigateTool {
-    fn name(&self) -> &str { Self::NAME }
-
-    fn description(&self) -> &str {
-        "Navigate to a URL in the browser. Returns the page title and an accessibility snapshot of \
-         the page content."
-    }
-
-    fn parameters_schema(&self) -> serde_json::Value {
+    fn schema() -> serde_json::Value {
         serde_json::json!({
             "type": "object",
             "required": ["url"],
@@ -60,7 +51,7 @@ impl AgentTool for BrowserNavigateTool {
         })
     }
 
-    async fn execute(
+    async fn exec(
         &self,
         params: serde_json::Value,
         _context: &ToolContext,
@@ -82,4 +73,9 @@ impl AgentTool for BrowserNavigateTool {
         })
         .into())
     }
+}
+
+#[derive(Debug, Deserialize)]
+struct Params {
+    url: String,
 }

--- a/crates/kernel/src/tool/browser/navigate_back.rs
+++ b/crates/kernel/src/tool/browser/navigate_back.rs
@@ -14,40 +14,37 @@
 
 //! Navigate back in the active browser tab.
 
-use async_trait::async_trait;
+use rara_tool_macro::ToolDef;
 
 use crate::{
     browser::BrowserManagerRef,
-    tool::{AgentTool, ToolContext, ToolOutput},
+    tool::{ToolContext, ToolOutput},
 };
 
 /// Navigate back in the active tab's history.
+#[derive(ToolDef)]
+#[tool(
+    name = "browser-navigate-back",
+    description = "Navigate back in the active browser tab. Returns a fresh accessibility \
+                   snapshot.",
+    params_schema = "Self::schema()",
+    execute_fn = "self.exec"
+)]
 pub struct BrowserNavigateBackTool {
     manager: BrowserManagerRef,
 }
 
 impl BrowserNavigateBackTool {
-    pub const NAME: &str = crate::tool_names::BROWSER_NAVIGATE_BACK;
-
     pub fn new(manager: BrowserManagerRef) -> Self { Self { manager } }
-}
 
-#[async_trait]
-impl AgentTool for BrowserNavigateBackTool {
-    fn name(&self) -> &str { Self::NAME }
-
-    fn description(&self) -> &str {
-        "Navigate back in the active browser tab. Returns a fresh accessibility snapshot."
-    }
-
-    fn parameters_schema(&self) -> serde_json::Value {
+    fn schema() -> serde_json::Value {
         serde_json::json!({
             "type": "object",
             "properties": {}
         })
     }
 
-    async fn execute(
+    async fn exec(
         &self,
         _params: serde_json::Value,
         _context: &ToolContext,

--- a/crates/kernel/src/tool/browser/network.rs
+++ b/crates/kernel/src/tool/browser/network.rs
@@ -14,35 +14,31 @@
 
 //! Retrieve browser network requests (stub — not yet implemented).
 
-use async_trait::async_trait;
+use rara_tool_macro::ToolDef;
 
-use crate::tool::{AgentTool, ToolContext, ToolOutput};
+use crate::tool::{ToolContext, ToolOutput};
 
 /// Retrieve network requests made by the browser page. Stub — pending
 /// Lightpanda support.
+#[derive(ToolDef)]
+#[tool(
+    name = "browser-network-requests",
+    description = "Retrieve network requests made by the browser page, including URLs, methods, \
+                   and status codes.",
+    params_schema = "Self::schema()",
+    execute_fn = "self.exec"
+)]
 pub struct BrowserNetworkRequestsTool;
 
 impl BrowserNetworkRequestsTool {
-    pub const NAME: &str = crate::tool_names::BROWSER_NETWORK_REQUESTS;
-}
-
-#[async_trait]
-impl AgentTool for BrowserNetworkRequestsTool {
-    fn name(&self) -> &str { Self::NAME }
-
-    fn description(&self) -> &str {
-        "Retrieve network requests made by the browser page, including URLs, methods, and status \
-         codes."
-    }
-
-    fn parameters_schema(&self) -> serde_json::Value {
+    fn schema() -> serde_json::Value {
         serde_json::json!({
             "type": "object",
             "properties": {}
         })
     }
 
-    async fn execute(
+    async fn exec(
         &self,
         _params: serde_json::Value,
         _context: &ToolContext,

--- a/crates/kernel/src/tool/browser/press_key.rs
+++ b/crates/kernel/src/tool/browser/press_key.rs
@@ -14,40 +14,31 @@
 
 //! Press a keyboard key in the active browser page.
 
-use async_trait::async_trait;
+use rara_tool_macro::ToolDef;
 use serde::Deserialize;
 
 use crate::{
     browser::BrowserManagerRef,
-    tool::{AgentTool, ToolContext, ToolOutput},
+    tool::{ToolContext, ToolOutput},
 };
 
 /// Press a keyboard key (e.g. Enter, Escape, ArrowDown) in the active page.
+#[derive(ToolDef)]
+#[tool(
+    name = "browser-press-key",
+    description = "Press a keyboard key in the active browser page. Use key names like 'Enter', \
+                   'Escape', 'Tab', 'ArrowDown', etc.",
+    params_schema = "Self::schema()",
+    execute_fn = "self.exec"
+)]
 pub struct BrowserPressKeyTool {
     manager: BrowserManagerRef,
 }
 
 impl BrowserPressKeyTool {
-    pub const NAME: &str = crate::tool_names::BROWSER_PRESS_KEY;
-
     pub fn new(manager: BrowserManagerRef) -> Self { Self { manager } }
-}
 
-#[derive(Debug, Deserialize)]
-struct Params {
-    key: String,
-}
-
-#[async_trait]
-impl AgentTool for BrowserPressKeyTool {
-    fn name(&self) -> &str { Self::NAME }
-
-    fn description(&self) -> &str {
-        "Press a keyboard key in the active browser page. Use key names like 'Enter', 'Escape', \
-         'Tab', 'ArrowDown', etc."
-    }
-
-    fn parameters_schema(&self) -> serde_json::Value {
+    fn schema() -> serde_json::Value {
         serde_json::json!({
             "type": "object",
             "required": ["key"],
@@ -60,7 +51,7 @@ impl AgentTool for BrowserPressKeyTool {
         })
     }
 
-    async fn execute(
+    async fn exec(
         &self,
         params: serde_json::Value,
         _context: &ToolContext,
@@ -75,4 +66,9 @@ impl AgentTool for BrowserPressKeyTool {
 
         Ok(serde_json::json!({ "status": "ok" }).into())
     }
+}
+
+#[derive(Debug, Deserialize)]
+struct Params {
+    key: String,
 }

--- a/crates/kernel/src/tool/browser/select_option.rs
+++ b/crates/kernel/src/tool/browser/select_option.rs
@@ -14,26 +14,22 @@
 
 //! Select an option from a dropdown (stub — not yet implemented).
 
-use async_trait::async_trait;
+use rara_tool_macro::ToolDef;
 
-use crate::tool::{AgentTool, ToolContext, ToolOutput};
+use crate::tool::{ToolContext, ToolOutput};
 
 /// Select an option from a dropdown element. Stub — pending Lightpanda support.
+#[derive(ToolDef)]
+#[tool(
+    name = "browser-select-option",
+    description = "Select an option from a dropdown (select) element on the page.",
+    params_schema = "Self::schema()",
+    execute_fn = "self.exec"
+)]
 pub struct BrowserSelectOptionTool;
 
 impl BrowserSelectOptionTool {
-    pub const NAME: &str = crate::tool_names::BROWSER_SELECT_OPTION;
-}
-
-#[async_trait]
-impl AgentTool for BrowserSelectOptionTool {
-    fn name(&self) -> &str { Self::NAME }
-
-    fn description(&self) -> &str {
-        "Select an option from a dropdown (select) element on the page."
-    }
-
-    fn parameters_schema(&self) -> serde_json::Value {
+    fn schema() -> serde_json::Value {
         serde_json::json!({
             "type": "object",
             "required": ["ref", "values"],
@@ -51,7 +47,7 @@ impl AgentTool for BrowserSelectOptionTool {
         })
     }
 
-    async fn execute(
+    async fn exec(
         &self,
         _params: serde_json::Value,
         _context: &ToolContext,

--- a/crates/kernel/src/tool/browser/snapshot.rs
+++ b/crates/kernel/src/tool/browser/snapshot.rs
@@ -14,41 +14,38 @@
 
 //! Take an accessibility tree snapshot of the active page.
 
-use async_trait::async_trait;
+use rara_tool_macro::ToolDef;
 
 use crate::{
     browser::BrowserManagerRef,
-    tool::{AgentTool, ToolContext, ToolOutput},
+    tool::{ToolContext, ToolOutput},
 };
 
 /// Capture a fresh accessibility tree snapshot of the active browser page.
+#[derive(ToolDef)]
+#[tool(
+    name = "browser-snapshot",
+    description = "Take an accessibility snapshot of the current page without performing any \
+                   action. Use this to inspect the page content after waiting or to refresh your \
+                   view.",
+    params_schema = "Self::schema()",
+    execute_fn = "self.exec"
+)]
 pub struct BrowserSnapshotTool {
     manager: BrowserManagerRef,
 }
 
 impl BrowserSnapshotTool {
-    pub const NAME: &str = crate::tool_names::BROWSER_SNAPSHOT;
-
     pub fn new(manager: BrowserManagerRef) -> Self { Self { manager } }
-}
 
-#[async_trait]
-impl AgentTool for BrowserSnapshotTool {
-    fn name(&self) -> &str { Self::NAME }
-
-    fn description(&self) -> &str {
-        "Take an accessibility snapshot of the current page without performing any action. Use \
-         this to inspect the page content after waiting or to refresh your view."
-    }
-
-    fn parameters_schema(&self) -> serde_json::Value {
+    fn schema() -> serde_json::Value {
         serde_json::json!({
             "type": "object",
             "properties": {}
         })
     }
 
-    async fn execute(
+    async fn exec(
         &self,
         _params: serde_json::Value,
         _context: &ToolContext,

--- a/crates/kernel/src/tool/browser/tabs.rs
+++ b/crates/kernel/src/tool/browser/tabs.rs
@@ -14,55 +14,32 @@
 
 //! Manage browser tabs — list, select, close, or create new tabs.
 
-use async_trait::async_trait;
+use rara_tool_macro::ToolDef;
 use serde::Deserialize;
 
 use crate::{
     browser::BrowserManagerRef,
-    tool::{AgentTool, ToolContext, ToolOutput},
+    tool::{ToolContext, ToolOutput},
 };
 
 /// Manage browser tabs: list, select, close, or create new tabs.
+#[derive(ToolDef)]
+#[tool(
+    name = "browser-tabs",
+    description = "Manage browser tabs. Actions: 'list' — list all tabs; 'select' — switch to a \
+                   tab by index; 'close' — close a tab by index (or the active tab); 'new' — open \
+                   a new blank tab.",
+    params_schema = "Self::schema()",
+    execute_fn = "self.exec"
+)]
 pub struct BrowserTabsTool {
     manager: BrowserManagerRef,
 }
 
 impl BrowserTabsTool {
-    pub const NAME: &str = crate::tool_names::BROWSER_TABS;
-
     pub fn new(manager: BrowserManagerRef) -> Self { Self { manager } }
-}
 
-#[derive(Debug, Deserialize)]
-struct Params {
-    action: String,
-    #[serde(default)]
-    index:  Option<usize>,
-}
-
-/// Serialize a list of tabs into JSON.
-fn tabs_json(tabs: &[crate::browser::TabInfo]) -> Vec<serde_json::Value> {
-    tabs.iter()
-        .map(|t| {
-            serde_json::json!({
-                "index": t.index,
-                "tab_id": t.tab_id,
-                "is_active": t.is_active,
-            })
-        })
-        .collect()
-}
-
-#[async_trait]
-impl AgentTool for BrowserTabsTool {
-    fn name(&self) -> &str { Self::NAME }
-
-    fn description(&self) -> &str {
-        "Manage browser tabs. Actions: 'list' — list all tabs; 'select' — switch to a tab by \
-         index; 'close' — close a tab by index (or the active tab); 'new' — open a new blank tab."
-    }
-
-    fn parameters_schema(&self) -> serde_json::Value {
+    fn schema() -> serde_json::Value {
         serde_json::json!({
             "type": "object",
             "required": ["action"],
@@ -80,7 +57,7 @@ impl AgentTool for BrowserTabsTool {
         })
     }
 
-    async fn execute(
+    async fn exec(
         &self,
         params: serde_json::Value,
         _context: &ToolContext,
@@ -131,4 +108,24 @@ impl AgentTool for BrowserTabsTool {
             )),
         }
     }
+}
+
+#[derive(Debug, Deserialize)]
+struct Params {
+    action: String,
+    #[serde(default)]
+    index:  Option<usize>,
+}
+
+/// Serialize a list of tabs into JSON.
+fn tabs_json(tabs: &[crate::browser::TabInfo]) -> Vec<serde_json::Value> {
+    tabs.iter()
+        .map(|t| {
+            serde_json::json!({
+                "index": t.index,
+                "tab_id": t.tab_id,
+                "is_active": t.is_active,
+            })
+        })
+        .collect()
 }

--- a/crates/kernel/src/tool/browser/type_text.rs
+++ b/crates/kernel/src/tool/browser/type_text.rs
@@ -14,45 +14,31 @@
 
 //! Type text into an element in the active browser page.
 
-use async_trait::async_trait;
+use rara_tool_macro::ToolDef;
 use serde::Deserialize;
 
 use crate::{
     browser::BrowserManagerRef,
-    tool::{AgentTool, ToolContext, ToolOutput},
+    tool::{ToolContext, ToolOutput},
 };
 
 /// Type text into an input element identified by its ref ID.
+#[derive(ToolDef)]
+#[tool(
+    name = "browser-type",
+    description = "Type text into an input element on the page. Optionally submit the form by \
+                   pressing Enter after typing.",
+    params_schema = "Self::schema()",
+    execute_fn = "self.exec"
+)]
 pub struct BrowserTypeTool {
     manager: BrowserManagerRef,
 }
 
 impl BrowserTypeTool {
-    pub const NAME: &str = crate::tool_names::BROWSER_TYPE;
-
     pub fn new(manager: BrowserManagerRef) -> Self { Self { manager } }
-}
 
-#[derive(Debug, Deserialize)]
-struct Params {
-    r#ref:   String,
-    text:    String,
-    #[serde(default)]
-    submit:  bool,
-    #[serde(default)]
-    element: Option<String>,
-}
-
-#[async_trait]
-impl AgentTool for BrowserTypeTool {
-    fn name(&self) -> &str { Self::NAME }
-
-    fn description(&self) -> &str {
-        "Type text into an input element on the page. Optionally submit the form by pressing Enter \
-         after typing."
-    }
-
-    fn parameters_schema(&self) -> serde_json::Value {
+    fn schema() -> serde_json::Value {
         serde_json::json!({
             "type": "object",
             "required": ["ref", "text"],
@@ -77,7 +63,7 @@ impl AgentTool for BrowserTypeTool {
         })
     }
 
-    async fn execute(
+    async fn exec(
         &self,
         params: serde_json::Value,
         _context: &ToolContext,
@@ -93,4 +79,14 @@ impl AgentTool for BrowserTypeTool {
 
         Ok(serde_json::json!({ "snapshot": snapshot }).into())
     }
+}
+
+#[derive(Debug, Deserialize)]
+struct Params {
+    r#ref:   String,
+    text:    String,
+    #[serde(default)]
+    submit:  bool,
+    #[serde(default)]
+    element: Option<String>,
 }

--- a/crates/kernel/src/tool/browser/wait_for.rs
+++ b/crates/kernel/src/tool/browser/wait_for.rs
@@ -14,46 +14,31 @@
 
 //! Wait for a condition in the active browser page.
 
-use async_trait::async_trait;
+use rara_tool_macro::ToolDef;
 use serde::Deserialize;
 
 use crate::{
     browser::BrowserManagerRef,
-    tool::{AgentTool, ToolContext, ToolOutput},
+    tool::{ToolContext, ToolOutput},
 };
 
 /// Wait for text to appear, disappear, or for a time delay, then snapshot.
+#[derive(ToolDef)]
+#[tool(
+    name = "browser-wait-for",
+    description = "Wait for a condition before taking a snapshot. You can wait for text to \
+                   appear, text to disappear, or a fixed number of seconds.",
+    params_schema = "Self::schema()",
+    execute_fn = "self.exec"
+)]
 pub struct BrowserWaitForTool {
     manager: BrowserManagerRef,
 }
 
 impl BrowserWaitForTool {
-    pub const NAME: &str = crate::tool_names::BROWSER_WAIT_FOR;
-
     pub fn new(manager: BrowserManagerRef) -> Self { Self { manager } }
-}
 
-#[derive(Debug, Deserialize)]
-#[serde(rename_all = "camelCase")]
-struct Params {
-    #[serde(default)]
-    time:      Option<f64>,
-    #[serde(default)]
-    text:      Option<String>,
-    #[serde(default)]
-    text_gone: Option<String>,
-}
-
-#[async_trait]
-impl AgentTool for BrowserWaitForTool {
-    fn name(&self) -> &str { Self::NAME }
-
-    fn description(&self) -> &str {
-        "Wait for a condition before taking a snapshot. You can wait for text to appear, text to \
-         disappear, or a fixed number of seconds."
-    }
-
-    fn parameters_schema(&self) -> serde_json::Value {
+    fn schema() -> serde_json::Value {
         serde_json::json!({
             "type": "object",
             "properties": {
@@ -73,7 +58,7 @@ impl AgentTool for BrowserWaitForTool {
         })
     }
 
-    async fn execute(
+    async fn exec(
         &self,
         params: serde_json::Value,
         _context: &ToolContext,
@@ -89,4 +74,15 @@ impl AgentTool for BrowserWaitForTool {
 
         Ok(serde_json::json!({ "snapshot": snapshot }).into())
     }
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct Params {
+    #[serde(default)]
+    time:      Option<f64>,
+    #[serde(default)]
+    text:      Option<String>,
+    #[serde(default)]
+    text_gone: Option<String>,
 }


### PR DESCRIPTION
## Summary

Migrate all 17 browser tool files to use the `#[derive(ToolDef)]` macro, replacing manual `impl AgentTool` blocks:

- 10 real tools (navigate, snapshot, click, type, press_key, evaluate, wait_for, tabs, close, navigate_back) use override mode with `params_schema` + `execute_fn`
- 7 stub tools (hover, drag, select_option, fill_form, handle_dialog, console, network) use override mode with custom schema

Net reduction of ~57 lines of boilerplate.

**Stacked on #517** (kernel tools migration)

Closes #511