### PR TITLE
fix(skills): include install_repo in marketplace tool description (#704)

### DIFF
--- a/crates/app/src/tools/marketplace.rs
+++ b/crates/app/src/tools/marketplace.rs
@@ -50,9 +50,11 @@ pub struct MarketplaceParams {
 #[derive(ToolDef)]
 #[tool(
     name = "marketplace",
-    description = "Browse, search, install, enable/disable plugins from Claude Code marketplace \
-                   repos and ClawHub (clawhub.ai). Actions: browse, search, install, enable, \
-                   disable, add_source, refresh, clawhub_search, clawhub_browse, clawhub_install."
+    description = "Browse, search, and install skills and plugins. Use install_repo to install a \
+                   skill repo from GitHub (owner/repo or full URL). Use install to install a \
+                   single plugin from a marketplace. Actions: browse, search, install, \
+                   install_repo, enable, disable, add_source, remove_source, refresh, \
+                   clawhub_search, clawhub_browse, clawhub_install."
 )]
 pub struct MarketplaceTool {
     service: Arc<MarketplaceService>,


### PR DESCRIPTION
## Summary

The marketplace tool description omitted the `install_repo` action and keywords like "skill repo" and "GitHub". This caused the agent to not recognize when to use this tool for installing skill repos from GitHub (e.g., `rararulab/rara-skills`).

Updated the description to explicitly mention `install_repo`, "skill repo", and "GitHub" so the agent can match user intent.

## Type of change

| Type | Label |
|------|-------|
| Bug fix | `bug` |

## Component

`core`

## Closes

Closes #704

## Test plan

- [x] `cargo check` passes
- [x] `cargo clippy` passes
- [x] `cargo fmt` passes
- [x] `cargo doc` passes
- [x] Pre-commit hooks all green