### PR TITLE
fix(kernel): pass parsed arguments to ToolCallStart for trace summaries (#621)

### DIFF
--- a/crates/kernel/src/agent/mod.rs
+++ b/crates/kernel/src/agent/mod.rs
@@ -1560,10 +1560,14 @@ pub(crate) async fn run_agent_loop(
 
             // Emit ToolCallStart BEFORE parsing so the forwarder always
             // receives it — even if argument parsing fails below.
+            // Pre-parse arguments for display purposes (summary extraction);
+            // fall back to empty object if the buffer is malformed.
+            let start_args = serde_json::from_str(&tool_call.arguments_buf)
+                .unwrap_or_else(|_| serde_json::Value::Object(Default::default()));
             stream_handle.emit(StreamEvent::ToolCallStart {
                 name:      tool_call.name.clone(),
                 id:        tool_call.id.clone(),
-                arguments: serde_json::Value::Object(Default::default()),
+                arguments: start_args,
             });
 
             let args = match parse_tool_call_arguments(&tool_call.arguments_buf) {

--- a/docs/src/quality-matrix.md
+++ b/docs/src/quality-matrix.md
@@ -10,7 +10,7 @@ A living dashboard that tracks the health of every crate in the Rara workspace. 
 
 | Crate | Layer | AGENT.md | Tests | Docs | LOC | Notes |
 |-------|-------|----------|-------|------|----:|-------|
-| `rara-kernel` | kernel | ✅ | ✅ | ✅ 524/618 (84%) | 31,407 | — |
+| `rara-kernel` | kernel | ✅ | ✅ | ✅ 524/618 (84%) | 31,411 | — |
 | `rara-app` | app | ✅ | ✅ | ⚠️ 100/209 (47%) | 11,324 | — |
 | `rara-channels` | app | ✅ | ✅ | ✅ 69/75 (92%) | 8,385 | Excellent docs |
 | `rara-skills` | app | ✅ | ✅ | ✅ 84/103 (81%) | 4,487 | — |
@@ -50,7 +50,7 @@ A living dashboard that tracks the health of every crate in the Rara workspace. 
 | **With AGENT.md** | 31 | 100% |
 | **With tests** | 11 | 35% |
 | **Doc coverage > 50%** | 23 | 74% |
-| **Total Rust LOC** | 88,088 | — |
+| **Total Rust LOC** | 88,092 | — |
 
 ### By Layer
 


### PR DESCRIPTION
## Summary
- `ToolCallStart` was emitted with empty `arguments: {}`, so trace detail view showed no tool summaries
- Now pre-parses `arguments_buf` before emitting, enabling `tool_display_info()` to extract meaningful summaries (file paths, commands, URLs)
- Single line change in `agent/mod.rs`

**Before:** `├ fetch (899ms) ✓`  
**After:** `├ fetch (899ms) ✓ — https://github.com/foo/bar`

Closes #621

## Test plan
- [ ] Send a message that triggers multiple tool calls
- [ ] Click the message plan button in TG to view trace detail
- [ ] Verify tool summaries appear after each tool entry (e.g. `— git status`, `— src/main.rs`)