### PR TITLE
chore(codex-oauth): align auth URL params with upstream (#973)

### DIFF
--- a/crates/integrations/codex-oauth/src/lib.rs
+++ b/crates/integrations/codex-oauth/src/lib.rs
@@ -188,9 +188,7 @@ pub fn build_auth_url(state: &str, code_challenge: &str) -> Result<String> {
         .append_pair("scope", CODEX_SCOPES)
         .append_pair("code_challenge", code_challenge)
         .append_pair("code_challenge_method", "S256")
-        .append_pair("state", state)
-        .append_pair("id_token_add_organizations", "true")
-        .append_pair("codex_cli_simplified_flow", "true");
+        .append_pair("state", state);
     Ok(url.into())
 }
 


### PR DESCRIPTION
## Summary

Remove `id_token_add_organizations` and `codex_cli_simplified_flow` query parameters from the Codex OAuth authorization URL. These are non-standard params not used by the upstream implementation (crabclaw/openai-codex).

## Type of change

| Type | Label |
|------|-------|
| Chore | `chore` |

## Component

`core`

## Closes

Closes #973

## Test plan

- [x] `cargo check -p rara-codex-oauth` passes
- [x] Pre-commit hooks pass