### PR TITLE
chore(ci): auto-delete stale release-plz branches on PR close

### DIFF
--- a/.github/workflows/cleanup-branches.yml
+++ b/.github/workflows/cleanup-branches.yml
@@ -1,0 +1,22 @@
+name: Cleanup stale branches
+
+on:
+  pull_request:
+    types: [closed]
+
+permissions:
+  contents: write
+
+jobs:
+  delete-branch:
+    name: Delete closed PR branch
+    runs-on: ubuntu-latest
+    if: >-
+      github.event.pull_request.merged == false &&
+      startsWith(github.event.pull_request.head.ref, 'release-plz-')
+    steps:
+      - name: Delete branch
+        run: |
+          gh api -X DELETE "repos/${{ github.repository }}/git/refs/heads/${{ github.event.pull_request.head.ref }}"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Closes #529

## Summary

- Add `cleanup-branches.yml` workflow: when a `release-plz-*` PR is closed without merging, automatically delete its branch
- Enabled `delete_branch_on_merge` repo setting (covers merged PRs)
- Cleaned up 34 stale `release-plz-*` remote branches

## How it works

`release-plz` creates a new timestamped branch + PR each run. When a newer PR supersedes the old, the old PR is closed but its branch was never deleted. The new workflow triggers on `pull_request: closed` and deletes the head branch if it matches `release-plz-*` and was not merged.