### PR TITLE
fix(kernel): preserve multimodal content on first-turn spawn (#1068)

### DIFF
--- a/crates/kernel/src/io.rs
+++ b/crates/kernel/src/io.rs
@@ -2094,13 +2094,11 @@ mod inbound_message_tests {
             SessionKey::new(),
         );
 
-        match msg.content {
-            MessageContent::Multimodal(blocks) => {
-                assert_eq!(blocks.len(), 2);
-                assert!(matches!(blocks[0], ContentBlock::Text { .. }));
-                assert!(matches!(blocks[1], ContentBlock::ImageUrl { .. }));
-            }
-            MessageContent::Text(_) => panic!("synthetic_content should preserve multimodal input"),
-        }
+        let MessageContent::Multimodal(blocks) = msg.content else {
+            panic!("expected Multimodal");
+        };
+        assert_eq!(blocks.len(), 2);
+        assert!(matches!(blocks[0], ContentBlock::Text { .. }));
+        assert!(matches!(blocks[1], ContentBlock::ImageUrl { .. }));
     }
 }

--- a/crates/kernel/src/kernel.rs
+++ b/crates/kernel/src/kernel.rs
@@ -53,6 +53,7 @@ use crate::{
         AgentEnv, AgentManifest, AgentRegistryRef, AgentRole, AgentTurnResult, ExecutionMode,
         Priority, run_agent_loop,
     },
+    channel::types::MessageContent,
     event::{KernelEvent, KernelEventEnvelope},
     identity::Principal,
     io::{IOSubsystem, InboundMessage, MessageId, OutboundEnvelope, PipeRegistry, StreamId},
@@ -618,7 +619,7 @@ impl Kernel {
                 let result = self
                     .handle_spawn_agent(
                         manifest,
-                        crate::channel::types::MessageContent::Text(input),
+                        MessageContent::Text(input),
                         principal,
                         parent_id,
                         None,
@@ -1421,7 +1422,7 @@ impl Kernel {
         match self
             .handle_spawn_agent(
                 manifest,
-                crate::channel::types::MessageContent::Text(job.message.clone()),
+                MessageContent::Text(job.message.clone()),
                 principal,
                 None, // no parent
                 None, // no resume
@@ -1649,7 +1650,7 @@ impl Kernel {
             match self
                 .handle_spawn_agent(
                     manifest,
-                    crate::channel::types::MessageContent::Text(
+                    MessageContent::Text(
                         "Mita session initialized. Awaiting heartbeat instructions.".to_string(),
                     ),
                     principal,
@@ -1907,7 +1908,7 @@ impl Kernel {
                     msg_id,
                     user,
                     session_key,
-                    crate::channel::types::MessageContent::Text(response_text),
+                    MessageContent::Text(response_text),
                     vec![],
                 )
                 .with_origin(origin_endpoint);
@@ -2558,7 +2559,7 @@ impl Kernel {
                         in_reply_to,
                         user.clone(),
                         egress_session_key.clone(),
-                        crate::channel::types::MessageContent::Text(turn.text),
+                        MessageContent::Text(turn.text),
                         vec![],
                     )
                     .with_origin(origin_endpoint.clone());
@@ -2607,7 +2608,7 @@ impl Kernel {
                         in_reply_to,
                         user.clone(),
                         egress_session_key.clone(),
-                        crate::channel::types::MessageContent::Text(fallback_text.to_string()),
+                        MessageContent::Text(fallback_text.to_string()),
                         vec![],
                     )
                     .with_origin(origin_endpoint.clone());


### PR DESCRIPTION
## Summary

- fix first-turn/rebuild runtime spawn path to preserve full MessageContent instead of coercing to as_text()
- add InboundMessage::synthetic_content(...) and use it in spawn flow so multimodal blocks (including images) are kept
- add regression test: io::inbound_message_tests::synthetic_content_keeps_multimodal_blocks

## Type of change

| Type | Label |
|------|-------|
| Bug fix | `bug` |

## Component

`core`

## Closes

Closes #1068

## Test plan

- [x] `cargo +nightly fmt --all --check`
- [x] `cargo check -p rara-kernel`
- [x] `cargo test -p rara-kernel inbound_message_tests::synthetic_content_keeps_multimodal_blocks -- --nocapture`
- [x] pre-commit hooks during `git commit` (`cargo check`, `cargo fmt`, `cargo clippy`, `cargo doc`)
