### PR TITLE
feat(kernel): enrich tape metadata with latency, model, and stop_reason (#548)

### DIFF
--- a/crates/kernel/src/agent/mod.rs
+++ b/crates/kernel/src/agent/mod.rs
@@ -1186,6 +1186,7 @@ pub(crate) async fn run_agent_loop(
         let mut pending_tool_calls: HashMap<u32, PendingToolCall> = HashMap::new();
         let mut has_tool_calls = false;
         let mut last_usage: Option<llm::Usage> = None;
+        let mut last_stop_reason: Option<llm::StopReason> = None;
         // Per-iteration reasoning timer — set on the first ReasoningDelta,
         // settled (added to cumulative_thinking_ms) on either:
         //   a) the first TextDelta (reasoning → content transition), or
@@ -1262,24 +1263,7 @@ pub(crate) async fn run_agent_loop(
                 }
                 llm::StreamDelta::Done { stop_reason, usage } => {
                     has_tool_calls = stop_reason == llm::StopReason::ToolCalls;
-                    if let Some(u) = usage {
-                        if let Err(e) = tape
-                            .append_event(
-                                tape_name,
-                                "llm.run",
-                                serde_json::json!({
-                                    "usage": {
-                                        "prompt_tokens": u.prompt_tokens,
-                                        "completion_tokens": u.completion_tokens,
-                                        "total_tokens": u.total_tokens
-                                    }
-                                }),
-                            )
-                            .await
-                        {
-                            warn!(error = %e, "failed to persist llm usage event");
-                        }
-                    }
+                    last_stop_reason = Some(stop_reason);
                     last_usage = usage;
                     // Fallback: settle reasoning if no TextDelta arrived
                     // (e.g. tool-only iteration with extended thinking).
@@ -1375,22 +1359,45 @@ pub(crate) async fn run_agent_loop(
             );
         }
 
+        // Compute timing metrics once, used by both tape entries and traces.
+        let stream_ms = stream_start.elapsed().as_millis() as u64;
+        let first_token_ms =
+            first_token_at.map(|t| t.duration_since(stream_start).as_millis() as u64);
+
+        // Persist LLM usage event to tape with performance metrics.
+        if let Some(u) = last_usage {
+            let event = crate::memory::LlmRunEvent {
+                usage: u,
+                model: model.clone(),
+                stop_reason: last_stop_reason.unwrap_or(llm::StopReason::Stop),
+                iteration,
+                stream_ms,
+                first_token_ms,
+            };
+            if let Err(e) = tape
+                .append_event(
+                    tape_name,
+                    "llm.run",
+                    serde_json::to_value(&event).unwrap_or_default(),
+                )
+                .await
+            {
+                warn!(error = %e, "failed to persist llm usage event");
+            }
+        }
+
         // Terminal response (no tool calls, or recovery iteration must exit)
         if !has_tool_calls || llm_error_recovery_used {
             // Persist final assistant message to tape.
-            let meta = {
-                let mut m = serde_json::json!({
-                    "rara_message_id": rara_message_id.to_string(),
-                });
-                if let Some(u) = last_usage.as_ref() {
-                    m["usage"] = serde_json::json!({
-                        "prompt_tokens": u.prompt_tokens,
-                        "completion_tokens": u.completion_tokens,
-                        "total_tokens": u.total_tokens,
-                    });
-                }
-                Some(m)
-            };
+            let meta = serde_json::to_value(crate::memory::LlmEntryMetadata {
+                rara_message_id: rara_message_id.to_string(),
+                usage: last_usage,
+                model: model.clone(),
+                iteration,
+                stream_ms,
+                first_token_ms,
+            })
+            .ok();
             let _ = tape
                 .append_message(
                     tape_name,
@@ -1402,9 +1409,6 @@ pub(crate) async fn run_agent_loop(
                 )
                 .await;
 
-            let first_token_ms =
-                first_token_at.map(|t| t.duration_since(stream_start).as_millis() as u64);
-            let stream_ms = stream_start.elapsed().as_millis() as u64;
             let text_preview: String = accumulated_text.chars().take(200).collect();
             iteration_traces.push(IterationTrace {
                 index: iteration,
@@ -1496,9 +1500,16 @@ pub(crate) async fn run_agent_loop(
                                     "error": &error_message,
                                 }]
                             }),
-                            Some(
-                                serde_json::json!({"rara_message_id": rara_message_id.to_string()}),
-                            ),
+                            serde_json::to_value(crate::memory::ToolResultMetadata {
+                                rara_message_id: rara_message_id.to_string(),
+                                tool_metrics:    vec![crate::memory::ToolMetric {
+                                    name:        tool_call.name.clone(),
+                                    duration_ms: 0,
+                                    success:     false,
+                                    error:       Some(error_message.clone()),
+                                }],
+                            })
+                            .ok(),
                         )
                         .await;
                     let raw_args: String = tool_call.arguments_buf.chars().take(100).collect();
@@ -1539,19 +1550,15 @@ pub(crate) async fn run_agent_loop(
                     })
                 })
                 .collect();
