### PR TITLE
feat(cmd): add enhanced progress display to chat TUI (#977)

### DIFF
--- a/crates/channels/src/terminal.rs
+++ b/crates/channels/src/terminal.rs
@@ -68,6 +68,20 @@ pub enum CliEvent {
         limit_id:        u64,
         tool_calls_made: usize,
     },
+    /// Plan created with goal, total steps, and step descriptions.
+    PlanCreated {
+        goal:              String,
+        total_steps:       u32,
+        step_descriptions: Vec<String>,
+    },
+    /// Plan step progress update.
+    PlanProgress {
+        current_step: u32,
+        total_steps:  u32,
+        status_text:  String,
+    },
+    /// Plan completed with summary.
+    PlanCompleted { summary: String },
     /// Per-iteration token usage update (cumulative values from kernel).
     UsageUpdate {
         input_tokens:  u32,

--- a/crates/cmd/src/chat/app.rs
+++ b/crates/cmd/src/chat/app.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::time::{Duration, Instant};
+
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 use rara_channels::terminal::CliEvent;
 
@@ -95,6 +97,16 @@ pub struct ChatState {
     pub pending_question:        Option<PendingQuestion>,
     /// Tool call limit pause awaiting user decision (continue/stop).
     pub pending_tool_call_limit: Option<PendingToolCallLimit>,
+    /// Per-tool progress entries for the current turn.
+    pub tool_progress:           Vec<ToolProgressEntry>,
+    /// When the current turn started (reset each time user sends a message).
+    pub turn_started:            Option<Instant>,
+    /// Active plan goal description.
+    pub plan_goal:               Option<String>,
+    /// Steps in the active plan.
+    pub plan_steps:              Option<Vec<PlanStepInfo>>,
+    /// Index of the currently executing plan step (0-based).
+    pub plan_current_step:       Option<usize>,
 }
 
 /// A guard approval request pending user decision.
@@ -119,6 +131,45 @@ pub struct PendingToolCallLimit {
     pub session_key:     String,
     pub limit_id:        u64,
     pub tool_calls_made: usize,
+}
+
+/// Tracks an individual tool invocation's progress within a turn.
+#[derive(Debug, Clone)]
+pub struct ToolProgressEntry {
+    /// Display name of the tool.
+    pub name:       String,
+    /// Brief summary of what the tool is doing.
+    pub summary:    String,
+    /// When the tool started executing.
+    pub started_at: Instant,
+    /// Whether the tool has finished.
+    pub finished:   bool,
+    /// Whether the tool succeeded (only meaningful when `finished` is true).
+    pub success:    bool,
+    /// Elapsed duration (set when finished).
+    pub duration:   Option<Duration>,
+}
+
+/// Status of an individual plan step.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PlanStepStatus {
+    /// Step has not started yet.
+    Pending,
+    /// Step is currently being executed.
+    Running,
+    /// Step completed successfully.
+    Done,
+    /// Step failed.
+    Failed,
+}
+
+/// Describes a single step within a plan.
+#[derive(Debug, Clone)]
+pub struct PlanStepInfo {
+    /// Human-readable description of this step.
+    pub description: String,
+    /// Current status of this step.
+    pub status:      PlanStepStatus,
 }
 
 #[derive(Debug, PartialEq, Eq)]
@@ -181,6 +232,11 @@ impl ChatState {
             pending_approval:        None,
             pending_question:        None,
             pending_tool_call_limit: None,
+            tool_progress:           Vec::new(),
+            turn_started:            None,
+            plan_goal:               None,
+            plan_steps:              None,
+            plan_current_step:       None,
         };
         state.push_message(Role::System, CHAT_BANNER.to_owned());
         state
@@ -209,6 +265,11 @@ impl ChatState {
         self.pending_approval = None;
         self.pending_question = None;
         self.pending_tool_call_limit = None;
+        self.tool_progress.clear();
+        self.turn_started = None;
+        self.plan_goal = None;
+        self.plan_steps = None;
+        self.plan_current_step = None;
     }
 
     /// Set a pending guard approval request for the user to decide on.
@@ -335,6 +396,14 @@ impl ChatState {
                     let text = std::mem::take(&mut self.streaming_text);
                     self.push_message(Role::Agent, text);
                 }
+                self.tool_progress.push(ToolProgressEntry {
+                    name:       name.clone(),
+                    summary:    summary.clone(),
+                    started_at: Instant::now(),
+                    finished:   false,
+                    success:    true,
+                    duration:   None,
+                });
                 self.tool_start(&name);
                 self.tool_use_end(&name, &summary);
             }
