### PR TITLE
refactor(tg): cascade viewer toggles in-place instead of sending new message

### DIFF
--- a/crates/channels/src/telegram/adapter.rs
+++ b/crates/channels/src/telegram/adapter.rs
@@ -1711,6 +1711,10 @@ async fn handle_trace_callback(
 /// existing message (edit instead of sending a new message).
 ///
 /// Callback data format: `"cas:{show|hide}:{chat_id}:{msg_id}:{trace_id}"`
+///
+/// NOTE: The full callback_data string approaches the Telegram 64-byte limit
+/// (worst case ~60 bytes with supergroup chat_id + ULID). Do not add more
+/// segments without shortening existing ones.
 async fn handle_cascade_callback(
     bot: &teloxide::Bot,
     callback: &teloxide::types::CallbackQuery,
@@ -1731,82 +1735,103 @@ async fn handle_cascade_callback(
     let msg_id_str = parts[3];
     let trace_id = parts[4];
 
-    // Answer callback immediately to dismiss the Telegram spinner.
-    let _ = bot.answer_callback_query(callback.id.clone()).await;
-
     let (Ok(cid), Ok(mid)) = (chat_id_str.parse::<i64>(), msg_id_str.parse::<i32>()) else {
+        let _ = bot.answer_callback_query(callback.id.clone()).await;
         return;
     };
 
-    // "hide" → restore compact summary with the original buttons.
-    if action != "show" {
-        let trace = match handle.trace_service().get(trace_id).await {
-            Ok(Some(t)) => t,
-            _ => return,
-        };
-        let compact = render_compact_summary(&trace);
-        let trace_cb = format!("trace:show:{chat_id_str}:{msg_id_str}:{trace_id}");
-        let cascade_cb = format!("cas:show:{chat_id_str}:{msg_id_str}:{trace_id}");
-        let keyboard = InlineKeyboardMarkup::new(vec![vec![
-            InlineKeyboardButton::callback("\u{1f4ca} \u{8be6}\u{60c5}", trace_cb),
-            InlineKeyboardButton::callback("\u{1f50d} Cascade", cascade_cb),
-        ]]);
-        let _ = bot
-            .edit_message_text(ChatId(cid), MessageId(mid), &compact)
-            .parse_mode(ParseMode::Html)
-            .reply_markup(keyboard)
-            .await;
-        return;
-    }
-
-    // "show" → build cascade trace and display in-place.
-    let session_id = match handle.trace_service().get_session_id(trace_id).await {
-        Ok(Some(s)) => s,
-        _ => return,
-    };
-
-    let entries = match handle.tape().entries(&session_id).await {
-        Ok(e) => e,
-        Err(e) => {
-            warn!(error = %e, "cascade: failed to read tape entries");
-            return;
+    match action {
+        // "hide" → restore compact summary with the original buttons.
+        "hide" => {
+            let _ = bot.answer_callback_query(callback.id.clone()).await;
+            let trace = match handle.trace_service().get(trace_id).await {
+                Ok(Some(t)) => t,
+                _ => return,
+            };
+            let compact = render_compact_summary(&trace);
+            let trace_cb = format!("trace:show:{chat_id_str}:{msg_id_str}:{trace_id}");
+            let cascade_cb = format!("cas:show:{chat_id_str}:{msg_id_str}:{trace_id}");
+            let keyboard = InlineKeyboardMarkup::new(vec![vec![
+                InlineKeyboardButton::callback("\u{1f4ca} \u{8be6}\u{60c5}", trace_cb),
+                InlineKeyboardButton::callback("\u{1f50d} Cascade", cascade_cb),
+            ]]);
+            let _ = bot
+                .edit_message_text(ChatId(cid), MessageId(mid), &compact)
+                .parse_mode(ParseMode::Html)
+                .reply_markup(keyboard)
+                .await;
         }
-    };
 
-    let rara_message_id = match handle.trace_service().get(trace_id).await {
-        Ok(Some(t)) => t.rara_message_id,
-        _ => String::new(),
-    };
+        // "show" → build cascade trace and display in-place.
+        _ => {
+            let session_id = match handle.trace_service().get_session_id(trace_id).await {
+                Ok(Some(s)) => s,
+                _ => {
+                    let _ = bot
+                        .answer_callback_query(callback.id.clone())
+                        .text("Cascade not available: trace not found")
+                        .await;
+                    return;
+                }
+            };
 
-    // Extract only the turn that corresponds to this trace.
-    let boundaries = rara_kernel::cascade::find_turn_boundaries(&entries);
-    let turn_entries = if let Ok(ulid) = ulid::Ulid::from_string(trace_id) {
-        let ts_ms = ulid.timestamp_ms() as i64;
-        let target =
-            jiff::Timestamp::from_millisecond(ts_ms).unwrap_or_else(|_| jiff::Timestamp::now());
-        let turn = rara_kernel::cascade::find_turn_by_timestamp(&entries, &boundaries, target);
-        rara_kernel::cascade::turn_slice(&entries, &boundaries, turn)
-    } else {
-        &entries
-    };
+            let entries = match handle.tape().entries(&session_id).await {
+                Ok(e) => e,
+                Err(e) => {
+                    warn!(error = %e, "cascade: failed to read tape entries");
+                    let _ = bot
+                        .answer_callback_query(callback.id.clone())
+                        .text("Cascade not available: tape read error")
+                        .await;
+                    return;
+                }
+            };
 
-    let cascade = rara_kernel::cascade::build_cascade(turn_entries, &rara_message_id);
+            let rara_message_id = match handle.trace_service().get(trace_id).await {
+                Ok(Some(t)) => t.rara_message_id,
+                _ => String::new(),
+            };
 
-    if cascade.ticks.is_empty() {
-        return;
+            // Extract only the turn that corresponds to this trace.
+            let boundaries = rara_kernel::cascade::find_turn_boundaries(&entries);
+            let turn_entries = if let Ok(ulid) = ulid::Ulid::from_string(trace_id) {
+                let ts_ms = ulid.timestamp_ms() as i64;
+                let target = jiff::Timestamp::from_millisecond(ts_ms)
+                    .unwrap_or_else(|_| jiff::Timestamp::now());
+                let turn =
+                    rara_kernel::cascade::find_turn_by_timestamp(&entries, &boundaries, target);
+                rara_kernel::cascade::turn_slice(&entries, &boundaries, turn)
+            } else {
+                &entries
+            };
+
+            let cascade = rara_kernel::cascade::build_cascade(turn_entries, &rara_message_id);
+
+            if cascade.ticks.is_empty() {
+                let _ = bot
+                    .answer_callback_query(callback.id.clone())
+                    .text("Cascade trace is empty")
+                    .await;
+                return;
+            }
+
+            // Answer callback only after data is ready — errors above
+            // use answer_callback_query with toast text instead.
+            let _ = bot.answer_callback_query(callback.id.clone()).await;
+
+            let html = render_cascade_html(&cascade);
+            let hide_cb = format!("cas:hide:{chat_id_str}:{msg_id_str}:{trace_id}");
+            let keyboard = InlineKeyboardMarkup::new(vec![vec![InlineKeyboardButton::callback(
+                "\u{1f50d} \u{6536}\u{8d77}",
+                hide_cb,
+            )]]);
+            let _ = bot
+                .edit_message_text(ChatId(cid), MessageId(mid), &html)
+                .parse_mode(ParseMode::Html)
+                .reply_markup(keyboard)
+                .await;
+        }
     }
-
-    let html = render_cascade_html(&cascade);
-    let hide_cb = format!("cas:hide:{chat_id_str}:{msg_id_str}:{trace_id}");
-    let keyboard = InlineKeyboardMarkup::new(vec![vec![InlineKeyboardButton::callback(
-        "\u{1f50d} \u{6536}\u{8d77}",
-        hide_cb,
-    )]]);
-    let _ = bot
-        .edit_message_text(ChatId(cid), MessageId(mid), &html)
-        .parse_mode(ParseMode::Html)
-        .reply_markup(keyboard)
-        .await;
 }
 
 /// Listens for new approval requests and sends inline keyboard messages


### PR DESCRIPTION
## Summary
- Cascade 按钮点击后改为在原消息上切换（`edit_message_text`），跟"详情"按钮行为一致
- 回调数据格式从 `cas:{cid}:{mid}:{tid}` 改为 `cas:{show|hide}:{cid}:{mid}:{tid}`
- 展开 cascade 时显示"🔍 收起"按钮，收起时恢复 compact summary + 原按钮

Closes #527