### PR TITLE
fix(kernel): allow multiple LLM error recoveries per agent turn (#930)

### DIFF
--- a/crates/kernel/src/agent/mod.rs
+++ b/crates/kernel/src/agent/mod.rs
@@ -1006,8 +1006,8 @@ pub(crate) async fn run_agent_loop(
     let mut iteration_traces: Vec<IterationTrace> = Vec::new();
     let mut cascade_asm = crate::cascade::CascadeAssembler::new(rara_message_id.to_string());
     cascade_asm.push_user(&input_text, jiff::Timestamp::now(), None);
-    /// Maximum number of LLM error recoveries (tools-disabled retries) allowed
-    /// per agent turn before the error becomes fatal.
+    // Maximum number of LLM error recoveries (tools-disabled retries) allowed
+    // per agent turn before the error becomes fatal.
     const MAX_LLM_ERROR_RECOVERIES: u32 = 3;
     let mut llm_error_recovery_count: u32 = 0;
     // Snapshot of tool definitions before any recovery disables them, so we


### PR DESCRIPTION
## Summary

- Replace the one-shot `llm_error_recovery_used` boolean with a counter-based approach (`llm_error_recovery_count` / `MAX_LLM_ERROR_RECOVERIES = 3`) allowing up to 3 retries per turn
- After a successful recovery iteration, restore original tool definitions so the agent resumes normal tool-calling behaviour
- Fix the terminal exit condition to only exit when no tool calls are present, not permanently after any recovery

## Type of change

| Type | Label |
|------|-------|
| Bug fix | `bug` |

## Component

`core`

## Closes

Closes #930

## Test plan

- [x] `cargo check -p rara-kernel` passes
- [x] Pre-commit hooks pass (check, fmt, clippy, doc)