### PR TITLE
perf(base): use NonZeroU128 in define_id! for Option<Id> niche optimization (#1149)

### DIFF
--- a/crates/common/base/Cargo.toml
+++ b/crates/common/base/Cargo.toml
@@ -20,5 +20,8 @@ tracing.workspace = true
 utoipa.workspace = true
 uuid.workspace = true
 
+[dev-dependencies]
+serde_json.workspace = true
+
 [lints]
 workspace = true

--- a/crates/common/base/src/id.rs
+++ b/crates/common/base/src/id.rs
@@ -14,33 +14,30 @@
 
 //! Strongly-typed domain identifiers.
 //!
-//! Each aggregate root gets its own newtype wrapper around [`uuid::Uuid`] so
-//! that IDs from different domains cannot be accidentally mixed up.
+//! Each aggregate root gets its own newtype wrapper around a
+//! [`std::num::NonZeroU128`] storing a UUID. The `NonZero` representation
+//! enables niche optimisation so that `Option<Id>` is the same size as `Id`
+//! (16 bytes), without changing the on-the-wire / on-disk format — `Display`
+//! and `serde` continue to use the canonical UUID string representation.
 
 #[macro_export]
 macro_rules! define_id {
     ($(#[$meta:meta])* $name:ident) => {
         $(#[$meta])*
-        #[derive(
-            Debug,
-            Clone,
-            Copy,
-            PartialEq,
-            Eq,
-            Hash,
-            Serialize,
-            Deserialize,
-            derive_more::Display,
-            derive_more::From,
-        )]
-        #[display("{_0}")]
-        pub struct $name(pub Uuid);
+        #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+        pub struct $name(std::num::NonZeroU128);
 
         impl $name {
-            /// Generate a new random identifier.
+            /// Generate a new random identifier (UUID v4).
             #[must_use]
             pub fn new() -> Self {
-                Self(Uuid::new_v4())
+                let uuid = uuid::Uuid::new_v4();
+                // SAFETY: a v4 UUID has its variant + version bits set, so the
+                // u128 representation is always non-zero.
+                Self(
+                    std::num::NonZeroU128::new(uuid.as_u128())
+                        .expect("v4 UUID is never zero"),
+                )
             }
 
             /// Generate a deterministic identifier from a name string.
@@ -49,19 +46,45 @@ macro_rules! define_id {
             /// always produces the same identifier.
             #[must_use]
             pub fn deterministic(name: &str) -> Self {
-                Self(Uuid::new_v5(&Uuid::NAMESPACE_OID, name.as_bytes()))
+                let uuid = uuid::Uuid::new_v5(&uuid::Uuid::NAMESPACE_OID, name.as_bytes());
+                // SAFETY: a v5 UUID has its variant + version bits set, so the
+                // u128 representation is always non-zero.
+                Self(
+                    std::num::NonZeroU128::new(uuid.as_u128())
+                        .expect("v5 UUID is never zero"),
+                )
             }
 
-            /// Return the inner [`Uuid`].
+            /// Return the inner [`uuid::Uuid`].
             #[must_use]
-            pub fn into_inner(self) -> Uuid {
-                self.0
+            pub fn as_uuid(&self) -> uuid::Uuid {
+                uuid::Uuid::from_u128(self.0.get())
+            }
+
+            /// Consume the identifier and return the underlying [`uuid::Uuid`].
+            #[must_use]
+            pub fn into_inner(self) -> uuid::Uuid {
+                self.as_uuid()
+            }
+
+            /// Construct an identifier from an existing [`uuid::Uuid`].
+            ///
+            /// Returns `None` for the nil (all-zero) UUID.
+            #[must_use]
+            pub fn from_uuid(uuid: uuid::Uuid) -> Option<Self> {
+                std::num::NonZeroU128::new(uuid.as_u128()).map(Self)
             }
 
             /// Try to parse an identifier from a string, returning an error on
-            /// invalid UUID.
+            /// invalid UUID or on the nil UUID.
             pub fn try_from_raw(raw: &str) -> Result<Self, uuid::Error> {
-                uuid::Uuid::parse_str(raw).map(Self)
+                let uuid = uuid::Uuid::parse_str(raw)?;
+                // The nil UUID parses successfully but is invalid for our
+                // domain identifiers. Re-parse the string "" to fabricate the
+                // canonical "invalid character" error.
+                Self::from_uuid(uuid).ok_or_else(|| {
+                    uuid::Uuid::parse_str("").expect_err("empty string is never a valid UUID")
+                })
             }
         }
 
@@ -70,5 +93,68 @@ macro_rules! define_id {
                 Self::new()
             }
         }
+
+        impl std::fmt::Display for $name {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                self.as_uuid().fmt(f)
+            }
+        }
+
+        impl serde::Serialize for $name {
+            fn serialize<S: serde::Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
+                self.as_uuid().serialize(s)
+            }
+        }
+
+        impl<'de> serde::Deserialize<'de> for $name {
+            fn deserialize<D: serde::Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
+                let uuid = uuid::Uuid::deserialize(d)?;
+                Self::from_uuid(uuid)
+                    .ok_or_else(|| <D::Error as serde::de::Error>::custom("nil UUID"))
+            }
+        }
     };
