### PR TITLE
feat(drivers): create rara-tts crate with OpenAI-compatible TTS client (#1162)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -137,6 +137,7 @@ members = [
     "crates/rara-acp",
     "crates/drivers/browser",
     "crates/drivers/stt",
+    "crates/drivers/tts",
 ]
 
 [workspace.dependencies]
@@ -249,6 +250,7 @@ rara-app = { path = "crates/app" }
 rara-backend-admin = { path = "crates/extensions/backend-admin" }
 rara-browser = { path = "crates/drivers/browser" }
 rara-stt = { path = "crates/drivers/stt" }
+rara-tts = { path = "crates/drivers/tts" }
 rara-channels = { path = "crates/channels" }
 rara-cli = { path = "crates/cmd" }
 rara-codex-oauth = { path = "crates/integrations/codex-oauth" }

--- a/crates/drivers/tts/AGENT.md
+++ b/crates/drivers/tts/AGENT.md
@@ -1,0 +1,24 @@
+# rara-tts — Agent Guidelines
+
+## Purpose
+OpenAI-compatible Text-to-Speech HTTP client that sends JSON to `/v1/audio/speech` and returns raw audio bytes.
+
+## Architecture
+- `config.rs` — `TtsConfig` (base_url + model + voice + format required; api_key, speed, timeout, max_text_length optional)
+- `error.rs` — `TtsError` via `snafu` with `TextTooLong`, `Http`, `ServerError` variants
+- `service.rs` — `TtsService::from_config()` builds a reqwest client; `synthesize()` / `synthesize_with_voice()` POST JSON and return `AudioOutput { data, mime_type }`
+
+## Critical Invariants
+- No hardcoded defaults in Rust — all config values come from YAML.
+- `TtsService` is a concrete struct, not a trait impl. No dynamic dispatch.
+- `api_key` is sent as `Authorization: Bearer` only when `Some`.
+
+## What NOT To Do
+- Do NOT add a `Tts` trait or provider abstraction — YAGNI until a second backend exists.
+- Do NOT add ElevenLabs, fallback chains, or retry logic.
+- Do NOT persist audio output to disk — callers decide storage policy.
+- Do NOT wire into app startup here — that belongs in `rara-app` (#1163).
+
+## Dependencies
+- Upstream: reqwest (HTTP), serde/serde_json (serialization), snafu (errors), bon (builder)
+- Downstream: `rara-channels` and `rara-app` will consume this crate (future PRs)

--- a/crates/drivers/tts/Cargo.toml
+++ b/crates/drivers/tts/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "rara-tts"
+version = "0.0.1"
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+repository.workspace = true
+homepage.workspace = true
+readme.workspace = true
+keywords.workspace = true
+categories.workspace = true
+description = "Text-to-speech driver for rara agents (OpenAI-compatible TTS HTTP client)"
+
+[dependencies]
+bon.workspace = true
+reqwest.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+snafu.workspace = true
+tracing.workspace = true
+
+[dev-dependencies]
+serde_yaml.workspace = true
+tokio = { workspace = true, features = ["rt"] }
+
+[lints]
+workspace = true

--- a/crates/drivers/tts/src/config.rs
+++ b/crates/drivers/tts/src/config.rs
@@ -1,0 +1,117 @@
+use bon::Builder;
+use serde::{Deserialize, Serialize};
+
+/// Configuration for the Text-to-Speech service.
+///
+/// All fields are loaded from `config.yaml` — no hardcoded defaults in Rust.
+///
+/// ```yaml
+/// tts:
+///   base_url: "https://api.openai.com/v1"
+///   api_key: "sk-..."
+///   model: "tts-1"
+///   voice: "alloy"
+///   format: "opus"
+///   speed: 1.0              # optional, 0.25-4.0
+///   timeout_secs: 30        # optional
+///   max_text_length: 4096   # optional
+/// ```
+#[derive(Debug, Clone, Builder, Serialize, Deserialize)]
+pub struct TtsConfig {
+    /// Base URL of the TTS API (e.g. `https://api.openai.com/v1`).
+    pub base_url: String,
+
+    /// Bearer token for authentication. Optional for self-hosted servers.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub api_key: Option<String>,
+
+    /// Model identifier (e.g. `"tts-1"`, `"tts-1-hd"`).
+    pub model: String,
+
+    /// Voice name (e.g. `"alloy"`, `"echo"`, `"fable"`, `"onyx"`, `"nova"`,
+    /// `"shimmer"`).
+    pub voice: String,
+
+    /// Output audio format (e.g. `"opus"`, `"mp3"`, `"aac"`, `"flac"`).
+    pub format: String,
+
+    /// Speech speed multiplier (0.25-4.0). When `None`, server default is used.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub speed: Option<f32>,
+
+    /// Timeout per synthesis request in seconds. When `None`, reqwest default
+    /// is used.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub timeout_secs: Option<u64>,
+
+    /// Maximum allowed input text length. When `None`, no client-side limit is
+    /// enforced.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max_text_length: Option<usize>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn config_deserializes_from_yaml() {
+        let yaml = r#"
+base_url: "https://api.openai.com/v1"
+api_key: "sk-test-key"
+model: "tts-1"
+voice: "alloy"
+format: "opus"
+speed: 1.5
+timeout_secs: 30
+max_text_length: 4096
+"#;
+        let config: TtsConfig = serde_yaml::from_str(yaml).expect("failed to parse YAML");
+        assert_eq!(config.base_url, "https://api.openai.com/v1");
+        assert_eq!(config.api_key.as_deref(), Some("sk-test-key"));
+        assert_eq!(config.model, "tts-1");
+        assert_eq!(config.voice, "alloy");
+        assert_eq!(config.format, "opus");
+        assert_eq!(config.speed, Some(1.5));
+        assert_eq!(config.timeout_secs, Some(30));
+        assert_eq!(config.max_text_length, Some(4096));
+    }
+
+    #[test]
+    fn config_deserializes_minimal_yaml() {
+        let yaml = r#"
+base_url: "http://localhost:8080/v1"
+model: "tts-1"
+voice: "nova"
+format: "mp3"
+"#;
+        let config: TtsConfig = serde_yaml::from_str(yaml).expect("failed to parse YAML");
+        assert_eq!(config.base_url, "http://localhost:8080/v1");
+        assert!(config.api_key.is_none());
+        assert_eq!(config.voice, "nova");
+        assert_eq!(config.format, "mp3");
+        assert!(config.speed.is_none());
+        assert!(config.timeout_secs.is_none());
+        assert!(config.max_text_length.is_none());
+    }
+
+    #[test]
+    fn config_round_trips_through_serde() {
+        let config = TtsConfig::builder()
+            .base_url("https://api.openai.com/v1".to_owned())
+            .model("tts-1-hd".to_owned())
+            .voice("shimmer".to_owned())
+            .format("flac".to_owned())
+            .speed(2.0)
+            .build();
+
+        let yaml = serde_yaml::to_string(&config).expect("failed to serialize");
+        let parsed: TtsConfig = serde_yaml::from_str(&yaml).expect("failed to deserialize");
+
+        assert_eq!(parsed.base_url, config.base_url);
+        assert_eq!(parsed.model, config.model);
+        assert_eq!(parsed.voice, config.voice);
+        assert_eq!(parsed.format, config.format);
+        assert_eq!(parsed.speed, config.speed);
+    }
+}

