### PR TITLE
feat(browser): add browser-fetch tool for Markdown page retrieval (#1112)

### DIFF
--- a/crates/app/src/tools/http_fetch.rs
+++ b/crates/app/src/tools/http_fetch.rs
@@ -46,8 +46,10 @@ pub struct HttpFetchResult {
 #[derive(ToolDef)]
 #[tool(
     name = "http-fetch",
-    description = "Fetch a URL via HTTP GET or POST; returns status, content type, and body \
-                   (truncated to 100KB).",
+    description = "Fetch a URL via raw HTTP GET or POST; returns status, content type, and body \
+                   (truncated to 100KB). For human-readable web pages use `browser-fetch` instead \
+                   — it executes JavaScript and returns clean Markdown. Reserve this tool for raw \
+                   API calls (JSON/XML endpoints) where you need the exact HTTP response.",
     tier = "deferred"
 )]
 pub struct HttpFetchTool {

--- a/crates/kernel/src/browser/error.rs
+++ b/crates/kernel/src/browser/error.rs
@@ -67,6 +67,10 @@ pub enum BrowserError {
     /// Lightpanda process exited unexpectedly.
     #[snafu(display("lightpanda process crashed: {message}"))]
     ProcessCrashed { message: String },
+
+    /// `lightpanda fetch` subprocess failed.
+    #[snafu(display("lightpanda fetch failed for {url}: {message}"))]
+    FetchFailed { url: String, message: String },
 }
 
 /// Convenience alias for browser results.

--- a/crates/kernel/src/browser/manager.rs
+++ b/crates/kernel/src/browser/manager.rs
@@ -704,6 +704,41 @@ impl BrowserManager {
     }
 
     /// Close all tabs and release their CDP pages.
+    /// Fetch a URL and return its content as Markdown.
+    ///
+    /// Spawns `lightpanda fetch --dump markdown <url>` as a subprocess — no
+    /// CDP connection needed. Faster than `navigate` for read-only page
+    /// retrieval; executes JavaScript so dynamic/SPA pages render correctly.
+    ///
+    /// Output is truncated to `snapshot_max_bytes` to keep LLM context bounded.
+    pub async fn fetch_markdown(&self, url: &str) -> BrowserResult<String> {
+        let output = tokio::time::timeout(
+            Duration::from_secs(self.config.navigate_timeout_secs),
+            tokio::process::Command::new(&self.config.binary_path)
+                .args(["fetch", "--dump", "markdown", url])
+                .output(),
+        )
+        .await
+        .map_err(|_| PageLoadTimeoutSnafu { url }.build())?
+        .map_err(|e| {
+            FetchFailedSnafu {
+                url,
+                message: e.to_string(),
+            }
+            .build()
+        })?;
+
+        // lightpanda always exits 0, even on navigation failure — errors are
+        // reported as Markdown content ("# Navigation failed\n\nReason: ...").
+        // Return stdout as-is so the LLM can read the failure reason directly.
+        let mut markdown = String::from_utf8_lossy(&output.stdout).into_owned();
+        if markdown.len() > self.config.snapshot_max_bytes {
+            markdown.truncate(self.config.snapshot_max_bytes);
+            markdown.push_str("\n…[truncated]");
+        }
+        Ok(markdown)
+    }
+
     pub async fn close_all(&self) -> BrowserResult<Vec<TabInfo>> {
         let pages: Vec<Page> = {
             let mut store = self.store.write().await;

--- a/crates/kernel/src/tool/browser/fetch.rs
+++ b/crates/kernel/src/tool/browser/fetch.rs
@@ -1,0 +1,82 @@
+// Copyright 2025 Rararulab
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Fetch a URL and return its content as Markdown via Lightpanda.
+
+use async_trait::async_trait;
+use rara_tool_macro::ToolDef;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    browser::BrowserManagerRef,
+    tool::{ToolContext, ToolExecute},
+};
+
+/// Fetch a URL and return its rendered Markdown content via Lightpanda.
+#[derive(ToolDef)]
+#[tool(
+    name = "browser-fetch",
+    description = "Fetch a URL and return its content as clean Markdown. Executes JavaScript so \
+                   dynamic and SPA pages render correctly. Preferred over `http-fetch` for \
+                   human-readable web pages. Use `browser-navigate` instead when you need to \
+                   interact with the page (click, type, etc.).",
+    tier = "deferred"
+)]
+pub struct BrowserFetchTool {
+    manager: BrowserManagerRef,
+}
+
+impl BrowserFetchTool {
+    pub fn new(manager: BrowserManagerRef) -> Self { Self { manager } }
+}
+
+/// Parameters for the browser-fetch tool.
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct BrowserFetchParams {
+    /// The URL to fetch
+    url: String,
+}
+
+/// Result of the browser-fetch tool.
+#[derive(Debug, Clone, Serialize)]
+pub struct BrowserFetchResult {
+    /// The URL that was fetched
+    url:      String,
+    /// Page content rendered as Markdown
+    markdown: String,
+}
+
+#[async_trait]
+impl ToolExecute for BrowserFetchTool {
+    type Output = BrowserFetchResult;
+    type Params = BrowserFetchParams;
+
+    async fn run(
+        &self,
+        p: BrowserFetchParams,
+        _context: &ToolContext,
+    ) -> anyhow::Result<BrowserFetchResult> {
+        let markdown = self
+            .manager
+            .fetch_markdown(&p.url)
+            .await
+            .map_err(|e| anyhow::anyhow!("browser-fetch failed: {e}"))?;
+
+        Ok(BrowserFetchResult {
+            url: p.url,
+            markdown,
+        })
+    }
+}

--- a/crates/kernel/src/tool/browser/mod.rs
+++ b/crates/kernel/src/tool/browser/mod.rs
@@ -19,6 +19,7 @@
 mod click;
 mod close;
 mod evaluate;
+mod fetch;
 mod navigate;
 mod navigate_back;
 mod press_key;
@@ -33,6 +34,7 @@ use crate::{browser::BrowserManagerRef, tool::AgentToolRef};
 pub fn browser_tools(manager: BrowserManagerRef) -> Vec<AgentToolRef> {
     use std::sync::Arc;
     vec![
+        Arc::new(fetch::BrowserFetchTool::new(manager.clone())),
         Arc::new(navigate::BrowserNavigateTool::new(manager.clone())),
         Arc::new(navigate_back::BrowserNavigateBackTool::new(manager.clone())),
         Arc::new(snapshot::BrowserSnapshotTool::new(manager.clone())),


### PR DESCRIPTION
## Summary

- Adds `browser-fetch` tool: spawns `lightpanda fetch --dump markdown <url>` as a subprocess, returning clean Markdown. No CDP overhead — lighter than `browser-navigate` for read-only fetches; executes JavaScript so dynamic/SPA pages render correctly.
- Adds `BrowserManager::fetch_markdown()` method and `FetchFailed` error variant.
- Updates `http-fetch` description to redirect LLM toward `browser-fetch` for human-readable pages.

**lightpanda behavior note**: always exits 0 even on failure — navigation errors surface as Markdown content (`# Navigation failed\n\nReason: ...`), which the LLM can read directly.

## Type of change

| Type | Label |
|------|-------|
| New feature | `enhancement` |

## Component

`core`

## Closes

Closes #1112

## Test plan

- [x] `cargo check` passes
- [x] `just lint` passes
- [x] `lightpanda fetch --dump markdown https://example.com` verified locally — returns clean Markdown
- [x] Failure case (`bad URL`) returns `# Navigation failed\nReason: ...` — LLM-readable