### PR TITLE
refactor(kernel): remove single-impl EventQueue trait, use ShardedEventQueue directly (#1142)

### DIFF
--- a/crates/kernel/src/handle.rs
+++ b/crates/kernel/src/handle.rs
@@ -23,11 +23,6 @@ use std::sync::Arc;
 use jiff::Timestamp;
 use tokio::sync::Semaphore;
 
-/// Provider that generates a skills prompt block for injection into the agent
-/// system prompt. Called on each agent turn to reflect the latest registry
-/// state.
-pub type SkillPromptProvider = Arc<dyn Fn() -> String + Send + Sync>;
-
 use crate::{
     agent::{AgentManifest, AgentRegistryRef, TurnTrace},
     error::{KernelError, Result},
@@ -39,13 +34,21 @@ use crate::{
     },
     kernel::{KernelConfig, SettingsRef},
     kv::KvScope,
-    queue::EventQueueRef,
+    queue::ShardedQueueRef,
     security::SecurityRef,
     session::{
         SessionIndex, SessionKey, SessionState, SessionStats, SessionTable, Signal, SystemStats,
     },
     tool::{ToolRegistry, ToolRegistryRef},
 };
+
+/// Provider that generates a skills prompt block for injection into the agent
+/// system prompt. Called on each agent turn to reflect the latest registry
+/// state.
+///
+/// Stored as a boxed closure rather than a trait object alias so the concrete
+/// erased type is visible at the field site.
+pub type SkillPromptProvider = Arc<dyn Fn() -> String + Send + Sync>;
 /// Public entry point for interacting with the kernel.
 ///
 /// Provides both mutation methods (spawn, signal, shutdown) that flow through
@@ -68,7 +71,7 @@ use crate::{
 #[derive(Clone)]
 pub struct KernelHandle {
     /// Core: the unified event queue sender.
-    event_queue:           EventQueueRef,
+    event_queue:           ShardedQueueRef,
     /// Agent registry for resolving named agents to manifests.
     agent_registry:        AgentRegistryRef,
     /// The session table tracking all running sessions.
@@ -103,7 +106,7 @@ impl KernelHandle {
     /// Create a new `KernelHandle`.
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn new(
-        event_queue: EventQueueRef,
+        event_queue: ShardedQueueRef,
         agent_registry: AgentRegistryRef,
         process_table: Arc<SessionTable>,
         io: Arc<IOSubsystem>,
@@ -317,7 +320,7 @@ impl KernelHandle {
     pub fn config(&self) -> &KernelConfig { &self.config }
 
     /// Access the unified event queue.
-    pub fn event_queue(&self) -> &EventQueueRef { &self.event_queue }
+    pub fn event_queue(&self) -> &ShardedQueueRef { &self.event_queue }
 
     /// Access the tape service for persistent read/write.
     pub fn tape(&self) -> &crate::memory::TapeService { &self.tape }

--- a/crates/kernel/src/io.rs
+++ b/crates/kernel/src/io.rs
@@ -17,7 +17,7 @@
 //! This module implements the kernel's I/O transport layer:
 //!
 //! - **Ingress**: channel adapters publish messages through `IngressPipeline`
-//!   into the unified [`EventQueue`](crate::queue::EventQueue).
+//!   into the unified [`ShardedEventQueue`](crate::queue::ShardedEventQueue).
 //! - **Egress**: the kernel event loop delivers outbound envelopes via
 //!   [`IOSubsystem::deliver`] to registered adapters.
 //! - **Streaming**: ephemeral real-time events (token deltas, tool progress)

--- a/crates/kernel/src/kernel.rs
+++ b/crates/kernel/src/kernel.rs
@@ -65,7 +65,7 @@ use crate::{
     memory::TapeService,
     notification::{BroadcastNotificationBus, NotificationBusRef},
     plan::run_plan_loop,
-    queue::{EventQueueRef, ShardedEventQueueConfig, ShardedQueueRef},
+    queue::{ShardedEventQueueConfig, ShardedQueueRef},
     security::SecurityRef,
     session::{
         AgentRunLoopResult, Session, SessionIndexRef, SessionKey, SessionState, SessionTable,
@@ -182,7 +182,7 @@ pub struct Kernel {
     /// Bundled I/O subsystem (ingress, stream hub, delivery).
     io:                    Arc<IOSubsystem>,
     /// Unified event queue for all kernel interactions.
-    event_queue:           EventQueueRef,
+    event_queue:           ShardedQueueRef,
     /// Sharded event queue backing the kernel event loop.
     ///
     /// Always present. When `num_shards == 0` (single-queue mode), all
@@ -249,7 +249,7 @@ impl Kernel {
         let sharded_queue: ShardedQueueRef = Arc::new(crate::queue::ShardedEventQueue::new(
             config.event_queue.clone(),
         ));
-        let event_queue: EventQueueRef = sharded_queue.clone();
+        let event_queue: ShardedQueueRef = sharded_queue.clone();
 
         let global_semaphore = Arc::new(Semaphore::new(config.max_concurrency));
         let guard_pipeline = Arc::new(crate::guard::pipeline::GuardPipeline::new(
@@ -1792,7 +1792,7 @@ impl Kernel {
         //   - the response stream is closed
         //   - a TurnCompleted(Err) event is pushed so the process returns to Ready
         struct TurnGuard {
-            event_queue:     EventQueueRef,
+            event_queue:     ShardedQueueRef,
             stream_hub:      Arc<crate::io::StreamHub>,
             stream_id:       StreamId,
             typing_refresh:  Option<tokio::task::JoinHandle<()>>,

--- a/crates/kernel/src/queue/mod.rs
+++ b/crates/kernel/src/queue/mod.rs
@@ -14,30 +14,13 @@
 
 //! Queue subsystem for kernel event dispatch.
 //!
-//! The [`EventQueue`] trait is a push-only sink. The drain/wait hot path
-//! goes through `ShardQueue` directly.
+//! The kernel uses a single concrete sharded queue — [`ShardedEventQueue`] —
+//! as its ingress sink. The drain/wait hot path goes through `ShardQueue`
+//! directly.
 
 mod sharded;
-
-use std::sync::Arc;
 
 pub(crate) use sharded::ShardQueue;
 pub use sharded::{ShardedEventQueue, ShardedEventQueueConfig, ShardedQueueRef};
 
 pub use crate::event::{EventPriority, KernelEvent, KernelEventEnvelope};
-use crate::io::IOError;
-
-/// Shared reference to an [`EventQueue`] implementation.
-pub type EventQueueRef = Arc<dyn EventQueue>;
-
-/// Push-only event sink for the kernel event queue.
-///
-/// The drain/wait hot path is handled by `ShardQueue` directly —
-/// this trait only covers the ingress (push) side.
-pub trait EventQueue: Send + Sync + 'static {
-    /// Push an event into the queue. Returns `IOError::Full` if at capacity.
-    fn push(&self, event: KernelEventEnvelope) -> Result<(), IOError>;
-
-    /// Non-blocking push (identical to `push` for in-memory queues).
-    fn try_push(&self, event: KernelEventEnvelope) -> Result<(), IOError>;
-}

--- a/crates/kernel/src/queue/sharded.rs
+++ b/crates/kernel/src/queue/sharded.rs
@@ -28,7 +28,6 @@ use std::sync::Arc;
 use crossbeam_queue::SegQueue;
 use tokio::sync;
 
-use super::EventQueue;
 use crate::{event::KernelEventEnvelope, io::IOError};
 
 /// A single lock-free FIFO shard with async notification.
@@ -127,8 +126,8 @@ fn num_cpus() -> usize {
 
 /// Sharded event queue with N agent shards + 1 global queue.
 ///
-/// Implements [`EventQueue`] and provides internal access to individual
-/// shards for the multi-processor event loop.
+/// Provides the push ingress path and internal access to individual shards
+/// for the multi-processor event loop.
 ///
 /// All shard queues are stored as `Arc<ShardQueue>` so that
 /// `EventProcessor` tasks can
@@ -186,17 +185,20 @@ impl ShardedEventQueue {
                 .map(|shard| shard.pending_count())
                 .sum::<usize>()
     }
-}
 
-impl EventQueue for ShardedEventQueue {
-    fn push(&self, event: KernelEventEnvelope) -> Result<(), IOError> { self.try_push(event) }
-
-    fn try_push(&self, event: KernelEventEnvelope) -> Result<(), IOError> {
+    /// Push an event into the queue, routing it to the correct shard or the
+    /// global queue. Returns `IOError::Full` if the target queue is at
+    /// capacity.
+    pub fn push(&self, event: KernelEventEnvelope) -> Result<(), IOError> {
         match self.classify(&event) {
             ShardTarget::Global => self.global.push(event),
             ShardTarget::Shard(idx) => self.shards[idx].push(event),
         }
     }
+
+    /// Non-blocking push — identical to [`push`](Self::push) for this
+    /// in-memory queue.
+    pub fn try_push(&self, event: KernelEventEnvelope) -> Result<(), IOError> { self.push(event) }
 }
 
 #[cfg(test)]

--- a/crates/kernel/src/tool/mod.rs
+++ b/crates/kernel/src/tool/mod.rs
@@ -311,7 +311,7 @@ pub struct ToolContext {
     /// The originating endpoint (e.g. Telegram chat) for routing replies.
     pub origin_endpoint:       Option<crate::io::Endpoint>,
     /// Event queue for pushing outbound events.
-    pub event_queue:           crate::queue::EventQueueRef,
+    pub event_queue:           crate::queue::ShardedQueueRef,
     /// The inbound message ID that triggered the current turn.
     pub rara_message_id:       crate::io::MessageId,
     /// Context window size in tokens for the current model.


### PR DESCRIPTION
Closes #1142

First pass of the matklad review item: **remove single-implementation trait objects**.

The `EventQueue` trait had only one production implementation (`ShardedEventQueue`). Trait objects are not free — they cost vtable indirection, block inlining, and add reading overhead. Where there is no second implementation and no test mock requirement, use the concrete type.

**Changes**:
- Delete the `EventQueue` trait in `queue/mod.rs`
- Remove `EventQueueRef` alias; use `ShardedQueueRef` (= `Arc<ShardedEventQueue>`)
- Inline `push` / `try_push` directly on `ShardedEventQueue` as inherent methods
- Update all consumers (`handle.rs`, `kernel.rs`, `tool/mod.rs`, `io.rs` doc link)

**Deferred to follow-up** (same issue, larger blast radius — need a careful audit):
- `NotificationBusRef` → concrete `BroadcastNotificationBus`
- `SessionIndexRef` → concrete `FileSessionIndex`
- `SkillPromptProvider` trait object cleanup

Net: -12 lines, 1 fewer trait object on the hot path.