### PR TITLE
refactor(kernel): type-state InboundMessage<Unresolved/Resolved> (#1125)

### DIFF
--- a/crates/app/tests/anchor_checkout_e2e.rs
+++ b/crates/app/tests/anchor_checkout_e2e.rs
@@ -4,7 +4,7 @@ use rara_app::{AppConfig, StartOptions, start_with_options};
 use rara_kernel::{
     channel::types::{ChannelType, MessageContent},
     identity::{Principal, UserId},
-    io::{ChannelSource, InboundMessage, MessageId},
+    io::{ChannelSource, InboundMessage, MessageId, Unresolved},
     memory::{FileTapeStore, TapEntryKind, TapeService},
     session::SessionKey,
 };
@@ -16,23 +16,23 @@ fn build_test_message(
     session_key: Option<SessionKey>,
     chat_id: &str,
     text: &str,
-) -> InboundMessage {
-    InboundMessage {
-        id: MessageId::new(),
-        source: ChannelSource {
+) -> InboundMessage<Unresolved> {
+    InboundMessage::unresolved(
+        MessageId::new(),
+        ChannelSource {
             channel_type:        ChannelType::Internal,
             platform_message_id: None,
             platform_user_id:    "ryan".to_string(),
             platform_chat_id:    Some(chat_id.to_string()),
         },
-        user: UserId("ryan".to_string()),
+        UserId("ryan".to_string()),
         session_key,
-        target_session_key: None,
-        content: MessageContent::Text(text.to_string()),
-        reply_context: None,
-        timestamp: jiff::Timestamp::now(),
-        metadata: Default::default(),
-    }
+        None,
+        MessageContent::Text(text.to_string()),
+        None,
+        jiff::Timestamp::now(),
+        Default::default(),
+    )
 }
 
 async fn wait_for_turn_count(

--- a/crates/app/tests/real_tape_flow.rs
+++ b/crates/app/tests/real_tape_flow.rs
@@ -5,7 +5,7 @@ use rara_kernel::{
     agent::TurnTrace,
     channel::types::MessageContent,
     identity::{Principal, UserId},
-    io::{ChannelSource, InboundMessage, MessageId},
+    io::{ChannelSource, InboundMessage, MessageId, Unresolved},
     memory::{FileTapeStore, TapEntry, TapEntryKind, TapeService},
     session::SessionKey,
 };
@@ -40,23 +40,23 @@ fn build_test_message(
     session_key: Option<SessionKey>,
     chat_id: &str,
     text: &str,
-) -> InboundMessage {
-    InboundMessage {
-        id: MessageId::new(),
-        source: ChannelSource {
+) -> InboundMessage<Unresolved> {
+    InboundMessage::unresolved(
+        MessageId::new(),
+        ChannelSource {
             channel_type:        rara_kernel::channel::types::ChannelType::Internal,
             platform_message_id: None,
             platform_user_id:    "ryan".to_string(),
             platform_chat_id:    Some(chat_id.to_string()),
         },
-        user: UserId("ryan".to_string()),
+        UserId("ryan".to_string()),
         session_key,
-        target_session_key: None,
-        content: MessageContent::Text(text.to_string()),
-        reply_context: None,
-        timestamp: jiff::Timestamp::now(),
-        metadata: Default::default(),
-    }
+        None,
+        MessageContent::Text(text.to_string()),
+        None,
+        jiff::Timestamp::now(),
+        Default::default(),
+    )
 }
 
 fn large_file_paths() -> [String; 3] {

--- a/crates/channels/src/telegram/adapter.rs
+++ b/crates/channels/src/telegram/adapter.rs
@@ -2765,7 +2765,7 @@ async fn handle_update(
         }
     };
 
-    let session_id = msg.session_key.clone();
+    let session_id = msg.session_key_opt().copied();
     let rara_message_id = msg.id.to_string();
 
     // Route: group proactive candidates go through GroupMessage event for

--- a/crates/channels/src/web.rs
+++ b/crates/channels/src/web.rs
@@ -753,16 +753,15 @@ async fn handle_ws(socket: WebSocket, params: SessionQuery, state: WebAdapterSta
                     // instead of creating a duplicate.
                     match s.resolve(raw).await {
                         Ok(mut msg) => {
-                            if msg.session_key.is_none() {
+                            if msg.session_key_opt().is_none() {
                                 if let Ok(sk) =
                                     rara_kernel::session::SessionKey::try_from_raw(&session_key)
                                 {
-                                    msg.session_key = Some(sk);
+                                    msg.set_session_key(sk);
                                 }
                             }
                             let resolved_key = msg
-                                .session_key
-                                .as_ref()
+                                .session_key_opt()
                                 .map(|k| k.to_string())
                                 .unwrap_or_else(|| session_key.clone());
                             if let Err(e) = s.submit_message(msg) {

--- a/crates/kernel/src/event.rs
+++ b/crates/kernel/src/event.rs
@@ -28,7 +28,7 @@ use uuid::Uuid;
 use crate::{
     agent::{AgentManifest, AgentTurnResult},
     identity::{Principal, UserId},
-    io::{InboundMessage, MessageId, OutboundEnvelope, PipeReader, PipeWriter},
+    io::{InboundMessage, MessageId, OutboundEnvelope, PipeReader, PipeWriter, Unresolved},
     kv::KvScope,
     schedule::JobEntry,
     session::{AgentRunLoopResult, SessionKey, Signal},
@@ -272,16 +272,16 @@ impl Syscall {
 pub enum KernelEvent {
     // === Input: from external sources ===
     /// A new user message from a channel adapter (via IngressPipeline).
-    #[debug("UserMessage(session={:?})", _0.session_key)]
-    UserMessage(InboundMessage),
+    #[debug("UserMessage(session={:?})", _0.session_key_opt())]
+    UserMessage(InboundMessage<Unresolved>),
 
     /// A group-chat message where the bot was **not** directly mentioned.
     ///
     /// Handled separately from `UserMessage`: the kernel records the message
     /// to the session tape, runs a lightweight LLM judgment to decide whether
     /// to reply, and only promotes to a full `UserMessage` turn on approval.
-    #[debug("GroupMessage(session={:?})", _0.session_key)]
-    GroupMessage(InboundMessage),
+    #[debug("GroupMessage(session={:?})", _0.session_key_opt())]
+    GroupMessage(InboundMessage<Unresolved>),
 
     // === Session control ===
     /// Request to create (or reactivate) a session.
@@ -429,8 +429,8 @@ pub struct KernelEventEnvelope {
 
 impl KernelEventEnvelope {
     /// Create a `UserMessage` event.
-    pub fn user_message(msg: InboundMessage) -> Self {
-        let base_key = msg.session_key.clone().unwrap_or_default();
+    pub fn user_message(msg: InboundMessage<Unresolved>) -> Self {
+        let base_key = msg.session_key_opt().copied().unwrap_or_default();
         Self {
             base: EventBase::from(base_key),
             kind: KernelEvent::UserMessage(msg),
@@ -438,8 +438,8 @@ impl KernelEventEnvelope {
     }
 
     /// Create a `GroupMessage` event.
-    pub fn group_message(msg: InboundMessage) -> Self {
-        let base_key = msg.session_key.clone().unwrap_or_default();
+    pub fn group_message(msg: InboundMessage<Unresolved>) -> Self {
+        let base_key = msg.session_key_opt().copied().unwrap_or_default();
         Self {
             base: EventBase::from(base_key),
             kind: KernelEvent::GroupMessage(msg),
@@ -629,11 +629,11 @@ impl KernelEventEnvelope {
     /// Human-readable summary for observability.
     pub fn summary(&self) -> String {
         match &self.kind {
-            KernelEvent::UserMessage(msg) => match &msg.session_key {
+            KernelEvent::UserMessage(msg) => match msg.session_key_opt() {
                 Some(key) => format!("user message queued for session {key}"),
                 None => "user message queued (no session yet)".to_string(),
             },
-            KernelEvent::GroupMessage(msg) => match &msg.session_key {
+            KernelEvent::GroupMessage(msg) => match msg.session_key_opt() {
                 Some(key) => format!("group message queued for session {key}"),
                 None => "group message queued (no session yet)".to_string(),
             },

--- a/crates/kernel/src/handle.rs
+++ b/crates/kernel/src/handle.rs
@@ -35,7 +35,7 @@ use crate::{
     identity::Principal,
     io::{
         AgentHandle, EndpointRegistryRef, IOError, IOSubsystem, InboundMessage, PipeReader,
-        PipeWriter, RawPlatformMessage, StreamHubRef,
+        PipeWriter, RawPlatformMessage, StreamHubRef, Unresolved,
     },
     kernel::{KernelConfig, SettingsRef},
     kv::KvScope,
@@ -225,7 +225,7 @@ impl KernelHandle {
     ///
     /// Uses `try_push` (non-async) so this can be called from synchronous
     /// contexts.
-    pub fn submit_message(&self, msg: InboundMessage) -> Result<()> {
+    pub fn submit_message(&self, msg: InboundMessage<Unresolved>) -> Result<()> {
         self.event_queue
             .try_push(KernelEventEnvelope::user_message(msg))
             .map_err(|_| KernelError::Other {
@@ -237,7 +237,7 @@ impl KernelHandle {
     ///
     /// The kernel will record the message to tape, run a lightweight LLM
     /// judgment, and only promote to a full agent turn if approved.
-    pub fn submit_group_message(&self, msg: InboundMessage) -> Result<()> {
+    pub fn submit_group_message(&self, msg: InboundMessage<Unresolved>) -> Result<()> {
         self.event_queue
             .try_push(KernelEventEnvelope::group_message(msg))
             .map_err(|_| KernelError::Other {
@@ -274,13 +274,16 @@ impl KernelHandle {
     /// Access the process table for querying.
     pub fn process_table(&self) -> &Arc<SessionTable> { &self.process_table }
 
-    /// Resolve identity and session for a raw platform message.
+    /// Resolve identity and (possibly) session for a raw platform message.
+    ///
+    /// Returns an [`InboundMessage<Unresolved>`] — the caller must still
+    /// promote it to `Resolved` before routing.
     ///
     /// Delegates to [`IOSubsystem::resolve`].
     pub async fn resolve(
         &self,
         raw: RawPlatformMessage,
-    ) -> std::result::Result<InboundMessage, IOError> {
+    ) -> std::result::Result<InboundMessage<crate::io::Unresolved>, IOError> {
         self.io.resolve(raw).await
     }
 
@@ -818,6 +821,6 @@ impl KernelHandle {
     pub async fn deliver_internal(&self, msg: crate::io::InboundMessage) {
         let _ = self
             .event_queue
-            .push(KernelEventEnvelope::user_message(msg));
+            .push(KernelEventEnvelope::user_message(msg.into_unresolved()));
     }
 }

--- a/crates/kernel/src/io.rs
+++ b/crates/kernel/src/io.rs
@@ -35,6 +35,7 @@
 
 use std::{
     collections::{HashMap, HashSet},
+    marker::PhantomData,
     sync::{Arc, Mutex},
 };
 
@@ -146,37 +147,52 @@ pub enum InteractionType {
 }
 
 // ---------------------------------------------------------------------------
+// InboundMessage type states
+// ---------------------------------------------------------------------------
+
+/// Marker: the message has not yet been assigned a session.
+///
+/// Produced by [`IOSubsystem::resolve()`] at ingress. The I/O layer looks up
+/// channel bindings but never creates sessions, so `session_key` may be
+/// `None`.
+#[derive(Debug, Clone, Copy)]
+pub struct Unresolved;
+
+/// Marker: the message has a guaranteed [`SessionKey`].
+///
+/// Produced by [`InboundMessage::resolve()`] inside the kernel after session
+/// creation / lookup. All downstream code (routing, LLM turn, stream
+/// forwarder) operates on this state.
+#[derive(Debug, Clone, Copy)]
+pub struct Resolved;
+
+// ---------------------------------------------------------------------------
 // InboundMessage
 // ---------------------------------------------------------------------------
 
 /// A unified inbound message from any channel adapter.
 ///
-/// Produced by [`IOSubsystem::resolve()`] and published to the
-/// [`EventQueue`](crate::queue::EventQueue).
+/// Parameterised over a *type state* (`Unresolved` or `Resolved`) that
+/// tracks whether a [`SessionKey`] has been assigned.
 ///
-/// ## `session_key` lifecycle
+/// - **`InboundMessage<Unresolved>`** — produced by [`IOSubsystem::resolve()`]
+///   and carried through the event queue. `session_key` is an `Option` that may
+///   be `None` for first-contact messages.
+/// - **`InboundMessage<Resolved>`** (the default) — produced by calling
+///   [`InboundMessage::resolve()`] inside the kernel. `session_key()` is
+///   guaranteed to return a valid reference.
 ///
-/// `session_key` starts as `Option<SessionKey>`:
-/// - **`Some(key)`** — a channel binding already maps this chat to a session.
-/// - **`None`** — first message from a new chat; no binding exists yet.
-///
-/// Before routing, `Kernel::handle_user_message()` resolves `None` by
-/// creating a new session + writing a channel binding, then patches
-/// `session_key` to `Some`. All downstream code (routing, LLM turn,
-/// stream forwarder) therefore always sees `Some`.
+/// The default type parameter is `Resolved` so that downstream code that
+/// always operates on resolved messages can write `InboundMessage` without
+/// a type argument.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct InboundMessage {
+pub struct InboundMessage<State = Resolved> {
     /// Unique message identifier (ULID).
     pub id:                 MessageId,
     /// Platform source details.
     pub source:             ChannelSource,
     /// Unified user identity (resolved by ingress).
     pub user:               UserId,
-    /// Session this message belongs to.
-    ///
-    /// `None` on ingress when no channel binding exists (first message).
-    /// Patched to `Some` by the kernel before routing — see struct-level docs.
-    pub session_key:        Option<SessionKey>,
     /// Direct process targeting (agent-to-agent communication).
     /// When set, routing bypasses session/name resolution entirely.
     pub target_session_key: Option<SessionKey>,
@@ -189,9 +205,122 @@ pub struct InboundMessage {
     pub timestamp:     jiff::Timestamp,
     /// Extension metadata (adapter-specific fields only).
     pub metadata:      HashMap<String, Value>,
+
+    // -- private fields --
+    /// Session this message belongs to.
+    ///
+    /// `None` on ingress when no channel binding exists (first message).
+    /// Always `Some` after [`InboundMessage::resolve()`].
+    session_key: Option<SessionKey>,
+
+    /// Phantom field to carry the type-state parameter.
+    /// Transparent to serde (skipped on both ser and de).
+    #[serde(skip)]
+    _state: PhantomData<State>,
 }
 
-impl InboundMessage {
+// -- Unresolved constructors & transition -----------------------------------
+
+impl InboundMessage<Unresolved> {
+    /// Construct an unresolved message at ingress.
+    ///
+    /// `session_key` is `Some` when a channel binding already exists, `None`
+    /// for first-contact messages. The kernel will call
+    /// [`resolve()`](Self::resolve) before routing.
+    pub fn unresolved(
+        id: MessageId,
+        source: ChannelSource,
+        user: UserId,
+        session_key: Option<SessionKey>,
+        target_session_key: Option<SessionKey>,
+        content: MessageContent,
+        reply_context: Option<ReplyContext>,
+        timestamp: jiff::Timestamp,
+        metadata: HashMap<String, Value>,
+    ) -> Self {
+        Self {
+            id,
+            source,
+            user,
+            target_session_key,
+            content,
+            reply_context,
+            timestamp,
+            metadata,
+            session_key,
+            _state: PhantomData,
+        }
+    }
+
+    /// Read the optional session key before resolution.
+    ///
+    /// Returns `Some` when a channel binding already mapped this chat to a
+    /// session, `None` for first-contact messages.
+    pub fn session_key_opt(&self) -> Option<&SessionKey> { self.session_key.as_ref() }
+
+    /// Set the session key before resolution.
+    ///
+    /// Used by channel adapters (e.g. web) that know the target session from
+    /// the URL but may receive `None` from the channel-binding lookup.
+    pub fn set_session_key(&mut self, key: SessionKey) { self.session_key = Some(key); }
+
+    /// Transition to `Resolved` by supplying the definitive session key.
+    ///
+    /// Consumes `self` and moves all fields into a new
+    /// `InboundMessage<Resolved>`.
+    pub fn resolve(self, key: SessionKey) -> InboundMessage<Resolved> {
+        InboundMessage {
+            id:                 self.id,
+            source:             self.source,
+            user:               self.user,
+            target_session_key: self.target_session_key,
+            content:            self.content,
+            reply_context:      self.reply_context,
+            timestamp:          self.timestamp,
+            metadata:           self.metadata,
+            session_key:        Some(key),
+            _state:             PhantomData,
+        }
+    }
+}
+
+// -- Resolved constructors & accessors --------------------------------------
+
+impl InboundMessage<Resolved> {
+    /// Guaranteed session key accessor.
+    ///
+    /// # Panics
+    ///
+    /// Never panics — the type-state contract guarantees `session_key` is
+    /// `Some` for `Resolved` messages. The `expect` is a defensive assertion
+    /// only.
+    pub fn session_key(&self) -> &SessionKey {
+        self.session_key
+            .as_ref()
+            .expect("resolved message always has session_key")
+    }
+
+    /// Downgrade to `Unresolved` for re-entry into the event queue.
+    ///
+    /// Synthetic messages are constructed as `Resolved` (they already have a
+    /// session key), but the event queue expects `Unresolved`. The session key
+    /// is preserved in the `Option` and will pass through resolution as a
+    /// no-op `Some` match.
+    pub fn into_unresolved(self) -> InboundMessage<Unresolved> {
+        InboundMessage {
+            id:                 self.id,
+            source:             self.source,
+            user:               self.user,
+            target_session_key: self.target_session_key,
+            content:            self.content,
+            reply_context:      self.reply_context,
+            timestamp:          self.timestamp,
+            metadata:           self.metadata,
+            session_key:        self.session_key,
+            _state:             PhantomData,
+        }
+    }
+
     /// Create a synthetic internal message (for workers, SyscallTool, etc.).
     pub fn synthetic(text: String, user: UserId, session_id: SessionKey) -> Self {
         Self::synthetic_content(MessageContent::Text(text), user, session_id)
@@ -218,6 +347,7 @@ impl InboundMessage {
             reply_context: None,
             timestamp: jiff::Timestamp::now(),
             metadata: HashMap::new(),
+            _state: PhantomData,
         }
     }
 
@@ -244,6 +374,7 @@ impl InboundMessage {
             reply_context: None,
             timestamp: jiff::Timestamp::now(),
             metadata: HashMap::new(),
+            _state: PhantomData,
         }
     }
 
@@ -270,9 +401,14 @@ impl InboundMessage {
             reply_context: None,
             timestamp: jiff::Timestamp::now(),
             metadata: HashMap::new(),
+            _state: PhantomData,
         }
     }
+}
 
+// -- State-independent methods ----------------------------------------------
+
+impl<S> InboundMessage<S> {
     /// Build the originating endpoint for session-scoped reply routing.
     ///
     /// Returns `Some(Endpoint)` for channel types that support multiple
@@ -1562,7 +1698,10 @@ impl IOSubsystem {
             user_id,
         )
     )]
-    pub async fn resolve(&self, raw: RawPlatformMessage) -> Result<InboundMessage, IOError> {
+    pub async fn resolve(
+        &self,
+        raw: RawPlatformMessage,
+    ) -> Result<InboundMessage<Unresolved>, IOError> {
         let span = tracing::Span::current();
 
         // 1. Rate-limit ingress before any expensive operations.
@@ -1602,28 +1741,28 @@ impl IOSubsystem {
             None => None,
         };
 
-        // 4. Build InboundMessage
-        let msg = InboundMessage {
-            id: MessageId::new(),
-            source: ChannelSource {
+        // 4. Build InboundMessage<Unresolved>
+        let msg = InboundMessage::unresolved(
+            MessageId::new(),
+            ChannelSource {
                 channel_type:        raw.channel_type,
                 platform_message_id: raw.platform_message_id,
                 platform_user_id:    raw.platform_user_id,
                 platform_chat_id:    raw.platform_chat_id,
             },
-            user: user_id,
+            user_id,
             session_key,
-            target_session_key: None,
-            content: raw.content,
-            reply_context: raw.reply_context,
-            timestamp: jiff::Timestamp::now(),
-            metadata: raw.metadata,
-        };
+            None,
+            raw.content,
+            raw.reply_context,
+            jiff::Timestamp::now(),
+            raw.metadata,
+        );
 
         tracing::info!(
             channel = ?msg.source.channel_type,
             user_id = %msg.user.0,
-            session_id = ?msg.session_key,
+            session_id = ?msg.session_key_opt(),
             content = %msg.content.as_text(),
             "resolved inbound message",
         );
@@ -1708,7 +1847,7 @@ impl IOSubsystem {
     /// Connection-oriented channels (Web) register on WS/SSE connect.
     /// Stateless channels have no persistent connection, so we register on
     /// every inbound message (idempotent — EndpointRegistry uses a HashSet).
-    pub fn register_stateless_endpoint(&self, msg: &InboundMessage) {
+    pub fn register_stateless_endpoint<S>(&self, msg: &InboundMessage<S>) {
         let endpoint = match msg.source.channel_type {
             ChannelType::Telegram => {
                 let chat_id_str = msg.source.platform_chat_id.as_ref();

--- a/crates/kernel/src/kernel.rs
+++ b/crates/kernel/src/kernel.rs
@@ -56,7 +56,10 @@ use crate::{
     channel::types::MessageContent,
     event::{KernelEvent, KernelEventEnvelope},
     identity::Principal,
-    io::{IOSubsystem, InboundMessage, MessageId, OutboundEnvelope, PipeRegistry, StreamId},
+    io::{
+        IOSubsystem, InboundMessage, MessageId, OutboundEnvelope, PipeRegistry, StreamId,
+        Unresolved,
+    },
     kv::SharedKv,
     llm::DriverRegistryRef,
     memory::TapeService,
@@ -815,7 +818,7 @@ impl Kernel {
             InboundMessage::synthetic_content(input, principal.user_id.clone(), msg_session);
         if let Err(e) = &self
             .event_queue
-            .try_push(KernelEventEnvelope::user_message(inbound))
+            .try_push(KernelEventEnvelope::user_message(inbound.into_unresolved()))
         {
             error!(%e, "failed to push initial UserMessage for spawned agent");
         }
@@ -1145,14 +1148,10 @@ impl Kernel {
     ///
     /// ## Session resolution (before routing)
     ///
-    /// `msg.session_key` arrives as `Option<SessionKey>` from the I/O layer:
-    /// - `Some` — channel binding already exists, reuse the session.
-    /// - `None` — first message from this chat. Creates a new `SessionEntry`
-    ///   + `ChannelBinding` so future messages are routed automatically, then
-    ///   patches `msg.session_key = Some(new_key)`.
-    ///
-    /// After resolution, `session_id` is always a valid key and all
-    /// downstream code sees `Some`.
+    /// The message arrives as `InboundMessage<Unresolved>` from the event
+    /// queue. The `session_key` may be `None` for first-contact messages.
+    /// This method resolves the session (creating one if needed) and
+    /// transitions the message to `InboundMessage<Resolved>` before routing.
     ///
     /// ## 3-path routing
     ///
@@ -1165,13 +1164,13 @@ impl Kernel {
     #[tracing::instrument(
         skip(self, msg),
         fields(
-            session_id = ?msg.session_key,
+            session_id = ?msg.session_key_opt(),
             user_id = %msg.user.0,
             channel = ?msg.source.channel_type,
             routing_path,
         )
     )]
-    async fn handle_user_message(&self, msg: InboundMessage) {
+    async fn handle_user_message(&self, msg: InboundMessage<Unresolved>) {
         let span = tracing::Span::current();
 
         // -- Session resolution --------------------------------------------------
@@ -1186,7 +1185,7 @@ impl Kernel {
         //      routed to this session automatically.
         //
         // After this block, `session_id` is always a valid SessionKey.
-        let session_id = match msg.session_key.clone() {
+        let session_id = match msg.session_key_opt().copied() {
             Some(key) => key,
             None => {
                 let now = chrono::Utc::now();
@@ -1226,10 +1225,9 @@ impl Kernel {
             }
         };
 
-        // Patch msg so downstream code (routing, LLM turn, stream forwarder)
-        // always sees Some(session_key). See InboundMessage doc for lifecycle.
-        let mut msg = msg;
-        msg.session_key = Some(session_id.clone());
+        // Transition to Resolved — downstream code gets a type-safe guarantee
+        // that session_key is always present.
+        let msg = msg.resolve(session_id.clone());
 
         let user = msg.user.clone();
 
@@ -1462,14 +1460,14 @@ impl Kernel {
     #[tracing::instrument(
         skip(self, msg),
         fields(
-            session_id = ?msg.session_key,
+            session_id = ?msg.session_key_opt(),
             user_id = %msg.user.0,
             channel = ?msg.source.channel_type,
         )
     )]
-    async fn handle_group_message(&self, msg: InboundMessage) {
+    async fn handle_group_message(&self, msg: InboundMessage<Unresolved>) {
         // -- Session resolution (same as handle_user_message) ------------------
-        let session_id = match msg.session_key.clone() {
+        let session_id = match msg.session_key_opt().copied() {
             Some(key) => key,
             None => {
                 let now = chrono::Utc::now();
@@ -1507,10 +1505,10 @@ impl Kernel {
             }
         };
 
-        let mut msg = msg;
-        msg.session_key = Some(session_id.clone());
-
         self.io.register_stateless_endpoint(&msg);
+
+        // Transition to Resolved for downstream code.
+        let msg = msg.resolve(session_id.clone());
 
         // -- Record message to tape -------------------------------------------
         let tape_name = session_id.to_string();
@@ -1586,7 +1584,7 @@ impl Kernel {
         );
         if let Err(e) = self
             .event_queue
-            .try_push(KernelEventEnvelope::user_message(msg))
+            .try_push(KernelEventEnvelope::user_message(msg.into_unresolved()))
         {
             error!(%e, "group: failed to push promoted UserMessage");
         }
@@ -1691,13 +1689,15 @@ impl Kernel {
 
         let should_buffer = self.process_table.with_mut(&session_key, |rt| {
             if rt.paused {
-                rt.pause_buffer
-                    .push(KernelEventEnvelope::user_message(msg.clone()));
+                rt.pause_buffer.push(KernelEventEnvelope::user_message(
+                    msg.clone().into_unresolved(),
+                ));
                 return true;
             }
             if is_active {
-                rt.pause_buffer
-                    .push(KernelEventEnvelope::user_message(msg.clone()));
+                rt.pause_buffer.push(KernelEventEnvelope::user_message(
+                    msg.clone().into_unresolved(),
+                ));
                 return true;
             }
             false
@@ -1781,7 +1781,7 @@ impl Kernel {
     /// Tape forking provides transactional semantics: the agent writes to a
     /// fork during its turn. On success the fork is merged back; on failure
     /// it is discarded, keeping the main tape clean.
-    #[tracing::instrument(skip_all, fields(session_key = %session_key, msg_session_key = ?msg.session_key))]
+    #[tracing::instrument(skip_all, fields(session_key = %session_key, msg_session_key = %msg.session_key()))]
     async fn start_llm_turn(&self, session_key: SessionKey, msg: InboundMessage) {
         // -- TurnGuard: RAII safety net ------------------------------------------
         //


### PR DESCRIPTION
Closes #1125

Introduce phantom type states for `InboundMessage` so that only `InboundMessage<Resolved>` can be routed. Ingress path produces `Unresolved`, and the kernel router promotes it to `Resolved` before dispatching.