### PR TITLE
docs(kernel): add ARCHITECTURE.md mapping kernel data flow and module roles (#1140)

### DIFF
--- a/crates/kernel/ARCHITECTURE.md
+++ b/crates/kernel/ARCHITECTURE.md
@@ -1,0 +1,199 @@
+# kernel — Architecture
+
+> A bird's-eye map of the `rara-kernel` crate, in the spirit of
+> [matklad's ARCHITECTURE.md](https://matklad.github.io/2021/02/06/ARCHITECTURE.md.html).
+> For crate-level invariants and anti-patterns see
+> [`AGENT.md`](./AGENT.md). For per-subsystem deep dives, follow the
+> `AGENT.md` files referenced inline below.
+
+## Mission
+
+`rara-kernel` is an OS-inspired event loop that coordinates LLM agent
+"processes". Channel adapters (Telegram, web, CLI, STT, ...) publish
+inbound messages onto a shared event queue; event processors drain
+that queue, dispatch each event to a typed handler, and drive a
+session through its lifecycle — loading tape memory, calling the LLM,
+invoking tools, and delivering responses back out through the I/O
+subsystem. The kernel owns no agent business logic of its own; it is
+a scheduler, a resource gate, and an integration surface for the
+subsystems listed below.
+
+## Entry Point
+
+The single public entry point is
+[`Kernel::start`](./src/kernel.rs) at `src/kernel.rs:373`:
+
+```rust
+pub fn start(
+    self,
+    cancel_token: CancellationToken,
+) -> (Arc<Self>, crate::handle::KernelHandle) { ... }
+```
+
+`start` consumes the assembled `Kernel`, wraps it in `Arc`, and spawns
+the unified event loop via `Kernel::run` (`src/kernel.rs:404`). `run`
+spawns one global processor plus `N` shard processors, each executing
+`Kernel::run_processor` (`src/kernel.rs:454`). Only processor `id=0`
+also runs the unified scheduler (Mita heartbeat + job wheel + rate
+limiter GC).
+
+External callers interact exclusively through the returned
+[`KernelHandle`](./src/handle.rs) — mutations flow through the event
+queue, so there is no second "control plane" to reason about.
+
+## Data Flow — the Happy Path
+
+A single bullet path covers the majority of traffic. Every arrow is a
+real file you can grep for:
+
+- **channel adapters** ([`src/channel/adapter.rs`](./src/channel/adapter.rs))
+  receive raw platform events and construct
+  `InboundMessage<Unresolved>`.
+- **`IngressPipeline`** ([`src/io.rs:1308`](./src/io.rs)) resolves
+  identity, applies rate limiting, and pushes a
+  `KernelEventEnvelope::UserMessage` (`src/event.rs:274`) onto the
+  queue.
+- **`EventQueue`** / `ShardedQueue`
+  ([`src/queue/mod.rs`](./src/queue/mod.rs),
+  [`src/queue/sharded.rs`](./src/queue/sharded.rs)) buffers events
+  per shard with back-pressure.
+- **`run_processor`** (`src/kernel.rs:454`) drains up to 32 events at a
+  time and spawns `handle_event` (`src/kernel.rs:600`) as a short-lived
+  tokio task per event.
+- **`handle_event`** dispatches to a typed handler — e.g.
+  `handle_user_message` (`src/kernel.rs:1173`),
+  `handle_group_message` (`src/kernel.rs:1468`),
+  `handle_spawn_agent` (`src/kernel.rs:708`),
+  `handle_signal` (`src/kernel.rs:835`),
+  `handle_scheduled_task` (`src/kernel.rs:1361`),
+  `handle_mita_heartbeat` (`src/kernel.rs:1625`),
+  `handle_turn_completed` (`src/kernel.rs:2475`).
+- Each handler calls into the agent run loop
+  ([`src/agent/mod.rs`](./src/agent/mod.rs)) which interleaves
+  **tape memory** writes ([`src/memory/`](./src/memory)) with LLM
+  calls ([`src/llm/`](./src/llm)) and tool invocations
+  ([`src/tool/`](./src/tool)).
+- Output is delivered back out via
+  **`IOSubsystem::deliver`** ([`src/io.rs`](./src/io.rs)) which routes
+  to the originating channel adapter.
+
+Other event kinds (child completion, signals, scheduled tasks) reuse
+the same queue → processor → handler path.
+
+## Module Taxonomy
+
+The `src/` tree has 27 top-level modules across three tiers:
+
+### Core — the kernel proper
+
+These define the event loop, the agent process abstraction, and the
+syscall / handle surface. Touching them means touching the scheduler.
+
+| Module | Path | Role |
+|---|---|---|
+| kernel | [`src/kernel.rs`](./src/kernel.rs) | `Kernel` struct, event loop, handlers |
+| event | [`src/event.rs`](./src/event.rs) | `KernelEventEnvelope` + event kinds |
+| queue | [`src/queue/`](./src/queue) | `ShardedQueue`, per-shard `ShardQueue` |
+| session | [`src/session/`](./src/session) | `SessionKey`, `SessionState`, registry |
+| agent | [`src/agent/`](./src/agent) | Agent run loop, fold, loop-breaker, repetition guard |
+| io | [`src/io.rs`](./src/io.rs) | `IngressPipeline`, `IOSubsystem::deliver`, rate limiter |
+| syscall | [`src/syscall.rs`](./src/syscall.rs) | Syscall surface invoked by agents |
+| handle | [`src/handle.rs`](./src/handle.rs) | `KernelHandle` — the external API |
+| security | [`src/security.rs`](./src/security.rs) | `Principal` resolution, permission checks |
+| channel | [`src/channel/`](./src/channel) | Adapter trait + registry |
+
+### Subsystems — state holders called by the kernel
+
+These are assembled into `Kernel` at construction time and are
+accessed through typed subsystem fields. They each own persistent
+state but do not run their own event loop.
+
+| Module | Path | Role |
+|---|---|---|
+| tool | [`src/tool/`](./src/tool) | Tool registry + dispatch |
+| llm | [`src/llm/`](./src/llm) | LLM clients + streaming |
+| memory | [`src/memory/`](./src/memory) | Tape memory (JSONL) + session index |
+| guard | [`src/guard/`](./src/guard) | Guard pipeline — see [`src/guard/AGENT.md`](./src/guard/AGENT.md) |
+| schedule | [`src/schedule.rs`](./src/schedule.rs) | Job wheel driving scheduled tasks |
+| notification | [`src/notification/`](./src/notification) | User-facing notification fan-out |
+
+### Leaves — peripheral features
+
+Opt-in integrations and domain features. They depend on Core and
+Subsystems but nothing depends on them, so they can be modified in
+isolation.
+
+`browser` ([`src/browser/AGENT.md`](./src/browser/AGENT.md)),
+`stt` ([`src/stt/AGENT.md`](./src/stt/AGENT.md)),
+`mood` ([`src/mood.rs`](./src/mood.rs)),
+`proactive` ([`src/proactive.rs`](./src/proactive.rs)),
+`plan` ([`src/plan.rs`](./src/plan.rs)),
+`debug` ([`src/debug.rs`](./src/debug.rs)),
+`cascade` ([`src/cascade.rs`](./src/cascade.rs)),
+`trace` ([`src/trace.rs`](./src/trace.rs)),
+`metrics` ([`src/metrics.rs`](./src/metrics.rs)),
+`identity` ([`src/identity.rs`](./src/identity.rs)),
+`kv` ([`src/kv.rs`](./src/kv.rs)),
+`task_report` ([`src/task_report.rs`](./src/task_report.rs)),
+`user_question` ([`src/user_question.rs`](./src/user_question.rs)).
+
+## Concurrency Model
+
+- **One unified event loop** with `1 + N` processors
+  (`src/kernel.rs:404`). With `num_shards == 0` only the global
+  processor runs — the sharded and single-queue modes share one code
+  path.
+- **Per-event handlers** are spawned as independent tokio tasks
+  (`src/kernel.rs:507`); handlers do not block the drain loop.
+- **Global semaphore** (`src/kernel.rs:166`, initialised at
+  `src/kernel.rs:254`) caps total concurrent agent processes across
+  all shards. `handle_spawn_agent` acquires a permit at
+  `src/kernel.rs:730`; per-session child limits are enforced by a
+  separate `child_semaphore` (`src/kernel.rs:791`).
+- **Scheduler ticks** (Mita heartbeat, job wheel, rate-limiter GC)
+  only run on processor `id=0` (`src/kernel.rs:513`), so there is
+  exactly one authoritative source of wall-clock-driven work.
+
+## State Machines
+
+### Session lifecycle
+
+Defined in [`src/session/mod.rs:206`](./src/session/mod.rs) as
+`enum SessionState { Active, Ready, Suspended, Paused }`:
+
+- `Ready` — idle, awaiting next message.
+- `Active` — an agent turn is in flight (LLM call or tool call).
+- `Suspended` — timed out; resources released, but can be resumed.
+- `Paused` — manually paused; rejects incoming messages.
+
+`SessionState::is_terminal()` always returns `false`
+(`src/session/mod.rs:222`): sessions are never truly terminal — they
+transition to `Suspended` instead. Transitions happen via
+`SessionRegistry::set_state` (`src/session/mod.rs:526`).
+
+## Key Invariants
+
+1. **The event loop is the only writer of kernel state.** External
+   callers mutate state by pushing events through `KernelHandle`;
+   they never touch `Kernel` fields directly.
+2. **Handlers never hold kernel state across await points that could
+   block the drain loop.** Handlers are spawned as independent tasks
+   (`src/kernel.rs:507`) so the processor can keep draining.
+3. **Syscalls are queued and processed by the event loop.** Agents
+   do not mutate session or memory state directly — they issue
+   syscalls ([`src/syscall.rs`](./src/syscall.rs)) dispatched through
+   the same handler machinery as external events.
+4. **`Principal` is never fabricated.** Every `Principal` must come
+   from `SecuritySubsystem::resolve_principal`
+   ([`src/security.rs`](./src/security.rs)) or `Principal::from_user`.
+   Hollow principals bypass permission checks and are a review-blocker.
+5. **Processor `id=0` is the single owner of scheduler ticks.** Mita
+   heartbeat, job wheel drain, and rate-limiter GC only fire on the
+   global processor (`src/kernel.rs:513`).
+
+## See Also
+
+- [`AGENT.md`](./AGENT.md) — crate-level invariants and anti-patterns
+- [`src/guard/AGENT.md`](./src/guard/AGENT.md) — guard pipeline internals
+- [`src/browser/AGENT.md`](./src/browser/AGENT.md) — browser tool integration
+- [`src/stt/AGENT.md`](./src/stt/AGENT.md) — speech-to-text subsystem


### PR DESCRIPTION
Closes #1140

Adds `crates/kernel/ARCHITECTURE.md` — a 199-line human-facing architecture map in matklad's style.

Covers:
- **Mission**: one-paragraph framing of the kernel as an OS-inspired event loop
- **Entry point**: `Kernel::start` at `src/kernel.rs:373` with real file:line refs
- **Data flow (happy path)**: channel adapters → IngressPipeline → EventQueue → run_processor → handle_event → agent loop → tape + IOSubsystem.deliver
- **Module taxonomy**: 27 modules split into Core (event loop + scheduler), Subsystems (stateful dependencies), and Leaves (peripheral features)
- **Concurrency model**: unified event loop, per-event handler spawn, global + per-session semaphores
- **Session state machine**: Active / Ready / Suspended / Paused
- **Key invariants** (5): event loop is the only writer, handlers don't block the drain loop, syscalls are queued, Principal is never fabricated, processor id=0 owns scheduler ticks

Every reference uses real file paths and line numbers so readers can jump directly from the document into the code. Documentation only — no Rust code changes.