### PR TITLE
feat(cmd): add Ctrl+C interrupt and /stop to chat TUI (#976)

### DIFF
--- a/crates/cmd/src/chat/app.rs
+++ b/crates/cmd/src/chat/app.rs
@@ -121,10 +121,13 @@ pub struct PendingToolCallLimit {
     pub tool_calls_made: usize,
 }
 
+#[derive(Debug, PartialEq, Eq)]
 pub enum ChatAction {
     Continue,
     SendMessage(String),
     Back,
+    /// Interrupt the agent's current streaming turn (Ctrl+C while streaming).
+    Interrupt,
     SlashCommand(String),
     /// User approved a pending guard request.
     ApproveGuard {
@@ -435,6 +438,9 @@ impl ChatState {
     #[must_use]
     pub fn handle_key(&mut self, key: KeyEvent) -> ChatAction {
         if key.code == KeyCode::Char('c') && key.modifiers.contains(KeyModifiers::CONTROL) {
+            if self.is_streaming {
+                return ChatAction::Interrupt;
+            }
             return ChatAction::Back;
         }
 
@@ -1282,5 +1288,23 @@ mod tests {
         assert_eq!(chat.turn_input_tokens, 0);
         assert_eq!(chat.turn_output_tokens, 0);
         assert_eq!(chat.turn_thinking_ms, 0);
+    }
+
+    #[test]
+    fn ctrl_c_returns_interrupt_when_streaming() {
+        let mut chat = ChatState::new("default".into(), "local".into());
+        chat.is_streaming = true;
+
+        let key = KeyEvent::new(KeyCode::Char('c'), KeyModifiers::CONTROL);
+        assert_eq!(chat.handle_key(key), ChatAction::Interrupt);
+    }
+
+    #[test]
+    fn ctrl_c_returns_back_when_idle() {
+        let mut chat = ChatState::new("default".into(), "local".into());
+        chat.is_streaming = false;
+
+        let key = KeyEvent::new(KeyCode::Char('c'), KeyModifiers::CONTROL);
+        assert_eq!(chat.handle_key(key), ChatAction::Back);
     }
 }

--- a/crates/cmd/src/chat/mod.rs
+++ b/crates/cmd/src/chat/mod.rs
@@ -243,6 +243,14 @@ async fn run_chat_tui(
                     match state.handle_key(key) {
                         ChatAction::Continue => {}
                         ChatAction::Back => break,
+                        ChatAction::Interrupt => {
+                            let resolved = session_tx.borrow().clone();
+                            let _ = kernel_handle.send_signal(
+                                resolved,
+                                rara_kernel::session::Signal::Interrupt,
+                            );
+                            state.status_msg = Some("Interrupting...".to_owned());
+                        }
                         ChatAction::ApproveGuard { id } => {
                             let uuid = uuid::Uuid::parse_str(&id).expect("valid approval uuid");
                             let _ = kernel_handle.security().approval().resolve(

--- a/crates/cmd/src/chat/ui.rs
+++ b/crates/cmd/src/chat/ui.rs
@@ -108,7 +108,7 @@ pub fn render(frame: &mut Frame, state: &ChatState, area: Rect) {
     } else if state.pending_tool_call_limit.is_some() {
         "    [c/Enter] Continue  [s/Esc] Stop"
     } else if state.is_streaming {
-        "    [Enter] Stage  [↑↓/PgUp/PgDn] Scroll  [Esc] Stop"
+        "    [Ctrl+C] Interrupt  [Enter] Stage  [↑↓/PgUp/PgDn] Scroll  [Esc] Stop"
     } else {
         "    [Enter] Send  [/help] Commands  [↑↓/PgUp/PgDn] Scroll  [Esc] Back"
     };


### PR DESCRIPTION
## Summary

Change Ctrl+C behavior during streaming: sends `Signal::Interrupt` to cancel the agent's current turn instead of exiting the TUI. Ctrl+C when idle still exits.

- `ChatAction::Interrupt` variant for streaming Ctrl+C
- `kernel_handle.send_signal(session_key, Signal::Interrupt)` on interrupt
- Hint bar shows `[Ctrl+C] Interrupt` during streaming
- `/stop` already works via `StopCommandHandler`

Part of #961. Stacked on #979.

## Type of change

| Type | Label |
|------|-------|
| New feature | `enhancement` |

## Component

`core`

## Closes

Closes #976

## Test plan

- [x] `cargo check -p rara-cli` passes
- [x] Pre-commit hooks pass
- [x] 2 new tests, 55 total pass