### PR TITLE
docs: update README to reflect tape-based architecture (#783)

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,42 +14,40 @@ Unlike generic AI assistants that wait for your commands, Rara proactively monit
 
 ## Architecture
 
-```
-┌──────────────────────────────────────────────────────────────┐
-│                         Channels                              │
-│               Telegram  ·  WebChat  ·  Terminal                │
-└───────────────────────────┬──────────────────────────────────┘
-                            │
-┌───────────────────────────▼──────────────────────────────────┐
-│                         Kernel                                │
-│                                                               │
-│   ┌─────────┐  ┌──────────┐  ┌──────────┐  ┌─────────────┐  │
-│   │   LLM   │  │   Tool   │  │  Memory  │  │   Session    │  │
-│   │ Driver  │  │ Registry │  │  (Tape)  │  │   Index      │  │
-│   └─────────┘  └──────────┘  └──────────┘  └─────────────┘  │
-│   ┌─────────┐  ┌──────────────────────────────────────────┐  │
-│   │  Guard  │  │  EventBus · Notifications · Queue        │  │
-│   │Pipeline │  │  (sharded event dispatch + pub/sub)      │  │
-│   └─────────┘  └──────────────────────────────────────────┘  │
-│                                                               │
-│   Agent Loop · Context Budget · IO Subsystem · Rate Limiter  │
-└───┬──────────────┬──────────────┬────────────────────────────┘
-    │              │              │
-    ▼              ▼              ▼
-┌────────┐  ┌───────────┐  ┌──────────────┐
-│  Tape  │  │   Skills  │  │  Extensions  │
-│        │  │           │  │              │
-│ JSONL  │  │ discovery │  │ git          │
-│ append │  │ registry  │  │ backend-admin│
-│ anchor │  │           │  │              │
-│ fork   │  │           │  │              │
-└────────┘  └───────────┘  └──────────────┘
-    │              │              │
-    ▼              ▼              ▼
-┌──────────────────────────────────────────────────────────────┐
-│                       Integrations                            │
-│          MCP  ·  Composio  ·  OAuth  ·  Credential Store      │
-└──────────────────────────────────────────────────────────────┘
+```mermaid
+graph TD
+    subgraph Channels
+        Telegram
+        WebChat
+        Terminal
+    end
+
+    subgraph Kernel
+        LLM[LLM Driver]
+        Tool[Tool Registry]
+        Memory[Memory / Tape]
+        Session[Session Index]
+        Guard[Guard Pipeline]
+        EventBus[EventBus · Notifications · Queue]
+        AgentLoop[Agent Loop · Context Budget · IO · Rate Limiter]
+    end
+
+    subgraph Capabilities
+        Tape[Tape\nJSONL · append · anchor · fork]
+        Skills[Skills\ndiscovery · registry]
+        Extensions[Extensions\ngit · backend-admin]
+    end
+
+    subgraph Integrations
+        MCP
+        Composio
+        OAuth
+        CredentialStore[Credential Store]
+    end
+
+    Channels --> Kernel
+    Kernel --> Capabilities
+    Capabilities --> Integrations
 ```
 
 ### Tape Memory


### PR DESCRIPTION
## Summary

Update README to reflect the current architecture:
- Replace outdated mem0/Memos/Hindsight memory references with tape system (append-only JSONL with anchors, fork/merge)
- Update architecture diagram to show kernel 6 components (LLM, Tool, Memory, Session, Guard, EventBus)
- Refresh crate map to match current workspace members (add rara-agents, rara-soul, rara-symphony, rara-vault, rara-dock, rara-acp, etc.; remove deleted crates)
- Update configuration section (YAML-based instead of .env)
- Add Tape Memory subsection explaining the core memory architecture

## Type of change

| Type | Label |
|------|-------|
| Documentation | `documentation` |

## Component

`ci`

## Closes

Closes #783

## Test plan

- [x] README renders correctly on GitHub
- [x] Architecture diagram is accurate
- [x] Crate map matches `Cargo.toml` workspace members