### PR TITLE
fix(chat): preserve multimodal in api (#1066)

### DIFF
--- a/crates/extensions/backend-admin/src/chat/service.rs
+++ b/crates/extensions/backend-admin/src/chat/service.rs
@@ -405,7 +405,12 @@ fn tap_entries_to_chat_messages(entries: &[TapEntry]) -> Vec<ChatMessage> {
                         Role::Assistant => MessageRole::Assistant,
                         Role::Tool => MessageRole::Tool,
                     };
-                    let content = MessageContent::Text(msg.content.as_text().to_owned());
+                    // Preserve multimodal content (images) via serde round-trip
+                    // between llm::MessageContent and channel::types::MessageContent
+                    // (both share the same serde format).
+                    let content: MessageContent = serde_json::to_value(&msg.content)
+                        .and_then(|v| serde_json::from_value(v))
+                        .unwrap_or_else(|_| MessageContent::Text(msg.content.as_text().to_owned()));
                     let tool_calls: Vec<ChannelToolCall> = msg
                         .tool_calls
                         .iter()

--- a/crates/kernel/src/kernel.rs
+++ b/crates/kernel/src/kernel.rs
@@ -2044,7 +2044,16 @@ impl Kernel {
             // Serialize multimodal content (with images) directly so image
             // blocks survive the tape round-trip into LLM context.
             let tape_content = match &msg.content {
-                crate::channel::types::MessageContent::Multimodal(_) => {
+                crate::channel::types::MessageContent::Multimodal(blocks) => {
+                    info!(
+                        block_count = blocks.len(),
+                        has_images = blocks.iter().any(|b| matches!(
+                            b,
+                            crate::channel::types::ContentBlock::ImageBase64 { .. }
+                                | crate::channel::types::ContentBlock::ImageUrl { .. }
+                        )),
+                        "persisting multimodal user message to tape"
+                    );
                     serde_json::to_value(&msg.content).unwrap_or_else(|e| {
                         warn!(%e, "failed to serialize multimodal content; falling back to text");
                         serde_json::Value::String(user_text.clone())


### PR DESCRIPTION
## Summary

- `tap_entries_to_chat_messages` in `backend-admin/chat/service.rs` unconditionally called `msg.content.as_text()` which stripped image blocks from tape entries when returning via the REST API
- Fix: use serde round-trip to convert `llm::MessageContent` → `channel::types::MessageContent`, preserving multimodal image blocks
- Add diagnostic `tracing::info!` at the kernel tape persistence path to log multimodal block count and image presence

## Type of change

| Type | Label |
|------|-------|
| Bug fix | `bug` |

## Component

`backend`

## Closes

Closes #1066

## Test plan

- [x] `cargo check` passes for both `rara-kernel` and `rara-backend-admin`
- [x] Pre-commit hooks pass (fmt, clippy, doc)
- [x] Verified via Playwright that REST API currently returns text-only for multimodal messages