### PR TITLE
feat(cmd): add ask-user question flow to chat TUI (#969)

### DIFF
--- a/crates/app/src/lib.rs
+++ b/crates/app/src/lib.rs
@@ -610,6 +610,7 @@ pub async fn start_with_options(
         cancellation_token: cancellation_token.clone(),
         kernel_handle: Some(kernel_handle),
         command_handlers,
+        user_question_manager: Some(rara.user_question_manager.clone()),
     };
 
     let running_clone = Arc::clone(&running);
@@ -785,14 +786,17 @@ async fn init_infra(config: &AppConfig) -> Result<DBStore, Whatever> {
 /// Handle for controlling a running application.
 #[allow(dead_code)]
 pub struct AppHandle {
-    shutdown_tx:          Option<oneshot::Sender<()>>,
-    running:              Arc<AtomicBool>,
-    cancellation_token:   CancellationToken,
+    shutdown_tx:               Option<oneshot::Sender<()>>,
+    running:                   Arc<AtomicBool>,
+    cancellation_token:        CancellationToken,
     /// Kernel handle (for injecting inbound messages, accessing stream hub,
     /// endpoint registry, etc.).
-    pub kernel_handle:    Option<rara_kernel::handle::KernelHandle>,
+    pub kernel_handle:         Option<rara_kernel::handle::KernelHandle>,
     /// Command handlers shared across all channels (Telegram, CLI, etc.).
     pub command_handlers: Vec<std::sync::Arc<dyn rara_kernel::channel::command::CommandHandler>>,
+    /// User question manager for the ask-user tool (CLI needs it to subscribe
+    /// and resolve agent questions).
+    pub user_question_manager: Option<rara_kernel::user_question::UserQuestionManagerRef>,
 }
 
 #[allow(dead_code)]

--- a/crates/channels/src/terminal.rs
+++ b/crates/channels/src/terminal.rs
@@ -60,6 +60,8 @@ pub enum CliEvent {
         summary:    String,
         risk_level: String,
     },
+    /// Agent question requiring user answer.
+    UserQuestion { id: String, question: String },
     /// Stream completed.
     Done,
 }

--- a/crates/cmd/src/chat/app.rs
+++ b/crates/cmd/src/chat/app.rs
@@ -84,6 +84,8 @@ pub struct ChatState {
     pub loading_hint:     String,
     /// Guard approval request awaiting user decision (y/n).
     pub pending_approval: Option<PendingApproval>,
+    /// Agent question awaiting user answer (free-form text input).
+    pub pending_question: Option<PendingQuestion>,
 }
 
 /// A guard approval request pending user decision.
@@ -93,6 +95,13 @@ pub struct PendingApproval {
     pub tool_name:  String,
     pub summary:    String,
     pub risk_level: String,
+}
+
+/// A question from the agent pending user answer.
+#[derive(Debug, Clone)]
+pub struct PendingQuestion {
+    pub id:       String,
+    pub question: String,
 }
 
 pub enum ChatAction {
@@ -107,6 +116,11 @@ pub enum ChatAction {
     /// User denied a pending guard request.
     DenyGuard {
         id: String,
+    },
+    /// User answered a pending agent question.
+    AnswerQuestion {
+        id:     String,
+        answer: String,
     },
 }
 
@@ -136,6 +150,7 @@ impl ChatState {
             tool_input_buf:   String::new(),
             loading_hint:     String::new(),
             pending_approval: None,
+            pending_question: None,
         };
         state.push_message(Role::System, CHAT_BANNER.to_owned());
         state
@@ -159,11 +174,17 @@ impl ChatState {
         self.tool_input_buf.clear();
         self.loading_hint.clear();
         self.pending_approval = None;
+        self.pending_question = None;
     }
 
     /// Set a pending guard approval request for the user to decide on.
     pub fn set_pending_approval(&mut self, approval: PendingApproval) {
         self.pending_approval = Some(approval);
+    }
+
+    /// Set a pending agent question for the user to answer.
+    pub fn set_pending_question(&mut self, question: PendingQuestion) {
+        self.pending_question = Some(question);
     }
 
     pub fn push_message(&mut self, role: Role, text: String) {
@@ -324,6 +345,9 @@ impl ChatState {
                     risk_level,
                 });
             }
+            CliEvent::UserQuestion { id, question } => {
+                self.set_pending_question(PendingQuestion { id, question });
+            }
             CliEvent::Done => self.finalize_stream(),
         }
     }
@@ -334,7 +358,7 @@ impl ChatState {
             return ChatAction::Back;
         }
 
