### PR TITLE
fix(kernel): reword deferred tools prompt to stop agent claiming tools unavailable (#935)

### DIFF
--- a/crates/kernel/src/agent/mod.rs
+++ b/crates/kernel/src/agent/mod.rs
@@ -824,7 +824,7 @@ fn build_runtime_contract_prompt(
                 .collect()
         };
         format!(
-            "\n**Discoverable tools** (use `discover-tools` to activate):\n{}",
+            "\n**Discoverable tools** (use `discover-tools` to load):\n{}",
             entries.join("\n")
         )
     };


### PR DESCRIPTION
## Summary

The agent system prompt used **"NOT yet available"** to describe on-demand tools, which caused the LLM to tell users "marketplace 工具还没激活" instead of calling `discover-tools` itself. Reworded to positive framing ("available on-demand") with explicit instruction to load immediately rather than report unavailability.

**Before**: `The tools listed below are NOT yet available. To use one, you MUST first CALL discover-tools...`
**After**: `The tools below are available on-demand. When a user request matches one, IMMEDIATELY call discover-tools to load it — do NOT tell the user the tool is unavailable or needs activation.`

## Type of change

| Type | Label |
|------|-------|
| Bug fix | `bug` |

## Component

`core`

## Closes

Closes #935

## Test plan

- [x] `cargo check -p rara-kernel` passes
- [x] All pre-commit hooks pass (cargo check, fmt, clippy, doc)
- [x] Verified prompt wording reads as actionable instruction rather than status report