### PR TITLE
feat(cmd): add 'rara debug <message_id>' CLI command (#1135)

### DIFF
--- a/crates/channels/src/telegram/commands/debug.rs
+++ b/crates/channels/src/telegram/commands/debug.rs
@@ -15,9 +15,8 @@
 //! `/debug <message_id>` command — retrieve full execution context for a
 //! message by walking the session tape.
 //!
-//! All data (tokens, model, tools, timings) is derived from tape entry
-//! metadata — the tape is the single source of truth, no parallel SQL
-//! lookup needed.
+//! Aggregation lives in [`rara_kernel::debug::MessageDebugSummary`]; this
+//! handler only renders the result as Telegram HTML.
 
 use std::fmt::Write;
 
@@ -26,6 +25,7 @@ use rara_kernel::{
     channel::command::{
         CommandContext, CommandDefinition, CommandHandler, CommandInfo, CommandResult,
     },
+    debug::MessageDebugSummary,
     error::KernelError,
     memory::TapeService,
 };
@@ -80,185 +80,95 @@ impl CommandHandler for DebugCommandHandler {
                 message: format!("tape search failed: {e}").into(),
             })?;
 
-        let matched: Vec<_> = entries
-            .into_iter()
-            .filter(|e| {
-                e.metadata.as_ref().is_some_and(|m| {
-                    m.get("rara_message_id")
-                        .and_then(|v| v.as_str())
-                        .is_some_and(|id| id == message_id)
-                })
-            })
-            .collect();
+        let summary = MessageDebugSummary::from_entries(message_id, entries);
+        Ok(CommandResult::Html(render_html(&summary)))
+    }
+}
 
