### PR TITLE
feat(symphony): implement stall detection to reclaim stuck agent slots (#642)

### DIFF
--- a/crates/symphony/src/service.rs
+++ b/crates/symphony/src/service.rs
@@ -227,6 +227,7 @@ impl IssueRuntime {
     async fn reap_finished(&mut self, tracker: &dyn IssueTracker) {
         let issue_ids: Vec<String> = self.running.keys().cloned().collect();
         let mut completed = Vec::new();
+        let mut stalled = Vec::new();
 
         for issue_id in issue_ids {
             let Some(run) = self.running.get_mut(&issue_id) else {
@@ -235,7 +236,11 @@ impl IssueRuntime {
 
             match run.child.try_wait() {
                 Ok(Some(status)) => completed.push((issue_id, status)),
-                Ok(None) => {}
+                Ok(None) => {
+                    if run.started_at.elapsed() > self.config.stall_timeout {
+                        stalled.push(issue_id);
+                    }
+                }
                 Err(err) => {
                     warn!(issue_id = %issue_id, error = %err, "failed to poll ralph child status")
                 }
@@ -289,6 +294,29 @@ impl IssueRuntime {
                     },
                 );
             }
+        }
+
+        // Kill stalled processes that exceeded the configured timeout
+        for issue_id in stalled {
+            let Some(mut run) = self.running.remove(&issue_id) else {
+                continue;
+            };
+            let elapsed = run.started_at.elapsed();
+            warn!(
+                issue_id = %issue_id,
+                elapsed_secs = elapsed.as_secs(),
+                stall_timeout_secs = self.config.stall_timeout.as_secs(),
+                log_path = %run.log_path.display(),
+                "killing stalled ralph agent"
+            );
+            let _ = run.child.kill().await;
+            self.failed.insert(
+                issue_id,
+                FinishedIssue {
+                    issue:     run.issue,
+                    workspace: run.workspace,
+                },
+            );
         }
     }
 
@@ -707,7 +735,7 @@ fn resolve_env_var(value: &str) -> crate::error::Result<String> {
 
 #[cfg(test)]
 mod tests {
-    use std::time::Duration;
+    use std::time::{Duration, Instant};
 
     use tokio_util::sync::CancellationToken;
 
@@ -810,5 +838,19 @@ mod tests {
             .expect("configured repo should resolve");
 
         assert_eq!(repo.url, "https://example.com/custom.git");
+    }
+
+    #[test]
+    fn stalled_issue_is_detected_by_elapsed_time() {
+        let timeout = Duration::from_secs(10);
+        let started = Instant::now()
+            .checked_sub(Duration::from_secs(20))
+            .expect("20s subtraction should not underflow");
+        assert!(started.elapsed() > timeout);
+
+        let started_recent = Instant::now()
+            .checked_sub(Duration::from_secs(5))
+            .expect("5s subtraction should not underflow");
+        assert!(started_recent.elapsed() <= timeout);
     }
 }

--- a/docs/src/quality-matrix.md
+++ b/docs/src/quality-matrix.md
@@ -10,7 +10,7 @@ A living dashboard that tracks the health of every crate in the Rara workspace. 
 
 | Crate | Layer | AGENT.md | Tests | Docs | LOC | Notes |
 |-------|-------|----------|-------|------|----:|-------|
-| `rara-kernel` | kernel | ✅ | ✅ | ✅ 524/618 (84%) | 31,411 | — |
+| `rara-kernel` | kernel | ✅ | ✅ | ✅ 524/618 (84%) | 31,577 | — |
 | `rara-app` | app | ✅ | ✅ | ⚠️ 100/209 (47%) | 11,324 | — |
 | `rara-channels` | app | ✅ | ✅ | ✅ 69/75 (92%) | 8,385 | Excellent docs |
 | `rara-skills` | app | ✅ | ✅ | ✅ 84/103 (81%) | 4,487 | — |
@@ -18,7 +18,7 @@ A living dashboard that tracks the health of every crate in the Rara workspace. 
 | `common-worker` | common | ✅ | ❌ | ✅ 70/80 (87%) | 3,857 | No tests |
 | `rara-mcp` | integrations | ✅ | ❌ | ✅ 18/24 (75%) | 3,519 | No tests |
 | `rara-backend-admin` | extensions | ✅ | ❌ | ✅ 24/41 (58%) | 3,284 | No tests |
-| `rara-symphony` | app | ✅ | ✅ | ⚠️ 12/33 (36%) | 2,951 | — |
+| `rara-symphony` | app | ✅ | ✅ | ⚠️ 12/33 (36%) | 2,976 | — |
 | `rara-dock` | app | ✅ | ✅ | ✅ 64/72 (88%) | 2,394 | — |
 | `rara-acp` | app | ✅ | ✅ | ✅ 29/29 (100%) | 2,183 | Fully documented |
 | `rara-soul` | app | ✅ | ✅ | ✅ 34/34 (100%) | 1,223 | Fully documented |
@@ -50,7 +50,7 @@ A living dashboard that tracks the health of every crate in the Rara workspace. 
 | **With AGENT.md** | 31 | 100% |
 | **With tests** | 11 | 35% |
 | **Doc coverage > 50%** | 23 | 74% |
-| **Total Rust LOC** | 88,092 | — |
+| **Total Rust LOC** | 88,283 | — |
 
 ### By Layer
 


### PR DESCRIPTION
## Summary

- Added stall detection to `IssueRuntime::reap_finished` — kills agents exceeding `stall_timeout`
- Stalled processes are moved to the `failed` map, reclaiming their concurrency slot
- Warning log includes elapsed time, timeout config, and log path for debugging

## Type of change

| Type | Label |
|------|-------|
| New feature | `enhancement` |

## Component

`core`

## Closes

Closes #642

## Test plan

- [x] `cargo test -p rara-symphony` passes (25 tests)
- [x] `cargo clippy -p rara-symphony --all-targets -- -D warnings` clean
- [x] Pre-commit hooks pass