-        // Intercept y/n when a guard approval request is pending.
+        // Intercept y/n when a guard approval request is pending (highest priority).
         if let Some(approval) = &self.pending_approval {
             let id = approval.id.clone();
             return match key.code {
@@ -345,6 +369,47 @@ impl ChatState {
                 KeyCode::Char('n') | KeyCode::Esc => {
                     self.pending_approval = None;
                     ChatAction::DenyGuard { id }
+                }
+                _ => ChatAction::Continue,
+            };
+        }
+
+        // When a question is pending, user types an answer into self.input.
+        if let Some(question) = &self.pending_question {
+            let id = question.id.clone();
+            return match key.code {
+                KeyCode::Enter => {
+                    let answer = self.input.trim().to_owned();
+                    self.input.clear();
+                    if answer.is_empty() {
+                        return ChatAction::Continue;
+                    }
+                    self.pending_question = None;
+                    ChatAction::AnswerQuestion { id, answer }
+                }
+                KeyCode::Esc => {
+                    self.input.clear();
+                    self.pending_question = None;
+                    ChatAction::AnswerQuestion {
+                        id,
+                        answer: "(no answer)".to_owned(),
+                    }
+                }
+                KeyCode::Char('u') if key.modifiers.contains(KeyModifiers::CONTROL) => {
+                    self.input.clear();
+                    ChatAction::Continue
+                }
+                KeyCode::Char(ch)
+                    if !key
+                        .modifiers
+                        .intersects(KeyModifiers::CONTROL | KeyModifiers::ALT) =>
+                {
+                    self.input.push(ch);
+                    ChatAction::Continue
+                }
+                KeyCode::Backspace => {
+                    self.input.pop();
+                    ChatAction::Continue
                 }
                 _ => ChatAction::Continue,
             };
@@ -481,7 +546,7 @@ mod tests {
     use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
     use rara_channels::terminal::CliEvent;
 
-    use super::{ChatAction, ChatState, PendingApproval, Role};
+    use super::{ChatAction, ChatState, PendingApproval, PendingQuestion, Role};
 
     #[test]
     fn new_chat_state_starts_with_openfang_banner() {
@@ -707,5 +772,111 @@ mod tests {
 
         let _ = chat.handle_key(KeyEvent::new(KeyCode::Down, KeyModifiers::NONE));
         assert_eq!(chat.scroll_offset, 10);
+    }
+
+    fn make_pending_question() -> PendingQuestion {
+        PendingQuestion {
+            id:       "660e8400-e29b-41d4-a716-446655440000".into(),
+            question: "What is the API key?".into(),
+        }
+    }
+
+    #[test]
+    fn user_question_event_sets_pending_question() {
+        let mut chat = ChatState::new("default".into(), "local".into());
+        chat.handle_cli_event(CliEvent::UserQuestion {
+            id:       "660e8400-e29b-41d4-a716-446655440000".into(),
+            question: "What is the API key?".into(),
+        });
+
+        assert!(chat.pending_question.is_some());
+        let q = chat.pending_question.as_ref().expect("pending question");
+        assert_eq!(q.id, "660e8400-e29b-41d4-a716-446655440000");
+        assert_eq!(q.question, "What is the API key?");
+    }
+
+    #[test]
+    fn enter_submits_answer_when_question_pending() {
+        let mut chat = ChatState::new("default".into(), "local".into());
+        chat.set_pending_question(make_pending_question());
+        chat.input = "sk-12345".into();
+
+        let action = chat.handle_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE));
+
+        assert!(matches!(action, ChatAction::AnswerQuestion { id, answer }
+                if id == "660e8400-e29b-41d4-a716-446655440000" && answer == "sk-12345"));
+        assert!(chat.pending_question.is_none());
+        assert!(chat.input.is_empty());
+    }
+
+    #[test]
+    fn empty_enter_does_not_submit_question() {
+        let mut chat = ChatState::new("default".into(), "local".into());
+        chat.set_pending_question(make_pending_question());
+
+        let action = chat.handle_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE));
+
+        assert!(matches!(action, ChatAction::Continue));
+        assert!(chat.pending_question.is_some());
+    }
+
+    #[test]
+    fn esc_skips_question_with_no_answer() {
+        let mut chat = ChatState::new("default".into(), "local".into());
+        chat.set_pending_question(make_pending_question());
+
+        let action = chat.handle_key(KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE));
+
+        assert!(matches!(action, ChatAction::AnswerQuestion { id, answer }
+                if id == "660e8400-e29b-41d4-a716-446655440000" && answer == "(no answer)"));
+        assert!(chat.pending_question.is_none());
+    }
+
+    #[test]
+    fn typing_in_question_mode_appends_to_input() {
+        let mut chat = ChatState::new("default".into(), "local".into());
+        chat.set_pending_question(make_pending_question());
+
+        let _ = chat.handle_key(KeyEvent::new(KeyCode::Char('a'), KeyModifiers::NONE));
+        let _ = chat.handle_key(KeyEvent::new(KeyCode::Char('b'), KeyModifiers::NONE));
+
+        assert_eq!(chat.input, "ab");
+        assert!(chat.pending_question.is_some());
+    }
+
+    #[test]
+    fn backspace_in_question_mode_removes_char() {
+        let mut chat = ChatState::new("default".into(), "local".into());
+        chat.set_pending_question(make_pending_question());
+        chat.input = "abc".into();
+
+        let _ = chat.handle_key(KeyEvent::new(KeyCode::Backspace, KeyModifiers::NONE));
+
+        assert_eq!(chat.input, "ab");
+    }
+
+    #[test]
+    fn approval_takes_priority_over_question() {
+        let mut chat = ChatState::new("default".into(), "local".into());
+        chat.set_pending_approval(make_pending_approval());
+        chat.set_pending_question(make_pending_question());
+
+        // 'y' should trigger approval, not question input.
+        let action = chat.handle_key(KeyEvent::new(KeyCode::Char('y'), KeyModifiers::NONE));
+
+        assert!(matches!(action, ChatAction::ApproveGuard { .. }));
+        assert!(chat.pending_approval.is_none());
+        // Question should still be pending.
+        assert!(chat.pending_question.is_some());
+    }
+
+    #[test]
+    fn reset_messages_clears_pending_question() {
+        let mut chat = ChatState::new("default".into(), "local".into());
+        chat.set_pending_question(make_pending_question());
+
+        chat.reset_messages();
+
+        assert!(chat.pending_question.is_none());
     }
 }

