### PR TITLE
refactor(acp): address code review findings across rara-acp crate (#672)

### DIFF
--- a/crates/app/src/tools/acp_delegate.rs
+++ b/crates/app/src/tools/acp_delegate.rs
@@ -24,8 +24,9 @@ use std::{future::Future, path::PathBuf, pin::Pin};
 use async_trait::async_trait;
 use rara_acp::{
     AcpThread, PermissionRequestInfo, RequestPermissionOutcome, SelectedPermissionOutcome,
-    events::{AcpEvent, StopReason, ToolCallStatus},
+    events::{AcpEvent, PermissionOptionKind, StopReason, ToolCallStatus},
     registry::AcpRegistryRef,
+    thread::PermissionPolicy,
 };
 use rara_kernel::tool::{ToolContext, ToolExecute};
 use rara_tool_macro::ToolDef;
@@ -164,9 +165,14 @@ impl ToolExecute for AcpDelegateTool {
 
         // Spawn the AcpThread — handles subprocess, handshake, and session
         // creation internally.
-        let mut thread = AcpThread::spawn(&params.agent, command, cwd)
-            .await
-            .map_err(|e| anyhow::anyhow!("ACP spawn failed (cmd: `{cmd_display}`): {e}"))?;
+        // Use AutoApprove policy: the delegate auto-approves directly,
+        // eliminating the double auto-approve overhead through the bridge.
+        // When ToolContext gains ApprovalManager support, switch to
+        // PermissionPolicy::Interactive for user-facing confirmation.
+        let mut thread =
+            AcpThread::spawn(&params.agent, command, cwd, PermissionPolicy::AutoApprove)
+                .await
+                .map_err(|e| anyhow::anyhow!("ACP spawn failed (cmd: `{cmd_display}`): {e}"))?;
 
         // Collect streaming events into structured output.
         let mut text_chunks: Vec<String> = Vec::new();
@@ -225,8 +231,12 @@ fn auto_approve_resolver(
         let selected = info
             .options
             .iter()
-            .find(|o| o.kind == "AllowAlways")
-            .or_else(|| info.options.iter().find(|o| o.kind == "AllowOnce"));
+            .find(|o| o.kind == PermissionOptionKind::AllowAlways)
+            .or_else(|| {
+                info.options
+                    .iter()
+                    .find(|o| o.kind == PermissionOptionKind::AllowOnce)
+            });
 
         let option_id = match selected {
             Some(opt) => opt.id.clone(),

--- a/crates/rara-acp/src/delegate.rs
+++ b/crates/rara-acp/src/delegate.rs
@@ -8,18 +8,19 @@ use std::path::PathBuf;
 
 use agent_client_protocol::{
     Client, ContentBlock, CreateTerminalRequest, CreateTerminalResponse, KillTerminalRequest,
-    KillTerminalResponse, PermissionOptionKind, ReadTextFileRequest, ReadTextFileResponse,
-    ReleaseTerminalRequest, ReleaseTerminalResponse, RequestPermissionOutcome,
-    RequestPermissionRequest, RequestPermissionResponse, Result, SelectedPermissionOutcome,
-    SessionNotification, SessionUpdate, TerminalOutputRequest, TerminalOutputResponse,
-    ToolCallStatus as AcpToolCallStatus, WaitForTerminalExitRequest, WaitForTerminalExitResponse,
-    WriteTextFileRequest, WriteTextFileResponse,
+    KillTerminalResponse, PermissionOptionKind as AcpPermOptionKind, ReadTextFileRequest,
+    ReadTextFileResponse, ReleaseTerminalRequest, ReleaseTerminalResponse,
+    RequestPermissionOutcome, RequestPermissionRequest, RequestPermissionResponse, Result,
+    SelectedPermissionOutcome, SessionNotification, SessionUpdate, TerminalOutputRequest,
+    TerminalOutputResponse, ToolCallStatus as AcpToolCallStatus, WaitForTerminalExitRequest,
+    WaitForTerminalExitResponse, WriteTextFileRequest, WriteTextFileResponse,
 };
 use tokio::sync::mpsc;
 use tracing::{debug, warn};
 
 use crate::events::{
-    AcpEvent, FileOperation, PermissionBridge, PermissionOptionInfo, ToolCallStatus,
+    AcpEvent, FileOperation, PermissionBridge, PermissionOptionInfo, PermissionOptionKind,
+    ToolCallStatus,
 };
 
 /// Permission handling mode for the delegate.
@@ -104,11 +105,11 @@ impl RaraDelegate {
         let selected = args
             .options
             .iter()
-            .find(|o| o.kind == PermissionOptionKind::AllowAlways)
+            .find(|o| o.kind == AcpPermOptionKind::AllowAlways)
             .or_else(|| {
                 args.options
                     .iter()
-                    .find(|o| o.kind == PermissionOptionKind::AllowOnce)
+                    .find(|o| o.kind == AcpPermOptionKind::AllowOnce)
             });
 
         let option_id = match selected {
@@ -158,7 +159,13 @@ impl RaraDelegate {
             .map(|o| PermissionOptionInfo {
                 id:    o.option_id.to_string(),
                 label: o.name.clone(),
-                kind:  format!("{:?}", o.kind),
+                kind:  match o.kind {
+                    AcpPermOptionKind::AllowOnce => PermissionOptionKind::AllowOnce,
+                    AcpPermOptionKind::AllowAlways => PermissionOptionKind::AllowAlways,
+                    AcpPermOptionKind::RejectOnce => PermissionOptionKind::DenyOnce,
+                    AcpPermOptionKind::RejectAlways => PermissionOptionKind::DenyAlways,
+                    other => PermissionOptionKind::Unknown(format!("{other:?}")),
+                },
             })
             .collect();
 
@@ -331,6 +338,7 @@ impl Client for RaraDelegate {
         &self,
         _args: CreateTerminalRequest,
     ) -> Result<CreateTerminalResponse> {
+        warn!("agent requested terminal creation, which is not supported");
         Err(agent_client_protocol::Error::method_not_found())
     }
 
@@ -338,6 +346,7 @@ impl Client for RaraDelegate {
         &self,
         _args: TerminalOutputRequest,
     ) -> Result<TerminalOutputResponse> {
+        warn!("agent requested terminal output, which is not supported");
         Err(agent_client_protocol::Error::method_not_found())
     }
 
@@ -345,6 +354,7 @@ impl Client for RaraDelegate {
         &self,
         _args: ReleaseTerminalRequest,
     ) -> Result<ReleaseTerminalResponse> {
+        warn!("agent requested terminal release, which is not supported");
         Err(agent_client_protocol::Error::method_not_found())
     }
 
@@ -352,10 +362,12 @@ impl Client for RaraDelegate {
         &self,
         _args: WaitForTerminalExitRequest,
     ) -> Result<WaitForTerminalExitResponse> {
+        warn!("agent requested wait for terminal exit, which is not supported");
         Err(agent_client_protocol::Error::method_not_found())
     }
 
     async fn kill_terminal(&self, _args: KillTerminalRequest) -> Result<KillTerminalResponse> {
+        warn!("agent requested terminal kill, which is not supported");
         Err(agent_client_protocol::Error::method_not_found())
     }
 }

--- a/crates/rara-acp/src/events.rs
+++ b/crates/rara-acp/src/events.rs
@@ -129,6 +129,21 @@ pub struct PermissionBridge {
     pub reply_tx:     oneshot::Sender<RequestPermissionOutcome>,
 }
 
+/// Kind of permission option, mirroring the upstream ACP protocol types.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PermissionOptionKind {
+    /// Allow this specific invocation only.
+    AllowOnce,
+    /// Allow all future invocations of this tool.
+    AllowAlways,
+    /// Deny this specific invocation.
+    DenyOnce,
+    /// Deny all future invocations.
+    DenyAlways,
+    /// An unknown/unrecognized option kind from the protocol.
+    Unknown(String),
+}
+
 /// Simplified permission option for UI display.
 #[derive(Debug, Clone)]
 pub struct PermissionOptionInfo {
@@ -136,7 +151,6 @@ pub struct PermissionOptionInfo {
     pub id:    String,
     /// Human-readable label.
     pub label: String,
-    /// Option kind: `"allow_once"`, `"allow_always"`, `"reject_once"`,
-    /// `"reject_always"`.
-    pub kind:  String,
+    /// Option kind.
+    pub kind:  PermissionOptionKind,
 }

--- a/crates/rara-acp/src/lib.rs
+++ b/crates/rara-acp/src/lib.rs
@@ -16,7 +16,11 @@ pub use agent_client_protocol::{RequestPermissionOutcome, SelectedPermissionOutc
 pub use connection::{AcpConnection, AgentCommand};
 pub use error::AcpError;
 pub use events::{
-    AcpEvent, FileOperation, PermissionBridge, PermissionOptionInfo, StopReason, ToolCallStatus,
+    AcpEvent, FileOperation, PermissionBridge, PermissionOptionInfo, PermissionOptionKind,
+    StopReason, ToolCallStatus,
 };
 pub use registry::{AcpAgentConfig, AcpRegistry, AcpRegistryRef, FSAcpRegistry};
-pub use thread::{AcpThread, AcpThreadEntry, AcpThreadStatus, AcpToolCall, PermissionRequestInfo};
+pub use thread::{
+    AcpThread, AcpThreadEntry, AcpThreadStatus, AcpToolCall, PermissionPolicy,
+    PermissionRequestInfo,
+};

--- a/crates/rara-acp/src/registry.rs
+++ b/crates/rara-acp/src/registry.rs
@@ -201,6 +201,8 @@ impl AcpRegistry for FSAcpRegistry {
 }
 
 /// Configuration for a single ACP agent.
+// Note: `Default` is required by `#[serde(default)]` for deserialization.
+// This is an exception to the project convention against deriving Default on config structs.
 #[derive(Debug, Clone, Serialize, Deserialize, Default, bon::Builder)]
 #[serde(default)]
 #[builder(on(String, into))]

--- a/crates/rara-acp/src/thread.rs
+++ b/crates/rara-acp/src/thread.rs
@@ -21,6 +21,16 @@ use crate::{
     events::{AcpEvent, PermissionBridge, PermissionOptionInfo, StopReason, ToolCallStatus},
 };
 
+/// Policy for handling permission requests from the external agent.
+#[derive(Debug, Clone, Default)]
+pub enum PermissionPolicy {
+    /// Auto-approve all requests at the delegate level (no bridge channel).
+    #[default]
+    AutoApprove,
+    /// Forward requests to the caller for interactive resolution.
+    Interactive,
+}
+
 /// Commands sent from AcpThread (Send) to the connection actor (!Send).
 pub(crate) enum AcpCommand {
     /// Send a user prompt to the agent.
@@ -87,6 +97,7 @@ pub enum AcpThreadEntry {
 }
 
 /// A tool call tracked by the AcpThread.
+#[derive(Debug)]
 pub struct AcpToolCall {
     /// Tool call identifier.
     pub id:     String,
@@ -117,6 +128,22 @@ pub enum AcpToolCallStatus {
     Failed,
     /// User rejected the permission request.
     Rejected,
+}
+
+impl std::fmt::Debug for AcpToolCallStatus {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Pending => write!(f, "Pending"),
+            Self::WaitingForConfirmation { options, .. } => f
+                .debug_struct("WaitingForConfirmation")
+                .field("options", options)
+                .finish(),
+            Self::Running => write!(f, "Running"),
+            Self::Completed => write!(f, "Completed"),
+            Self::Failed => write!(f, "Failed"),
+            Self::Rejected => write!(f, "Rejected"),
+        }
+    }
 }
 
 /// Information about a permission request, passed to the resolver callback.
@@ -161,14 +188,29 @@ impl AcpThread {
         agent_name: impl Into<String>,
         command: AgentCommand,
         cwd: PathBuf,
+        permission_policy: PermissionPolicy,
     ) -> Result<Self, AcpError> {
         let agent_name = agent_name.into();
 
         // Channels: command (thread -> actor), event (actor -> thread),
-        // permission (delegate -> thread).
+        // permission (delegate -> thread, only for Interactive mode).
         let (cmd_tx, cmd_rx) = mpsc::channel::<AcpCommand>(8);
         let (event_tx, event_rx) = mpsc::channel::<AcpEvent>(256);
-        let (perm_tx, perm_rx) = mpsc::channel::<PermissionBridge>(8);
+
+        // Only create the permission bridge channel when Interactive mode is
+        // requested. In AutoApprove mode the delegate handles permissions
+        // directly, so no bridge is needed.
+        let (perm_tx, perm_rx) = match &permission_policy {
+            PermissionPolicy::AutoApprove => {
+                // Create a dummy receiver that will never receive anything.
+                let (_tx, rx) = mpsc::channel::<PermissionBridge>(1);
+                (None, rx)
+            }
+            PermissionPolicy::Interactive => {
+                let (tx, rx) = mpsc::channel::<PermissionBridge>(8);
+                (Some(tx), rx)
+            }
+        };
 
         // Session ID delivered after handshake via a oneshot.
         let (session_id_tx, session_id_rx) = oneshot::channel();
@@ -406,6 +448,16 @@ impl AcpThread {
                             message: "prompt reply channel closed".into(),
                         })??;
 
+                    // Prune terminal tool calls to prevent unbounded growth.
+                    self.tool_calls.retain(|_, tc| {
+                        !matches!(
+                            tc.status,
+                            AcpToolCallStatus::Completed
+                                | AcpToolCallStatus::Failed
+                                | AcpToolCallStatus::Rejected
+                        )
+                    });
+
                     self.status = AcpThreadStatus::TurnComplete {
                         stop_reason: stop_reason.clone(),
                     };
@@ -536,12 +588,12 @@ async fn run_connection_actor(
     cwd: PathBuf,
     mut cmd_rx: mpsc::Receiver<AcpCommand>,
     event_fwd_tx: mpsc::Sender<AcpEvent>,
-    perm_tx: mpsc::Sender<PermissionBridge>,
+    perm_tx: Option<mpsc::Sender<PermissionBridge>>,
     session_id_tx: oneshot::Sender<Result<agent_client_protocol::SessionId, AcpError>>,
 ) {
     // Connect and handshake.
     let (mut conn, mut event_rx) =
-        match crate::AcpConnection::connect(&command, &cwd, Some(perm_tx)).await {
+        match crate::AcpConnection::connect(&command, &cwd, perm_tx).await {
             Ok(pair) => pair,
             Err(e) => {
                 let _ = session_id_tx.send(Err(e));
@@ -585,6 +637,12 @@ async fn run_connection_actor(
             }
         }
     }
+
+    // Fallback: ensure ProcessExited is always emitted even if stderr
+    // monitoring didn't fire (e.g. agent kept stderr open).
+    let _ = event_fwd_tx
+        .send(AcpEvent::ProcessExited { code: None })
+        .await;
 }
 
 impl Drop for AcpThread {

--- a/crates/rara-acp/tests/integration_test.rs
+++ b/crates/rara-acp/tests/integration_test.rs
@@ -6,7 +6,7 @@
 use agent_client_protocol::{RequestPermissionOutcome, SelectedPermissionOutcome};
 use rara_acp::{
     AcpAgentConfig, AcpEvent, AcpRegistry, AcpThreadStatus, FSAcpRegistry, FileOperation,
-    PermissionBridge, PermissionOptionInfo, StopReason, ToolCallStatus,
+    PermissionBridge, PermissionOptionInfo, PermissionOptionKind, StopReason, ToolCallStatus,
 };
 use tokio::sync::{mpsc, oneshot};
 
@@ -259,7 +259,7 @@ fn event_types_are_clone_and_debug() {
             options:      vec![PermissionOptionInfo {
                 id:    "allow".into(),
                 label: "Allow".into(),
-                kind:  "allow_once".into(),
+                kind:  PermissionOptionKind::AllowOnce,
             }],
         },
         AcpEvent::FileAccess {
@@ -310,12 +310,12 @@ async fn permission_bridge_roundtrip() {
                 PermissionOptionInfo {
                     id:    "allow".into(),
                     label: "Allow".into(),
-                    kind:  "allow_once".into(),
+                    kind:  PermissionOptionKind::AllowOnce,
                 },
                 PermissionOptionInfo {
                     id:    "deny".into(),
                     label: "Deny".into(),
-                    kind:  "reject_once".into(),
+                    kind:  PermissionOptionKind::DenyOnce,
                 },
             ],
             reply_tx,
@@ -393,7 +393,7 @@ fn permission_option_info_is_clone_and_debug() {
     let opt = PermissionOptionInfo {
         id:    "allow-once".into(),
         label: "Allow Once".into(),
-        kind:  "allow_once".into(),
+        kind:  PermissionOptionKind::AllowOnce,
     };
     let cloned = opt.clone();
     assert_eq!(cloned.id, "allow-once");


### PR DESCRIPTION
## Summary

Addresses 8 code review findings in `rara-acp`:

- **PermissionOptionInfo.kind**: `String` → typed `PermissionOptionKind` enum, eliminating fragile string matching
- **PermissionPolicy**: new enum parameter on `AcpThread::spawn` — `AutoApprove` skips bridge channel entirely, `Interactive` forwards to caller. Eliminates double auto-approve redundancy
- **Process exit detection**: fallback `ProcessExited` event in `run_connection_actor` when stderr EOF doesn't fire
- **tool_calls cleanup**: prune terminal-state entries after turn completion to prevent unbounded growth
- **Debug impls**: manual `Debug` for `AcpToolCallStatus` (skips `oneshot::Sender`), derive on `AcpToolCall`
- **Terminal warnings**: log `warn!` when agent requests unsupported terminal operations
- **AcpAgentConfig Default**: documented as serde exception

## Type of change

| Type | Label |
|------|-------|
| Refactor | `refactor` |

## Component

`core`

## Closes

Closes #672

## Test plan

- [x] `cargo check -p rara-acp -p rara-app` passes
- [x] `cargo clippy -p rara-acp -p rara-app --all-targets --no-deps -- -D warnings` passes
- [x] Pre-commit hooks pass
- [x] Integration tests updated for new enum types