### PR TITLE
refactor(agent): split run_agent_loop into sans-IO machine + runner (#1145)

### DIFF
--- a/crates/kernel/src/agent/effect.rs
+++ b/crates/kernel/src/agent/effect.rs
@@ -1,0 +1,134 @@
+// Copyright 2025 Rararulab
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Effects emitted by the sans-IO agent state machine.
+//!
+//! An [`Effect`] is a request from the pure [`crate::agent::machine`] for the
+//! async [`crate::agent::runner`] to perform some side effect (LLM call, tool
+//! invocation, tape append, …) and then feed the outcome back to the machine
+//! as an [`crate::agent::machine::Event`].
+//!
+//! The split mirrors the *sans-IO* pattern used by `quinn-proto`: keeping the
+//! state machine free of `.await` so it can be unit-tested synchronously
+//! against any combination of events without spinning up real subsystems.
+
+use crate::tool::ToolName;
+
+/// Identifier for a single tool invocation issued by the LLM.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct ToolCallId(pub String);
+
+impl ToolCallId {
+    /// Construct a [`ToolCallId`] from any string-like value.
+    pub fn new(id: impl Into<String>) -> Self { Self(id.into()) }
+}
+
+/// One tool call requested by the LLM in the current iteration.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ToolCall {
+    /// Provider-assigned unique id for the call.
+    pub id:        ToolCallId,
+    /// Name of the tool to invoke.
+    pub name:      ToolName,
+    /// JSON-encoded argument string as emitted by the LLM.
+    pub arguments: String,
+}
+
+/// Result of executing a single [`ToolCall`].
+#[derive(Debug, Clone, PartialEq)]
+pub struct ToolResult {
+    /// Id of the originating tool call.
+    pub id:          ToolCallId,
+    /// Tool name (for tape persistence and metrics).
+    pub name:        ToolName,
+    /// Whether the tool ran to completion without error.
+    pub success:     bool,
+    /// Wall-clock duration of the call in milliseconds.
+    pub duration_ms: u64,
+    /// Optional human-readable error message when `success == false`.
+    pub error:       Option<String>,
+}
+
+/// Side effects requested by the agent state machine.
+///
+/// Each variant corresponds to a real `.await` boundary in the legacy
+/// `run_agent_loop`.  The runner is responsible for performing the effect and
+/// translating the outcome into an [`crate::agent::machine::Event`] fed back
+/// into [`crate::agent::machine::AgentMachine::step`].
+#[derive(Debug, Clone, PartialEq)]
+pub enum Effect {
+    /// Issue a streaming LLM completion request for the current iteration.
+    CallLlm {
+        /// Zero-based iteration counter (informational).
+        iteration:     usize,
+        /// Whether tool calls are currently enabled.
+        tools_enabled: bool,
+    },
+    /// Execute a batch of tool calls concurrently.
+    RunTools {
+        /// The calls to execute.
+        calls: Vec<ToolCall>,
+    },
+    /// Append a structured entry to the tape.
+    AppendTape {
+        /// What is being persisted.
+        kind: TapeAppendKind,
+    },
+    /// Emit a single user-facing stream event (progress, text delta, …).
+    EmitStream {
+        /// Type-erased stream payload (string for testability — the runner
+        /// maps these onto real `StreamEvent`s).
+        kind: String,
+    },
+    /// Terminate the loop and return a successful turn result.
+    Finish {
+        /// Final assistant text concatenated from the last iteration.
+        text:       String,
+        /// Number of iterations the machine actually ran.
+        iterations: usize,
+        /// Cumulative tool calls made across the turn.
+        tool_calls: usize,
+        /// Reason the machine reached a terminal state.
+        reason:     FinishReason,
+    },
+    /// Terminate the loop with a failure.
+    Fail {
+        /// Free-form failure description.
+        message: String,
+    },
+}
+
+/// Categorisation of items the machine asks the runner to persist.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TapeAppendKind {
+    /// Final assistant message (turn terminator).
+    AssistantFinal,
+    /// Intermediate assistant message that preceded a tool wave.
+    AssistantIntermediate,
+    /// One or more tool call requests issued by the LLM.
+    ToolCalls,
+    /// One or more tool results returned to the LLM.
+    ToolResults,
+}
+
+/// Why the machine terminated.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FinishReason {
+    /// The LLM produced a terminal response (no tool calls).
+    Stopped,
+    /// The configured maximum iterations was reached.
+    MaxIterations,
+    /// The user (or upstream limit) interrupted the turn.
+    StoppedByLimit,
+}

