### PR TITLE
fix(channels): always refresh progress timer once message exists (#893)

### DIFF
--- a/crates/channels/src/telegram/adapter.rs
+++ b/crates/channels/src/telegram/adapter.rs
@@ -3255,10 +3255,16 @@ fn spawn_stream_forwarder(
                     }
 
                     // Flush throttled progress updates.
-                    // Also refresh when tools are still running so the elapsed
-                    // timer keeps ticking even without new stream events.
-                    let has_running = progress.tools.iter().any(|t| !t.finished);
-                    if (progress_dirty || has_running) && (!progress.tools.is_empty() || progress.thinking) {
+                    let should_refresh = if progress.message_id.is_some() {
+                        // Once a progress message exists, always refresh the elapsed
+                        // timer — even after thinking ends and before tools start
+                        // (e.g. during LLM API wait or pure text generation).
+                        true
+                    } else {
+                        // No message yet — only create one if there's content to show.
+                        progress_dirty && (!progress.tools.is_empty() || progress.thinking)
+                    };
+                    if should_refresh {
                         let text = progress.render_text();
                         match progress.message_id {
                             Some(mid) => {


### PR DESCRIPTION
## Summary

Fix progress timer freezing when no tools or thinking are active. The throttle tick branch previously gated progress message updates on `!progress.tools.is_empty() || progress.thinking`, which caused the elapsed time display to freeze during LLM API waits or pure text generation.

Now, once a progress message is created (`message_id.is_some()`), the timer always refreshes on each throttle tick. A new message is still only created when there is content to show.

## Type of change

| Type | Label |
|------|-------|
| Bug fix | `bug` |

## Component

`ui`

## Closes

Closes #893

## Test plan

- [x] `cargo check -p rara-channels` passes with no warnings
- [x] All pre-commit hooks pass (check, fmt, clippy, doc)