### PR TITLE
fix(symphony): include source in Linear error display (#724)

### DIFF
--- a/crates/symphony/src/error.rs
+++ b/crates/symphony/src/error.rs
@@ -33,7 +33,7 @@ pub enum SymphonyError {
         location: snafu::Location,
     },
 
-    #[snafu(display("linear API error: {message}"))]
+    #[snafu(display("linear API error: {message}: {source}"))]
     Linear {
         message:  String,
         source:   lineark_sdk::LinearError,

--- a/crates/symphony/src/service.rs
+++ b/crates/symphony/src/service.rs
@@ -194,7 +194,7 @@ impl IssueRuntime {
         let issues = match tracker.fetch_active_issues().await {
             Ok(issues) => issues,
             Err(err) => {
-                warn!(error = %err, "failed to fetch active issues");
+                warn!(error = ?err, "failed to fetch active issues");
                 return;
             }
         };


### PR DESCRIPTION
## Summary

- Include `{source}` in `SymphonyError::Linear` display format so the underlying `lineark_sdk::LinearError` is visible in logs
- Switch `service.rs` warn log from `%err` (Display) to `?err` (Debug) to show the full error chain

## Type of change

| Type | Label |
|------|-------|
| Bug fix | `bug` |

## Component

`backend`

## Closes

Closes #724

## Test plan

- [x] `cargo check -p rara-symphony` passes
- [x] Pre-commit hooks pass (fmt, clippy, doc, check)