### PR TITLE
refactor(tg): unify plan and progress into single in-progress message (#580)

### DIFF
--- a/crates/channels/src/telegram/adapter.rs
+++ b/crates/channels/src/telegram/adapter.rs
@@ -2490,7 +2490,7 @@ fn spawn_stream_forwarder(
     trace_service: rara_kernel::trace::TraceService,
     rara_message_id: String,
 ) {
-    use rara_kernel::io::StreamEvent;
+    use rara_kernel::io::{PlanStepStatus, StreamEvent};
 
     tokio::spawn(async move {
         let hub = {
@@ -2712,7 +2712,7 @@ fn spawn_stream_forwarder(
                                 progress.last_edit = Instant::now();
                             }
                         }
-                        Ok(StreamEvent::PlanProgress { current_step, status_text, .. }) => {
+                        Ok(StreamEvent::PlanProgress { current_step, step_status, status_text, .. }) => {
                             if progress.plan_steps.is_some() {
                                 // Detect step transition: clear tools when step changes.
                                 if Some(current_step) != progress.plan_current_step {
@@ -2729,12 +2729,7 @@ fn spawn_stream_forwarder(
                                     progress.plan_current_step = Some(current_step);
                                 }
 
-                                // TODO(#590): status detection relies on Chinese string matching
-                                // ("完成"/"失败"/full-width colon). Ideally StreamEvent::PlanProgress
-                                // should carry a structured StepStatus enum instead of free-text.
-                                // See: https://github.com/rararulab/rara/issues/590
-
-                                // Update current step.
+                                // Update current step using structured status.
                                 if let Some(ref mut steps) = progress.plan_steps {
                                     // Dynamically extend steps if replan introduced new indices.
                                     while current_step >= steps.len() {
@@ -2744,14 +2739,13 @@ fn spawn_stream_forwarder(
                                         });
                                     }
                                     if let Some(step) = steps.get_mut(current_step) {
-                                        if status_text.contains("\u{5b8c}\u{6210}") {
-                                            step.status = StepStatus::Done;
-                                        } else if status_text.contains("\u{5931}\u{8d25}") {
-                                            step.status = StepStatus::Failed(status_text.clone());
-                                        } else {
-                                            step.status = StepStatus::Running;
-                                        }
-                                        // Extract task name from status on first Running.
+                                        step.status = match &step_status {
+                                            PlanStepStatus::Running => StepStatus::Running,
+                                            PlanStepStatus::Done => StepStatus::Done,
+                                            PlanStepStatus::Failed { reason } => StepStatus::Failed(reason.clone()),
+                                            PlanStepStatus::NeedsReplan { reason } => StepStatus::Failed(reason.clone()),
+                                        };
+                                        // Extract task name from status_text on first Running.
                                         if step.task.is_empty() {
                                             if let Some(colon_pos) = status_text.find('\u{ff1a}') {
                                                 let task: String = status_text[colon_pos + '\u{ff1a}'.len_utf8()..]
@@ -2785,12 +2779,18 @@ fn spawn_stream_forwarder(
                             // PlanCreated. Subsequent PlanProgress events carry the
                             // new (higher) step indices, handled by dynamic expansion
                             // in the PlanProgress handler above.
-                            if progress.plan_steps.is_some() {
-                                if let (Some(steps), Some(cur)) = (&mut progress.plan_steps, progress.plan_current_step) {
+                            if let Some(ref mut steps) = progress.plan_steps {
+                                // Mark the current step as failed.
+                                if let Some(cur) = progress.plan_current_step {
                                     if let Some(step) = steps.get_mut(cur) {
                                         step.status = StepStatus::Failed(reason.clone());
                                     }
                                 }
+                                // Remove remaining Pending steps — they won't execute
+                                // after replan; new steps arrive via PlanProgress with
+                                // higher indices and are dynamically expanded.
+                                steps.retain(|s| !matches!(s.status, StepStatus::Pending));
+
                                 let text = progress.render_text();
                                 if let Some(mid) = progress.message_id {
                                     let _ = bot.edit_message_text(ChatId(chat_id), mid, &text).await;

--- a/crates/channels/src/web.rs
+++ b/crates/channels/src/web.rs
@@ -128,6 +128,7 @@ pub enum WebEvent {
     PlanProgress {
         current_step: usize,
         total_steps:  usize,
+        step_status:  rara_kernel::io::PlanStepStatus,
         status_text:  String,
     },
     /// The plan has been revised.
@@ -229,10 +230,12 @@ fn stream_event_to_web_event(event: StreamEvent) -> Option<WebEvent> {
         StreamEvent::PlanProgress {
             current_step,
             total_steps,
+            step_status,
             status_text,
         } => Some(WebEvent::PlanProgress {
             current_step,
             total_steps,
+            step_status,
             status_text,
         }),
         StreamEvent::PlanReplan { reason } => Some(WebEvent::PlanReplan { reason }),

--- a/crates/kernel/src/io.rs
+++ b/crates/kernel/src/io.rs
@@ -843,6 +843,20 @@ pub enum ToolCallLimitDecision {
     Stop,
 }
 
+/// Structured step status carried by [`StreamEvent::PlanProgress`].
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum PlanStepStatus {
+    /// Step execution is starting.
+    Running,
+    /// Step completed successfully.
+    Done,
+    /// Step failed with a reason.
+    Failed { reason: String },
+    /// Step needs replanning.
+    NeedsReplan { reason: String },
+}
+
 /// Incremental events emitted during agent execution.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
@@ -919,6 +933,7 @@ pub enum StreamEvent {
     PlanProgress {
         current_step: usize,
         total_steps:  usize,
+        step_status:  PlanStepStatus,
         status_text:  String,
     },
     /// The plan has been revised.

--- a/crates/kernel/src/plan.rs
+++ b/crates/kernel/src/plan.rs
@@ -34,7 +34,7 @@ use crate::{
     error::{KernelError, Result},
     guard::pipeline::GuardPipeline,
     handle::KernelHandle,
-    io::{StreamEvent, StreamHandle},
+    io::{PlanStepStatus, StreamEvent, StreamHandle},
     llm,
     memory::{TapEntryKind, TapeService},
     notification::NotificationBusRef,
@@ -313,6 +313,7 @@ pub(crate) async fn run_plan_loop(
         stream_handle.emit(StreamEvent::PlanProgress {
             current_step: step.index,
             total_steps:  plan.steps.len(),
+            step_status:  PlanStepStatus::Running,
             status_text:  format!("正在执行第{}步：{}…", step.index + 1, step.task),
         });
 
@@ -342,19 +343,26 @@ pub(crate) async fn run_plan_loop(
             ExecutionMode::Worker => execute_worker_step(handle, session_key, &step).await,
         };
 
-        let end_status = match &outcome {
-            StepOutcome::Success => format!("第{}步完成", step.index + 1),
-            StepOutcome::Failed { reason } => {
-                format!("第{}步失败：{}", step.index + 1, reason)
-            }
-            StepOutcome::NeedsReplan { reason } => {
-                format!("第{}步需要调整：{}", step.index + 1, reason)
-            }
+        let (step_status, end_status) = match &outcome {
+            StepOutcome::Success => (PlanStepStatus::Done, format!("第{}步完成", step.index + 1)),
+            StepOutcome::Failed { reason } => (
+                PlanStepStatus::Failed {
+                    reason: reason.clone(),
+                },
+                format!("第{}步失败：{}", step.index + 1, reason),
+            ),
+            StepOutcome::NeedsReplan { reason } => (
+                PlanStepStatus::NeedsReplan {
+                    reason: reason.clone(),
+                },
+                format!("第{}步需要调整：{}", step.index + 1, reason),
+            ),
         };
         stream_handle.emit(StreamEvent::PlanProgress {
             current_step: step.index,
-            total_steps:  plan.steps.len(),
-            status_text:  end_status,
+            total_steps: plan.steps.len(),
+            step_status,
+            status_text: end_status,
         });
 
         // If interrupted during step execution, exit immediately


### PR DESCRIPTION
Closes #580

## Summary
- Merge PlanDisplay into ProgressMessage for unified plan+progress display
- Plan steps shown as primary structure with tool calls nested under current step
- Simplify tier system: Micro (1 step, no plan UI) / Normal (>=2 steps)
- Fix bug where Medium tier plan message was never sent (render returned empty)

## Render format (plan mode)
```
📋 {goal}（{N}步）

✅ 第1步：搜索新闻
▶️ 第2步：筛选重要内容
  🔧 web_search (2.1s) ✓
⬜ 第3步：生成总结

✳ 12s · ↑8.2k ↓1.5k
```

## Changes
- `crates/channels/src/telegram/adapter.rs`: Remove `PlanDisplay`/`PlanTier`, add `PlanStepState`/`StepStatus`, add `render_plan_progress()`, update all event handlers