### PR TITLE
fix(channels): send wechat replies to bot account_id, not from_user_id (#877)

### DIFF
--- a/crates/channels/src/wechat/adapter.rs
+++ b/crates/channels/src/wechat/adapter.rs
@@ -253,8 +253,11 @@ impl ChannelAdapter for WechatAdapter {
                     ),
                 })?;
                 let plain = markdown_to_plain_text(&content);
+                // Send to the bot's own account_id — the iLink API uses the
+                // context_token (not to_user_id) to route the reply to the
+                // actual human user.
                 self.send_client
-                    .send_text_message(&user_id, &token, &plain)
+                    .send_text_message(&self.account_id, &token, &plain)
                     .await
                     .map_err(|e| EgressError::DeliveryFailed {
                         message: format!("wechat send_text_message failed: {e}"),
@@ -292,9 +295,10 @@ impl ChannelAdapter for WechatAdapter {
             .unwrap_or_default();
 
         // Best-effort — typing indicators are optional UX hooks.
+        // Send to account_id; context_token routes to the human user.
         let _ = self
             .send_client
-            .send_typing(session_key, &context_token)
+            .send_typing(&self.account_id, &context_token)
             .await;
         Ok(())
     }


### PR DESCRIPTION
## Summary

The iLink API routes replies via `context_token`, not `to_user_id`. The adapter was sending to `from_user_id` (the bot's own WeChat user ID), which means the bot was messaging itself. Changed to use `account_id` as the send target so the `context_token` can route to the actual human user.

Also fixes `typing_indicator` to use `account_id` consistently.

## Type of change

| Type | Label |
|------|-------|
| Bug fix | `bug` |

## Component

`backend`

## Closes

Closes #877

## Test plan

- [x] `cargo check -p rara-channels` passes
- [x] Pre-commit hooks pass (fmt, clippy, doc)