### PR TITLE
chore(channels): add delivery debug logging for wechat send path (#881)

### DIFF
--- a/crates/channels/src/wechat/adapter.rs
+++ b/crates/channels/src/wechat/adapter.rs
@@ -256,12 +256,19 @@ impl ChannelAdapter for WechatAdapter {
                 // Send to the bot's own account_id — the iLink API uses the
                 // context_token (not to_user_id) to route the reply to the
                 // actual human user.
-                self.send_client
+                info!(
+                    to = %self.account_id,
+                    text_len = plain.len(),
+                    "sending wechat reply"
+                );
+                let result = self
+                    .send_client
                     .send_text_message(&self.account_id, &token, &plain)
-                    .await
-                    .map_err(|e| EgressError::DeliveryFailed {
-                        message: format!("wechat send_text_message failed: {e}"),
-                    })?;
+                    .await;
+                info!(?result, "wechat send_text_message result");
+                result.map_err(|e| EgressError::DeliveryFailed {
+                    message: format!("wechat send_text_message failed: {e}"),
+                })?;
             }
             // WeChat does not support streaming edits or progress messages.
             PlatformOutbound::StreamChunk { .. } | PlatformOutbound::Progress { .. } => {}

--- a/crates/kernel/src/io.rs
+++ b/crates/kernel/src/io.rs
@@ -1779,11 +1779,18 @@ impl IOSubsystem {
         };
         let targets = resolve_delivery_targets(candidates, &envelope.routing);
 
+        tracing::info!(
+            targets = targets.len(),
+            adapters = self.adapters.len(),
+            "deliver_to_endpoints"
+        );
+
         let futs = targets.into_iter().map(|endpoint| {
             let adapter = self.adapters.get(&endpoint.channel_type).cloned();
             let outbound = envelope.to_platform_outbound();
             async move {
                 if let Some(adapter) = adapter {
+                    tracing::info!(?endpoint, "delivering to adapter");
                     match tokio::time::timeout(
                         std::time::Duration::from_secs(10),
                         adapter.send(&endpoint, outbound),
@@ -1791,6 +1798,7 @@ impl IOSubsystem {
                     .await
                     {
                         Ok(Ok(())) => {
+                            tracing::info!(?endpoint, "delivery succeeded");
                             crate::metrics::record_message_outbound(&format!(
                                 "{:?}",
                                 endpoint.channel_type
@@ -1803,6 +1811,8 @@ impl IOSubsystem {
                             tracing::warn!(?endpoint, "delivery timeout");
                         }
                     }
+                } else {
+                    tracing::warn!(?endpoint, "no adapter registered for channel type");
                 }
             }
         });


### PR DESCRIPTION
## Summary

Adds info-level logging to diagnose why WeChat replies are not reaching users:

- `deliver_to_endpoints`: log targets count and registered adapters count
- Per-target: log before delivery attempt, after success, and when no adapter found
- WeChat adapter `send`: log target account_id, text length, and API response

## Type of change

| Type | Label |
|------|-------|
| Chore | `chore` |

## Component

`backend`

## Closes

Closes #881

## Test plan

- [x] `cargo check` passes
- [x] Pre-commit hooks pass