--- a/crates/drivers/tts/src/error.rs
+++ b/crates/drivers/tts/src/error.rs
@@ -1,0 +1,21 @@
+use snafu::prelude::*;
+
+/// Errors produced by [`TtsService`](crate::TtsService).
+#[derive(Debug, Snafu)]
+#[snafu(visibility(pub))]
+pub enum TtsError {
+    /// Input text exceeds the configured maximum length.
+    #[snafu(display("text exceeds max length {max}: got {actual}"))]
+    TextTooLong { max: usize, actual: usize },
+
+    /// The HTTP request to the TTS server failed at the transport level.
+    #[snafu(display("TTS HTTP request failed: {source}"))]
+    Http { source: reqwest::Error },
+
+    /// The TTS server returned a non-2xx status code.
+    #[snafu(display("TTS server returned {status}: {body}"))]
+    Server { status: u16, body: String },
+}
+
+/// Convenience alias used throughout this crate.
+pub type Result<T> = std::result::Result<T, TtsError>;

--- a/crates/drivers/tts/src/lib.rs
+++ b/crates/drivers/tts/src/lib.rs
@@ -1,0 +1,10 @@
+//! Text-to-Speech (TTS) HTTP client for OpenAI-compatible speech synthesis
+//! endpoints.
+
+mod config;
+mod error;
+mod service;
+
+pub use config::TtsConfig;
+pub use error::{Result, TtsError};
+pub use service::{AudioOutput, TtsService};

