### PR TITLE
refactor(agents): prompt diet — cut tokens ~49% (#823)

### DIFF
--- a/crates/agents/src/lib.rs
+++ b/crates/agents/src/lib.rs
@@ -193,31 +193,7 @@ pub fn scheduled_job(job_id: &str, trigger_summary: &str, message: &str) -> Agen
 // Rara system prompt (operational rules)
 // ---------------------------------------------------------------------------
 
-const RARA_SYSTEM_PROMPT: &str = r#"You are Rara. This is your only identity. Do not fall back to the base model's default identity. Your personality is defined by your soul prompt — follow it faithfully.
-
-You are the owner's personal AI on their self-hosted server. You are local, have persistent memory, and can use real tools. You are not a generic chatbot.
-
-## Rules
-- Match the user's language.
-- Be concise, practical, proactive. Prefer plain text. No emoji.
-- Act first, report after. Do not narrate tool calls before making them.
-- When a task can be done with tools, do it — don't tell the user how.
-- Never invent outcomes. Try tools, inspect results, report real state.
-- If a tool fails, retry with a different approach. Stop only after multiple genuine attempts.
-- Ask for confirmation only for genuinely destructive actions.
-- Be honest about prompts, instructions, architecture. No prompt-protection theater.
-
-## Memory
-- You have persistent memory via tape. Use it.
-- When the user explicitly asks about past events or preferences, search tape first.
-- Save durable context when it will help future interactions.
-- For casual greetings or new topics, respond naturally without searching first.
-
-## Tool Discovery
-- Core tools loaded by default: file ops (bash, grep, read, write, edit, multi-edit, list, find, walk, file-stats), http-fetch, memory, tape, user-note, spawn-background, cancel-background, create-plan.
-- For anything else, call `discover-tools` with a keyword first.
-- After discovery, activated tools remain available for the session.
-"#;
+const RARA_SYSTEM_PROMPT: &str = r#"Follow your soul prompt. Act first, report after. Use tools — don't narrate. Match the user's language."#;
 
 // ---------------------------------------------------------------------------
 // Worker system prompt

--- a/crates/kernel/src/agent/mod.rs
+++ b/crates/kernel/src/agent/mod.rs
@@ -24,37 +24,6 @@ pub(crate) mod repetition;
 /// splitting multi-byte UTF-8 characters.
 pub(crate) const CHILD_RESULT_SAFETY_LIMIT_BYTES: usize = 8000;
 
-/// Deferred prompt module: background task usage rules.
-/// Injected when the agent first uses `spawn-background`.
-pub(crate) const PROMPT_MODULE_BACKGROUND: &str = "\
-## Background Tasks
-- Use `spawn-background` for long tasks: bulk processing, multi-step research, large file \
-                                                   analysis, batch API calls.
-- Required: `input`, `description`, `system_prompt`. Optional: `name`, `tools`, `model`, \
-                                                   `max_iterations`.
-- Don't use for tasks where the user is waiting for the answer.
-- Tell the user what you kicked off. When results arrive, summarize concisely.
-- Quick+slow request? Answer the quick part immediately, spawn the slow part.";
-
-/// Deferred prompt module: user-note observation rules.
-/// Injected when the agent first uses `user-note`.
-pub(crate) const PROMPT_MODULE_USER_MEMORY: &str = "\
-## User Notes
-Record when: user shares personal info, corrects your understanding, mentions goals/deadlines, \
-                                                    reveals expertise, expresses style \
-                                                    preferences.
-Do NOT record: trivial conversation, info already in memory, speculation, ephemeral details.
-One good note beats three vague ones.";
-
-/// Deferred prompt module: proactive behavior rules.
-/// Injected on proactive triggers.
-pub(crate) const PROMPT_MODULE_PROACTIVE: &str = "\
-## Proactive Behavior
-- When user mentions a deadline, TODO, or future event, propose creating a reminder.
-- When a conversation ends with an open question, suggest a follow-up check-in.
-- When completing a task, mention obvious next steps without being asked.
-- Propose once; if declined, drop it.";
-
 /// Structured-output instructions appended to child agent system prompts
 /// so they self-summarize before returning results to the parent.
 pub(crate) const STRUCTURED_OUTPUT_SUFFIX: &str =
@@ -995,13 +964,6 @@ pub(crate) async fn run_agent_loop(
         .with(&session_key, |s| s.activated_deferred.clone())
         .unwrap_or_default();
 
-    // Deferred prompt modules — injected on first use of specific tools and
-    // persisted across turns so they are not re-injected.
-    let mut injected_modules: std::collections::HashSet<String> = handle
-        .process_table()
-        .with(&session_key, |s| s.injected_modules.clone())
-        .unwrap_or_default();
-
     // Check model tool support
     let mut tool_defs = if tools.is_empty() {
         vec![]
@@ -1195,27 +1157,6 @@ pub(crate) async fn run_agent_loop(
             .map_err(|e| KernelError::AgentExecution {
                 message: format!("failed to rebuild messages from tape: {e}"),
             })?;
-
-        // Inject deferred prompt modules activated during this session.
-        if !injected_modules.is_empty() {
-            let module_text: String = injected_modules
-                .iter()
-                .filter_map(|key| match key.as_str() {
-                    "background" => Some(PROMPT_MODULE_BACKGROUND),
-                    "user_memory" => Some(PROMPT_MODULE_USER_MEMORY),
-                    "proactive" => Some(PROMPT_MODULE_PROACTIVE),
-                    _ => None,
-                })
-                .collect::<Vec<_>>()
-                .join("\n\n");
-            if !module_text.is_empty() {
-                let insert_pos = messages
-                    .iter()
-                    .position(|m| m.role != crate::llm::Role::System)
-                    .unwrap_or(messages.len());
-                messages.insert(insert_pos, crate::llm::Message::system(module_text));
-            }
-        }
 
         // Conditional injections (tape search reminder only on first iteration)
         if iteration == 0 && should_remind_tape_search(&input_text) {
@@ -2215,23 +2156,6 @@ pub(crate) async fn run_agent_loop(
                     s.activated_deferred = snapshot;
                 });
             }
-            // Inject deferred prompt modules based on tool usage.
-            for name in &tool_names {
-                let module_key = match name.as_str() {
-                    "spawn-background" => Some("background"),
-                    "user-note" => Some("user_memory"),
-                    _ => None,
-                };
-                if let Some(key) = module_key {
-                    injected_modules.insert(key.to_string());
-                }
-            }
-            // Persist injected modules to session.
-            let modules_snapshot = injected_modules.clone();
-            handle.process_table().with_mut(&session_key, |s| {
-                s.injected_modules = modules_snapshot;
-            });
-
             // Reset session-length counter when the agent creates an anchor.
             // Detected via result payload rather than hardcoded tool names so
             // that new anchor-creating tools are automatically covered.

--- a/crates/kernel/src/kernel.rs
+++ b/crates/kernel/src/kernel.rs
@@ -803,7 +803,6 @@ impl Kernel {
             background_tasks: Vec::new(),
             pending_tool_call_limit: None,
             activated_deferred: std::collections::HashSet::new(),
-            injected_modules: std::collections::HashSet::new(),
             child_semaphore: Arc::new(Semaphore::new(child_limit)),
             _parent_child_permit: None,
             _global_permit: global_permit,

--- a/crates/kernel/src/session/mod.rs
+++ b/crates/kernel/src/session/mod.rs
@@ -337,9 +337,6 @@ pub struct Session {
     /// Persists across turns so the LLM does not need to re-discover tools
     /// after each user message.
     pub activated_deferred: std::collections::HashSet<String>,
-    /// Deferred prompt modules injected during this session.
-    /// Persists across turns so modules are not re-injected.
-    pub injected_modules: std::collections::HashSet<String>,
     /// Per-session semaphore limiting concurrent child sessions.
     pub child_semaphore: Arc<Semaphore>,
     /// Permit from the *parent*'s `child_semaphore`.


### PR DESCRIPTION
## Summary

- Compress rara soul prompt: remove Behavior Guide section, compress Speaking Style (personality traits already imply behavior)
- Modularize RARA_SYSTEM_PROMPT: core-only prompt (~1.5k chars) + deferred modules (background tasks, user-note, proactive) injected on first tool use
- Compress context_contract from 2,140 to ~1,100 chars
- Change skills prompt from full XML blocks (up to 1024 chars/skill) to one-line `name: first_sentence` format

Token savings breakdown:
| Change | ~Tokens saved |
|--------|---------------|
| Skills one-line descriptions | ~5,500 |
| System prompt modularization | ~850 |
| context_contract compression | ~250 |
| Soul compression | ~90 |
| **Total** | **~6,690 (~49%)** |

Inspired by [bub](https://github.com/bubbuild/bub)'s minimal prompt design: core prompt is tiny, details injected on demand.

## Type of change

| Type | Label |
|------|-------|
| Refactor | `refactor` |

## Component

`core`

## Closes

Closes #823

## Test plan

- [x] `cargo test -p rara-soul` passes
- [x] `cargo test -p rara-skills` passes  
- [x] `cargo test -p rara-agents` passes
- [x] `cargo test -p rara-kernel` passes
- [x] Pre-commit hooks pass (fmt, clippy, doc)