### PR TITLE
fix(kernel): set max_tokens to 1024 in agent loop CompletionRequest (#802)

### DIFF
--- a/crates/kernel/src/agent/mod.rs
+++ b/crates/kernel/src/agent/mod.rs
@@ -1310,7 +1310,7 @@ pub(crate) async fn run_agent_loop(
             messages:            messages.clone(),
             tools:               tool_defs.clone(),
             temperature:         Some(0.7),
-            max_tokens:          None,
+            max_tokens:          Some(1024),
             thinking:            None,
             tool_choice:         if tool_defs.is_empty() {
                 llm::ToolChoice::None


### PR DESCRIPTION
## Summary

Set `max_tokens` from `None` to `Some(1024)` in the `CompletionRequest` constructed within `run_agent_loop`, limiting single completion output length.

## Type of change

| Type | Label |
|------|-------|
| Bug fix | `bug` |

## Component

`core`

## Closes

Closes #802

## Test plan

- [x] `cargo check -p rara-kernel` passes
- [x] `prek run --all-files` passes (fmt, clippy, check, doc)