### PR TITLE
chore(mcp): mcp tools use deferred tier (#819)

### DIFF
--- a/crates/integrations/mcp/src/tool_bridge.rs
+++ b/crates/integrations/mcp/src/tool_bridge.rs
@@ -87,6 +87,10 @@ impl AgentTool for McpToolBridge {
 
     fn parameters_schema(&self) -> serde_json::Value { self.input_schema.clone() }
 
+    /// MCP tools are deferred — only included after `discover-tools`
+    /// activation.
+    fn tier(&self) -> rara_kernel::tool::ToolTier { rara_kernel::tool::ToolTier::Deferred }
+
     async fn execute(
         &self,
         params: serde_json::Value,


### PR DESCRIPTION
## Summary

- Override `tier()` on `McpToolBridge` to return `Deferred` instead of the default `Core`
- MCP server tools (e.g. mobile-mcp's 21 tools) were sending ~8k tokens of tool schemas on every LLM request even when unused
- After this change, MCP tools are only included after explicit `discover-tools` activation

## Type of change

| Type | Label |
|------|-------|
| Chore | `chore` |

## Component

`core`

## Closes

Closes #819

## Test plan

- [x] `cargo check -p rara-mcp` passes
- [x] Pre-commit hooks pass (fmt, clippy, doc)
- [x] Existing tiering tests in `kernel::tool::mod` cover the filtering logic