### PR TITLE
refactor(symphony): fix path typo and eliminate ensure+expect pattern (#636)

### DIFF
--- a/crates/symphony/src/agent.rs
+++ b/crates/symphony/src/agent.rs
@@ -43,10 +43,13 @@ pub struct RalphAgent {
     config: AgentConfig,
 }
 
-// `ralph init -c <core>` uses the extra config while generating defaults, but
-// does not write those overrides back into the resulting `ralph.yml`. We merge
-// the repo-maintained core config into the generated file so later `ralph run`
-// can rely on the worktree-local config alone.
+/// Merge repository-maintained core config into the `ralph init`-generated
+/// config.
+///
+/// This is a **shallow merge**: top-level keys from `core` overwrite the
+/// corresponding keys in `generated` entirely. Nested mappings (e.g. `agent:`)
+/// are replaced, not deep-merged. This is intentional — the core config is
+/// authoritative for any key it defines.
 pub fn merge_core_config(generated: &str, core: &str) -> Result<String> {
     let generated_value: Value = serde_yaml::from_str(generated).context(ConfigYamlSnafu {
         message: String::from("failed to parse generated ralph.yml"),

--- a/crates/symphony/src/config.rs
+++ b/crates/symphony/src/config.rs
@@ -311,7 +311,7 @@ pub(crate) fn default_repo_checkout_root(repo_name: &str) -> PathBuf {
 
 fn default_workspace_root(repo_name: &str) -> PathBuf {
     rara_paths::config_dir()
-        .join("ralpha/worktress")
+        .join("ralpha/worktrees")
         .join(repo_name)
         .join("worktrees")
 }

--- a/crates/symphony/src/workspace.rs
+++ b/crates/symphony/src/workspace.rs
@@ -17,7 +17,7 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use snafu::{ResultExt, ensure};
+use snafu::ResultExt;
 use tracing::{info, warn};
 
 use crate::{
@@ -37,13 +37,13 @@ pub struct WorkspaceManager;
 
 impl WorkspaceManager {
     fn ensure_repo_checkout(&self, repo: &RepoConfig) -> Result<(git2::Repository, PathBuf)> {
-        ensure!(
-            repo.repo_path.is_some(),
-            crate::error::WorkspaceSnafu {
+        let Some(repo_path) = &repo.repo_path else {
+            return crate::error::WorkspaceSnafu {
                 message: format!("repo {} is missing repo_path", repo.name),
             }
-        );
-        let repo_path = repo.repo_path.clone().expect("checked repo_path above");
+            .fail();
+        };
+        let repo_path = repo_path.clone();
 
         if repo_path.exists() {
             let checkout = git2::Repository::open(&repo_path).context(GitSnafu)?;
@@ -78,21 +78,18 @@ impl WorkspaceManager {
         issue_number: u64,
         issue_title: &str,
     ) -> Result<WorkspaceInfo> {
-        ensure!(
-            repo.repo_path.is_some(),
-            crate::error::WorkspaceSnafu {
+        if repo.repo_path.is_none() {
+            return crate::error::WorkspaceSnafu {
                 message: format!("repo {} is missing repo_path", repo.name),
             }
-        );
-        ensure!(
-            repo.effective_workspace_root().is_some(),
-            crate::error::WorkspaceSnafu {
+            .fail();
+        }
+        let Some(workspace_root) = repo.effective_workspace_root() else {
+            return crate::error::WorkspaceSnafu {
                 message: format!("repo {} is missing workspace_root", repo.name),
             }
-        );
-        let workspace_root = repo
-            .effective_workspace_root()
-            .expect("checked workspace_root above");
+            .fail();
+        };
         let branch = branch_name(issue_number, issue_title);
         let path = workspace_root.join(&branch);
         let (checkout, _) = self.ensure_repo_checkout(repo)?;
@@ -156,12 +153,12 @@ impl WorkspaceManager {
 
     /// Remove the issue worktree and prune the matching git worktree/branch.
     pub fn cleanup_worktree(&self, repo: &RepoConfig, workspace: &WorkspaceInfo) -> Result<()> {
-        ensure!(
-            repo.repo_path.is_some(),
-            crate::error::WorkspaceSnafu {
+        if repo.repo_path.is_none() {
+            return crate::error::WorkspaceSnafu {
                 message: format!("repo {} is missing repo_path", repo.name),
             }
-        );
+            .fail();
+        }
         let (repo, _) = self.ensure_repo_checkout(repo)?;
 
         if workspace.path.exists() {

--- a/crates/symphony/tests/ralph_run_runtime.rs
+++ b/crates/symphony/tests/ralph_run_runtime.rs
@@ -28,7 +28,7 @@ fn repo_config_defaults_workspace_root_under_rara_config_dir() {
     assert_eq!(
         workspace_root,
         rara_paths::config_dir()
-            .join("ralpha/worktress")
+            .join("ralpha/worktrees")
             .join("rararulab/rara")
             .join("worktrees")
     );

--- a/docs/src/quality-matrix.md
+++ b/docs/src/quality-matrix.md
@@ -50,7 +50,11 @@ A living dashboard that tracks the health of every crate in the Rara workspace. 
 | **With AGENT.md** | 31 | 100% |
 | **With tests** | 11 | 35% |
 | **Doc coverage > 50%** | 23 | 74% |
+<<<<<<< HEAD
 | **Total Rust LOC** | 88,283 | — |
+=======
+| **Total Rust LOC** | 88,258 | — |
+>>>>>>> 62dd1dc7 (refactor(symphony): fix path typo and eliminate ensure+expect pattern (#636))
 
 ### By Layer
 
@@ -59,7 +63,7 @@ A living dashboard that tracks the health of every crate in the Rara workspace. 
 | common | 8 | 68% | 8 | 0 |
 | domain | 1 | 12% | 1 | 0 |
 | kernel | 1 | 84% | 1 | 1 |
-| app | 12 | 85% | 12 | 9 |
+| app | 12 | 86% | 12 | 9 |
 | server | 1 | 82% | 1 | 0 |
 | cmd | 1 | 6% | 1 | 1 |
 | extensions | 2 | 74% | 2 | 0 |


### PR DESCRIPTION
## Summary

- Fixed `worktress` → `worktrees` typo in `default_workspace_root()`
- Replaced `ensure!` + `.expect()` anti-pattern with `let-else` / `if is_none()` in workspace.rs (3 occurrences)
- Added doc comment clarifying shallow-merge behavior of `merge_core_config`

## Type of change

| Type | Label |
|------|-------|
| Refactor | `refactor` |

## Component

`core`

## Closes

Closes #636

## Test plan

- [x] `cargo test -p rara-symphony` passes (24 tests)
- [x] `cargo clippy -p rara-symphony --all-targets -- -D warnings` clean
- [x] Pre-commit hooks pass