### PR TITLE
fix(agents): mita_system_prompt string formatting and minor cleanups (#995)

### DIFF
--- a/crates/agents/src/lib.rs
+++ b/crates/agents/src/lib.rs
@@ -540,10 +540,14 @@ When dispatching to Rara, include:
 
 /// Compose the full Mita system prompt from fragments at runtime.
 fn mita_system_prompt() -> String {
-    format!(
-        "{MITA_BASE_PROMPT}\n\n{MITA_DISTILLATION_FRAGMENT}\n\n{MITA_SOUL_EVOLUTION_FRAGMENT}\n\\
-         n{MITA_SKILL_DISCOVERY_FRAGMENT}\n\n{MITA_CLOSING_PROMPT}"
-    )
+    [
+        MITA_BASE_PROMPT,
+        MITA_DISTILLATION_FRAGMENT,
+        MITA_SOUL_EVOLUTION_FRAGMENT,
+        MITA_SKILL_DISCOVERY_FRAGMENT,
+        MITA_CLOSING_PROMPT,
+    ]
+    .join("\n\n")
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/app/src/tools/mita_write_skill_draft.rs
+++ b/crates/app/src/tools/mita_write_skill_draft.rs
@@ -121,10 +121,11 @@ impl ToolExecute for WriteSkillDraftTool {
             ),
         );
 
+        let message = format!("Skill draft written to {path_str}");
         Ok(WriteSkillDraftResult {
-            status:  "ok".to_owned(),
-            path:    path_str.clone(),
-            message: format!("Skill draft written to {path_str}"),
+            status: "ok".to_owned(),
+            path: path_str,
+            message,
         })
     }
 }

--- a/crates/paths/src/lib.rs
+++ b/crates/paths/src/lib.rs
@@ -324,13 +324,19 @@ pub fn skills_dir() -> &'static PathBuf {
 ///
 /// Mita writes draft skill files here; Rara reads and archives them.
 /// Location: `<data_dir>/skill-drafts/`
-pub fn skill_drafts_dir() -> PathBuf { data_dir().join("skill-drafts") }
+pub fn skill_drafts_dir() -> &'static PathBuf {
+    static SKILL_DRAFTS_DIR: OnceLock<PathBuf> = OnceLock::new();
+    SKILL_DRAFTS_DIR.get_or_init(|| data_dir().join("skill-drafts"))
+}
 
 /// Returns the path to the archived skill drafts directory.
 ///
 /// Successfully created skills have their drafts moved here.
 /// Location: `<data_dir>/skill-drafts/archived/`
-pub fn skill_drafts_archived_dir() -> PathBuf { skill_drafts_dir().join("archived") }
+pub fn skill_drafts_archived_dir() -> &'static PathBuf {
+    static SKILL_DRAFTS_ARCHIVED_DIR: OnceLock<PathBuf> = OnceLock::new();
+    SKILL_DRAFTS_ARCHIVED_DIR.get_or_init(|| skill_drafts_dir().join("archived"))
+}
 
 /// Returns the path to the resources directory for tool-produced artifacts.
 pub fn resources_dir() -> &'static PathBuf {


### PR DESCRIPTION
## Summary

Code review fixes for #993:

1. **P1 fix**: `mita_system_prompt` used `format!` with a broken line continuation that produced literal `\n` (backslash + n) instead of a newline between SOUL_EVOLUTION and SKILL_DISCOVERY fragments. Replaced with `.join("\n\n")` array pattern matching `rara_system_prompt`.
2. **P3 fix**: Removed unnecessary `path_str.clone()` in `WriteSkillDraftTool` — construct `message` first, then move `path_str`.
3. **P3 fix**: `skill_drafts_dir()` and `skill_drafts_archived_dir()` now use `OnceLock<PathBuf>` consistent with other path functions in `rara-paths`.

## Type of change

| Type | Label |
|------|-------|
| Bug fix | `bug` |

## Component

`core`

## Closes

Closes #995

## Test plan

- [x] `cargo check -p rara-agents -p rara-app -p rara-paths` passes
- [x] `cargo clippy` passes with no warnings
- [x] `cargo +nightly fmt --all -- --check` passes
- [x] Pre-commit hooks (prek) all pass