### PR TITLE
feat(login): replace callback server with paste-URL flow for codex OAuth (#957)

### DIFF
--- a/crates/cmd/src/login/mod.rs
+++ b/crates/cmd/src/login/mod.rs
@@ -84,7 +84,7 @@ async fn run_codex_login() -> Result<(), Whatever> {
     let (code, returned_state) =
         parse_callback_url(&callback_url).whatever_context("failed to parse callback URL")?;
 
-    validate_state(&state, Some(&returned_state))
+    validate_state(&state, &returned_state)
         .whatever_context("OAuth state mismatch — please retry the login")?;
 
     println!("\nExchanging authorization code for tokens...");

--- a/crates/integrations/codex-oauth/src/lib.rs
+++ b/crates/integrations/codex-oauth/src/lib.rs
@@ -27,8 +27,6 @@
 //! callback URL from their browser's address bar and exchanges the code
 //! locally via [`parse_callback_url`] + [`exchange_authorization_code`].
 
-use std::collections::HashMap;
-
 use async_trait::async_trait;
 use base64::{Engine as _, engine::general_purpose::URL_SAFE_NO_PAD};
 use rara_kernel::llm::{LlmCredential, LlmCredentialResolver};
@@ -265,20 +263,25 @@ pub fn parse_callback_url(url: &str) -> Result<(String, String)> {
             reason: e.to_string(),
         })?;
 
-    let params: HashMap<_, _> = parsed.query_pairs().into_owned().collect();
+    let find = |key: &str| {
+        parsed
+            .query_pairs()
+            .find(|(k, _)| k == key)
+            .map(|(_, v)| v.into_owned())
+    };
 
-    if let Some(err) = params.get("error") {
+    if let Some(err) = find("error") {
         return OAuthValidationSnafu {
             message: format!("provider returned error: {err}"),
         }
         .fail();
     }
 
-    let code = params.get("code").cloned().context(OAuthValidationSnafu {
+    let code = find("code").context(OAuthValidationSnafu {
         message: "missing authorization code in callback URL",
     })?;
 
-    let state = params.get("state").cloned().context(OAuthValidationSnafu {
+    let state = find("state").context(OAuthValidationSnafu {
         message: "missing state in callback URL",
     })?;
 
@@ -304,13 +307,7 @@ pub fn generate_code_challenge(verifier: &str) -> String {
 }
 
 /// Validate callback state against expected state.
-pub fn validate_state(expected: &str, actual: Option<&str>) -> Result<()> {
-    let Some(actual) = actual else {
-        return OAuthValidationSnafu {
-            message: "missing oauth state",
-        }
-        .fail();
-    };
+pub fn validate_state(expected: &str, actual: &str) -> Result<()> {
     if expected.is_empty() {
         return OAuthValidationSnafu {
             message: "missing expected oauth state",


### PR DESCRIPTION
## Summary

- Remove the ephemeral `localhost:1455` HTTP server from the codex OAuth login flow
- After the user authorizes in their browser, the CLI prompts them to paste the full callback URL from the address bar
- Code and state are extracted locally; token exchange happens without the browser needing to reach `localhost`
- Remove unused `axum` and `tokio-util` dependencies from `rara-codex-oauth`

**Root cause fixed**: `rara login codex` ran on machine A, but browser on machine B — `localhost:1455` on machine B had no server, so the OAuth redirect always failed.

## Type of change

| Type | Label |
|------|-------|
| New feature | `enhancement` |

## Component

`backend`

## Closes

Closes #957

## Test plan

- [x] `cargo check` passes for `rara-codex-oauth` and `rara` binary
- [x] Tested flow: run `rara login codex`, open auth URL in browser on any machine, paste callback URL into terminal