### PR TITLE
fix(kernel): make typing_refresh respect turn cancellation (#900)

### DIFF
--- a/crates/kernel/src/kernel.rs
+++ b/crates/kernel/src/kernel.rs
@@ -2232,6 +2232,7 @@ impl Kernel {
                 let usr = user.clone();
                 let mid = msg_id.clone();
                 let oe = origin_endpoint.clone();
+                let cancel = turn_cancel.clone();
                 tokio::spawn(async move {
                     let oe = match oe {
                         Some(ep) => Some(ep),
@@ -2240,17 +2241,21 @@ impl Kernel {
                     let mut interval = tokio::time::interval(std::time::Duration::from_secs(4));
                     interval.tick().await; // skip the immediate first tick
                     loop {
-                        interval.tick().await;
-                        let _ = eq.try_push(KernelEventEnvelope::deliver(
-                            OutboundEnvelope::progress(
-                                mid.clone(),
-                                usr.clone(),
-                                sid.clone(),
-                                crate::io::stages::THINKING,
-                                None,
-                            )
-                            .with_origin(oe.clone()),
-                        ));
+                        tokio::select! {
+                            _ = cancel.cancelled() => break,
+                            _ = interval.tick() => {
+                                let _ = eq.try_push(KernelEventEnvelope::deliver(
+                                    OutboundEnvelope::progress(
+                                        mid.clone(),
+                                        usr.clone(),
+                                        sid.clone(),
+                                        crate::io::stages::THINKING,
+                                        None,
+                                    )
+                                    .with_origin(oe.clone()),
+                                ));
+                            }
+                        }
                     }
                 })
             };


### PR DESCRIPTION
## Summary

The `typing_refresh` task ran an infinite loop sending progress messages every 4s but never checked the `turn_cancel` token. When a user sent `/stop`, the agent loop stopped but `typing_refresh` kept running indefinitely, causing the client to show a perpetual "typing..." indicator.

- Pass `turn_cancel` into the `typing_refresh` spawned task
- Use `tokio::select!` to break the loop when the token is cancelled

## Type of change

| Type | Label |
|------|-------|
| Bug fix | `bug` |

## Component

`core`

## Closes

Closes #900

## Test plan

- [x] `cargo check -p rara-kernel` passes
- [x] `cargo clippy` passes
- [x] `cargo fmt` passes
- [x] `cargo doc` passes
- [x] All pre-commit hooks pass