### PR TITLE
refactor(kernel): flatten spawn-background params — remove nested manifest (#764)

### DIFF
--- a/crates/agents/src/lib.rs
+++ b/crates/agents/src/lib.rs
@@ -236,6 +236,7 @@ Your personality and speaking style are defined entirely by your soul prompt. Fo
 
 ## Background Tasks
 - Use `spawn-background` for tasks that take a long time but do not need immediate user interaction: bulk data processing, multi-step research, large file analysis, batch API calls, or deep codebase searches.
+- Required params: `input` (task instruction), `description` (short status label), `system_prompt` (agent behavior). Optional: `name`, `tools` (list of tool names), `model`, `max_iterations`.
 - Do NOT use it for tasks where the user is waiting for the answer to continue their train of thought, or tasks that need clarification mid-way.
 - When spawning a background task, briefly tell the user what you kicked off and that they will be notified when it finishes. Then move on.
 - When a background task result arrives, summarize the outcome concisely. If it failed, explain what went wrong.

--- a/crates/kernel/src/tool/spawn_background.rs
+++ b/crates/kernel/src/tool/spawn_background.rs
@@ -34,9 +34,10 @@ use crate::{
 #[derive(ToolDef)]
 #[tool(
     name = "spawn-background",
-    description = "Spawn a background agent to handle a long-running task. The agent runs \
-                   independently and results are delivered when complete. You cannot interact \
-                   with the background agent after spawning it."
+    description = "Spawn a background agent for a long-running task. Provide `input` (task \
+                   instruction), `description` (short status label), and `system_prompt` (agent \
+                   behavior). Optional: `name`, `tools`, `model`, `max_iterations`. The agent \
+                   runs independently and results are delivered when complete."
 )]
 pub struct SpawnBackgroundTool {
     handle:      KernelHandle,


### PR DESCRIPTION
## Summary

- Replace the opaque `manifest: serde_json::Value` parameter with flat top-level fields (`system_prompt`, `name`, `tools`, `model`, `max_iterations`)
- Build `AgentManifest` internally with sensible defaults (Worker role, max_iterations=15, no children)
- Auto-generate kebab-case agent name from `description` when `name` is omitted
- LLMs no longer need to construct a nested JSON object — just pass simple string/array params

## Type of change

| Type | Label |
|------|-------|
| Refactor | `refactor` |

## Component

`core`

## Closes

Closes #764

## Test plan

- [x] `cargo check --all` passes
- [x] `cargo +nightly fmt --all -- --check` passes
- [x] `cargo clippy` passes
- [x] `cargo doc` passes
- [x] All pre-commit hooks pass