### PR TITLE
fix(ci): add go.work so pre-commit Go hooks find the module (#652)

### DIFF
--- a/go.work
+++ b/go.work
@@ -1,0 +1,3 @@
+go 1.26.0
+
+use ./scripts


### PR DESCRIPTION
## Summary

The `quality-matrix` and `check-agent-md` pre-commit hooks run `go run ./scripts/cmd/devtool/` from the project root, but `go.mod` lives in `scripts/`. Go can't resolve the module, causing hook failures.

Adding a root-level `go.work` with `use ./scripts` lets Go workspace resolution find the module without changing working directories or hook entries.

## Type of change

| Type | Label |
|------|-------|
| Bug fix | `chore` |

## Component

`ci`

## Closes

Closes #652

## Test plan

- [x] `go run ./scripts/cmd/devtool/ check-agent-md` passes from project root
- [x] Pre-commit hooks no longer fail on Go module resolution