### PR TITLE
fix(app): start wechat adapter polling loop on boot (#848)

### DIFF
--- a/crates/app/src/lib.rs
+++ b/crates/app/src/lib.rs
@@ -576,6 +576,13 @@ pub async fn start_with_options(
             Err(e) => warn!(error = %e, "Failed to start WebAdapter"),
         }
     }
+    if let Some(ref wc) = wechat_adapter {
+        use rara_kernel::channel::adapter::ChannelAdapter as _;
+        match wc.start(kernel_handle.clone()).await {
+            Ok(()) => info!("WeChat adapter started"),
+            Err(e) => warn!(error = %e, "Failed to start WeChat adapter"),
+        }
+    }
     info!("Kernel I/O subsystem running");
 
     // -- Symphony sync bridge -------------------------------------------------


### PR DESCRIPTION
## Summary

The WeChat adapter was built and registered with `IOSubsystem` but `.start(kernel_handle)` was never called. The Telegram and Web adapters both had explicit `.start()` calls, but WeChat was missed during integration (#827). This meant the long-polling loop never ran and inbound WeChat messages were silently dropped.

Adds the missing `.start()` call, matching the pattern used by the other adapters.

## Type of change

| Type | Label |
|------|-------|
| Bug fix | `bug` |

## Component

`backend`

## Closes

Closes #848

## Test plan

- [x] `cargo check -p rara-app` passes
- [x] Pre-commit hooks pass
- [x] Verified "WeChat adapter started" log appears on boot