### PR TITLE
refactor(kernel): replace anyhow with snafu typed errors in kernel internals (#1124)

### DIFF
--- a/crates/kernel/src/kv.rs
+++ b/crates/kernel/src/kv.rs
@@ -22,6 +22,27 @@
 use opendal::Operator;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
+use snafu::prelude::*;
+
+// ---------------------------------------------------------------------------
+// Errors
+// ---------------------------------------------------------------------------
+
+/// Typed errors for [`SharedKv`] operations.
+#[derive(Debug, Snafu)]
+#[snafu(visibility(pub))]
+pub enum KvError {
+    /// JSON serialization/deserialization failed.
+    #[snafu(display("serialization failed: {source}"))]
+    Serialize { source: serde_json::Error },
+
+    /// Underlying OpenDAL storage operation failed.
+    #[snafu(display("storage operation failed: {source}"))]
+    Storage { source: opendal::Error },
+}
+
+/// Result alias for [`KvError`].
+pub type Result<T> = std::result::Result<T, KvError>;
 
 /// Cross-agent shared KV store backed by an [`opendal::Operator`].
 pub struct SharedKv {
@@ -54,15 +75,15 @@ impl SharedKv {
     }
 
     /// Set a JSON value. Creates or overwrites.
-    pub async fn set(&self, key: &str, value: Value) -> anyhow::Result<()> {
-        let bytes = serde_json::to_vec(&value)?;
-        self.op.write(key, bytes).await?;
+    pub async fn set(&self, key: &str, value: Value) -> Result<()> {
+        let bytes = serde_json::to_vec(&value).context(SerializeSnafu)?;
+        self.op.write(key, bytes).await.context(StorageSnafu)?;
         Ok(())
     }
 
     /// Delete a key (no-op if absent).
-    pub async fn delete(&self, key: &str) -> anyhow::Result<()> {
-        self.op.delete(key).await?;
+    pub async fn delete(&self, key: &str) -> Result<()> {
+        self.op.delete(key).await.context(StorageSnafu)?;
         Ok(())
     }
 

--- a/crates/kernel/src/memory/knowledge/categories.rs
+++ b/crates/kernel/src/memory/knowledge/categories.rs
@@ -20,7 +20,24 @@
 
 use std::path::PathBuf;
 
+use snafu::prelude::*;
 use tokio::fs;
+
+// ---------------------------------------------------------------------------
+// Errors
+// ---------------------------------------------------------------------------
+
+/// Typed errors for category file operations.
+#[derive(Debug, Snafu)]
+#[snafu(visibility(pub))]
+pub enum CategoryError {
+    /// Filesystem I/O failed.
+    #[snafu(display("category io error: {source}"))]
+    Io { source: std::io::Error },
+}
+
+/// Result alias for [`CategoryError`].
+pub type Result<T> = std::result::Result<T, CategoryError>;
 
 /// Return the base directory for a user's knowledge categories.
 fn user_knowledge_dir(username: &str) -> PathBuf {
@@ -33,15 +50,15 @@ fn category_path(username: &str, category: &str) -> PathBuf {
 }
 
 /// List all category names for a user by scanning the knowledge directory.
-pub async fn list_categories(username: &str) -> anyhow::Result<Vec<String>> {
+pub async fn list_categories(username: &str) -> Result<Vec<String>> {
     let dir = user_knowledge_dir(username);
     if !dir.exists() {
         return Ok(Vec::new());
     }
 
-    let mut entries = fs::read_dir(&dir).await?;
+    let mut entries = fs::read_dir(&dir).await.context(IoSnafu)?;
     let mut categories = Vec::new();
-    while let Some(entry) = entries.next_entry().await? {
+    while let Some(entry) = entries.next_entry().await.context(IoSnafu)? {
         let path = entry.path();
         if path.extension().and_then(|e| e.to_str()) == Some("md") {
             if let Some(stem) = path.file_stem().and_then(|s| s.to_str()) {
@@ -54,20 +71,20 @@ pub async fn list_categories(username: &str) -> anyhow::Result<Vec<String>> {
 }
 
 /// Read the content of a category markdown file.
-pub async fn read_category(username: &str, category: &str) -> anyhow::Result<Option<String>> {
+pub async fn read_category(username: &str, category: &str) -> Result<Option<String>> {
     let path = category_path(username, category);
     if !path.exists() {
         return Ok(None);
     }
-    let content = fs::read_to_string(&path).await?;
+    let content = fs::read_to_string(&path).await.context(IoSnafu)?;
     Ok(Some(content))
 }
 
 /// Write (overwrite) a category markdown file.
-pub async fn write_category(username: &str, category: &str, content: &str) -> anyhow::Result<()> {
+pub async fn write_category(username: &str, category: &str, content: &str) -> Result<()> {
     let dir = user_knowledge_dir(username);
-    fs::create_dir_all(&dir).await?;
+    fs::create_dir_all(&dir).await.context(IoSnafu)?;
     let path = category_path(username, category);
-    fs::write(&path, content).await?;
+    fs::write(&path, content).await.context(IoSnafu)?;
     Ok(())
 }

--- a/crates/kernel/src/memory/knowledge/embedding.rs
+++ b/crates/kernel/src/memory/knowledge/embedding.rs
@@ -19,11 +19,44 @@
 
 use std::{path::PathBuf, sync::Mutex};
 
+use snafu::prelude::*;
 use tracing::{debug, info, warn};
 use usearch::{Index, IndexOptions, MetricKind, ScalarKind};
 
 use super::config::KnowledgeConfig;
 use crate::llm::{EmbeddingRequest, LlmEmbedderRef};
+
+// ---------------------------------------------------------------------------
+// Errors
+// ---------------------------------------------------------------------------
+
+/// Typed errors for [`EmbeddingService`] operations.
+#[derive(Debug, Snafu)]
+#[snafu(visibility(pub))]
+pub enum EmbeddingError {
+    /// Filesystem I/O failed (e.g. creating the index directory).
+    #[snafu(display("io error: {source}"))]
+    Io { source: std::io::Error },
+
+    /// usearch index operation failed.
+    #[snafu(display("usearch index error: {message}"))]
+    Index { message: String },
+
+    /// Embedding API call to the LLM provider failed.
+    #[snafu(display("embedding request failed: {source}"))]
+    EmbedRequest { source: crate::error::KernelError },
+
+    /// Embedding response count did not match input count.
+    #[snafu(display("embedding response count mismatch: expected {expected}, got {actual}"))]
+    CountMismatch { expected: usize, actual: usize },
+
+    /// Internal mutex was poisoned.
+    #[snafu(display("index lock poisoned"))]
+    LockPoisoned,
+}
+
+/// Result alias for [`EmbeddingError`].
+pub type Result<T> = std::result::Result<T, EmbeddingError>;
 
 /// Manages embedding generation (via [`LlmEmbedderRef`]) and vector search
 /// (usearch).
@@ -41,10 +74,10 @@ impl EmbeddingService {
         config: KnowledgeConfig,
         embedder: LlmEmbedderRef,
         embedding_model: String,
-    ) -> anyhow::Result<Self> {
+    ) -> Result<Self> {
         let index_path = rara_paths::data_dir().join("knowledge/memory.usearch");
         if let Some(parent) = index_path.parent() {
-            std::fs::create_dir_all(parent)?;
+            std::fs::create_dir_all(parent).context(IoSnafu)?;
         }
 
         let options = IndexOptions {
@@ -53,14 +86,23 @@ impl EmbeddingService {
             quantization: ScalarKind::F32,
             ..Default::default()
         };
-        let index = Index::new(&options)
-            .map_err(|e| anyhow::anyhow!("failed to create usearch index: {e}"))?;
+        let index = Index::new(&options).map_err(|e| {
+            IndexSnafu {
+                message: e.to_string(),
+            }
+            .build()
+        })?;
 
         // Load existing index from disk if available.
         if index_path.exists() {
             index
                 .load(index_path.to_str().unwrap_or_default())
-                .map_err(|e| anyhow::anyhow!("failed to load usearch index: {e}"))?;
+                .map_err(|e| {
+                    IndexSnafu {
+                        message: e.to_string(),
+                    }
+                    .build()
+                })?;
             info!(
                 size = index.size(),
                 capacity = index.capacity(),
@@ -68,9 +110,12 @@ impl EmbeddingService {
             );
         } else {
             // Reserve initial capacity.
-            index
-                .reserve(1024)
-                .map_err(|e| anyhow::anyhow!("failed to reserve usearch capacity: {e}"))?;
+            index.reserve(1024).map_err(|e| {
+                IndexSnafu {
+                    message: e.to_string(),
+                }
+                .build()
+            })?;
         }
 
         Ok(Self {
@@ -84,7 +129,7 @@ impl EmbeddingService {
 
     /// Generate embeddings for one or more texts via the configured
     /// [`LlmEmbedderRef`].
-    pub async fn embed(&self, texts: &[String]) -> anyhow::Result<Vec<Vec<f32>>> {
+    pub async fn embed(&self, texts: &[String]) -> Result<Vec<Vec<f32>>> {
         if texts.is_empty() {
             return Ok(Vec::new());
         }
@@ -99,38 +144,41 @@ impl EmbeddingService {
             .embedder
             .embed(request)
             .await
-            .map_err(|e| anyhow::anyhow!("embedding request failed: {e}"))?;
+            .context(EmbedRequestSnafu)?;
 
-        if response.embeddings.len() != texts.len() {
-            anyhow::bail!(
-                "embedding response count mismatch: expected {}, got {}",
-                texts.len(),
-                response.embeddings.len()
-            );
-        }
+        ensure!(
+            response.embeddings.len() == texts.len(),
+            CountMismatchSnafu {
+                expected: texts.len(),
+                actual:   response.embeddings.len(),
+            }
+        );
 
         debug!(count = response.embeddings.len(), "generated embeddings");
         Ok(response.embeddings)
     }
 
     /// Add a vector to the usearch index with the given key (memory_item id).
-    pub fn add_to_index(&self, key: u64, vector: &[f32]) -> anyhow::Result<()> {
-        let index = self
-            .index
-            .lock()
-            .map_err(|e| anyhow::anyhow!("index lock poisoned: {e}"))?;
+    pub fn add_to_index(&self, key: u64, vector: &[f32]) -> Result<()> {
+        let index = self.index.lock().map_err(|_| LockPoisonedSnafu.build())?;
 
         // Grow capacity if needed.
         if index.size() >= index.capacity() {
             let new_cap = index.capacity() * 2;
-            index
-                .reserve(new_cap)
-                .map_err(|e| anyhow::anyhow!("failed to reserve capacity: {e}"))?;
+            index.reserve(new_cap).map_err(|e| {
+                IndexSnafu {
+                    message: e.to_string(),
+                }
+                .build()
+            })?;
         }
 
-        index
-            .add(key, vector)
-            .map_err(|e| anyhow::anyhow!("failed to add vector: {e}"))?;
+        index.add(key, vector).map_err(|e| {
+            IndexSnafu {
+                message: e.to_string(),
+            }
+            .build()
+        })?;
         Ok(())
     }
 
@@ -138,33 +186,35 @@ impl EmbeddingService {
     /// vector.
     ///
     /// Returns `(key, distance)` pairs sorted by increasing distance.
-    pub fn search(&self, query: &[f32], top_k: usize) -> anyhow::Result<Vec<(u64, f32)>> {
-        let index = self
-            .index
-            .lock()
-            .map_err(|e| anyhow::anyhow!("index lock poisoned: {e}"))?;
+    pub fn search(&self, query: &[f32], top_k: usize) -> Result<Vec<(u64, f32)>> {
+        let index = self.index.lock().map_err(|_| LockPoisonedSnafu.build())?;
 
         if index.size() == 0 {
             return Ok(Vec::new());
         }
 
-        let matches = index
-            .search(query, top_k)
-            .map_err(|e| anyhow::anyhow!("search failed: {e}"))?;
+        let matches = index.search(query, top_k).map_err(|e| {
+            IndexSnafu {
+                message: e.to_string(),
+            }
+            .build()
+        })?;
 
         Ok(matches.keys.into_iter().zip(matches.distances).collect())
     }
 
     /// Persist the usearch index to disk.
-    pub fn save_index(&self) -> anyhow::Result<()> {
-        let index = self
-            .index
-            .lock()
-            .map_err(|e| anyhow::anyhow!("index lock poisoned: {e}"))?;
+    pub fn save_index(&self) -> Result<()> {
+        let index = self.index.lock().map_err(|_| LockPoisonedSnafu.build())?;
 
         index
             .save(self.index_path.to_str().unwrap_or_default())
-            .map_err(|e| anyhow::anyhow!("failed to save usearch index: {e}"))?;
+            .map_err(|e| {
+                IndexSnafu {
+                    message: e.to_string(),
+                }
+                .build()
+            })?;
 
         info!(size = index.size(), "saved usearch index to disk");
         Ok(())
@@ -174,23 +224,26 @@ impl EmbeddingService {
     ///
     /// Each `(id, blob)` pair contains a memory-item id and its raw f32
     /// embedding bytes (little-endian).
-    pub fn rebuild_index(&self, items: &[(i64, Vec<u8>)]) -> anyhow::Result<()> {
-        let index = self
-            .index
-            .lock()
-            .map_err(|e| anyhow::anyhow!("index lock poisoned: {e}"))?;
+    pub fn rebuild_index(&self, items: &[(i64, Vec<u8>)]) -> Result<()> {
+        let index = self.index.lock().map_err(|_| LockPoisonedSnafu.build())?;
 
-        index
-            .reset()
-            .map_err(|e| anyhow::anyhow!("failed to reset index: {e}"))?;
+        index.reset().map_err(|e| {
+            IndexSnafu {
+                message: e.to_string(),
+            }
+            .build()
+        })?;
 
         if items.is_empty() {
             return Ok(());
         }
 
-        index
-            .reserve(items.len().max(1024))
-            .map_err(|e| anyhow::anyhow!("failed to reserve capacity: {e}"))?;
+        index.reserve(items.len().max(1024)).map_err(|e| {
+            IndexSnafu {
+                message: e.to_string(),
+            }
+            .build()
+        })?;
 
         for (id, blob) in items {
             let floats = blob_to_f32s(blob);
@@ -203,9 +256,12 @@ impl EmbeddingService {
                 );
                 continue;
             }
-            index
-                .add(*id as u64, &floats)
-                .map_err(|e| anyhow::anyhow!("failed to add vector {id}: {e}"))?;
+            index.add(*id as u64, &floats).map_err(|e| {
+                IndexSnafu {
+                    message: e.to_string(),
+                }
+                .build()
+            })?;
         }
 
         info!(count = items.len(), "rebuilt usearch index from database");

--- a/crates/kernel/src/memory/knowledge/extractor.rs
+++ b/crates/kernel/src/memory/knowledge/extractor.rs
@@ -21,6 +21,7 @@
 //! embedding similarity, persists new items, and regenerates category files.
 
 use serde::{Deserialize, Serialize};
+use snafu::prelude::*;
 use sqlx::SqlitePool;
 use tracing::{info, warn};
 
@@ -33,6 +34,38 @@ use crate::{
     llm::{CompletionRequest, LlmDriver, Message, ToolChoice},
     memory::{TapEntry, TapEntryKind},
 };
+
+// ---------------------------------------------------------------------------
+// Errors
+// ---------------------------------------------------------------------------
+
+/// Typed errors for the knowledge extraction pipeline.
+#[derive(Debug, Snafu)]
+#[snafu(visibility(pub))]
+pub enum ExtractorError {
+    /// LLM completion call failed.
+    #[snafu(display("LLM call failed: {source}"))]
+    Llm { source: crate::error::KernelError },
+
+    /// Embedding operation failed.
+    #[snafu(display("embedding failed: {source}"))]
+    Embedding {
+        source: super::embedding::EmbeddingError,
+    },
+
+    /// Database operation failed.
+    #[snafu(display("database error: {source}"))]
+    Database { source: sqlx::Error },
+
+    /// Category file I/O failed.
+    #[snafu(display("category error: {source}"))]
+    Category {
+        source: super::categories::CategoryError,
+    },
+}
+
+/// Result alias for [`ExtractorError`].
+pub type Result<T> = std::result::Result<T, ExtractorError>;
 
 /// A raw extracted memory from LLM output.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -59,7 +92,7 @@ pub async fn extract_knowledge(
     driver: &dyn LlmDriver,
     extractor_model: &str,
     similarity_threshold: f32,
-) -> anyhow::Result<usize> {
+) -> Result<usize> {
     // Step 1: Build conversation text from tape entries.
     let conversation = build_conversation_text(entries);
     if conversation.is_empty() {
@@ -82,11 +115,14 @@ pub async fn extract_knowledge(
     // Step 3 + 4: Deduplicate and persist.
     let mut new_count = 0;
     let contents: Vec<String> = extracted.iter().map(|e| e.content.clone()).collect();
-    let embeddings = embedding_svc.embed(&contents).await?;
+    let embeddings = embedding_svc
+        .embed(&contents)
+        .await
+        .context(EmbeddingSnafu)?;
 
     for (item, emb) in extracted.iter().zip(embeddings.iter()) {
         // Check for duplicates via vector similarity.
-        let similar = embedding_svc.search(emb, 1)?;
+        let similar = embedding_svc.search(emb, 1).context(EmbeddingSnafu)?;
         if let Some(&(_, distance)) = similar.first() {
             // usearch cosine distance: 0.0 = identical, 2.0 = opposite.
             // Convert to similarity: 1.0 - distance/2.0
@@ -107,14 +143,18 @@ pub async fn extract_knowledge(
             embedding:       Some(blob),
         };
 
-        let row_id = items::insert_item(pool, &new_item).await?;
-        embedding_svc.add_to_index(row_id as u64, emb)?;
+        let row_id = items::insert_item(pool, &new_item)
+            .await
+            .context(DatabaseSnafu)?;
+        embedding_svc
+            .add_to_index(row_id as u64, emb)
+            .context(EmbeddingSnafu)?;
         new_count += 1;
     }
 
     // Save usearch index after batch insert.
     if new_count > 0 {
-        embedding_svc.save_index()?;
+        embedding_svc.save_index().context(EmbeddingSnafu)?;
     }
 
     if new_count == 0 {
@@ -158,7 +198,7 @@ async fn llm_extract_items(
     driver: &dyn LlmDriver,
     model: &str,
     conversation: &str,
-) -> anyhow::Result<Vec<ExtractedMemory>> {
+) -> Result<Vec<ExtractedMemory>> {
     let system_prompt = r#"You are a memory extraction agent. Given a conversation, extract key facts, preferences, events, habits, and skills about the user.
 
 Output a JSON array where each element has:
@@ -186,10 +226,7 @@ Output ONLY the JSON array, no markdown fences or explanation."#;
         frequency_penalty:   None,
     };
 
-    let response = driver
-        .complete(request)
-        .await
-        .map_err(|e| anyhow::anyhow!("LLM extraction call failed: {e}"))?;
+    let response = driver.complete(request).await.context(LlmSnafu)?;
     let text = response.content.unwrap_or_default();
 
     // Parse JSON array from response.
@@ -207,8 +244,10 @@ async fn update_category_files(
     model: &str,
     username: &str,
     pool: &SqlitePool,
-) -> anyhow::Result<()> {
-    let all_items = items::list_items_by_username(pool, username).await?;
+) -> Result<()> {
+    let all_items = items::list_items_by_username(pool, username)
+        .await
+        .context(DatabaseSnafu)?;
     if all_items.is_empty() {
         return Ok(());
     }
@@ -226,7 +265,7 @@ async fn update_category_files(
     for (category, cat_items) in &by_category {
         let existing = categories::read_category(username, category)
             .await
-            .unwrap_or(None)
+            .context(CategorySnafu)?
             .unwrap_or_default();
 
         let items_text: String = cat_items
@@ -258,13 +297,12 @@ async fn update_category_files(
             frequency_penalty:   None,
         };
 
-        let response = driver
-            .complete(request)
-            .await
-            .map_err(|e| anyhow::anyhow!("LLM category update failed: {e}"))?;
+        let response = driver.complete(request).await.context(LlmSnafu)?;
         let content = response.content.unwrap_or_default();
         if !content.is_empty() {
-            categories::write_category(username, category, &content).await?;
+            categories::write_category(username, category, &content)
+                .await
+                .context(CategorySnafu)?;
         }
     }
 


### PR DESCRIPTION
## Summary

- Replace `anyhow::Result` with per-module snafu error enums in four kernel-internal files that violated the project rule (snafu in domain/kernel, anyhow only at app boundaries)
- `kv.rs`: `KvError` with `Serialize` and `Storage` variants
- `embedding.rs`: `EmbeddingError` with `Io`, `Index`, `EmbedRequest`, `CountMismatch`, `LockPoisoned` variants
- `extractor.rs`: `ExtractorError` with `Llm`, `Embedding`, `Database`, `Category` variants
- `categories.rs`: `CategoryError` with `Io` variant

## Type of change

| Type | Label |
|------|-------|
| Refactor | `refactor` |

## Component

`core`

## Closes

Closes #1124

## Test plan

- [x] `cargo check --all --all-targets` passes
- [x] `cargo +nightly fmt --all` passes
- [x] Pre-commit hooks (check, fmt, clippy, doc) all pass
- [x] App-boundary callers (tool.rs, kernel.rs) unchanged — `?` auto-converts snafu errors to anyhow at those boundaries