### PR TITLE
fix(cmd): default chat user-id to first configured user (#986)

### DIFF
--- a/crates/cmd/src/chat/mod.rs
+++ b/crates/cmd/src/chat/mod.rs
@@ -79,6 +79,7 @@ impl ChatArgs {
             None,
         );
 
+        let config_users = config.users.clone();
         let (adapter, event_rx) = TerminalAdapter::new();
         let adapter = Arc::new(adapter);
         let mut app_handle = start_with_options(
@@ -98,7 +99,16 @@ impl ChatArgs {
         let stream_hub = kernel_handle.stream_hub().clone();
 
         let session_alias = self.session.clone();
-        let user_id = self.user_id.clone();
+        // When --user-id is not explicitly set, default to the first
+        // configured user so that identity resolution succeeds.
+        let user_id = if self.user_id == "local" {
+            config_users
+                .first()
+                .map(|u| u.name.clone())
+                .unwrap_or(self.user_id.clone())
+        } else {
+            self.user_id.clone()
+        };
         let resolved_user_id = cli_kernel_user_id(&user_id);
         let resolved_session_id =
             get_or_create_cli_session(kernel_handle.session_index().as_ref(), &session_alias)


### PR DESCRIPTION
## Summary

`rara chat` fails with "unknown platform user: cli:local" because the default `--user-id` value (`local`) doesn't match any configured user. This fix extracts the user list from config before startup and falls back to the first configured user name when `--user-id` is not explicitly set.

Also includes review fixes from #961 that landed after the squash merge:
- Replace UUID `.expect()` with graceful `let..else` (P1 — prevents TUI panic)
- Remove duplicate doc comment
- Deduplicate `format_tool_duration`
- Prune finished stream handles

## Type of change

| Type | Label |
|------|-------|
| Bug fix | `bug` |

## Component

`ui`

## Closes

Closes #986

## Test plan

- [x] `cargo check -p rara-cli` passes
- [x] `rara chat` resolves identity without `--user-id` flag
- [x] Pre-commit hooks pass