### PR TITLE
test(kernel): tool call round-trip E2E test with FakeTool (#1177)

### DIFF
--- a/crates/app/tests/e2e_scripted.rs
+++ b/crates/app/tests/e2e_scripted.rs
@@ -19,15 +19,21 @@
 //! messages through the standard `KernelHandle` API, and asserts on turn
 //! traces and tape entries.
 
-use std::{path::Path, sync::Once, time::Duration};
+use std::{
+    path::Path,
+    sync::{Arc, Once},
+    time::Duration,
+};
 
 use rara_kernel::{
     channel::types::{ChannelType, MessageContent},
     identity::{Principal, UserId},
     io::{ChannelSource, InboundMessage, MessageId, Unresolved},
+    llm::ToolCallRequest,
     session::SessionKey,
-    testing::{TestKernelBuilder, scripted_response},
+    testing::{FakeTool, TestKernelBuilder, scripted_response, scripted_tool_call_response},
 };
+use serde_json::json;
 use tokio::time::{Instant, sleep};
 
 /// Override rara_paths directories to a writable temp path so tests
@@ -255,6 +261,85 @@ async fn empty_llm_response_handled() {
         turn.success,
         "empty response should not crash the session: {:?}",
         turn.error
+    );
+
+    tk.shutdown();
+}
+
+#[tokio::test]
+async fn tool_call_round_trip() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    init_test_env(tmp.path());
+
+    // The FakeTool echoes back a single scripted result.
+    let fake_tool = Arc::new(FakeTool::new(
+        "echo",
+        vec![json!({"output": "hello world"})],
+    ));
+
+    // Script: turn 1 asks the LLM, which requests the `echo` tool; after the
+    // tool result is fed back, the LLM produces the final user-visible reply.
+    // Extra padding covers any auxiliary calls (e.g. knowledge extraction).
+    let tk = TestKernelBuilder::new(tmp.path())
+        .with_tool(fake_tool.clone())
+        .responses(vec![
+            scripted_tool_call_response(vec![ToolCallRequest {
+                id:        "call_echo_1".to_string(),
+                name:      "echo".to_string(),
+                arguments: json!({"text": "hello"}).to_string(),
+            }]),
+            scripted_response("The tool said: hello world"),
+            scripted_response("(padding)"),
+            scripted_response("(padding)"),
+        ])
+        .build()
+        .await;
+
+    let principal = Principal::lookup("test".to_string());
+    let session_key = tk
+        .handle
+        .spawn_named(
+            &tk.agent_name,
+            "use the echo tool".to_string(),
+            principal,
+            None,
+        )
+        .await
+        .expect("spawn session");
+
+    wait_for_turn_count(&tk.handle, session_key, 1).await;
+
+    // The tool must have been invoked exactly once with the scripted args.
+    let inputs = fake_tool.captured_inputs();
+    assert_eq!(
+        inputs.len(),
+        1,
+        "FakeTool should be called exactly once, got: {inputs:?}"
+    );
+    assert_eq!(
+        inputs[0],
+        json!({"text": "hello"}),
+        "FakeTool received unexpected arguments"
+    );
+
+    // The final iteration should carry the LLM's post-tool reply.
+    let traces = tk.handle.get_process_turns(session_key);
+    assert_eq!(traces.len(), 1, "should have exactly 1 turn");
+    let turn = &traces[0];
+    assert!(turn.success, "turn should succeed: {:?}", turn.error);
+    assert!(
+        turn.iterations.len() >= 2,
+        "expected at least 2 iterations (tool call + final reply), got {}",
+        turn.iterations.len()
+    );
+    let preview = turn
+        .iterations
+        .last()
+        .map(|i| i.text_preview.as_str())
+        .unwrap_or("");
+    assert!(
+        preview.contains("hello world"),
+        "expected tool output to surface in final reply, got: {preview}"
     );
 
     tk.shutdown();