-            let tool_call_meta = {
-                let mut m = serde_json::json!({
-                    "rara_message_id": rara_message_id.to_string(),
-                });
-                if let Some(u) = last_usage.as_ref() {
-                    m["usage"] = serde_json::json!({
-                        "prompt_tokens": u.prompt_tokens,
-                        "completion_tokens": u.completion_tokens,
-                        "total_tokens": u.total_tokens,
-                    });
-                }
-                Some(m)
-            };
+            let tool_call_meta = serde_json::to_value(crate::memory::LlmEntryMetadata {
+                rara_message_id: rara_message_id.to_string(),
+                usage: last_usage,
+                model: model.clone(),
+                iteration,
+                stream_ms,
+                first_token_ms,
+            })
+            .ok();
             let _ = tape
                 .append_tool_call(
                     tape_name,
@@ -1774,11 +1781,27 @@ pub(crate) async fn run_agent_loop(
                 .iter()
                 .map(|(_id, name, _args)| name.clone())
                 .collect();
+            let tool_metrics: Vec<crate::memory::ToolMetric> = results
+                .iter()
+                .zip(valid_tool_calls.iter())
+                .map(|((success, _, err, duration_ms), (_id, name, _args))| {
+                    crate::memory::ToolMetric {
+                        name:        name.clone(),
+                        duration_ms: *duration_ms,
+                        success:     *success,
+                        error:       err.clone(),
+                    }
+                })
+                .collect();
             let _ = tape
                 .append_tool_result(
                     tape_name,
                     serde_json::json!({ "results": results_json.clone() }),
-                    Some(serde_json::json!({"rara_message_id": rara_message_id.to_string()})),
+                    serde_json::to_value(crate::memory::ToolResultMetadata {
+                        rara_message_id: rara_message_id.to_string(),
+                        tool_metrics,
+                    })
+                    .ok(),
                 )
                 .await;
             if should_remind_tape_anchor(&tool_names, &results_json) {
@@ -1828,9 +1851,6 @@ pub(crate) async fn run_agent_loop(
 
         // Collect iteration trace (with tool calls)
         {
-            let first_token_ms =
-                first_token_at.map(|t| t.duration_since(stream_start).as_millis() as u64);
-            let stream_ms = stream_start.elapsed().as_millis() as u64;
             let text_preview: String = accumulated_text.chars().take(200).collect();
             iteration_traces.push(IterationTrace {
                 index: iteration,

--- a/crates/kernel/src/memory/mod.rs
+++ b/crates/kernel/src/memory/mod.rs
@@ -143,6 +143,9 @@ pub use context::{
     anchor_context, anchor_summary_from_entries, default_tape_context, user_tape_context,
 };
 pub use error::{TapError, TapResult};
+// Re-export typed metadata structs for use in the agent loop.
+// These are defined here (alongside `TapEntry`) because they describe the
+// schema of the `metadata` field on tape entries.
 pub use fork_metadata::{ForkMetadata, get_fork_metadata, set_fork_metadata};
 use jiff::Timestamp;
 use serde::{Deserialize, Serialize};
@@ -190,6 +193,72 @@ pub enum TapEntryKind {
     Plan,
     /// Structured task report from background/scheduled tasks.
     TaskReport,
+}
+
+// ---------------------------------------------------------------------------
+// Typed tape metadata
+// ---------------------------------------------------------------------------
+
+/// Metadata attached to `Message` and `ToolCall` tape entries produced by the
+/// agent loop.  Captures timing and model information alongside token usage so
+/// that the tape alone is sufficient for post-hoc observability analysis.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LlmEntryMetadata {
+    /// Internal message ID for end-to-end correlation.
+    pub rara_message_id: String,
+    /// Token consumption for this LLM iteration.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub usage:           Option<crate::llm::Usage>,
+    /// Model identifier used for this completion.
+    pub model:           String,
+    /// Zero-based iteration index within the turn.
+    pub iteration:       usize,
+    /// Wall-clock duration of the streaming response in milliseconds.
+    pub stream_ms:       u64,
+    /// Time-to-first-token in milliseconds.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub first_token_ms:  Option<u64>,
+}
+
+/// Metadata attached to `ToolResult` tape entries.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ToolResultMetadata {
+    /// Internal message ID for end-to-end correlation.
+    pub rara_message_id: String,
+    /// Per-tool execution metrics.
+    pub tool_metrics:    Vec<ToolMetric>,
+}
+
+/// Execution metrics for a single tool call.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ToolMetric {
+    /// Tool name.
+    pub name:        String,
+    /// Execution duration in milliseconds.
+    pub duration_ms: u64,
+    /// Whether the tool call succeeded.
+    pub success:     bool,
+    /// Error message (only present on failure).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error:       Option<String>,
+}
+
+/// Data payload for the `llm.run` event entry.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LlmRunEvent {
+    /// Token consumption.
+    pub usage:          crate::llm::Usage,
+    /// Model identifier.
+    pub model:          String,
+    /// Why the LLM stopped generating.
+    pub stop_reason:    crate::llm::StopReason,
+    /// Zero-based iteration index within the turn.
+    pub iteration:      usize,
+    /// Wall-clock duration of the streaming response in milliseconds.
+    pub stream_ms:      u64,
+    /// Time-to-first-token in milliseconds.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub first_token_ms: Option<u64>,
 }
 
 /// Canonical tape name prefix for per-user tapes.


### PR DESCRIPTION
## Summary

- Enrich tape entry metadata at all 5 `append_*` call sites with performance metrics
- `append_event` (llm.run): add `model`, `stop_reason`, `iteration`, `stream_ms`, `first_token_ms`
- `append_message` / `append_tool_call`: add `model`, `iteration`, `stream_ms`, `first_token_ms`
- `append_tool_result`: add `tool_metrics` array with per-tool `name`, `duration_ms`, `success`, `error`
- Moved `append_event` call to after timing calculations for accurate `stream_ms` values

## Test plan

- [ ] Verify `cargo check -p rara-kernel` passes
- [ ] Verify tape JSONL entries contain new metadata fields after a conversation turn
- [ ] Verify LLM context reconstruction (`default_tape_context`) still ignores metadata

Closes #548

🤖 Generated with [Claude Code](https://claude.com/claude-code)