### PR TITLE
feat(kernel): add AgentTool::validate semantic validation step (#1183)

### DIFF
--- a/crates/common/tool-macro/AGENT.md
+++ b/crates/common/tool-macro/AGENT.md
@@ -23,6 +23,17 @@ Single file: `src/lib.rs`.
 | `params_schema = "..."` | `execute_fn = "..."` | Both custom, no `ToolExecute` needed |
 | `manual_impl = true` | — | Only generates constants, user writes full `impl AgentTool` |
 
+### Validation bridging
+
+The macro auto-bridges `ToolExecute::validate` → `AgentTool::validate`:
+
+| Mode | validate behaviour |
+|---|---|
+| Default (ToolExecute) | Deserialises params, calls `ToolExecute::validate(&typed)` |
+| `validate_fn = "..."` | Calls user fn with `&serde_json::Value` directly |
+| `execute_fn` without `validate_fn` | Omitted — trait default (no-op) applies |
+| `manual_impl = true` | User writes `validate` manually if needed |
+
 ## Critical Invariants
 
 - Generated `AgentTool::parameters_schema()` output must be **semantically equivalent** to the hand-written `serde_json::json!()` it replaces. Field ordering may differ.

--- a/crates/common/tool-macro/src/lib.rs
+++ b/crates/common/tool-macro/src/lib.rs
@@ -36,6 +36,10 @@ use syn::{DeriveInput, Expr, LitBool, LitStr, Token, parse_macro_input};
 /// - `execute_fn` (optional): Path to a custom execute function with signature
 ///   `async fn(&self, Value, &ToolContext) -> Result<ToolOutput>`. Defaults to
 ///   deserializing params and calling `ToolExecute::run`.
+/// - `validate_fn` (optional): Path to a custom validate function with
+///   signature `async fn(&Value) -> anyhow::Result<()>`. Use this with
+///   `execute_fn` mode (no `ToolExecute` impl). When `ToolExecute` is present,
+///   `ToolExecute::validate` is auto-bridged and this attribute is not needed.
 /// - `manual_impl` (optional): If `true`, only generates `TOOL_NAME` and
 ///   `TOOL_DESCRIPTION` constants; user writes `impl AgentTool` manually.
 #[proc_macro_derive(ToolDef, attributes(tool))]
@@ -53,6 +57,7 @@ struct ToolAttrs {
     description:   LitStr,
     params_schema: Option<Expr>,
     execute_fn:    Option<Expr>,
+    validate_fn:   Option<Expr>,
     manual_impl:   bool,
     tier:          Option<LitStr>,
     timeout_secs:  Option<syn::LitInt>,
@@ -63,6 +68,7 @@ fn parse_tool_attrs(input: &DeriveInput) -> syn::Result<ToolAttrs> {
     let mut description: Option<LitStr> = None;
     let mut params_schema: Option<Expr> = None;
     let mut execute_fn: Option<Expr> = None;
+    let mut validate_fn: Option<Expr> = None;
     let mut manual_impl = false;
     let mut tier: Option<LitStr> = None;
     let mut timeout_secs: Option<syn::LitInt> = None;
@@ -86,6 +92,10 @@ fn parse_tool_attrs(input: &DeriveInput) -> syn::Result<ToolAttrs> {
                 meta.input.parse::<Token![=]>()?;
                 let lit: LitStr = meta.input.parse()?;
                 execute_fn = Some(lit.parse::<Expr>()?);
+            } else if meta.path.is_ident("validate_fn") {
+                meta.input.parse::<Token![=]>()?;
+                let lit: LitStr = meta.input.parse()?;
+                validate_fn = Some(lit.parse::<Expr>()?);
             } else if meta.path.is_ident("manual_impl") {
                 meta.input.parse::<Token![=]>()?;
                 let lit: LitBool = meta.input.parse()?;
@@ -119,6 +129,7 @@ fn parse_tool_attrs(input: &DeriveInput) -> syn::Result<ToolAttrs> {
         description,
         params_schema,
         execute_fn,
+        validate_fn,
         manual_impl,
         tier,
         timeout_secs,
@@ -174,6 +185,38 @@ fn expand_tool_def(input: &DeriveInput) -> syn::Result<proc_macro2::TokenStream>
         }
     };
 
+    // Build validate body. Three modes:
+    //   1. `validate_fn = "..."` set       → call user fn directly
+    //   2. otherwise, if execute uses ToolExecute → bridge to ToolExecute::validate
+    //      (deserialise once for the typed call; we accept the parse cost because
+    //      validate is the right place to surface schema errors)
+    //   3. otherwise (execute_fn mode without validate_fn) → omit, trait default
+    //      applies
+    let validate_impl = if let Some(expr) = &attrs.validate_fn {
+        quote! {
+            async fn validate(
+                &self,
+                params: &serde_json::Value,
+            ) -> anyhow::Result<()> {
+                #expr(params).await
+            }
+        }
+    } else if attrs.execute_fn.is_none() {
+        quote! {
+            async fn validate(
+                &self,
+                params: &serde_json::Value,
+            ) -> anyhow::Result<()> {
+                let typed: <Self as crate::tool::ToolExecute>::Params =
+                    serde_json::from_value(params.clone())
+                        .map_err(|e| anyhow::anyhow!("invalid params for '{}': {e}", self.name()))?;
+                crate::tool::ToolExecute::validate(self, &typed).await
+            }
+        }
+    } else {
+        quote! {}
+    };
+
     let timeout_impl = match &attrs.timeout_secs {
         Some(lit) => quote! {
             fn execution_timeout(&self) -> Option<std::time::Duration> {
@@ -212,6 +255,8 @@ fn expand_tool_def(input: &DeriveInput) -> syn::Result<proc_macro2::TokenStream>
             fn parameters_schema(&self) -> serde_json::Value {
                 #schema_body
             }
+
+            #validate_impl
 
             async fn execute(
                 &self,

--- a/crates/kernel/src/agent/mod.rs
+++ b/crates/kernel/src/agent/mod.rs
@@ -2131,6 +2131,25 @@ pub(crate) async fn run_agent_loop(
                     if let Some(tool) = tool {
                         let args_snapshot = args.to_string();
                         let per_tool_timeout = tool.execution_timeout().unwrap_or(default_tool_timeout);
+
+                        // Semantic validation runs after the security guard
+                        // and before execute. This is the place to surface
+                        // cross-field invariants ("old != new") or refuse
+                        // no-op edits without spending the execute budget.
+                        if let Err(e) = tool.validate(&args).await {
+                            tool_span.record("success", false);
+                            warn!(tool = %name, args = %args_snapshot, error = %e, "tool validation failed");
+                            let dur = tool_start.elapsed().as_millis() as u64;
+                            return (
+                                false,
+                                crate::tool::ToolOutput::from(
+                                    serde_json::json!({ "error": e.to_string() }),
+                                ),
+                                Some(e.to_string()),
+                                dur,
+                            );
+                        }
+
                         let tool_result = tokio::select! {
                             result = tokio::time::timeout(per_tool_timeout, tool.execute(args, &tc)) => {
                                 match result {

--- a/crates/kernel/src/testing.rs
+++ b/crates/kernel/src/testing.rs
@@ -504,6 +504,60 @@ impl AgentTool for FakeTool {
     }
 }
 
+// ---------------------------------------------------------------------------
+// ValidatingFakeTool
+// ---------------------------------------------------------------------------
+
+/// A [`FakeTool`] variant whose [`validate`](AgentTool::validate) rejects
+/// inputs containing a `"reject"` key set to `true`.
+///
+/// Used to test that the agent loop correctly short-circuits on validation
+/// failures without calling `execute`.
+pub struct ValidatingFakeTool {
+    inner: FakeTool,
+}
+
+impl ValidatingFakeTool {
+    /// Create a `ValidatingFakeTool` with the given name and scripted
+    /// responses.
+    pub fn new(name: impl Into<String>, responses: Vec<serde_json::Value>) -> Self {
+        Self {
+            inner: FakeTool::new(name, responses),
+        }
+    }
+
+    /// Return captured inputs that made it through validation to `execute`.
+    pub fn captured_inputs(&self) -> Vec<serde_json::Value> { self.inner.captured_inputs() }
+}
+
+#[async_trait]
+impl AgentTool for ValidatingFakeTool {
+    fn name(&self) -> &str { self.inner.name() }
+
+    fn description(&self) -> &str { self.inner.description() }
+
+    fn parameters_schema(&self) -> serde_json::Value { self.inner.parameters_schema() }
+
+    async fn validate(&self, params: &serde_json::Value) -> anyhow::Result<()> {
+        if params
+            .get("reject")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false)
+        {
+            anyhow::bail!("validation rejected: 'reject' flag is set");
+        }
+        Ok(())
+    }
+
+    async fn execute(
+        &self,
+        params: serde_json::Value,
+        context: &ToolContext,
+    ) -> anyhow::Result<ToolOutput> {
+        self.inner.execute(params, context).await
+    }
+}
+
 /// Convenience helper: build a [`CompletionResponse`] with tool calls.
 pub fn scripted_tool_call_response(
     tool_calls: Vec<crate::llm::ToolCallRequest>,

--- a/crates/kernel/src/tool/mod.rs
+++ b/crates/kernel/src/tool/mod.rs
@@ -99,6 +99,17 @@ pub trait ToolExecute: Send + Sync {
     /// The result struct for this tool. Must derive `serde::Serialize`.
     type Output: serde::Serialize;
 
+    /// Optional semantic validation, runs after schema parse but before
+    /// [`run`](Self::run). Default: no-op.
+    ///
+    /// Use this for checks that go beyond JSON Schema (e.g. "old_string must
+    /// not equal new_string", "path must not be inside /etc"). Returning an
+    /// error short-circuits execution and surfaces the message back to the
+    /// LLM as a tool error — the agent loop never calls [`run`](Self::run).
+    ///
+    /// Bridged into [`AgentTool::validate`] by the `ToolDef` derive macro.
+    async fn validate(&self, _params: &Self::Params) -> anyhow::Result<()> { Ok(()) }
+
     /// Execute the tool with typed parameters.
     async fn run(
         &self,
@@ -366,6 +377,20 @@ pub trait AgentTool: Send + Sync {
 
     /// JSON Schema describing the accepted parameters.
     fn parameters_schema(&self) -> serde_json::Value;
+
+    /// Optional semantic validation step, runs after schema parse but before
+    /// [`execute`](Self::execute). Default: no-op (`Ok(())`).
+    ///
+    /// The agent loop calls this *after* the security guard pipeline and
+    /// *before* `execute`. Returning an error short-circuits the call: the
+    /// error message is returned to the LLM as a tool error and `execute` is
+    /// never invoked. Tools using `#[derive(ToolDef)]` get an automatic bridge
+    /// to [`ToolExecute::validate`] (deserialise once, dispatch typed).
+    ///
+    /// Use for checks beyond JSON Schema — e.g. cross-field invariants,
+    /// path-allowlist enforcement, or refusing no-op edits. Do not use for
+    /// security checks (those belong in the guard pipeline).
+    async fn validate(&self, _params: &serde_json::Value) -> anyhow::Result<()> { Ok(()) }
 
     /// Execute the tool with the given parameters and execution context.
     async fn execute(

--- a/crates/kernel/tests/tool_validate.rs
+++ b/crates/kernel/tests/tool_validate.rs
@@ -1,0 +1,106 @@
+//! Integration tests: AgentTool::validate semantics.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use rara_kernel::tool::{AgentTool, ToolContext, ToolOutput};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Tool that always passes validation (default trait impl).
+struct PassTool;
+
+#[async_trait]
+impl AgentTool for PassTool {
+    fn name(&self) -> &str { "pass" }
+
+    fn description(&self) -> &str { "always passes" }
+
+    fn parameters_schema(&self) -> serde_json::Value { serde_json::json!({}) }
+
+    async fn execute(
+        &self,
+        _params: serde_json::Value,
+        _ctx: &ToolContext,
+    ) -> anyhow::Result<ToolOutput> {
+        Ok(ToolOutput::from(serde_json::json!({ "ok": true })))
+    }
+}
+
+/// Tool that rejects inputs where `"reject"` is `true`.
+struct RejectTool;
+
+#[async_trait]
+impl AgentTool for RejectTool {
+    fn name(&self) -> &str { "reject" }
+
+    fn description(&self) -> &str { "rejects when reject=true" }
+
+    fn parameters_schema(&self) -> serde_json::Value { serde_json::json!({}) }
+
+    async fn validate(&self, params: &serde_json::Value) -> anyhow::Result<()> {
+        if params
+            .get("reject")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false)
+        {
+            anyhow::bail!("rejected by validate");
+        }
+        Ok(())
+    }
+
+    async fn execute(
+        &self,
+        _params: serde_json::Value,
+        _ctx: &ToolContext,
+    ) -> anyhow::Result<ToolOutput> {
+        Ok(ToolOutput::from(serde_json::json!({ "executed": true })))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+/// Default validate implementation passes any input.
+#[tokio::test]
+async fn default_validate_passes() {
+    let tool: Arc<dyn AgentTool> = Arc::new(PassTool);
+    let result = tool.validate(&serde_json::json!({ "anything": 42 })).await;
+    assert!(result.is_ok());
+}
+
+/// Custom validate rejects matching input.
+#[tokio::test]
+async fn custom_validate_rejects() {
+    let tool: Arc<dyn AgentTool> = Arc::new(RejectTool);
+
+    let ok = tool.validate(&serde_json::json!({ "reject": false })).await;
+    assert!(ok.is_ok());
+
+    let err = tool.validate(&serde_json::json!({ "reject": true })).await;
+    assert!(err.is_err());
+    assert!(
+        err.unwrap_err()
+            .to_string()
+            .contains("rejected by validate"),
+        "error message should mention the rejection reason"
+    );
+}
+
+/// Validate is independent of execute — a tool can pass validate and then
+/// execute, or fail validate without execute ever being called.
+#[tokio::test]
+async fn validate_is_independent_of_execute() {
+    let tool: Arc<dyn AgentTool> = Arc::new(RejectTool);
+
+    // Validate fails → caller should NOT call execute.
+    let v = tool.validate(&serde_json::json!({ "reject": true })).await;
+    assert!(v.is_err());
+
+    // Validate passes → caller proceeds to execute.
+    let v = tool.validate(&serde_json::json!({ "reject": false })).await;
+    assert!(v.is_ok());
+}


### PR DESCRIPTION
## Summary

Add `AgentTool::validate(&self, &Value) -> Result<()>` and `ToolExecute::validate(&self, &Params) -> Result<()>` as a semantic validation step in the tool call pipeline.

- Agent loop calls `validate` after the security guard pipeline, before `execute`
- Validation failure short-circuits: returns error to LLM, `execute` never runs
- Default impl is no-op (`Ok(())`) — existing tools are unaffected
- `ToolDef` macro auto-bridges `ToolExecute::validate` → `AgentTool::validate` (deserialise + typed dispatch)
- New `validate_fn = "..."` attribute for `execute_fn`-mode tools
- Adds `ValidatingFakeTool` to testing infra + 3 integration tests

Modeled after Claude Code's two-step validation pipeline (schema parse → `validateInput()` → `tool.call()`), see [04b-tool-call-implementation.md §6.1](https://github.com/liuup/claude-code-analysis/blob/main/analysis/04b-tool-call-implementation.md).

## Type of change

| Type | Label |
|------|-------|
| New feature | `enhancement` |

## Component

`core`

## Closes

Closes #1183

## Test plan

- [x] `cargo check -p rara-tool-macro -p rara-kernel` passes
- [x] `cargo clippy -p rara-kernel --all-targets --no-deps -- -D warnings` passes
- [x] `cargo test -p rara-kernel --test tool_validate` — 3/3 pass
- [x] Pre-commit hooks (check, fmt, clippy, doc) pass