--- a/crates/drivers/tts/src/service.rs
+++ b/crates/drivers/tts/src/service.rs
@@ -1,0 +1,157 @@
+//! TTS service — HTTP client for OpenAI-compatible speech synthesis endpoints.
+
+use serde_json::json;
+use snafu::ResultExt;
+use tracing::instrument;
+
+use crate::{
+    config::TtsConfig,
+    error::{self, Result},
+};
+
+/// HTTP client for an OpenAI-compatible `/v1/audio/speech` endpoint.
+pub struct TtsService {
+    client: reqwest::Client,
+    config: TtsConfig,
+}
+
+/// Raw audio output returned by [`TtsService::synthesize`].
+#[derive(Debug)]
+pub struct AudioOutput {
+    /// Audio bytes in the requested format.
+    pub data:      Vec<u8>,
+    /// MIME type corresponding to the output format (e.g. `"audio/mpeg"`).
+    pub mime_type: String,
+}
+
+impl TtsService {
+    /// Build a new service from config.
+    pub fn from_config(config: &TtsConfig) -> Self {
+        let mut builder = reqwest::Client::builder();
+
+        if let Some(secs) = config.timeout_secs {
+            builder = builder.timeout(std::time::Duration::from_secs(secs));
+        }
+
+        let client = builder
+            .build()
+            .expect("failed to build reqwest client for TTS");
+
+        Self {
+            client,
+            config: config.clone(),
+        }
+    }
+
+    /// Synthesize speech from text using the default voice.
+    #[instrument(skip_all, fields(text_len = text.len()))]
+    pub async fn synthesize(&self, text: &str) -> Result<AudioOutput> {
+        self.synthesize_with_voice(text, &self.config.voice).await
+    }
+
+    /// Synthesize speech from text using a specific voice override.
+    #[instrument(skip_all, fields(text_len = text.len(), voice))]
+    pub async fn synthesize_with_voice(&self, text: &str, voice: &str) -> Result<AudioOutput> {
+        // 1. Check max_text_length
+        if let Some(max) = self.config.max_text_length {
+            snafu::ensure!(
+                text.len() <= max,
+                error::TextTooLongSnafu {
+                    max,
+                    actual: text.len(),
+                }
+            );
+        }
+
+        // 2. Build JSON body
+        let mut body = json!({
+            "model": self.config.model,
+            "input": text,
+            "voice": voice,
+            "response_format": self.config.format,
+        });
+
+        if let Some(speed) = self.config.speed {
+            body["speed"] = json!(speed);
+        }
+
+        // 3. Build request
+        let url = format!(
+            "{}/audio/speech",
+            self.config.base_url.trim_end_matches('/')
+        );
+
+        let mut req = self.client.post(&url).json(&body);
+
+        if let Some(ref api_key) = self.config.api_key {
+            req = req.bearer_auth(api_key);
+        }
+
+        // 4. Send and read response
+        let resp = req.send().await.context(error::HttpSnafu)?;
+
+        if !resp.status().is_success() {
+            let status = resp.status().as_u16();
+            let body = resp.text().await.unwrap_or_default();
+            return Err(error::ServerSnafu { status, body }.build());
+        }
+
+        let data = resp.bytes().await.context(error::HttpSnafu)?.to_vec();
+
+        Ok(AudioOutput {
+            data,
+            mime_type: format_to_mime(&self.config.format),
+        })
+    }
+}
+
+/// Map the OpenAI response_format name to a MIME type.
+fn format_to_mime(format: &str) -> String {
+    match format {
+        "opus" => "audio/ogg;codecs=opus".to_owned(),
+        "mp3" => "audio/mpeg".to_owned(),
+        "aac" => "audio/aac".to_owned(),
+        "flac" => "audio/flac".to_owned(),
+        _ => format!("audio/{format}"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn format_to_mime_mapping() {
+        assert_eq!(format_to_mime("opus"), "audio/ogg;codecs=opus");
+        assert_eq!(format_to_mime("mp3"), "audio/mpeg");
+        assert_eq!(format_to_mime("aac"), "audio/aac");
+        assert_eq!(format_to_mime("flac"), "audio/flac");
+        assert_eq!(format_to_mime("wav"), "audio/wav");
+    }
+
+    #[test]
+    fn text_too_long_is_rejected() {
+        let config = TtsConfig::builder()
+            .base_url("http://localhost".to_owned())
+            .model("tts-1".to_owned())
+            .voice("alloy".to_owned())
+            .format("opus".to_owned())
+            .max_text_length(10_usize)
+            .build();
+
+        let service = TtsService::from_config(&config);
+
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .build()
+            .unwrap();
+
+        let err = rt
+            .block_on(service.synthesize("this text is definitely longer than ten characters"))
+            .unwrap_err();
+
+        assert!(
+            err.to_string().contains("text exceeds max length"),
+            "unexpected error: {err}"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- Add `rara-tts` crate (`crates/drivers/tts/`) — a concrete OpenAI-compatible TTS HTTP client symmetric to `rara-stt`
- `TtsService::synthesize()` POSTs JSON to `/v1/audio/speech` and returns raw audio bytes with MIME type
- `TtsConfig` with `bon::Builder` + `serde`: base_url, api_key, model, voice, format, speed, timeout, max_text_length
- `TtsError` via `snafu`: `TextTooLong`, `Http`, `Server` variants
- 5 unit tests: YAML deserialization (full + minimal), serde round-trip, format-to-MIME mapping, text length validation
- Registered in workspace `Cargo.toml` (members + dependencies)

## Type of change

| Type | Label |
|------|-------|
| New feature | `enhancement` |

## Component

`core`

## Closes

Closes #1162

## Test plan

- [x] `cargo check -p rara-tts` passes
- [x] `cargo test -p rara-tts` — 5 tests pass
- [x] `cargo +nightly fmt --all` — clean
- [x] `cargo clippy -p rara-tts --all-targets --no-deps -- -D warnings` — clean
- [x] Pre-commit hooks pass (check, fmt, clippy, doc, AGENT.md)