### PR TITLE
fix(kernel): treat empty LLM stream as error with auto-fold recovery (#1116)

### DIFF
--- a/crates/kernel/src/agent/mod.rs
+++ b/crates/kernel/src/agent/mod.rs
@@ -1655,6 +1655,42 @@ pub(crate) async fn run_agent_loop(
             continue;
         }
 
+        // Empty stream detection: when the LLM returned no text, no tool
+        // calls, AND no usage info, the provider likely rejected the request
+        // silently (e.g. context window exceeded on free-tier models).  Treat
+        // this as a retryable error: trigger an auto-fold to compress context
+        // and retry with tools disabled.
+        if !has_tool_calls
+            && accumulated_text.is_empty()
+            && last_usage.is_none()
+            && llm_error_recovery_count < MAX_LLM_ERROR_RECOVERIES
+        {
+            llm_error_recovery_count += 1;
+            warn!(
+                iteration,
+                model = model.as_str(),
+                recovery_attempt = llm_error_recovery_count,
+                max_recoveries = MAX_LLM_ERROR_RECOVERIES,
+                "LLM stream returned empty (no text, no tools, no usage) — likely context window \
+                 exceeded, attempting fold + recovery"
+            );
+
+            // Force an auto-fold on the next iteration to compress context
+            // before retrying.  The fold runs at the top of the loop (line
+            // ~1110) when force_fold_next_iteration is set.
+            force_fold_next_iteration = true;
+
+            llm_error_recovery_message = Some(
+                "[System] The previous request produced an empty response (possible context \
+                 window limit). Context has been compressed. Please reply to the user's question \
+                 directly without using tools."
+                    .to_string(),
+            );
+            tool_defs = vec![];
+            in_llm_error_recovery = true;
+            continue;
+        }
+
         // Terminal response: exit when the LLM produced no tool calls.
         // Recovery iterations always land here because tools were disabled,
         // but subsequent iterations (after tool restoration) can resume


### PR DESCRIPTION
## Summary

When a provider returns HTTP 200 but an empty SSE stream (no text, no tool calls, no usage), the agent now detects this as a likely context window exceeded condition and attempts recovery:

1. **Detect**: `accumulated_text.is_empty() && !has_tool_calls && last_usage.is_none()`
2. **Fold**: Set `force_fold_next_iteration` to compress tape context before retry
3. **Retry**: Disable tools + inject recovery message (fewer tokens) → retry with compressed context
4. **Cap**: `MAX_LLM_ERROR_RECOVERIES` (3) prevents infinite retry loops

Previously this silently returned "I wasn't able to generate a response" with no recovery, even when context compression would fix the issue. Inspired by claw-code's approach of treating empty streams as hard errors.

## Type of change

| Type | Label |
|------|-------|
| Bug fix | `bug` |

## Component

`core`

## Closes

Closes #1116

## Test plan

- [x] `cargo check -p rara-kernel` passes
- [x] `prek run --all-files` passes (fmt, clippy, doc, check)
- [x] Logic review: recovery path reuses existing `llm_error_recovery` mechanism + `force_fold_next_iteration`