### PR TITLE
fix(kernel): repetition guard post-merge fixes (#616)

### DIFF
--- a/crates/kernel/src/agent/mod.rs
+++ b/crates/kernel/src/agent/mod.rs
@@ -1215,6 +1215,7 @@ pub(crate) async fn run_agent_loop(
         let mut first_token_at: Option<Instant> = None;
         let mut accumulated_text = String::new();
         let mut repetition_guard = repetition::RepetitionGuard::new();
+        let mut repetition_aborted = false;
         let mut accumulated_reasoning = String::new();
         let mut pending_tool_calls: HashMap<u32, PendingToolCall> = HashMap::new();
         let mut has_tool_calls = false;
@@ -1274,10 +1275,16 @@ pub(crate) async fn run_agent_loop(
                                 "repetition loop detected, truncating output"
                             );
                             accumulated_text.truncate(trunc_byte);
+                            repetition_aborted = true;
                             stream_task.abort();
                             break;
                         }
 
+                        // Emit AFTER repetition check: when the guard fires, the
+                        // triggering delta is intentionally not forwarded. Prior
+                        // deltas (including repeated text) were already streamed;
+                        // the final Reply will carry the truncated version, so the
+                        // Telegram adapter's prefix-slicing reconciles the mismatch.
                         stream_handle.emit(StreamEvent::TextDelta { text });
                     }
                 }
