### PR TITLE
refactor(kernel): introduce ToolName newtype for type-safe tool identifiers (#1123)

### DIFF
--- a/crates/agents/src/lib.rs
+++ b/crates/agents/src/lib.rs
@@ -31,7 +31,10 @@
 
 use std::sync::LazyLock;
 
-use rara_kernel::agent::{AgentManifest, AgentRole, Priority};
+use rara_kernel::{
+    agent::{AgentManifest, AgentRole, Priority},
+    tool::ToolName,
+};
 
 static RARA_MANIFEST: LazyLock<AgentManifest> = LazyLock::new(|| AgentManifest {
     name:                   "rara".to_string(),
@@ -70,7 +73,7 @@ static NANA_MANIFEST: LazyLock<AgentManifest> = LazyLock::new(|| AgentManifest {
     soul_prompt:            None,
     provider_hint:          None,
     max_iterations:         Some(10),
-    tools:                  vec!["tape".to_string()],
+    tools:                  vec![ToolName::new("tape")],
     excluded_tools:         vec![],
     max_children:           Some(0),
     max_context_tokens:     None,
@@ -130,16 +133,16 @@ static MITA_MANIFEST: LazyLock<AgentManifest> = LazyLock::new(|| AgentManifest {
     provider_hint:          None,
     max_iterations:         Some(20),
     tools:                  vec![
-        "tape".to_string(),
-        "list-sessions".to_string(),
-        "read-tape".to_string(),
-        "dispatch-rara".to_string(),
-        "write-user-note".to_string(),
-        "distill-user-notes".to_string(),
-        "update-soul-state".to_string(),
-        "evolve-soul".to_string(),
-        "update-session-title".to_string(),
-        "write-skill-draft".to_string(),
+        ToolName::new("tape"),
+        ToolName::new("list-sessions"),
+        ToolName::new("read-tape"),
+        ToolName::new("dispatch-rara"),
+        ToolName::new("write-user-note"),
+        ToolName::new("distill-user-notes"),
+        ToolName::new("update-soul-state"),
+        ToolName::new("evolve-soul"),
+        ToolName::new("update-session-title"),
+        ToolName::new("write-skill-draft"),
     ],
     excluded_tools:         vec![],
     max_children:           Some(0),

--- a/crates/app/src/tools/mod.rs
+++ b/crates/app/src/tools/mod.rs
@@ -106,27 +106,24 @@ use write_file::WriteFileTool;
 /// Only **Core** tools appear here. All other tools are registered in the
 /// [`ToolRegistry`] but marked `tier = "deferred"` and discovered on demand
 /// via the `discover-tools` tool.
-pub fn rara_tool_names() -> Vec<String> {
-    use rara_kernel::tool_names;
+pub fn rara_tool_names() -> Vec<rara_kernel::tool::ToolName> {
+    use rara_kernel::{tool::ToolName, tool_names};
 
     vec![
         // File operations
-        BashTool::TOOL_NAME,
-        GrepTool::TOOL_NAME,
-        ReadFileTool::TOOL_NAME,
-        WriteFileTool::TOOL_NAME,
-        EditFileTool::TOOL_NAME,
-        ListDirectoryTool::TOOL_NAME,
-        FindFilesTool::TOOL_NAME,
+        ToolName::new(BashTool::TOOL_NAME),
+        ToolName::new(GrepTool::TOOL_NAME),
+        ToolName::new(ReadFileTool::TOOL_NAME),
+        ToolName::new(WriteFileTool::TOOL_NAME),
+        ToolName::new(EditFileTool::TOOL_NAME),
+        ToolName::new(ListDirectoryTool::TOOL_NAME),
+        ToolName::new(FindFilesTool::TOOL_NAME),
         // Tape memory (2 Core; info/anchors/entries/between/checkout are Deferred)
-        tool_names::TAPE_ANCHOR,
-        tool_names::TAPE_SEARCH,
+        tool_names::TAPE_ANCHOR.clone(),
+        tool_names::TAPE_SEARCH.clone(),
         // Discovery
-        DiscoverToolsTool::TOOL_NAME,
+        ToolName::new(DiscoverToolsTool::TOOL_NAME),
     ]
-    .into_iter()
-    .map(String::from)
-    .collect()
 }
 
 /// Dependencies required to construct all tools.

--- a/crates/extensions/backend-admin/src/agents/router.rs
+++ b/crates/extensions/backend-admin/src/agents/router.rs
@@ -19,7 +19,7 @@ use axum::{
     response::{IntoResponse, Response},
     routing::get,
 };
-use rara_kernel::{agent::AgentManifest, handle::KernelHandle};
+use rara_kernel::{agent::AgentManifest, handle::KernelHandle, tool::ToolName};
 use serde::{Deserialize, Serialize};
 
 // ---------------------------------------------------------------------------
@@ -47,7 +47,7 @@ impl AgentResponse {
             role: Some(format!("{:?}", m.role)),
             provider_hint: m.provider_hint.clone(),
             max_iterations: m.max_iterations,
-            tools: m.tools.clone(),
+            tools: m.tools.iter().map(|t| t.to_string()).collect(),
             builtin,
         }
     }
@@ -164,7 +164,7 @@ async fn create_agent(
         soul_prompt:            req.soul_prompt,
         provider_hint:          req.provider_hint,
         max_iterations:         req.max_iterations,
-        tools:                  req.tools,
+        tools:                  req.tools.into_iter().map(ToolName::from).collect(),
         excluded_tools:         vec![],
         max_children:           None,
         max_context_tokens:     None,

--- a/crates/kernel/src/agent/mod.rs
+++ b/crates/kernel/src/agent/mod.rs
@@ -226,14 +226,14 @@ pub struct AgentManifest {
     /// Tool names this agent is allowed to use (empty = inherit parent's
     /// tools).
     #[serde(default)]
-    pub tools:                  Vec<String>,
+    pub tools:                  Vec<crate::tool::ToolName>,
     /// Tool names the agent is NOT allowed to use (denylist).
     ///
     /// Applied after `tools` allowlist filtering. If `tools` is empty (inherit
     /// all), excluded tools are removed from the full set. If `tools` is
     /// explicit, excluded tools are additionally removed.
     #[serde(default)]
-    pub excluded_tools:         Vec<String>,
+    pub excluded_tools:         Vec<crate::tool::ToolName>,
     /// Maximum number of concurrent child agents this agent can spawn.
     #[serde(default)]
     pub max_children:           Option<usize>,
@@ -991,7 +991,7 @@ pub(crate) async fn run_agent_loop(
 
     // Deferred tool activation state — persists across turns within the same
     // session so the LLM does not need to re-discover tools after each message.
-    let mut activated_deferred: std::collections::HashSet<String> = handle
+    let mut activated_deferred: std::collections::HashSet<crate::tool::ToolName> = handle
         .process_table()
         .with(&session_key, |s| s.activated_deferred.clone())
         .unwrap_or_default();
@@ -2069,11 +2069,11 @@ pub(crate) async fn run_agent_loop(
                             "tool call blocked by guard, requesting user approval"
                         );
 
-                        let risk_level = crate::security::ApprovalManager::classify_risk(&blocked_tool);
+                        let risk_level = crate::security::ApprovalManager::classify_risk(blocked_tool.as_str());
                         let approval_req = crate::security::ApprovalRequest {
                             id:           uuid::Uuid::new_v4(),
                             session_key:  session_key_for_guard,
-                            tool_name:    blocked_tool.clone(),
+                            tool_name:    blocked_tool.to_string(),
                             tool_args:    args.clone(),
                             summary:      format!("Guard blocked ({layer}): {reason}"),
                             risk_level,
@@ -2107,7 +2107,7 @@ pub(crate) async fn run_agent_loop(
                                 notification_bus
                                     .publish(KernelNotification::GuardDenied {
                                         agent_id,
-                                        tool_name: blocked_tool.clone(),
+                                        tool_name: blocked_tool.to_string(),
                                         reason: reason.clone(),
                                         timestamp: jiff::Timestamp::now(),
                                     })
@@ -2309,7 +2309,7 @@ pub(crate) async fn run_agent_loop(
                             result.clone(),
                         ) {
                             for entry in &parsed.tools {
-                                activated_deferred.insert(entry.name.clone());
+                                activated_deferred.insert(crate::tool::ToolName::new(&entry.name));
                             }
                         }
                     }

--- a/crates/kernel/src/guard/pipeline.rs
+++ b/crates/kernel/src/guard/pipeline.rs
@@ -60,7 +60,7 @@ pub enum GuardVerdict {
         /// Human-readable reason.
         reason:    String,
         /// The tool that was blocked.
-        tool_name: String,
+        tool_name: crate::tool::ToolName,
     },
 }
 
@@ -99,7 +99,7 @@ impl GuardPipeline {
             return GuardVerdict::Blocked {
                 layer:     GuardLayer::Taint,
                 reason:    violation.to_string(),
-                tool_name: tool_name.to_string(),
+                tool_name: crate::tool::ToolName::new(tool_name),
             };
         }
 
@@ -117,7 +117,7 @@ impl GuardPipeline {
                     "{}: matched '{}'",
                     critical.rule_name, critical.matched_pattern
                 ),
-                tool_name: tool_name.to_string(),
+                tool_name: crate::tool::ToolName::new(tool_name),
             };
         }
 
@@ -126,7 +126,7 @@ impl GuardPipeline {
             return GuardVerdict::Blocked {
                 layer: GuardLayer::PathScope,
                 reason,
-                tool_name: tool_name.to_string(),
+                tool_name: crate::tool::ToolName::new(tool_name),
             };
         }
 

--- a/crates/kernel/src/identity.rs
+++ b/crates/kernel/src/identity.rs
@@ -47,7 +47,7 @@ pub enum Permission {
     /// Can use all tools without restriction.
     UseAllTools,
     /// Can use a specific named tool.
-    UseTool(String),
+    UseTool(crate::tool::ToolName),
     /// Can manage skills.
     ManageSkills,
     /// Can manage MCP servers.
@@ -74,7 +74,10 @@ impl KernelUser {
     pub fn can_use_tool(&self, tool_name: &str) -> bool {
         self.has_permission(&Permission::All)
             || self.has_permission(&Permission::UseAllTools)
-            || self.has_permission(&Permission::UseTool(tool_name.to_string()))
+            || self
+                .permissions
+                .iter()
+                .any(|p| matches!(p, Permission::UseTool(n) if n.as_str() == tool_name))
     }
 }
 
@@ -190,7 +193,10 @@ mod tests {
         let user = KernelUser {
             name:        "limited".into(),
             role:        Role::User,
-            permissions: vec![Permission::Spawn, Permission::UseTool("http-fetch".into())],
+            permissions: vec![
+                Permission::Spawn,
+                Permission::UseTool(crate::tool::ToolName::new("http-fetch")),
+            ],
             enabled:     true,
         };
         assert!(user.can_use_tool("http-fetch"));

--- a/crates/kernel/src/lib.rs
+++ b/crates/kernel/src/lib.rs
@@ -61,56 +61,68 @@ pub mod user_question;
 /// Tool name constants for kernel-provided tools.
 ///
 /// External crates use these for manifest construction without
-/// accessing internal tool modules or structs.
+/// accessing internal tool modules or structs. Each constant is a
+/// [`ToolName`](tool::ToolName) wrapped in `LazyLock` for zero-cost
+/// reuse.
 pub mod tool_names {
-    pub const TAPE_INFO: &str = "tape-info";
-    pub const TAPE_SEARCH: &str = "tape-search";
-    pub const TAPE_ANCHOR: &str = "tape-anchor";
-    pub const TAPE_ANCHORS: &str = "tape-anchors";
-    pub const TAPE_ENTRIES: &str = "tape-entries";
-    pub const TAPE_BETWEEN: &str = "tape-between";
-    pub const TAPE_CHECKOUT: &str = "tape-checkout";
-    pub const TAPE_CHECKOUT_ROOT: &str = "tape-checkout-root";
-    pub const CREATE_PLAN: &str = "create-plan";
-    pub const KERNEL: &str = "kernel";
-    pub const MEMORY: &str = "memory";
-    pub const SCHEDULE_ONCE: &str = "schedule-once";
-    pub const SCHEDULE_INTERVAL: &str = "schedule-interval";
-    pub const SCHEDULE_CRON: &str = "schedule-cron";
-    pub const SCHEDULE_REMOVE: &str = "schedule-remove";
-    pub const SCHEDULE_LIST: &str = "schedule-list";
-    pub const SPAWN_BACKGROUND: &str = "spawn-background";
-    pub const CANCEL_BACKGROUND: &str = "cancel-background";
-    pub const TASK: &str = "task";
-    pub const FOLD_BRANCH: &str = "fold-branch";
+    use std::sync::LazyLock;
+
+    use super::tool::ToolName;
+
+    macro_rules! tool {
+        ($name:ident, $val:expr) => {
+            pub static $name: LazyLock<ToolName> = LazyLock::new(|| ToolName::new($val));
+        };
+    }
+
+    tool!(TAPE_INFO, "tape-info");
+    tool!(TAPE_SEARCH, "tape-search");
+    tool!(TAPE_ANCHOR, "tape-anchor");
+    tool!(TAPE_ANCHORS, "tape-anchors");
+    tool!(TAPE_ENTRIES, "tape-entries");
+    tool!(TAPE_BETWEEN, "tape-between");
+    tool!(TAPE_CHECKOUT, "tape-checkout");
+    tool!(TAPE_CHECKOUT_ROOT, "tape-checkout-root");
+    tool!(CREATE_PLAN, "create-plan");
+    tool!(KERNEL, "kernel");
+    tool!(MEMORY, "memory");
+    tool!(SCHEDULE_ONCE, "schedule-once");
+    tool!(SCHEDULE_INTERVAL, "schedule-interval");
+    tool!(SCHEDULE_CRON, "schedule-cron");
+    tool!(SCHEDULE_REMOVE, "schedule-remove");
+    tool!(SCHEDULE_LIST, "schedule-list");
+    tool!(SPAWN_BACKGROUND, "spawn-background");
+    tool!(CANCEL_BACKGROUND, "cancel-background");
+    tool!(TASK, "task");
+    tool!(FOLD_BRANCH, "fold-branch");
 
     // App-layer tools referenced by kernel presets
-    pub const BASH: &str = "bash";
-    pub const READ_FILE: &str = "read-file";
-    pub const WRITE_FILE: &str = "write-file";
-    pub const EDIT_FILE: &str = "edit-file";
-    pub const LIST_DIRECTORY: &str = "list-directory";
-    pub const GREP: &str = "grep";
-    pub const FIND_FILES: &str = "find-files";
-    pub const WALK_DIRECTORY: &str = "walk-directory";
+    tool!(BASH, "bash");
+    tool!(READ_FILE, "read-file");
+    tool!(WRITE_FILE, "write-file");
+    tool!(EDIT_FILE, "edit-file");
+    tool!(LIST_DIRECTORY, "list-directory");
+    tool!(GREP, "grep");
+    tool!(FIND_FILES, "find-files");
+    tool!(WALK_DIRECTORY, "walk-directory");
 
     // Browser tools
-    pub const BROWSER_NAVIGATE: &str = "browser-navigate";
-    pub const BROWSER_NAVIGATE_BACK: &str = "browser-navigate-back";
-    pub const BROWSER_SNAPSHOT: &str = "browser-snapshot";
-    pub const BROWSER_CLICK: &str = "browser-click";
-    pub const BROWSER_TYPE: &str = "browser-type";
-    pub const BROWSER_PRESS_KEY: &str = "browser-press-key";
-    pub const BROWSER_EVALUATE: &str = "browser-evaluate";
-    pub const BROWSER_WAIT_FOR: &str = "browser-wait-for";
-    pub const BROWSER_TABS: &str = "browser-tabs";
-    pub const BROWSER_CLOSE: &str = "browser-close";
+    tool!(BROWSER_NAVIGATE, "browser-navigate");
+    tool!(BROWSER_NAVIGATE_BACK, "browser-navigate-back");
+    tool!(BROWSER_SNAPSHOT, "browser-snapshot");
+    tool!(BROWSER_CLICK, "browser-click");
+    tool!(BROWSER_TYPE, "browser-type");
+    tool!(BROWSER_PRESS_KEY, "browser-press-key");
+    tool!(BROWSER_EVALUATE, "browser-evaluate");
+    tool!(BROWSER_WAIT_FOR, "browser-wait-for");
+    tool!(BROWSER_TABS, "browser-tabs");
+    tool!(BROWSER_CLOSE, "browser-close");
 
     // ACP delegation
-    pub const ACP_DELEGATE: &str = "acp-delegate";
+    tool!(ACP_DELEGATE, "acp-delegate");
 
     // User interaction
-    pub const ASK_USER: &str = "ask-user";
+    tool!(ASK_USER, "ask-user");
 }
 
 pub use error::{KernelError, Result};

--- a/crates/kernel/src/plan.rs
+++ b/crates/kernel/src/plan.rs
@@ -1021,7 +1021,7 @@ async fn execute_worker_step(
         soul_prompt:            None,
         provider_hint:          None,
         max_iterations:         Some(WORKER_MAX_ITERATIONS),
-        tools:                  vec!["*".to_string()], // inherit all tools
+        tools:                  vec![crate::tool::ToolName::new("*")], // inherit all tools
         excluded_tools:         vec![],
         max_children:           None,
         max_context_tokens:     None,

--- a/crates/kernel/src/session/mod.rs
+++ b/crates/kernel/src/session/mod.rs
@@ -336,7 +336,7 @@ pub struct Session {
     /// Deferred tools activated via `discover-tools` during this session.
     /// Persists across turns so the LLM does not need to re-discover tools
     /// after each user message.
-    pub activated_deferred: std::collections::HashSet<String>,
+    pub activated_deferred: std::collections::HashSet<crate::tool::ToolName>,
     /// Per-session semaphore limiting concurrent child sessions.
     pub child_semaphore: Arc<Semaphore>,
     /// Permit from the *parent*'s `child_semaphore`.

--- a/crates/kernel/src/syscall.rs
+++ b/crates/kernel/src/syscall.rs
@@ -831,7 +831,7 @@ pub struct SyscallTool {
 }
 
 impl SyscallTool {
-    pub const NAME: &str = crate::tool_names::KERNEL;
+    pub const NAME: &str = "kernel";
 
     pub fn new(handle: KernelHandle, session_key: SessionKey) -> Self {
         Self {

--- a/crates/kernel/src/tool/fold_branch.rs
+++ b/crates/kernel/src/tool/fold_branch.rs
@@ -114,7 +114,7 @@ pub struct FoldBranchParams {
     /// Detailed instruction for the child agent.
     instruction:    String,
     /// Tool names the child agent can use (inherits parent if omitted).
-    tools:          Option<Vec<String>>,
+    tools:          Option<Vec<crate::tool::ToolName>>,
     /// Maximum LLM iterations for the child agent.
     max_iterations: Option<usize>,
     /// Timeout in seconds for the child agent (default: 120).

--- a/crates/kernel/src/tool/mod.rs
+++ b/crates/kernel/src/tool/mod.rs
@@ -26,16 +26,63 @@ mod background_common;
 use std::{collections::HashMap, sync::Arc};
 
 use async_trait::async_trait;
-use serde::de::DeserializeOwned;
+use serde::{Deserialize, Serialize, de::DeserializeOwned};
+
+/// Type-safe wrapper for tool identifiers.
+///
+/// Replaces bare `String` / `&str` in tool registries, manifests, and
+/// permission checks so the compiler can distinguish tool names from
+/// other string-typed fields.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, schemars::JsonSchema)]
+#[serde(transparent)]
+pub struct ToolName(String);
+
+impl ToolName {
+    /// Create a new `ToolName` from anything that can become a `String`.
+    pub fn new(name: impl Into<String>) -> Self { Self(name.into()) }
+
+    /// Borrow the inner string slice.
+    pub fn as_str(&self) -> &str { &self.0 }
+}
+
+impl std::fmt::Display for ToolName {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result { self.0.fmt(f) }
+}
+
+impl AsRef<str> for ToolName {
+    fn as_ref(&self) -> &str { &self.0 }
+}
+
+impl From<String> for ToolName {
+    fn from(s: String) -> Self { Self(s) }
+}
+
+impl From<&str> for ToolName {
+    fn from(s: &str) -> Self { Self(s.to_owned()) }
+}
+
+impl std::borrow::Borrow<str> for ToolName {
+    fn borrow(&self) -> &str { &self.0 }
+}
+
+impl PartialEq<str> for ToolName {
+    fn eq(&self, other: &str) -> bool { self.0 == other }
+}
+
+impl PartialEq<&str> for ToolName {
+    fn eq(&self, other: &&str) -> bool { self.0 == *other }
+}
 
 /// Tool names that background/child agents must never have access to,
 /// preventing recursive subagent spawning.
-pub(crate) const RECURSIVE_TOOL_DENYLIST: &[&str] = &[
-    crate::tool_names::TASK,
-    crate::tool_names::SPAWN_BACKGROUND,
-    crate::tool_names::CREATE_PLAN,
-    crate::tool_names::ASK_USER,
-];
+pub(crate) fn recursive_tool_denylist() -> Vec<ToolName> {
+    vec![
+        crate::tool_names::TASK.clone(),
+        crate::tool_names::SPAWN_BACKGROUND.clone(),
+        crate::tool_names::CREATE_PLAN.clone(),
+        crate::tool_names::ASK_USER.clone(),
+    ]
+}
 
 /// Typed tool execution trait.
 ///
@@ -342,7 +389,7 @@ pub trait AgentTool: Send + Sync {
 /// Registry of available tools for an agent run.
 #[derive(Clone)]
 pub struct ToolRegistry {
-    tools: HashMap<String, AgentToolRef>,
+    tools: HashMap<ToolName, AgentToolRef>,
 }
 
 impl ToolRegistry {
@@ -356,10 +403,11 @@ impl ToolRegistry {
     /// Register a tool. Returns the previously registered tool with the same
     /// name, if any.
     pub fn register(&mut self, tool: AgentToolRef) -> Option<AgentToolRef> {
-        let name = tool.name().to_owned();
+        let name = ToolName::new(tool.name());
         self.tools.insert(name, tool)
     }
 
+    /// Look up a tool by name.
     pub fn get(&self, name: &str) -> Option<&AgentToolRef> { self.tools.get(name) }
 
     #[must_use]
@@ -368,6 +416,7 @@ impl ToolRegistry {
     #[must_use]
     pub fn len(&self) -> usize { self.tools.len() }
 
+    /// Iterate over `(name, tool)` pairs.
     pub fn iter(&self) -> impl Iterator<Item = (&str, &AgentToolRef)> {
         self.tools.iter().map(|(name, tool)| (name.as_str(), tool))
     }
@@ -377,11 +426,13 @@ impl ToolRegistry {
     #[must_use]
     pub fn to_llm_tool_definitions_active(
         &self,
-        activated: &std::collections::HashSet<String>,
+        activated: &std::collections::HashSet<ToolName>,
     ) -> Vec<crate::llm::ToolDefinition> {
         self.tools
             .values()
-            .filter(|tool| tool.tier() == ToolTier::Core || activated.contains(tool.name()))
+            .filter(|tool| {
+                tool.tier() == ToolTier::Core || activated.contains(&ToolName::new(tool.name()))
+            })
             .map(|tool| crate::llm::ToolDefinition {
                 name:        tool.name().to_string(),
                 description: tool.description().to_string(),
@@ -395,11 +446,14 @@ impl ToolRegistry {
     #[must_use]
     pub fn deferred_catalog(
         &self,
-        activated: &std::collections::HashSet<String>,
+        activated: &std::collections::HashSet<ToolName>,
     ) -> Vec<(String, String)> {
         self.tools
             .values()
-            .filter(|tool| tool.tier() == ToolTier::Deferred && !activated.contains(tool.name()))
+            .filter(|tool| {
+                tool.tier() == ToolTier::Deferred
+                    && !activated.contains(&ToolName::new(tool.name()))
+            })
             .map(|tool| (tool.name().to_string(), tool.description().to_string()))
             .collect()
     }
@@ -420,7 +474,7 @@ impl ToolRegistry {
 
     /// Return the names of all registered tools.
     #[must_use]
-    pub fn tool_names(&self) -> Vec<String> { self.tools.keys().cloned().collect() }
+    pub fn tool_names(&self) -> Vec<ToolName> { self.tools.keys().cloned().collect() }
 
     /// Create a new registry containing only tools the user is authorized to
     /// use (based on `KernelUser::can_use_tool`).
@@ -428,7 +482,7 @@ impl ToolRegistry {
     pub fn filtered_by_user(&self, user: &crate::identity::KernelUser) -> Self {
         let mut new = Self::new();
         for (name, tool) in &self.tools {
-            if user.can_use_tool(name) {
+            if user.can_use_tool(name.as_str()) {
                 new.register(Arc::clone(tool));
             }
         }
@@ -441,12 +495,12 @@ impl ToolRegistry {
     ///   tools (no filtering).
     /// - Otherwise only tools whose name appears in `tool_names` are kept.
     #[must_use]
-    pub fn filtered(&self, tool_names: &[String]) -> Self {
-        if tool_names.is_empty() || tool_names.iter().any(|n| n == "*") {
+    pub fn filtered(&self, tool_names: &[ToolName]) -> Self {
+        if tool_names.is_empty() || tool_names.iter().any(|n| n.as_str() == "*") {
             return self.clone();
         }
         let allow: std::collections::HashSet<&str> =
-            tool_names.iter().map(String::as_str).collect();
+            tool_names.iter().map(ToolName::as_str).collect();
         let mut new = Self::new();
         for (name, tool) in &self.tools {
             if allow.contains(name.as_str()) {
@@ -462,12 +516,12 @@ impl ToolRegistry {
     /// if the manifest allowlist includes `discover-tools`, all deferred tools
     /// are retained so they can be discovered and activated at runtime.
     #[must_use]
-    pub fn filtered_for_manifest(&self, tool_names: &[String]) -> Self {
-        if tool_names.is_empty() || tool_names.iter().any(|n| n == "*") {
+    pub fn filtered_for_manifest(&self, tool_names: &[ToolName]) -> Self {
+        if tool_names.is_empty() || tool_names.iter().any(|n| n.as_str() == "*") {
             return self.clone();
         }
         let allow: std::collections::HashSet<&str> =
-            tool_names.iter().map(String::as_str).collect();
+            tool_names.iter().map(ToolName::as_str).collect();
         let keep_deferred = allow.contains("discover-tools");
         let mut new = Self::new();
         for (name, tool) in &self.tools {
@@ -481,8 +535,8 @@ impl ToolRegistry {
 
     /// Create a new registry excluding the named tools.
     #[must_use]
-    pub fn without(&self, excluded: &[String]) -> Self {
-        let deny: std::collections::HashSet<&str> = excluded.iter().map(String::as_str).collect();
+    pub fn without(&self, excluded: &[ToolName]) -> Self {
+        let deny: std::collections::HashSet<&str> = excluded.iter().map(ToolName::as_str).collect();
         let mut new = Self::new();
         for (name, tool) in &self.tools {
             if !deny.contains(name.as_str()) {
@@ -655,8 +709,8 @@ mod tests {
             role:        Role::User,
             permissions: vec![
                 Permission::Spawn,
-                Permission::UseTool("http-fetch".into()),
-                Permission::UseTool("read-file".into()),
+                Permission::UseTool(ToolName::new("http-fetch")),
+                Permission::UseTool(ToolName::new("read-file")),
             ],
             enabled:     true,
         };
@@ -678,14 +732,14 @@ mod tests {
     #[test]
     fn filtered_wildcard_returns_all() {
         let reg = build_registry();
-        let filtered = reg.filtered(&["*".to_string()]);
+        let filtered = reg.filtered(&[ToolName::new("*")]);
         assert_eq!(filtered.len(), 4, "wildcard '*' should return all tools");
     }
 
     #[test]
     fn filtered_specific_names() {
         let reg = build_registry();
-        let filtered = reg.filtered(&["bash".to_string(), "read-file".to_string()]);
+        let filtered = reg.filtered(&[ToolName::new("bash"), ToolName::new("read-file")]);
         assert_eq!(filtered.len(), 2);
         assert!(filtered.get("bash").is_some());
         assert!(filtered.get("read-file").is_some());
@@ -695,7 +749,7 @@ mod tests {
     #[test]
     fn without_excludes_named_tools() {
         let reg = build_registry();
-        let filtered = reg.without(&["bash".to_string(), "http-fetch".to_string()]);
+        let filtered = reg.without(&[ToolName::new("bash"), ToolName::new("http-fetch")]);
         assert_eq!(filtered.len(), 2);
         assert!(filtered.get("bash").is_none());
         assert!(filtered.get("http-fetch").is_none());
@@ -713,7 +767,7 @@ mod tests {
     #[test]
     fn filtered_unknown_names_ignored() {
         let reg = build_registry();
-        let filtered = reg.filtered(&["nonexistent".to_string()]);
+        let filtered = reg.filtered(&[ToolName::new("nonexistent")]);
         assert!(
             filtered.is_empty(),
             "unknown tool names should result in empty registry"
@@ -829,7 +883,7 @@ mod tests {
 
         // With activation: both tools
         let mut activated = HashSet::new();
-        activated.insert("deferred-tool".to_string());
+        activated.insert(ToolName::new("deferred-tool"));
         let defs = reg.to_llm_tool_definitions_active(&activated);
         assert_eq!(defs.len(), 2);
 

--- a/crates/kernel/src/tool/spawn_background.rs
+++ b/crates/kernel/src/tool/spawn_background.rs
@@ -21,7 +21,7 @@ use crate::{
     agent::{AgentManifest, AgentRole, Priority},
     handle::KernelHandle,
     session::SessionKey,
-    tool::{RECURSIVE_TOOL_DENYLIST, ToolContext, ToolExecute},
+    tool::{ToolContext, ToolExecute, ToolName, recursive_tool_denylist},
 };
 
 /// Builtin tool that spawns a background agent for long-running tasks.
@@ -69,7 +69,7 @@ pub struct SpawnBackgroundParams {
     name:           Option<String>,
     /// Tool names the agent can use (empty = inherit parent's tools).
     #[serde(default)]
-    tools:          Vec<String>,
+    tools:          Vec<ToolName>,
     /// LLM model override (uses the system default if omitted).
     #[serde(default)]
     model:          Option<String>,
@@ -92,10 +92,7 @@ impl ToolExecute for SpawnBackgroundTool {
             .name
             .unwrap_or_else(|| slug_from_description(&p.description));
 
-        let excluded_tools: Vec<String> = RECURSIVE_TOOL_DENYLIST
-            .iter()
-            .map(|s| (*s).to_owned())
-            .collect();
+        let excluded_tools = recursive_tool_denylist();
 
         // Build manifest from flat params + sensible defaults.
         let manifest = AgentManifest {

--- a/crates/kernel/src/tool/task/mod.rs
+++ b/crates/kernel/src/tool/task/mod.rs
@@ -181,11 +181,15 @@ mod tests {
         };
         assert_eq!(manifest.role, AgentRole::Worker);
         assert_eq!(manifest.max_children, Some(0));
-        assert!(manifest.excluded_tools.contains(&"task".to_string()));
         assert!(
             manifest
                 .excluded_tools
-                .contains(&"spawn-background".to_string())
+                .contains(&crate::tool::ToolName::new("task"))
+        );
+        assert!(
+            manifest
+                .excluded_tools
+                .contains(&crate::tool::ToolName::new("spawn-background"))
         );
         // general-purpose inherits all tools
         assert!(manifest.tools.is_empty());
@@ -195,9 +199,9 @@ mod tests {
     fn bash_preset_has_explicit_tools() {
         let preset = presets::get_preset("bash").unwrap();
         let manifest_tools = &preset.allowed_tools;
-        assert!(manifest_tools.contains(&"bash".to_string()));
-        assert!(manifest_tools.contains(&"read-file".to_string()));
+        assert!(manifest_tools.contains(&crate::tool::ToolName::new("bash")));
+        assert!(manifest_tools.contains(&crate::tool::ToolName::new("read-file")));
         // bash preset should NOT include task
-        assert!(!manifest_tools.contains(&"task".to_string()));
+        assert!(!manifest_tools.contains(&crate::tool::ToolName::new("task")));
     }
 }

--- a/crates/kernel/src/tool/task/presets.rs
+++ b/crates/kernel/src/tool/task/presets.rs
@@ -20,7 +20,10 @@
 
 use std::sync::LazyLock;
 
-use crate::{tool::RECURSIVE_TOOL_DENYLIST, tool_names};
+use crate::{
+    tool::{ToolName, recursive_tool_denylist},
+    tool_names,
+};
 
 /// Configuration for a predefined task type.
 ///
@@ -36,9 +39,9 @@ pub struct TaskTypeConfig {
     pub system_prompt:    &'static str,
     /// Tools the child agent is allowed to use. Empty means inherit all
     /// parent tools (minus `disallowed_tools`).
-    pub allowed_tools:    Vec<String>,
+    pub allowed_tools:    Vec<ToolName>,
     /// Tools the child agent must never use (e.g. recursive spawning tools).
-    pub disallowed_tools: Vec<String>,
+    pub disallowed_tools: Vec<ToolName>,
     /// Maximum number of agent loop iterations before the task is stopped.
     pub max_iterations:   usize,
 }
@@ -84,10 +87,7 @@ Rules:
 - Respond in the same language as the task description.";
 
 static PRESETS: LazyLock<Vec<TaskTypeConfig>> = LazyLock::new(|| {
-    let disallowed: Vec<String> = RECURSIVE_TOOL_DENYLIST
-        .iter()
-        .map(|s| (*s).to_owned())
-        .collect();
+    let disallowed = recursive_tool_denylist();
 
     vec![
         TaskTypeConfig {
@@ -103,12 +103,12 @@ static PRESETS: LazyLock<Vec<TaskTypeConfig>> = LazyLock::new(|| {
             description:      "Shell/CLI specialist for command-line tasks",
             system_prompt:    BASH_PROMPT,
             allowed_tools:    vec![
-                tool_names::BASH.into(),
-                tool_names::READ_FILE.into(),
-                tool_names::WRITE_FILE.into(),
-                tool_names::EDIT_FILE.into(),
-                tool_names::LIST_DIRECTORY.into(),
-                tool_names::GREP.into(),
+                tool_names::BASH.clone(),
+                tool_names::READ_FILE.clone(),
+                tool_names::WRITE_FILE.clone(),
+                tool_names::EDIT_FILE.clone(),
+                tool_names::LIST_DIRECTORY.clone(),
+                tool_names::GREP.clone(),
             ],
             disallowed_tools: disallowed.clone(),
             max_iterations:   15,
@@ -118,11 +118,11 @@ static PRESETS: LazyLock<Vec<TaskTypeConfig>> = LazyLock::new(|| {
             description:      "Read-only codebase exploration and analysis specialist",
             system_prompt:    EXPLORE_PROMPT,
             allowed_tools:    vec![
-                tool_names::READ_FILE.into(),
-                tool_names::GREP.into(),
-                tool_names::FIND_FILES.into(),
-                tool_names::WALK_DIRECTORY.into(),
-                tool_names::LIST_DIRECTORY.into(),
+                tool_names::READ_FILE.clone(),
+                tool_names::GREP.clone(),
+                tool_names::FIND_FILES.clone(),
+                tool_names::WALK_DIRECTORY.clone(),
+                tool_names::LIST_DIRECTORY.clone(),
             ],
             disallowed_tools: disallowed,
             max_iterations:   20,
@@ -154,7 +154,7 @@ mod tests {
         );
         assert_eq!(preset.max_iterations, 25);
         assert!(
-            preset.disallowed_tools.contains(&"task".to_owned()),
+            preset.disallowed_tools.contains(&ToolName::new("task")),
             "must disallow recursive task spawning"
         );
         assert!(
@@ -169,21 +169,23 @@ mod tests {
         assert_eq!(preset.name, "bash");
         assert_eq!(preset.max_iterations, 15);
         assert!(
-            preset.allowed_tools.contains(&"bash".to_owned()),
+            preset.allowed_tools.contains(&ToolName::new("bash")),
             "bash preset must include the bash tool"
         );
         assert!(
-            preset.allowed_tools.contains(&"read-file".to_owned()),
+            preset.allowed_tools.contains(&ToolName::new("read-file")),
             "bash preset must include read-file"
         );
         assert!(
             preset
                 .disallowed_tools
-                .contains(&"spawn-background".to_owned()),
+                .contains(&ToolName::new("spawn-background")),
             "must disallow spawn-background"
         );
         assert!(
-            preset.disallowed_tools.contains(&"create-plan".to_owned()),
+            preset
+                .disallowed_tools
+                .contains(&ToolName::new("create-plan")),
             "must disallow create-plan"
         );
     }
@@ -194,26 +196,28 @@ mod tests {
         assert_eq!(preset.name, "explore");
         assert_eq!(preset.max_iterations, 20);
         assert!(
-            preset.allowed_tools.contains(&"read-file".to_owned()),
+            preset.allowed_tools.contains(&ToolName::new("read-file")),
             "explore preset must include read-file"
         );
         assert!(
-            preset.allowed_tools.contains(&"grep".to_owned()),
+            preset.allowed_tools.contains(&ToolName::new("grep")),
             "explore preset must include grep"
         );
         assert!(
-            preset.allowed_tools.contains(&"find-files".to_owned()),
+            preset.allowed_tools.contains(&ToolName::new("find-files")),
             "explore preset must include find-files"
         );
         assert!(
-            preset.allowed_tools.contains(&"walk-directory".to_owned()),
+            preset
+                .allowed_tools
+                .contains(&ToolName::new("walk-directory")),
             "explore preset must include walk-directory"
         );
-        assert!(!preset.allowed_tools.contains(&"bash".to_owned()));
-        assert!(!preset.allowed_tools.contains(&"write-file".to_owned()));
-        assert!(!preset.allowed_tools.contains(&"edit-file".to_owned()));
+        assert!(!preset.allowed_tools.contains(&ToolName::new("bash")));
+        assert!(!preset.allowed_tools.contains(&ToolName::new("write-file")));
+        assert!(!preset.allowed_tools.contains(&ToolName::new("edit-file")));
         assert!(
-            preset.disallowed_tools.contains(&"task".to_owned()),
+            preset.disallowed_tools.contains(&ToolName::new("task")),
             "must disallow recursive task spawning"
         );
     }


### PR DESCRIPTION
Closes #1123

Replace stringly-typed tool names across `AgentManifest`, `ToolRegistry`, `Permission::UseTool`, and related APIs with a `ToolName` newtype. Prevents accidentally mixing tool names with other string IDs at compile time.