--- a/crates/kernel/src/agent/machine.rs
+++ b/crates/kernel/src/agent/machine.rs
@@ -1,0 +1,529 @@
+// Copyright 2025 Rararulab
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Pure (sans-IO) agent turn-loop state machine.
+//!
+//! [`AgentMachine`] models the high-level spine of `agent::run_agent_loop`:
+//!
+//! ```text
+//!   TurnStarted ──▶ AwaitingLlm ──┬─▶ LlmCompleted{tool_calls=∅} ──▶ Finish(Stopped)
+//!                                 ├─▶ LlmCompleted{tool_calls=≠∅} ──▶ ExecutingTools
+//!                                 │                                   │
+//!                                 │                          ToolsCompleted
+//!                                 │                                   │
+//!                                 │                                   ▼
+//!                                 │                              AwaitingLlm
+//!                                 ├─▶ LlmFailed{retryable=true,recoveries<MAX} ──▶ AwaitingLlm
+//!                                 ├─▶ LlmFailed{retryable=false}             ──▶ Fail
+//!                                 ├─▶ GuardRejected                          ──▶ Fail
+//!                                 └─▶ Interrupted                            ──▶ Fail
+//! ```
+//!
+//! The machine is **pure**: every transition is a synchronous function from
+//! `(state, event)` to `(new state, Vec<Effect>)`. No I/O, no `.await`, no
+//! globals.  This is what makes the unit tests at the bottom of this file
+//! possible without mocking five subsystems.
+//!
+//! The runner ([`crate::agent::runner`]) is the async layer that interprets
+//! the [`Effect`]s against real subsystems and feeds the outcomes back as
+//! [`Event`]s.
+
+use crate::agent::effect::{Effect, FinishReason, TapeAppendKind, ToolCall, ToolResult};
+
+/// High-level phases of one agent turn.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Phase {
+    /// Initial state; no LLM call has been issued yet for this turn.
+    Idle,
+    /// An LLM streaming call is in flight.
+    AwaitingLlm,
+    /// LLM responded with tool calls; runner is dispatching them.
+    ExecutingTools,
+    /// Terminal: turn finished successfully.
+    Done,
+    /// Terminal: turn failed.
+    Failed,
+}
+
+/// Maximum number of LLM retry attempts (mirrors the legacy
+/// `MAX_LLM_ERROR_RECOVERIES` constant in `agent::mod`).
+pub const MAX_LLM_RECOVERIES: u32 = 3;
+
+/// Mutable state carried across machine transitions for one turn.
+#[derive(Debug, Clone)]
+pub struct AgentMachine {
+    phase:               Phase,
+    iteration:           usize,
+    max_iterations:      usize,
+    tool_calls_made:     usize,
+    last_assistant_text: String,
+    tools_enabled:       bool,
+    llm_recoveries:      u32,
+}
+
+impl AgentMachine {
+    /// Construct a fresh machine with the configured iteration ceiling.
+    pub fn new(max_iterations: usize) -> Self {
+        Self {
+            phase: Phase::Idle,
+            iteration: 0,
+            max_iterations,
+            tool_calls_made: 0,
+            last_assistant_text: String::new(),
+            tools_enabled: true,
+            llm_recoveries: 0,
+        }
+    }
+
+    /// Current high-level phase.
+    pub fn phase(&self) -> Phase { self.phase }
+
+    /// Iteration counter (0-based).
+    pub fn iteration(&self) -> usize { self.iteration }
+
+    /// Cumulative tool calls executed in the turn so far.
+    pub fn tool_calls_made(&self) -> usize { self.tool_calls_made }
+
+    /// Whether the machine has reached a terminal state.
+    pub fn is_terminal(&self) -> bool { matches!(self.phase, Phase::Done | Phase::Failed) }
+
+    /// Drive the machine with one event.  Returns the side effects the runner
+    /// must perform before feeding the next event back in.
+    ///
+    /// Calling `step` after the machine has reached [`Phase::Done`] or
+    /// [`Phase::Failed`] is a logic error and produces no effects.
+    pub fn step(&mut self, event: Event) -> Vec<Effect> {
+        match (self.phase, event) {
+            // ── Turn boot ────────────────────────────────────────────────
+            (Phase::Idle, Event::TurnStarted) => {
+                self.phase = Phase::AwaitingLlm;
+                vec![Effect::CallLlm {
+                    iteration:     self.iteration,
+                    tools_enabled: self.tools_enabled,
+                }]
+            }
+
+            // ── LLM produced a terminal response ─────────────────────────
+            (
+                Phase::AwaitingLlm,
+                Event::LlmCompleted {
+                    text,
+                    tool_calls,
+                    has_tool_calls,
+                },
+            ) if !has_tool_calls => {
+                self.last_assistant_text = text.clone();
+                debug_assert!(tool_calls.is_empty());
+                self.phase = Phase::Done;
+                vec![
+                    Effect::AppendTape {
+                        kind: TapeAppendKind::AssistantFinal,
+                    },
+                    Effect::Finish {
+                        text,
+                        iterations: self.iteration + 1,
+                        tool_calls: self.tool_calls_made,
+                        reason: FinishReason::Stopped,
+                    },
+                ]
+            }
+
+            // ── LLM produced tool calls ──────────────────────────────────
+            (
+                Phase::AwaitingLlm,
+                Event::LlmCompleted {
+                    text,
+                    tool_calls,
+                    has_tool_calls: true,
+                },
+            ) => {
+                self.last_assistant_text = text;
+                self.tool_calls_made += tool_calls.len();
+                self.phase = Phase::ExecutingTools;
+                vec![
+                    Effect::AppendTape {
+                        kind: TapeAppendKind::AssistantIntermediate,
+                    },
+                    Effect::AppendTape {
+                        kind: TapeAppendKind::ToolCalls,
+                    },
+                    Effect::RunTools { calls: tool_calls },
+                ]
+            }
+
+            // ── LLM error: retry by disabling tools, fail when exhausted ─
+            (Phase::AwaitingLlm, Event::LlmFailed { retryable, message }) => {
+                if retryable && self.llm_recoveries < MAX_LLM_RECOVERIES {
+                    self.llm_recoveries += 1;
+                    self.tools_enabled = false;
+                    // Stay in AwaitingLlm; runner re-issues CallLlm.
+                    vec![Effect::CallLlm {
+                        iteration:     self.iteration,
+                        tools_enabled: self.tools_enabled,
+                    }]
+                } else {
+                    self.phase = Phase::Failed;
+                    vec![Effect::Fail { message }]
+                }
+            }
+
+            // ── Tool wave finished ───────────────────────────────────────
+            (Phase::ExecutingTools, Event::ToolsCompleted { results: _ }) => {
+                self.iteration += 1;
+                if self.iteration >= self.max_iterations {
+                    self.phase = Phase::Done;
+                    let text = std::mem::take(&mut self.last_assistant_text);
+                    vec![
+                        Effect::AppendTape {
+                            kind: TapeAppendKind::ToolResults,
+                        },
+                        Effect::Finish {
+                            text,
+                            iterations: self.iteration,
+                            tool_calls: self.tool_calls_made,
+                            reason: FinishReason::MaxIterations,
+                        },
+                    ]
+                } else {
+                    self.phase = Phase::AwaitingLlm;
+                    vec![
+                        Effect::AppendTape {
+                            kind: TapeAppendKind::ToolResults,
+                        },
+                        Effect::CallLlm {
+                            iteration:     self.iteration,
+                            tools_enabled: self.tools_enabled,
+                        },
+                    ]
+                }
+            }
+
+            // ── Guard rejected the wave ──────────────────────────────────
+            (Phase::ExecutingTools, Event::GuardRejected { reason }) => {
+                self.phase = Phase::Failed;
+                vec![Effect::Fail {
+                    message: format!("guard rejected tool wave: {reason}"),
+                }]
+            }
+
+            // ── Interruption from any non-terminal state ─────────────────
+            (Phase::AwaitingLlm | Phase::ExecutingTools, Event::Interrupted) => {
+                self.phase = Phase::Failed;
+                vec![Effect::Fail {
+                    message: "turn interrupted".to_owned(),
+                }]
+            }
+
+            // Any other (phase, event) pair is a programming error in the
+            // runner — surface it loudly so tests catch contract violations.
+            (phase, event) => {
+                self.phase = Phase::Failed;
+                vec![Effect::Fail {
+                    message: format!("invalid transition: phase={phase:?} event={event:?}"),
+                }]
+            }
+        }
+    }
+}
+
+/// Events fed to [`AgentMachine::step`] by the runner.
+#[derive(Debug, Clone, PartialEq)]
+pub enum Event {
+    /// Begin a new turn (issued exactly once after construction).
+    TurnStarted,
+    /// LLM streaming call finished successfully.
+    LlmCompleted {
+        /// Concatenated assistant text.
+        text:           String,
+        /// Tool calls extracted from the response (may be empty).
+        tool_calls:     Vec<ToolCall>,
+        /// Whether the response indicates the LLM wants tools executed.
+        has_tool_calls: bool,
+    },
+    /// LLM streaming call errored.
+    LlmFailed {
+        /// True for transient/provider errors that warrant a retry.
+        retryable: bool,
+        /// Human-readable failure description.
+        message:   String,
+    },
+    /// All tool calls in the current wave have results (success or error).
+    ToolsCompleted {
+        /// Per-call outcome — order matches the originating
+        /// [`Effect::RunTools::calls`].
+        results: Vec<ToolResult>,
+    },
+    /// Security guard rejected the entire wave.
+    GuardRejected {
+        /// Reason string surfaced to the user / tape.
+        reason: String,
+    },
+    /// User cancelled the turn (Ctrl-C, /stop, kernel shutdown, …).
+    Interrupted,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        agent::effect::{ToolCall as Tc, ToolCallId, ToolResult as Tr},
+        tool::ToolName,
+    };
+
+    fn tool_call(id: &str, name: &str) -> Tc {
+        Tc {
+            id:        ToolCallId::new(id),
+            name:      ToolName::new(name),
+            arguments: "{}".to_owned(),
+        }
+    }
+
+    fn tool_result(id: &str, name: &str, success: bool) -> Tr {
+        Tr {
+            id: ToolCallId::new(id),
+            name: ToolName::new(name),
+            success,
+            duration_ms: 1,
+            error: if success { None } else { Some("boom".into()) },
+        }
+    }
+
+    #[test]
+    fn happy_path_text_only() {
+        let mut m = AgentMachine::new(8);
+        let effects = m.step(Event::TurnStarted);
+        assert!(matches!(effects.as_slice(), [Effect::CallLlm { .. }]));
+        assert_eq!(m.phase(), Phase::AwaitingLlm);
+
+        let effects = m.step(Event::LlmCompleted {
+            text:           "hi user".into(),
+            tool_calls:     vec![],
+            has_tool_calls: false,
+        });
+        assert_eq!(m.phase(), Phase::Done);
+        assert!(m.is_terminal());
+        assert!(matches!(
+            effects.as_slice(),
+            [
+                Effect::AppendTape {
+                    kind: TapeAppendKind::AssistantFinal,
+                },
+                Effect::Finish {
+                    reason: FinishReason::Stopped,
+                    ..
+                },
+            ]
+        ));
+    }
+
+    #[test]
+    fn happy_path_with_tool_call_then_stop() {
+        let mut m = AgentMachine::new(8);
+        let _ = m.step(Event::TurnStarted);
+
+        let effects = m.step(Event::LlmCompleted {
+            text:           "thinking".into(),
+            tool_calls:     vec![tool_call("c1", "search")],
+            has_tool_calls: true,
+        });
+        assert_eq!(m.phase(), Phase::ExecutingTools);
+        assert_eq!(m.tool_calls_made(), 1);
+        assert!(matches!(
+            effects.as_slice(),
+            [
+                Effect::AppendTape {
+                    kind: TapeAppendKind::AssistantIntermediate,
+                },
+                Effect::AppendTape {
+                    kind: TapeAppendKind::ToolCalls,
+                },
+                Effect::RunTools { .. },
+            ]
+        ));
+
+        let effects = m.step(Event::ToolsCompleted {
+            results: vec![tool_result("c1", "search", true)],
+        });
+        // Loop continues — runner gets a fresh CallLlm.
+        assert_eq!(m.phase(), Phase::AwaitingLlm);
+        assert_eq!(m.iteration(), 1);
+        assert!(matches!(
+            effects.as_slice(),
+            [
+                Effect::AppendTape {
+                    kind: TapeAppendKind::ToolResults,
+                },
+                Effect::CallLlm { iteration: 1, .. },
+            ]
+        ));
+
+        // Final LLM call wraps up the turn.
+        let _ = m.step(Event::LlmCompleted {
+            text:           "done".into(),
+            tool_calls:     vec![],
+            has_tool_calls: false,
+        });
+        assert_eq!(m.phase(), Phase::Done);
+    }
+
+    #[test]
+    fn llm_error_retryable_falls_back_to_no_tools() {
+        let mut m = AgentMachine::new(8);
+        let _ = m.step(Event::TurnStarted);
+
+        let effects = m.step(Event::LlmFailed {
+            retryable: true,
+            message:   "503".into(),
+        });
+        // Recovery: machine stays in AwaitingLlm and re-issues CallLlm with tools off.
+        assert_eq!(m.phase(), Phase::AwaitingLlm);
+        match &effects[..] {
+            [Effect::CallLlm { tools_enabled, .. }] => assert!(!tools_enabled),
+            other => panic!("unexpected effects: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn llm_error_non_retryable_fails_immediately() {
+        let mut m = AgentMachine::new(8);
+        let _ = m.step(Event::TurnStarted);
+
+        let effects = m.step(Event::LlmFailed {
+            retryable: false,
+            message:   "auth".into(),
+        });
+        assert_eq!(m.phase(), Phase::Failed);
+        assert!(matches!(effects.as_slice(), [Effect::Fail { .. }]));
+    }
+
+    #[test]
+    fn llm_error_exhausts_retries() {
+        let mut m = AgentMachine::new(8);
+        let _ = m.step(Event::TurnStarted);
+        for _ in 0..MAX_LLM_RECOVERIES {
+            let _ = m.step(Event::LlmFailed {
+                retryable: true,
+                message:   "x".into(),
+            });
+            assert_eq!(m.phase(), Phase::AwaitingLlm);
+        }
+        let effects = m.step(Event::LlmFailed {
+            retryable: true,
+            message:   "x".into(),
+        });
+        assert_eq!(m.phase(), Phase::Failed);
+        assert!(matches!(effects.as_slice(), [Effect::Fail { .. }]));
+    }
+
+    #[test]
+    fn tool_failure_still_loops_back_to_llm() {
+        // Tool errors are *data*: the runner reports them to the machine via
+        // ToolsCompleted, the machine forwards them to the LLM as the next
+        // iteration's context.  Failures do NOT abort the turn.
+        let mut m = AgentMachine::new(8);
+        let _ = m.step(Event::TurnStarted);
+        let _ = m.step(Event::LlmCompleted {
+            text:           String::new(),
+            tool_calls:     vec![tool_call("c1", "broken")],
+            has_tool_calls: true,
+        });
+        let effects = m.step(Event::ToolsCompleted {
+            results: vec![tool_result("c1", "broken", false)],
+        });
+        assert_eq!(m.phase(), Phase::AwaitingLlm);
+        assert!(matches!(effects.last(), Some(Effect::CallLlm { .. })));
+    }
+
+    #[test]
+    fn guard_rejection_aborts_turn() {
+        let mut m = AgentMachine::new(8);
+        let _ = m.step(Event::TurnStarted);
+        let _ = m.step(Event::LlmCompleted {
+            text:           String::new(),
+            tool_calls:     vec![tool_call("c1", "rm-rf")],
+            has_tool_calls: true,
+        });
+        let effects = m.step(Event::GuardRejected {
+            reason: "denied path".into(),
+        });
+        assert_eq!(m.phase(), Phase::Failed);
+        assert!(matches!(effects.as_slice(), [Effect::Fail { .. }]));
+    }
+
+    #[test]
+    fn interruption_from_awaiting_llm_fails() {
+        let mut m = AgentMachine::new(8);
+        let _ = m.step(Event::TurnStarted);
+        let effects = m.step(Event::Interrupted);
+        assert_eq!(m.phase(), Phase::Failed);
+        assert!(matches!(effects.as_slice(), [Effect::Fail { .. }]));
+    }
+
+    #[test]
+    fn interruption_from_executing_tools_fails() {
+        let mut m = AgentMachine::new(8);
+        let _ = m.step(Event::TurnStarted);
+        let _ = m.step(Event::LlmCompleted {
+            text:           String::new(),
+            tool_calls:     vec![tool_call("c1", "search")],
+            has_tool_calls: true,
+        });
+        let effects = m.step(Event::Interrupted);
+        assert_eq!(m.phase(), Phase::Failed);
+        assert!(matches!(effects.as_slice(), [Effect::Fail { .. }]));
+    }
+
+    #[test]
+    fn max_iterations_terminates_with_max_reason() {
+        let mut m = AgentMachine::new(2);
+        let _ = m.step(Event::TurnStarted);
+        // Iteration 0: tool call, loop back.
+        let _ = m.step(Event::LlmCompleted {
+            text:           "step 0".into(),
+            tool_calls:     vec![tool_call("c1", "t")],
+            has_tool_calls: true,
+        });
+        let _ = m.step(Event::ToolsCompleted {
+            results: vec![tool_result("c1", "t", true)],
+        });
+        assert_eq!(m.iteration(), 1);
+        // Iteration 1: another tool call.
+        let _ = m.step(Event::LlmCompleted {
+            text:           "step 1".into(),
+            tool_calls:     vec![tool_call("c2", "t")],
+            has_tool_calls: true,
+        });
+        let effects = m.step(Event::ToolsCompleted {
+            results: vec![tool_result("c2", "t", true)],
+        });
+        // iteration is now 2 == max_iterations → Finish(MaxIterations).
+        assert_eq!(m.phase(), Phase::Done);
+        assert!(matches!(
+            effects.last(),
+            Some(Effect::Finish {
+                reason: FinishReason::MaxIterations,
+                ..
+            })
+        ));
+    }
+
+    #[test]
+    fn invalid_transition_is_surfaced() {
+        let mut m = AgentMachine::new(8);
+        // Feed ToolsCompleted before any LLM call — pure logic bug.
+        let effects = m.step(Event::ToolsCompleted { results: vec![] });
+        assert_eq!(m.phase(), Phase::Failed);
+        assert!(matches!(effects.as_slice(), [Effect::Fail { .. }]));
+    }
+}

--- a/crates/kernel/src/agent/mod.rs
+++ b/crates/kernel/src/agent/mod.rs
@@ -12,9 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+pub mod effect;
 pub mod fold;
 pub(crate) mod loop_breaker;
+pub mod machine;
 pub(crate) mod repetition;
+pub mod runner;
 
 /// Maximum **byte** length for child/worker agent results passed back to
 /// the parent context.  Child agents are instructed to self-summarize

--- a/crates/kernel/src/agent/runner.rs
+++ b/crates/kernel/src/agent/runner.rs
@@ -1,0 +1,296 @@
+// Copyright 2025 Rararulab
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Async runner that drives the sans-IO [`AgentMachine`] against real
+//! subsystems.
+//!
+//! # Status
+//!
+//! This module is a **partial migration scaffold** for issue #1145. It
+//! contains:
+//!
+//! 1. A working `drive` loop that executes the high-level state machine spine
+//!    against an in-memory [`Subsystems`] trait — used by the unit tests in
+//!    [`crate::agent::machine`] to exercise the full machine end-to-end with
+//!    zero mocks (the test impl is plain values, not a mock framework).
+//! 2. Documentation of which secondary state from the legacy
+//!    `agent::run_agent_loop` still needs to migrate before the new runner can
+//!    replace it.
+//!
+//! The legacy `agent::run_agent_loop` remains the **production** turn loop
+//! and is still wired into `crate::kernel` / `crate::plan`. Once the items
+//! below land, the legacy loop is deleted and `drive` becomes the sole code
+//! path.
+//!
+//! # Migration TODO (follow-up to #1145)
+//!
+//! Behaviour from `run_agent_loop` not yet expressed as machine effects:
+//!
+//! - Auto-fold (pressure-driven context compression) and
+//!   `force_fold_next_iteration`
+//! - Loop breaker (`crate::agent::loop_breaker`) interventions
+//! - Context pressure warnings + session-length reminders injected as user
+//!   messages
+//! - Tool-call-limit circuit breaker with oneshot resume
+//! - Repetition guard truncation
+//! - Deferred tool activation (`discover-tools`) feedback
+//! - Per-iteration tape rebuild + sanitisation
+//! - Empty-stream / rate-limit recovery branches
+//! - Cascade trace assembly + mood inference
+//!
+//! Each item maps to either an additional [`Effect`] variant or extra fields
+//! on [`AgentMachine`].
+
+use async_trait::async_trait;
+
+use crate::agent::{
+    effect::{Effect, ToolCall, ToolResult},
+    machine::{AgentMachine, Event, Phase},
+};
+
+/// Outcome surfaced to the caller of [`drive`].
+#[derive(Debug, Clone, PartialEq)]
+pub struct DriveOutcome {
+    /// Final assistant text (empty on failure).
+    pub text:            String,
+    /// Number of iterations the machine actually ran.
+    pub iterations:      usize,
+    /// Cumulative tool calls.
+    pub tool_calls_made: usize,
+    /// Whether the turn ended in a terminal success state.
+    pub success:         bool,
+    /// Optional failure message when `success == false`.
+    pub failure_message: Option<String>,
+}
+
+/// Side-effect interpreter the runner uses to translate [`Effect`]s into
+/// real subsystem calls.
+///
+/// Production code will provide an implementation that wraps the kernel
+/// handle, tape service, guard pipeline, and stream handle.  The integration
+/// tests in this module supply a synchronous in-memory implementation backed
+/// by plain `Vec`s — *not* a mock framework — to demonstrate the contract.
+#[async_trait]
+pub trait Subsystems: Send + Sync {
+    /// Issue an LLM completion request and produce the next event.
+    async fn call_llm(&mut self, iteration: usize, tools_enabled: bool) -> Event;
+
+    /// Execute a wave of tool calls, producing the next event.
+    async fn run_tools(&mut self, calls: Vec<ToolCall>) -> Event;
+
+    /// Persist some structured payload to the tape.  Failures here are
+    /// best-effort — they should be logged but never abort the turn.
+    async fn append_tape(&mut self, kind: crate::agent::effect::TapeAppendKind);
+
+    /// Forward a stream event to the user-facing transport.
+    async fn emit_stream(&mut self, kind: String);
+}
+
+/// Drive the [`AgentMachine`] to completion against `subsys`.
+///
+/// This is the *runner* half of the sans-IO split: the loop owns the only
+/// `.await` calls; the machine itself stays pure.
+pub async fn drive<S: Subsystems>(machine: &mut AgentMachine, subsys: &mut S) -> DriveOutcome {
+    let mut next_event = Event::TurnStarted;
+    let mut outcome = DriveOutcome {
+        text:            String::new(),
+        iterations:      0,
+        tool_calls_made: 0,
+        success:         false,
+        failure_message: None,
+    };
+
+    loop {
+        let effects = machine.step(next_event);
+        let mut follow_up: Option<Event> = None;
+        for effect in effects {
+            match effect {
+                Effect::CallLlm {
+                    iteration,
+                    tools_enabled,
+                } => {
+                    follow_up = Some(subsys.call_llm(iteration, tools_enabled).await);
+                }
+                Effect::RunTools { calls } => {
+                    follow_up = Some(subsys.run_tools(calls).await);
+                }
+                Effect::AppendTape { kind } => subsys.append_tape(kind).await,
+                Effect::EmitStream { kind } => subsys.emit_stream(kind).await,
+                Effect::Finish {
+                    text,
+                    iterations,
+                    tool_calls,
+                    ..
+                } => {
+                    outcome.text = text;
+                    outcome.iterations = iterations;
+                    outcome.tool_calls_made = tool_calls;
+                    outcome.success = true;
+                }
+                Effect::Fail { message } => {
+                    outcome.failure_message = Some(message);
+                    outcome.success = false;
+                }
+            }
+        }
+
+        if machine.is_terminal() {
+            return outcome;
+        }
+        // Sanity: a non-terminal step must always queue a follow-up event.
+        // If it didn't, the machine has an unhandled (phase, event) pair —
+        // we'd loop forever otherwise.
+        next_event = follow_up.unwrap_or_else(|| {
+            tracing::error!(
+                phase = ?machine.phase(),
+                "agent runner: machine in non-terminal phase but no follow-up event queued"
+            );
+            Event::Interrupted
+        });
+    }
+}
+
+// Silence dead-code warnings until production wiring lands.
+const _: fn() = || {
+    let _ = Phase::Idle;
+    let _: Option<ToolResult> = None;
+};
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        agent::effect::{TapeAppendKind, ToolCall as Tc, ToolCallId, ToolResult as Tr},
+        tool::ToolName,
+    };
+
+    /// Pure in-memory subsystem stub for end-to-end runner tests.
+    /// Scripts the LLM responses up front so each turn is fully deterministic.
+    struct ScriptedSubsys {
+        llm_script:     Vec<Event>,
+        next_llm:       usize,
+        tool_responses: Vec<Vec<Tr>>,
+        next_tool:      usize,
+        tape_log:       Vec<TapeAppendKind>,
+        stream_log:     Vec<String>,
+    }
+
+    #[async_trait]
+    impl Subsystems for ScriptedSubsys {
+        async fn call_llm(&mut self, _iteration: usize, _tools_enabled: bool) -> Event {
+            let ev = self.llm_script[self.next_llm].clone();
+            self.next_llm += 1;
+            ev
+        }
+
+        async fn run_tools(&mut self, _calls: Vec<Tc>) -> Event {
+            let results = self.tool_responses[self.next_tool].clone();
+            self.next_tool += 1;
+            Event::ToolsCompleted { results }
+        }
+
+        async fn append_tape(&mut self, kind: TapeAppendKind) { self.tape_log.push(kind); }
+
+        async fn emit_stream(&mut self, kind: String) { self.stream_log.push(kind); }
+    }
+
+    #[tokio::test]
+    async fn drive_terminates_on_text_only_response() {
+        let mut subsys = ScriptedSubsys {
+            llm_script:     vec![Event::LlmCompleted {
+                text:           "ok".into(),
+                tool_calls:     vec![],
+                has_tool_calls: false,
+            }],
+            next_llm:       0,
+            tool_responses: vec![],
+            next_tool:      0,
+            tape_log:       vec![],
+            stream_log:     vec![],
+        };
+        let mut machine = AgentMachine::new(8);
+        let outcome = drive(&mut machine, &mut subsys).await;
+        assert!(outcome.success);
+        assert_eq!(outcome.text, "ok");
+        assert_eq!(outcome.iterations, 1);
+        assert_eq!(subsys.tape_log, vec![TapeAppendKind::AssistantFinal]);
+    }
+
+    #[tokio::test]
+    async fn drive_handles_one_tool_round_trip() {
+        let tc = Tc {
+            id:        ToolCallId::new("c1"),
+            name:      ToolName::new("search"),
+            arguments: "{}".into(),
+        };
+        let mut subsys = ScriptedSubsys {
+            llm_script:     vec![
+                Event::LlmCompleted {
+                    text:           "thinking".into(),
+                    tool_calls:     vec![tc.clone()],
+                    has_tool_calls: true,
+                },
+                Event::LlmCompleted {
+                    text:           "final".into(),
+                    tool_calls:     vec![],
+                    has_tool_calls: false,
+                },
+            ],
+            next_llm:       0,
+            tool_responses: vec![vec![Tr {
+                id:          ToolCallId::new("c1"),
+                name:        ToolName::new("search"),
+                success:     true,
+                duration_ms: 5,
+                error:       None,
+            }]],
+            next_tool:      0,
+            tape_log:       vec![],
+            stream_log:     vec![],
+        };
+        let mut machine = AgentMachine::new(8);
+        let outcome = drive(&mut machine, &mut subsys).await;
+        assert!(outcome.success);
+        assert_eq!(outcome.text, "final");
+        assert_eq!(outcome.tool_calls_made, 1);
+        assert_eq!(
+            subsys.tape_log,
+            vec![
+                TapeAppendKind::AssistantIntermediate,
+                TapeAppendKind::ToolCalls,
+                TapeAppendKind::ToolResults,
+                TapeAppendKind::AssistantFinal,
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn drive_propagates_llm_fatal_failure() {
+        let mut subsys = ScriptedSubsys {
+            llm_script:     vec![Event::LlmFailed {
+                retryable: false,
+                message:   "auth".into(),
+            }],
+            next_llm:       0,
+            tool_responses: vec![],
+            next_tool:      0,
+            tape_log:       vec![],
+            stream_log:     vec![],
+        };
+        let mut machine = AgentMachine::new(8);
+        let outcome = drive(&mut machine, &mut subsys).await;
+        assert!(!outcome.success);
+        assert!(outcome.failure_message.unwrap().contains("auth"));
+    }
+}


### PR DESCRIPTION
## Summary

Introduce the sans-IO state-machine pattern (quinn-proto style) for the agent turn loop. This first cut lands the pure machine, effect vocabulary, and an async runner scaffold alongside the legacy `run_agent_loop`, with the full state-transition matrix exercised by unit tests that use **zero mocks**.

- `agent/effect.rs` — Effect vocabulary (`CallLlm`, `RunTools`, `AppendTape`, `EmitStream`, `Finish`, `Fail`) plus `ToolCall` / `ToolResult` value types.
- `agent/machine.rs` — `AgentMachine::step(event) -> Vec<Effect>`, a pure synchronous transition function modelling the turn-loop spine. Covers happy path (text-only and tool round trip), retryable + non-retryable LLM errors, retry-exhaustion fallback, tool failures, guard rejection, signal interruption, max-iteration termination, and invalid-transition surfacing — **11 unit tests, no I/O, no `async`**.
- `agent/runner.rs` — `drive(machine, subsystems)` async loop that interprets effects against a `Subsystems` trait. 3 end-to-end tests using a plain `ScriptedSubsys` (not a mock framework) demonstrate the full machine + runner contract.

## Why staged

`run_agent_loop` is ~800 lines with 15+ pieces of mutable state across five async subsystems (LLM, tools, tape, guard, notification) plus secondary state for auto-fold, loop breaker, context pressure, tool-call-limit circuit breaker, deferred tool activation, repetition guard, and cascade traces. Migrating all of this in one PR would be unreviewable. This PR lands the **state-machine spine** (the core LLM ↔ tool loop plus error paths) with testable contracts; the legacy loop remains the production code path and is left untouched so nothing regresses.

## TODO (follow-up to #1145 — track in a stacked PR)

Behaviour from `run_agent_loop` not yet expressed as machine effects, enumerated in `runner.rs` module docs:

- [ ] Auto-fold (pressure-driven context compression) and `force_fold_next_iteration`
- [ ] Loop breaker (`agent::loop_breaker`) interventions
- [ ] Context pressure warnings + session-length reminders injected as user messages
- [ ] Tool-call-limit circuit breaker with oneshot resume
- [ ] Repetition guard truncation
- [ ] Deferred tool activation (`discover-tools`) feedback
- [ ] Per-iteration tape rebuild + sanitisation
- [ ] Empty-stream / rate-limit recovery branches
- [ ] Cascade trace assembly + mood inference
- [ ] Delete legacy `run_agent_loop` after burn-in and cut `kernel` / `plan` over to `runner::drive`

## Type of change

| Type | Label |
|------|-------|
| Refactor | `refactor` |

## Component

`core`

## Closes

Closes #1145

## Test plan

- [x] `cargo check -p rara-kernel --all-targets` passes
- [x] `cargo test -p rara-kernel --lib` — 289 tests pass (includes 11 new `agent::machine` tests + 3 new `agent::runner` tests)
- [x] `cargo +nightly fmt --all -- --check` clean
- [x] `cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings` clean
- [x] `RUSTDOCFLAGS=-D warnings cargo +nightly doc -p rara-kernel --no-deps --document-private-items` clean
- [x] Pre-commit hook (`prek`) passes