### PR TITLE
fix(symphony): address code review feedback (#635)

### DIFF
--- a/crates/symphony/src/service.rs
+++ b/crates/symphony/src/service.rs
@@ -67,6 +67,7 @@ struct RunningIssue {
     output:     ProcessOutputSummaryHandle,
     rpc_rx:     mpsc::Receiver<crate::rpc::RpcEvent>,
     run_state:  RunState,
+    attempt:    u32,
 }
 
 struct FinishedIssue {
@@ -349,7 +350,7 @@ impl IssueRuntime {
                         FinishedIssue {
                             issue:     run.issue,
                             workspace: run.workspace,
-                            attempt:   0,
+                            attempt:   run.attempt,
                             failed_at: Instant::now(),
                         },
                     );
@@ -372,7 +373,7 @@ impl IssueRuntime {
                     FinishedIssue {
                         issue:     run.issue,
                         workspace: run.workspace,
-                        attempt:   0,
+                        attempt:   run.attempt,
                         failed_at: Instant::now(),
                     },
                 );
@@ -398,7 +399,7 @@ impl IssueRuntime {
                 FinishedIssue {
                     issue:     run.issue,
                     workspace: run.workspace,
-                    attempt:   0,
+                    attempt:   run.attempt,
                     failed_at: Instant::now(),
                 },
             );
@@ -503,7 +504,8 @@ impl IssueRuntime {
     /// Exponential backoff: min(2^attempt * 60s, max_retry_backoff).
     fn retry_delay(&self, attempt: u32) -> Duration {
         let base = Duration::from_secs(60);
-        let exp = base.saturating_mul(1u32.wrapping_shl(attempt));
+        let shift = attempt.min(31);
+        let exp = base.saturating_mul(1u32 << shift);
         exp.min(self.config.max_retry_backoff)
     }
 
@@ -535,29 +537,32 @@ impl IssueRuntime {
                 "retrying failed issue"
             );
 
-            // Clean up old workspace before re-provisioning
-            self.cleanup_workspace(&finished.issue.repo, &finished.workspace);
-
             let issue = finished.issue;
-            if let Err(err) = self
+            match self
                 .start_issue(tracker, issue.clone(), Some(next_attempt))
                 .await
             {
-                error!(
-                    issue_id = %issue_id,
-                    attempt = next_attempt,
-                    error = %err,
-                    "failed to retry issue"
-                );
-                self.failed.insert(
-                    issue_id,
-                    FinishedIssue {
-                        issue,
-                        workspace: finished.workspace,
-                        attempt: next_attempt,
-                        failed_at: Instant::now(),
-                    },
-                );
+                Ok(()) => {
+                    // Clean up old workspace only after successful re-provisioning
+                    self.cleanup_workspace(&issue.repo, &finished.workspace);
+                }
+                Err(err) => {
+                    error!(
+                        issue_id = %issue_id,
+                        attempt = next_attempt,
+                        error = %err,
+                        "failed to retry issue"
+                    );
+                    self.failed.insert(
+                        issue_id,
+                        FinishedIssue {
+                            issue,
+                            workspace: finished.workspace,
+                            attempt: next_attempt,
+                            failed_at: Instant::now(),
+                        },
+                    );
+                }
             }
         }
     }
@@ -612,6 +617,7 @@ impl IssueRuntime {
                 output,
                 rpc_rx,
                 run_state: RunState::default(),
+                attempt: 0,
             },
         );
         Ok(())
@@ -747,6 +753,7 @@ impl IssueRuntime {
                 output,
                 rpc_rx,
                 run_state: RunState::default(),
+                attempt: attempt.unwrap_or(0),
             },
         );
         Ok(())
@@ -1001,13 +1008,20 @@ struct ProcessOutputSummaryHandle(std::sync::Arc<std::sync::Mutex<ProcessOutputS
 
 impl ProcessOutputSummaryHandle {
     fn record(&self, stream_name: &'static str, line: String) {
-        if let Ok(mut guard) = self.0.lock() {
-            guard.record(stream_name, line);
+        match self.0.lock() {
+            Ok(mut guard) => guard.record(stream_name, line),
+            Err(_) => warn!("ProcessOutputSummary mutex poisoned, dropping output line"),
         }
     }
 
     fn snapshot(&self) -> ProcessOutputSummary {
-        self.0.lock().map(|g| g.clone()).unwrap_or_default()
+        match self.0.lock() {
+            Ok(guard) => guard.clone(),
+            Err(poisoned) => {
+                warn!("ProcessOutputSummary mutex poisoned, recovering");
+                poisoned.into_inner().clone()
+            }
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

Applies code review fixes from the symphony refinement effort (#635):
- **P1**: Fix `retry_delay` overflow — cap shift to `min(attempt, 31)` before left-shift
- **P1**: Add `attempt` field to `RunningIssue`, propagate through all `FinishedIssue` sites
- **P2**: Log warning on poisoned mutex instead of silently dropping/defaulting
- **P2**: Clean up old workspace only after successful retry re-provisioning

Supersedes #660 (which had merge conflicts due to squash-merge history divergence).

## Type of change

| Type | Label |
|------|-------|
| Bug fix | `bug` |

## Component

`core`

## Closes

Closes #635

## Test plan

- [x] `cargo test -p rara-symphony` — 33 tests pass
- [x] `cargo clippy -p rara-symphony` clean
- [x] All pre-commit checks pass