### PR TITLE
chore: downgrade go.mod to Go 1.26.0

### DIFF
--- a/scripts/go.mod
+++ b/scripts/go.mod
@@ -1,6 +1,6 @@
 module github.com/rararulab/rara/scripts
 
-go 1.26.1
+go 1.26.0
 
 require (
 	charm.land/bubbles/v2 v2.0.0


### PR DESCRIPTION
## Summary
- Downgrade `scripts/go.mod` from Go 1.26.1 to 1.26.0 to match CI environment

Closes #557