### PR TITLE
chore(ci): add cargo-doc pre-commit hook to match CI (#560)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,6 +25,14 @@ repos:
         types_or: [rust, toml]
         files: \.(rs|toml)$|Cargo\.lock$|rust-toolchain\.toml$
 
+      - id: cargo-doc
+        name: cargo doc
+        entry: env RUSTDOCFLAGS="-D warnings" cargo +nightly doc --workspace --no-deps --document-private-items
+        language: system
+        pass_filenames: false
+        types_or: [rust, toml]
+        files: \.(rs|toml)$|Cargo\.lock$|rust-toolchain\.toml$
+
       - id: check-agent-md
         name: check AGENT.md presence
         entry: scripts/bin/devtool check-agent-md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,6 +65,7 @@ Hooks configured in `.pre-commit-config.yaml`:
 - `cargo check --all --all-targets`
 - `cargo +nightly fmt --all -- --check`
 - `cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings`
+- `RUSTDOCFLAGS="-D warnings" cargo +nightly doc --workspace --no-deps --document-private-items`
 
 Triggers on: `.rs`, `.toml`, `Cargo.lock`, `rust-toolchain.toml` changes.
 


### PR DESCRIPTION
## Summary
- Add `cargo-doc` hook to `.pre-commit-config.yaml`, matching CI's `cargo +nightly doc --workspace --no-deps --document-private-items` with `RUSTDOCFLAGS="-D warnings"`
- Update CLAUDE.md to document the new hook

Closes #560