### PR TITLE
perf(cascade): build CascadeTrace incrementally during agent loop (#625)

### DIFF
--- a/crates/channels/src/telegram/adapter.rs
+++ b/crates/channels/src/telegram/adapter.rs
@@ -1855,26 +1855,25 @@ async fn handle_cascade_callback(
                 _ => String::new(),
             };
 
-            // Try pre-built trace first (sessions with real-time cascade).
-            let cascade = if let Some(trace) =
-                rara_kernel::cascade::load_persisted_cascade(&entries, &rara_message_id)
-            {
-                trace
+            // Locate the turn slice for this trace.
+            let boundaries = rara_kernel::cascade::find_turn_boundaries(&entries);
+            let turn_entries = if let Ok(ulid) = ulid::Ulid::from_string(trace_id) {
+                let ts_ms = ulid.timestamp_ms() as i64;
+                let target = jiff::Timestamp::from_millisecond(ts_ms)
+                    .unwrap_or_else(|_| jiff::Timestamp::now());
+                let turn =
+                    rara_kernel::cascade::find_turn_by_timestamp(&entries, &boundaries, target);
+                rara_kernel::cascade::turn_slice(&entries, &boundaries, turn)
             } else {
-                // Fallback: post-hoc build for legacy sessions.
-                let boundaries = rara_kernel::cascade::find_turn_boundaries(&entries);
-                let turn_entries = if let Ok(ulid) = ulid::Ulid::from_string(trace_id) {
-                    let ts_ms = ulid.timestamp_ms() as i64;
-                    let target = jiff::Timestamp::from_millisecond(ts_ms)
-                        .unwrap_or_else(|_| jiff::Timestamp::now());
-                    let turn =
-                        rara_kernel::cascade::find_turn_by_timestamp(&entries, &boundaries, target);
-                    rara_kernel::cascade::turn_slice(&entries, &boundaries, turn)
-                } else {
-                    &entries
-                };
-                rara_kernel::cascade::build_cascade(turn_entries, &rara_message_id)
+                &entries
             };
+
+            // Try pre-built trace first; fall back to post-hoc build for
+            // legacy sessions.
+            let cascade = rara_kernel::cascade::load_persisted_cascade(turn_entries)
+                .unwrap_or_else(|| {
+                    rara_kernel::cascade::build_cascade(turn_entries, &rara_message_id)
+                });
 
             tracing::debug!(
                 ticks = cascade.ticks.len(),

--- a/crates/extensions/backend-admin/src/chat/service.rs
+++ b/crates/extensions/backend-admin/src/chat/service.rs
@@ -27,7 +27,9 @@ use std::sync::Arc;
 use chrono::Utc;
 use rara_domain_shared::settings::{SettingsProvider, keys};
 use rara_kernel::{
-    cascade::{CascadeTrace, build_cascade, find_turn_boundaries, turn_slice},
+    cascade::{
+        CascadeTrace, build_cascade, find_turn_boundaries, load_persisted_cascade, turn_slice,
+    },
     channel::types::{ChatMessage, MessageContent, MessageRole, ToolCall as ChannelToolCall},
     llm::{Message, Role},
     memory::{TapEntry, TapEntryKind, TapeService},
@@ -302,12 +304,6 @@ impl SessionService {
                     message: format!("failed to read tape: {e}"),
                 })?;
 
-        // Fast path: try pre-built cascade trace (sessions with real-time building).
-        let message_id = format!("{}-{}", key, message_seq);
-        if let Some(trace) = rara_kernel::cascade::load_persisted_cascade(&entries, &message_id) {
-            return Ok(trace);
-        }
-
         // Convert tape → chat messages so we can map the 1-based message_seq
         // back to the owning user-message turn.  The seq values in ChatMessage
         // can skip numbers (e.g. a ToolResult with N results increments seq
@@ -333,9 +329,16 @@ impl SessionService {
             .position(|m| m.seq == owner.seq)
             .unwrap_or(0);
 
-        // Use turn boundary helpers to extract the right slice of tape entries.
+        // Extract the turn slice, then try the pre-built trace before
+        // falling back to the post-hoc builder.
         let boundaries = find_turn_boundaries(&entries);
         let turn_entries = turn_slice(&entries, &boundaries, user_ordinal);
+
+        if let Some(trace) = load_persisted_cascade(turn_entries) {
+            return Ok(trace);
+        }
+
+        let message_id = format!("{}-{}", key, message_seq);
         let trace = build_cascade(turn_entries, &message_id);
         Ok(trace)
     }

--- a/crates/kernel/src/agent/mod.rs
+++ b/crates/kernel/src/agent/mod.rs
@@ -539,15 +539,7 @@ impl AgentTurnResult {
                 error:            None,
                 rara_message_id:  crate::io::MessageId::new(),
             },
-            cascade:    crate::cascade::CascadeTrace {
-                message_id: String::new(),
-                ticks:      Vec::new(),
-                summary:    crate::cascade::CascadeSummary {
-                    tick_count:      0,
-                    tool_call_count: 0,
-                    total_entries:   0,
-                },
-            },
+            cascade:    crate::cascade::CascadeTrace::empty(),
         }
     }
 }
