### PR TITLE
fix(web): Settings page — two-panel sidebar + content layout (#1262)

### DIFF
--- a/web/src/layouts/DashboardLayout.tsx
+++ b/web/src/layouts/DashboardLayout.tsx
@@ -17,7 +17,7 @@
 import { useState } from 'react';
 import { Outlet, useLocation, useNavigate } from 'react-router';
 import { useQuery } from '@tanstack/react-query';
-import { Activity, Bot, LayoutDashboard } from 'lucide-react';
+import { Activity, Bot, LayoutDashboard, Settings } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { settingsApi } from '@/api/client';
 import { Button } from '@/components/ui/button';
@@ -25,7 +25,7 @@ import OnboardingModal, { isOnboardingDismissed } from '@/components/OnboardingM
 import ThemeToggle from '@/components/ThemeToggle';
 
 /** Routes that need zero padding in the main content area. */
-const FULL_BLEED_ROUTES = new Set(['/agent', '/docs', '/dock']);
+const FULL_BLEED_ROUTES = new Set(['/agent', '/docs', '/dock', '/settings']);
 
 /** Routes that need full bleed when they match as a prefix. */
 const FULL_BLEED_PREFIXES: string[] = [];
@@ -125,6 +125,15 @@ export default function DashboardLayout() {
           >
             <LayoutDashboard className="h-3.5 w-3.5" />
             Dock
+          </Button>
+          <Button
+            variant="ghost"
+            size="sm"
+            className="h-7 gap-1.5 text-xs text-muted-foreground hover:text-foreground"
+            onClick={() => navigate('/settings')}
+          >
+            <Settings className="h-3.5 w-3.5" />
+            Settings
           </Button>
           <ThemeToggle />
         </div>

--- a/web/src/pages/Settings.tsx
+++ b/web/src/pages/Settings.tsx
@@ -416,9 +416,9 @@ export default function Settings() {
   ];
 
   return (
-    <div className="grid gap-4 xl:grid-cols-[16rem_minmax(0,1fr)]">
+    <div className="flex h-full gap-4 overflow-hidden">
       {/* Sidebar */}
-      <aside className="data-panel h-fit xl:sticky xl:top-4">
+      <aside className="data-panel w-64 shrink-0 overflow-y-auto">
         <div className="border-b border-border/70 px-4 py-4">
           <h1 className="text-lg font-semibold tracking-tight">Settings</h1>
           <p className="mt-1 text-xs text-muted-foreground">
@@ -463,7 +463,7 @@ export default function Settings() {
       </aside>
 
       {/* Content */}
-      <div className="space-y-6">
+      <div className="flex-1 space-y-6 overflow-y-auto pr-1">
         {/* Toast */}
         {toast && (
           <div className={cn(


### PR DESCRIPTION
## Summary

- Replace `xl:grid-cols-[16rem_minmax(0,1fr)]` (only active at 1280px+) with an always-on `flex` layout: sidebar `w-64 shrink-0` + content `flex-1 overflow-y-auto`
- Add `/settings` to `FULL_BLEED_ROUTES` in DashboardLayout so the page gets `overflow-hidden` instead of `overflow-auto` (prevents double scrollbars)
- Add a Settings gear icon button to the top bar navigation alongside Kernel/Symphony/Dock

## Type of change

| Type | Label |
|------|-------|
| Bug fix | `bug` |

## Component

`ui`

## Closes

Closes #1262

## Test plan

- [x] `npm run build` passes
- [x] Sidebar + content render side-by-side at all viewport widths
- [x] Content panel scrolls independently from sidebar