### PR TITLE
fix(kernel): align deferred tool catalog with executable tool registry (#941)

### DIFF
--- a/crates/kernel/src/agent/mod.rs
+++ b/crates/kernel/src/agent/mod.rs
@@ -819,12 +819,13 @@ fn build_runtime_contract_prompt(
                 .map(|(name, desc)| {
                     // Truncate description to first sentence for brevity.
                     let short = desc.find(". ").map_or(desc.as_str(), |pos| &desc[..=pos]);
-                    format!("  - `{name}` — {short}")
+                    format!("  - {name}: {short}")
                 })
                 .collect()
         };
         format!(
-            "\n**Discoverable tools** (use `discover-tools` to load):\n{}",
+            "\n**Discoverable tools** (these are keywords, NOT callable tool names — you MUST \
+             call `discover-tools` first to load them):\n{}",
             entries.join("\n")
         )
     };
@@ -836,11 +837,11 @@ fn build_runtime_contract_prompt(
 
 **Tape tools**: `tape-anchor` (checkpoint + trim), `tape-search` (recall old context).
 
-**On-demand tools**: The tools below are available on-demand. When a user request matches one, \
-IMMEDIATELY call `discover-tools` with a keyword (e.g. `discover-tools({{"query":"marketplace"}})`) \
-to load it — do NOT tell the user the tool is unavailable or needs activation. \
-After calling, matched tools are loaded and you can call them directly. \
-Do NOT read source code or config files to learn about a tool — call `discover-tools` instead.{tool_list}
+**MANDATORY: On-demand tool activation**: You MUST call `discover-tools` BEFORE using any tool \
+from the list below. These names are search keywords, NOT callable tools. \
+Example: `discover-tools({{"query":"marketplace"}})` — this loads the real tools so you can call them. \
+NEVER call a listed name directly. NEVER tell the user a tool is unavailable — \
+call `discover-tools` to load it first.{tool_list}
 {system_paths}
 
 **MUST anchor when:**
@@ -912,7 +913,7 @@ pub(crate) async fn run_agent_loop(
         })?;
 
     // Filter tools by manifest allowlist, then remove excluded tools.
-    let manifest_filtered = full_tools.filtered(&manifest.tools);
+    let manifest_filtered = full_tools.filtered_for_manifest(&manifest.tools);
     let manifest_filtered = if manifest.excluded_tools.is_empty() {
         manifest_filtered
     } else {
@@ -957,7 +958,7 @@ pub(crate) async fn run_agent_loop(
     let max_iterations = manifest
         .max_iterations
         .unwrap_or(handle.config().default_max_iterations);
-    let (effective_prompt, has_soul) = build_agent_system_prompt(&manifest, &full_tools);
+    let (effective_prompt, has_soul) = build_agent_system_prompt(&manifest, tools.as_ref());
     let provider_hint = manifest.provider_hint.as_deref();
 
     // Resolve driver + model via the DriverRegistry syscall.
@@ -2627,9 +2628,11 @@ mod tests {
             ),
         ];
         let prompt = build_runtime_contract_prompt("base", &catalog, "");
-        assert!(prompt.contains("`http-fetch` — Fetch HTTP resources."));
-        assert!(prompt.contains("`system-paths` — Show system paths."));
+        assert!(prompt.contains("http-fetch: Fetch HTTP resources."));
+        assert!(prompt.contains("system-paths: Show system paths."));
         assert!(prompt.contains("Discoverable tools"));
+        assert!(prompt.contains("NOT callable tool names"));
+        assert!(!prompt.contains("`http-fetch`"));
     }
 
     #[test]

--- a/crates/kernel/src/plan.rs
+++ b/crates/kernel/src/plan.rs
@@ -270,8 +270,8 @@ pub(crate) async fn run_plan_loop(
         .map_err(|e| KernelError::AgentExecution {
             message: format!("failed to get tool registry for planning: {e}"),
         })?;
-    let (agent_prompt, _) = crate::agent::build_agent_system_prompt(&manifest, &full_tools);
-    let tools_for_plan = full_tools.filtered(&manifest.tools);
+    let tools_for_plan = full_tools.filtered_for_manifest(&manifest.tools);
+    let (agent_prompt, _) = crate::agent::build_agent_system_prompt(&manifest, &tools_for_plan);
 
     let plan = create_plan_via_llm(
         handle,

--- a/crates/kernel/src/tool/mod.rs
+++ b/crates/kernel/src/tool/mod.rs
@@ -407,6 +407,29 @@ impl ToolRegistry {
         new
     }
 
+    /// Create a manifest-scoped registry.
+    ///
+    /// Behaves like [`Self::filtered`], with one deferred-tools exception:
+    /// if the manifest allowlist includes `discover-tools`, all deferred tools
+    /// are retained so they can be discovered and activated at runtime.
+    #[must_use]
+    pub fn filtered_for_manifest(&self, tool_names: &[String]) -> Self {
+        if tool_names.is_empty() || tool_names.iter().any(|n| n == "*") {
+            return self.clone();
+        }
+        let allow: std::collections::HashSet<&str> =
+            tool_names.iter().map(String::as_str).collect();
+        let keep_deferred = allow.contains("discover-tools");
+        let mut new = Self::new();
+        for (name, tool) in &self.tools {
+            if allow.contains(name.as_str()) || (keep_deferred && tool.tier() == ToolTier::Deferred)
+            {
+                new.register(Arc::clone(tool));
+            }
+        }
+        new
+    }
+
     /// Create a new registry excluding the named tools.
     #[must_use]
     pub fn without(&self, excluded: &[String]) -> Self {

--- a/crates/skills/src/prompt_gen.rs
+++ b/crates/skills/src/prompt_gen.rs
@@ -85,7 +85,7 @@ pub fn generate_skills_prompt(skills: &[SkillMetadata]) -> String {
     out.push('\n');
     out.push_str(
         "To use a skill, use `discover-tools` to find it and read its SKILL.md for full \
-         instructions.\nUse YOUR actual tools (http_fetch, bash, read_file, etc.) — not tool \
+         instructions.\nUse YOUR actual tools (http-fetch, bash, read-file, etc.) — not tool \
          names from skills written for other environments.\n\n",
     );
     out


### PR DESCRIPTION
## Summary
- reformat deferred tool catalog entries so they are presented as discover keywords (not callable tool names) and strengthen the mandatory `discover-tools` guidance
- ensure manifest filtering keeps deferred tools available when `discover-tools` is allowed (`filtered_for_manifest`)
- build runtime contract prompts from the actual executable tool registry (after manifest/user filtering) to avoid listing tools that would fail at execution time
- apply the same manifest filtering behavior in plan mode
- fix skills prompt examples to use real tool names (`http-fetch`, `read-file`)

## Testing
- cargo test -p rara-kernel runtime_contract_ -- --nocapture
- cargo test -p rara-kernel filtered_specific_names -- --nocapture
- cargo test -p rara-skills prompt_gen -- --nocapture

Closes #941