-        let mut output = String::new();
+/// Render a [`MessageDebugSummary`] as Telegram HTML.
+fn render_html(summary: &MessageDebugSummary) -> String {
+    let mut output = String::new();
+    let _ = writeln!(
+        output,
+        "<b>🔍 Debug: <code>{}</code></b>\n",
+        html_escape(&summary.message_id)
+    );
+
+    if summary.is_empty() {
+        output.push_str(
+            "<i>No tape entries found for this message ID. It may have expired or never \
+             existed.</i>",
+        );
+        return output;
+    }
+
+    // -- Section 1: Summary ----------------------------------------------------
+    let _ = writeln!(output, "<b>📊 Summary</b>");
+    let _ = writeln!(output, "• Entries: {}", summary.entries.len());
+    if let Some(ref model) = summary.model {
+        let _ = writeln!(output, "• Model: <code>{}</code>", html_escape(model));
+    }
+    if summary.iterations > 0 {
+        let _ = writeln!(output, "• Iterations: {}", summary.iterations);
+    }
+    if summary.stream_ms > 0 {
         let _ = writeln!(
             output,
-            "<b>🔍 Debug: <code>{}</code></b>\n",
-            html_escape(message_id)
+            "• Stream: {:.1}s",
+            summary.stream_ms as f64 / 1000.0
         );
-
-        if matched.is_empty() {
-            output.push_str(
-                "<i>No tape entries found for this message ID. It may have expired or never \
-                 existed.</i>",
-            );
-            return Ok(CommandResult::Html(output));
-        }
-
-        // Aggregate metrics from tape entry metadata.
-        let mut model = String::new();
-        let mut total_input = 0u64;
-        let mut total_output = 0u64;
-        let mut iterations = 0usize;
-        let mut total_stream_ms = 0u64;
-        let mut tool_calls = 0usize;
-        let mut tool_failures = 0usize;
-
-        for entry in &matched {
-            let Some(meta) = entry.metadata.as_ref() else {
-                continue;
-            };
-
-            // LlmEntryMetadata fields (assistant messages).
-            if let Some(m) = meta.get("model").and_then(|v| v.as_str()) {
-                if model.is_empty() {
-                    model = m.to_owned();
-                }
-            }
-            if let Some(usage) = meta.get("usage") {
-                if let Some(t) = usage.get("input_tokens").and_then(|v| v.as_u64()) {
-                    total_input += t;
-                }
-                if let Some(t) = usage.get("output_tokens").and_then(|v| v.as_u64()) {
-                    total_output += t;
-                }
-            }
-            if meta.get("iteration").is_some() {
-                iterations += 1;
-            }
-            if let Some(ms) = meta.get("stream_ms").and_then(|v| v.as_u64()) {
-                total_stream_ms += ms;
-            }
-
-            // ToolResultMetadata fields.
-            if let Some(metrics) = meta.get("tool_metrics").and_then(|v| v.as_array()) {
-                tool_calls += metrics.len();
-                tool_failures += metrics
-                    .iter()
-                    .filter(|m| m.get("success").and_then(|v| v.as_bool()) == Some(false))
-                    .count();
-            }
-        }
-
-        // -- Section 1: Summary ------------------------------------------------
-        let _ = writeln!(output, "<b>📊 Summary</b>");
-        let _ = writeln!(output, "• Entries: {}", matched.len());
-        if !model.is_empty() {
-            let _ = writeln!(output, "• Model: <code>{}</code>", html_escape(&model));
-        }
-        if iterations > 0 {
-            let _ = writeln!(output, "• Iterations: {iterations}");
-        }
-        if total_stream_ms > 0 {
-            let _ = writeln!(output, "• Stream: {:.1}s", total_stream_ms as f64 / 1000.0);
-        }
-        if total_input > 0 || total_output > 0 {
-            let _ = writeln!(
-                output,
-                "• Tokens: ↑{} ↓{}",
-                format_tokens(total_input),
-                format_tokens(total_output)
-            );
-        }
-        if tool_calls > 0 {
-            let _ = writeln!(
-                output,
-                "• Tool calls: {tool_calls} ({tool_failures} failed)"
-            );
-        }
-
-        // -- Section 2: Tool execution detail ----------------------------------
-        let mut tool_lines: Vec<String> = Vec::new();
-        for entry in &matched {
-            let Some(meta) = entry.metadata.as_ref() else {
-                continue;
-            };
-            let Some(metrics) = meta.get("tool_metrics").and_then(|v| v.as_array()) else {
-                continue;
-            };
-            for m in metrics {
-                let name = m.get("name").and_then(|v| v.as_str()).unwrap_or("?");
-                let duration = m
-                    .get("duration_ms")
-                    .and_then(|v| v.as_u64())
-                    .map(|ms| format!("{ms}ms"))
-                    .unwrap_or_else(|| "—".to_owned());
-                let success = m.get("success").and_then(|v| v.as_bool()).unwrap_or(true);
-                let icon = if success { "✓" } else { "✗" };
-                let mut line = format!("  {icon} <code>{}</code> ({duration})", html_escape(name));
-                if let Some(err) = m.get("error").and_then(|v| v.as_str()) {
-                    let preview: String = err.chars().take(150).collect();
-                    let _ = write!(line, "\n    ⚠️ {}", html_escape(&preview));
-                }
-                tool_lines.push(line);
-            }
-        }
-        if !tool_lines.is_empty() {
-            let _ = writeln!(output, "\n<b>🔧 Tools</b>");
-            for line in tool_lines {
-                output.push_str(&line);
-                output.push('\n');
-            }
-        }
-
-        // -- Section 3: Timeline -----------------------------------------------
-        let _ = writeln!(output, "\n<b>📝 Timeline</b>");
-        for entry in &matched {
-            let kind = entry.kind.to_string();
-            let ts = entry.timestamp.strftime("%H:%M:%S").to_string();
-
-            let detail = match kind.as_str() {
-                "message" => entry
-                    .payload
-                    .get("content")
-                    .and_then(|v| v.as_str())
-                    .map(|s| s.chars().take(100).collect::<String>())
-                    .unwrap_or_default(),
-                "tool_call" => {
-                    let name = entry
-                        .payload
-                        .get("name")
-                        .and_then(|v| v.as_str())
-                        .unwrap_or("?");
-                    format!("→ {name}")
-                }
-                "tool_result" => {
-                    let name = entry
-                        .payload
-                        .get("name")
-                        .and_then(|v| v.as_str())
-                        .unwrap_or("?");
-                    let success = entry
-                        .payload
-                        .get("success")
-                        .and_then(|v| v.as_bool())
-                        .unwrap_or(true);
-                    let icon = if success { "✓" } else { "✗" };
-                    format!("{icon} {name}")
-                }
-                _ => String::new(),
-            };
-
-            let _ = writeln!(
-                output,
-                "<code>{ts}</code> [{kind}] {}",
-                html_escape(&detail)
-            );
-        }
-
-        Ok(CommandResult::Html(output))
     }
+    if summary.input_tokens > 0 || summary.output_tokens > 0 {
+        let _ = writeln!(
+            output,
+            "• Tokens: ↑{} ↓{}",
+            format_tokens(summary.input_tokens),
+            format_tokens(summary.output_tokens)
+        );
+    }
+    if !summary.tools.is_empty() {
+        let _ = writeln!(
+            output,
+            "• Tool calls: {} ({} failed)",
+            summary.tools.len(),
+            summary.tool_failures
+        );
+    }
+
+    // -- Section 2: Tool execution detail --------------------------------------
+    if !summary.tools.is_empty() {
+        let _ = writeln!(output, "\n<b>🔧 Tools</b>");
+        for tool in &summary.tools {
+            let duration = tool
+                .duration_ms
+                .map(|ms| format!("{ms}ms"))
+                .unwrap_or_else(|| "—".to_owned());
+            let icon = if tool.success { "✓" } else { "✗" };
+            let _ = writeln!(
+                output,
+                "  {icon} <code>{}</code> ({duration})",
+                html_escape(&tool.name)
+            );
+            if let Some(ref err) = tool.error {
+                let preview: String = err.chars().take(150).collect();
+                let _ = writeln!(output, "    ⚠️ {}", html_escape(&preview));
+            }
+        }
+    }
+
+    // -- Section 3: Timeline ---------------------------------------------------
+    let _ = writeln!(output, "\n<b>📝 Timeline</b>");
+    for item in &summary.timeline {
+        let _ = writeln!(
+            output,
+            "<code>{}</code> [{}] {}",
+            item.timestamp,
+            item.kind,
+            html_escape(&item.detail)
+        );
+    }
+
+    output
 }
 
 /// Format token count for display (e.g. 15200 → "15.2k").

