### PR TITLE
refactor(docs): optimize prompts with Polanyi prompt-refinery framework (#1103)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,9 +3,35 @@
 ## Communication
 - 用中文与用户交流
 
-## Project Identity
+## Project Philosophy
 
-Rara is a self-evolving, developer-first personal proactive agent built in Rust. It uses a kernel-inspired architecture with heartbeat-driven proactive behavior, 3-layer memory, and a skills system.
+Rara is a kernel-inspired personal AI agent in Rust — self-evolving, developer-first,
+with heartbeat-driven proactive behavior, 3-layer memory, and a skills system.
+
+Design ethos: **"Boring Technology"** (Dan McKinley) meets **Linux kernel discipline**.
+Proven Rust patterns over novel abstractions. Explicit resource ownership, clear subsystem
+boundaries, no hidden magic. When in doubt, choose the solution a senior kernel developer
+would find unsurprising.
+
+## Style Anchors
+
+Rust style triangulated from three voices — each covers a different blind spot:
+
+- **BurntSushi** (Andrew Gallant): error ergonomics via `snafu`, CLI patterns, exhaustive matching, documentation-first design
+- **dtolnay** (David Tolnay): API minimalism, derive-macro philosophy (`serde`, `bon`), "if it compiles it works" surface area
+- **Niko Matsakis**: ownership-first API design, type safety as a feature, making invalid states unrepresentable
+
+When these anchors conflict, prefer: safety (Niko) > ergonomics (BurntSushi) > minimalism (dtolnay).
+
+## External Reality
+
+These artifacts are authoritative — your work is accountable to them, not just to the user:
+
+- `.pre-commit-config.yaml` — code quality gate (clippy, fmt, doc warnings)
+- `.github/ISSUE_TEMPLATE/` — issue structure and required fields
+- `.github/pull_request_template.md` — PR structure
+- `config.example.yaml` — all config keys; no hardcoded defaults in Rust
+- `AGENT.md` files per crate — architecture invariants and anti-patterns
 
 ## Development Workflow
 
@@ -28,3 +54,10 @@ All changes — no matter how small — follow the issue → worktree → PR →
 ## Guardrails
 
 @docs/guides/anti-patterns.md
+
+## Anti-sycophancy
+
+If the user's architectural request conflicts with the style anchors above, an existing
+`AGENT.md`, or the pre-commit quality gate, say so directly. Quote the specific conflict.
+Do not soften disagreement with hedge phrases like "you might want to consider" —
+state the conflict, explain why, and propose the alternative.

--- a/docs/guides/anti-patterns.md
+++ b/docs/guides/anti-patterns.md
@@ -1,27 +1,31 @@
 # What NOT To Do
 
+Every entry has a **why** — the reasoning generalizes better than the rule alone.
+
 ## Code & Architecture
-- Do NOT put repository impls or routes in `yunara-store` — business logic stays in its own crates
-- Do NOT use manual `impl Display` + `impl Error` — use `snafu`
-- Do NOT use mock repositories in tests — use `testcontainers`
-- Do NOT use noop/hollow trait implementations — trait methods with real implementations must not have default empty bodies (silently return `Ok(())` / `Ok(None)` / `vec![]`). Optional UX hooks (`typing_indicator`, lifecycle hooks) are the only exception
-- Do NOT construct hollow identity objects — `Principal` must be built via `SecuritySubsystem::resolve_principal()` or `Principal::from_user()` with full role + permissions from the database. Never store placeholder values in Session
-- Do NOT write manual `fn new()` constructors for structs with 3+ fields — use `#[derive(bon::Builder)]` and construct via `Foo::builder().field(val).build()`. Config structs must also derive `Deserialize` and never `#[derive(Default)]`
-- Do NOT hardcode database URLs or config defaults in Rust code — use the YAML config file
-- Do NOT modify already-applied migration files — create a new migration instead
-- Do NOT write code comments in any language other than English
+
+- Do NOT put repository impls or routes in `yunara-store` — **why:** business logic mixed into the store layer creates circular dependencies and makes testing impossible without the full store stack
+- Do NOT use manual `impl Display` + `impl Error` — **why:** `snafu` generates consistent, composable error types; hand-rolled impls drift in style and miss context propagation
+- Do NOT use mock repositories in tests — **why:** mock/prod divergence masked a broken migration (historical incident); `testcontainers` catches real DB behavior
+- Do NOT use noop/hollow trait implementations (silently return `Ok(())` / `Ok(None)` / `vec![]`) — **why:** silent success hides integration bugs; if nothing tests or calls a method's return value, the method shouldn't exist. Exception: optional UX hooks (`typing_indicator`, lifecycle hooks) where no-op is the correct default
+- Do NOT construct hollow `Principal` objects — **why:** placeholder values bypass permission checks; `Principal` must come from `SecuritySubsystem::resolve_principal()` or `Principal::from_user()` with real role + permissions from the database
+- Do NOT write manual `fn new()` for 3+ field structs — **why:** `bon::Builder` provides consistent, IDE-friendly construction; manual constructors create positional-argument bugs
+- Do NOT hardcode database URLs or config defaults in Rust — **why:** config must be explicit and auditable in YAML; hidden defaults cause "works on my machine" failures
+- Do NOT modify already-applied migration files — **why:** SQLx tracks checksums; any change breaks startup on every deployed instance
+- Do NOT write code comments in any language other than English — **why:** non-English comments fragment search and break tooling for international contributors
 
 ## Workflow
-- Do NOT work directly on `main` — ALL changes (code, docs, config) require a worktree + PR, no exceptions
-- Do NOT merge locally on `main` — all merges go through GitHub PRs; never `git merge` or `git commit` on main
-- Do NOT edit files in the main checkout for 'quick fixes' — even one-line changes must go through the full issue → worktree → PR flow
-- Do NOT create issues without the appropriate agent label (`agent:claude`, `agent:codex`, etc.)
-- Do NOT create PRs or issues without type + component labels — every PR and issue must have a type label (`bug`, `enhancement`, `refactor`, `chore`, `documentation`) and a component label (`core`, `backend`, `ui`, `extension`, `ci`)
-- Do NOT leave stale worktrees — clean up after PR is merged
-- Do NOT report PR as complete before CI is green — use `gh pr checks --watch` and fix failures before reporting
-- Do NOT create a new crate without an `AGENT.md` — every crate must ship with agent guidelines from day one
+
+- Do NOT work directly on `main` — **why:** direct commits bypass CI, review, and issue tracking; even one-line changes need the safety net
+- Do NOT merge locally — **why:** local merges skip CI checks and lose the PR audit trail
+- Do NOT edit files in the main checkout for 'quick fixes' — **why:** this is the same rule as above, stated explicitly because "just this once" is the most common failure mode
+- Do NOT create issues/PRs without proper labels (agent + type + component) — **why:** unlabeled items break automated dashboards and make triage impossible
+- Do NOT leave stale worktrees — **why:** stale worktrees accumulate disk usage and cause branch confusion
+- Do NOT report PR as complete before CI is green — **why:** user acts on "done" signal; reporting prematurely wastes their time when CI fails
+- Do NOT create a new crate without an `AGENT.md` — **why:** without agent guidelines, the next agent working in this crate will repeat the same mistakes
 
 ## Agent System Prompt
-- Do NOT add "plan before act" rules to agent system prompts — this causes redundant/repetitive narrative text even for simple interactions (hello). The correct principle is "act first, report after" (see #201)
-- Do NOT use overly broad conditions to trigger memory search — "proactively search memory" causes every interaction to trigger search + meaningless narrative. Trigger conditions must be explicitly scoped (e.g., "user explicitly asks about past events")
-- Do NOT modify agent system prompts without testing — at minimum, verify with simple inputs like "hello" / "你好" that no abnormal/repetitive output is produced
+
+- Do NOT add "plan before act" rules — **why:** causes redundant narrative even for simple "hello" interactions; the correct principle is "act first, report after" (see #201)
+- Do NOT use overly broad memory search triggers — **why:** "proactively search memory" fires on every interaction, producing meaningless narrative; scope triggers explicitly (e.g., "user explicitly asks about past events")
+- Do NOT modify agent system prompts without testing — **why:** prompt changes have non-obvious emergent effects; verify with simple inputs ("hello" / "你好") that no abnormal output is produced

--- a/docs/guides/code-comments.md
+++ b/docs/guides/code-comments.md
@@ -1,7 +1,7 @@
 # Code Comments
 
-- All new or modified public items (`pub fn`, `pub struct`, `pub enum`, `pub trait`) MUST have English doc comments (`///`)
-- Add inline comments to explain **why**, not **what** — skip comments that merely restate the code
-- Do NOT retroactively add comments to unchanged code — only comment what you touch
+All comments and doc comments must be in English.
+
+- New or modified `pub` items require `///` doc comments — but only comment what you touch, not unchanged code
+- Inline comments explain **why**, not **what** — skip comments that restate the code
 - Complex algorithms, non-obvious invariants, and safety-critical logic require comments even on private items
-- All comments, doc comments, and string literals must be in English

--- a/docs/guides/rust-style.md
+++ b/docs/guides/rust-style.md
@@ -1,107 +1,45 @@
 # Rust Code Style
 
-## Error Handling
+## Style Direction
 
-- Use `snafu` exclusively — never `thiserror` or manual `impl Error`
-- `anyhow` allowed at application boundaries (tool implementations, integrations, app bootstrap) but NOT in domain/kernel core logic — use `snafu` there
-- Every error enum: `#[derive(Debug, Snafu)]` + `#[snafu(visibility(pub))]`
-- Name: `{CrateName}Error`, variants use `#[snafu(display("..."))]`
-- Propagate with `.context(XxxSnafu)?` or `.whatever_context("msg")?`
-- Define `pub type Result<T> = std::result::Result<T, CrateError>` per crate
+Write Rust in the style region defined by BurntSushi, dtolnay, and Niko Matsakis (see CLAUDE.md
+for what to take from each). This means: functional-first, iterator chains over imperative loops,
+combinators on Option/Result for simple transforms, `match` for complex branching, immutable by
+default, early returns with `?` to keep the happy path flat.
 
-## Type Patterns
+If you're unsure whether a pattern fits, ask: "Would BurntSushi write it this way in `ripgrep`?"
+If yes, it's probably right. If it feels like enterprise Java, it's probably wrong.
 
-- Trait objects: always create `pub type XRef = Arc<dyn X>` alias
-- No hardcoded config defaults in Rust — all via YAML
+## Toolchain Constraints
 
-## Struct Construction — Use `bon::Builder`
+These are zero-ambiguity rules — not style preferences, but mechanical requirements.
 
-Structs with 3+ fields MUST use `#[derive(bon::Builder)]` — do NOT write manual `fn new()` constructors.
+### Error Handling
+- `snafu` exclusively in domain/kernel — never `thiserror` or manual `impl Error`
+- `anyhow` allowed only at application boundaries (tool implementations, integrations, bootstrap)
+- Error enum pattern: `#[derive(Debug, Snafu)]` + `#[snafu(visibility(pub))]`
+- Naming: `{CrateName}Error`, variants use `#[snafu(display("..."))]`
+- Propagation: `.context(XxxSnafu)?` or `.whatever_context("msg")?`
+- Per-crate alias: `pub type Result<T> = std::result::Result<T, CrateError>`
 
-**Rules:**
-- `#[derive(bon::Builder)]` on any struct with 3+ fields (config, domain objects, options, etc.)
-- Config structs: always pair with `Deserialize`, never `#[derive(Default)]` — defaults come from YAML
-- Do NOT write `impl Foo { pub fn new(a, b, c, d, ...) -> Self }` — use the generated builder instead
-- Cross-module construction: use `Foo::builder().field(val).build()`, not struct literals
-- Within the defining module, struct literals are fine when all fields are straightforward
-- `Option<T>` fields automatically default to `None` in bon — no need for `#[builder(default)]`
-- For non-Option defaults, use `#[builder(default = value)]`
-- Simple 1-2 field structs can use direct construction (no builder needed)
+### Struct Construction — `bon::Builder`
+- 3+ fields: `#[derive(bon::Builder)]` — no manual `fn new()` constructors
+- Config structs: pair with `Deserialize`, never `#[derive(Default)]` — defaults come from YAML
+- Cross-module: `Foo::builder().field(val).build()`, not struct literals
+- Within the defining module: struct literals are fine
+- `Option<T>` fields auto-default to `None` in bon — no need for `#[builder(default)]`
+- 1-2 field structs: direct construction, no builder needed
 
-```rust
-// Good: derive builder + Deserialize for config
-#[derive(Debug, Clone, bon::Builder, Serialize, Deserialize)]
-pub struct ServerConfig {
-    pub host: String,
-    pub port: u16,
-    pub max_connections: usize,
-    pub tls_enabled: bool,
-}
+### Type Patterns
+- Trait objects: `pub type XRef = Arc<dyn X>` alias
+- No hardcoded config defaults in Rust — all via YAML config file
 
-// Good: construct via builder (especially from outside the module)
-let config = ServerConfig::builder()
-    .host("0.0.0.0".into())
-    .port(8080)
-    .max_connections(100)
-    .tls_enabled(true)
-    .build();
-
-// Bad: manual constructor — use the generated builder
-impl ServerConfig {
-    pub fn new(host: String, port: u16, max_connections: usize, tls_enabled: bool) -> Self {
-        Self { host, port, max_connections, tls_enabled }
-    }
-}
-```
-
-## Async
-
+### Async
 - `#[async_trait]` + `Send + Sync` bound on async trait definitions
 - Logging: `tracing` macros + `#[instrument(skip_all)]`
 
-## Functional Style
-
-Prefer functional programming patterns over imperative code:
-
-- **Iterator chains** over `for` loops with manual accumulation — use `.map()`, `.filter()`, `.flat_map()`, `.fold()`, `.collect()`
-- **Early returns with `?`** over nested `if let` / `match` — keep the happy path flat
-- **Combinators on Option/Result** — `.map()`, `.and_then()`, `.unwrap_or_else()`, `.ok_or_else()` over `match` when the logic is a simple transform
-- **`match` for complex branching** — use `match` when there are 3+ arms or when destructuring is needed; don't force combinators into unreadable chains
-- **Closures** for short inline logic; extract to named functions when the closure exceeds ~5 lines
-- **Immutable by default** — only use `mut` when mutation is genuinely needed
-- **`let` bindings for intermediate results** — name intermediate values to improve readability rather than chaining everything into one expression
-- Avoid side effects in iterator chains — if you need side effects, use `for` or `.for_each()`
-
-```rust
-// Good: functional chain
-let active_names: Vec<_> = users
-    .iter()
-    .filter(|u| u.is_active)
-    .map(|u| &u.name)
-    .collect();
-
-// Bad: imperative accumulation
-let mut active_names = Vec::new();
-for u in &users {
-    if u.is_active {
-        active_names.push(&u.name);
-    }
-}
-
-// Good: combinator on Option
-let display = user.nickname.as_deref().unwrap_or(&user.name);
-
-// Bad: match for simple default
-let display = match &user.nickname {
-    Some(n) => n.as_str(),
-    None => &user.name,
-};
-```
-
-## Code Organization
-
-- Split logic into sub-files; `mod.rs` only for re-exports + `//!` module docs
-- Imports grouped: `std` → external crates → internal (`crate::` / `super::`)
+### Code Organization
+- `mod.rs` only for re-exports + `//!` module docs — split logic into sub-files
+- Imports: `std` → external crates → internal (`crate::` / `super::`)
 - No wildcard imports (`use foo::*`)
-- All `pub` items must have `///` doc comments in English
-- Use `.expect("context")` over `unwrap()` in non-test code
+- `.expect("context")` over `unwrap()` in non-test code


### PR DESCRIPTION
## Summary

Apply the [prompt-refinery](https://github.com/rararulab/rara-skills/blob/main/skills/prompt-refinery/SKILL.md) Polanyi framework to restructure CLAUDE.md and referenced guide files from a flat rule list into a 5-layer boundary-condition system:

- **Layer 1 (Project Philosophy):** Added "Boring Technology" + Linux kernel discipline as concept anchors — compresses the entire design ethos into two pointers the model can unpack
- **Layer 2 (Style Anchors):** Triangulated Rust style from BurntSushi + dtolnay + Niko Matsakis with explicit conflict resolution order (safety > ergonomics > minimalism)
- **Layer 3 (External Reality):** Elevated `.pre-commit-config.yaml`, issue templates, and `AGENT.md` files as accountability anchors
- **Layer 4 (Constraints):** Consolidated `rust-style.md` to toolchain constraints only — removed code examples and style rules now covered by anchors
- **Layer 5 (Anti-sycophancy):** Added explicit clause directing the model to push back when user requests conflict with project anchors
- **Anti-patterns:** Added "why" to every entry for better generalization to unlisted scenarios
- **Code comments:** Consolidated from 5 rules to 3

Net: -25 lines, anchor-to-rule ratio improved from ~1:11 to ~1:3.

## Type of change

| Type | Label |
|------|-------|
| Refactor | `documentation` |

## Component

`core`

## Closes

Closes #1103

## Test plan

- [x] All changes are documentation-only (no Rust/TS code touched)
- [x] No pre-commit hooks triggered (doc-only change)
- [x] Verified CLAUDE.md @ references still point to correct file paths