### PR TITLE
test(channels): web adapter E2E tests via direct handler invocation (#1178)

### DIFF
--- a/crates/channels/Cargo.toml
+++ b/crates/channels/Cargo.toml
@@ -42,8 +42,14 @@ url = "2"
 uuid = { workspace = true }
 
 [dev-dependencies]
+base64 = { workspace = true }
+rara-kernel = { workspace = true }
+rara-paths = { workspace = true }
+rara-stt = { workspace = true }
+serde_json = { workspace = true }
 tempfile = { workspace = true }
 tokio = { workspace = true, features = ["full", "test-util"] }
+wiremock = "0.6"
 
 [lints]
 workspace = true

--- a/crates/channels/src/web.rs
+++ b/crates/channels/src/web.rs
@@ -420,6 +420,43 @@ impl WebAdapter {
             .with_state(state)
     }
 
+    /// Test-only entry point that mirrors the inbound code path exercised by
+    /// the WebSocket and `POST /messages` handlers, without requiring an HTTP
+    /// round-trip. The adapter must have been `start`ed first so `sink` is
+    /// populated.
+    ///
+    /// Runs audio transcription (if any), constructs the `RawPlatformMessage`,
+    /// resolves identity + session, and submits the resulting message into
+    /// the kernel's event queue — mirroring the WebSocket / `POST /messages`
+    /// code path without requiring an HTTP round-trip.
+    ///
+    /// On first contact from a new `session_key` the kernel auto-creates a
+    /// session; callers can discover the resulting `SessionKey` by polling
+    /// `KernelHandle::list_processes` after this returns.
+    #[doc(hidden)]
+    pub async fn handle_inbound_for_test(
+        &self,
+        session_key: &str,
+        user_id: &str,
+        content: MessageContent,
+    ) -> Result<(), String> {
+        let content = transcribe_audio_blocks(content, &self.stt_service).await;
+        let raw = build_raw_platform_message(session_key, user_id, content);
+
+        let handle = {
+            let guard = self.sink.read().await;
+            guard
+                .as_ref()
+                .cloned()
+                .ok_or_else(|| "adapter not started".to_owned())?
+        };
+
+        let msg = handle.resolve(raw).await.map_err(|e| e.to_string())?;
+        handle.submit_message(msg).map_err(|e| e.to_string())?;
+
+        Ok(())
+    }
+
     /// Get or create a broadcast channel for the given session key.
     fn get_or_create_session(
         sessions: &DashMap<String, broadcast::Sender<String>>,

--- a/crates/channels/tests/web_e2e.rs
+++ b/crates/channels/tests/web_e2e.rs
@@ -1,0 +1,232 @@
+// Copyright 2025 Rararulab
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! End-to-end tests for the `WebAdapter` inbound code path.
+//!
+//! These tests are NOT kernel tests — they drive the web adapter directly
+//! via its test-only inbound handler so the adapter itself (audio
+//! transcription routing, `RawPlatformMessage` construction, session
+//! resolution, kernel submission) is the system under test.
+//!
+//! The kernel is still booted via [`TestKernelBuilder`] so the adapter has a
+//! real `KernelHandle` to submit to, and assertions read from real turn
+//! traces.
+
+use std::{path::Path, sync::Once, time::Duration};
+
+use rara_channels::web::WebAdapter;
+use rara_kernel::{
+    channel::{
+        adapter::ChannelAdapter,
+        types::{ContentBlock, MessageContent},
+    },
+    session::SessionKey,
+    testing::{TestKernelBuilder, scripted_response},
+};
+use rara_stt::{SttConfig, SttService};
+use serde_json::json;
+use tokio::time::{Instant, sleep};
+use wiremock::{
+    Mock, MockServer, ResponseTemplate,
+    matchers::{method, path},
+};
+
+/// Override rara_paths directories to a writable temp path so tests
+/// don't touch `~/.config/rara`.
+fn init_test_env(tmp: &Path) {
+    static INIT: Once = Once::new();
+    let data = tmp.join("rara_data");
+    let config = tmp.join("rara_config");
+    INIT.call_once(move || {
+        rara_paths::set_custom_data_dir(&data);
+        rara_paths::set_custom_config_dir(&config);
+    });
+}
+
+/// Poll `list_processes` until at least one session exists, returning its key.
+async fn wait_for_first_session(handle: &rara_kernel::handle::KernelHandle) -> SessionKey {
+    let deadline = Instant::now() + Duration::from_secs(10);
+    loop {
+        let processes = handle.list_processes();
+        if let Some(first) = processes.first() {
+            return first.session_key;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "timed out waiting for a session to be created by the adapter"
+        );
+        sleep(Duration::from_millis(50)).await;
+    }
+}
+
+/// Poll until the session has at least `expected_turns` completed turns.
+async fn wait_for_turn_count(
+    handle: &rara_kernel::handle::KernelHandle,
+    session_key: SessionKey,
+    expected_turns: usize,
+) {
+    let deadline = Instant::now() + Duration::from_secs(10);
+    loop {
+        let traces = handle.get_process_turns(session_key);
+        if traces.len() >= expected_turns {
+            return;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "timed out waiting for turn {expected_turns} in session {session_key}; \
+             current_turns={} latest_trace={:?}",
+            traces.len(),
+            traces.last()
+        );
+        sleep(Duration::from_millis(50)).await;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+/// A text message handed to the web adapter must reach the kernel as a
+/// resolved user message, spawn a session, and produce a turn whose reply
+/// matches the scripted LLM response.
+#[tokio::test]
+async fn web_text_message_reaches_kernel() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    init_test_env(tmp.path());
+
+    let tk = TestKernelBuilder::new(tmp.path())
+        .responses(vec![
+            scripted_response("hello back"),
+            // Padding for any auxiliary LLM calls the kernel may issue.
+            scripted_response("(padding)"),
+        ])
+        .build()
+        .await;
+
+    let adapter = WebAdapter::new(None);
+    adapter
+        .start(tk.handle.clone())
+        .await
+        .expect("adapter start");
+
+    adapter
+        .handle_inbound_for_test(
+            "web-session-alpha",
+            "test-user",
+            MessageContent::Text("hello".to_owned()),
+        )
+        .await
+        .expect("handle_inbound_for_test");
+
+    let session_key = wait_for_first_session(&tk.handle).await;
+    wait_for_turn_count(&tk.handle, session_key, 1).await;
+
+    let traces = tk.handle.get_process_turns(session_key);
+    assert_eq!(traces.len(), 1, "should have exactly 1 turn");
+    let turn = &traces[0];
+    assert!(turn.success, "turn should succeed: {:?}", turn.error);
+
+    let preview = turn
+        .iterations
+        .last()
+        .map(|i| i.text_preview.as_str())
+        .unwrap_or("");
+    assert!(
+        preview.contains("hello back"),
+        "expected scripted response in preview, got: {preview}"
+    );
+
+    tk.shutdown();
+}
+
+/// An inbound message carrying a base64 audio block must be routed through
+/// the STT service (mocked by wiremock) before reaching the kernel. The
+/// kernel should then see the transcribed text, not raw audio bytes.
+#[tokio::test]
+async fn web_audio_message_is_transcribed_via_stt() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    init_test_env(tmp.path());
+
+    // Spin up a fake STT server that returns a known transcription.
+    let mock_stt = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/v1/audio/transcriptions"))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_json(json!({"text": "transcribed voice"})),
+        )
+        .mount(&mock_stt)
+        .await;
+
+    let stt_config = SttConfig::builder()
+        .base_url(mock_stt.uri())
+        .model("whisper-1".to_owned())
+        .build();
+    let stt = SttService::from_config(&stt_config);
+
+    let tk = TestKernelBuilder::new(tmp.path())
+        .responses(vec![
+            scripted_response("got your voice"),
+            scripted_response("(padding)"),
+        ])
+        .build()
+        .await;
+
+    let adapter = WebAdapter::new(None).with_stt_service(Some(stt));
+    adapter
+        .start(tk.handle.clone())
+        .await
+        .expect("adapter start");
+
+    // Build a multimodal payload with a single (fake) audio clip.
+    use base64::Engine;
+    let fake_audio = base64::engine::general_purpose::STANDARD.encode(b"fake-ogg-bytes");
+    let content = MessageContent::Multimodal(vec![ContentBlock::AudioBase64 {
+        media_type: "audio/webm".to_owned(),
+        data:       fake_audio,
+    }]);
+
+    adapter
+        .handle_inbound_for_test("web-session-voice", "test-user", content)
+        .await
+        .expect("handle_inbound_for_test");
+
+    let session_key = wait_for_first_session(&tk.handle).await;
+    wait_for_turn_count(&tk.handle, session_key, 1).await;
+
+    // The kernel must have replied via the scripted driver — this only
+    // happens if the adapter successfully transcribed the audio and
+    // submitted a text message.
+    let traces = tk.handle.get_process_turns(session_key);
+    let preview = traces
+        .last()
+        .and_then(|t| t.iterations.last())
+        .map(|i| i.text_preview.as_str())
+        .unwrap_or("");
+    assert!(
+        preview.contains("got your voice"),
+        "scripted reply missing — STT transcription likely did not run; got: {preview}"
+    );
+
+    // And the STT mock must have been hit at least once.
+    let requests = mock_stt
+        .received_requests()
+        .await
+        .expect("wiremock received_requests");
+    assert!(
+        !requests.is_empty(),
+        "STT mock server received no requests — adapter bypassed transcription"
+    );
+
+    tk.shutdown();
+}


### PR DESCRIPTION
## Summary

- Add `handle_inbound_for_test` method on `WebAdapter` — a test-only entry point that mirrors the WS/POST inbound code path without HTTP round-trips
- Add two E2E tests: `web_text_message_reaches_kernel` (plain text flow) and `web_audio_message_is_transcribed_via_stt` (wiremock STT mock for audio transcription)
- Both tests use `TestKernelBuilder` with `ScriptedLlmDriver`, requiring no network or API keys

## Type of change

| Type | Label |
|------|-------|
| New feature | `enhancement` |

## Component

`backend`

## Closes

Closes #1178

## Test plan

- [x] `cargo test -p rara-channels --test web_e2e` passes (2 tests)
- [x] `cargo check --all --all-targets` passes
- [x] `cargo +nightly fmt --all -- --check` passes
- [x] `cargo clippy --workspace --all-targets --no-deps -- -D warnings` passes
- [x] All pre-commit hooks pass