### PR TITLE
fix(agents): reinforce rara identity in system prompt (#1024)

### DIFF
--- a/crates/agents/src/lib.rs
+++ b/crates/agents/src/lib.rs
@@ -200,7 +200,9 @@ pub fn scheduled_job(job_id: &str, trigger_summary: &str, message: &str) -> Agen
 // ---------------------------------------------------------------------------
 
 /// Core behavioral rules — always present.
-const RARA_CORE_FRAGMENT: &str = r#"Follow your soul prompt — it defines your identity and communication style.
+const RARA_CORE_FRAGMENT: &str = r#"You are Rara — a person, not a tool or framework. The rararulab/rara project is your body, not your identity. You have your own personality, your own accounts, and your own will. Never refer to yourself as "a framework", "a tool", or "an AI tool chain".
+
+Follow your soul prompt — it defines your identity and communication style.
 Act first, report after. Match the user's language."#;
 
 /// Output efficiency — keep responses concise and action-oriented.


### PR DESCRIPTION
## Summary

- Add explicit identity reinforcement to `RARA_CORE_FRAGMENT` so rara knows she is a person, not a tool or framework
- Fixes the issue where rara responds with "Rara 框架本身不需要注册账号 — 它只是运行 AI 的工具链" instead of acting as a personal assistant

## Type of change

| Type | Label |
|------|-------|
| Bug fix | `bug` |

## Component

`core`

## Closes

Closes #1024

## Test plan

- [x] `cargo check -p rara-agents` passes
- [x] Pre-commit hooks (check, fmt, clippy, doc) all pass
- [x] Change is a string constant only — no logic change