--- a/crates/cmd/src/debug.rs
+++ b/crates/cmd/src/debug.rs
@@ -1,0 +1,146 @@
+// Copyright 2025 Rararulab
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! `rara debug <message_id>` — print the full execution context for a
+//! message without booting the chat UI or kernel runtime.
+//!
+//! Reads tape JSONL files directly via [`TapeService`] and renders the
+//! shared [`MessageDebugSummary`] as plain text suitable for terminals
+//! and log triage.
+
+use std::fmt::Write;
+
+use clap::Args;
+use rara_kernel::{
+    debug::MessageDebugSummary,
+    memory::{FileTapeStore, TapeService},
+};
+use snafu::{ResultExt, Whatever};
+
+/// Maximum tape entries scanned per debug request — same cap as the
+/// Telegram handler so behavior matches.
+const MAX_ENTRIES: usize = 200;
+
+#[derive(Debug, Clone, Args)]
+#[command(about = "Inspect a message by its rara_message_id")]
+#[command(
+    long_about = "Inspect a message by its rara_message_id.\n\nReads tape entries from disk (no \
+                  kernel boot required) and prints execution metrics, tool calls, and a \
+                  chronological timeline.\n\nExamples:\n  rara debug 01J4M8VW9XYZAB..."
+)]
+pub struct DebugCmd {
+    /// The rara_message_id to inspect.
+    pub message_id: String,
+}
+
+impl DebugCmd {
+    pub async fn run(self) -> Result<(), Whatever> {
+        let workspace = std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from("."));
+        let store = FileTapeStore::new(rara_paths::memory_dir(), &workspace)
+            .await
+            .whatever_context("failed to open tape store")?;
+        let tape_service = TapeService::new(store);
+
+        // Cross-tape search — empty tape_name + all_tapes=true scans every
+        // session JSONL on disk.
+        let entries = tape_service
+            .search("", &self.message_id, MAX_ENTRIES, true)
+            .await
+            .whatever_context("tape search failed")?;
+
+        let summary = MessageDebugSummary::from_entries(&self.message_id, entries);
+        println!("{}", render_text(&summary));
+        Ok(())
+    }
+}
+
+/// Render a [`MessageDebugSummary`] as plain text for terminal output.
+fn render_text(summary: &MessageDebugSummary) -> String {
+    let mut out = String::new();
+    let _ = writeln!(out, "🔍 Debug: {}", summary.message_id);
+    let _ = writeln!(out, "{}", "─".repeat(60));
+
+    if summary.is_empty() {
+        out.push_str("No tape entries found for this message ID.\n");
+        out.push_str("It may have expired or never existed.\n");
+        return out;
+    }
+
+    // -- Summary ---------------------------------------------------------------
+    let _ = writeln!(out, "\n📊 Summary");
+    let _ = writeln!(out, "  Entries:    {}", summary.entries.len());
+    if let Some(ref model) = summary.model {
+        let _ = writeln!(out, "  Model:      {model}");
+    }
+    if summary.iterations > 0 {
+        let _ = writeln!(out, "  Iterations: {}", summary.iterations);
+    }
+    if summary.stream_ms > 0 {
+        let _ = writeln!(
+            out,
+            "  Stream:     {:.1}s",
+            summary.stream_ms as f64 / 1000.0
+        );
+    }
+    if summary.input_tokens > 0 || summary.output_tokens > 0 {
+        let _ = writeln!(
+            out,
+            "  Tokens:     ↑{} ↓{}",
+            format_tokens(summary.input_tokens),
+            format_tokens(summary.output_tokens)
+        );
+    }
+    if !summary.tools.is_empty() {
+        let _ = writeln!(
+            out,
+            "  Tool calls: {} ({} failed)",
+            summary.tools.len(),
+            summary.tool_failures
+        );
+    }
+
+    // -- Tools -----------------------------------------------------------------
+    if !summary.tools.is_empty() {
+        let _ = writeln!(out, "\n🔧 Tools");
+        for tool in &summary.tools {
+            let duration = tool
+                .duration_ms
+                .map(|ms| format!("{ms}ms"))
+                .unwrap_or_else(|| "—".to_owned());
+            let icon = if tool.success { "✓" } else { "✗" };
+            let _ = writeln!(out, "  {icon} {} ({duration})", tool.name);
+            if let Some(ref err) = tool.error {
+                let preview: String = err.chars().take(150).collect();
+                let _ = writeln!(out, "    ⚠ {preview}");
+            }
+        }
+    }
+
+    // -- Timeline --------------------------------------------------------------
+    let _ = writeln!(out, "\n📝 Timeline");
+    for item in &summary.timeline {
+        let _ = writeln!(out, "  {} [{}] {}", item.timestamp, item.kind, item.detail);
+    }
+
+    out
+}
+
+/// Format token count for display (e.g. 15200 → "15.2k").
+fn format_tokens(tokens: u64) -> String {
+    if tokens >= 1000 {
+        format!("{:.1}k", tokens as f64 / 1000.0)
+    } else {
+        tokens.to_string()
+    }
+}

