### PR TITLE
test(drivers): wiremock-based integration tests for STT and TTS (#1176)

### DIFF
--- a/crates/drivers/stt/Cargo.toml
+++ b/crates/drivers/stt/Cargo.toml
@@ -23,5 +23,10 @@ tokio-util.workspace = true
 tracing.workspace = true
 url.workspace = true
 
+[dev-dependencies]
+serde_json.workspace = true
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
+wiremock = "0.6"
+
 [lints]
 workspace = true

--- a/crates/drivers/stt/tests/wiremock_test.rs
+++ b/crates/drivers/stt/tests/wiremock_test.rs
@@ -1,0 +1,134 @@
+//! HTTP integration tests for `SttService` using a real in-process
+//! wiremock server.
+//!
+//! These exercise the real HTTP/JSON code path end-to-end — multipart
+//! serialization, response parsing, status-code handling, and retry
+//! logic — without mocking `SttService` itself.
+
+use rara_stt::{SttConfig, SttError, SttService};
+use wiremock::{
+    Mock, MockServer, ResponseTemplate,
+    matchers::{method, path},
+};
+
+async fn make_server() -> MockServer { MockServer::start().await }
+
+fn config_for(server: &MockServer) -> SttConfig {
+    SttConfig::builder()
+        .base_url(server.uri())
+        .model("whisper-1".to_owned())
+        .build()
+}
+
+#[tokio::test]
+async fn happy_path_returns_text() {
+    let server = make_server().await;
+    Mock::given(method("POST"))
+        .and(path("/v1/audio/transcriptions"))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_json(serde_json::json!({ "text": "hello world" })),
+        )
+        .mount(&server)
+        .await;
+
+    let svc = SttService::from_config(&config_for(&server));
+    let result = svc.transcribe(b"fake audio".to_vec(), "audio/ogg").await;
+    assert_eq!(result.expect("transcription should succeed"), "hello world");
+}
+
+#[tokio::test]
+async fn empty_response_returns_empty_response_error() {
+    let server = make_server().await;
+    Mock::given(method("POST"))
+        .and(path("/v1/audio/transcriptions"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({ "text": "" })))
+        .mount(&server)
+        .await;
+
+    let svc = SttService::from_config(&config_for(&server));
+    let result = svc.transcribe(b"fake audio".to_vec(), "audio/ogg").await;
+    assert!(
+        matches!(result, Err(SttError::EmptyResponse)),
+        "expected EmptyResponse, got {result:?}"
+    );
+}
+
+#[tokio::test]
+async fn client_error_returns_server_error_without_retry() {
+    // 4xx is not transient — service should surface it immediately.
+    let server = make_server().await;
+    Mock::given(method("POST"))
+        .and(path("/v1/audio/transcriptions"))
+        .respond_with(ResponseTemplate::new(400).set_body_string("bad request"))
+        .expect(1) // must NOT be retried
+        .mount(&server)
+        .await;
+
+    let svc = SttService::from_config(&config_for(&server));
+    let result = svc.transcribe(b"fake audio".to_vec(), "audio/ogg").await;
+    assert!(
+        matches!(result, Err(SttError::ServerError { status: 400, .. })),
+        "expected ServerError(400), got {result:?}"
+    );
+}
+
+#[tokio::test]
+async fn server_error_eventually_fails() {
+    let server = make_server().await;
+    Mock::given(method("POST"))
+        .and(path("/v1/audio/transcriptions"))
+        .respond_with(ResponseTemplate::new(500).set_body_string("internal error"))
+        .mount(&server)
+        .await;
+
+    let svc = SttService::from_config(&config_for(&server));
+    let result = svc.transcribe(b"fake audio".to_vec(), "audio/ogg").await;
+    assert!(
+        matches!(result, Err(SttError::ServerError { status: 500, .. })),
+        "expected ServerError(500), got {result:?}"
+    );
+}
+
+#[tokio::test]
+async fn transient_error_then_success_retries() {
+    // First request: 503, follow-up: 200. Retry logic should recover.
+    let server = make_server().await;
+    Mock::given(method("POST"))
+        .and(path("/v1/audio/transcriptions"))
+        .respond_with(ResponseTemplate::new(503))
+        .up_to_n_times(1)
+        .mount(&server)
+        .await;
+    Mock::given(method("POST"))
+        .and(path("/v1/audio/transcriptions"))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_json(serde_json::json!({ "text": "after retry" })),
+        )
+        .mount(&server)
+        .await;
+
+    let svc = SttService::from_config(&config_for(&server));
+    let result = svc.transcribe(b"fake audio".to_vec(), "audio/ogg").await;
+    assert_eq!(result.expect("retry should succeed"), "after retry");
+}
+
+#[tokio::test]
+async fn malformed_json_returns_parse_error() {
+    let server = make_server().await;
+    Mock::given(method("POST"))
+        .and(path("/v1/audio/transcriptions"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_string("not valid json")
+                .insert_header("content-type", "application/json"),
+        )
+        .mount(&server)
+        .await;
+
+    let svc = SttService::from_config(&config_for(&server));
+    let result = svc.transcribe(b"fake audio".to_vec(), "audio/ogg").await;
+    assert!(
+        matches!(result, Err(SttError::Parse { .. })),
+        "expected Parse error, got {result:?}"
+    );
+}

--- a/crates/drivers/tts/Cargo.toml
+++ b/crates/drivers/tts/Cargo.toml
@@ -21,7 +21,8 @@ tracing.workspace = true
 
 [dev-dependencies]
 serde_yaml.workspace = true
-tokio = { workspace = true, features = ["rt"] }
+tokio = { workspace = true, features = ["macros", "rt", "rt-multi-thread"] }
+wiremock = "0.6"
 
 [lints]
 workspace = true

--- a/crates/drivers/tts/tests/wiremock_test.rs
+++ b/crates/drivers/tts/tests/wiremock_test.rs
@@ -1,0 +1,105 @@
+//! HTTP integration tests for `TtsService` using a real in-process
+//! wiremock server.
+//!
+//! These exercise the real HTTP/JSON code path — request serialization,
+//! bearer-auth header, response byte decoding, and error mapping — without
+//! mocking `TtsService` itself.
+
+use rara_tts::{TtsConfig, TtsError, TtsService};
+use wiremock::{
+    Mock, MockServer, ResponseTemplate,
+    matchers::{header, method, path},
+};
+
+async fn make_server() -> MockServer { MockServer::start().await }
+
+fn config_for(server: &MockServer) -> TtsConfig {
+    // `TtsService` appends `/audio/speech` to `base_url`, so include `/v1`
+    // in the base URL to hit the OpenAI-style path.
+    TtsConfig::builder()
+        .base_url(format!("{}/v1", server.uri()))
+        .api_key("test-key".to_owned())
+        .model("tts-1".to_owned())
+        .voice("alloy".to_owned())
+        .format("opus".to_owned())
+        .build()
+}
+
+#[tokio::test]
+async fn happy_path_returns_audio_bytes() {
+    let server = make_server().await;
+    let fake_audio: Vec<u8> = vec![0x4F, 0x67, 0x67, 0x53]; // "OggS" magic bytes
+    Mock::given(method("POST"))
+        .and(path("/v1/audio/speech"))
+        .respond_with(ResponseTemplate::new(200).set_body_bytes(fake_audio.clone()))
+        .mount(&server)
+        .await;
+
+    let svc = TtsService::from_config(&config_for(&server));
+    let result = svc.synthesize("hello world").await.expect("synthesize ok");
+    assert_eq!(result.data, fake_audio);
+    assert_eq!(result.mime_type, "audio/ogg;codecs=opus");
+}
+
+#[tokio::test]
+async fn authorization_header_is_sent() {
+    // Request is only matched when the bearer token is present; absent the
+    // header wiremock returns 404 and the test fails.
+    let server = make_server().await;
+    Mock::given(method("POST"))
+        .and(path("/v1/audio/speech"))
+        .and(header("authorization", "Bearer test-key"))
+        .respond_with(ResponseTemplate::new(200).set_body_bytes(vec![0u8; 4]))
+        .mount(&server)
+        .await;
+
+    let svc = TtsService::from_config(&config_for(&server));
+    svc.synthesize("hello")
+        .await
+        .expect("synthesize must succeed when auth header matches");
+}
+
+#[tokio::test]
+async fn server_error_is_mapped_to_server_variant() {
+    let server = make_server().await;
+    Mock::given(method("POST"))
+        .and(path("/v1/audio/speech"))
+        .respond_with(ResponseTemplate::new(500).set_body_string("server error"))
+        .mount(&server)
+        .await;
+
+    let svc = TtsService::from_config(&config_for(&server));
+    let result = svc.synthesize("hello").await;
+    assert!(
+        matches!(result, Err(TtsError::Server { status: 500, .. })),
+        "expected Server(500), got {result:?}"
+    );
+}
+
+#[tokio::test]
+async fn text_too_long_is_rejected_client_side() {
+    // Server is started but should NOT be hit — expect(0) enforces this.
+    let server = make_server().await;
+    Mock::given(method("POST"))
+        .respond_with(ResponseTemplate::new(200))
+        .expect(0)
+        .mount(&server)
+        .await;
+
+    let config = TtsConfig::builder()
+        .base_url(format!("{}/v1", server.uri()))
+        .model("tts-1".to_owned())
+        .voice("alloy".to_owned())
+        .format("opus".to_owned())
+        .max_text_length(10_usize)
+        .build();
+
+    let svc = TtsService::from_config(&config);
+    let result = svc
+        .synthesize("this text is definitely longer than 10 chars")
+        .await;
+    assert!(
+        matches!(result, Err(TtsError::TextTooLong { max: 10, .. })),
+        "expected TextTooLong, got {result:?}"
+    );
+}


### PR DESCRIPTION
## Summary

Add wiremock-powered HTTP integration tests for `SttService` and `TtsService`. These exercise the real HTTP/JSON code paths (multipart serialization, bearer-auth, response parsing, status-code mapping, retry logic) without mocking the service layer itself.

matklad principle: do not wrap single-impl concrete types in traits purely for testability. wiremock spins up a real in-process HTTP server on a random port, so we can test the production code rather than a fake.

### STT coverage (`crates/drivers/stt/tests/wiremock_test.rs`)
- happy path returns decoded text
- empty `text` field returns `SttError::EmptyResponse`
- 4xx surfaces immediately as `ServerError` (`expect(1)` enforces no retry)
- 5xx eventually fails as `ServerError`
- 503 then 200 — retry logic recovers
- malformed JSON returns `SttError::Parse`

### TTS coverage (`crates/drivers/tts/tests/wiremock_test.rs`)
- happy path returns audio bytes + correct MIME type
- `Authorization: Bearer <key>` header is sent (matcher-enforced)
- 5xx mapped to `TtsError::Server { status, body }`
- client-side `max_text_length` rejects without hitting the network (`expect(0)`)

wiremock added as **dev-dependency only**. No production deps changed.

## Type of change

| Type | Label |
|------|-------|
| Test / enhancement | `enhancement` |

## Component

`core`

## Closes

Closes #1176

## Test plan

- [x] `cargo test -p rara-stt --test wiremock_test` passes (6 tests)
- [x] `cargo test -p rara-tts --test wiremock_test` passes (4 tests)
- [x] `cargo check --all --all-targets` passes
- [x] `cargo +nightly fmt --all` clean
- [x] `cargo clippy -p rara-stt -p rara-tts --all-targets --no-deps -- -D warnings` clean
- [x] `RUSTDOCFLAGS=-D warnings cargo +nightly doc` clean