@@ -940,7 +932,7 @@ pub(crate) async fn run_agent_loop(
     let turn_start = Instant::now();
     let mut iteration_traces: Vec<IterationTrace> = Vec::new();
     let mut cascade_asm = crate::cascade::CascadeAssembler::new(rara_message_id.to_string());
-    cascade_asm.push_user(0, &input_text, jiff::Timestamp::now(), None);
+    cascade_asm.push_user(&input_text, jiff::Timestamp::now(), None);
     let mut llm_error_recovery_used = false;
     let mut context_window_recovery_used = false;
     let mut consecutive_silent_iters: usize = 0;
@@ -1475,7 +1467,6 @@ pub(crate) async fn run_agent_loop(
                 .await;
 
             cascade_asm.push_assistant(
-                0,
                 &accumulated_text,
                 if accumulated_reasoning.is_empty() {
                     None
@@ -1523,7 +1514,10 @@ pub(crate) async fn run_agent_loop(
                 .append_event(
                     tape_name,
                     "cascade.trace",
-                    serde_json::to_value(&cascade).unwrap_or_default(),
+                    serde_json::to_value(&cascade).unwrap_or_else(|e| {
+                        tracing::warn!(error = %e, "failed to serialize cascade trace");
+                        serde_json::Value::Null
+                    }),
                 )
                 .await;
 
@@ -1655,7 +1649,6 @@ pub(crate) async fn run_agent_loop(
         }
 
         cascade_asm.push_assistant(
-            0,
             &accumulated_text,
             if accumulated_reasoning.is_empty() {
                 None
@@ -1701,7 +1694,7 @@ pub(crate) async fn run_agent_loop(
                 .iter()
                 .map(|tc| (tc.name.as_str(), tc.arguments.as_str()))
                 .collect();
-            cascade_asm.push_tool_calls(0, &calls_for_cascade, jiff::Timestamp::now(), None);
+            cascade_asm.push_tool_calls(&calls_for_cascade, jiff::Timestamp::now(), None);
         }
 
         iter_span.record("tool_count", valid_tool_calls.len());
@@ -1954,7 +1947,7 @@ pub(crate) async fn run_agent_loop(
                     })
                     .collect();
                 let results_refs: Vec<&str> = results_strs.iter().map(|s| s.as_str()).collect();
-                cascade_asm.push_tool_results(0, &results_refs, jiff::Timestamp::now(), None);
+                cascade_asm.push_tool_results(&results_refs, jiff::Timestamp::now(), None);
             }
             if should_remind_tape_anchor(&tool_names, &results_json) {
                 needs_anchor_reminder = true;
@@ -2212,7 +2205,10 @@ pub(crate) async fn run_agent_loop(
         .append_event(
             tape_name,
             "cascade.trace",
-            serde_json::to_value(&cascade).unwrap_or_default(),
+            serde_json::to_value(&cascade).unwrap_or_else(|e| {
+                tracing::warn!(error = %e, "failed to serialize cascade trace");
+                serde_json::Value::Null
+            }),
         )
         .await;
 

--- a/crates/kernel/src/cascade.rs
+++ b/crates/kernel/src/cascade.rs
@@ -40,6 +40,21 @@ pub struct CascadeTrace {
     pub summary:    CascadeSummary,
 }
 
+impl CascadeTrace {
+    /// An empty trace with no ticks or entries.
+    pub fn empty() -> Self {
+        Self {
+            message_id: String::new(),
+            ticks:      Vec::new(),
+            summary:    CascadeSummary {
+                tick_count:      0,
+                tool_call_count: 0,
+                total_entries:   0,
+            },
+        }
+    }
+}
+
 /// One reasoning-action cycle within a turn.
 ///
 /// A new tick starts when a new assistant `Message` entry appears after
@@ -145,19 +160,12 @@ impl CascadeAssembler {
     }
 
     /// Append a user-input entry.
-    pub fn push_user(
-        &mut self,
-        entry_id: u64,
-        content: &str,
-        timestamp: Timestamp,
-        metadata: Option<Value>,
-    ) {
+    pub fn push_user(&mut self, content: &str, timestamp: Timestamp, metadata: Option<Value>) {
         self.global_seq += 1;
         self.current_entries.push(CascadeEntry {
-            id: format_entry_id(
+            id: format_seq_id(
                 CascadeEntryKind::UserInput,
                 self.tick_index,
-                entry_id,
                 self.global_seq,
             ),
             kind: CascadeEntryKind::UserInput,
@@ -174,7 +182,6 @@ impl CascadeAssembler {
     /// least one entry already exists in the current tick.
     pub fn push_assistant(
         &mut self,
-        entry_id: u64,
         text: &str,
         reasoning: Option<&str>,
         timestamp: Timestamp,
@@ -203,12 +210,7 @@ impl CascadeAssembler {
         if !content.is_empty() {
             self.global_seq += 1;
             self.current_entries.push(CascadeEntry {
-                id: format_entry_id(
-                    CascadeEntryKind::Thought,
-                    self.tick_index,
-                    entry_id,
-                    self.global_seq,
-                ),
+                id: format_seq_id(CascadeEntryKind::Thought, self.tick_index, self.global_seq),
                 kind: CascadeEntryKind::Thought,
                 content,
                 timestamp,
@@ -223,7 +225,6 @@ impl CascadeAssembler {
     /// entry, matching the per-call expansion in [`build_cascade`].
     pub fn push_tool_calls(
         &mut self,
-        entry_id: u64,
         calls: &[(&str, &str)],
         timestamp: Timestamp,
         metadata: Option<Value>,
@@ -233,12 +234,7 @@ impl CascadeAssembler {
             self.global_seq += 1;
             self.tool_call_count += 1;
             self.current_entries.push(CascadeEntry {
-                id: format_entry_id(
-                    CascadeEntryKind::Action,
-                    self.tick_index,
-                    entry_id,
-                    self.global_seq,
-                ),
+                id: format_seq_id(CascadeEntryKind::Action, self.tick_index, self.global_seq),
                 kind: CascadeEntryKind::Action,
                 content: format!("{name}({args})"),
                 timestamp,
@@ -252,7 +248,6 @@ impl CascadeAssembler {
     /// Each result string produces one [`CascadeEntryKind::Observation`] entry.
     pub fn push_tool_results(
         &mut self,
-        entry_id: u64,
         results: &[&str],
         timestamp: Timestamp,
         metadata: Option<Value>,
@@ -261,10 +256,9 @@ impl CascadeAssembler {
         for result in results {
             self.global_seq += 1;
             self.current_entries.push(CascadeEntry {
-                id: format_entry_id(
+                id: format_seq_id(
                     CascadeEntryKind::Observation,
                     self.tick_index,
-                    entry_id,
                     self.global_seq,
                 ),
                 kind: CascadeEntryKind::Observation,
@@ -481,6 +475,14 @@ fn format_entry_id(kind: CascadeEntryKind, tick: usize, entry_id: u64, seq: usiz
     format!("{} \u{2022} {}-{}-{}", kind.prefix(), tick, short_id, seq)
 }
 
+/// Format a sequence-only entry ID for [`CascadeAssembler`].
+///
+/// Unlike [`format_entry_id`] which uses a tape entry ID, this uses only the
+/// global sequence counter — the assembler does not have access to tape IDs.
+fn format_seq_id(kind: CascadeEntryKind, tick: usize, seq: usize) -> String {
+    format!("{} \u{2022} {}-{}", kind.prefix(), tick, seq)
+}
+
 /// Find indices of user-message entries in a tape, defining turn boundaries.
 ///
 /// Each returned index marks the start of a new "turn" (user → assistant
@@ -530,25 +532,21 @@ pub fn find_turn_by_timestamp(
 }
 
 /// Try to load a pre-built cascade trace from a persisted `cascade.trace`
-/// event in the tape. Returns `None` if no matching entry exists (e.g.
+/// event within a turn slice. Returns `None` if no such event exists (e.g.
 /// legacy sessions that pre-date real-time cascade building).
-pub fn load_persisted_cascade(entries: &[TapEntry], message_id: &str) -> Option<CascadeTrace> {
-    entries
+///
+/// The caller should pass the turn's entry slice (from [`turn_slice`]) so
+/// the search is scoped to a single turn and does not need `message_id`
+/// matching.
+pub fn load_persisted_cascade(turn_entries: &[TapEntry]) -> Option<CascadeTrace> {
+    turn_entries
         .iter()
         .rev()
-        .filter(|e| {
+        .find(|e| {
             e.kind == TapEntryKind::Event
                 && e.payload.get("name").and_then(Value::as_str) == Some("cascade.trace")
         })
-        .find_map(|e| {
-            let trace: CascadeTrace =
-                serde_json::from_value(e.payload.get("data")?.clone()).ok()?;
-            if trace.message_id == message_id {
-                Some(trace)
-            } else {
-                None
-            }
-        })
+        .and_then(|e| serde_json::from_value(e.payload.get("data")?.clone()).ok())
 }
 
 /// Extract plain text content from a message payload.
@@ -1317,14 +1315,14 @@ mod tests {
 
         // -- CascadeAssembler path --
         let mut builder = CascadeAssembler::new(msg_id.to_owned());
-        builder.push_user(1, "do two things", ts, None);
-        builder.push_assistant(2, "first I'll search", None, ts, None);
-        builder.push_tool_calls(3, &[("search", "{}")], ts, None);
-        builder.push_tool_results(4, &["result1"], ts, None);
-        builder.push_assistant(5, "now I'll read", None, ts, None);
-        builder.push_tool_calls(6, &[("read", "{}")], ts, None);
-        builder.push_tool_results(7, &["result2"], ts, None);
-        builder.push_assistant(8, "done", None, ts, None);
+        builder.push_user("do two things", ts, None);
+        builder.push_assistant("first I'll search", None, ts, None);
+        builder.push_tool_calls(&[("search", "{}")], ts, None);
+        builder.push_tool_results(&["result1"], ts, None);
+        builder.push_assistant("now I'll read", None, ts, None);
+        builder.push_tool_calls(&[("read", "{}")], ts, None);
+        builder.push_tool_results(&["result2"], ts, None);
+        builder.push_assistant("done", None, ts, None);
         let actual = builder.finish();
 
         // Structural parity checks.
@@ -1343,7 +1341,8 @@ mod tests {
             for (a_entry, e_entry) in a_tick.entries.iter().zip(e_tick.entries.iter()) {
                 assert_eq!(a_entry.kind, e_entry.kind);
                 assert_eq!(a_entry.content, e_entry.content);
-                assert_eq!(a_entry.id, e_entry.id);
+                // Entry IDs use different formats (seq-only vs tape-entry-id),
+                // so we only verify kind + content parity here.
             }
         }
     }

--- a/crates/kernel/src/plan.rs
+++ b/crates/kernel/src/plan.rs
@@ -600,15 +600,7 @@ pub(crate) async fn run_plan_loop(
             },
             rara_message_id,
         },
-        cascade:    crate::cascade::CascadeTrace {
-            message_id: String::new(),
-            ticks:      Vec::new(),
-            summary:    crate::cascade::CascadeSummary {
-                tick_count:      0,
-                tool_call_count: 0,
-                total_entries:   0,
-            },
-        },
+        cascade:    crate::cascade::CascadeTrace::empty(),
     })
 }
 


### PR DESCRIPTION
## Summary

- Add `CascadeBuilder` — incremental state machine that builds `CascadeTrace` entry-by-entry, mirroring `build_cascade()` logic exactly
- Wire builder into `run_agent_loop()`: feed user/assistant/tool-call/tool-result entries as they are appended to tape
- Persist finished `CascadeTrace` as a `cascade.trace` event at end of turn
- Optimize Telegram callback and backend-admin to load persisted trace first (O(1) from tape tail), falling back to post-hoc `build_cascade()` for legacy sessions

## Performance Impact

| Path | Before | After |
|------|--------|-------|
| Cascade view (new session) | O(tape_size) scan + parse | O(1) deserialize from event |
| Cascade view (old session) | O(tape_size) | O(tape_size) — unchanged fallback |
| Agent turn overhead | 0 | ~microseconds per push call |

## Test plan

- [x] 26 cascade unit tests pass (25 existing + 1 new parity test)
- [x] `cargo check --workspace` passes
- [x] `cargo clippy --workspace` clean
- [ ] Manual: trigger cascade view on new session → should use persisted trace
- [ ] Manual: trigger cascade view on old session → should fallback gracefully

Closes #625

🤖 Generated with [Claude Code](https://claude.com/claude-code)