### PR TITLE
refactor(kernel): make LlmCredential fields private with constructor (#1122)

### DIFF
--- a/crates/integrations/codex-oauth/src/lib.rs
+++ b/crates/integrations/codex-oauth/src/lib.rs
@@ -430,10 +430,10 @@ impl LlmCredentialResolver for CodexCredentialResolver {
             }
         }
 
-        Ok(LlmCredential {
-            base_url: "https://api.openai.com/v1".to_owned(),
-            api_key:  tokens.access_token,
-        })
+        Ok(LlmCredential::new(
+            "https://api.openai.com/v1",
+            tokens.access_token,
+        ))
     }
 }
 

--- a/crates/kernel/src/llm/driver.rs
+++ b/crates/kernel/src/llm/driver.rs
@@ -83,12 +83,29 @@ pub type LlmModelListerRef = Arc<dyn LlmModelLister>;
 pub type LlmEmbedderRef = Arc<dyn LlmEmbedder>;
 
 /// Credential resolved by a [`LlmCredentialResolver`].
+///
+/// Fields are private so that callers go through accessor methods,
+/// making it straightforward to add auditing or redaction later.
 #[derive(Debug, Clone)]
 pub struct LlmCredential {
+    base_url: String,
+    api_key:  String,
+}
+
+impl LlmCredential {
+    /// Create a new credential pair.
+    pub fn new(base_url: impl Into<String>, api_key: impl Into<String>) -> Self {
+        Self {
+            base_url: base_url.into(),
+            api_key:  api_key.into(),
+        }
+    }
+
     /// Provider base URL (e.g. `https://api.openai.com/v1`).
-    pub base_url: String,
+    pub fn base_url(&self) -> &str { &self.base_url }
+
     /// Bearer token or API key.
-    pub api_key:  String,
+    pub fn api_key(&self) -> &str { &self.api_key }
 }
 
 /// Dynamic credential resolver for LLM providers that need runtime

--- a/crates/kernel/src/llm/openai.rs
+++ b/crates/kernel/src/llm/openai.rs
@@ -291,8 +291,8 @@ impl OpenAiDriver {
             OpenAiDriverConfigSource::Dynamic { resolver } => {
                 let cred = resolver.resolve().await?;
                 Ok(ResolvedConfig {
-                    base_url: cred.base_url,
-                    api_key:  cred.api_key,
+                    base_url: cred.base_url().to_owned(),
+                    api_key:  cred.api_key().to_owned(),
                 })
             }
         }


### PR DESCRIPTION
Closes #1122

Make `LlmCredential` fields private and add constructor + accessor methods. Prevents uncontrolled field access to API keys and base URLs.