### PR TITLE
fix(kernel,web): preserve image content in LLM pipeline (#1063)

### DIFF
--- a/crates/kernel/src/kernel.rs
+++ b/crates/kernel/src/kernel.rs
@@ -2041,9 +2041,20 @@ impl Kernel {
                 warn!(%e, "failed to persist Mita directive to tape");
             }
         } else {
+            // Serialize multimodal content (with images) directly so image
+            // blocks survive the tape round-trip into LLM context.
+            let tape_content = match &msg.content {
+                crate::channel::types::MessageContent::Multimodal(_) => {
+                    serde_json::to_value(&msg.content).unwrap_or_else(|e| {
+                        warn!(%e, "failed to serialize multimodal content; falling back to text");
+                        serde_json::Value::String(user_text.clone())
+                    })
+                }
+                _ => serde_json::Value::String(user_text.clone()),
+            };
             let tape_payload = serde_json::json!({
                 "role": "user",
-                "content": &user_text,
+                "content": tape_content,
             });
             if let Err(e) = &self
                 .tape_service

--- a/web/src/adapters/rara-stream.ts
+++ b/web/src/adapters/rara-stream.ts
@@ -19,6 +19,7 @@ import type {
   AssistantMessage,
   AssistantMessageEvent,
   Context,
+  ImageContent,
   Model,
   SimpleStreamOptions,
   TextContent,
@@ -130,19 +131,47 @@ function buildWsUrl(sessionKey: string): string {
 }
 
 /**
- * Extract the latest user message text from a pi-ai Context.
- * Falls back to empty string if no user message is found.
+ * Extract the latest user message content from a pi-ai Context.
+ * Returns a plain string for text-only messages, or a JSON string
+ * matching the backend InboundPayload format when images are present.
  */
-function extractUserText(context: Context): string {
+function extractUserPayload(context: Context): string {
   for (let i = context.messages.length - 1; i >= 0; i--) {
     const msg = context.messages[i];
     if (msg.role === "user") {
       if (typeof msg.content === "string") return msg.content;
-      // Array of content blocks — concatenate text parts
-      return msg.content
-        .filter((c): c is TextContent => c.type === "text")
-        .map((c) => c.text)
-        .join("\n");
+
+      // Check if there are any image blocks
+      const hasImages = msg.content.some((c) => c.type === "image");
+
+      if (!hasImages) {
+        // Text-only — return plain string (backend parses as plain text)
+        return msg.content
+          .filter((c): c is TextContent => c.type === "text")
+          .map((c) => c.text)
+          .join("\n");
+      }
+
+      // Multimodal — build JSON payload matching backend InboundPayload.
+      // Backend's parse_inbound_text_frame() tries JSON first, so this
+      // will be deserialized as InboundPayload { content: MessageContent }.
+      type RaraBlock =
+        | { type: "text"; text: string }
+        | { type: "image_base64"; media_type: string; data: string };
+      const blocks: RaraBlock[] = msg.content.flatMap((c): RaraBlock[] => {
+        if (c.type === "text") {
+          return [{ type: "text", text: c.text }];
+        }
+        if (c.type === "image") {
+          // pi-ai uses { mimeType, data }, rara uses { media_type, data }
+          const img = c as ImageContent;
+          if (img.mimeType && img.data) {
+            return [{ type: "image_base64", media_type: img.mimeType, data: img.data }];
+          }
+        }
+        return [];
+      });
+      return JSON.stringify({ content: blocks });
     }
   }
   return "";
@@ -177,7 +206,7 @@ export function createRaraStreamFn(getSessionKey: SessionKeyFn): StreamFn {
       return stream;
     }
 
-    const userText = extractUserText(context);
+    const userPayload = extractUserPayload(context);
     const wsUrl = buildWsUrl(sessionKey);
 
     // Accumulated content blocks for building partial messages
@@ -222,7 +251,7 @@ export function createRaraStreamFn(getSessionKey: SessionKeyFn): StreamFn {
         // Emit start event
         safePush({ type: "start", partial: buildPartial(model, content) });
         // Send user message
-        ws.send(userText);
+        ws.send(userPayload);
       };
 
       ws.onmessage = (ev: MessageEvent) => {

--- a/web/src/pages/PiChat.tsx
+++ b/web/src/pages/PiChat.tsx
@@ -25,7 +25,7 @@ import {
 } from "@mariozechner/pi-web-ui";
 import { Agent } from "@mariozechner/pi-agent-core";
 import type { AgentMessage } from "@mariozechner/pi-agent-core";
-import type { UserMessage, AssistantMessage, TextContent } from "@mariozechner/pi-ai";
+import type { UserMessage, AssistantMessage, TextContent, ImageContent } from "@mariozechner/pi-ai";
 import { RaraStorageBackend } from "@/adapters/rara-storage";
 import { createRaraStreamFn } from "@/adapters/rara-stream";
 import { api } from "@/api/client";
@@ -40,18 +40,39 @@ function stripThinkTags(text: string): string {
 function toAgentMessages(msgs: ChatMessageData[]): AgentMessage[] {
   const result: AgentMessage[] = [];
   for (const m of msgs) {
-    const raw =
-      typeof m.content === "string"
-        ? m.content
-        : m.content
-            .filter((b): b is { type: "text"; text: string } => b.type === "text")
-            .map((b) => b.text)
-            .join("\n");
     const ts = new Date(m.created_at).getTime();
 
     if (m.role === "user") {
-      result.push({ role: "user", content: raw, timestamp: ts } as UserMessage);
+      if (typeof m.content === "string") {
+        result.push({ role: "user", content: m.content, timestamp: ts } as UserMessage);
+      } else {
+        // Map rara content blocks to pi-ai content types, preserving images.
+        const piContent: (TextContent | ImageContent)[] = m.content.flatMap(
+          (b): (TextContent | ImageContent)[] => {
+            if (b.type === "text") return [{ type: "text", text: b.text }];
+            if (b.type === "image_base64") {
+              const img = b as { type: "image_base64"; media_type: string; data: string };
+              return [{ type: "image", mimeType: img.media_type, data: img.data }];
+            }
+            return [];
+          },
+        );
+        const hasImages = piContent.some((c) => c.type === "image");
+        // pi-ai UserMessage accepts string | (TextContent | ImageContent)[];
+        // use array form only when images are present to avoid rendering issues.
+        const content: string | (TextContent | ImageContent)[] = hasImages
+          ? piContent
+          : piContent.filter((c): c is TextContent => c.type === "text").map(c => c.text).join("\n");
+        result.push({ role: "user", content, timestamp: ts } as UserMessage);
+      }
     } else if (m.role === "assistant") {
+      const raw =
+        typeof m.content === "string"
+          ? m.content
+          : m.content
+              .filter((b): b is { type: "text"; text: string } => b.type === "text")
+              .map((b) => b.text)
+              .join("\n");
       const text = stripThinkTags(raw);
       const content: TextContent[] = text ? [{ type: "text", text }] : [];
       result.push({


### PR DESCRIPTION
## Summary

- Kernel tape persistence (`kernel.rs`) was calling `msg.content.as_text()` which strips image blocks, then storing only text. Now multimodal content is serialized directly via `serde_json::to_value` so images survive the tape→LLM round-trip
- Web frontend `extractUserText()` was discarding image blocks from pi-web-ui messages. Replaced with `extractUserPayload()` that sends JSON `InboundPayload` with `image_base64` blocks when images are present
- Chat history display now maps `image_base64` blocks to pi-ai `ImageContent` for rendering

## Type of change

| Type | Label |
|------|-------|
| Bug fix | `bug` |

## Component

`core`, `ui`

## Closes

Closes #1063

## Test plan

- [x] `cargo clippy -p rara-kernel` passes
- [x] `npm run build` passes
- [ ] Send image via Telegram → LLM describes it
- [ ] Send image via Web UI → LLM describes it
- [ ] Load session with images → images display in history