### PR TITLE
refactor(kernel): type-state Principal<Lookup> vs Principal<Resolved> (#1121)

### DIFF
--- a/crates/kernel/src/event.rs
+++ b/crates/kernel/src/event.rs
@@ -292,7 +292,7 @@ pub enum KernelEvent {
         #[debug("{}", manifest.name)]
         manifest:            AgentManifest,
         input:               String,
-        principal:           Principal,
+        principal:           Principal<crate::identity::Lookup>,
         parent_id:           Option<SessionKey>,
         desired_session_key: Option<SessionKey>,
         #[debug(skip)]
@@ -459,7 +459,7 @@ impl KernelEventEnvelope {
     pub fn create_session(
         manifest: AgentManifest,
         input: String,
-        principal: Principal,
+        principal: Principal<crate::identity::Lookup>,
         parent_id: Option<SessionKey>,
         desired_session_key: Option<SessionKey>,
         reply_tx: oneshot::Sender<crate::error::Result<SessionKey>>,
@@ -481,7 +481,7 @@ impl KernelEventEnvelope {
     pub fn spawn_agent(
         manifest: AgentManifest,
         input: String,
-        principal: Principal,
+        principal: Principal<crate::identity::Lookup>,
         parent_id: Option<SessionKey>,
         desired_session_key: Option<SessionKey>,
         reply_tx: oneshot::Sender<crate::error::Result<SessionKey>>,

--- a/crates/kernel/src/handle.rs
+++ b/crates/kernel/src/handle.rs
@@ -150,7 +150,7 @@ impl KernelHandle {
         &self,
         manifest: AgentManifest,
         input: String,
-        principal: Principal,
+        principal: Principal<crate::identity::Lookup>,
         parent_id: Option<SessionKey>,
         desired_session_key: Option<SessionKey>,
     ) -> Result<SessionKey> {
@@ -180,7 +180,7 @@ impl KernelHandle {
         &self,
         agent_name: &str,
         input: String,
-        principal: Principal,
+        principal: Principal<crate::identity::Lookup>,
         parent_id: Option<SessionKey>,
     ) -> Result<SessionKey> {
         let manifest =
@@ -429,7 +429,7 @@ impl KernelHandle {
         let event = KernelEventEnvelope::spawn_agent(
             manifest,
             input,
-            principal.clone(),
+            principal.clone().into_lookup(),
             Some(session_key),
             None,
             reply_tx,

--- a/crates/kernel/src/identity.rs
+++ b/crates/kernel/src/identity.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::sync::Arc;
+use std::{marker::PhantomData, sync::Arc};
 
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
@@ -81,21 +81,100 @@ impl KernelUser {
     }
 }
 
+// ---------------------------------------------------------------------------
+// Principal — type-state marker types
+// ---------------------------------------------------------------------------
+
+/// Marker: principal only carries the user id; permissions have not yet
+/// been resolved from the user store. Never safe to use for permission
+/// checks.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct Lookup;
+
+/// Marker: principal was fully populated from the user store with a real
+/// role and permission list. Safe for authorization decisions.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct Resolved;
+
 /// The identity under which an agent process runs.
+///
+/// Parameterised over a type state:
+///
+/// - [`Principal<Lookup>`] — produced by [`Principal::lookup`]. Only the
+///   `user_id` is populated; `role` and `permissions` are placeholders.
+///   Intended purely as a query key for
+///   [`crate::security::SecuritySubsystem::resolve_principal`]. Calling
+///   authorization methods is a **compile error**.
+/// - [`Principal<Resolved>`] (the default) — produced by
+///   [`Principal::from_user`] or
+///   [`crate::security::SecuritySubsystem::resolve_principal`]. Carries the
+///   full role + permission list from the database and is the only form that
+///   exposes `has_permission`, `is_admin`, and `role`.
+///
+/// The default type parameter is `Resolved` so that downstream code that
+/// stores or passes around fully-resolved principals stays unchanged.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct Principal {
-    pub user_id:     UserId,
-    pub role:        Role,
-    pub permissions: Vec<Permission>,
+pub struct Principal<State = Resolved> {
+    pub user_id: UserId,
+    role:        Role,
+    permissions: Vec<Permission>,
+    #[serde(skip)]
+    _state:      PhantomData<State>,
 }
 
-impl Principal {
-    /// Create a principal from a [`KernelUser`].
+impl<State> PartialEq for Principal<State> {
+    fn eq(&self, other: &Self) -> bool {
+        self.user_id == other.user_id
+            && self.role == other.role
+            && self.permissions == other.permissions
+    }
+}
+
+impl<State> Eq for Principal<State> {}
+
+// -- Constructors common to any state --------------------------------------
+
+impl Principal<Lookup> {
+    /// Create a lookup-key principal for identity resolution.
+    ///
+    /// The returned value only carries the user id — role and permissions
+    /// are placeholders. Pass it to
+    /// [`crate::security::SecuritySubsystem::resolve_principal`] to obtain a
+    /// [`Principal<Resolved>`] before storing it in a session or performing
+    /// any permission check.
+    pub fn lookup(user_id: impl Into<String>) -> Self {
+        Self {
+            user_id:     UserId(user_id.into()),
+            role:        Role::User,
+            permissions: Vec::new(),
+            _state:      PhantomData,
+        }
+    }
+}
+
+impl Principal<Resolved> {
+    /// Downgrade a resolved principal back to a lookup key, discarding the
+    /// cached role and permissions. Used when re-validating a principal
+    /// through [`crate::security::SecuritySubsystem::resolve_principal`].
+    pub fn into_lookup(self) -> Principal<Lookup> {
+        Principal {
+            user_id:     self.user_id,
+            role:        Role::User,
+            permissions: Vec::new(),
+            _state:      PhantomData,
+        }
+    }
+
+    /// Create a resolved principal from a [`KernelUser`] record.
+    ///
+    /// This is the canonical entry point for producing a principal that is
+    /// safe to use for permission checks.
     pub fn from_user(user: &KernelUser) -> Self {
         Self {
             user_id:     UserId(user.name.clone()),
             role:        user.role,
             permissions: user.permissions.clone(),
+            _state:      PhantomData,
         }
     }
 
@@ -106,22 +185,14 @@ impl Principal {
             || self.permissions.contains(perm)
     }
 
-    /// Create a lookup-key principal for identity resolution.
-    ///
-    /// The returned `Principal` only carries the user id — role and
-    /// permissions are placeholders. Call
-    /// `SecuritySubsystem::resolve_principal` to obtain a fully-populated
-    /// principal before storing it in a session.
-    pub fn lookup(user_id: impl Into<String>) -> Self {
-        Self {
-            user_id:     UserId(user_id.into()),
-            role:        Role::User,
-            permissions: vec![],
-        }
-    }
-
     /// Whether this principal has admin privileges.
     pub fn is_admin(&self) -> bool { self.role == Role::Admin || self.role == Role::Root }
+
+    /// Access this principal's role.
+    pub fn role(&self) -> Role { self.role }
+
+    /// Access this principal's permission list.
+    pub fn permissions(&self) -> &[Permission] { &self.permissions }
 }
 
 pub type UserStoreRef = Arc<dyn UserStore>;
@@ -213,5 +284,22 @@ mod tests {
         };
         assert!(user.can_use_tool("bash"));
         assert!(user.can_use_tool("write-file"));
+    }
+
+    #[test]
+    fn resolved_principal_exposes_permissions() {
+        let user = root_user();
+        let principal = Principal::from_user(&user);
+        assert!(principal.has_permission(&Permission::Spawn));
+        assert!(principal.is_admin());
+        assert_eq!(principal.role(), Role::Root);
+    }
+
+    #[test]
+    fn lookup_principal_only_carries_user_id() {
+        let p = Principal::<Lookup>::lookup("alice");
+        assert_eq!(p.user_id, UserId("alice".into()));
+        // Compile-time: p.has_permission(...), p.is_admin(), p.role() do NOT
+        // exist on Principal<Lookup> — only Principal<Resolved>.
     }
 }

--- a/crates/kernel/src/kernel.rs
+++ b/crates/kernel/src/kernel.rs
@@ -706,7 +706,7 @@ impl Kernel {
         &self,
         manifest: AgentManifest,
         input: crate::channel::types::MessageContent,
-        principal: Principal,
+        principal: Principal<crate::identity::Lookup>,
         parent_id: Option<SessionKey>,
         // TODO: not yet implemented — intended for restoring a previous
         // session's tape/history so the agent can resume where it left off.

--- a/crates/kernel/src/security.rs
+++ b/crates/kernel/src/security.rs
@@ -326,7 +326,10 @@ impl SecuritySubsystem {
     ///
     /// Returns a fully-populated `Principal` with the correct role and
     /// permissions from the database — never a hollow placeholder.
-    pub async fn resolve_principal(&self, principal: &Principal) -> Result<Principal> {
+    pub async fn resolve_principal(
+        &self,
+        principal: &Principal<crate::identity::Lookup>,
+    ) -> Result<Principal> {
         let user = self
             .user_store
             .get_by_name(&principal.user_id.0)

--- a/crates/kernel/src/syscall.rs
+++ b/crates/kernel/src/syscall.rs
@@ -605,7 +605,9 @@ impl SyscallDispatcher {
                         reason: format!(
                             "agent {} (role {:?}) cannot access {:?} scope — requires Root or \
                              Admin",
-                            session_key, principal.role, scope,
+                            session_key,
+                            principal.role(),
+                            scope,
                         ),
                     });
                 }

--- a/crates/kernel/tests/task_report_test.rs
+++ b/crates/kernel/tests/task_report_test.rs
@@ -486,7 +486,13 @@ fn test_in_flight_recovery() {
     let jobs_path = tmp.path().join("jobs.json");
     let in_flight_path = tmp.path().join("in_flight.json");
 
-    let principal = rara_kernel::identity::Principal::lookup("test-user".to_string());
+    let test_user = rara_kernel::identity::KernelUser {
+        name:        "test-user".into(),
+        role:        rara_kernel::identity::Role::User,
+        permissions: vec![rara_kernel::identity::Permission::Spawn],
+        enabled:     true,
+    };
+    let principal = rara_kernel::identity::Principal::from_user(&test_user);
     let session = SessionKey::new();
     let now = jiff::Timestamp::now();
     let past = now
@@ -596,7 +602,13 @@ fn test_complete_in_flight() {
     let tmp = tempfile::tempdir().unwrap();
     let jobs_path = tmp.path().join("jobs.json");
 
-    let principal = rara_kernel::identity::Principal::lookup("test-user".to_string());
+    let test_user = rara_kernel::identity::KernelUser {
+        name:        "test-user".into(),
+        role:        rara_kernel::identity::Role::User,
+        permissions: vec![rara_kernel::identity::Permission::Spawn],
+        enabled:     true,
+    };
+    let principal = rara_kernel::identity::Principal::from_user(&test_user);
     let session = SessionKey::new();
     let past = jiff::Timestamp::now()
         .checked_sub(jiff::SignedDuration::from_secs(10))


### PR DESCRIPTION
Closes #1121

Introduce phantom type states for `Principal` so that permission checks are only available on fully-resolved principals.

- `Principal<Lookup>`: produced by `Principal::lookup`, only carries `user_id`. Permission methods (`has_permission`, `is_admin`, `role`, `permissions`) are not available — calling them is a **compile error**.
- `Principal<Resolved>` (default): produced by `Principal::from_user` or `SecuritySubsystem::resolve_principal`. Exposes the full permission API.
- `Principal::into_lookup()`: downgrade for re-resolution.

Wired through `resolve_principal`, `handle_spawn_agent`, `CreateSession` event, and the `spawn_with_input` / `spawn_named` handle APIs. Session still stores `Principal<Resolved>`.