### PR TITLE
fix(web): preserve image attachments when sending chat messages

### DIFF
--- a/web/src/pages/PiChat.tsx
+++ b/web/src/pages/PiChat.tsx
@@ -22,6 +22,7 @@ import {
   SettingsStore,
   ProviderKeysStore,
   CustomProvidersStore,
+  defaultConvertToLlm,
 } from "@mariozechner/pi-web-ui";
 import { Agent } from "@mariozechner/pi-agent-core";
 import type { AgentMessage } from "@mariozechner/pi-agent-core";
@@ -314,6 +315,7 @@ export default function PiChat() {
       //    The streamFn reads agent.sessionId at call time to get the active session key.
       const agent: Agent = new Agent({
         streamFn: createRaraStreamFn(() => agent.sessionId),
+        convertToLlm: defaultConvertToLlm,
         sessionId: initialSession.key,
       });
       agentRef.current = agent;


### PR DESCRIPTION
## Summary\n- pass `defaultConvertToLlm` from pi-web-ui when creating the PiChat Agent\n- ensure `user-with-attachments` messages are converted to standard LLM user multimodal messages before streamFn extraction\n- fixes websocket payload becoming empty string for image+text sends\n\n## Verification\n- npm --prefix web run build\n- Playwright runtime check against http://10.0.0.183:25555 confirmed outbound payload now contains:\n  - `{"content":[{"type":"text"...},{"type":"image_base64"...}]}`\n  - text-only send still emits plain string payload\n\nCloses #1073