### PR TITLE
fix(channels): implement correct iLink typing indicator protocol (#887)

### DIFF
--- a/crates/channels/src/wechat/adapter.rs
+++ b/crates/channels/src/wechat/adapter.rs
@@ -302,10 +302,29 @@ impl ChannelAdapter for WechatAdapter {
             .unwrap_or_default();
 
         // Best-effort — typing indicators are optional UX hooks.
-        // Send to account_id; context_token routes to the human user.
+        // iLink protocol requires a two-step flow:
+        // 1. getconfig to obtain a typing_ticket
+        // 2. sendtyping with that ticket
+        let config_resp = match self
+            .send_client
+            .get_config(session_key, &context_token)
+            .await
+        {
+            Ok(resp) => resp,
+            Err(e) => {
+                warn!(error = %e, "wechat getconfig failed for typing indicator");
+                return Ok(());
+            }
+        };
+
+        let typing_ticket = config_resp["typing_ticket"].as_str().unwrap_or_default();
+        if typing_ticket.is_empty() {
+            return Ok(());
+        }
+
         let _ = self
             .send_client
-            .send_typing(&self.account_id, &context_token)
+            .send_typing(session_key, typing_ticket, 1)
             .await;
         Ok(())
     }

--- a/crates/channels/src/wechat/api.rs
+++ b/crates/channels/src/wechat/api.rs
@@ -234,11 +234,33 @@ impl WeixinApiClient {
         self.post("ilink/bot/sendmessage", &body).await
     }
 
-    /// Sends a typing indicator to `to_user_id`.
-    pub async fn send_typing(&self, to_user_id: &str, context_token: &str) -> Result<Value> {
+    /// Fetches a `typing_ticket` for the given user via the iLink `getconfig`
+    /// endpoint. The ticket is required by `send_typing`.
+    pub async fn get_config(&self, ilink_user_id: &str, context_token: &str) -> Result<Value> {
         let body = serde_json::json!({
-            "to_user_id": to_user_id,
+            "ilink_user_id": ilink_user_id,
             "context_token": context_token,
+            "base_info": {}
+        });
+        self.post("ilink/bot/getconfig", &body).await
+    }
+
+    /// Sends a typing indicator for the given user.
+    ///
+    /// Requires a `typing_ticket` obtained from
+    /// [`get_config`](Self::get_config). `status` should be `1` (typing) or
+    /// `2` (cancel).
+    pub async fn send_typing(
+        &self,
+        ilink_user_id: &str,
+        typing_ticket: &str,
+        status: u8,
+    ) -> Result<Value> {
+        let body = serde_json::json!({
+            "ilink_user_id": ilink_user_id,
+            "typing_ticket": typing_ticket,
+            "status": status,
+            "base_info": {}
         });
         self.post("ilink/bot/sendtyping", &body).await
     }


### PR DESCRIPTION
## Summary

- Add `get_config` API method to fetch `typing_ticket` from `POST /ilink/bot/getconfig`
- Rewrite `send_typing` to use correct iLink fields: `ilink_user_id`, `typing_ticket`, `status`, `base_info`
- Update adapter `typing_indicator` to do the required 2-step flow: getconfig → sendtyping

Aligned with [weclaw](https://github.com/fastclaw-ai/weclaw) reference implementation.

## Type of change

| Type | Label |
|------|-------|
| Bug fix | `bug` |

## Component

`core`

## Closes

Closes #887

## Test plan

- [x] `cargo check -p rara-channels` passes
- [x] Pre-commit hooks pass (check, fmt, clippy, doc)
- [x] Protocol aligned with weclaw reference