--- a/crates/cmd/src/main.rs
+++ b/crates/cmd/src/main.rs
@@ -17,6 +17,7 @@ use snafu::{ResultExt, Whatever, whatever};
 
 mod build_info;
 mod chat;
+mod debug;
 mod login;
 mod setup;
 mod top;
@@ -47,6 +48,7 @@ enum Commands {
     Login(login::LoginCmd),
     Setup(setup::SetupCmd),
     Wechat(wechat::WechatCmd),
+    Debug(debug::DebugCmd),
 }
 
 #[derive(Debug, Clone, Args)]
@@ -379,5 +381,6 @@ async fn main() -> Result<(), Whatever> {
         Commands::Login(cmd) => cmd.run().await,
         Commands::Setup(cmd) => cmd.run().await,
         Commands::Wechat(cmd) => cmd.run().await,
+        Commands::Debug(cmd) => cmd.run().await,
     }
 }

--- a/crates/kernel/src/debug.rs
+++ b/crates/kernel/src/debug.rs
@@ -1,0 +1,194 @@
+// Copyright 2025 Rararulab
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Message debug summary — aggregates tape entries belonging to a single
+//! `rara_message_id` into a structured view used by both the Telegram
+//! `/debug` command and the `rara debug` CLI subcommand.
+//!
+//! This module is presentation-agnostic. It produces structured data
+//! ([`MessageDebugSummary`]); rendering (HTML, plain text, JSON) lives in
+//! the caller.
+
+use crate::memory::TapEntry;
+
+/// Aggregated debug view of a single message turn.
+#[derive(Debug, Clone)]
+pub struct MessageDebugSummary {
+    /// The `rara_message_id` this summary describes.
+    pub message_id:    String,
+    /// All tape entries that referenced the message ID.
+    pub entries:       Vec<TapEntry>,
+    /// LLM model name (first non-empty value seen in metadata).
+    pub model:         Option<String>,
+    /// Cumulative input tokens across all iterations.
+    pub input_tokens:  u64,
+    /// Cumulative output tokens across all iterations.
+    pub output_tokens: u64,
+    /// Number of LLM iterations (entries with an `iteration` field).
+    pub iterations:    usize,
+    /// Cumulative streaming duration across all iterations, in milliseconds.
+    pub stream_ms:     u64,
+    /// Per-tool execution metrics extracted from `tool_metrics` metadata.
+    pub tools:         Vec<ToolMetric>,
+    /// Number of tool calls that reported `success: false`.
+    pub tool_failures: usize,
+    /// Timeline entries — kind, timestamp, and rendered detail.
+    pub timeline:      Vec<TimelineItem>,
+}
+
+/// Single tool execution record extracted from tape metadata.
+#[derive(Debug, Clone)]
+pub struct ToolMetric {
+    pub name:        String,
+    pub duration_ms: Option<u64>,
+    pub success:     bool,
+    pub error:       Option<String>,
+}
+
+/// Timeline item shown in chronological order.
+#[derive(Debug, Clone)]
+pub struct TimelineItem {
+    /// Tape entry kind ("message", "tool_call", "tool_result", ...).
+    pub kind:      String,
+    /// ISO timestamp string.
+    pub timestamp: String,
+    /// Rendered detail text (content preview, tool name, etc.).
+    pub detail:    String,
+}
+
+impl MessageDebugSummary {
+    /// Aggregate tape entries into a debug summary. Filters entries to
+    /// only those whose `metadata.rara_message_id` matches the target.
+    pub fn from_entries(message_id: &str, entries: Vec<TapEntry>) -> Self {
+        let matched: Vec<TapEntry> = entries
+            .into_iter()
+            .filter(|e| {
+                e.metadata.as_ref().is_some_and(|m| {
+                    m.get("rara_message_id")
+                        .and_then(|v| v.as_str())
+                        .is_some_and(|id| id == message_id)
+                })
+            })
+            .collect();
+
+        let mut model: Option<String> = None;
+        let mut input_tokens = 0u64;
+        let mut output_tokens = 0u64;
+        let mut iterations = 0usize;
+        let mut stream_ms = 0u64;
+        let mut tools: Vec<ToolMetric> = Vec::new();
+        let mut tool_failures = 0usize;
+        let mut timeline: Vec<TimelineItem> = Vec::with_capacity(matched.len());
+
+        for entry in &matched {
+            // Timeline detail derived from the payload.
+            let kind = entry.kind.to_string();
+            let detail = match kind.as_str() {
+                "message" => entry
+                    .payload
+                    .get("content")
+                    .and_then(|v| v.as_str())
+                    .map(|s| s.chars().take(100).collect::<String>())
+                    .unwrap_or_default(),
+                "tool_call" => {
+                    let name = entry
+                        .payload
+                        .get("name")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("?");
+                    format!("→ {name}")
+                }
+                "tool_result" => {
+                    let name = entry
+                        .payload
+                        .get("name")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("?");
+                    let success = entry
+                        .payload
+                        .get("success")
+                        .and_then(|v| v.as_bool())
+                        .unwrap_or(true);
+                    let icon = if success { "✓" } else { "✗" };
+                    format!("{icon} {name}")
+                }
+                _ => String::new(),
+            };
+            timeline.push(TimelineItem {
+                kind,
+                timestamp: entry.timestamp.strftime("%H:%M:%S").to_string(),
+                detail,
+            });
+
+            // Aggregations from the metadata blob.
+            let Some(meta) = entry.metadata.as_ref() else {
+                continue;
+            };
+
+            if model.is_none() {
+                if let Some(m) = meta.get("model").and_then(|v| v.as_str()) {
+                    model = Some(m.to_owned());
+                }
+            }
+            if let Some(usage) = meta.get("usage") {
+                if let Some(t) = usage.get("input_tokens").and_then(|v| v.as_u64()) {
+                    input_tokens += t;
+                }
+                if let Some(t) = usage.get("output_tokens").and_then(|v| v.as_u64()) {
+                    output_tokens += t;
+                }
+            }
+            if meta.get("iteration").is_some() {
+                iterations += 1;
+            }
+            if let Some(ms) = meta.get("stream_ms").and_then(|v| v.as_u64()) {
+                stream_ms += ms;
+            }
+            if let Some(metrics) = meta.get("tool_metrics").and_then(|v| v.as_array()) {
+                for m in metrics {
+                    let success = m.get("success").and_then(|v| v.as_bool()).unwrap_or(true);
+                    if !success {
+                        tool_failures += 1;
+                    }
+                    tools.push(ToolMetric {
+                        name: m
+                            .get("name")
+                            .and_then(|v| v.as_str())
+                            .unwrap_or("?")
+                            .to_owned(),
+                        duration_ms: m.get("duration_ms").and_then(|v| v.as_u64()),
+                        success,
+                        error: m.get("error").and_then(|v| v.as_str()).map(str::to_owned),
+                    });
+                }
+            }
+        }
+
+        Self {
+            message_id: message_id.to_owned(),
+            entries: matched,
+            model,
+            input_tokens,
+            output_tokens,
+            iterations,
+            stream_ms,
+            tools,
+            tool_failures,
+            timeline,
+        }
+    }
+
+    /// Returns true if no tape entries matched the message ID.
+    pub fn is_empty(&self) -> bool { self.entries.is_empty() }
+}

