### PR TITLE
feat(kernel): add tool-level Prometheus duration histogram (#549)

### DIFF
--- a/crates/kernel/src/agent/mod.rs
+++ b/crates/kernel/src/agent/mod.rs
@@ -1815,6 +1815,8 @@ pub(crate) async fn run_agent_loop(
                     .await;
             }
 
+            crate::metrics::record_tool_duration(&manifest.name, name, *duration_ms);
+
             tool_call_traces.push(ToolCallTrace {
                 name: name.clone(),
                 id: id.clone(),

--- a/crates/kernel/src/metrics.rs
+++ b/crates/kernel/src/metrics.rs
@@ -192,3 +192,23 @@ pub fn record_turn_tool_call(agent_name: &str, tool_name: &str) {
         .with_label_values(&[agent_name, tool_name])
         .inc();
 }
+
+// -- Tool execution ----------------------------------------------------------
+
+/// Per-tool execution duration histogram.
+pub static TOOL_DURATION_SECONDS: LazyLock<HistogramVec> = LazyLock::new(|| {
+    register_histogram_vec!(
+        "kernel_tool_duration_seconds",
+        "Tool execution duration in seconds",
+        &[AGENT_NAME_LABEL, TOOL_NAME_LABEL],
+        vec![0.05, 0.1, 0.25, 0.5, 1.0, 2.0, 5.0, 10.0, 30.0, 60.0]
+    )
+    .unwrap()
+});
+
+/// Record tool execution duration for Prometheus.
+pub fn record_tool_duration(agent_name: &str, tool_name: &str, duration_ms: u64) {
+    TOOL_DURATION_SECONDS
+        .with_label_values(&[agent_name, tool_name])
+        .observe(duration_ms as f64 / 1000.0);
+}


### PR DESCRIPTION
## Summary

- Add `kernel_tool_duration_seconds` HistogramVec with `[agent_name, tool_name]` labels
- Buckets: 50ms to 60s (0.05, 0.1, 0.25, 0.5, 1.0, 2.0, 5.0, 10.0, 30.0, 60.0)
- Add `record_tool_duration()` helper in metrics module
- Record at tool execution result site in agent loop

## Test plan

- [ ] Verify `cargo check -p rara-kernel` passes
- [ ] Verify `/metrics` endpoint exposes `kernel_tool_duration_seconds` after tool calls

Closes #549

🤖 Generated with [Claude Code](https://claude.com/claude-code)