### PR TITLE
fix(tg): show tool call parameters in plan progress view (#598)

### DIFF
--- a/crates/channels/src/telegram/adapter.rs
+++ b/crates/channels/src/telegram/adapter.rs
@@ -376,6 +376,7 @@ fn format_phase_line(phase: &Phase, loading_hint: &str) -> String {
             format!("\u{2705} {}{time}{suffix}", phase.activity)
         } else {
             match &phase.first_error {
+                // Error message takes priority over summary.
                 Some(err) => {
                     let short_err: String = err.chars().take(60).collect();
                     format!("\u{274c} {}{time}: {short_err}", phase.activity)
@@ -386,7 +387,7 @@ fn format_phase_line(phase: &Phase, loading_hint: &str) -> String {
     } else if phase.activity == rara_kernel::io::stages::THINKING {
         loading_hint.to_string()
     } else {
-        format!("正在{}… {}", phase.activity, phase.first_summary)
+        format!("正在{}…{suffix}", phase.activity)
     }
 }
 


### PR DESCRIPTION
## Summary
- Add `first_summary` field to `Phase` struct to preserve tool call parameters through phase aggregation
- Display tool summary (file path, shell command, search query) in plan progress and reactive progress views
- Only shown for single-tool phases (`count == 1`) to avoid noise in aggregated phases

**Before:** `✅ 执行命令 (2.3s)`
**After:** `✅ 执行命令 (2.3s) — git status`

Closes #598

## Test plan
- [ ] Send a message that triggers plan mode, verify tool summaries appear under running step
- [ ] Verify multi-tool phases (e.g. 3× read-file) still show aggregated without summary
- [ ] Check reactive (non-plan) mode also shows summaries
- [ ] Verify in-progress tools show summary: "正在读取文件… src/main.rs"