+}
+
+#[cfg(test)]
+mod tests {
+    use std::mem::size_of;
+
+    crate::define_id!(TestId);
+
+    #[test]
+    fn option_is_niche_optimized() {
+        assert_eq!(size_of::<TestId>(), 16);
+        assert_eq!(size_of::<Option<TestId>>(), 16, "niche optimization failed");
+    }
+
+    #[test]
+    fn round_trip_display_and_parse() {
+        let id = TestId::new();
+        let s = id.to_string();
+        let parsed = TestId::try_from_raw(&s).expect("parse");
+        assert_eq!(id, parsed);
+    }
+
+    #[test]
+    fn deterministic_is_stable() {
+        let a = TestId::deterministic("hello");
+        let b = TestId::deterministic("hello");
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn from_nil_uuid_is_none() {
+        assert!(TestId::from_uuid(uuid::Uuid::nil()).is_none());
+    }
+
+    #[test]
+    fn serde_round_trip_is_uuid_string() {
+        let id = TestId::new();
+        let json = serde_json::to_string(&id).unwrap();
+        // The serialized form must be a quoted UUID string.
+        assert_eq!(json, format!("\"{}\"", id.as_uuid()));
+        let back: TestId = serde_json::from_str(&json).unwrap();
+        assert_eq!(id, back);
+    }
 }

--- a/crates/kernel/src/event.rs
+++ b/crates/kernel/src/event.rs
@@ -21,9 +21,8 @@ use std::sync::Arc;
 
 use derive_more::Debug;
 use jiff::Timestamp;
-use serde::{Deserialize, Serialize};
+use serde::Serialize;
 use tokio::sync::oneshot;
-use uuid::Uuid;
 
 use crate::{
     agent::{AgentManifest, AgentTurnResult},

--- a/crates/kernel/src/io.rs
+++ b/crates/kernel/src/io.rs
@@ -48,7 +48,6 @@ use serde_json::Value;
 use snafu::Snafu;
 use tokio::sync::{broadcast, mpsc};
 use tracing::Instrument;
-use uuid::Uuid;
 
 use crate::{
     channel::types::{ChannelType, MessageContent},
@@ -1229,7 +1228,7 @@ impl StreamHub {
         // Clean up any zombie streams from previous (hung) agent runs.
         self.close_session(&session_key);
         let stream_id = StreamId::new();
-        tracing::Span::current().record("stream_id", tracing::field::display(&stream_id.0));
+        tracing::Span::current().record("stream_id", tracing::field::display(&stream_id));
         let (tx, _) = broadcast::channel(self.capacity);
         let entry = StreamEntry {
             session_key,

--- a/crates/kernel/src/kernel.rs
+++ b/crates/kernel/src/kernel.rs
@@ -1102,8 +1102,10 @@ impl Kernel {
                     .get("scheduled_job_id")
                     .and_then(|v| v.as_str())
                 {
-                    if let Ok(uuid) = uuid::Uuid::parse_str(job_id_str) {
-                        let job_id = crate::schedule::JobId(uuid);
+                    if let Some(job_id) = uuid::Uuid::parse_str(job_id_str)
+                        .ok()
+                        .and_then(crate::schedule::JobId::from_uuid)
+                    {
                         self.syscall.job_wheel().lock().complete_in_flight(&job_id);
                     }
                 }

--- a/crates/kernel/src/queue/sharded.rs
+++ b/crates/kernel/src/queue/sharded.rs
@@ -162,7 +162,7 @@ impl ShardedEventQueue {
         }
         match event.shard_key() {
             Some(session_key) => {
-                let shard_idx = session_key.0.as_u128() as usize % self.shards.len();
+                let shard_idx = session_key.as_uuid().as_u128() as usize % self.shards.len();
                 ShardTarget::Shard(shard_idx)
             }
             None => ShardTarget::Global,

--- a/crates/kernel/src/schedule.rs
+++ b/crates/kernel/src/schedule.rs
@@ -148,7 +148,9 @@ pub struct JobWheel {
 
 impl JobWheel {
     /// Build a wheel key from a job entry.
-    fn key(entry: &JobEntry) -> WheelKey { (entry.trigger.next_at().as_second(), entry.id.0) }
+    fn key(entry: &JobEntry) -> WheelKey {
+        (entry.trigger.next_at().as_second(), entry.id.as_uuid())
+    }
 
     /// Derive the in-flight ledger path from the jobs.json path.
     fn in_flight_path(jobs_path: &std::path::Path) -> PathBuf {
@@ -446,11 +448,7 @@ impl JobResultStore {
     ///
     /// Object key: `{job_id}/{completed_at_epoch}.json`
     pub async fn append(&self, result: &JobResult) -> anyhow::Result<()> {
-        let key = format!(
-            "{}/{}.json",
-            result.job_id.0,
-            result.completed_at.as_second()
-        );
+        let key = format!("{}/{}.json", result.job_id, result.completed_at.as_second());
         let bytes = serde_json::to_vec_pretty(result)?;
         self.op.write(&key, bytes).await?;
         Ok(())
@@ -459,7 +457,7 @@ impl JobResultStore {
     /// Read all execution results for a given job, ordered by completion
     /// time (lexicographic on the epoch filename).
     pub async fn read(&self, job_id: &JobId) -> Vec<JobResult> {
-        let prefix = format!("{}/", job_id.0);
+        let prefix = format!("{job_id}/");
         let mut entries = match self.op.list(&prefix).await {
             Ok(v) => v,
             Err(_) => return Vec::new(),

--- a/crates/kernel/src/session/mod.rs
+++ b/crates/kernel/src/session/mod.rs
@@ -35,7 +35,6 @@ use serde::{Deserialize, Serialize};
 use snafu::Snafu;
 use tokio::sync::{OwnedSemaphorePermit, Semaphore};
 use tokio_util::sync::CancellationToken;
-use uuid::Uuid;
 
 use crate::{
     agent::{AgentEnv, AgentManifest, ExecutionMode, TurnTrace},

--- a/crates/kernel/src/syscall.rs
+++ b/crates/kernel/src/syscall.rs
@@ -536,7 +536,7 @@ impl SyscallDispatcher {
                             .get("scheduled_job_id")
                             .and_then(|v| v.as_str())
                             .and_then(|s| uuid::Uuid::parse_str(s).ok())
-                            .map(crate::schedule::JobId);
+                            .and_then(crate::schedule::JobId::from_uuid);
                         (uid, jid)
                     })
                     .unwrap_or((crate::identity::UserId("unknown".into()), None));
@@ -566,13 +566,13 @@ impl SyscallDispatcher {
         key: &str,
         value: serde_json::Value,
     ) -> crate::error::Result<()> {
-        let namespaced = format!("agent:{}:{}", session_key.0, key);
+        let namespaced = format!("agent:{}:{}", session_key, key);
 
         // Check quota before inserting — only if this is a new key.
         if !self.shared_kv.contains_key(&namespaced).await {
             let max = memory_quota;
             if max > 0 {
-                let prefix = format!("agent:{}:", session_key.0);
+                let prefix = format!("agent:{}:", session_key);
                 let count = self.shared_kv.count_prefix(&prefix).await;
                 if count >= max {
                     return Err(KernelError::MemoryQuotaExceeded {
@@ -613,7 +613,7 @@ impl SyscallDispatcher {
                 }
             }
             KvScope::Agent(target_id) => {
-                if *target_id != session_key.0 && !principal.is_admin() {
+                if *target_id != session_key.as_uuid() && !principal.is_admin() {
                     return Err(KernelError::MemoryScopeDenied {
                         reason: format!(
                             "agent {} cannot access agent {}'s scope — not admin",
@@ -1298,9 +1298,7 @@ struct SpawnRequest {
 // ============================================================================
 
 fn parse_session_key(s: &str) -> anyhow::Result<SessionKey> {
-    let uuid =
-        uuid::Uuid::parse_str(s).map_err(|e| anyhow::anyhow!("invalid session key '{s}': {e}"))?;
-    Ok(SessionKey(uuid))
+    SessionKey::try_from_raw(s).map_err(|e| anyhow::anyhow!("invalid session key '{s}': {e}"))
 }
 
 fn parse_scope(scope: &str) -> anyhow::Result<KvScope> {

--- a/crates/kernel/tests/task_report_test.rs
+++ b/crates/kernel/tests/task_report_test.rs
@@ -502,7 +502,7 @@ fn test_in_flight_recovery() {
     // 1. Create a wheel with one Once job and one Interval job, both expired.
     let mut wheel = JobWheel::load(jobs_path.clone());
     let once_job = JobEntry {
-        id:          JobId(uuid::Uuid::new_v4()),
+        id:          JobId::new(),
         trigger:     Trigger::Once { run_at: past },
         message:     "once task".into(),
         session_key: session,
@@ -511,7 +511,7 @@ fn test_in_flight_recovery() {
         tags:        vec!["test".into()],
     };
     let interval_job = JobEntry {
-        id:          JobId(uuid::Uuid::new_v4()),
+        id:          JobId::new(),
         trigger:     Trigger::Interval {
             every_secs: 60,
             next_at:    past,
@@ -616,7 +616,7 @@ fn test_complete_in_flight() {
 
     let mut wheel = JobWheel::load(jobs_path);
     let job = JobEntry {
-        id: JobId(uuid::Uuid::new_v4()),
+        id: JobId::new(),
         trigger: Trigger::Once { run_at: past },
         message: "task".into(),
         session_key: session,
@@ -654,7 +654,7 @@ async fn test_job_result_store_roundtrip() {
     let tmp = tempfile::tempdir().unwrap();
     let store = JobResultStore::new(tmp.path().join("results"));
 
-    let job_id = JobId(uuid::Uuid::new_v4());
+    let job_id = JobId::new();
 
     // Append two results for the same job (simulates recurring execution).
     let r1 = JobResult {
@@ -691,7 +691,7 @@ async fn test_job_result_store_roundtrip() {
     assert_eq!(results[1].status, TaskReportStatus::Failed);
 
     // A different job_id returns empty.
-    let other_id = JobId(uuid::Uuid::new_v4());
+    let other_id = JobId::new();
     let results = store.read(&other_id).await;
     assert!(results.is_empty());
 }

--- a/crates/rara-dock/src/routes.rs
+++ b/crates/rara-dock/src/routes.rs
@@ -229,8 +229,7 @@ async fn ensure_dock_kernel_session(
 ) -> Result<rara_kernel::session::SessionKey, anyhow::Error> {
     use rara_kernel::session::{ChannelBinding, SessionEntry, SessionKey};
 
-    let session_uuid = uuid::Uuid::new_v5(&uuid::Uuid::NAMESPACE_OID, dock_session_id.as_bytes());
-    let session_key = SessionKey::from(session_uuid);
+    let session_key = SessionKey::deterministic(dock_session_id);
 
     let index = kernel.session_index();
 


### PR DESCRIPTION
## Summary

Wrap `define_id!`-generated identifiers in `NonZeroU128` instead of `Uuid` so
the compiler can use a niche for `None`. `Option<SessionKey>` now fits in 16
bytes (down from 24 on 64-bit), halving padding cost in hot paths (event
queue, session table, channel routing).

UUID v4/v5 always have variant + version bits set, so the u128 representation
is guaranteed non-zero — both constructors unwrap with an `expect` that can
never fire.

### Wire / on-disk compatibility preserved

- `Display` still emits the canonical UUID string (hand-written impl replaces
  `derive_more::Display`).
- `serde::{Serialize, Deserialize}` still use the UUID string form — existing
  JSONL tapes and persisted session indexes load unchanged.
- `try_from_raw` / `deterministic` / `into_inner` / `new` / `Default` methods
  are preserved.

### API change

- `derive_more::From<Uuid>` is dropped (would panic on the nil UUID).
  Replaced with `from_uuid(uuid: Uuid) -> Option<Self>`.
- The `pub` field `.0` is no longer directly accessible — call sites use
  `as_uuid()` / `from_uuid` / `deterministic` instead.

## Type of change

| Type | Label |
|------|-------|
| New feature | `enhancement` |

## Component

`core`

## Closes

Closes #1149

## Test plan

- [x] `cargo check --all --all-targets` passes
- [x] `cargo test --workspace` passes (one flaky pre-existing clock-based
      rate-limiter test, unrelated — passes when run in isolation)
- [x] `cargo +nightly fmt --all -- --check` passes
- [x] `cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings` passes
- [x] Added `option_is_niche_optimized` static assertion test — `size_of::<TestId>() == size_of::<Option<TestId>>() == 16`
- [x] Added `serde_round_trip_is_uuid_string` test — confirms wire format is still the canonical UUID string