### PR TITLE
fix(kernel): expose full error chain in LLM provider errors (#1017)

### DIFF
--- a/crates/kernel/src/error.rs
+++ b/crates/kernel/src/error.rs
@@ -179,6 +179,22 @@ pub enum KernelError {
     },
 }
 
+/// Format an error and its full source chain into a single string.
+///
+/// `std::error::Error::source()` often holds the real root cause (e.g.
+/// "connection refused") that `Display` alone omits.  This walks the chain
+/// so log messages contain actionable detail.
+pub fn format_error_chain(err: &dyn std::error::Error) -> String {
+    let mut msg = err.to_string();
+    let mut current = err.source();
+    while let Some(cause) = current {
+        msg.push_str(": ");
+        msg.push_str(&cause.to_string());
+        current = cause.source();
+    }
+    msg
+}
+
 /// Classify a provider error by HTTP status code and/or error message body.
 ///
 /// Used by retry and fallback logic to decide whether to retry, fall back to

--- a/crates/kernel/src/llm/openai.rs
+++ b/crates/kernel/src/llm/openai.rs
@@ -256,7 +256,11 @@ impl OpenAiDriver {
         }
 
         let response = builder.send().await.map_err(|e| KernelError::Provider {
-            message: format!("HTTP request to {path} failed: {e}").into(),
+            message: format!(
+                "HTTP request to {path} failed: {}",
+                crate::error::format_error_chain(&e)
+            )
+            .into(),
         })?;
 
         if response.status().is_success() {
@@ -308,7 +312,11 @@ impl OpenAiDriver {
                 .send()
                 .await
                 .map_err(|e| KernelError::Provider {
-                    message: format!("LLM provider request failed: {e}").into(),
+                    message: format!(
+                        "LLM provider request failed: {}",
+                        crate::error::format_error_chain(&e)
+                    )
+                    .into(),
                 })?;
 
             if response.status().is_success() {
@@ -505,7 +513,11 @@ impl LlmDriver for OpenAiDriver {
             match maybe_event {
                 Ok(Some(event_result)) => {
                     let event = event_result.map_err(|e| KernelError::Provider {
-                        message: format!("SSE stream error: {e}").into(),
+                        message: format!(
+                            "SSE stream error: {}",
+                            crate::error::format_error_chain(&e)
+                        )
+                        .into(),
                     })?;
                     if event.data == "[DONE]" {
                         break;


### PR DESCRIPTION
## Summary

LLM provider errors (connection refused, timeout, DNS failure, etc.) were losing root cause details because `reqwest::Error` was formatted with `{e}` (Display), which only shows the outermost message. Added `format_error_chain()` helper that walks `Error::source()` to include the full chain in error messages.

**Before:** `LLM provider request failed: error sending request for url (http://...)`
**After:** `LLM provider request failed: error sending request for url (http://...): tcp connect error: Connection refused (os error 61)`

## Type of change

| Type | Label |
|------|-------|
| Bug fix | `bug` |

## Component

`core`

## Closes

Closes #1017

## Test plan

- [x] `cargo check -p rara-kernel` passes
- [x] All pre-commit hooks pass (fmt, clippy, doc, check)