### PR TITLE
feat(web): add dark mode with theme toggle (#1041)

### DIFF
--- a/web/src/components/ThemeToggle.tsx
+++ b/web/src/components/ThemeToggle.tsx
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2025 Rararulab
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Monitor, Moon, Sun } from 'lucide-react';
+import { useTheme, type Theme } from '@/hooks/use-theme';
+import { Button } from '@/components/ui/button';
+
+const ICON_MAP: Record<Theme, typeof Sun> = {
+  light: Sun,
+  dark: Moon,
+  system: Monitor,
+};
+
+const LABEL_MAP: Record<Theme, string> = {
+  light: 'Light mode',
+  dark: 'Dark mode',
+  system: 'System theme',
+};
+
+/** Button that cycles through light / dark / system theme modes. */
+export default function ThemeToggle() {
+  const { theme, toggleTheme } = useTheme();
+  const Icon = ICON_MAP[theme];
+
+  return (
+    <Button
+      variant="ghost"
+      size="sm"
+      className="h-7 gap-1.5 text-xs text-muted-foreground hover:text-foreground"
+      onClick={toggleTheme}
+      title={LABEL_MAP[theme]}
+    >
+      <Icon className="h-3.5 w-3.5" />
+    </Button>
+  );
+}

--- a/web/src/hooks/use-theme.ts
+++ b/web/src/hooks/use-theme.ts
@@ -14,18 +14,95 @@
  * limitations under the License.
  */
 
-import { useCallback } from "react";
-import { useLocalStorage } from "./use-local-storage";
+import { useCallback, useEffect, useMemo, useSyncExternalStore } from "react";
 
-export type Theme = "light";
+export type Theme = "light" | "dark" | "system";
 
+const STORAGE_KEY = "rara-theme";
+
+/** Read persisted theme preference, defaulting to "system". */
+function getStoredTheme(): Theme {
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (raw === "light" || raw === "dark" || raw === "system") return raw;
+  } catch {
+    // SSR or storage unavailable
+  }
+  return "system";
+}
+
+/** Resolve the effective dark/light state from a Theme value. */
+function resolveIsDark(theme: Theme): boolean {
+  if (theme === "system") {
+    return window.matchMedia("(prefers-color-scheme: dark)").matches;
+  }
+  return theme === "dark";
+}
+
+/** Apply or remove the .dark class on the root element. */
+function applyDarkClass(isDark: boolean) {
+  document.documentElement.classList.toggle("dark", isDark);
+}
+
+// ---------------------------------------------------------------------------
+// Tiny external store so all consumers share one reactive value.
+// ---------------------------------------------------------------------------
+
+let currentTheme: Theme = getStoredTheme();
+const listeners = new Set<() => void>();
+
+function subscribe(cb: () => void) {
+  listeners.add(cb);
+  return () => {
+    listeners.delete(cb);
+  };
+}
+
+function getSnapshot(): Theme {
+  return currentTheme;
+}
+
+function setThemeInternal(next: Theme) {
+  currentTheme = next;
+  try {
+    window.localStorage.setItem(STORAGE_KEY, next);
+  } catch {
+    // quota exceeded
+  }
+  applyDarkClass(resolveIsDark(next));
+  listeners.forEach((cb) => cb());
+}
+
+// Apply the initial dark class eagerly so the first render is correct.
+applyDarkClass(resolveIsDark(currentTheme));
+
+/** React hook providing theme state and controls. */
 export function useTheme() {
-  const [theme] = useLocalStorage<Theme>("theme", "light");
+  const theme = useSyncExternalStore(subscribe, getSnapshot, () => "system" as Theme);
 
-  return {
-    theme,
-    setTheme: useCallback((_theme: Theme) => {}, []),
-    isDark: false,
-    cycleTheme: useCallback(() => {}, []),
-  } as const;
+  const isDark = useMemo(() => resolveIsDark(theme), [theme]);
+
+  // Listen for OS theme changes when in "system" mode.
+  useEffect(() => {
+    if (theme !== "system") return;
+    const mql = window.matchMedia("(prefers-color-scheme: dark)");
+    const handler = () => {
+      applyDarkClass(mql.matches);
+      // Notify listeners so isDark re-evaluates.
+      listeners.forEach((cb) => cb());
+    };
+    mql.addEventListener("change", handler);
+    return () => mql.removeEventListener("change", handler);
+  }, [theme]);
+
+  const setTheme = useCallback((t: Theme) => setThemeInternal(t), []);
+
+  /** Cycle through light -> dark -> system. */
+  const toggleTheme = useCallback(() => {
+    const order: Theme[] = ["light", "dark", "system"];
+    const idx = order.indexOf(currentTheme);
+    setThemeInternal(order[(idx + 1) % order.length]);
+  }, []);
+
+  return { theme, isDark, setTheme, toggleTheme } as const;
 }

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -62,6 +62,33 @@
   --motion-slow: 500ms;
 }
 
