### PR TITLE
fix(kernel): explicit backpressure retry for IOError::Full in ingress pipeline (#1148)

### DIFF
--- a/crates/channels/src/telegram/adapter.rs
+++ b/crates/channels/src/telegram/adapter.rs
@@ -2770,11 +2770,14 @@ async fn handle_update(
 
     // Route: group proactive candidates go through GroupMessage event for
     // lightweight LLM judgment; directly-addressed messages go through the
-    // normal UserMessage path.
+    // normal UserMessage path. Both use the async ingest variants so
+    // `IOError::Full` is retried with bounded backoff (and exhausted
+    // envelopes routed to the dead-letter sink) rather than being silently
+    // dropped — see issue #1148.
     let submit_result = if is_group_proactive {
-        handle.submit_group_message(msg)
+        handle.ingest_group_message(msg).await
     } else {
-        handle.submit_message(msg)
+        handle.ingest_user_message(msg).await
     };
 
     match submit_result {

--- a/crates/kernel/src/handle.rs
+++ b/crates/kernel/src/handle.rs
@@ -34,7 +34,7 @@ use crate::{
     },
     kernel::{KernelConfig, SettingsRef},
     kv::KvScope,
-    queue::ShardedQueueRef,
+    queue::{ShardedQueueRef, push_with_retry},
     security::SecurityRef,
     session::{
         SessionIndex, SessionKey, SessionState, SessionStats, SessionTable, Signal, SystemStats,
@@ -212,12 +212,20 @@ impl KernelHandle {
     /// Ingest a raw platform message: resolve identity + session, then push
     /// the resulting [`InboundMessage`] into the event queue.
     ///
-    /// This is the primary entry point for channel adapters.
+    /// This is the primary entry point for channel adapters. Push errors go
+    /// through [`push_with_retry`], which applies bounded exponential backoff
+    /// on `IOError::Full` and routes exhausted envelopes to the dead-letter
+    /// sink (or a structured error log).
     pub async fn ingest(&self, raw: RawPlatformMessage) -> std::result::Result<(), IOError> {
         let msg = self.io.resolve(raw).await?;
         let channel_label = format!("{:?}", msg.source.channel_type);
 
-        self.submit_message(msg).map_err(|_| IOError::SystemBusy)?;
+        push_with_retry(
+            &self.event_queue,
+            KernelEventEnvelope::user_message(msg),
+            &self.config.ingress,
+        )
+        .await?;
 
         crate::metrics::record_message_inbound(&channel_label);
 
@@ -227,7 +235,9 @@ impl KernelHandle {
     /// Submit an inbound user message (fire-and-forget).
     ///
     /// Uses `try_push` (non-async) so this can be called from synchronous
-    /// contexts.
+    /// contexts. Prefer [`ingest_user_message`](Self::ingest_user_message)
+    /// from async ingress paths so backpressure is retried instead of
+    /// silently dropped.
     pub fn submit_message(&self, msg: InboundMessage<Unresolved>) -> Result<()> {
         self.event_queue
             .try_push(KernelEventEnvelope::user_message(msg))
@@ -240,12 +250,50 @@ impl KernelHandle {
     ///
     /// The kernel will record the message to tape, run a lightweight LLM
     /// judgment, and only promote to a full agent turn if approved.
+    ///
+    /// Synchronous variant — async ingress callers should use
+    /// [`ingest_group_message`](Self::ingest_group_message) so transient
+    /// `Full` errors are retried instead of dropping the message.
     pub fn submit_group_message(&self, msg: InboundMessage<Unresolved>) -> Result<()> {
         self.event_queue
             .try_push(KernelEventEnvelope::group_message(msg))
             .map_err(|_| KernelError::Other {
                 message: "event queue full for group message".into(),
             })
+    }
+
+    /// Async ingress entry point for an already-resolved user message.
+    ///
+    /// Same payload as [`submit_message`](Self::submit_message), but routes
+    /// the push through [`push_with_retry`] so backpressure (`IOError::Full`)
+    /// is retried with bounded exponential backoff and exhausted messages
+    /// land in the dead-letter sink rather than being dropped silently.
+    pub async fn ingest_user_message(
+        &self,
+        msg: InboundMessage<Unresolved>,
+    ) -> std::result::Result<(), IOError> {
+        push_with_retry(
+            &self.event_queue,
+            KernelEventEnvelope::user_message(msg),
+            &self.config.ingress,
+        )
+        .await
+    }
+
+    /// Async ingress entry point for a group-chat candidate message.
+    ///
+    /// Mirrors [`ingest_user_message`](Self::ingest_user_message) but
+    /// produces a `GroupMessage` event for the proactive-judgment path.
+    pub async fn ingest_group_message(
+        &self,
+        msg: InboundMessage<Unresolved>,
+    ) -> std::result::Result<(), IOError> {
+        push_with_retry(
+            &self.event_queue,
+            KernelEventEnvelope::group_message(msg),
+            &self.config.ingress,
+        )
+        .await
     }
 
     /// Dispatch a Mita directive to a target session.

--- a/crates/kernel/src/kernel.rs
+++ b/crates/kernel/src/kernel.rs
@@ -137,6 +137,12 @@ pub struct KernelConfig {
     pub event_queue:             ShardedEventQueueConfig,
     /// Context folding (auto-anchor) configuration.
     pub context_folding:         ContextFoldingConfig,
+    /// Ingress retry / dead-letter configuration.
+    ///
+    /// Controls how `push_with_retry` handles `IOError::Full` from the
+    /// sharded queue when channel adapters publish messages. See
+    /// [`crate::queue::push_with_retry`].
+    pub ingress:                 crate::queue::IngressConfig,
 }
 
 /// Shared reference to a

--- a/crates/kernel/src/queue/mod.rs
+++ b/crates/kernel/src/queue/mod.rs
@@ -17,10 +17,19 @@
 //! The kernel uses a single concrete sharded queue — [`ShardedEventQueue`] —
 //! as its ingress sink. The drain/wait hot path goes through `ShardQueue`
 //! directly.
+//!
+//! ## Backpressure
+//!
+//! The queue is bounded. When all retries fail, the in-process callers in the
+//! ingress path MUST use [`push_with_retry`] rather than
+//! [`ShardedEventQueue::push`] directly so that transient backpressure does not
+//! silently drop user messages — see issue #1148.
 
+mod retry;
 mod sharded;
 
 pub(crate) use sharded::ShardQueue;
 pub use sharded::{ShardedEventQueue, ShardedEventQueueConfig, ShardedQueueRef};
 
+pub use self::retry::{IngressConfig, push_with_retry};
 pub use crate::event::{EventPriority, KernelEvent, KernelEventEnvelope};

--- a/crates/kernel/src/queue/retry.rs
+++ b/crates/kernel/src/queue/retry.rs
@@ -1,0 +1,211 @@
+// Copyright 2025 Rararulab
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Backpressure retry helper for the ingress pipeline.
+//!
+//! Channel adapters publish messages into the kernel's bounded
+//! [`ShardedEventQueue`](crate::queue::ShardedEventQueue). When the target
+//! shard is at capacity the queue returns [`IOError::Full`]. Without retry
+//! the adapters would silently drop user messages — a latent reliability
+//! bug (see issue #1148).
+//!
+//! [`push_with_retry`] applies a small bounded exponential-backoff retry,
+//! and on exhaustion either appends the dropped envelope as a JSON line to
+//! a configured dead-letter file or emits a structured error log.
+
+use std::{
+    path::{Path, PathBuf},
+    time::Duration,
+};
+
+use crate::{event::KernelEventEnvelope, io::IOError, queue::ShardedQueueRef};
+
+/// Maximum number of `Full` retries before giving up.
+const MAX_RETRIES: u32 = 3;
+
+/// Initial backoff between retries (doubled on each attempt).
+const BASE_DELAY: Duration = Duration::from_millis(100);
+
+/// Configuration for the ingress retry/dead-letter behaviour.
+///
+/// `dead_letter_path` is intentionally an [`Option`] — defaults come from the
+/// YAML config file, never from Rust. When unset, exhausted messages are only
+/// recorded in the structured error log.
+#[derive(Debug, Clone, Default)]
+pub struct IngressConfig {
+    /// Optional path to a dead-letter file. Dropped envelopes are appended as
+    /// one JSON object per line. Parent directories must already exist.
+    pub dead_letter_path: Option<PathBuf>,
+}
+
+/// Push an event into the sharded queue with bounded exponential-backoff
+/// retry on [`IOError::Full`].
+///
+/// The retry budget is intentionally tiny — the queue is local and in-memory,
+/// so persistent fullness indicates a stuck consumer rather than a transient
+/// hiccup. The goal is to absorb micro-bursts (a few hundred ms), not to
+/// paper over a real outage.
+///
+/// On exhaustion:
+/// - If `cfg.dead_letter_path` is set, the dropped envelope is appended as a
+///   JSON line to that file. Failure to write the dead letter is logged but
+///   does not change the returned error — the caller still sees `Full`.
+/// - Otherwise, a structured `error!` log is emitted.
+///
+/// Other [`IOError`] variants are returned immediately without retry; only
+/// `Full` is retryable.
+#[tracing::instrument(skip_all, fields(retries = MAX_RETRIES))]
+pub async fn push_with_retry(
+    queue: &ShardedQueueRef,
+    event: KernelEventEnvelope,
+    cfg: &IngressConfig,
+) -> Result<(), IOError> {
+    let mut delay = BASE_DELAY;
+    let mut last_event = event;
+    for attempt in 0..MAX_RETRIES {
+        match queue.push_returning(last_event) {
+            Ok(()) => return Ok(()),
+            Err((IOError::Full, returned)) => {
+                tracing::warn!(
+                    attempt = attempt + 1,
+                    backoff_ms = delay.as_millis() as u64,
+                    "ingress queue full, backing off",
+                );
+                tokio::time::sleep(delay).await;
+                delay = delay.saturating_mul(2);
+                last_event = returned;
+            }
+            Err((other, _)) => return Err(other),
+        }
+    }
+
+    handle_dead_letter(&last_event, cfg);
+    Err(IOError::Full)
+}
+
+/// Either append the dropped envelope to the dead-letter file or emit a
+/// structured error log when no path is configured.
+fn handle_dead_letter(event: &KernelEventEnvelope, cfg: &IngressConfig) {
+    let kind = event.event_type();
+    if let Some(path) = cfg.dead_letter_path.as_deref() {
+        match write_dead_letter(path, event) {
+            Ok(()) => tracing::error!(
+                event_kind = kind,
+                dead_letter_path = %path.display(),
+                "ingress queue full after retries — wrote dropped event to dead-letter file",
+            ),
+            Err(e) => tracing::error!(
+                event_kind = kind,
+                dead_letter_path = %path.display(),
+                error = %e,
+                "ingress queue full after retries — FAILED to write dead-letter file; event dropped",
+            ),
+        }
+    } else {
+        tracing::error!(
+            event_kind = kind,
+            "ingress queue full after retries — no dead-letter path configured; event dropped",
+        );
+    }
+}
+
+/// Append a JSON-encoded envelope as a single line to `path`.
+fn write_dead_letter(path: &Path, event: &KernelEventEnvelope) -> std::io::Result<()> {
+    use std::{
+        fs::OpenOptions,
+        io::{BufWriter, Write},
+    };
+
+    let payload = serde_json::to_string(event).map_err(std::io::Error::other)?;
+
+    let file = OpenOptions::new().create(true).append(true).open(path)?;
+    let mut writer = BufWriter::new(file);
+    writer.write_all(payload.as_bytes())?;
+    writer.write_all(b"\n")?;
+    writer.flush()
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use super::*;
+    use crate::queue::{ShardedEventQueue, ShardedEventQueueConfig};
+
+    fn build_queue(global_capacity: usize) -> ShardedQueueRef {
+        Arc::new(ShardedEventQueue::new(ShardedEventQueueConfig {
+            num_shards: 0,
+            shard_capacity: 1,
+            global_capacity,
+        }))
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn push_with_retry_succeeds_when_space_frees_up() {
+        let queue = build_queue(1);
+        // Pre-fill the global queue.
+        queue
+            .push(KernelEventEnvelope::shutdown())
+            .expect("first push fits");
+
+        // Spawn a draining task that frees up space after a short delay.
+        let drain_queue = queue.clone();
+        tokio::spawn(async move {
+            tokio::time::sleep(Duration::from_millis(150)).await;
+            // Drop one event from the global queue to make room.
+            let _ = drain_queue.global().drain(1).next();
+        });
+
+        let cfg = IngressConfig::default();
+        push_with_retry(&queue, KernelEventEnvelope::shutdown(), &cfg)
+            .await
+            .expect("retry should eventually succeed once the queue drains");
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn push_with_retry_returns_full_after_exhaustion() {
+        let queue = build_queue(1);
+        queue
+            .push(KernelEventEnvelope::shutdown())
+            .expect("first push fits");
+
+        let cfg = IngressConfig::default();
+        let err = push_with_retry(&queue, KernelEventEnvelope::shutdown(), &cfg)
+            .await
+            .expect_err("queue stays full so retry must surface IOError::Full");
+        assert!(matches!(err, IOError::Full));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn dead_letter_file_is_appended_on_exhaustion() {
+        let queue = build_queue(1);
+        queue
+            .push(KernelEventEnvelope::shutdown())
+            .expect("first push fits");
+
+        let tmp = tempfile::NamedTempFile::new().expect("tempfile");
+        let cfg = IngressConfig {
+            dead_letter_path: Some(tmp.path().to_path_buf()),
+        };
+
+        let err = push_with_retry(&queue, KernelEventEnvelope::shutdown(), &cfg).await;
+        assert!(matches!(err, Err(IOError::Full)));
+
+        let contents = std::fs::read_to_string(tmp.path()).expect("read dead-letter file");
+        assert!(
+            contents.lines().count() >= 1,
+            "dead-letter file should contain at least one JSON line, got: {contents:?}",
+        );
+    }
+}

--- a/crates/kernel/src/queue/sharded.rs
+++ b/crates/kernel/src/queue/sharded.rs
@@ -56,6 +56,22 @@ impl ShardQueue {
         Ok(())
     }
 
+    /// Push an event, returning the rejected event back to the caller on
+    /// `Full`. Used by retry helpers that need to keep ownership of the
+    /// envelope across attempts (events are not `Clone` because they may
+    /// carry oneshot reply channels).
+    pub fn push_returning(
+        &self,
+        event: KernelEventEnvelope,
+    ) -> Result<(), (IOError, KernelEventEnvelope)> {
+        if self.queue.len() >= self.capacity {
+            return Err((IOError::Full, event));
+        }
+        self.queue.push(event);
+        self.notify.notify_one();
+        Ok(())
+    }
+
     /// Lazy iterator that pops up to `max` events. Zero allocation.
     pub fn drain(&self, max: usize) -> impl Iterator<Item = KernelEventEnvelope> + '_ {
         let mut remaining = max;
@@ -187,8 +203,12 @@ impl ShardedEventQueue {
     }
 
     /// Push an event into the queue, routing it to the correct shard or the
-    /// global queue. Returns `IOError::Full` if the target queue is at
-    /// capacity.
+    /// global queue.
+    ///
+    /// Returns `Err(IOError::Full)` if the target queue is at capacity.
+    /// Callers in the ingress path SHOULD use
+    /// [`push_with_retry`](crate::queue::push_with_retry) to handle
+    /// backpressure — silent drops are a reliability bug (see issue #1148).
     pub fn push(&self, event: KernelEventEnvelope) -> Result<(), IOError> {
         match self.classify(&event) {
             ShardTarget::Global => self.global.push(event),
@@ -199,6 +219,22 @@ impl ShardedEventQueue {
     /// Non-blocking push — identical to [`push`](Self::push) for this
     /// in-memory queue.
     pub fn try_push(&self, event: KernelEventEnvelope) -> Result<(), IOError> { self.push(event) }
+
+    /// Push an event, returning the rejected envelope back to the caller on
+    /// `Full` so it can be reused across retry attempts.
+    ///
+    /// This is the entry point used by
+    /// [`push_with_retry`](crate::queue::push_with_retry); direct callers
+    /// should keep using [`push`](Self::push)/[`try_push`](Self::try_push).
+    pub fn push_returning(
+        &self,
+        event: KernelEventEnvelope,
+    ) -> Result<(), (IOError, KernelEventEnvelope)> {
+        match self.classify(&event) {
+            ShardTarget::Global => self.global.push_returning(event),
+            ShardTarget::Shard(idx) => self.shards[idx].push_returning(event),
+        }
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

Channel adapters were silently losing user messages when the sharded event
queue hit capacity: `ShardedEventQueue::push` returns `Err(IOError::Full)`,
but the sync `submit_message` / `submit_group_message` helpers mapped every
error to a generic "busy" response and dropped the envelope. This PR gives
the ingress path explicit retry + dead-letter semantics.

- `queue::retry::push_with_retry` applies a 3-attempt exponential backoff
  (100ms base, doubled each retry) on `IOError::Full`. On exhaustion the
  dropped envelope is either appended as a JSON line to the configured
  dead-letter file or recorded in a structured error log.
- `ShardedEventQueue::push_returning` / `ShardQueue::push_returning` hand
  the envelope back to the caller on `Full` — kernel events are not
  `Clone` because they may carry oneshot reply channels, so the retry
  helper needs to keep ownership of the envelope across attempts.
  Existing `push` / `try_push` call sites are unchanged.
- `KernelHandle` gains `ingest_user_message` / `ingest_group_message`
  async variants that route through `push_with_retry`; `ingest(raw)` now
  uses them, and the Telegram adapter switches to the new async variants
  for its primary inbound path.
- `KernelConfig.ingress: IngressConfig` carries an optional dead-letter
  path from YAML (no hardcoded Rust default — defaults to `None`, which
  falls back to a structured error log).
- `ShardedEventQueue::push` doc-comment now explicitly directs ingress
  callers to prefer `push_with_retry`.

## Type of change

| Type | Label |
|------|-------|
| Bug fix | `bug` |

## Component

`core`

## Closes

Closes #1148

## Test plan

- [x] `cargo check --all --all-targets`
- [x] `cargo test -p rara-kernel queue::retry` (3 new tests: success after drain, exhaustion surfaces `Full`, dead-letter file is appended)
- [x] `cargo test -p rara-channels --lib` (84 passed)
- [x] `cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings`
- [x] `cargo +nightly fmt --all`
- [x] `RUSTDOCFLAGS="-D warnings" cargo +nightly doc --workspace --no-deps --document-private-items`