### PR TITLE
refactor(kernel): prompt diet tool tiering (#831)

### DIFF
--- a/crates/app/src/tools/http_fetch.rs
+++ b/crates/app/src/tools/http_fetch.rs
@@ -47,7 +47,8 @@ pub struct HttpFetchResult {
 #[tool(
     name = "http-fetch",
     description = "Fetch a URL via HTTP GET or POST; returns status, content type, and body \
-                   (truncated to 100KB)."
+                   (truncated to 100KB).",
+    tier = "deferred"
 )]
 pub struct HttpFetchTool {
     client: reqwest::Client,

--- a/crates/app/src/tools/mod.rs
+++ b/crates/app/src/tools/mod.rs
@@ -107,18 +107,9 @@ pub fn rara_tool_names() -> Vec<String> {
         EditFileTool::TOOL_NAME,
         ListDirectoryTool::TOOL_NAME,
         FindFilesTool::TOOL_NAME,
-        // Network
-        HttpFetchTool::TOOL_NAME,
-        // Tape memory (7 Core tools; tape-checkout-root is Deferred)
-        tool_names::TAPE_INFO,
-        tool_names::TAPE_SEARCH,
+        // Tape memory (2 Core; info/anchors/entries/between/checkout are Deferred)
         tool_names::TAPE_ANCHOR,
-        tool_names::TAPE_ANCHORS,
-        tool_names::TAPE_ENTRIES,
-        tool_names::TAPE_BETWEEN,
-        tool_names::TAPE_CHECKOUT,
-        // Long-term memory
-        tool_names::MEMORY,
+        tool_names::TAPE_SEARCH,
         // Discovery
         DiscoverToolsTool::TOOL_NAME,
     ]
@@ -254,11 +245,18 @@ mod tests {
         let names = rara_tool_names();
         // Only Core tools appear in the manifest; deferred tools (kernel,
         // marketplace, schedule-*, etc.) are discovered on demand.
-        for expected in ["bash", "tape-anchor", "memory", "discover-tools"] {
+        for expected in ["bash", "tape-anchor", "tape-search", "discover-tools"] {
             assert!(names.iter().any(|n| n == expected), "missing: {expected}");
         }
         // Verify deferred tools are NOT in the core list.
-        for deferred in ["kernel", "marketplace", "schedule-once", "send-email"] {
+        for deferred in [
+            "kernel",
+            "marketplace",
+            "schedule-once",
+            "send-email",
+            "memory",
+            "http-fetch",
+        ] {
             assert!(
                 !names.iter().any(|n| n == deferred),
                 "deferred tool should not be in core: {deferred}"
@@ -270,8 +268,8 @@ mod tests {
     fn rara_core_tool_count_stays_slim() {
         let names = rara_tool_names();
         assert!(
-            names.len() <= 17,
-            "Core tool set has {} tools — keep it under 17 to control token costs. Use tier = \
+            names.len() <= 10,
+            "Core tool set has {} tools — keep it under 10 to control token costs. Use tier = \
              \"deferred\" for non-essential tools.",
             names.len()
         );

--- a/crates/kernel/src/agent/mod.rs
+++ b/crates/kernel/src/agent/mod.rs
@@ -763,10 +763,7 @@ fn ensure_agent_md(path: &Path, agent_name: &str) {
 ///
 /// Returns `(prompt, has_soul)` so callers can avoid re-calling
 /// `resolve_soul_prompt`.
-pub(crate) fn build_agent_system_prompt(
-    handle: &KernelHandle,
-    manifest: &AgentManifest,
-) -> (String, bool) {
+pub(crate) fn build_agent_system_prompt(manifest: &AgentManifest) -> (String, bool) {
     // 1. Soul prompt: prepend soul text if available, otherwise use manifest prompt
     //    as-is.
     let (effective_prompt, has_soul) = match resolve_soul_prompt(&manifest.name) {
@@ -779,65 +776,23 @@ pub(crate) fn build_agent_system_prompt(
     } else {
         effective_prompt
     };
-    // 3. Append runtime contract (tape actions, delegation rules, etc.).
-    let has_kernel_tool = handle.tool_registry().get("kernel").is_some();
-    let effective_prompt =
-        build_runtime_contract_prompt(&effective_prompt, has_kernel_tool, manifest.max_children);
-    // 4. Append available skills after the static runtime contract so that
-    // the stable prefix (soul + system_prompt + agent.md + contract) stays
-    // intact for provider-side prompt caching.
-    let skills_block = handle.skills_prompt();
-    let prompt = if skills_block.is_empty() {
-        effective_prompt
-    } else {
-        format!("{effective_prompt}\n\n{skills_block}")
-    };
-    (prompt, has_soul)
+    // 3. Append runtime contract (tape actions, discover-tools hint).
+    let effective_prompt = build_runtime_contract_prompt(&effective_prompt);
+    (effective_prompt, has_soul)
 }
 
-fn build_runtime_contract_prompt(
-    base_prompt: &str,
-    has_kernel_tool: bool,
-    max_children: Option<usize>,
-) -> String {
-    let mut prompt = format!(
+fn build_runtime_contract_prompt(base_prompt: &str) -> String {
+    format!(
         r#"{base_prompt}
 
 <context_contract>
-The `tape-*` tools are your persistent memory.
-
-`tape-anchor` (checkpoint + trim), `tape-search`/`tape-entries` (recall old context), `tape-anchors` (list checkpoints), `tape-checkout` (fork from a past anchor).
+`tape-anchor` (checkpoint + trim), `tape-search` (recall old context). Use `discover-tools` to find additional tape tools, memory, http-fetch, scheduling, browser, skills, and more.
 
 MUST anchor when: context is long or [Context Usage Warning] appears, tool result exceeds ~2000 chars, user switches topic.
-SHOULD anchor when: completing a logical phase, processing multiple tool results.
 MUST search when: question refers to content before an anchor, or you need exact details from earlier.
-
-Always include `summary` and `next_steps` in anchors — missing summary = lost context.
+Always include `summary` and `next_steps` in anchors.
 </context_contract>"#
-    );
-
-    let can_delegate = has_kernel_tool && max_children != Some(0);
-    if can_delegate {
-        prompt.push_str(
-            r#"
-
-<delegation_contract>
-Use the `kernel` tool to delegate to child agents.
-
-## MUST delegate when:
-- 2+ independent subtasks exist
-- Broad discovery + implementation + verification across many files
-- Long tool-heavy execution that would bloat your context
-
-## How:
-- `action: "spawn"`, `agent: "worker"` — single focused task
-- `action: "spawn_parallel"` — multiple independent tasks
-- Keep each worker's scope narrow; synthesize results in parent
-</delegation_contract>"#,
-        );
-    }
-
-    prompt
+    )
 }
 
 /// Execute a single agent turn inline: build messages, stream LLM responses,
@@ -935,7 +890,7 @@ pub(crate) async fn run_agent_loop(
     let max_iterations = manifest
         .max_iterations
         .unwrap_or(handle.config().default_max_iterations);
-    let (effective_prompt, has_soul) = build_agent_system_prompt(handle, &manifest);
+    let (effective_prompt, has_soul) = build_agent_system_prompt(&manifest);
     let provider_hint = manifest.provider_hint.as_deref();
 
     // Resolve driver + model via the DriverRegistry syscall.
@@ -2549,34 +2504,14 @@ mod tests {
     }
 
     #[test]
-    fn runtime_contract_prompt_includes_tape_and_delegation_rules() {
-        let prompt = build_runtime_contract_prompt("base", true, None);
+    fn runtime_contract_prompt_includes_tape_and_discover_tools() {
+        let prompt = build_runtime_contract_prompt("base");
         assert!(prompt.contains("<context_contract>"));
-        assert!(prompt.contains("`tape-*`"));
         assert!(prompt.contains("`tape-anchor` (checkpoint + trim)"));
-        assert!(prompt.contains("`tape-search`/`tape-entries` (recall old context)"));
+        assert!(prompt.contains("`tape-search` (recall old context)"));
+        assert!(prompt.contains("`discover-tools`"));
         assert!(prompt.contains("you need exact details from earlier"));
         assert!(prompt.contains("`summary` and `next_steps` in anchors"));
-        assert!(prompt.contains("<delegation_contract>"));
-        assert!(prompt.contains("action: \"spawn\""));
-        assert!(prompt.contains("action: \"spawn_parallel\""));
-        assert!(prompt.contains("agent: \"worker\""));
-    }
-
-    #[test]
-    fn runtime_contract_prompt_keeps_tape_rules_without_kernel() {
-        let prompt = build_runtime_contract_prompt("base", false, None);
-        assert!(prompt.contains("<context_contract>"));
-        assert!(!prompt.contains("<delegation_contract>"));
-        assert!(!prompt.contains("action: \"spawn_parallel\""));
-    }
-
-    #[test]
-    fn runtime_contract_prompt_skips_delegation_when_children_disabled() {
-        let prompt = build_runtime_contract_prompt("base", true, Some(0));
-        assert!(prompt.contains("<context_contract>"));
-        assert!(!prompt.contains("<delegation_contract>"));
-        assert!(!prompt.contains("action: \"spawn\""));
     }
 
     #[test]
@@ -2594,10 +2529,8 @@ mod tests {
 
     #[test]
     fn runtime_contract_includes_topic_switch_in_must_anchor() {
-        let prompt = build_runtime_contract_prompt("base", false, None);
+        let prompt = build_runtime_contract_prompt("base");
         assert!(prompt.contains("user switches topic"));
-        // Verify "switching subtasks" is no longer in the SHOULD section
-        assert!(!prompt.contains("switching subtasks"));
     }
 
     #[test]

--- a/crates/kernel/src/memory/knowledge/tool.rs
+++ b/crates/kernel/src/memory/knowledge/tool.rs
@@ -36,7 +36,8 @@ use crate::tool::{ToolContext, ToolExecute};
 #[tool(
     name = "memory",
     description = "Search and read the user's long-term memory by keyword, category listing, or \
-                   full category read."
+                   full category read.",
+    tier = "deferred"
 )]
 pub struct MemoryTool {
     pool:          SqlitePool,

--- a/crates/kernel/src/plan.rs
+++ b/crates/kernel/src/plan.rs
@@ -264,7 +264,7 @@ pub(crate) async fn run_plan_loop(
             .map_err(|e| KernelError::AgentExecution {
                 message: format!("failed to get manifest for planning: {e}"),
             })?;
-    let (agent_prompt, _) = crate::agent::build_agent_system_prompt(handle, &manifest);
+    let (agent_prompt, _) = crate::agent::build_agent_system_prompt(&manifest);
     let full_tools = handle
         .session_tool_registry(session_key)
         .await

--- a/crates/kernel/src/syscall.rs
+++ b/crates/kernel/src/syscall.rs
@@ -1323,9 +1323,10 @@ impl crate::tool::AgentTool for SyscallTool {
     fn name(&self) -> &str { Self::NAME }
 
     fn description(&self) -> &str {
-        "Interact with the kernel: spawn agents, query process status, send signals, manage memory \
-         (private & shared), publish events, subscribe to task notifications, and publish task \
-         reports. Set the 'action' field to select the operation."
+        "Interact with the kernel: spawn child agents, query status, send signals, manage memory, \
+         publish events. MUST delegate when: 2+ independent subtasks, or long tool-heavy execution \
+         that would bloat context. Use 'spawn' for single tasks, 'spawn_parallel' for multiple \
+         independent tasks with 'agent: worker'."
     }
 
     fn parameters_schema(&self) -> serde_json::Value {

--- a/crates/kernel/src/tool/fold_branch.rs
+++ b/crates/kernel/src/tool/fold_branch.rs
@@ -83,7 +83,8 @@ pub(crate) const FOLD_BRANCH_NAME_PREFIX: &str = "fold-branch-";
     name = "fold-branch",
     description = "Spawn a child agent for a focused sub-task, wait for completion, and return a \
                    compressed result. Use this when you need the result inline (synchronous). For \
-                   fire-and-forget tasks, use spawn-background instead."
+                   fire-and-forget tasks, use spawn-background instead.",
+    tier = "deferred"
 )]
 pub struct FoldBranchTool {
     handle:         KernelHandle,

--- a/crates/kernel/src/tool/tape/anchors.rs
+++ b/crates/kernel/src/tool/tape/anchors.rs
@@ -44,7 +44,11 @@ pub struct TapeAnchorsResult {
 
 /// List recent tape anchors.
 #[derive(ToolDef)]
-#[tool(name = "tape-anchors", description = "List recent tape anchors.")]
+#[tool(
+    name = "tape-anchors",
+    description = "List recent tape anchors.",
+    tier = "deferred"
+)]
 pub(crate) struct TapeAnchorsTool {
     tape_service: TapeService,
     tape_name:    String,

--- a/crates/kernel/src/tool/tape/between.rs
+++ b/crates/kernel/src/tool/tape/between.rs
@@ -51,7 +51,8 @@ pub struct TapeBetweenResult {
 #[derive(ToolDef)]
 #[tool(
     name = "tape-between",
-    description = "Read entries between two named anchors."
+    description = "Read entries between two named anchors.",
+    tier = "deferred"
 )]
 pub(crate) struct TapeBetweenTool {
     tape_service: TapeService,

--- a/crates/kernel/src/tool/tape/checkout.rs
+++ b/crates/kernel/src/tool/tape/checkout.rs
@@ -48,7 +48,8 @@ pub struct TapeCheckoutResult {
 #[derive(ToolDef)]
 #[tool(
     name = "tape-checkout",
-    description = "Fork a new session from a named anchor."
+    description = "Fork a new session from a named anchor.",
+    tier = "deferred"
 )]
 pub(crate) struct TapeCheckoutTool {
     tape_service: TapeService,

--- a/crates/kernel/src/tool/tape/entries.rs
+++ b/crates/kernel/src/tool/tape/entries.rs
@@ -49,7 +49,8 @@ pub struct TapeEntriesResult {
 #[derive(ToolDef)]
 #[tool(
     name = "tape-entries",
-    description = "Read tape entries from current or named anchor."
+    description = "Read tape entries from current or named anchor.",
+    tier = "deferred"
 )]
 pub(crate) struct TapeEntriesTool {
     tape_service: TapeService,

--- a/crates/kernel/src/tool/tape/info.rs
+++ b/crates/kernel/src/tool/tape/info.rs
@@ -48,7 +48,8 @@ pub struct TapeInfoParams {}
 #[derive(ToolDef)]
 #[tool(
     name = "tape-info",
-    description = "Show tape state: entry count, anchor count, context token estimate."
+    description = "Show tape state: entry count, anchor count, context token estimate.",
+    tier = "deferred"
 )]
 pub(crate) struct TapeInfoTool {
     tape_service: TapeService,


### PR DESCRIPTION
## Summary

Reduce per-turn baseline token cost by ~50% following Claude Code's tool tiering pattern.

- Core tools 18 → 10: demote tape-info, tape-anchors, tape-entries, tape-between, tape-checkout, http-fetch, memory, fold-branch to deferred tier
- Remove skills block injection from system prompt (~800 tokens)
- Move delegation contract into kernel tool description (~100 tokens)
- Trim context contract to essentials with discover-tools hint

## Type of change

| Type | Label |
|------|-------|
| Refactor | `refactor` |

## Component

`core`

## Closes

Closes #831

## Test plan

- [x] `cargo check --all --all-targets` passes
- [x] `cargo clippy` passes
- [x] `cargo test --workspace` passes
- [x] Core tool count test updated to assert ≤ 10
- [x] Deferred tool assertion updated to include memory, http-fetch