### PR TITLE
fix(kernel): persist intermediate assistant messages to tape for cascade tick detection (#606)

### DIFF
--- a/crates/kernel/src/agent/mod.rs
+++ b/crates/kernel/src/agent/mod.rs
@@ -1427,6 +1427,11 @@ pub(crate) async fn run_agent_loop(
                 iteration,
                 stream_ms,
                 first_token_ms,
+                reasoning_content: if accumulated_reasoning.is_empty() {
+                    None
+                } else {
+                    Some(accumulated_reasoning.clone())
+                },
             })
             .ok();
             let _ = tape
@@ -1570,7 +1575,35 @@ pub(crate) async fn run_agent_loop(
             valid_tool_calls.push((tool_call.id, tool_call.name, args));
         }
 
-        // Persist assistant message with tool calls to tape.
+        // Persist intermediate assistant message to tape so that
+        // `build_cascade` can detect tick boundaries between iterations.
+        // Without this, the cascade trace always shows a single tick.
+        {
+            let mut meta = crate::memory::LlmEntryMetadata {
+                rara_message_id: rara_message_id.to_string(),
+                usage: last_usage,
+                model: model.clone(),
+                iteration,
+                stream_ms,
+                first_token_ms,
+                reasoning_content: None,
+            };
+            if !accumulated_reasoning.is_empty() {
+                meta.reasoning_content = Some(accumulated_reasoning.clone());
+            }
+            let _ = tape
+                .append_message(
+                    tape_name,
+                    serde_json::json!({
+                        "role": "assistant",
+                        "content": &accumulated_text,
+                    }),
+                    serde_json::to_value(&meta).ok(),
+                )
+                .await;
+        }
+
+        // Persist tool calls to tape.
         if !assistant_tool_calls.is_empty() {
             let calls_json: Vec<serde_json::Value> = assistant_tool_calls
                 .iter()
@@ -1588,6 +1621,7 @@ pub(crate) async fn run_agent_loop(
                 iteration,
                 stream_ms,
                 first_token_ms,
+                reasoning_content: None,
             })
             .ok();
             let _ = tape

--- a/crates/kernel/src/memory/mod.rs
+++ b/crates/kernel/src/memory/mod.rs
@@ -205,19 +205,23 @@ pub enum TapEntryKind {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct LlmEntryMetadata {
     /// Internal message ID for end-to-end correlation.
-    pub rara_message_id: String,
+    pub rara_message_id:   String,
     /// Token consumption for this LLM iteration.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub usage:           Option<crate::llm::Usage>,
+    pub usage:             Option<crate::llm::Usage>,
     /// Model identifier used for this completion.
-    pub model:           String,
+    pub model:             String,
     /// Zero-based iteration index within the turn.
-    pub iteration:       usize,
+    pub iteration:         usize,
     /// Wall-clock duration of the streaming response in milliseconds.
-    pub stream_ms:       u64,
+    pub stream_ms:         u64,
     /// Time-to-first-token in milliseconds.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub first_token_ms:  Option<u64>,
+    pub first_token_ms:    Option<u64>,
+    /// Extended-thinking reasoning text, persisted so that `build_cascade`
+    /// can display reasoning in the cascade trace view.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reasoning_content: Option<String>,
 }
 
 /// Metadata attached to `ToolResult` tape entries.


### PR DESCRIPTION
## Summary

- Non-terminal iterations (with tool calls) now write their assistant `Message` to tape **before** the `ToolCall` entry, enabling `build_cascade` to correctly detect tick boundaries
- Adds `reasoning_content` field to `LlmEntryMetadata` so cascade trace can display extended-thinking reasoning

## Root Cause

Previously only `ToolCall` + `ToolResult` were written per iteration — no intermediate assistant `Message`. The cascade tick boundary detection requires `seen_assistant && last_was_tool_result`, which never triggered because the only assistant message was the final terminal response.

## Test plan

- [x] All 25 existing cascade tests pass
- [ ] Manual test: send a multi-tool-call message in TG, click 🔍 Cascade, verify multiple ticks shown

Closes #606