### PR TITLE
fix(app): set browser User-Agent on http-fetch tool (#1189)

### DIFF
--- a/crates/app/src/tools/http_fetch.rs
+++ b/crates/app/src/tools/http_fetch.rs
@@ -60,6 +60,10 @@ impl HttpFetchTool {
         Self {
             client: reqwest::Client::builder()
                 .timeout(std::time::Duration::from_secs(30))
+                .user_agent(
+                    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, \
+                     like Gecko) Chrome/131.0.0.0 Safari/537.36",
+                )
                 .build()
                 .unwrap_or_default(),
         }


### PR DESCRIPTION
## Summary

http-fetch had no User-Agent header → GitHub API returned 403.

One-line fix: set a Chrome/macOS UA string on the reqwest client builder.

## Type of change

| Type | Label |
|------|-------|
| Bug fix | `bug` |

## Component

`backend`

## Closes

Closes #1189

## Test plan

- [x] `prek run --all-files` passes