### PR TITLE
feat(cmd): add guard approval to chat TUI (#966)

### DIFF
--- a/crates/cmd/Cargo.toml
+++ b/crates/cmd/Cargo.toml
@@ -26,6 +26,7 @@ path = "src/main.rs"
 
 [dependencies]
 base64.workspace = true
+bon.workspace = true
 chrono.workspace = true
 clap = { workspace = true }
 common-telemetry.workspace = true

--- a/crates/cmd/src/chat/app.rs
+++ b/crates/cmd/src/chat/app.rs
@@ -87,7 +87,7 @@ pub struct ChatState {
 }
 
 /// A guard approval request pending user decision.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, bon::Builder)]
 pub struct PendingApproval {
     pub id:         String,
     pub tool_name:  String,
@@ -311,18 +311,10 @@ impl ChatState {
             CliEvent::TurnRationale { text } => {
                 self.status_msg = Some(text);
             }
-            CliEvent::ApprovalRequest {
-                id,
-                tool_name,
-                summary,
-                risk_level,
-            } => {
-                self.set_pending_approval(PendingApproval {
-                    id,
-                    tool_name,
-                    summary,
-                    risk_level,
-                });
+            CliEvent::ApprovalRequest { .. } => {
+                // Approvals arrive via the dedicated `approval_rx` channel in
+                // mod.rs, not through CLI events. This arm exists only to
+                // satisfy the exhaustive match.
             }
             CliEvent::Done => self.finalize_stream(),
         }

--- a/crates/cmd/src/chat/mod.rs
+++ b/crates/cmd/src/chat/mod.rs
@@ -213,12 +213,14 @@ async fn run_chat_tui(
             }
             result = approval_rx.recv() => {
                 if let Ok(request) = result {
-                    state.set_pending_approval(PendingApproval {
-                        id: request.id.to_string(),
-                        tool_name: request.tool_name.clone(),
-                        summary: request.summary.clone(),
-                        risk_level: format!("{:?}", request.risk_level),
-                    });
+                    state.set_pending_approval(
+                        PendingApproval::builder()
+                            .id(request.id.to_string())
+                            .tool_name(request.tool_name.clone())
+                            .summary(request.summary.clone())
+                            .risk_level(format!("{:?}", request.risk_level))
+                            .build(),
+                    );
                 }
             }
             maybe_event = poll_crossterm_event() => {
@@ -233,7 +235,6 @@ async fn run_chat_tui(
                                 ApprovalDecision::Approved,
                                 Some("cli-user".to_owned()),
                             );
-                            state.pending_approval = None;
                             state.push_message(Role::System, format!("Guard approved: {id}"));
                         }
                         ChatAction::DenyGuard { id } => {
@@ -243,7 +244,6 @@ async fn run_chat_tui(
                                 ApprovalDecision::Denied,
                                 Some("cli-user".to_owned()),
                             );
-                            state.pending_approval = None;
                             state.push_message(Role::System, format!("Guard denied: {id}"));
                         }
                         ChatAction::SlashCommand(command) => {


### PR DESCRIPTION
## Summary

Add guard approval flow to the Chat TUI. When the kernel's guard subsystem blocks a tool call, the TUI now displays an interactive approval prompt allowing the user to approve (y/Enter) or deny (n/Esc).

- Subscribe to `ApprovalRequest` broadcasts from kernel security subsystem
- `PendingApproval` state in `ChatState` with key interception
- Yellow-bordered approval box in UI showing tool name, risk level, action summary
- Resolve via `ApprovalManager.resolve()` with `Approved`/`Denied` decision

Part of #961. Stacked on #965.

## Type of change

| Type | Label |
|------|-------|
| New feature | `enhancement` |

## Component

`core`

## Closes

Closes #966

## Test plan

- [x] `cargo check -p rara-cli` passes
- [x] Pre-commit hooks pass
- [x] 24 tests pass (5 new: y/Enter approve, n/Esc deny, other keys ignored)