--- a/crates/kernel/src/lib.rs
+++ b/crates/kernel/src/lib.rs
@@ -32,6 +32,7 @@ pub mod agent;
 pub mod browser;
 pub mod cascade;
 pub mod channel;
+pub mod debug;
 pub mod error;
 pub mod event;
 pub mod guard;


### PR DESCRIPTION
## Summary

Add a CLI subcommand \`rara debug <message_id>\` that retrieves the same context as the Telegram \`/debug\` command, but without needing a chat session — useful for log triage and post-mortem analysis.

**Architecture**: extracted aggregation logic into \`rara_kernel::debug::MessageDebugSummary\` so both Telegram and CLI share one data layer with two presentations:
- Telegram: HTML rendering
- CLI: plain text rendering

The CLI reads tape JSONL files directly via \`FileTapeStore + TapeService\` — no kernel boot required.

\`\`\`
rara debug 01J4M8VW9XYZAB...
\`\`\`

## Type of change

| Type | Label |
|------|-------|
| New feature | \`enhancement\` |

## Component

\`core\`

## Closes

Closes #1135

## Test plan

- [x] \`cargo check -p rara-kernel -p rara-channels -p rara-cli\` passes
- [x] \`prek run --all-files\` passes (fmt, clippy, doc, check)
- [x] Telegram \`/debug\` behavior preserved (refactored to use shared summary)