### PR TITLE
fix(kernel): use SessionKey/ChannelType types in ChannelMessage and ChannelBinding (#1120)

### DIFF
--- a/crates/channels/src/telegram/commands/kernel_client.rs
+++ b/crates/channels/src/telegram/commands/kernel_client.rs
@@ -20,6 +20,7 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use chrono::Utc;
 use rara_kernel::{
+    channel::types::ChannelType,
     handle::KernelHandle,
     memory::{TapeService, get_fork_metadata, set_fork_metadata},
     session::{self as ks, SessionIndex, SessionKey},
@@ -110,8 +111,11 @@ impl BotServiceClient for KernelBotServiceClient {
         channel_type: &str,
         chat_id: &str,
     ) -> Result<Option<ChannelBinding>, BotServiceError> {
+        let ct: ChannelType = channel_type.parse().map_err(|_| BotServiceError::Service {
+            message: format!("unknown channel type: {channel_type}"),
+        })?;
         self.sessions
-            .get_channel_binding(channel_type, chat_id)
+            .get_channel_binding(ct, chat_id)
             .await
             .map(|opt| opt.as_ref().map(binding_to_client))
             .context(SessionSnafu)
@@ -123,12 +127,15 @@ impl BotServiceClient for KernelBotServiceClient {
         chat_id: &str,
         session_key: &str,
     ) -> Result<ChannelBinding, BotServiceError> {
+        let ct: ChannelType = channel_type.parse().map_err(|_| BotServiceError::Service {
+            message: format!("unknown channel type: {channel_type}"),
+        })?;
         let key = SessionKey::try_from_raw(session_key).map_err(|e| BotServiceError::Service {
             message: format!("invalid session key: {e}"),
         })?;
         let now = Utc::now();
         let binding = ks::ChannelBinding {
-            channel_type: channel_type.to_owned(),
+            channel_type: ct,
             chat_id:      chat_id.to_owned(),
             session_key:  key,
             created_at:   now,
@@ -522,7 +529,7 @@ mod tests {
     #[derive(Default)]
     struct InMemorySessionIndex {
         sessions: DashMap<String, SessionEntry>,
-        bindings: DashMap<(String, String), ChannelBinding>,
+        bindings: DashMap<(ChannelType, String), ChannelBinding>,
     }
 
     #[async_trait]
@@ -578,7 +585,7 @@ mod tests {
             binding: &ChannelBinding,
         ) -> Result<ChannelBinding, SessionError> {
             self.bindings.insert(
-                (binding.channel_type.clone(), binding.chat_id.clone()),
+                (binding.channel_type, binding.chat_id.clone()),
                 binding.clone(),
             );
             Ok(binding.clone())
@@ -586,12 +593,12 @@ mod tests {
 
         async fn get_channel_binding(
             &self,
-            channel_type: &str,
+            channel_type: ChannelType,
             chat_id: &str,
         ) -> Result<Option<ChannelBinding>, SessionError> {
             Ok(self
                 .bindings
-                .get(&(channel_type.to_owned(), chat_id.to_owned()))
+                .get(&(channel_type, chat_id.to_owned()))
                 .map(|binding| binding.clone()))
         }
 

--- a/crates/cmd/src/chat/mod.rs
+++ b/crates/cmd/src/chat/mod.rs
@@ -568,7 +568,7 @@ async fn handle_new_session(state: &mut ChatState, kernel_handle: &KernelHandle)
     // Use the short UUID prefix as the CLI alias for the new session.
     let new_alias = short_session_key(&created.key);
     let binding = ChannelBinding {
-        channel_type: "cli".to_owned(),
+        channel_type: ChannelType::Cli,
         chat_id:      new_alias.clone(),
         session_key:  created.key,
         created_at:   now,
@@ -612,7 +612,7 @@ async fn handle_list_sessions(
 
     // Resolve the current session's internal key for comparison.
     let current_internal_key = session_index
-        .get_channel_binding("cli", current_session_key)
+        .get_channel_binding(ChannelType::Cli, current_session_key)
         .await
         .ok()
         .flatten()
@@ -683,7 +683,7 @@ async fn handle_switch_session(
     let new_alias = short_session_key(&entry.key);
     let now = Utc::now();
     let binding = ChannelBinding {
-        channel_type: "cli".to_owned(),
+        channel_type: ChannelType::Cli,
         chat_id:      new_alias.clone(),
         session_key:  entry.key,
         created_at:   now,
@@ -800,7 +800,7 @@ async fn get_or_create_cli_session(
     chat_id: &str,
 ) -> Result<SessionKey, Whatever> {
     if let Some(binding) = session_index
-        .get_channel_binding("cli", chat_id)
+        .get_channel_binding(ChannelType::Cli, chat_id)
         .await
         .whatever_context("Failed to load CLI channel binding")?
     {
@@ -824,7 +824,7 @@ async fn get_or_create_cli_session(
         .await
         .whatever_context("Failed to create CLI chat session")?;
     let binding = ChannelBinding {
-        channel_type: "cli".to_owned(),
+        channel_type: ChannelType::Cli,
         chat_id:      chat_id.to_owned(),
         session_key:  created.key.clone(),
         created_at:   now,
@@ -1073,7 +1073,7 @@ async fn poll_crossterm_event() -> Option<Event> {
 mod tests {
     use rara_channels::terminal::CliEvent;
     use rara_kernel::{
-        channel::types::{ContentBlock, MessageContent},
+        channel::types::{ChannelType, ContentBlock, MessageContent},
         identity::UserId,
         io::StreamEvent,
         session::SessionIndex,
@@ -1099,7 +1099,7 @@ mod tests {
             .await
             .expect("second session");
         let binding = session_index
-            .get_channel_binding("cli", "default")
+            .get_channel_binding(ChannelType::Cli, "default")
             .await
             .expect("binding query")
             .expect("binding");

--- a/crates/extensions/backend-admin/src/chat/router.rs
+++ b/crates/extensions/backend-admin/src/chat/router.rs
@@ -37,7 +37,10 @@ use axum::{
     extract::{Path, Query, State},
     http::StatusCode,
 };
-use rara_kernel::{cascade::CascadeTrace, channel::types::ChatMessage};
+use rara_kernel::{
+    cascade::CascadeTrace,
+    channel::types::{ChannelType, ChatMessage},
+};
 use rara_sessions::types::{ChannelBinding, SessionEntry, SessionKey};
 use serde::Deserialize;
 use tracing::instrument;
@@ -50,6 +53,13 @@ use crate::chat::{error::ChatError, model_catalog::ChatModel, service::SessionSe
 fn parse_session_key(raw: &str) -> Result<SessionKey, ChatError> {
     SessionKey::try_from_raw(raw).map_err(|_| ChatError::InvalidRequest {
         message: format!("invalid session key: {raw}"),
+    })
+}
+
+/// Parse a channel type from a URL path / request body parameter.
+fn parse_channel_type(raw: &str) -> Result<ChannelType, ChatError> {
+    raw.parse().map_err(|_| ChatError::InvalidRequest {
+        message: format!("unknown channel type: {raw}"),
     })
 }
 
@@ -388,7 +398,7 @@ async fn bind_channel(
 ) -> Result<Json<ChannelBinding>, ChatError> {
     let binding = service
         .bind_channel(
-            req.channel_type,
+            parse_channel_type(&req.channel_type)?,
             req.chat_id,
             parse_session_key(&req.session_key)?,
         )
@@ -415,6 +425,8 @@ async fn get_channel_binding(
     State(service): State<SessionService>,
     Path((channel_type, chat_id)): Path<(String, String)>,
 ) -> Result<Json<Option<ChannelBinding>>, ChatError> {
-    let binding = service.get_channel_session(&channel_type, &chat_id).await?;
+    let binding = service
+        .get_channel_session(parse_channel_type(&channel_type)?, &chat_id)
+        .await?;
     Ok(Json(binding))
 }

--- a/crates/extensions/backend-admin/src/chat/service.rs
+++ b/crates/extensions/backend-admin/src/chat/service.rs
@@ -30,7 +30,9 @@ use rara_kernel::{
     cascade::{
         CascadeTrace, build_cascade, find_turn_boundaries, load_persisted_cascade, turn_slice,
     },
-    channel::types::{ChatMessage, MessageContent, MessageRole, ToolCall as ChannelToolCall},
+    channel::types::{
+        ChannelType, ChatMessage, MessageContent, MessageRole, ToolCall as ChannelToolCall,
+    },
     llm::{Message, Role},
     memory::{TapEntry, TapEntryKind, TapeService},
     session::SessionIndexRef,
@@ -344,7 +346,7 @@ impl SessionService {
     #[instrument(skip(self))]
     pub async fn bind_channel(
         &self,
-        channel_type: String,
+        channel_type: ChannelType,
         chat_id: String,
         session_key: SessionKey,
     ) -> Result<ChannelBinding, ChatError> {
@@ -364,7 +366,7 @@ impl SessionService {
     #[instrument(skip(self))]
     pub async fn get_channel_session(
         &self,
-        channel_type: &str,
+        channel_type: ChannelType,
         chat_id: &str,
     ) -> Result<Option<ChannelBinding>, ChatError> {
         let binding = self

--- a/crates/kernel/src/channel/types.rs
+++ b/crates/kernel/src/channel/types.rs
@@ -41,6 +41,7 @@ use serde::{Deserialize, Serialize};
     Serialize,
     Deserialize,
     strum::Display,
+    strum::EnumString,
     strum::IntoStaticStr,
 )]
 #[serde(rename_all = "snake_case")]
@@ -349,7 +350,7 @@ pub struct ChannelMessage {
     /// The user who sent this message.
     pub user:         ChannelUser,
     /// Session key for conversation continuity.
-    pub session_key:  String,
+    pub session_key:  crate::session::SessionKey,
     /// Message role.
     pub role:         MessageRole,
     /// Message content.

--- a/crates/kernel/src/io.rs
+++ b/crates/kernel/src/io.rs
@@ -1585,7 +1585,7 @@ impl IOSubsystem {
             Some(chat_id) => {
                 match self
                     .session_index
-                    .get_channel_binding(&raw.channel_type.to_string(), chat_id)
+                    .get_channel_binding(raw.channel_type, chat_id)
                     .await
                 {
                     Ok(Some(binding)) => {

--- a/crates/kernel/src/kernel.rs
+++ b/crates/kernel/src/kernel.rs
@@ -1212,7 +1212,7 @@ impl Kernel {
                 // IOSubsystem can resolve future messages from this chat.
                 if let Some(chat_id) = msg.source.platform_chat_id.as_deref() {
                     let binding = crate::session::ChannelBinding {
-                        channel_type: msg.source.channel_type.to_string(),
+                        channel_type: msg.source.channel_type,
                         chat_id:      chat_id.to_string(),
                         session_key:  session.key.clone(),
                         created_at:   now,
@@ -1493,7 +1493,7 @@ impl Kernel {
                 };
                 if let Some(chat_id) = msg.source.platform_chat_id.as_deref() {
                     let binding = crate::session::ChannelBinding {
-                        channel_type: msg.source.channel_type.to_string(),
+                        channel_type: msg.source.channel_type,
                         chat_id:      chat_id.to_string(),
                         session_key:  session.key.clone(),
                         created_at:   now,

--- a/crates/kernel/src/session/mod.rs
+++ b/crates/kernel/src/session/mod.rs
@@ -139,8 +139,10 @@ pub struct SessionEntry {
 /// a binding with the same composite key will update the target session.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ChannelBinding {
-    /// Channel type identifier, e.g. `"telegram"`, `"slack"`, `"web"`.
-    pub channel_type: String,
+    /// Channel type identifier, e.g.
+    /// [`crate::channel::types::ChannelType::Telegram`],
+    /// [`crate::channel::types::ChannelType::Web`].
+    pub channel_type: crate::channel::types::ChannelType,
     /// External chat or conversation identifier within the channel
     /// (e.g. Telegram chat id, Slack channel id).
     pub chat_id:      String,
@@ -190,7 +192,7 @@ pub trait SessionIndex: Send + Sync + 'static {
     /// Resolve a channel binding by `(channel_type, chat_id)`.
     async fn get_channel_binding(
         &self,
-        channel_type: &str,
+        channel_type: crate::channel::types::ChannelType,
         chat_id: &str,
     ) -> Result<Option<ChannelBinding>, SessionError>;
 

--- a/crates/kernel/src/session/test_utils.rs
+++ b/crates/kernel/src/session/test_utils.rs
@@ -21,12 +21,13 @@ use chrono::Utc;
 use dashmap::DashMap;
 
 use super::{ChannelBinding, SessionEntry, SessionError, SessionIndex, SessionKey};
+use crate::channel::types::ChannelType;
 
 /// A minimal in-memory [`SessionIndex`] for unit tests.
 #[derive(Default)]
 pub(crate) struct InMemorySessionIndex {
     pub sessions: DashMap<String, SessionEntry>,
-    pub bindings: DashMap<(String, String), ChannelBinding>,
+    pub bindings: DashMap<(ChannelType, String), ChannelBinding>,
 }
 
 impl InMemorySessionIndex {
@@ -80,7 +81,7 @@ impl SessionIndex for InMemorySessionIndex {
 
     async fn bind_channel(&self, binding: &ChannelBinding) -> Result<ChannelBinding, SessionError> {
         self.bindings.insert(
-            (binding.channel_type.clone(), binding.chat_id.clone()),
+            (binding.channel_type, binding.chat_id.clone()),
             binding.clone(),
         );
         Ok(binding.clone())
@@ -88,12 +89,12 @@ impl SessionIndex for InMemorySessionIndex {
 
     async fn get_channel_binding(
         &self,
-        channel_type: &str,
+        channel_type: ChannelType,
         chat_id: &str,
     ) -> Result<Option<ChannelBinding>, SessionError> {
         Ok(self
             .bindings
-            .get(&(channel_type.to_owned(), chat_id.to_owned()))
+            .get(&(channel_type, chat_id.to_owned()))
             .map(|entry| entry.clone()))
     }
 

--- a/crates/kernel/tests/anchor_checkout_e2e.rs
+++ b/crates/kernel/tests/anchor_checkout_e2e.rs
@@ -80,7 +80,7 @@ impl SessionIndex for TestSessionIndex {
 
     async fn get_channel_binding(
         &self,
-        _channel_type: &str,
+        _channel_type: rara_kernel::channel::types::ChannelType,
         _chat_id: &str,
     ) -> Result<Option<ChannelBinding>, SessionError> {
         Ok(None)

--- a/crates/rara-dock/src/routes.rs
+++ b/crates/rara-dock/src/routes.rs
@@ -253,7 +253,7 @@ async fn ensure_dock_kernel_session(
     index.create_session(&entry).await?;
 
     let binding = ChannelBinding {
-        channel_type: "web".to_string(),
+        channel_type: rara_kernel::channel::types::ChannelType::Web,
         chat_id: dock_session_id.to_string(),
         session_key,
         created_at: now,

--- a/crates/sessions/src/file_index.rs
+++ b/crates/sessions/src/file_index.rs
@@ -22,7 +22,10 @@
 use std::path::{Path, PathBuf};
 
 use async_trait::async_trait;
-use rara_kernel::session::{ChannelBinding, SessionEntry, SessionError, SessionIndex, SessionKey};
+use rara_kernel::{
+    channel::types::ChannelType,
+    session::{ChannelBinding, SessionEntry, SessionError, SessionIndex, SessionKey},
+};
 use tokio::fs;
 
 /// File-based implementation of [`SessionIndex`].
@@ -185,11 +188,12 @@ impl SessionIndex for FileSessionIndex {
     }
 
     async fn bind_channel(&self, binding: &ChannelBinding) -> Result<ChannelBinding, SessionError> {
-        let path = self.binding_path(&binding.channel_type, &binding.chat_id);
-        let tmp = self.index_dir.join("bindings").join(format!(
-            "{}_{}.json.tmp",
-            binding.channel_type, binding.chat_id
-        ));
+        let ct = binding.channel_type.to_string();
+        let path = self.binding_path(&ct, &binding.chat_id);
+        let tmp = self
+            .index_dir
+            .join("bindings")
+            .join(format!("{}_{}.json.tmp", ct, binding.chat_id));
 
         let data =
             serde_json::to_vec_pretty(binding).map_err(|source| SessionError::Json { source })?;
@@ -199,10 +203,10 @@ impl SessionIndex for FileSessionIndex {
 
     async fn get_channel_binding(
         &self,
-        channel_type: &str,
+        channel_type: ChannelType,
         chat_id: &str,
     ) -> Result<Option<ChannelBinding>, SessionError> {
-        let path = self.binding_path(channel_type, chat_id);
+        let path = self.binding_path(&channel_type.to_string(), chat_id);
         self.read_json(&path).await
     }
 


### PR DESCRIPTION
Closes #1120

ChannelMessage.session_key was String instead of the existing SessionKey newtype, and ChannelBinding.channel_type was String instead of the existing ChannelType enum. Both types already existed — just not used where they should be.