--- a/crates/cmd/src/chat/mod.rs
+++ b/crates/cmd/src/chat/mod.rs
@@ -40,7 +40,7 @@ use rara_kernel::{
 use snafu::{ResultExt, Whatever, whatever};
 
 use crate::chat::{
-    app::{ChatAction, ChatState, HandleResult, PendingApproval, Role},
+    app::{ChatAction, ChatState, HandleResult, PendingApproval, PendingQuestion, Role},
     ui::render,
 };
 
@@ -121,6 +121,7 @@ impl ChatArgs {
         chat_state.model_label = default_model_label;
 
         let command_handlers = app_handle.command_handlers.clone();
+        let user_question_manager = app_handle.user_question_manager.clone();
 
         let result = run_chat_tui(
             &mut terminal,
@@ -131,6 +132,7 @@ impl ChatArgs {
             user_id,
             &command_handlers,
             session_tx,
+            user_question_manager,
         )
         .await;
 
@@ -198,9 +200,11 @@ async fn run_chat_tui(
     user_id: String,
     command_handlers: &[Arc<dyn CommandHandler>],
     session_tx: tokio::sync::watch::Sender<SessionKey>,
+    user_question_manager: Option<rara_kernel::user_question::UserQuestionManagerRef>,
 ) -> Result<(), Whatever> {
     let mut tick = tokio::time::interval(Duration::from_millis(100));
     let mut approval_rx = kernel_handle.security().approval().subscribe_requests();
+    let mut question_rx = user_question_manager.as_ref().map(|mgr| mgr.subscribe());
 
     loop {
         terminal
@@ -218,6 +222,19 @@ async fn run_chat_tui(
                         tool_name: request.tool_name.clone(),
                         summary: request.summary.clone(),
                         risk_level: format!("{:?}", request.risk_level),
+                    });
+                }
+            }
+            result = async {
+                match question_rx.as_mut() {
+                    Some(rx) => rx.recv().await,
+                    None => std::future::pending().await,
+                }
+            } => {
+                if let Ok(question) = result {
+                    state.set_pending_question(PendingQuestion {
+                        id: question.id.to_string(),
+                        question: question.question.clone(),
                     });
                 }
             }
@@ -245,6 +262,14 @@ async fn run_chat_tui(
                             );
                             state.pending_approval = None;
                             state.push_message(Role::System, format!("Guard denied: {id}"));
+                        }
+                        ChatAction::AnswerQuestion { id, answer } => {
+                            let uuid = uuid::Uuid::parse_str(&id).expect("valid question uuid");
+                            if let Some(ref mgr) = user_question_manager {
+                                let _ = mgr.resolve(uuid, answer.clone());
+                            }
+                            state.pending_question = None;
+                            state.push_message(Role::System, format!("Answered: {answer}"));
                         }
                         ChatAction::SlashCommand(command) => {
                             match handle_slash_command(

--- a/crates/cmd/src/chat/ui.rs
+++ b/crates/cmd/src/chat/ui.rs
@@ -21,7 +21,7 @@ use ratatui::{
 };
 
 use crate::chat::{
-    app::{ChatMessage, ChatState, PendingApproval, Role, ToolInfo},
+    app::{ChatMessage, ChatState, PendingApproval, PendingQuestion, Role, ToolInfo},
     theme,
 };
 
@@ -43,15 +43,14 @@ pub fn render(frame: &mut Frame, state: &ChatState, area: Rect) {
     let inner = block.inner(area);
     frame.render_widget(block, area);
 
-    let approval_height = if state.pending_approval.is_some() {
-        5
-    } else {
-        0
-    };
+    // Approval takes priority over question when both are present.
+    let show_approval = state.pending_approval.is_some();
+    let show_question = !show_approval && state.pending_question.is_some();
+    let prompt_height = if show_approval || show_question { 5 } else { 0 };
 
     let chunks = Layout::vertical([
         Constraint::Min(3),
-        Constraint::Length(approval_height),
+        Constraint::Length(prompt_height),
         Constraint::Length(1),
         Constraint::Length(1),
         Constraint::Length(1),
@@ -62,6 +61,8 @@ pub fn render(frame: &mut Frame, state: &ChatState, area: Rect) {
 
     if let Some(approval) = &state.pending_approval {
         draw_approval_prompt(frame, chunks[1], approval);
+    } else if let Some(question) = &state.pending_question {
+        draw_question_prompt(frame, chunks[1], question, &state.input);
     }
 
     let separator = Paragraph::new("─".repeat(chunks[2].width as usize))
@@ -102,6 +103,8 @@ pub fn render(frame: &mut Frame, state: &ChatState, area: Rect) {
 
     let hints = if state.pending_approval.is_some() {
         "    [y/Enter] Approve  [n/Esc] Deny"
+    } else if state.pending_question.is_some() {
+        "    [Enter] Submit answer  [Esc] Skip"
     } else if state.is_streaming {
         "    [Enter] Stage  [↑↓/PgUp/PgDn] Scroll  [Esc] Stop"
     } else {
@@ -380,6 +383,43 @@ fn draw_approval_prompt(frame: &mut Frame, area: Rect, approval: &PendingApprova
             "[y/Enter] Approve  [n/Esc] Deny",
             Style::default().fg(theme::YELLOW),
         )]),
+    ];
+
+    frame.render_widget(Paragraph::new(lines), inner);
+}
+
+/// Render a highlighted question prompt box for a pending agent question.
+fn draw_question_prompt(frame: &mut Frame, area: Rect, question: &PendingQuestion, input: &str) {
+    let border_style = Style::default().fg(theme::CYAN);
+    let block = Block::default()
+        .title(Span::styled(
+            " Agent Question ",
+            Style::default()
+                .fg(theme::CYAN)
+                .add_modifier(Modifier::BOLD),
+        ))
+        .borders(Borders::ALL)
+        .border_style(border_style)
+        .padding(Padding::horizontal(1));
+
+    let inner = block.inner(area);
+    frame.render_widget(block, area);
+
+    let lines = vec![
+        Line::from(vec![Span::raw(question.question.clone())]),
+        Line::from(""),
+        Line::from(vec![
+            Span::styled("> ", Style::default().fg(theme::CYAN)),
+            Span::raw(input.to_owned()),
+            Span::styled(
+                "\u{2588}",
+                Style::default()
+                    .fg(theme::CYAN)
+                    .add_modifier(Modifier::SLOW_BLINK),
+            ),
+            Span::raw("  "),
+            Span::styled("[Enter] Submit", Style::default().fg(theme::CYAN)),
+        ]),
     ];
 
     frame.render_widget(Paragraph::new(lines), inner);


### PR DESCRIPTION
## Summary

Add ask-user question flow to the Chat TUI. When the kernel's ask-user tool sends a question via UserQuestionManager, the TUI displays a cyan-bordered prompt and lets the user type an answer.

- Expose `UserQuestionManagerRef` on `AppHandle` for CLI access
- Subscribe to `UserQuestion` broadcasts in the TUI event loop
- `PendingQuestion` state with Enter to submit, Esc to skip
- Approval takes priority when both approval and question are pending
- Cyan-bordered question prompt with inline input cursor

Part of #961. Stacked on #968.

## Type of change

| Type | Label |
|------|-------|
| New feature | `enhancement` |

## Component

`core`

## Closes

Closes #969

## Test plan

- [x] `cargo check -p rara-cli` and `cargo check -p rara-app` pass
- [x] Pre-commit hooks pass
- [x] 32 tests pass (8 new)