### PR TITLE
fix(kernel): default execution mode to Plan instead of Reactive (#567)

### DIFF
--- a/crates/kernel/src/kernel.rs
+++ b/crates/kernel/src/kernel.rs
@@ -1721,8 +1721,8 @@ impl Kernel {
             return mode;
         }
 
-        // Default: reactive (v1).
-        ExecutionMode::Reactive
+        // Default: plan-execute (v2).
+        ExecutionMode::Plan
     }
 
     /// # What this method does


### PR DESCRIPTION
## Summary

- `resolve_execution_mode()` 的兜底值是 `ExecutionMode::Reactive`，但 `ExecutionMode` 的 `#[default]` 标注在 `Plan` 上
- 所有 agent manifest 的 `default_execution_mode` 都是 `None`，导致兜底值总是被命中
- 结果：消息默认走 v1 (Reactive) 而非预期的 v2 (Plan)，plan & cascade 从未自动触发
- Fix：将兜底值改为 `ExecutionMode::Plan`

Closes #567

## Test plan

- [ ] 发送普通消息，验证默认走 plan-execute (v2) 模式
- [ ] 用 `/msg_version 1` 切换到 reactive，验证 session 级别覆盖仍然有效
- [ ] 验证 `/plan <goal>` 显式触发仍正常工作