### PR TITLE
chore(ci): add-to-project caller workflow (#999)

### DIFF
--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -1,0 +1,17 @@
+# Auto-add issues and PRs to org project board
+# Copy to: .github/workflows/add-to-project.yml
+name: Add to project
+
+on:
+  issues:
+    types: [opened]
+  pull_request:
+    types: [opened]
+
+jobs:
+  add-to-project:
+    uses: rararulab/workflows/.github/workflows/add-to-project.yml@main
+    with:
+      project-url: https://github.com/orgs/rararulab/projects/1
+    secrets:
+      ADD_TO_PROJECT_TOKEN: ${{ secrets.ADD_TO_PROJECT_TOKEN }}


### PR DESCRIPTION
## Summary

Add caller workflow that uses the shared reusable workflow from `rararulab/workflows` to auto-add new issues and PRs to the org-level [Rara Roadmap](https://github.com/orgs/rararulab/projects/1) project board.

Depends on rararulab/workflows#2.

## Type of change

| Type | Label |
|------|-------|
| Chore | `chore` |

## Component

`ci`

## Closes

Closes #999

## Setup required

Add `ADD_TO_PROJECT_TOKEN` secret to the repo (PAT with `project` scope).

## Test plan

- [x] Workflow YAML syntax valid
- [ ] After workflows#2 merged + secret configured, new issues auto-appear on project board