### PR TITLE
fix(kernel): send fallback reply on empty LLM response after error recovery (#894)

### DIFF
--- a/crates/kernel/src/agent/mod.rs
+++ b/crates/kernel/src/agent/mod.rs
@@ -1546,7 +1546,6 @@ pub(crate) async fn run_agent_loop(
         if !has_tool_calls
             && accumulated_text.is_empty()
             && tool_calls_made > 0
-            && !llm_error_recovery_used
             && !empty_response_nudged
         {
             warn!(

--- a/crates/kernel/src/kernel.rs
+++ b/crates/kernel/src/kernel.rs
@@ -2606,6 +2606,25 @@ impl Kernel {
                     metrics.record_llm_call();
                     metrics.record_tool_calls(turn.tool_calls as u64);
                 }
+
+                // Send fallback message so the user is not left without a reply.
+                if origin_endpoint.is_some() {
+                    let fallback_text = "I wasn't able to generate a response. Please try again.";
+                    let envelope = OutboundEnvelope::reply(
+                        in_reply_to,
+                        user.clone(),
+                        egress_session_key.clone(),
+                        crate::channel::types::MessageContent::Text(fallback_text.to_string()),
+                        vec![],
+                    )
+                    .with_origin(origin_endpoint.clone());
+                    if let Err(e) = &self
+                        .event_queue
+                        .try_push(KernelEventEnvelope::deliver(envelope))
+                    {
+                        error!(%e, "failed to push fallback Deliver event");
+                    }
+                }
             }
             Err(err_msg) => {
                 span.record("success", false);


### PR DESCRIPTION
## Summary

- Remove `!llm_error_recovery_used` from the empty-response nudge condition in `agent/mod.rs` so the nudge fires even after error recovery when the LLM produces only reasoning tokens but no content text
- Add fallback message delivery in `kernel.rs` when the agent turn completes with empty text, preventing silent drops

## Type of change

| Type | Label |
|------|-------|
| Bug fix | `bug` |

## Component

`core`

## Closes

Closes #894

## Test plan

- [x] `cargo check -p rara-kernel` passes
- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy` passes
- [x] Pre-commit hooks pass