### PR TITLE
fix(skills): hybrid repo scan fallback (#714)

### DIFF
--- a/crates/skills/src/formats.rs
+++ b/crates/skills/src/formats.rs
@@ -685,4 +685,51 @@ mod tests {
 
         assert_eq!(extract_description_from_body(""), "");
     }
+
+    #[test]
+    fn hybrid_repo_detected_as_claude_code_but_scan_returns_empty() {
+        // A repo with marketplace.json but no plugin.json in the source dir,
+        // and native SKILL.md files — the ClaudeCode adapter should return
+        // empty so the caller can fallback to SKILL.md scanning.
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+
+        // Create marketplace.json pointing to root (no plugin.json there).
+        let claude_dir = root.join(".claude-plugin");
+        std::fs::create_dir_all(&claude_dir).unwrap();
+        std::fs::write(
+            claude_dir.join("marketplace.json"),
+            r#"{
+                "name": "hybrid-repo",
+                "plugins": [
+                    { "name": "my-skills", "source": "./" }
+                ]
+            }"#,
+        )
+        .unwrap();
+
+        // Create native SKILL.md files.
+        let skill_dir = root.join("skills/my-skill");
+        std::fs::create_dir_all(&skill_dir).unwrap();
+        std::fs::write(
+            skill_dir.join("SKILL.md"),
+            "---\nname: my-skill\ndescription: test\n---\n# My Skill\nDoes stuff.",
+        )
+        .unwrap();
+
+        // detect_format sees marketplace.json → ClaudeCode.
+        let format = detect_format(root);
+        assert_eq!(format, PluginFormat::ClaudeCode);
+
+        // But ClaudeCode scan returns empty (no plugin.json in source dir).
+        let adapter = ClaudeCodeAdapter;
+        let results = adapter.scan_skills(root).unwrap();
+        assert!(
+            results.is_empty(),
+            "ClaudeCode adapter should return empty for hybrid repo, got: {results:?}"
+        );
+
+        // Verify SKILL.md files exist (caller would fallback to scan_repo_skills).
+        assert!(has_skill_md_recursive(root));
+    }
 }

--- a/crates/skills/src/install.rs
+++ b/crates/skills/src/install.rs
@@ -70,36 +70,52 @@ pub async fn install_skill(source: &str, install_dir: &Path) -> Result<Vec<Skill
     let format = detect_format(&target);
     let (skills_meta, skill_states) = match format {
         PluginFormat::Skill => scan_repo_skills(&target, install_dir).await?,
-        _ => match scan_with_adapter(&target, format) {
-            Some(result) => {
-                let entries = result?;
-                let relative = target
-                    .strip_prefix(install_dir)
-                    .unwrap_or(&target)
-                    .to_string_lossy()
-                    .to_string();
-                let meta: Vec<SkillMetadata> = entries.iter().map(|e| e.metadata.clone()).collect();
-                let states: Vec<SkillState> = entries
-                    .iter()
-                    .map(|e| SkillState {
-                        name:          e.metadata.name.clone(),
-                        relative_path: relative.clone(),
-                        trusted:       false,
-                        enabled:       true,
-                    })
-                    .collect();
-                (meta, states)
-            }
-            None => {
-                let _ = tokio::fs::remove_dir_all(&target).await;
-                return InstallSnafu {
-                    message: format!(
-                        "no adapter available for format '{format}' in repo '{source}'"
-                    ),
+        _ => {
+            let adapter_result = match scan_with_adapter(&target, format) {
+                Some(result) => {
+                    let entries = result?;
+                    let relative = target
+                        .strip_prefix(install_dir)
+                        .unwrap_or(&target)
+                        .to_string_lossy()
+                        .to_string();
+                    let meta: Vec<SkillMetadata> =
+                        entries.iter().map(|e| e.metadata.clone()).collect();
+                    let states: Vec<SkillState> = entries
+                        .iter()
+                        .map(|e| SkillState {
+                            name:          e.metadata.name.clone(),
+                            relative_path: relative.clone(),
+                            trusted:       false,
+                            enabled:       true,
+                        })
+                        .collect();
+                    (meta, states)
                 }
-                .fail();
+                None => (Vec::new(), Vec::new()),
+            };
+
+            // Fallback: hybrid repos may use a non-Skill manifest (e.g.
+            // marketplace.json) alongside native SKILL.md files. When the
+            // format-specific adapter finds nothing, try SKILL.md scanning.
+            let (ref meta, _) = adapter_result;
+            if meta.is_empty() {
+                let (fallback_meta, fallback_states) =
+                    scan_repo_skills(&target, install_dir).await?;
+                if fallback_meta.is_empty() {
+                    adapter_result
+                } else {
+                    tracing::info!(
+                        format = %format,
+                        count = fallback_meta.len(),
+                        "adapter scan empty, fell back to SKILL.md scanning"
+                    );
+                    (fallback_meta, fallback_states)
+                }
+            } else {
+                adapter_result
             }
-        },
+        }
     };
 
     if skills_meta.is_empty() {


### PR DESCRIPTION
## Summary

Fix skill installation for hybrid repos that have `.claude-plugin/marketplace.json` (detected as `ClaudeCode` format) but use native `SKILL.md` files for actual skills.

When `scan_with_adapter` returns empty results, fallback to `scan_repo_skills` (SKILL.md scanning) before declaring "repository contains no skills".

## Type of change

| Type | Label |
|------|-------|
| Bug fix | `bug` |

## Component

`backend`

## Closes

Closes #714

## Test plan

- [x] `cargo test -p rara-skills` passes (14 tests)
- [x] `cargo check -p rara-skills` passes
- [x] New test `hybrid_repo_detected_as_claude_code_but_scan_returns_empty` validates the scenario

## Review Log

_Review in progress..._