### PR TITLE
fix(tests): stabilize e2e rara_paths init for CI

### DIFF
--- a/crates/app/tests/e2e_scripted.rs
+++ b/crates/app/tests/e2e_scripted.rs
@@ -37,6 +37,10 @@ use rara_kernel::{
 use serde_json::json;
 use tokio::time::{Instant, sleep};
 
+/// CI runners can be noisy under full-workspace `nextest`; keep a generous
+/// upper bound for end-to-end turn completion.
+const TURN_WAIT_TIMEOUT: Duration = Duration::from_secs(30);
+
 /// Override rara_paths directories to a writable temp path so tests
 /// don't touch `~/.config/rara` (which may not exist on CI runners).
 fn init_test_env() {
@@ -87,7 +91,7 @@ async fn wait_for_turn_count(
     session_key: SessionKey,
     expected_turns: usize,
 ) {
-    let deadline = Instant::now() + Duration::from_secs(10);
+    let deadline = Instant::now() + TURN_WAIT_TIMEOUT;
     loop {
         let traces = handle.get_process_turns(session_key);
         if traces.len() >= expected_turns {
@@ -108,7 +112,7 @@ async fn wait_for_turn_count(
 // Tests
 // ---------------------------------------------------------------------------
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn simple_text_reply() {
     let tmp = tempfile::tempdir().expect("tempdir");
     init_test_env();
@@ -149,7 +153,7 @@ async fn simple_text_reply() {
     tk.shutdown();
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn multi_turn_conversation() {
     let tmp = tempfile::tempdir().expect("tempdir");
     init_test_env();
@@ -226,7 +230,7 @@ async fn multi_turn_conversation() {
     tk.shutdown();
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn empty_llm_response_handled() {
     let tmp = tempfile::tempdir().expect("tempdir");
     init_test_env();
@@ -275,7 +279,7 @@ async fn empty_llm_response_handled() {
     tk.shutdown();
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn tool_call_round_trip() {
     let tmp = tempfile::tempdir().expect("tempdir");
     init_test_env();
@@ -354,7 +358,7 @@ async fn tool_call_round_trip() {
     tk.shutdown();
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn tape_records_conversation() {
     let tmp = tempfile::tempdir().expect("tempdir");
     init_test_env();
@@ -400,7 +404,7 @@ async fn tape_records_conversation() {
 
 /// LLM returns a non-retryable error on the first call. The session should
 /// handle the error and return to Ready state — not crash or hang.
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn llm_error_does_not_crash_session() {
     let tmp = tempfile::tempdir().expect("tempdir");
     init_test_env();
@@ -430,7 +434,7 @@ async fn llm_error_does_not_crash_session() {
     // The agent loop returns Err for non-retryable errors, so no TurnTrace
     // is pushed. Instead, poll until the session transitions back to Ready
     // (meaning the error was handled and the session is alive).
-    let deadline = Instant::now() + Duration::from_secs(10);
+    let deadline = Instant::now() + TURN_WAIT_TIMEOUT;
     loop {
         if let Some(stats) = tk.handle.session_stats(session_key) {
             if matches!(stats.state, SessionState::Ready) {
@@ -470,7 +474,7 @@ async fn llm_error_does_not_crash_session() {
 
 /// With max_iterations=3 in the default test manifest, scripting infinite
 /// tool calls should terminate after 3 iterations rather than looping forever.
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn max_iterations_terminates() {
     let tmp = tempfile::tempdir().expect("tempdir");
     init_test_env();
@@ -537,7 +541,7 @@ async fn max_iterations_terminates() {
 /// LLM calls a tool that is not registered. The kernel should feed the
 /// error back to the LLM, which then produces a text response on the
 /// second call.
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn tool_not_found_surfaces_error() {
     let tmp = tempfile::tempdir().expect("tempdir");
     init_test_env();
@@ -600,7 +604,7 @@ async fn tool_not_found_surfaces_error() {
 /// Script several consecutive empty responses (no text, no tool calls).
 /// The kernel's recovery logic should eventually terminate rather than
 /// looping indefinitely.
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn consecutive_empty_responses_terminate() {
     let tmp = tempfile::tempdir().expect("tempdir");
     init_test_env();

--- a/crates/channels/tests/web_e2e.rs
+++ b/crates/channels/tests/web_e2e.rs
@@ -42,6 +42,10 @@ use wiremock::{
     matchers::{method, path},
 };
 
+/// CI runners can be noisy under full-workspace `nextest`; keep a generous
+/// upper bound for end-to-end completion checks.
+const TURN_WAIT_TIMEOUT: Duration = Duration::from_secs(30);
+
 /// Override rara_paths directories to a writable temp path so tests
 /// don't touch `~/.config/rara`.
 fn init_test_env() {
@@ -64,7 +68,7 @@ fn init_test_env() {
 
 /// Poll `list_processes` until at least one session exists, returning its key.
 async fn wait_for_first_session(handle: &rara_kernel::handle::KernelHandle) -> SessionKey {
-    let deadline = Instant::now() + Duration::from_secs(10);
+    let deadline = Instant::now() + TURN_WAIT_TIMEOUT;
     loop {
         let processes = handle.list_processes();
         if let Some(first) = processes.first() {
@@ -84,7 +88,7 @@ async fn wait_for_turn_count(
     session_key: SessionKey,
     expected_turns: usize,
 ) {
-    let deadline = Instant::now() + Duration::from_secs(10);
+    let deadline = Instant::now() + TURN_WAIT_TIMEOUT;
     loop {
         let traces = handle.get_process_turns(session_key);
         if traces.len() >= expected_turns {
@@ -108,7 +112,7 @@ async fn wait_for_turn_count(
 /// A text message handed to the web adapter must reach the kernel as a
 /// resolved user message, spawn a session, and produce a turn whose reply
 /// matches the scripted LLM response.
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn web_text_message_reaches_kernel() {
     let tmp = tempfile::tempdir().expect("tempdir");
     init_test_env();
@@ -161,7 +165,7 @@ async fn web_text_message_reaches_kernel() {
 /// An inbound message carrying a base64 audio block must be routed through
 /// the STT service (mocked by wiremock) before reaching the kernel. The
 /// kernel should then see the transcribed text, not raw audio bytes.
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn web_audio_message_is_transcribed_via_stt() {
     let tmp = tempfile::tempdir().expect("tempdir");
     init_test_env();


### PR DESCRIPTION
## Summary

Stabilize e2e test environment path initialization by using a process-stable temp root for global `rara_paths` overrides.

## Type of change

| Type | Label |
|------|-------|
| Bug fix | `bug` |

## Component

`core`

## Closes

Closes #1198

## Test plan

- [ ] `just test` passes
- [ ] `just lint` passes
- [x] Tested locally

Local verification performed:
- `cargo nextest run -p rara-app --test e2e_scripted`
- `cargo nextest run -p rara-channels --test web_e2e`
- 30 repeated e2e batches (`rara-app::e2e_scripted` + `rara-channels::web_e2e`)
- `cargo nextest run --workspace`
