### PR TITLE
refactor(browser): remove BrowserConfig from AppConfig

### DIFF
--- a/crates/app/src/boot.rs
+++ b/crates/app/src/boot.rs
@@ -88,7 +88,6 @@ pub(crate) async fn boot(
     pool: sqlx::SqlitePool,
     settings_provider: Arc<dyn rara_domain_shared::settings::SettingsProvider>,
     users: &[UserConfig],
-    browser_config: Option<rara_kernel::browser::BrowserConfig>,
 ) -> Result<BootResult, Whatever> {
     // -- credential store --------------------------------------------------
 
@@ -203,19 +202,19 @@ pub(crate) async fn boot(
 
     // -- browser subsystem -------------------------------------------------
 
-    if let Some(browser_cfg) = browser_config {
-        match rara_kernel::browser::BrowserManager::start(browser_cfg).await {
-            Ok(manager) => {
-                let manager_ref: rara_kernel::browser::BrowserManagerRef =
-                    std::sync::Arc::new(manager);
-                for tool in rara_kernel::tool::browser::browser_tools(manager_ref) {
-                    tool_registry.register(tool);
-                }
-                info!("Browser subsystem initialized with Lightpanda");
+    match rara_kernel::browser::BrowserManager::start(rara_kernel::browser::BrowserConfig::default())
+        .await
+    {
+        Ok(manager) => {
+            let manager_ref: rara_kernel::browser::BrowserManagerRef =
+                std::sync::Arc::new(manager);
+            for tool in rara_kernel::tool::browser::browser_tools(manager_ref) {
+                tool_registry.register(tool);
             }
-            Err(e) => {
-                warn!("Browser subsystem disabled: {e}");
-            }
+            info!("Browser subsystem initialized with Lightpanda");
+        }
+        Err(e) => {
+            warn!("Browser subsystem disabled: {e}");
         }
     }
 

--- a/crates/app/src/lib.rs
+++ b/crates/app/src/lib.rs
@@ -102,9 +102,6 @@ pub struct AppConfig {
     /// Context folding (auto-anchor) configuration for the kernel.
     #[serde(default)]
     pub context_folding:        rara_kernel::kernel::ContextFoldingConfig,
-    /// Browser tool configuration (Lightpanda headless browser).
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub browser:                Option<rara_kernel::browser::BrowserConfig>,
 }
 
 /// Configuration for the Mita background proactive agent.
@@ -288,14 +285,9 @@ pub async fn start_with_options(
             .await
             .whatever_context("Failed to initialize config file sync")?;
 
-    let rara = crate::boot::boot(
-        pool.clone(),
-        settings_provider.clone(),
-        &config.users,
-        config.browser.clone(),
-    )
-    .await
-    .whatever_context("Failed to boot kernel dependencies")?;
+    let rara = crate::boot::boot(pool.clone(), settings_provider.clone(), &config.users)
+        .await
+        .whatever_context("Failed to boot kernel dependencies")?;
 
     let backend = rara_backend_admin::state::BackendState::init(
         rara.session_index.clone(),


### PR DESCRIPTION
## Summary
- Remove `browser: Option<BrowserConfig>` from `AppConfig` — all fields had sensible defaults, no need to expose
- Always attempt browser startup with `BrowserConfig::default()` in boot
- If lightpanda binary is unavailable, existing warn fallback handles it gracefully

Closes #525