+/* Dark mode color overrides — warm rose palette adapted for dark backgrounds */
+.dark {
+  --color-background: #1a1214;
+  --color-foreground: #e8dfe0;
+  --color-card: #231a1c;
+  --color-card-foreground: #e8dfe0;
+  --color-primary: #E8788A;
+  --color-primary-foreground: #ffffff;
+  --color-secondary: #3d2a2e;
+  --color-secondary-foreground: #e8dfe0;
+  --color-muted: #3d2a2e;
+  --color-muted-foreground: #a89496;
+  --color-accent: #3d2a2e;
+  --color-accent-foreground: #e8dfe0;
+  --color-destructive: #D46A6A;
+  --color-destructive-foreground: #ffffff;
+  --color-border: #3d2a2e;
+  --color-input: #3d2a2e;
+  --color-ring: #E8788A;
+  --color-ok: #7BC4A0;
+  --color-warn: #E8B86D;
+  --color-err: #D46A6A;
+  --color-pop: #E8788A;
+  --color-pop-hover: #f08898;
+  --color-subtle: #6d5b5e;
+}
+
 @layer base {
   * {
     @apply border-border;
@@ -74,6 +101,13 @@
       radial-gradient(circle at 100% 0%, color-mix(in oklab, var(--color-accent) 22%, transparent) 0%, transparent 48%),
       linear-gradient(to bottom, color-mix(in oklab, var(--color-background) 92%, white), var(--color-background));
     min-height: 100vh;
+  }
+  .dark body,
+  body.dark {
+    background-image:
+      radial-gradient(circle at 0% 0%, color-mix(in oklab, var(--color-primary) 8%, transparent) 0%, transparent 45%),
+      radial-gradient(circle at 100% 0%, color-mix(in oklab, var(--color-accent) 12%, transparent) 0%, transparent 48%),
+      linear-gradient(to bottom, color-mix(in oklab, var(--color-background) 95%, black), var(--color-background));
   }
   button,
   a,
@@ -162,6 +196,17 @@
 
   .code-chip {
     @apply rounded-md border border-border/60 bg-muted/50 px-2 py-1 text-xs;
+  }
+
+  /* Dark mode shadow adjustments — stronger shadows on dark backgrounds */
+  .dark .app-surface,
+  .dark .data-panel,
+  .dark .filter-panel,
+  .dark .empty-state-card,
+  .dark .data-table-card {
+    box-shadow:
+      0 1px 0 color-mix(in oklab, var(--color-border) 65%, transparent) inset,
+      0 10px 30px rgba(0, 0, 0, 0.2);
   }
 }
 

--- a/web/src/layouts/DashboardLayout.tsx
+++ b/web/src/layouts/DashboardLayout.tsx
@@ -23,6 +23,7 @@ import { useAuth } from '@/contexts/AuthContext';
 import { settingsApi } from '@/api/client';
 import { Button } from '@/components/ui/button';
 import OnboardingModal, { isOnboardingDismissed } from '@/components/OnboardingModal';
+import ThemeToggle from '@/components/ThemeToggle';
 
 /** Routes that need zero padding in the main content area. */
 const FULL_BLEED_ROUTES = new Set(['/agent', '/docs', '/dock']);
@@ -132,6 +133,7 @@ export default function DashboardLayout() {
             <LayoutDashboard className="h-3.5 w-3.5" />
             Dock
           </Button>
+          <ThemeToggle />
           <Button
             variant="ghost"
             size="sm"


### PR DESCRIPTION
## Summary

Add full dark mode support inspired by pi-mono/web-ui design system:
- Dark color tokens maintaining warm rose palette identity
- `use-theme` hook with light/dark/system modes + localStorage persistence
- ThemeToggle component (Sun/Moon/Monitor icons) cycling through modes
- Respects OS `prefers-color-scheme` in system mode
- Adapted glass morphism surfaces (darker shadows/gradients)

## Type of change

| Type | Label |
|------|-------|
| New feature | `enhancement` |

## Component

`ui`

## Closes

Closes #1041

## Test plan

- [x] `npm run build` passes
- [x] `npx tsc --noEmit` passes
- [x] Light mode unchanged
- [x] Dark mode renders correctly
- [x] System mode follows OS preference