### PR TITLE
fix(kernel): log and recover from job_wheel mutex poisoning (#689)

### DIFF
--- a/crates/kernel/src/kernel.rs
+++ b/crates/kernel/src/kernel.rs
@@ -443,8 +443,11 @@ impl Kernel {
                     .syscall
                     .job_wheel()
                     .lock()
-                    .ok()
-                    .and_then(|w| w.next_deadline())
+                    .unwrap_or_else(|e| {
+                        warn!(error = %e, "job_wheel mutex poisoned, recovering inner data");
+                        e.into_inner()
+                    })
+                    .next_deadline()
                     .map(|ts| {
                         let now_ts = jiff::Timestamp::now();
                         let delta = ts.duration_since(now_ts);
@@ -512,9 +515,14 @@ impl Kernel {
                     info!(processor_id = id, "event processor shutting down");
                     // Persist scheduled jobs on shutdown.
                     if id == 0 {
-                        if let Ok(wheel) = self.syscall.job_wheel().lock() {
-                            wheel.persist();
-                        }
+                        self.syscall
+                            .job_wheel()
+                            .lock()
+                            .unwrap_or_else(|e| {
+                                warn!(error = %e, "job_wheel mutex poisoned during shutdown, recovering");
+                                e.into_inner()
+                            })
+                            .persist();
                     }
                     for event in queue.drain(1024) {
                         if matches!(event.kind, KernelEvent::SendSignal { .. } | KernelEvent::Shutdown) {
@@ -1086,9 +1094,14 @@ impl Kernel {
                 {
                     if let Ok(uuid) = uuid::Uuid::parse_str(job_id_str) {
                         let job_id = crate::schedule::JobId(uuid);
-                        if let Ok(mut wheel) = self.syscall.job_wheel().lock() {
-                            wheel.complete_in_flight(&job_id);
-                        }
+                        self.syscall
+                            .job_wheel()
+                            .lock()
+                            .unwrap_or_else(|e| {
+                                warn!(error = %e, "job_wheel mutex poisoned, recovering");
+                                e.into_inner()
+                            })
+                            .complete_in_flight(&job_id);
                     }
                 }
             }


### PR DESCRIPTION
## Summary

Replaces all three `.lock().ok()` / `if let Ok(...)` patterns on `job_wheel()` mutex with `unwrap_or_else` that logs a `warn!` with structured tracing fields and recovers the inner data via `into_inner()`. Previously, mutex poisoning was silently swallowed, causing the scheduler to fall back to a 1-hour sleep with no log output.

## Type of change

| Type | Label |
|------|-------|
| Bug fix | `bug` |

## Component

`core`

## Closes

Closes #689

## Test plan

- [x] `cargo check -p kernel` passes
- [x] `cargo clippy -p kernel` passes
- [x] `cargo test -p kernel` passes
- [x] All 3 lock sites fixed consistently (lines ~445, ~515, ~1094)
- [x] Code review clean (autonomous, 1 round)