### PR TITLE
fix(drivers): structured STT errors with retry for transient failures (#1164)

### DIFF
--- a/crates/channels/src/telegram/adapter.rs
+++ b/crates/channels/src/telegram/adapter.rs
@@ -2703,7 +2703,7 @@ async fn handle_update(
         if let (Some(file_id), Some(stt)) = (file_id, stt_service) {
             match download_voice_file(bot, file_id, mime_hint).await {
                 Ok((audio_data, mime_type)) => match stt.transcribe(audio_data, &mime_type).await {
-                    Ok(text) if !text.trim().is_empty() => {
+                    Ok(text) => {
                         tracing::info!(len = text.len(), "voice message transcribed");
                         let combined = match raw.content {
                             MessageContent::Text(ref caption) if !caption.trim().is_empty() => {
@@ -2716,13 +2716,18 @@ async fn handle_update(
                             ..raw
                         }
                     }
-                    Ok(_) => {
-                        tracing::warn!("STT returned empty transcription, skipping");
-                        return;
-                    }
                     Err(e) => {
-                        tracing::warn!(error = %e, "STT transcription failed, skipping voice message");
-                        return;
+                        tracing::warn!(
+                            error = %e,
+                            msg_id = msg.id.0,
+                            "STT transcription failed, sending placeholder",
+                        );
+                        RawPlatformMessage {
+                            content: MessageContent::Text(
+                                "[voice message \u{2014} transcription failed]".to_owned(),
+                            ),
+                            ..raw
+                        }
                     }
                 },
                 Err(e) => {

--- a/crates/channels/src/web.rs
+++ b/crates/channels/src/web.rs
@@ -614,17 +614,13 @@ async fn transcribe_single_audio(
     };
 
     match stt.transcribe(audio_bytes, media_type).await {
-        Ok(text) if !text.trim().is_empty() => {
+        Ok(text) => {
             info!(len = text.len(), "voice message transcribed");
             text
         }
-        Ok(_) => {
-            warn!("STT returned empty transcription");
-            String::new()
-        }
         Err(e) => {
             warn!(error = %e, "STT transcription failed");
-            "[voice message]".to_owned()
+            "[voice message \u{2014} transcription failed]".to_owned()
         }
     }
 }

--- a/crates/drivers/stt/AGENT.md
+++ b/crates/drivers/stt/AGENT.md
@@ -5,22 +5,25 @@ HTTP client for OpenAI-compatible Speech-to-Text servers (e.g. whisper.cpp `whis
 
 ## Architecture
 - `config.rs` — `SttConfig` (base_url required, model + language optional, managed-mode fields)
-- `service.rs` — `SttService` sends multipart POST to `/v1/audio/transcriptions`
+- `error.rs` — `SttError` enum (Http, ServerError, Parse, EmptyResponse) with `is_transient()` helper; per-crate `Result<T>` alias
+- `service.rs` — `SttService::transcribe()` sends multipart POST to `/v1/audio/transcriptions`; retries once (2 s delay) on transient failures (timeout, 429, 5xx)
 - `process.rs` — `WhisperProcess` child-process supervisor (spawn, health-check, restart, graceful stop)
 
 ## Critical Invariants
 - When `stt` config section is present, `base_url` MUST be non-empty — startup panics otherwise.
-- Runtime STT failures (server down, empty response) degrade silently — voice messages are skipped, not queued.
+- `SttService::transcribe` returns typed `SttError`; callers must send a user-visible placeholder on failure, never silently skip.
 - Audio bytes are not persisted — transcribed text is the only artifact stored in tape.
 - `WhisperProcess` uses `kill_on_drop(true)` — if rara panics, the child is still cleaned up.
 - Supervisor restarts with a fixed 2s delay; no exponential backoff (whisper-server either works or config is wrong).
 
 ## What NOT To Do
-- Do NOT add retry logic in SttService — transient failures skip the message, user can resend.
+- Do NOT add retry logic in channel adapters — retry lives inside `SttService::transcribe`.
+- Do NOT use `anyhow` in `service.rs` or `error.rs` — these are domain-facing; `snafu` typed errors only. `process.rs` uses `anyhow` as an application boundary, which is fine.
+- Do NOT silently skip voice messages on transcription failure — callers must send a user-visible placeholder.
 - Do NOT store audio files on disk — transcribe and discard.
 - Do NOT add ContentBlock::Audio to the kernel — voice is transcribed to plain text.
-- Do NOT add exponential backoff to supervisor restart — a simple delay is sufficient; persistent failures are logged and voice messages degrade silently.
+- Do NOT add exponential backoff to supervisor restart — a simple delay is sufficient.
 
 ## Dependencies
-- Upstream: reqwest (HTTP client), url (URL parsing), tokio-util (CancellationToken)
-- Downstream: `rara-channels` (Telegram adapter consumes SttService), `rara-app` (wires WhisperProcess into startup)
+- Upstream: reqwest (HTTP client), snafu (typed errors), url (URL parsing), tokio (timer for retry + process supervision), tokio-util (CancellationToken)
+- Downstream: `rara-channels` (Telegram adapter + web adapter consume `SttService` + `SttError`), `rara-app` (wires WhisperProcess into startup)

--- a/crates/drivers/stt/Cargo.toml
+++ b/crates/drivers/stt/Cargo.toml
@@ -17,6 +17,7 @@ bon.workspace = true
 futures.workspace = true
 reqwest.workspace = true
 serde.workspace = true
+snafu.workspace = true
 tokio.workspace = true
 tokio-util.workspace = true
 tracing.workspace = true

--- a/crates/drivers/stt/src/error.rs
+++ b/crates/drivers/stt/src/error.rs
@@ -1,0 +1,40 @@
+//! Typed error types for the STT driver.
+
+use snafu::prelude::*;
+
+/// Errors returned by
+/// [`SttService::transcribe`](crate::SttService::transcribe).
+#[derive(Debug, Snafu)]
+#[snafu(visibility(pub))]
+pub enum SttError {
+    /// HTTP-level failure (timeout, connection refused, etc.).
+    #[snafu(display("STT HTTP request failed: {source}"))]
+    Http { source: reqwest::Error },
+
+    /// The STT server returned a non-2xx status code.
+    #[snafu(display("STT server returned {status}: {body}"))]
+    ServerError { status: u16, body: String },
+
+    /// Failed to deserialize the JSON response body.
+    #[snafu(display("failed to parse STT response: {source}"))]
+    Parse { source: reqwest::Error },
+
+    /// The server returned a valid response but the `text` field was empty.
+    #[snafu(display("STT response contained no text"))]
+    EmptyResponse,
+}
+
+/// Convenience alias used throughout this crate.
+pub type Result<T> = std::result::Result<T, SttError>;
+
+impl SttError {
+    /// Whether this error is likely transient and worth retrying
+    /// (network error, timeout, 429 rate-limit, or 5xx server error).
+    pub fn is_transient(&self) -> bool {
+        match self {
+            Self::Http { source } => source.is_timeout() || source.is_connect(),
+            Self::ServerError { status, .. } => *status == 429 || *status >= 500,
+            Self::Parse { .. } | Self::EmptyResponse => false,
+        }
+    }
+}

--- a/crates/drivers/stt/src/lib.rs
+++ b/crates/drivers/stt/src/lib.rs
@@ -1,9 +1,11 @@
 //! Speech-to-Text (STT) service for transcribing audio to text.
 
 mod config;
+mod error;
 mod process;
 mod service;
 
 pub use config::SttConfig;
+pub use error::{Result, SttError};
 pub use process::WhisperProcess;
 pub use service::SttService;

--- a/crates/drivers/stt/src/service.rs
+++ b/crates/drivers/stt/src/service.rs
@@ -1,10 +1,19 @@
 //! STT service — HTTP client for OpenAI-compatible transcription endpoints.
 
-use anyhow::Context;
 use reqwest::multipart;
+use snafu::ResultExt;
 use tracing::instrument;
 
-use super::SttConfig;
+use crate::{
+    SttConfig,
+    error::{self, HttpSnafu, ParseSnafu, Result},
+};
+
+/// Maximum number of retries for transient failures.
+const MAX_RETRIES: u32 = 1;
+
+/// Delay between retries — matches the whisper supervisor's restart delay.
+const RETRY_DELAY: std::time::Duration = std::time::Duration::from_secs(2);
 
 /// HTTP client for an OpenAI-compatible `/v1/audio/transcriptions` endpoint
 /// (e.g. whisper.cpp server).
@@ -43,15 +52,47 @@ impl SttService {
     /// `mime_type` should be the audio MIME type (e.g. `"audio/ogg"`,
     /// `"audio/mpeg"`). The file extension is inferred from the MIME type
     /// for the multipart form field.
+    ///
+    /// Transient failures (timeout, 429, 5xx) are retried once after a 2 s
+    /// delay before returning an error.
     #[instrument(skip_all, fields(audio_len = audio_data.len(), mime_type))]
-    pub async fn transcribe(&self, audio_data: Vec<u8>, mime_type: &str) -> anyhow::Result<String> {
+    pub async fn transcribe(&self, audio_data: Vec<u8>, mime_type: &str) -> Result<String> {
+        let mut last_err = None;
+
+        for attempt in 0..=MAX_RETRIES {
+            if attempt > 0 {
+                tracing::info!(
+                    attempt,
+                    "retrying STT transcription after transient failure"
+                );
+                tokio::time::sleep(RETRY_DELAY).await;
+            }
+
+            match self.transcribe_once(&audio_data, mime_type).await {
+                Ok(text) => return Ok(text),
+                Err(e) if e.is_transient() && attempt < MAX_RETRIES => {
+                    tracing::warn!(error = %e, attempt, "transient STT error, will retry");
+                    last_err = Some(e);
+                }
+                Err(e) => return Err(e),
+            }
+        }
+
+        // Unreachable in practice — the loop always returns — but the
+        // compiler cannot prove it.
+        Err(last_err.expect("retry loop must have recorded an error"))
+    }
+
+    /// Single-shot transcription attempt (no retry logic).
+    async fn transcribe_once(&self, audio_data: &[u8], mime_type: &str) -> Result<String> {
         let ext = extension_from_mime(mime_type);
         let filename = format!("voice.{ext}");
 
-        let file_part = multipart::Part::bytes(audio_data)
+        let file_part = multipart::Part::bytes(audio_data.to_vec())
             .file_name(filename)
             .mime_str(mime_type)
-            .context("invalid MIME type")?;
+            // mime_str only fails on invalid MIME — treat as HTTP-level error.
+            .map_err(|e| error::SttError::Http { source: e })?;
 
         let mut form = multipart::Form::new()
             .part("file", file_part)
@@ -69,16 +110,19 @@ impl SttService {
             .multipart(form)
             .send()
             .await
-            .context("STT request failed")?;
+            .context(HttpSnafu)?;
 
         if !resp.status().is_success() {
-            let status = resp.status();
+            let status = resp.status().as_u16();
             let body = resp.text().await.unwrap_or_default();
-            anyhow::bail!("STT server returned {status}: {body}");
+            return Err(error::SttError::ServerError { status, body });
         }
 
-        let result: TranscriptionResponse =
-            resp.json().await.context("failed to parse STT response")?;
+        let result: TranscriptionResponse = resp.json().await.context(ParseSnafu)?;
+
+        if result.text.trim().is_empty() {
+            return Err(error::SttError::EmptyResponse);
+        }
 
         Ok(result.text)
     }


### PR DESCRIPTION
## Summary

- Replace `anyhow::Result` with `snafu`-typed `SttError` in `SttService::transcribe`, exposing concrete error variants (Http, ServerError, Parse, EmptyResponse)
- Add retry for transient failures: 1 retry with 2s delay for HTTP timeout, 429 rate-limit, and 5xx server errors
- Channel adapters (Telegram + web) now send `"[voice message — transcription failed]"` placeholder instead of silently skipping voice messages

## Type of change

| Type | Label |
|------|-------|
| Bug fix | `bug` |

## Component

`core`

## Closes

Closes #1164

## Test plan

- [x] `cargo check --all --all-targets` passes
- [x] `cargo test -p rara-stt` passes
- [x] `cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings` passes
- [x] `cargo +nightly fmt --all -- --check` passes
- [x] `RUSTDOCFLAGS="-D warnings" cargo +nightly doc -p rara-stt --no-deps --document-private-items` passes
- [x] All pre-commit hooks pass