### PR TITLE
chore(channels): promote wechat adapter logs to info level (#860)

### DIFF
--- a/crates/channels/src/wechat/adapter.rs
+++ b/crates/channels/src/wechat/adapter.rs
@@ -33,7 +33,7 @@ use rara_kernel::{
     io::{EgressError, Endpoint, EndpointAddress, PlatformOutbound, RawPlatformMessage},
 };
 use tokio::sync::{Mutex, watch};
-use tracing::{debug, error, info, instrument, warn};
+use tracing::{error, info, instrument, warn};
 
 use super::{
     api::WeixinApiClient,
@@ -136,7 +136,7 @@ impl ChannelAdapter for WechatAdapter {
                         }
 
                         if let Some(messages) = resp["msg_list"].as_array() {
-                            debug!(count = messages.len(), "wechat poll returned messages");
+                            info!(count = messages.len(), "wechat poll returned messages");
                             for msg in messages {
                                 let item_list =
                                     msg["item_list"].as_array().cloned().unwrap_or_default();
@@ -160,11 +160,11 @@ impl ChannelAdapter for WechatAdapter {
 
                                 let body = body_from_item_list(&item_list);
                                 if body.is_empty() {
-                                    debug!(to_user_id, "skipping wechat message with empty body");
+                                    info!(to_user_id, "skipping wechat message with empty body");
                                     continue;
                                 }
 
-                                debug!(
+                                info!(
                                     to_user_id,
                                     body_len = body.len(),
                                     body_preview = &body[..body.len().min(100)],


### PR DESCRIPTION
## Summary

Promote the debug-level logs added in #859 to info level so they are visible with default RUST_LOG settings.

## Type of change

| Type | Label |
|------|-------|
| Chore | `chore` |

## Component

`backend`

## Closes

Closes #860

## Test plan

- [x] `cargo check -p rara-channels` passes
- [x] Pre-commit hooks pass