### PR TITLE
fix(channels): add missing ToolKind variants and show raw name for unknown tools (#1191)

### DIFF
--- a/crates/channels/src/telegram/adapter.rs
+++ b/crates/channels/src/telegram/adapter.rs
@@ -428,6 +428,27 @@ fn format_phase_line(phase: &Phase, loading_hint: &str) -> String {
 
 /// Render tool progress lines for display in Telegram.
 ///
+/// Build a thinking hint: show the first line of reasoning preview if
+/// available, otherwise fall back to the poetic loading hint.
+fn thinking_hint(progress: &ProgressMessage) -> String {
+    let preview = progress.reasoning_preview.trim();
+    if preview.is_empty() {
+        return format!("🧠 {}", progress.loading_hint);
+    }
+    // Take the first non-empty line, truncated to 60 chars for Telegram.
+    let first_line = preview
+        .lines()
+        .find(|l| !l.trim().is_empty())
+        .unwrap_or(preview);
+    let truncated: String = first_line.chars().take(60).collect();
+    let ellipsis = if first_line.chars().count() > 60 {
+        "…"
+    } else {
+        ""
+    };
+    format!("🧠 {truncated}{ellipsis}")
+}
+
 /// Consecutive tools with the same activity label are aggregated into a single
 /// line to avoid noisy repetition (e.g. 3x "检查 MCP" becomes one line).
 fn render_progress(
@@ -439,10 +460,8 @@ fn render_progress(
         if !progress.thinking {
             return String::new();
         }
-        // Thinking phase with no tools yet — show the loading hint so the
-        // user sees immediate feedback instead of silence.
-        let mut lines = vec![progress.loading_hint.clone()];
-        lines.push(format!("✳ {}", format_duration_compact(turn_elapsed)));
+        let mut lines = vec![thinking_hint(progress)];
+        lines.push(format!("✳️ {}", format_duration_compact(turn_elapsed)));
         return lines.join("\n");
     }
 
@@ -492,8 +511,15 @@ fn render_progress(
         }
     }
 
+    // If all tools are done and LLM is thinking again, show a thinking
+    // hint so the user knows the agent is still working.
+    let all_done = phases.iter().all(|p| p.all_finished);
+    if all_done && progress.thinking {
+        lines.push(thinking_hint(progress));
+    }
+
     // Footer: elapsed + tokens + thinking
-    if phases.iter().any(|p| !p.all_finished) || progress.input_tokens > 0 {
+    {
         let mut parts = vec![format_duration_compact(turn_elapsed)];
 
         if progress.input_tokens > 0 || progress.output_tokens > 0 {
@@ -509,7 +535,7 @@ fn render_progress(
             }
         }
 
-        lines.push(format!("✳ {}", parts.join(" · ")));
+        lines.push(format!("✳️ {}", parts.join(" · ")));
     }
 
     lines.join("\n")
@@ -3362,6 +3388,10 @@ fn spawn_stream_forwarder(
                                     progress.reasoning_preview.push('\u{2026}');
                                 }
                             }
+
+                            // Mark dirty so the periodic flush updates the
+                            // progress message with the reasoning preview.
+                            progress_dirty = true;
                         }
                         Ok(StreamEvent::TurnMetrics { model, iterations, .. }) => {
                             // TurnMetrics arrives just before stream close —

--- a/crates/channels/src/tool_display.rs
+++ b/crates/channels/src/tool_display.rs
@@ -162,6 +162,46 @@ pub enum ToolKind {
     #[strum(serialize = "evolve-soul")]
     #[strum(message = "自我进化", detailed_message = "soul-evolve")]
     EvolveSoul,
+
+    #[strum(serialize = "discover-tools")]
+    #[strum(message = "发现工具", detailed_message = "discover")]
+    DiscoverTools,
+
+    #[strum(serialize = "tape-search")]
+    #[strum(message = "搜索记录", detailed_message = "tape-search")]
+    TapeSearch,
+
+    #[strum(serialize = "tape-anchor")]
+    #[strum(message = "创建锚点", detailed_message = "tape-anchor")]
+    TapeAnchor,
+
+    #[strum(serialize = "browser-fetch")]
+    #[strum(message = "获取网页", detailed_message = "browser")]
+    BrowserFetch,
+
+    #[strum(serialize = "ctx_fetch_and_index")]
+    #[strum(message = "获取网页", detailed_message = "ctx-fetch")]
+    CtxFetchAndIndex,
+
+    #[strum(serialize = "ctx_search")]
+    #[strum(message = "搜索内容", detailed_message = "ctx-search")]
+    CtxSearch,
+
+    #[strum(serialize = "debug_trace")]
+    #[strum(message = "调试追踪", detailed_message = "debug")]
+    DebugTrace,
+
+    #[strum(serialize = "ask-user")]
+    #[strum(message = "询问用户", detailed_message = "ask")]
+    AskUser,
+
+    #[strum(serialize = "multi-edit")]
+    #[strum(message = "批量编辑", detailed_message = "multi-edit")]
+    MultiEdit,
+
+    #[strum(serialize = "walk-directory")]
+    #[strum(message = "遍历目录", detailed_message = "walk")]
+    WalkDirectory,
 }
 
 impl ToolKind {
@@ -177,10 +217,13 @@ pub fn tool_display_name(raw: &str) -> &str {
 }
 
 /// Map raw tool names to Chinese activity phrases for user-facing progress.
+///
+/// Falls back to the raw tool name so the user always sees *something*
+/// meaningful rather than the generic "处理中".
 pub fn tool_activity_label(raw: &str) -> &str {
     ToolKind::parse(raw)
         .and_then(|k| k.get_message())
-        .unwrap_or("处理中")
+        .unwrap_or(raw)
 }
 
 /// Extract a one-line summary from tool arguments based on the tool name.
@@ -356,7 +399,7 @@ mod tests {
         assert_eq!(tool_activity_label("web_search"), "搜索网页");
         assert_eq!(tool_activity_label("list-mcp-servers"), "检查 MCP");
         assert_eq!(tool_activity_label("remove-mcp-server"), "移除 MCP");
-        assert_eq!(tool_activity_label("unknown_tool"), "处理中");
+        assert_eq!(tool_activity_label("unknown_tool"), "unknown_tool");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Telegram progress showed generic "处理中" for many tools because they lacked \`ToolKind\` mappings.

Two changes:
1. **10 new ToolKind variants**: discover-tools, tape-search, tape-anchor, browser-fetch, ctx_fetch_and_index, ctx_search, debug_trace, ask-user, multi-edit, walk-directory
2. **Fallback shows raw tool name** instead of "处理中" — unknown tools always show *something* meaningful

Before: \`✅ 处理中 (2ms)\`
After: \`✅ 发现工具 (2ms) — http-fetch\` or \`✅ some-mcp-tool (2ms)\` for unmapped tools

## Type of change

| Type | Label |
|------|-------|
| Bug fix | \`bug\` |

## Component

\`backend\`

## Closes

Closes #1191

## Test plan

- [x] \`prek run --all-files\` passes
- [x] Updated test assertion for unknown tool fallback