### PR TITLE
feat(browser): seamless Lightpanda integration via config.yaml (#1109)

### DIFF
--- a/crates/app/src/boot.rs
+++ b/crates/app/src/boot.rs
@@ -88,10 +88,14 @@ pub struct PlatformBindingConfig {
 // =========================================================================
 
 /// Initialize all kernel-side infrastructure and return a [`BootResult`].
+///
+/// `browser_manager` is optional — pass `Some` when Lightpanda started
+/// successfully; browser tools are registered into the tool registry when set.
 pub(crate) async fn boot(
     pool: sqlx::SqlitePool,
     settings_provider: Arc<dyn rara_domain_shared::settings::SettingsProvider>,
     users: &[UserConfig],
+    browser_manager: Option<rara_kernel::browser::BrowserManagerRef>,
 ) -> Result<BootResult, Whatever> {
     // -- credential store --------------------------------------------------
 
@@ -198,21 +202,12 @@ pub(crate) async fn boot(
 
     // -- browser subsystem -------------------------------------------------
 
-    // match rara_kernel::browser::BrowserManager::start(rara_kernel::browser::BrowserConfig::default())
-    //     .await
-    // {
-    //     Ok(manager) => {
-    //         let manager_ref: rara_kernel::browser::BrowserManagerRef =
-    //             std::sync::Arc::new(manager);
-    //         for tool in rara_kernel::tool::browser::browser_tools(manager_ref) {
-    //             tool_registry.register(tool);
-    //         }
-    //         info!("Browser subsystem initialized with Lightpanda");
-    //     }
-    //     Err(e) => {
-    //         warn!("Browser subsystem disabled: {e}");
-    //     }
-    // }
+    if let Some(manager) = browser_manager {
+        for tool in rara_kernel::tool::browser::browser_tools(manager) {
+            tool_registry.register(tool);
+        }
+        info!("browser tools registered (Lightpanda)");
+    }
 
     // Register discover-tools — it reads the live registry from ToolContext at
     // query time, so dynamically registered tools (e.g. MCP) are always visible.

--- a/crates/app/src/lib.rs
+++ b/crates/app/src/lib.rs
@@ -108,6 +108,14 @@ pub struct AppConfig {
     /// Context folding (auto-anchor) configuration for the kernel.
     #[serde(default)]
     pub context_folding:        rara_kernel::kernel::ContextFoldingConfig,
+    /// Lightpanda browser subsystem (optional).
+    ///
+    /// When present, rara starts a Lightpanda CDP server and registers all
+    /// browser tools (`browser-navigate`, `browser-click`, etc.). When absent
+    /// or when the binary is not installed, browser tools are not available and
+    /// rara falls back to `http-fetch` for web access.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub browser:                Option<rara_kernel::browser::BrowserConfig>,
 }
 
 /// Configuration for the Mita background proactive agent.
@@ -321,9 +329,33 @@ pub async fn start_with_options(
             .await
             .whatever_context("Failed to initialize config file sync")?;
 
-    let rara = crate::boot::boot(pool.clone(), settings_provider.clone(), &config.users)
-        .await
-        .whatever_context("Failed to boot kernel dependencies")?;
+    // -- browser subsystem (optional) -------------------------------------
+    // Start Lightpanda if a `browser:` section exists in config. Failure to
+    // start is non-fatal — browser tools are simply not registered.
+    let browser_manager: Option<rara_kernel::browser::BrowserManagerRef> =
+        if let Some(browser_cfg) = config.browser.clone() {
+            match rara_kernel::browser::BrowserManager::start(browser_cfg).await {
+                Ok(manager) => {
+                    info!("browser subsystem initialized with Lightpanda");
+                    Some(std::sync::Arc::new(manager))
+                }
+                Err(e) => {
+                    warn!(error = %e, "browser subsystem disabled — Lightpanda failed to start");
+                    None
+                }
+            }
+        } else {
+            None
+        };
+
+    let rara = crate::boot::boot(
+        pool.clone(),
+        settings_provider.clone(),
+        &config.users,
+        browser_manager,
+    )
+    .await
+    .whatever_context("Failed to boot kernel dependencies")?;
 
     let backend = rara_backend_admin::state::BackendState::init(
         rara.session_index.clone(),


### PR DESCRIPTION
## Summary

Browser tools were compiled but never registered — the subsystem was commented out in `boot.rs`. rara had no browser capability at runtime and fell back to `bash`/`http-fetch`.

Follows the same optional-subsystem pattern used by `stt` and `symphony`:

- `AppConfig` gains `browser: Option<BrowserConfig>` (absent = disabled, no startup failure)
- `run_app` attempts `BrowserManager::start()` when the section is present; non-fatal on failure — logs a warning and continues without browser tools
- `boot()` accepts `Option<BrowserManagerRef>` and registers all 10 browser tools when set
- Dead commented-out block in `boot.rs` removed

**To enable**, add to `config.yaml`:

```yaml
browser:
  binary_path: lightpanda        # bare name = PATH lookup
  navigate_timeout_secs: 30      # optional, default 30s (from #1108)
  wait_for_timeout_secs: 30      # optional, default 30s (from #1108)
```

## Type of change

| Type | Label |
|------|-------|
| New feature | `enhancement` |

## Component

`core`

## Closes

Closes #1109

## Test plan

- [x] `cargo check -p rara-app` passes
- [x] `cargo clippy` zero warnings
- [x] `cargo +nightly fmt --check` passes
- [x] Without `browser:` in config — starts normally, no browser tools
- [x] With `browser:` but Lightpanda not installed — warns and continues