--- a/crates/kernel/src/llm/scripted.rs
+++ b/crates/kernel/src/llm/scripted.rs
@@ -112,10 +112,29 @@ impl LlmDriver for ScriptedLlmDriver {
         request: CompletionRequest,
         tx: mpsc::Sender<StreamDelta>,
     ) -> Result<CompletionResponse> {
-        // Emit the full text as a single delta, then Done.
+        // Emit the full text as a single delta, then any tool calls as
+        // ToolCallStart + ToolCallArgumentsDelta pairs, then Done. The
+        // agent loop aggregates these into the in-flight tool-call state,
+        // so omitting them would cause scripted tool calls to be silently
+        // dropped.
         let response = self.complete(request).await?;
         if let Some(ref text) = response.content {
             let _ = tx.send(StreamDelta::TextDelta { text: text.clone() }).await;
+        }
+        for (index, call) in response.tool_calls.iter().enumerate() {
+            let _ = tx
+                .send(StreamDelta::ToolCallStart {
+                    index: index as u32,
+                    id:    call.id.clone(),
+                    name:  call.name.clone(),
+                })
+                .await;
+            let _ = tx
+                .send(StreamDelta::ToolCallArgumentsDelta {
+                    index:     index as u32,
+                    arguments: call.arguments.clone(),
+                })
+                .await;
         }
         let _ = tx
             .send(StreamDelta::Done {

--- a/crates/kernel/src/testing.rs
+++ b/crates/kernel/src/testing.rs
@@ -19,9 +19,9 @@
 //! and no external dependencies (no DB, no network, no API keys).
 
 use std::{
-    collections::HashMap,
+    collections::{HashMap, VecDeque},
     path::{Path, PathBuf},
-    sync::Arc,
+    sync::{Arc, Mutex},
 };
 
 use async_trait::async_trait;
@@ -37,7 +37,7 @@ use crate::{
     memory::{FileTapeStore, TapeService},
     security::{ApprovalManager, ApprovalPolicy, SecuritySubsystem},
     session::test_utils::InMemorySessionIndex,
-    tool::ToolRegistry,
+    tool::{AgentTool, AgentToolRef, ToolContext, ToolOutput, ToolRegistry},
 };
 
 // ---------------------------------------------------------------------------
@@ -230,6 +230,7 @@ pub struct TestKernelBuilder {
     responses: Vec<CompletionResponse>,
     manifest:  Option<AgentManifest>,
     config:    KernelConfig,
+    tools:     Vec<AgentToolRef>,
 }
 
 impl TestKernelBuilder {
@@ -250,7 +251,18 @@ impl TestKernelBuilder {
             responses: Vec::new(),
             manifest: None,
             config,
+            tools: Vec::new(),
         }
+    }
+
+    /// Register a tool with the test kernel's tool registry.
+    ///
+    /// Tools are registered before the kernel starts, so they are visible to
+    /// the agent runtime from the first turn.
+    #[must_use]
+    pub fn with_tool(mut self, tool: AgentToolRef) -> Self {
+        self.tools.push(tool);
+        self
     }
 
     /// Set the scripted LLM responses.
@@ -287,8 +299,12 @@ impl TestKernelBuilder {
         driver_registry.register_driver("scripted", driver);
         driver_registry.set_provider_model("scripted", "scripted-model", vec![]);
 
-        // Tool registry (empty -- no tools for scripted tests)
-        let tool_registry = Arc::new(ToolRegistry::new());
+        // Tool registry -- seed with any tools registered on the builder.
+        let mut registry = ToolRegistry::new();
+        for tool in self.tools {
+            registry.register(tool);
+        }
+        let tool_registry = Arc::new(registry);
 
         // Agent manifest
         let manifest = self.manifest.unwrap_or_else(|| AgentManifest {
@@ -408,6 +424,83 @@ pub fn scripted_response(text: &str) -> CompletionResponse {
         stop_reason:       StopReason::Stop,
         usage:             None,
         model:             "scripted".to_string(),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// FakeTool
+// ---------------------------------------------------------------------------
+
+/// Test-only [`AgentTool`] that returns pre-recorded outputs for each call
+/// and captures received inputs for post-hoc assertions.
+///
+/// Unlike real tools, `FakeTool` performs no I/O: every invocation pops the
+/// next queued response and records the input. This makes it a drop-in
+/// scripted counterpart to [`ScriptedLlmDriver`] for tool-call round-trip
+/// tests.
+///
+/// # Panics
+///
+/// `execute` panics if called more times than there are scripted responses.
+pub struct FakeTool {
+    name:        String,
+    description: String,
+    responses:   Mutex<VecDeque<serde_json::Value>>,
+    captured:    Mutex<Vec<serde_json::Value>>,
+}
+
+impl FakeTool {
+    /// Create a `FakeTool` with the given name and scripted responses.
+    ///
+    /// Each call to `execute` pops one response from the front of the queue.
+    pub fn new(name: impl Into<String>, responses: Vec<serde_json::Value>) -> Self {
+        Self {
+            name:        name.into(),
+            description: "Test tool (FakeTool)".to_string(),
+            responses:   Mutex::new(VecDeque::from(responses)),
+            captured:    Mutex::new(Vec::new()),
+        }
+    }
+
+    /// Return a snapshot of every input the tool has received so far.
+    #[must_use]
+    pub fn captured_inputs(&self) -> Vec<serde_json::Value> {
+        self.captured
+            .lock()
+            .expect("FakeTool captured mutex poisoned")
+            .clone()
+    }
+}
+
+#[async_trait]
+impl AgentTool for FakeTool {
+    fn name(&self) -> &str { &self.name }
+
+    fn description(&self) -> &str { &self.description }
+
+    fn parameters_schema(&self) -> serde_json::Value {
+        serde_json::json!({
+            "type": "object",
+            "additionalProperties": true,
+        })
+    }
+
+    async fn execute(
+        &self,
+        params: serde_json::Value,
+        _context: &ToolContext,
+    ) -> anyhow::Result<ToolOutput> {
+        self.captured
+            .lock()
+            .expect("FakeTool captured mutex poisoned")
+            .push(params);
+        let output = self
+            .responses
+            .lock()
+            .expect("FakeTool responses mutex poisoned")
+            .pop_front()
+            .expect("FakeTool: no more scripted responses");
+        Ok(ToolOutput::from(output))
     }
 }
 


### PR DESCRIPTION
## Summary

- Add `FakeTool` to `rara_kernel::testing`: a scripted `AgentTool` impl that pops pre-recorded `serde_json::Value` outputs per call and captures inputs for assertions.
- Add `TestKernelBuilder::with_tool(AgentToolRef)` so tests can seed the kernel's `ToolRegistry` before startup.
- Add `tool_call_round_trip` E2E test in `crates/app/tests/e2e_scripted.rs`: scripted LLM requests `echo` tool, `FakeTool` returns scripted output, LLM produces final reply that surfaces the tool output.
- Fix `ScriptedLlmDriver::stream` to emit `ToolCallStart` + `ToolCallArgumentsDelta` for scripted tool calls. The agent loop aggregates tool calls from streaming deltas; without these, scripted tool calls were silently dropped (root cause for the round-trip test failing initially).

## Type of change

| Type | Label |
|------|-------|
| New feature | `enhancement` |

## Component

`core`

## Closes

Closes #1177

## Test plan

- [x] `cargo test -p rara-app --test e2e_scripted` (5 tests pass including the new `tool_call_round_trip`)
- [x] `cargo test -p rara-kernel --lib scripted` passes
- [x] `cargo +nightly fmt --all` clean
- [x] `cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings` clean
- [x] `RUSTDOCFLAGS="-D warnings" cargo +nightly doc --workspace --no-deps --document-private-items` clean