### PR TITLE
perf(kernel): batch sequential event handling in run_processor (#1141)

### DIFF
--- a/crates/kernel/src/kernel.rs
+++ b/crates/kernel/src/kernel.rs
@@ -493,20 +493,25 @@ impl Kernel {
 
             tokio::select! {
                 _ = queue.wait() => {
+                    // Drain and handle events sequentially within this shard.
+                    //
+                    // Handlers that would block the loop (LLM turns, child
+                    // agent execution) must spawn their own background task
+                    // and reply via a follow-up event (e.g. `TurnCompleted`,
+                    // `ChildSessionDone`) — see `start_llm_turn`. Processing
+                    // sequentially here preserves per-shard FIFO ordering and
+                    // avoids a per-event `tokio::spawn` tax.
                     loop {
                         let mut events = queue.drain(32).peekable();
                         if events.peek().is_none() { break; }
                         for event in events {
-                            let this = Arc::clone(self);
                             let event_type: &'static str = (&event.kind).into();
                             let span = info_span!(
                                 "handle_event",
                                 processor_id = id,
                                 event_type,
                             );
-                            tokio::spawn(async move {
-                                this.handle_event(event).instrument(span).await;
-                            });
+                            self.handle_event(event).instrument(span).await;
                         }
                     }
                 }


### PR DESCRIPTION
Closes #1141

The per-event `tokio::spawn` in `run_processor` had two problems:

1. **Task storm** — a busy session generates 50–100 events/sec, each one a separate tokio task. Pure scheduler tax.
2. **Per-shard FIFO was silently broken** — shards exist to give same-session events FIFO ordering, but `tokio::spawn` releases that ordering at the spawn site. Whoever finishes first wins the race to mutate session state.

**Change**: process events sequentially within the drain loop:

```rust
tokio::select! {
    _ = queue.wait() => {
        loop {
            let mut events = queue.drain(32).peekable();
            if events.peek().is_none() { break; }
            for event in events {
                // Sequential — no tokio::spawn per event
                self.handle_event(event).instrument(span).await;
            }
        }
    }
}
```

**Safety**: handlers that would block the loop (LLM turns, child agent execution) already spawn their own background task and reply via follow-up events (`TurnCompleted`, `ChildSessionDone`), so they don't stall draining.

**Net effect**:
- FIFO per shard is now a property of the code, not a comment
- Scheduler overhead drops roughly 32× for short events (drain batch size)

Only touches `run_processor` in `crates/kernel/src/kernel.rs` — 9 insertions, 4 deletions.