### PR TITLE
refactor(soul): introduce StyleScore newtype for bounded 1-10 values (#1126)

### DIFF
--- a/crates/soul/src/evolution.rs
+++ b/crates/soul/src/evolution.rs
@@ -221,8 +221,10 @@ mod tests {
     fn validate_boundaries_formality_violation() {
         let soul = test_soul();
         let mut proposed = test_soul();
-        proposed.frontmatter.boundaries.min_formality = Some(1); // lower than original 2
-        proposed.frontmatter.boundaries.max_formality = Some(10); // higher than original 8
+        proposed.frontmatter.boundaries.min_formality =
+            Some(crate::score::StyleScore::new(1).unwrap()); // lower than original 2
+        proposed.frontmatter.boundaries.max_formality =
+            Some(crate::score::StyleScore::new(10).unwrap()); // higher than original 8
 
         let violations = validate_boundaries(&soul.frontmatter, &proposed.frontmatter);
         assert_eq!(violations.len(), 2);

--- a/crates/soul/src/file.rs
+++ b/crates/soul/src/file.rs
@@ -17,7 +17,10 @@
 use serde::{Deserialize, Serialize};
 use snafu::ResultExt;
 
-use crate::error::{ParseFrontmatterSnafu, Result};
+use crate::{
+    error::{ParseFrontmatterSnafu, Result},
+    score::StyleScore,
+};
 
 /// Parsed soul file: frontmatter metadata + markdown body.
 #[derive(Debug, Clone)]
@@ -47,8 +50,8 @@ fn default_version() -> u32 { 1 }
 pub struct Boundaries {
     #[serde(default)]
     pub immutable_traits: Vec<String>,
-    pub min_formality:    Option<u8>,
-    pub max_formality:    Option<u8>,
+    pub min_formality:    Option<StyleScore>,
+    pub max_formality:    Option<StyleScore>,
 }
 
 /// Evolution feature flags.
@@ -192,8 +195,14 @@ Natural and friendly.
         assert_eq!(soul.frontmatter.version, 2);
         assert_eq!(soul.frontmatter.personality, vec!["温暖", "好奇"]);
         assert_eq!(soul.frontmatter.boundaries.immutable_traits, vec!["诚实"]);
-        assert_eq!(soul.frontmatter.boundaries.min_formality, Some(2));
-        assert_eq!(soul.frontmatter.boundaries.max_formality, Some(7));
+        assert_eq!(
+            soul.frontmatter.boundaries.min_formality,
+            Some(StyleScore::new(2).unwrap()),
+        );
+        assert_eq!(
+            soul.frontmatter.boundaries.max_formality,
+            Some(StyleScore::new(7).unwrap()),
+        );
         assert!(soul.frontmatter.evolution.enabled);
         assert!(soul.frontmatter.evolution.mood_tracking);
         assert!(soul.body.contains("## Background"));

--- a/crates/soul/src/lib.rs
+++ b/crates/soul/src/lib.rs
@@ -36,6 +36,7 @@ pub mod evolution;
 pub mod file;
 pub mod loader;
 pub mod render;
+pub mod score;
 pub mod state;
 
 // Re-export key types for convenience.
@@ -44,4 +45,5 @@ pub use evolution::{create_snapshot, list_snapshots, load_snapshot, validate_bou
 pub use file::{Boundaries, EvolutionConfig, SoulFile, SoulFrontmatter};
 pub use loader::{LoadedSoul, SoulSource, load_and_render, load_soul, soul_path};
 pub use render::render;
+pub use score::{StyleScore, StyleScoreError};
 pub use state::{MoodLabel, RelationshipStage, SoulState, StyleDrift};

--- a/crates/soul/src/score.rs
+++ b/crates/soul/src/score.rs
@@ -1,0 +1,127 @@
+// Copyright 2025 Rararulab
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Bounded 1-10 score type for soul style parameters.
+
+use std::fmt;
+
+use serde::{Deserialize, Serialize};
+use snafu::Snafu;
+
+/// Error returned when a score value is outside the valid 1-10 range.
+#[derive(Debug, Snafu)]
+#[snafu(display("style score {value} out of range 1-10"))]
+pub struct StyleScoreError {
+    pub(crate) value: u8,
+}
+
+/// A score value bounded to the 1-10 range (inclusive).
+///
+/// Used for style drift parameters (formality, verbosity, humor) and
+/// boundary formality limits. Deserialization via `serde(try_from)` ensures
+/// invalid values are rejected at parse time.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(try_from = "u8", into = "u8")]
+pub struct StyleScore(u8);
+
+impl StyleScore {
+    /// Create a new `StyleScore`, returning an error if `value` is outside
+    /// 1-10.
+    pub fn new(value: u8) -> Result<Self, StyleScoreError> {
+        if value == 0 || value > 10 {
+            Err(StyleScoreError { value })
+        } else {
+            Ok(Self(value))
+        }
+    }
+
+    /// Return the inner `u8` value.
+    pub fn get(self) -> u8 { self.0 }
+}
+
+impl TryFrom<u8> for StyleScore {
+    type Error = StyleScoreError;
+
+    fn try_from(value: u8) -> Result<Self, Self::Error> { Self::new(value) }
+}
+
+impl From<StyleScore> for u8 {
+    fn from(s: StyleScore) -> u8 { s.0 }
+}
+
+impl Default for StyleScore {
+    fn default() -> Self {
+        // Midpoint of 1-10.
+        Self(5)
+    }
+}
+
+impl fmt::Display for StyleScore {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result { write!(f, "{}", self.0) }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn valid_range() {
+        for v in 1..=10 {
+            assert!(StyleScore::new(v).is_ok());
+        }
+    }
+
+    #[test]
+    fn zero_rejected() {
+        assert!(StyleScore::new(0).is_err());
+    }
+
+    #[test]
+    fn above_ten_rejected() {
+        assert!(StyleScore::new(11).is_err());
+        assert!(StyleScore::new(255).is_err());
+    }
+
+    #[test]
+    fn default_is_midpoint() {
+        assert_eq!(StyleScore::default().get(), 5);
+    }
+
+    #[test]
+    fn ordering() {
+        let low = StyleScore::new(2).unwrap();
+        let high = StyleScore::new(9).unwrap();
+        assert!(low < high);
+    }
+
+    #[test]
+    fn serde_roundtrip() {
+        let score = StyleScore::new(7).unwrap();
+        let yaml = serde_yaml::to_string(&score).unwrap();
+        let parsed: StyleScore = serde_yaml::from_str(&yaml).unwrap();
+        assert_eq!(parsed, score);
+    }
+
+    #[test]
+    fn serde_rejects_zero() {
+        let result: Result<StyleScore, _> = serde_yaml::from_str("0");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn serde_rejects_eleven() {
+        let result: Result<StyleScore, _> = serde_yaml::from_str("11");
+        assert!(result.is_err());
+    }
+}

--- a/crates/soul/src/state.rs
+++ b/crates/soul/src/state.rs
@@ -20,7 +20,10 @@ use jiff::Timestamp;
 use serde::{Deserialize, Serialize};
 use snafu::ResultExt;
 
-use crate::error::{IoSnafu, ParseStateSnafu, Result, SerializeStateSnafu};
+use crate::{
+    error::{IoSnafu, ParseStateSnafu, Result, SerializeStateSnafu},
+    score::StyleScore,
+};
 
 /// Maximum history entries kept in state file.
 const MAX_HISTORY_ENTRIES: usize = 10;
@@ -101,25 +104,23 @@ pub struct EmergedTrait {
 /// Style drift parameters (1-10 scale).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct StyleDrift {
-    #[serde(default = "default_style_5")]
-    pub formality:       u8,
-    #[serde(default = "default_style_5")]
-    pub verbosity:       u8,
-    #[serde(default = "default_style_5")]
-    pub humor_frequency: u8,
+    #[serde(default)]
+    pub formality:       StyleScore,
+    #[serde(default)]
+    pub verbosity:       StyleScore,
+    #[serde(default)]
+    pub humor_frequency: StyleScore,
 }
 
 impl Default for StyleDrift {
     fn default() -> Self {
         Self {
-            formality:       5,
-            verbosity:       5,
-            humor_frequency: 5,
+            formality:       StyleScore::default(),
+            verbosity:       StyleScore::default(),
+            humor_frequency: StyleScore::default(),
         }
     }
 }
-
-fn default_style_5() -> u8 { 5 }
 
 /// A history entry recording a soul state change.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -188,7 +189,7 @@ impl SoulState {
     }
 
     /// Clamp style drift formality within the given boundaries.
-    pub fn clamp_formality(&mut self, min: Option<u8>, max: Option<u8>) {
+    pub fn clamp_formality(&mut self, min: Option<StyleScore>, max: Option<StyleScore>) {
         if let Some(lo) = min {
             if self.style_drift.formality < lo {
                 self.style_drift.formality = lo;
@@ -211,7 +212,7 @@ mod tests {
         let state = SoulState::default();
         assert_eq!(state.mood.current, MoodLabel::Calm);
         assert_eq!(state.relationship_stage, RelationshipStage::Stranger);
-        assert_eq!(state.style_drift.formality, 5);
+        assert_eq!(state.style_drift.formality, StyleScore::default());
         assert!(state.emerged_traits.is_empty());
     }
 
@@ -253,12 +254,18 @@ mod tests {
     #[test]
     fn clamp_formality() {
         let mut state = SoulState::default();
-        state.style_drift.formality = 1;
-        state.clamp_formality(Some(3), Some(8));
-        assert_eq!(state.style_drift.formality, 3);
+        state.style_drift.formality = StyleScore::new(1).unwrap();
+        state.clamp_formality(
+            Some(StyleScore::new(3).unwrap()),
+            Some(StyleScore::new(8).unwrap()),
+        );
+        assert_eq!(state.style_drift.formality, StyleScore::new(3).unwrap());
 
-        state.style_drift.formality = 10;
-        state.clamp_formality(Some(3), Some(8));
-        assert_eq!(state.style_drift.formality, 8);
+        state.style_drift.formality = StyleScore::new(10).unwrap();
+        state.clamp_formality(
+            Some(StyleScore::new(3).unwrap()),
+            Some(StyleScore::new(8).unwrap()),
+        );
+        assert_eq!(state.style_drift.formality, StyleScore::new(8).unwrap());
     }
 }


### PR DESCRIPTION
## Summary

- Introduce `StyleScore` newtype in `crates/soul/src/score.rs` that enforces the 1-10 range at construction time and during serde deserialization (via `try_from = "u8"`)
- Replace raw `u8` fields in `StyleDrift` (formality, verbosity, humor_frequency) and `Boundaries` (min_formality, max_formality) with `StyleScore` / `Option<StyleScore>`
- Update all call sites in evolution validation, state clamping, rendering, and tests

## Type of change

| Type | Label |
|------|-------|
| Refactor | `refactor` |

## Component

`core`

## Closes

Closes #1126

## Test plan

- [x] `cargo test -p rara-soul` — 31 tests pass (including 9 new `StyleScore` tests)
- [x] `cargo check --all --all-targets` passes
- [x] Pre-commit hooks pass (check, fmt, clippy, doc)