@@ -1343,8 +1350,29 @@ pub(crate) async fn run_agent_loop(
 
         // Wait for the stream task to complete (the driver accumulates the
         // full response internally).
+        // When repetition_aborted is true, stream_task was intentionally
+        // aborted — treat cancellation as success with valid truncated text.
+        // We skip the driver_result error path entirely since the stream
+        // was cut short on purpose and last_usage will be None (P1: accepted,
+        // logged as warning below).
         let driver_result = match stream_task.await {
-            Ok(result) => result,
+            Ok(result) => {
+                if repetition_aborted {
+                    // Stream completed before abort took effect; result is
+                    // available but we already truncated accumulated_text.
+                    None
+                } else {
+                    Some(result)
+                }
+            }
+            Err(join_err) if join_err.is_cancelled() && repetition_aborted => {
+                // Expected: we aborted the stream intentionally.
+                warn!(
+                    iteration,
+                    "repetition abort: token usage unavailable for this iteration"
+                );
+                None
+            }
             Err(join_err) if join_err.is_cancelled() => {
                 return Err(KernelError::Interrupted);
             }
@@ -1355,7 +1383,7 @@ pub(crate) async fn run_agent_loop(
             }
         };
 
-        if let Err(ref e) = driver_result {
+        if let Some(Err(ref e)) = driver_result {
             if !context_window_recovery_used && matches!(e, KernelError::ContextWindow) {
                 context_window_recovery_used = true;
             }
@@ -1386,6 +1414,7 @@ pub(crate) async fn run_agent_loop(
                 message: format!("Model \"{model}\" returned an error during streaming: {e}"),
             });
         }
+        // driver_result is None when repetition_aborted — skip error path above.
 
         iter_span.record("stream_ms", stream_start.elapsed().as_millis() as u64);
         iter_span.record("has_tools", has_tool_calls);

--- a/crates/kernel/src/agent/repetition.rs
+++ b/crates/kernel/src/agent/repetition.rs
@@ -36,9 +36,13 @@ const CHECK_INTERVAL: usize = 500;
 /// the point at which the output should be truncated (keeping only the
 /// first occurrence plus the probe).
 pub(crate) struct RepetitionGuard {
+    /// Characters accumulated since the last check.
     chars_since_check: usize,
     /// Running total of characters fed so far, avoiding O(n) recount.
     total_chars:       usize,
+    /// Running total of bytes fed so far, used to compute probe start
+    /// byte offset in O(1) instead of O(n) `char_indices().nth()`.
+    total_bytes:       usize,
 }
 
 impl RepetitionGuard {
@@ -47,6 +51,7 @@ impl RepetitionGuard {
         Self {
             chars_since_check: 0,
             total_chars:       0,
+            total_bytes:       0,
         }
     }
 
@@ -60,6 +65,13 @@ impl RepetitionGuard {
         let delta_chars = delta.chars().count();
         self.chars_since_check += delta_chars;
         self.total_chars += delta_chars;
+        self.total_bytes += delta.len();
+
+        debug_assert_eq!(
+            self.total_bytes,
+            accumulated.len(),
+            "RepetitionGuard byte count drifted from accumulated length"
+        );
 
         let total_chars = self.total_chars;
         if total_chars < MIN_CHECK_LEN {
@@ -71,13 +83,20 @@ impl RepetitionGuard {
 
         self.chars_since_check = 0;
 
-        // Convert the last PROBE_LEN chars into a byte-bounded slice.
-        let probe_char_start = total_chars - PROBE_LEN;
-        let probe_start_byte = accumulated
-            .char_indices()
-            .nth(probe_char_start)
-            .map(|(i, _)| i)
-            .unwrap_or(0);
+        // Compute the byte offset of the probe start. We know total_bytes
+        // matches accumulated.len(), so the probe spans the last N bytes
+        // corresponding to the last PROBE_LEN chars.  Walk backwards from
+        // the end to find the byte boundary — O(PROBE_LEN) not O(total).
+        let probe_char_count = PROBE_LEN.min(total_chars);
+        let mut probe_start_byte = self.total_bytes;
+        let mut chars_remaining = probe_char_count;
+        for (i, _) in accumulated.char_indices().rev() {
+            chars_remaining -= 1;
+            if chars_remaining == 0 {
+                probe_start_byte = i;
+                break;
+            }
+        }
 
         let probe = &accumulated[probe_start_byte..];
         let search_hay = &accumulated[..probe_start_byte];
@@ -174,6 +193,7 @@ mod tests {
         assert!(result.is_some(), "CJK repetition must be detected");
 
         let trunc = result.unwrap();
+        // CJK chars are 3 bytes each in UTF-8, so byte-level bound is 3x char count.
         assert!(
             trunc <= cjk_block.len() + PROBE_LEN * 3 + 3,
             "CJK truncation index {trunc} unexpectedly large"
@@ -242,6 +262,24 @@ mod tests {
         assert!(
             trunc <= two_copies,
             "truncation point {trunc} should be at most 2x paragraph length ({two_copies})"
+        );
+    }
+
+    #[test]
+    fn debug_assert_catches_drift() {
+        // Verify that mismatched accumulated length triggers debug_assert.
+        // We can only test this in debug mode (default for `cargo test`).
+        let mut guard = RepetitionGuard::new();
+        let delta = "hello";
+        guard.feed(delta, delta); // correct: 5 bytes fed, accumulated is 5 bytes
+
+        // Now feed a delta but pass wrong accumulated (shorter than expected).
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            guard.feed("world", "helloworl"); // 9 bytes but guard expects 10
+        }));
+        assert!(
+            result.is_err(),
+            "debug_assert should catch byte-count drift"
         );
     }
 }

--- a/docs/src/quality-matrix.md
+++ b/docs/src/quality-matrix.md
@@ -10,9 +10,9 @@ A living dashboard that tracks the health of every crate in the Rara workspace. 
 
 | Crate | Layer | AGENT.md | Tests | Docs | LOC | Notes |
 |-------|-------|----------|-------|------|----:|-------|
-| `rara-kernel` | kernel | ✅ | ✅ | ✅ 521/615 (84%) | 30,869 | — |
+| `rara-kernel` | kernel | ✅ | ✅ | ✅ 524/618 (84%) | 31,407 | — |
 | `rara-app` | app | ✅ | ✅ | ⚠️ 100/209 (47%) | 11,324 | — |
-| `rara-channels` | app | ✅ | ✅ | ✅ 69/75 (92%) | 8,370 | Excellent docs |
+| `rara-channels` | app | ✅ | ✅ | ✅ 69/75 (92%) | 8,385 | Excellent docs |
 | `rara-skills` | app | ✅ | ✅ | ✅ 84/103 (81%) | 4,487 | — |
 | `rara-cli` | cmd | ✅ | ✅ | ⚠️ 3/48 (6%) | 3,918 | — |
 | `common-worker` | common | ✅ | ❌ | ✅ 70/80 (87%) | 3,857 | No tests |
@@ -50,7 +50,7 @@ A living dashboard that tracks the health of every crate in the Rara workspace. 
 | **With AGENT.md** | 31 | 100% |
 | **With tests** | 11 | 35% |
 | **Doc coverage > 50%** | 23 | 74% |
-| **Total Rust LOC** | 87,535 | — |
+| **Total Rust LOC** | 88,088 | — |
 
 ### By Layer
 


### PR DESCRIPTION
## Summary

- Fix P0: `stream_task.abort()` no longer causes `KernelError::Interrupted` — `repetition_aborted` flag routes the cancelled join through a safe path, preserving valid truncated output
- Fix P1: Token usage unavailable after abort logged as warning; added comment explaining intentional stream/reply mismatch
- Fix P2: Replaced O(n) `char_indices().nth()` with O(PROBE_LEN) reverse iteration; added `total_bytes` tracking and `debug_assert` for byte-count drift detection
- Fix P3: Rustfmt auto-applied column-aligned struct spacing

## Test plan

- [x] All 8 kernel repetition tests pass (including new `debug_assert_catches_drift`)
- [x] All 219 kernel tests pass
- [x] cargo check, fmt, clippy, doc all pass

Closes #616