### PR TITLE
feat(cmd): show thinking content in TUI like Claude Code (#989)

### DIFF
--- a/crates/cmd/src/chat/app.rs
+++ b/crates/cmd/src/chat/app.rs
@@ -55,9 +55,12 @@ pub enum Role {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ChatMessage {
-    pub role: Role,
-    pub text: String,
-    pub tool: Option<ToolInfo>,
+    pub role:     Role,
+    pub text:     String,
+    pub tool:     Option<ToolInfo>,
+    /// Collapsed thinking summary for completed messages (e.g. "Thought for
+    /// 3s").
+    pub thinking: Option<String>,
 }
 
 pub struct ChatState {
@@ -81,9 +84,13 @@ pub struct ChatState {
     pub staged_queue:            Vec<(String, Vec<String>)>,
     pub staged_images:           Vec<String>,
     pub tool_input_buf:          String,
-    /// Cached loading hint, sampled once when entering thinking state to avoid
-    /// flicker on every render tick.
-    pub loading_hint:            String,
+    /// Accumulated thinking/reasoning content (separate from streaming_text).
+    pub streaming_thinking:      String,
+    /// When the current thinking phase started (for live duration display).
+    pub thinking_started:        Option<Instant>,
+    /// Duration of the last completed thinking phase (seconds), for the
+    /// collapsed "Thought for Xs" display in the streaming area.
+    pub thinking_duration_s:     Option<u64>,
     /// Cumulative input tokens for the current turn (latest iteration's context
     /// size).
     pub turn_input_tokens:       u32,
@@ -225,7 +232,9 @@ impl ChatState {
             staged_queue:            Vec::new(),
             staged_images:           Vec::new(),
             tool_input_buf:          String::new(),
-            loading_hint:            String::new(),
+            streaming_thinking:      String::new(),
+            thinking_started:        None,
+            thinking_duration_s:     None,
             turn_input_tokens:       0,
             turn_output_tokens:      0,
             turn_thinking_ms:        0,
@@ -258,7 +267,9 @@ impl ChatState {
         self.staged_queue.clear();
         self.staged_images.clear();
         self.tool_input_buf.clear();
-        self.loading_hint.clear();
+        self.streaming_thinking.clear();
+        self.thinking_started = None;
+        self.thinking_duration_s = None;
         self.turn_input_tokens = 0;
         self.turn_output_tokens = 0;
         self.turn_thinking_ms = 0;
@@ -287,15 +298,34 @@ impl ChatState {
             role,
             text,
             tool: None,
+            thinking: None,
         });
         self.scroll_offset = 0;
     }
 
     pub fn append_stream(&mut self, text: &str) {
-        self.thinking = false;
+        // Transition from thinking to text output.
+        if self.thinking {
+            self.finish_thinking();
+        }
         self.streaming_text.push_str(text);
         self.streaming_chars += text.len();
         self.scroll_offset = 0;
+    }
+
+    /// Transition from thinking phase to text output.
+    ///
+    /// Computes thinking duration and clears the thinking buffer so the UI
+    /// can render the collapsed summary.
+    fn finish_thinking(&mut self) {
+        let duration_s = self
+            .thinking_started
+            .map(|t| t.elapsed().as_secs())
+            .unwrap_or(0);
+        self.thinking = false;
+        self.thinking_duration_s = Some(duration_s);
+        self.streaming_thinking.clear();
+        self.thinking_started = None;
     }
 
     pub fn take_staged(&mut self) -> Option<(String, Vec<String>)> {
@@ -307,15 +337,33 @@ impl ChatState {
     }
 
     pub fn finalize_stream(&mut self) {
+        // If still thinking when stream ends, finish it.
+        if self.thinking {
+            self.finish_thinking();
+        }
+
+        let thinking = self
+            .thinking_duration_s
+            .map(|s| format!("Thought for {s}s"));
+
         if !self.streaming_text.is_empty() {
             let text = sanitize_function_tags(&std::mem::take(&mut self.streaming_text));
-            self.push_message(Role::Agent, text);
+            self.messages.push(ChatMessage {
+                role: Role::Agent,
+                text,
+                tool: None,
+                thinking,
+            });
         }
+
         self.is_streaming = false;
         self.thinking = false;
         self.active_tool = None;
         self.streaming_chars = 0;
         self.tool_input_buf.clear();
+        self.thinking_duration_s = None;
+        self.streaming_thinking.clear();
+        self.thinking_started = None;
     }
 
     pub fn tool_start(&mut self, name: &str) {
@@ -326,14 +374,15 @@ impl ChatState {
 
     pub fn tool_use_end(&mut self, name: &str, input: &str) {
         self.messages.push(ChatMessage {
-            role: Role::Tool,
-            text: name.to_owned(),
-            tool: Some(ToolInfo {
+            role:     Role::Tool,
+            text:     name.to_owned(),
+            tool:     Some(ToolInfo {
                 name:     name.to_owned(),
                 input:    input.to_owned(),
                 result:   String::new(),
                 is_error: false,
             }),
+            thinking: None,
         });
         self.active_tool = None;
         self.tool_input_buf.clear();
@@ -386,10 +435,11 @@ impl ChatState {
             CliEvent::ReasoningDelta { text } => {
                 self.is_streaming = true;
                 if !self.thinking {
-                    self.loading_hint = rara_kernel::io::loading_hints::random_hint().to_string();
+                    self.thinking_started = Some(Instant::now());
                 }
                 self.thinking = true;
-                self.append_stream(&text);
+                self.streaming_thinking.push_str(&text);
+                self.scroll_offset = 0;
             }
             CliEvent::ToolCallStart { name, summary } => {
                 if !self.streaming_text.is_empty() {

--- a/crates/cmd/src/chat/mod.rs
+++ b/crates/cmd/src/chat/mod.rs
@@ -951,8 +951,8 @@ async fn send_cli_message(
     image_paths: Vec<String>,
 ) {
     state.is_streaming = true;
-    state.loading_hint = rara_kernel::io::loading_hints::random_hint().to_string();
     state.thinking = true;
+    state.thinking_started = Some(std::time::Instant::now());
     state.streaming_chars = 0;
     state.last_tokens = None;
     state.last_cost_usd = None;

--- a/crates/cmd/src/chat/theme.rs
+++ b/crates/cmd/src/chat/theme.rs
@@ -36,3 +36,13 @@ pub fn dim_style() -> Style { Style::default().fg(TEXT_SECONDARY) }
 pub fn input_style() -> Style { Style::default().fg(ACCENT).add_modifier(Modifier::BOLD) }
 
 pub fn hint_style() -> Style { Style::default().fg(TEXT_TERTIARY) }
+
+/// Style for the thinking section header ("Thinking…" / "Thought for Xs").
+pub fn thinking_header_style() -> Style { Style::default().fg(CYAN).add_modifier(Modifier::BOLD) }
+
+/// Style for thinking content text (dimmed italic).
+pub fn thinking_text_style() -> Style {
+    Style::default()
+        .fg(TEXT_TERTIARY)
+        .add_modifier(Modifier::ITALIC)
+}

--- a/crates/cmd/src/chat/ui.rs
+++ b/crates/cmd/src/chat/ui.rs
@@ -259,19 +259,53 @@ fn draw_messages(frame: &mut Frame, area: Rect, state: &ChatState) {
         draw_message_lines(&mut lines, message, width, state.spinner_frame);
     }
 
+    // Collapsed thinking summary from a just-completed thinking phase.
+    if let Some(duration_s) = state.thinking_duration_s {
+        lines.push(Line::from(""));
+        lines.push(Line::from(vec![
+            Span::styled("  ⏵ ", theme::thinking_header_style()),
+            Span::styled(
+                format!("Thought for {duration_s}s"),
+                theme::thinking_header_style(),
+            ),
+        ]));
+    }
+
+    // Live thinking display.
+    if state.thinking {
+        let elapsed = state
+            .thinking_started
+            .map(|t| t.elapsed().as_secs())
+            .unwrap_or(0);
+        let spinner = theme::SPINNER_FRAMES[state.spinner_frame];
+
+        lines.push(Line::from(""));
+        lines.push(Line::from(vec![
+            Span::styled(format!("  {spinner} "), Style::default().fg(theme::CYAN)),
+            Span::styled("Thinking\u{2026}", theme::thinking_header_style()),
+            Span::styled(format!("  ({elapsed}s)"), theme::dim_style()),
+        ]));
+
+        // Show the last N lines of thinking content (dimmed italic).
+        let max_thinking_lines = 6;
+        let thinking_lines: Vec<&str> = state.streaming_thinking.lines().collect();
+        let start = thinking_lines.len().saturating_sub(max_thinking_lines);
+        for line in &thinking_lines[start..] {
+            for wrapped in wrap_text(line, width.saturating_sub(6)) {
+                lines.push(Line::from(vec![
+                    Span::raw("    "),
+                    Span::styled(wrapped, theme::thinking_text_style()),
+                ]));
+            }
+        }
+    }
+
+    // Regular streaming text.
     if !state.streaming_text.is_empty() {
         lines.push(Line::from(""));
         for wrapped in wrap_text(&state.streaming_text, width.saturating_sub(4)) {
             lines.push(Line::from(vec![Span::raw("  "), Span::raw(wrapped)]));
         }
-    }
-
-    if state.thinking {
-        let spinner = theme::SPINNER_FRAMES[state.spinner_frame];
-        lines.push(Line::from(vec![
-            Span::styled(format!("  {spinner} "), Style::default().fg(theme::CYAN)),
-            Span::styled(state.loading_hint.clone(), Style::default().fg(theme::DIM)),
-        ]));
     }
 
     if let Some(tool_name) = &state.active_tool {
@@ -363,6 +397,12 @@ fn draw_message_lines(
         }
         Role::Agent => {
             lines.push(Line::from(""));
+            if let Some(thinking) = &message.thinking {
+                lines.push(Line::from(vec![
+                    Span::styled("  ⏵ ", theme::thinking_header_style()),
+                    Span::styled(thinking.clone(), theme::thinking_header_style()),
+                ]));
+            }
             for wrapped in wrap_text(&message.text, width.saturating_sub(4)) {
                 lines.push(Line::from(vec![Span::raw("  "), Span::raw(wrapped)]));
             }


### PR DESCRIPTION
## Summary

- Separate thinking/reasoning text into its own buffer (`streaming_thinking`) instead of mixing into `streaming_text`
- Show live **"Thinking… (Ns)"** header with actual thinking content (last 6 lines, dimmed italic)
- Collapse to **"⏵ Thought for Ns"** summary in message history after thinking completes
- Remove `loading_hint` field — replaced by real thinking content display

## Type of change

| Type | Label |
|------|-------|
| New feature | `enhancement` |

## Component

`ui`

## Closes

Closes #989

## Test plan

- [x] `cargo check --all --all-targets` passes
- [x] `cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings` passes
- [x] `cargo +nightly fmt --all -- --check` passes
- [x] Pre-commit hooks pass
- [ ] Manual test: `rara chat` with a thinking-enabled model shows streaming thinking content