### PR TITLE
chore(ci): add-to-project workflow for org roadmap board (#999)

### DIFF
--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -1,0 +1,16 @@
+name: Add to Rara Roadmap
+
+on:
+  issues:
+    types: [opened]
+  pull_request:
+    types: [opened]
+
+jobs:
+  add-to-project:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/add-to-project@v1.0.2
+        with:
+          project-url: https://github.com/orgs/rararulab/projects/1
+          github-token: ${{ secrets.ADD_TO_PROJECT_TOKEN }}


### PR DESCRIPTION
## Summary

Add GitHub Actions workflow (`add-to-project.yml`) that automatically adds new issues and PRs to the org-level [Rara Roadmap](https://github.com/orgs/rararulab/projects/1) project board via `actions/add-to-project@v1.0.2`.

## Type of change

| Type | Label |
|------|-------|
| Chore | `chore` |

## Component

`ci`

## Closes

Closes #999

## Setup required

After merging, add a `ADD_TO_PROJECT_TOKEN` secret to the repo:
- GitHub Settings → Developer Settings → Personal Access Tokens
- Required scope: `project`
- Add to repo Settings → Secrets → Actions as `ADD_TO_PROJECT_TOKEN`

## Test plan

- [x] Workflow YAML syntax is valid
- [ ] After secret is configured, new issues/PRs auto-appear on the project board