@@ -342,6 +411,12 @@ impl ChatState {
                 success,
                 result_preview,
             } => {
+                // Mark the last unfinished progress entry as completed.
+                if let Some(entry) = self.tool_progress.iter_mut().rev().find(|e| !e.finished) {
+                    entry.finished = true;
+                    entry.success = success;
+                    entry.duration = Some(entry.started_at.elapsed());
+                }
                 let tool_name = self.messages.iter().rev().find_map(|message| {
                     let tool = message.tool.as_ref()?;
                     if tool.result.is_empty() {
@@ -365,6 +440,84 @@ impl ChatState {
             }
             CliEvent::TurnRationale { text } => {
                 self.status_msg = Some(text);
+            }
+            CliEvent::PlanCreated {
+                goal,
+                total_steps,
+                step_descriptions,
+            } => {
+                self.plan_goal = Some(goal);
+                let steps = step_descriptions
+                    .into_iter()
+                    .take(total_steps as usize)
+                    .map(|desc| PlanStepInfo {
+                        description: desc,
+                        status:      PlanStepStatus::Pending,
+                    })
+                    .collect::<Vec<_>>();
+                // Mark the first step as running if there are any.
+                self.plan_current_step = if steps.is_empty() { None } else { Some(0) };
+                self.plan_steps = Some(steps);
+                if let Some(steps) = self.plan_steps.as_mut() {
+                    if let Some(first) = steps.first_mut() {
+                        first.status = PlanStepStatus::Running;
+                    }
+                }
+            }
+            CliEvent::PlanProgress {
+                current_step,
+                total_steps,
+                status_text,
+            } => {
+                let step_idx = current_step.saturating_sub(1) as usize;
+                // Lazily create step entries if PlanCreated wasn't received
+                // or had empty descriptions.
+                if self.plan_steps.is_none() {
+                    self.plan_steps = Some(
+                        (0..total_steps as usize)
+                            .map(|_| PlanStepInfo {
+                                description: String::new(),
+                                status:      PlanStepStatus::Pending,
+                            })
+                            .collect(),
+                    );
+                }
+                if let Some(steps) = self.plan_steps.as_mut() {
+                    // Ensure we have enough step entries.
+                    while steps.len() <= step_idx {
+                        steps.push(PlanStepInfo {
+                            description: String::new(),
+                            status:      PlanStepStatus::Pending,
+                        });
+                    }
+                    // Mark previous steps as done, current as running.
+                    for (i, step) in steps.iter_mut().enumerate() {
+                        if i < step_idx && step.status == PlanStepStatus::Running {
+                            step.status = PlanStepStatus::Done;
+                        } else if i == step_idx && step.status != PlanStepStatus::Failed {
+                            step.status = PlanStepStatus::Running;
+                            // Use status_text as step description if not set.
+                            if step.description.is_empty() {
+                                step.description = status_text.clone();
+                            }
+                        }
+                    }
+                }
+                self.plan_current_step = Some(step_idx);
+                self.status_msg = Some(status_text);
+            }
+            CliEvent::PlanCompleted { summary } => {
+                // Mark all remaining steps as done.
+                if let Some(steps) = self.plan_steps.as_mut() {
+                    for step in steps.iter_mut() {
+                        if step.status == PlanStepStatus::Running
+                            || step.status == PlanStepStatus::Pending
+                        {
+                            step.status = PlanStepStatus::Done;
+                        }
+                    }
+                }
+                self.status_msg = Some(format!("Plan completed: {summary}"));
             }
             CliEvent::ApprovalRequest {
                 id,
@@ -659,6 +812,16 @@ fn format_tokens(tokens: u64) -> String {
     }
 }
 
+/// Format a tool execution duration into a compact display string.
+pub fn format_tool_duration(d: Duration) -> String {
+    let ms = d.as_millis();
+    if ms < 1000 {
+        format!("{ms}ms")
+    } else {
+        format!("{:.1}s", ms as f64 / 1000.0)
+    }
+}
+
 fn sanitize_function_tags(text: &str) -> String {
     let mut out = String::with_capacity(text.len());
     let mut rest = text;
@@ -680,7 +843,8 @@ mod tests {
     use rara_channels::terminal::CliEvent;
 
     use super::{
-        ChatAction, ChatState, PendingApproval, PendingQuestion, PendingToolCallLimit, Role,
+        ChatAction, ChatState, PendingApproval, PendingQuestion, PendingToolCallLimit,
+        PlanStepStatus, Role, ToolProgressEntry,
     };
 
     #[test]
@@ -1288,6 +1452,218 @@ mod tests {
         assert_eq!(chat.turn_input_tokens, 0);
         assert_eq!(chat.turn_output_tokens, 0);
         assert_eq!(chat.turn_thinking_ms, 0);
+    }
+
+    // -----------------------------------------------------------------------
+    // Tool progress tracking tests
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn tool_call_start_creates_progress_entry() {
+        let mut chat = ChatState::new("default".into(), "local".into());
+        chat.handle_cli_event(CliEvent::ToolCallStart {
+            name:    "read_file".into(),
+            summary: "README.md".into(),
+        });
+
+        assert_eq!(chat.tool_progress.len(), 1);
+        assert_eq!(chat.tool_progress[0].name, "read_file");
+        assert_eq!(chat.tool_progress[0].summary, "README.md");
+        assert!(!chat.tool_progress[0].finished);
+        assert!(chat.tool_progress[0].duration.is_none());
+    }
+
+    #[test]
+    fn tool_call_end_marks_progress_entry_finished() {
+        let mut chat = ChatState::new("default".into(), "local".into());
+        chat.handle_cli_event(CliEvent::ToolCallStart {
+            name:    "bash".into(),
+            summary: "npm test".into(),
+        });
+        chat.handle_cli_event(CliEvent::ToolCallEnd {
+            success:        true,
+            result_preview: "ok".into(),
+        });
+
+        assert_eq!(chat.tool_progress.len(), 1);
+        assert!(chat.tool_progress[0].finished);
+        assert!(chat.tool_progress[0].success);
+        assert!(chat.tool_progress[0].duration.is_some());
+    }
+
+    #[test]
+    fn tool_call_end_marks_failure() {
+        let mut chat = ChatState::new("default".into(), "local".into());
+        chat.handle_cli_event(CliEvent::ToolCallStart {
+            name:    "bash".into(),
+            summary: "failing cmd".into(),
+        });
+        chat.handle_cli_event(CliEvent::ToolCallEnd {
+            success:        false,
+            result_preview: "error".into(),
+        });
+
+        assert!(chat.tool_progress[0].finished);
+        assert!(!chat.tool_progress[0].success);
+    }
+
+    #[test]
+    fn multiple_tool_progress_entries_tracked() {
+        let mut chat = ChatState::new("default".into(), "local".into());
+        chat.handle_cli_event(CliEvent::ToolCallStart {
+            name:    "read_file".into(),
+            summary: "a.rs".into(),
+        });
+        chat.handle_cli_event(CliEvent::ToolCallEnd {
+            success:        true,
+            result_preview: "ok".into(),
+        });
+        chat.handle_cli_event(CliEvent::ToolCallStart {
+            name:    "search_code".into(),
+            summary: "pattern".into(),
+        });
+
+        assert_eq!(chat.tool_progress.len(), 2);
+        assert!(chat.tool_progress[0].finished);
+        assert!(!chat.tool_progress[1].finished);
+    }
+
+    #[test]
+    fn reset_messages_clears_tool_progress() {
+        let mut chat = ChatState::new("default".into(), "local".into());
+        chat.tool_progress.push(ToolProgressEntry {
+            name:       "test".into(),
+            summary:    "s".into(),
+            started_at: std::time::Instant::now(),
+            finished:   true,
+            success:    true,
+            duration:   Some(std::time::Duration::from_millis(100)),
+        });
+        chat.plan_goal = Some("goal".into());
+
+        chat.reset_messages();
+
+        assert!(chat.tool_progress.is_empty());
+        assert!(chat.plan_goal.is_none());
+        assert!(chat.plan_steps.is_none());
+        assert!(chat.turn_started.is_none());
+    }
+
+    // -----------------------------------------------------------------------
+    // Plan progress tracking tests
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn plan_created_sets_plan_state() {
+        let mut chat = ChatState::new("default".into(), "local".into());
+        chat.handle_cli_event(CliEvent::PlanCreated {
+            goal:              "Implement auth".into(),
+            total_steps:       3,
+            step_descriptions: vec![
+                "Add model".into(),
+                "Add middleware".into(),
+                "Add tests".into(),
+            ],
+        });
+
+        assert_eq!(chat.plan_goal.as_deref(), Some("Implement auth"));
+        let steps = chat.plan_steps.as_ref().expect("steps");
+        assert_eq!(steps.len(), 3);
+        assert_eq!(steps[0].status, PlanStepStatus::Running);
+        assert_eq!(steps[1].status, PlanStepStatus::Pending);
+        assert_eq!(steps[2].status, PlanStepStatus::Pending);
+        assert_eq!(steps[0].description, "Add model");
+    }
+
+    #[test]
+    fn plan_progress_advances_steps() {
+        let mut chat = ChatState::new("default".into(), "local".into());
+        chat.handle_cli_event(CliEvent::PlanCreated {
+            goal:              "Build feature".into(),
+            total_steps:       2,
+            step_descriptions: vec!["Step A".into(), "Step B".into()],
+        });
+
+        // Advance to step 2 (1-based).
+        chat.handle_cli_event(CliEvent::PlanProgress {
+            current_step: 2,
+            total_steps:  2,
+            status_text:  "Working on B".into(),
+        });
+
+        let steps = chat.plan_steps.as_ref().expect("steps");
+        assert_eq!(steps[0].status, PlanStepStatus::Done);
+        assert_eq!(steps[1].status, PlanStepStatus::Running);
+    }
+
+    #[test]
+    fn plan_completed_marks_all_steps_done() {
+        let mut chat = ChatState::new("default".into(), "local".into());
+        chat.handle_cli_event(CliEvent::PlanCreated {
+            goal:              "task".into(),
+            total_steps:       2,
+            step_descriptions: vec!["A".into(), "B".into()],
+        });
+        chat.handle_cli_event(CliEvent::PlanCompleted {
+            summary: "All done".into(),
+        });
+
+        let steps = chat.plan_steps.as_ref().expect("steps");
+        assert!(steps.iter().all(|s| s.status == PlanStepStatus::Done));
+        assert!(
+            chat.status_msg
+                .as_ref()
+                .expect("status")
+                .contains("All done")
+        );
+    }
+
+    #[test]
+    fn plan_progress_creates_steps_lazily() {
+        let mut chat = ChatState::new("default".into(), "local".into());
+        // No PlanCreated event — PlanProgress arrives directly.
+        chat.handle_cli_event(CliEvent::PlanProgress {
+            current_step: 1,
+            total_steps:  3,
+            status_text:  "First step".into(),
+        });
+
+        let steps = chat.plan_steps.as_ref().expect("steps");
+        assert_eq!(steps.len(), 3);
+        assert_eq!(steps[0].status, PlanStepStatus::Running);
+        assert_eq!(steps[0].description, "First step");
+    }
+
+    // -----------------------------------------------------------------------
+    // format_tool_duration tests
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn format_tool_duration_milliseconds() {
+        assert_eq!(
+            super::format_tool_duration(std::time::Duration::from_millis(50)),
+            "50ms"
+        );
+        assert_eq!(
+            super::format_tool_duration(std::time::Duration::from_millis(999)),
+            "999ms"
+        );
+    }
+
+    #[test]
+    fn format_tool_duration_seconds() {
+        assert_eq!(
+            super::format_tool_duration(std::time::Duration::from_millis(1000)),
+            "1.0s"
+        );
+        assert_eq!(
+            super::format_tool_duration(std::time::Duration::from_millis(1500)),
+            "1.5s"
+        );
+        assert_eq!(
+            super::format_tool_duration(std::time::Duration::from_millis(12345)),
+            "12.3s"
+        );
     }
 
     #[test]

--- a/crates/cmd/src/chat/mod.rs
+++ b/crates/cmd/src/chat/mod.rs
@@ -822,16 +822,25 @@ fn stream_event_to_cli_event(event: StreamEvent) -> CliEvent {
             compact_summary,
             total_steps,
             ..
-        } => CliEvent::Progress {
-            text: format!("Plan ({total_steps} steps): {compact_summary}"),
+        } => CliEvent::PlanCreated {
+            goal:              compact_summary,
+            total_steps:       total_steps as u32,
+            step_descriptions: Vec::new(),
         },
-        StreamEvent::PlanProgress { status_text, .. } => CliEvent::Progress { text: status_text },
+        StreamEvent::PlanProgress {
+            current_step,
+            total_steps,
+            status_text,
+            ..
+        } => CliEvent::PlanProgress {
+            current_step: current_step as u32,
+            total_steps: total_steps as u32,
+            status_text,
+        },
         StreamEvent::PlanReplan { reason } => CliEvent::Progress {
             text: format!("Replanning: {reason}"),
         },
-        StreamEvent::PlanCompleted { summary } => CliEvent::Progress {
-            text: format!("Plan completed: {summary}"),
-        },
+        StreamEvent::PlanCompleted { summary } => CliEvent::PlanCompleted { summary },
         StreamEvent::UsageUpdate {
             input_tokens,
             output_tokens,
@@ -896,6 +905,12 @@ async fn send_cli_message(
     state.turn_input_tokens = 0;
     state.turn_output_tokens = 0;
     state.turn_thinking_ms = 0;
+    // Clear progress state from previous turn.
+    state.tool_progress.clear();
+    state.turn_started = Some(std::time::Instant::now());
+    state.plan_goal = None;
+    state.plan_steps = None;
+    state.plan_current_step = None;
 
     let attachments = match load_image_blocks(&image_paths).await {
         Ok(attachments) => attachments,

--- a/crates/cmd/src/chat/ui.rs
+++ b/crates/cmd/src/chat/ui.rs
@@ -21,7 +21,10 @@ use ratatui::{
 };
 
 use crate::chat::{
-    app::{ChatMessage, ChatState, PendingApproval, PendingQuestion, Role, ToolInfo},
+    app::{
+        ChatMessage, ChatState, PendingApproval, PendingQuestion, PlanStepStatus, Role, ToolInfo,
+        format_tool_duration,
+    },
     theme,
 };
 
@@ -48,8 +51,11 @@ pub fn render(frame: &mut Frame, state: &ChatState, area: Rect) {
     let show_question = !show_approval && state.pending_question.is_some();
     let prompt_height = if show_approval || show_question { 5 } else { 0 };
 
+    let progress_height = compute_progress_height(state);
+
     let chunks = Layout::vertical([
         Constraint::Min(3),
+        Constraint::Length(progress_height),
         Constraint::Length(prompt_height),
         Constraint::Length(1),
         Constraint::Length(1),
@@ -59,15 +65,19 @@ pub fn render(frame: &mut Frame, state: &ChatState, area: Rect) {
 
     draw_messages(frame, chunks[0], state);
 
-    if let Some(approval) = &state.pending_approval {
-        draw_approval_prompt(frame, chunks[1], approval);
-    } else if let Some(question) = &state.pending_question {
-        draw_question_prompt(frame, chunks[1], question, &state.input);
+    if progress_height > 0 {
+        draw_progress_section(frame, chunks[1], state);
     }
 
-    let separator = Paragraph::new("─".repeat(chunks[2].width as usize))
+    if let Some(approval) = &state.pending_approval {
+        draw_approval_prompt(frame, chunks[2], approval);
+    } else if let Some(question) = &state.pending_question {
+        draw_question_prompt(frame, chunks[2], question, &state.input);
+    }
+
+    let separator = Paragraph::new("─".repeat(chunks[3].width as usize))
         .style(Style::default().fg(theme::BORDER));
-    frame.render_widget(separator, chunks[2]);
+    frame.render_widget(separator, chunks[3]);
 
     let input_line = if state.is_streaming {
         let mut spans = vec![
@@ -99,7 +109,7 @@ pub fn render(frame: &mut Frame, state: &ChatState, area: Rect) {
             ),
         ]))
     };
-    frame.render_widget(input_line, chunks[3]);
+    frame.render_widget(input_line, chunks[4]);
 
     let hints = if state.pending_approval.is_some() {
         "    [y/Enter] Approve  [n/Esc] Deny"
@@ -114,8 +124,110 @@ pub fn render(frame: &mut Frame, state: &ChatState, area: Rect) {
     };
     frame.render_widget(
         Paragraph::new(Line::from(vec![Span::styled(hints, theme::hint_style())])),
-        chunks[4],
+        chunks[5],
     );
+}
+
+/// Compute the height needed for the progress section (tool + plan progress).
+fn compute_progress_height(state: &ChatState) -> u16 {
+    if !state.is_streaming {
+        return 0;
+    }
+
+    let mut height: u16 = 0;
+
+    // Tool progress: show at most the last 5 entries.
+    let tool_count = state.tool_progress.len().min(5);
+    if tool_count > 0 {
+        height += tool_count as u16;
+    }
+
+    // Plan progress: header + steps.
+    if let Some(steps) = &state.plan_steps {
+        if !steps.is_empty() {
+            height += 1; // header line
+            height += steps.len() as u16;
+        }
+    }
+
+    height
+}
+
+/// Render the per-tool and plan progress section.
+fn draw_progress_section(frame: &mut Frame, area: Rect, state: &ChatState) {
+    let mut lines = Vec::new();
+
+    // Tool progress — show last 5 entries.
+    let tool_entries = if state.tool_progress.len() > 5 {
+        &state.tool_progress[state.tool_progress.len() - 5..]
+    } else {
+        &state.tool_progress
+    };
+
+    for entry in tool_entries {
+        let (icon, icon_color) = if !entry.finished {
+            let spinner = theme::SPINNER_FRAMES[state.spinner_frame];
+            (spinner.to_owned(), theme::CYAN)
+        } else if entry.success {
+            ("\u{2705}".to_owned(), theme::GREEN) // checkmark
+        } else {
+            ("\u{274c}".to_owned(), theme::RED) // cross
+        };
+
+        let duration_str = entry
+            .duration
+            .map(|d| format!(" ({})", format_tool_duration(d)))
+            .unwrap_or_default();
+
+        let summary_part = if !entry.finished && !entry.summary.is_empty() {
+            format!(" \u{2014} {}", entry.summary)
+        } else {
+            String::new()
+        };
+
+        lines.push(Line::from(vec![
+            Span::styled(format!("  {icon} "), Style::default().fg(icon_color)),
+            Span::styled(entry.name.clone(), Style::default().fg(theme::YELLOW)),
+            Span::styled(duration_str, Style::default().fg(theme::DIM)),
+            Span::styled(summary_part, Style::default().fg(theme::DIM)),
+        ]));
+    }
+
+    // Plan progress.
+    if let Some(steps) = &state.plan_steps {
+        if !steps.is_empty() {
+            let goal = state.plan_goal.as_deref().unwrap_or("Plan");
+            lines.push(Line::from(vec![Span::styled(
+                format!("  \u{1f4cb} {} ({} steps)", goal, steps.len()),
+                Style::default().fg(theme::CYAN),
+            )]));
+
+            for (i, step) in steps.iter().enumerate() {
+                let (icon, color) = match step.status {
+                    PlanStepStatus::Pending => ("\u{25fb}", theme::DIM), // white square
+                    PlanStepStatus::Running => ("\u{25b6}\u{fe0f}", theme::CYAN), // play
+                    PlanStepStatus::Done => ("\u{2705}", theme::GREEN),  // checkmark
+                    PlanStepStatus::Failed => ("\u{274c}", theme::RED),  // cross
+                };
+
+                let desc = if step.description.is_empty() {
+                    format!("Step {}", i + 1)
+                } else {
+                    step.description.clone()
+                };
+
+                lines.push(Line::from(vec![
+                    Span::styled(
+                        format!("    {icon} {}. ", i + 1),
+                        Style::default().fg(color),
+                    ),
+                    Span::raw(desc),
+                ]));
+            }
+        }
+    }
+
+    frame.render_widget(Paragraph::new(lines), area);
 }
 
 fn draw_messages(frame: &mut Frame, area: Rect, state: &ChatState) {


### PR DESCRIPTION
## Summary

Add rich per-tool progress tracking and plan step visualization to the Chat TUI, matching Telegram's progress UX.

- `ToolProgressEntry` tracks per-tool invocation with name, duration, success/failure
- Plan progress with `PlanStepInfo` and step status (Pending/Running/Done/Failed)
- Typed `CliEvent` variants for plan events (PlanCreated/PlanProgress/PlanCompleted)
- Progress section rendered between messages and input showing last 5 tools + plan steps
- Icons: ✅ success, ❌ failure, spinner for in-progress, 📋 plan header

Part of #961. Stacked on #980.

## Type of change

| Type | Label |
|------|-------|
| New feature | `enhancement` |

## Component

`core`

## Closes

Closes #977

## Test plan

- [x] `cargo check -p rara-cli` passes
- [x] Pre-commit hooks pass
- [x] 12 new tests, 67 total pass