### PR TITLE
fix(kernel): allow ancestor paths in path_scope guard for directory tools (#727)

### DIFF
--- a/crates/kernel/src/guard/path_scope.rs
+++ b/crates/kernel/src/guard/path_scope.rs
@@ -135,25 +135,38 @@ impl PathScopeGuard {
         // For directory-scanning tools, also allow paths that are *ancestors* of the
         // workspace or a whitelist entry. Example: `grep path:"/Users/foo/.config"`
         // when workspace is `/Users/foo/.config/rara/workspace`. The tool will
-        // naturally traverse into the workspace subtree.
+        // search the entire subtree of this ancestor path, which includes (but is
+        // not limited to) the workspace.
         //
         // Excluded: root path `/` (1 component) — would trivially match everything.
         // Excluded: file-targeting tools (read-file, write-file, edit-file) — they
         // operate on specific files, not directory trees.
-        if PATH_TOOLS.contains(&tool_name) && resolved.components().count() > 1 {
-            if path_starts_with(&self.workspace, &resolved) {
+        // Depth-limited: ancestors more than MAX_ANCESTOR_DEPTH levels above the
+        // workspace/whitelist entry are rejected to prevent overly broad scans.
+        const MAX_ANCESTOR_DEPTH: usize = 3;
+        let ancestor_components = resolved.components().count();
+        if PATH_TOOLS.contains(&tool_name) && ancestor_components > 1 {
+            let ws_components = self.workspace.components().count();
+            if ws_components.saturating_sub(ancestor_components) <= MAX_ANCESTOR_DEPTH
+                && path_starts_with(&self.workspace, &resolved)
+            {
                 tracing::debug!(
                     path = %resolved.display(),
                     workspace = %self.workspace.display(),
+                    depth = ws_components.saturating_sub(ancestor_components),
                     "path-scope guard: path is ancestor of workspace, allowing"
                 );
                 return None;
             }
             for allowed in &self.whitelist {
-                if path_starts_with(allowed, &resolved) {
+                let allowed_components = allowed.components().count();
+                if allowed_components.saturating_sub(ancestor_components) <= MAX_ANCESTOR_DEPTH
+                    && path_starts_with(allowed, &resolved)
+                {
                     tracing::debug!(
                         path = %resolved.display(),
                         whitelist_entry = %allowed.display(),
+                        depth = allowed_components.saturating_sub(ancestor_components),
                         "path-scope guard: path is ancestor of whitelist entry, allowing"
                     );
                     return None;
@@ -656,5 +669,23 @@ mod tests {
         // /home/us is NOT an ancestor of /home/user/project (component boundary)
         let args = json!({"path": "/home/us"});
         assert!(g.check("grep", &args).is_some());
+    }
+
+    #[test]
+    fn ancestor_beyond_max_depth_blocked() {
+        // workspace = /a/b/c/d/e/f (7 components). /a/b is 3 components.
+        // depth = 7 - 3 = 4 > MAX_ANCESTOR_DEPTH (3) → blocked.
+        let g = PathScopeGuard::new(PathBuf::from("/a/b/c/d/e/f"), vec![]);
+        let args = json!({"path": "/a/b"});
+        assert!(g.check("grep", &args).is_some());
+    }
+
+    #[test]
+    fn ancestor_at_max_depth_passes() {
+        // workspace = /a/b/c/d/e/f (7 components). /a/b/c is 4 components.
+        // depth = 7 - 4 = 3 == MAX_ANCESTOR_DEPTH → passes.
+        let g = PathScopeGuard::new(PathBuf::from("/a/b/c/d/e/f"), vec![]);
+        let args = json!({"path": "/a/b/c"});
+        assert_eq!(g.check("grep", &args), None);
     }
 }


### PR DESCRIPTION
## Summary

`PathScopeGuard` incorrectly blocks access to paths that are ancestors of the workspace or whitelist entries. For example, `grep path:"/Users/rara/.config"` is blocked when workspace is `/Users/rara/.config/rara/workspace`.

This PR adds a reverse `path_starts_with` check for directory-scanning tools (`grep`, `list-directory`, `find-files`), allowing them to access ancestor paths. File-targeting tools (`read-file`, `write-file`, `edit-file`) remain strictly scoped. Root path `/` is explicitly excluded to prevent guard bypass.

## Type of change

| Type | Label |
|------|-------|
| Bug fix | `bug` |

## Component

`core`

## Closes

Closes #727

## Test plan

- [x] `ancestor_of_workspace_passes_for_path_tools` — directory tools can access workspace parent
- [x] `ancestor_of_workspace_blocked_for_file_tools` — file tools remain strict
- [x] `grandparent_of_workspace_passes` — multi-level ancestor works
- [x] `root_path_blocked_despite_being_ancestor` — `/` is excluded
- [x] `ancestor_of_whitelist_entry_passes` — whitelist ancestor works
- [x] `unrelated_sibling_of_workspace_parent_blocked` — unrelated paths still blocked
- [x] `common_prefix_not_ancestor_blocked` — component boundary enforced
- [x] All existing 32 path_scope tests still pass
- [x] `cargo clippy` zero warnings
- [x] Pre-commit hooks pass

## Review Log

_Review in progress..._