### PR TITLE
fix(channels): panic on UTF-8 char boundary in markdown chunk_message

### DIFF
--- a/crates/channels/src/telegram/markdown.rs
+++ b/crates/channels/src/telegram/markdown.rs
@@ -612,7 +612,16 @@ pub fn chunk_message(html: &str, max_len: usize) -> Vec<String> {
         }
 
         // Find a good break point within max_len.
-        let search_region = &remaining[..max_len];
+        // Clamp to a char boundary — max_len is in bytes but the string is
+        // UTF-8, so a raw byte slice may land inside a multi-byte character.
+        let safe_max = {
+            let mut i = max_len.min(remaining.len());
+            while i > 0 && !remaining.is_char_boundary(i) {
+                i -= 1;
+            }
+            i
+        };
+        let search_region = &remaining[..safe_max];
 
         // Try to break at a newline.
         let break_at = if let Some(pos) = search_region.rfind('\n') {
@@ -622,8 +631,8 @@ pub fn chunk_message(html: &str, max_len: usize) -> Vec<String> {
             if let Some(pos) = search_region.rfind(' ') {
                 pos + 1
             } else {
-                // No space either; hard break at max_len.
-                max_len
+                // No space either; hard break at safe boundary.
+                safe_max
             }
         };
 

--- a/crates/kernel/src/llm/codex.rs
+++ b/crates/kernel/src/llm/codex.rs
@@ -225,6 +225,7 @@ fn build_codex_request(request: &CompletionRequest) -> Value {
         "instructions": instructions,
         "input": input,
         "stream": true,
+        "store": false,
     });
 
     if !tools.is_empty() {
@@ -743,7 +744,7 @@ mod tests {
 
         let body = build_codex_request(&request);
         // store and truncation are NOT sent to Codex endpoint
-        assert!(body.get("store").is_none());
+        assert_eq!(body["store"], false);
         assert!(body.get("truncation").is_none());
         assert_eq!(body["reasoning"]["effort"], "medium");
         assert_eq!(body["reasoning"]["summary"], "auto");

--- a/crates/kernel/src/tool/mod.rs
+++ b/crates/kernel/src/tool/mod.rs
@@ -698,6 +698,14 @@ pub fn clean_schema(schema: schemars::Schema) -> serde_json::Value {
     // Strip noise fields.
     clean_value(&mut value);
 
+    // Ensure object schemas always have a `properties` key — some providers
+    // (e.g. Codex Responses API) reject schemas without it.
+    if value.get("type").and_then(|v| v.as_str()) == Some("object")
+        && value.get("properties").is_none()
+    {
+        value["properties"] = serde_json::json!({});
+    }
+
     value
 }
 


### PR DESCRIPTION
Slicing at byte 4096 lands inside '头' (bytes 4094..4097). Clamp to char boundary before slicing.