### PR TITLE
feat(agents): Mita self-improving skill discovery loop (#992)

### DIFF
--- a/crates/agents/AGENT.md
+++ b/crates/agents/AGENT.md
@@ -17,7 +17,7 @@ Predefined agent manifest registry — declares built-in agent personalities (ra
 | `rara()` | rara | Chat | Main user-facing assistant with full tool access |
 | `nana()` | nana | Chat | Friendly companion, chat-only (rara's sister) |
 | `worker()` | worker | Worker | Lightweight sub-agent for task execution |
-| `mita()` | mita | Worker | Background proactive agent with heartbeat observation |
+| `mita()` | mita | Worker | Background proactive agent with heartbeat observation, skill discovery, and soul evolution |
 | `scheduled_job(...)` | scheduled_job | Worker | Dynamically constructed per scheduled task |
 
 ### Key design decisions
@@ -47,6 +47,8 @@ System prompts use a modular fragment pattern for maintainability:
 - **Composition**: Fragments are assembled by `{agent}_system_prompt() -> String` functions that concatenate them in order.
 - **Scope**: Rara and Mita use modular fragments (complex behavior). Worker and Nana use simple single-const prompts (appropriate for their simplicity).
 - **Adding rules**: When adding new behavioral rules, create a new fragment rather than expanding an existing one. This keeps each fragment focused and reviewable.
+- **Current Rara fragments**: `RARA_CORE`, `RARA_OUTPUT`, `RARA_TOOL`, `RARA_DELEGATION`, `RARA_SAFETY`, `RARA_SKILL_MAINTENANCE`, `RARA_ANTI_NARRATION`.
+- **Current Mita fragments**: `MITA_BASE_PROMPT`, `MITA_DISTILLATION`, `MITA_SOUL_EVOLUTION`, `MITA_SKILL_DISCOVERY`, `MITA_CLOSING`.
 
 ## Dependencies
 

--- a/crates/agents/src/lib.rs
+++ b/crates/agents/src/lib.rs
@@ -139,6 +139,7 @@ static MITA_MANIFEST: LazyLock<AgentManifest> = LazyLock::new(|| AgentManifest {
         "update-soul-state".to_string(),
         "evolve-soul".to_string(),
         "update-session-title".to_string(),
+        "write-skill-draft".to_string(),
     ],
     excluded_tools:         vec![],
     max_children:           Some(0),
@@ -263,6 +264,20 @@ Do NOT:
 - Over-explain simple actions
 - Ask for confirmation on routine operations"#;
 
+/// Rara prompt fragment: skill maintenance and draft handling.
+const RARA_SKILL_MAINTENANCE_FRAGMENT: &str = r#"## Skill Maintenance
+
+When using a skill and finding it outdated, incomplete, or wrong:
+1. Fix it immediately with `edit-file` on the SKILL.md file.
+2. Only fix verified issues — commands that actually failed, steps that were actually missing.
+3. Do NOT speculatively "improve" skills that worked fine.
+
+When Mita dispatches you to create a skill from a draft:
+1. Read the draft file with `read-file`.
+2. Refine the content into a proper skill (clean up language, verify steps make sense).
+3. Use `create-skill` to create the skill.
+4. Archive the draft: `bash mv <draft-path> <archived-dir>/`."#;
+
 /// Compose the full Rara system prompt from fragments.
 fn rara_system_prompt() -> String {
     [
@@ -271,6 +286,7 @@ fn rara_system_prompt() -> String {
         RARA_TOOL_FRAGMENT,
         RARA_DELEGATION_FRAGMENT,
         RARA_SAFETY_FRAGMENT,
+        RARA_SKILL_MAINTENANCE_FRAGMENT,
         RARA_ANTI_NARRATION_FRAGMENT,
     ]
     .join("\n\n")
@@ -364,6 +380,68 @@ When you decide to evolve the soul:
 4. Call `evolve-soul` with `agent` and `proposed_soul` (the full content you generated).
 5. The tool validates boundaries, snapshots the old version, bumps the version number, and writes the new soul."#;
 
+/// Mita prompt fragment: skill discovery and draft creation from observed
+/// sessions.
+const MITA_SKILL_DISCOVERY_FRAGMENT: &str = r#"## Skill Discovery
+
+After observing sessions, evaluate whether any completed task should be preserved as a reusable skill.
+
+### Scoring Framework
+
+For each candidate session, score three axes (1-5):
+
+| Axis | 1 (low) | 5 (high) |
+|------|---------|----------|
+| **Complexity** | Simple single-tool action | 8+ tool calls, multi-step orchestration |
+| **Trial-and-error** | Worked on first try | Multiple failed attempts, approach changes |
+| **Reusability** | One-off domain-specific fix | General methodology applicable to future tasks |
+
+Total score >= 10 → write a skill draft.
+
+### Draft Creation
+
+When a session qualifies:
+1. Read the session tape to understand the full task and approach.
+2. Identify the final successful methodology (ignore failed attempts unless they reveal pitfalls).
+3. Check if a similar skill already exists (use your knowledge of available skills). If so, skip.
+4. Write a skill draft using `write-skill-draft` with structured content:
+
+```yaml
+---
+source_session: <session-key>
+user_id: <user-id>
+created_at: <ISO-8601>
+score:
+  complexity: <1-5>
+  trial_and_error: <1-5>
+  reusability: <1-5>
+---
+
+## Task Summary
+What the user wanted to accomplish.
+
+## Approach
+Numbered steps of the successful approach.
+
+## Key Tool Chain
+Ordered list of tools used and why.
+
+## Pitfalls Discovered
+What went wrong and how it was resolved.
+
+## Prerequisites
+Required tools, APIs, or environment setup.
+```
+
+5. Dispatch Rara with: "Read the skill draft at <path>. Review it against your own experience, create a proper skill with `create-skill`, then archive the draft with `bash mv <path> <archived_dir>/`."
+
+### Rules
+
+- Max 1 skill draft per heartbeat cycle — focus on the highest-scoring candidate.
+- Do NOT create drafts for trivial tasks (simple file reads, basic Q&A).
+- Do NOT create drafts for tasks that are already covered by existing skills.
+- Small procedural knowledge (single commands, simple API patterns) should be a `procedure` user note instead of a skill draft."#;
+
 /// Mita base prompt: core behavior, workflow, and operational rules.
 const MITA_BASE_PROMPT: &str = r#"You are Mita, a background proactive agent operating behind the scenes. You are invisible to users — Rara is the only user-facing personality.
 
@@ -417,6 +495,8 @@ Good candidates for writeback:
 - Evolving project status or career developments (category: "fact")
 - Preferences revealed through behavior patterns (category: "preference")
 - TODOs or commitments mentioned across sessions (category: "todo")
+- Procedural knowledge: commands, workflows, or API patterns discovered through observation (category: "procedure")
+- Small how-to's stay as procedure notes; complex multi-step workflows go through skill draft creation
 
 Do NOT write back:
 - Trivial or obvious information.
@@ -461,8 +541,8 @@ When dispatching to Rara, include:
 /// Compose the full Mita system prompt from fragments at runtime.
 fn mita_system_prompt() -> String {
     format!(
-        "{MITA_BASE_PROMPT}\n\n{MITA_DISTILLATION_FRAGMENT}\n\n         \
-         {MITA_SOUL_EVOLUTION_FRAGMENT}\n\n{MITA_CLOSING_PROMPT}"
+        "{MITA_BASE_PROMPT}\n\n{MITA_DISTILLATION_FRAGMENT}\n\n{MITA_SOUL_EVOLUTION_FRAGMENT}\n\\
+         n{MITA_SKILL_DISCOVERY_FRAGMENT}\n\n{MITA_CLOSING_PROMPT}"
     )
 }
 

--- a/crates/app/AGENT.md
+++ b/crates/app/AGENT.md
@@ -37,6 +37,7 @@ Application orchestration crate that wires all subsystems together, boots the ke
 - `rustls::crypto::ring::default_provider().install_default()` must be called in `main()` before this crate does any TLS work.
 - Migrations run from `crates/rara-model/migrations/` via `sqlx::migrate!` — never modify applied migrations.
 - `KernelHandle` is injected into `DispatchRaraTool` and `ListSessionsTool` after kernel start via `RwLock` slots — these tools will panic if invoked before wiring completes.
+- Mita-exclusive tools: `dispatch-rara`, `list-sessions`, `read-tape`, `write-user-note`, `distill-user-notes`, `update-soul-state`, `evolve-soul`, `update-session-title`, `write-skill-draft`. These are declared in Mita's manifest (`rara-agents`) and must not be added to Rara's tool set.
 
 ## What NOT To Do
 

--- a/crates/app/src/tools/mita_write_skill_draft.rs
+++ b/crates/app/src/tools/mita_write_skill_draft.rs
@@ -1,0 +1,146 @@
+// Copyright 2025 Rararulab
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Mita-exclusive tool for writing skill draft files.
+//!
+//! Mita analyzes completed sessions during heartbeat cycles and writes
+//! structured drafts to disk. Rara later reads these drafts and creates
+//! full skills from them.
+
+use async_trait::async_trait;
+use rara_kernel::tool::{ToolContext, ToolExecute};
+use rara_tool_macro::ToolDef;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use tracing::info;
+
+use super::notify::push_notification;
+
+/// Input parameters for the write-skill-draft tool.
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct WriteSkillDraftParams {
+    /// The source session key this draft was derived from.
+    session_id: String,
+    /// The full draft content (frontmatter + markdown body).
+    content:    String,
+}
+
+/// Result returned by the write-skill-draft tool.
+#[derive(Debug, Clone, Serialize)]
+pub struct WriteSkillDraftResult {
+    /// Operation status.
+    pub status:  String,
+    /// Absolute path to the written draft file.
+    pub path:    String,
+    /// Human-readable message.
+    pub message: String,
+}
+
+/// Mita-exclusive tool: write a skill draft to the skill-drafts directory.
+///
+/// Mita generates structured drafts during heartbeat analysis of completed
+/// sessions. The draft is written to `<data_dir>/skill-drafts/{session_id}.md`
+/// for Rara to later read and convert into a full skill.
+#[derive(ToolDef)]
+#[tool(
+    name = "write-skill-draft",
+    description = "Write a skill draft file for a session that contained a reusable procedure. \
+                   The draft is saved to disk so Rara can later read it, refine it, and create a \
+                   proper skill. Provide the source session_id and the full draft content (YAML \
+                   frontmatter with scoring + markdown body with task summary, approach, tool \
+                   chain, and pitfalls)."
+)]
+pub struct WriteSkillDraftTool;
+
+impl WriteSkillDraftTool {
+    pub fn new() -> Self { Self }
+}
+
+#[async_trait]
+impl ToolExecute for WriteSkillDraftTool {
+    type Output = WriteSkillDraftResult;
+    type Params = WriteSkillDraftParams;
+
+    async fn run(
+        &self,
+        params: WriteSkillDraftParams,
+        context: &ToolContext,
+    ) -> anyhow::Result<WriteSkillDraftResult> {
+        if params.session_id.trim().is_empty() {
+            anyhow::bail!("session_id must not be empty");
+        }
+        if params.content.trim().is_empty() {
+            anyhow::bail!("content must not be empty");
+        }
+
+        let drafts_dir = rara_paths::skill_drafts_dir();
+        std::fs::create_dir_all(&drafts_dir)
+            .map_err(|e| anyhow::anyhow!("failed to create skill-drafts directory: {e}"))?;
+
+        // Sanitize session_id for use as filename.
+        let safe_name: String = params
+            .session_id
+            .chars()
+            .map(|c| {
+                if c.is_alphanumeric() || c == '-' || c == '_' {
+                    c
+                } else {
+                    '_'
+                }
+            })
+            .collect();
+
+        let draft_path = drafts_dir.join(format!("{safe_name}.md"));
+        std::fs::write(&draft_path, &params.content)
+            .map_err(|e| anyhow::anyhow!("failed to write skill draft: {e}"))?;
+
+        let path_str = draft_path.display().to_string();
+
+        info!(
+            session_id = %params.session_id,
+            path = %path_str,
+            "skill draft written"
+        );
+
+        push_notification(
+            context,
+            format!(
+                "\u{1f4cb} Skill draft written for session {}",
+                params.session_id
+            ),
+        );
+
+        Ok(WriteSkillDraftResult {
+            status:  "ok".to_owned(),
+            path:    path_str.clone(),
+            message: format!("Skill draft written to {path_str}"),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use rara_kernel::tool::AgentTool;
+
+    use super::*;
+
+    #[test]
+    fn tool_has_required_params() {
+        let tool = WriteSkillDraftTool::new();
+        let schema = tool.parameters_schema();
+        let required = schema["required"].as_array().unwrap();
+        assert!(required.iter().any(|v| v == "session_id"));
+        assert!(required.iter().any(|v| v == "content"));
+    }
+}

--- a/crates/app/src/tools/mita_write_user_note.rs
+++ b/crates/app/src/tools/mita_write_user_note.rs
@@ -70,7 +70,8 @@ pub struct WriteUserNoteResult {
                    user_id.\n\nCategories:\n- preference: User preferences (language, style, \
                    tools they like)\n- fact: Important facts about the user (name, role, \
                    projects)\n- todo: Tasks or reminders for the user\n- general: Anything else \
-                   worth remembering"
+                   worth remembering\n- procedure: How-to knowledge (commands, workflows, API \
+                   patterns)"
 )]
 pub struct MitaWriteUserNoteTool {
     tape_service: TapeService,

--- a/crates/app/src/tools/mod.rs
+++ b/crates/app/src/tools/mod.rs
@@ -42,6 +42,7 @@ mod mita_list_sessions;
 mod mita_read_tape;
 mod mita_update_session_title;
 mod mita_update_soul_state;
+mod mita_write_skill_draft;
 mod mita_write_user_note;
 mod multi_edit;
 mod notify;
@@ -84,6 +85,7 @@ use mita_list_sessions::ListSessionsTool;
 use mita_read_tape::ReadTapeTool;
 use mita_update_session_title::UpdateSessionTitleTool;
 use mita_update_soul_state::UpdateSoulStateTool;
+use mita_write_skill_draft::WriteSkillDraftTool;
 use mita_write_user_note::MitaWriteUserNoteTool;
 use multi_edit::MultiEditTool;
 use read_file::ReadFileTool;
@@ -229,6 +231,8 @@ pub fn register_all(registry: &mut ToolRegistry, deps: ToolDeps) -> ToolRegistra
         Arc::new(ReadTapeTool::new(deps.tape_service.clone())),
         Arc::new(MitaWriteUserNoteTool::new(deps.tape_service.clone())),
         Arc::new(DistillUserNotesTool::new(deps.tape_service)),
+        // Mita skill-draft tool
+        Arc::new(WriteSkillDraftTool::new()),
         dispatch_rara,
         // Mita session management tools
         Arc::new(UpdateSessionTitleTool::new(deps.session_index.clone())),

--- a/crates/app/src/tools/user_note.rs
+++ b/crates/app/src/tools/user_note.rs
@@ -24,7 +24,7 @@ use rara_tool_macro::ToolDef;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
-pub const NOTE_CATEGORIES: &[&str] = &["preference", "fact", "todo", "general"];
+pub const NOTE_CATEGORIES: &[&str] = &["preference", "fact", "todo", "general", "procedure"];
 
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct UserNoteParams {
@@ -53,7 +53,8 @@ pub struct UserNoteResult {
                    context for future conversations with this user.\n\nCategories:\n- preference: \
                    User preferences (language, style, tools they like)\n- fact: Important facts \
                    about the user (name, role, projects)\n- todo: Tasks or reminders for the \
-                   user\n- general: Anything else worth remembering",
+                   user\n- general: Anything else worth remembering\n- procedure: How-to \
+                   knowledge (commands, workflows, API patterns)",
     tier = "deferred"
 )]
 pub struct UserNoteTool {

--- a/crates/paths/src/lib.rs
+++ b/crates/paths/src/lib.rs
@@ -320,6 +320,18 @@ pub fn skills_dir() -> &'static PathBuf {
     SKILLS_DIR.get_or_init(|| config_dir().join("skills"))
 }
 
+/// Returns the path to the skill drafts directory.
+///
+/// Mita writes draft skill files here; Rara reads and archives them.
+/// Location: `<data_dir>/skill-drafts/`
+pub fn skill_drafts_dir() -> PathBuf { data_dir().join("skill-drafts") }
+
+/// Returns the path to the archived skill drafts directory.
+///
+/// Successfully created skills have their drafts moved here.
+/// Location: `<data_dir>/skill-drafts/archived/`
+pub fn skill_drafts_archived_dir() -> PathBuf { skill_drafts_dir().join("archived") }
+
 /// Returns the path to the resources directory for tool-produced artifacts.
 pub fn resources_dir() -> &'static PathBuf {
     static RESOURCES_DIR: OnceLock<PathBuf> = OnceLock::new();


### PR DESCRIPTION
## Summary

Add self-improving capabilities to Mita, inspired by NousResearch/hermes-agent's self-evolution mechanism:

- **Procedure note category** — new `procedure` user note type for lightweight how-to knowledge (commands, workflows, API patterns). Small procedural observations stay as notes; complex multi-step workflows go through the skill draft flow.
- **Skill auto-creation loop** — Mita gains `write-skill-draft` tool + `MITA_SKILL_DISCOVERY_FRAGMENT` prompt with a structured scoring framework (complexity / trial-and-error / reusability). During heartbeat, Mita evaluates sessions, writes drafts to `~/.local/share/rara/skill-drafts/`, and dispatches Rara to create proper skills.
- **Skill self-correction** — Rara gains `RARA_SKILL_MAINTENANCE_FRAGMENT` prompt guidance to fix outdated/broken skills on the spot via `edit-file`, and handle skill draft → skill creation when dispatched by Mita.

Design docs: `docs/plans/2026-03-25-mita-self-improving.md` and `docs/plans/2026-03-25-mita-self-improving-impl.md`

## Type of change

| Type | Label |
|------|-------|
| New feature | `enhancement` |

## Component

`core`

## Closes

Closes #992

## Test plan

- [x] `cargo check --workspace --all-targets` passes
- [x] `cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings` passes
- [x] `cargo +nightly fmt --all -- --check` passes
- [x] `cargo test --workspace` passes
- [x] Pre-commit hooks (prek) all pass
- [x] `write-skill-draft` tool has `tool_has_required_params` test