### PR TITLE
fix(kernel): make interceptor prompt fragment dynamic to track MCP state (#763)

### DIFF
--- a/crates/app/src/context_mode.rs
+++ b/crates/app/src/context_mode.rs
@@ -34,9 +34,6 @@ use tracing::{debug, warn};
 /// Name of the context-mode MCP server in the registry.
 const SERVER_NAME: &str = "context-mode";
 
-/// Tool name prefix used by context-mode MCP server.
-const TOOL_PREFIX: &str = "context-mode__";
-
 /// Default output size threshold in bytes (8 KB).
 const DEFAULT_THRESHOLD: usize = 8 * 1024;
 

--- a/crates/kernel/src/agent/mod.rs
+++ b/crates/kernel/src/agent/mod.rs
@@ -1061,13 +1061,10 @@ pub(crate) async fn run_agent_loop(
         None
     };
 
-    // Pre-fetch interceptor system prompt fragment (avoids per-iteration lock).
-    let interceptor_fragment: Option<String> = {
-        let guard = output_interceptor.read().await;
-        guard
-            .as_ref()
-            .and_then(|i| i.system_prompt_fragment().map(str::to_owned))
-    };
+    // Interceptor prompt fragment is read dynamically each iteration (not cached)
+    // so it reflects the current MCP connection state — when context-mode
+    // disconnects, the fragment disappears and the LLM stops being told to
+    // call tools that no longer exist.
 
     for iteration in 0..max_iterations {
         // ── Auto-fold: pressure-driven context compression ───────────
@@ -1169,12 +1166,16 @@ pub(crate) async fn run_agent_loop(
             })?;
 
         // Inject output interceptor system prompt (e.g. context-mode guidance).
-        if let Some(ref fragment) = interceptor_fragment {
-            let insert_pos = messages
-                .iter()
-                .position(|m| m.role != crate::llm::Role::System)
-                .unwrap_or(messages.len());
-            messages.insert(insert_pos, crate::llm::Message::system(fragment.clone()));
+        // Read fresh each iteration so it tracks MCP connection state (#763).
+        {
+            let guard = output_interceptor.read().await;
+            if let Some(fragment) = guard.as_ref().and_then(|i| i.system_prompt_fragment()) {
+                let insert_pos = messages
+                    .iter()
+                    .position(|m| m.role != crate::llm::Role::System)
+                    .unwrap_or(messages.len());
+                messages.insert(insert_pos, crate::llm::Message::system(fragment.to_owned()));
+            }
         }
 
         // Conditional injections (tape search reminder only on first iteration)


### PR DESCRIPTION
## Summary

The context-mode interceptor's system prompt fragment was cached once at boot and injected every agent iteration, regardless of whether the MCP server was still connected. When context-mode disconnected, the LLM was still told to call `ctx_search` — a tool that no longer existed in the registry.

**Fix:** Read the fragment fresh from the `output_interceptor` RwLock each iteration instead of caching it. When the MCP server disconnects and the interceptor is cleared, the fragment naturally disappears.

Also removed the dead `TOOL_PREFIX` constant from `context_mode.rs`.

## Type of change

| Type | Label |
|------|-------|
| Bug fix | `bug` |

## Component

`core`

## Closes

Closes #763

## Test plan

- [x] `cargo check -p rara-kernel -p rara-app` passes
- [x] `cargo test -p rara-kernel` passes (16/16)
- [x] Pre-commit hooks pass (check, fmt, clippy, doc)
- [x] Manual verification: when MCP disconnects, fragment is no longer injected