### PR TITLE
fix(docs): add missing ci component to PR template (#1009)

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -19,7 +19,7 @@
 ## Component
 
 <!-- Add the component label that best matches the area you changed -->
-<!-- `core` · `backend` · `ui` · `extension` -->
+<!-- `core` · `backend` · `ui` · `extension` · `ci` -->
 
 ## Closes
 


### PR DESCRIPTION
## Summary

PR template component list was missing `ci`. Added it to match the canonical set defined in workflow.md: `core`, `backend`, `ui`, `extension`, `ci`.

## Type of change

| Type | Label |
|------|-------|
| Bug fix | `bug` |

## Component

`ci`

## Closes

Closes #1009

## Test plan

- [x] Verified component list now matches workflow.md