### PR TITLE
chore(docs): replace created-by:claude with agent label system (#698)

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -508,7 +508,7 @@ for item in items {
 
 * 禁止直接在 `main` 上开发或合并。
 * 所有变更必须通过 GitHub PR 合并，流程如下：
-  1. 创建 issue（`gh issue create`，必须带 `created-by:claude` label）；
+  1. 创建 issue（`gh issue create`，必须带 `agent:claude` label）；
   2. 创建 worktree + 分支（`git worktree add .worktrees/issue-{N}-{name} -b issue-{N}-{name}`）；
   3. 在 worktree 中完成开发、验证并 commit；
   4. push 分支到 remote（`git push -u origin issue-{N}-{name}`）；

--- a/docs/guides/anti-patterns.md
+++ b/docs/guides/anti-patterns.md
@@ -15,7 +15,7 @@
 - Do NOT work directly on `main` — ALL changes (code, docs, config) require a worktree + PR, no exceptions
 - Do NOT merge locally on `main` — all merges go through GitHub PRs; never `git merge` or `git commit` on main
 - Do NOT edit files in the main checkout for 'quick fixes' — even one-line changes must go through the full issue → worktree → PR flow
-- Do NOT create issues without `created-by:claude` label
+- Do NOT create issues without the appropriate agent label (`agent:claude`, `agent:codex`, etc.)
 - Do NOT create PRs or issues without type + component labels — every PR and issue must have a type label (`bug`, `enhancement`, `refactor`, `chore`, `documentation`) and a component label (`core`, `backend`, `ui`, `extension`, `ci`)
 - Do NOT leave stale worktrees — clean up after PR is merged
 - Do NOT report PR as complete before CI is green — use `gh pr checks --watch` and fix failures before reporting

--- a/docs/guides/stacked-prs.md
+++ b/docs/guides/stacked-prs.md
@@ -29,7 +29,7 @@ kernel (core runtime, heartbeat, event bus)
 ### Alternatives considered
 N/A
 EOF
-)" --label "created-by:claude" --label "core"
+)" --label "agent:claude" --label "core"
 ```
 This is the tracking issue (e.g., #100). All sub-issues reference it.
 
@@ -55,7 +55,7 @@ kernel (core runtime, heartbeat, event bus)
 ### Alternatives considered
 N/A
 EOF
-)" --label "created-by:claude" --label "core"
+)" --label "agent:claude" --label "core"
 ```
 
 ## Step 4: Stack Branches and Work

--- a/docs/guides/workflow.md
+++ b/docs/guides/workflow.md
@@ -36,7 +36,7 @@ kernel (core runtime, heartbeat, event bus)
 ### Alternatives considered
 None.
 EOF
-)" --label "created-by:claude" --label "core"
+)" --label "agent:claude" --label "core"
 
 # Example: bug report
 gh issue create --template bug_report.yml \
@@ -59,11 +59,11 @@ web (frontend, UI)
 ### Version
 rara 0.0.1
 EOF
-)" --label "created-by:claude" --label "ui"
+)" --label "agent:claude" --label "ui"
 ```
 
 **Issue Labels** (all issues MUST have proper labels):
-- `created-by:claude` — required for all agent-created issues
+- **Agent** (required for agent-created issues): `agent:claude`, `agent:codex` — use the label matching the agent performing the operation
 - **Type**: auto-applied by the template (`enhancement`, `bug`, `refactor`, `chore`)
 - **Component** (pick one): `core`, `backend`, `ui`, `extension`, `ci`
 

--- a/docs/plans/2026-03-19-dev-pipeline-design.md
+++ b/docs/plans/2026-03-19-dev-pipeline-design.md
@@ -77,7 +77,7 @@ A single slash command `/dev "requirement"` that runs the full development pipel
 ```bash
 # Create issue (--template cannot be used with --body, so body must follow template structure)
 # Body fields: ### Description, ### Component, ### Alternatives considered
-gh issue create --title "{title}" --body "..." --label "created-by:claude" --label "{component}"
+gh issue create --title "{title}" --body "..." --label "agent:claude" --label "{component}"
 
 # Create worktree
 git worktree add .worktrees/issue-{N}-{name} -b issue-{N}-{name}


### PR DESCRIPTION
## Summary

Replace `created-by:claude` label with `agent:claude` across all workflow docs and skills. Update label descriptions to support multiple agent labels (`agent:claude`, `agent:codex`) for identifying which AI agent performed operations.

## Type of change

| Type | Label |
|------|-------|
| Maintenance | `chore` |

## Component

`ci`

## Closes

Closes #698

## Test plan

- [x] No `created-by:claude` references remaining in codebase
- [x] All 6 affected files updated consistently
- [x] GitHub labels `agent:claude` and `agent:codex` already created on repo