### PR TITLE
feat(web): backend URL configuration — connection dialog + status indicator (#1264)

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -14,9 +14,11 @@
  * limitations under the License.
  */
 
+import { useState } from 'react';
 import { BrowserRouter, Routes, Route } from 'react-router';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { ServerStatusProvider } from '@/components/ServerStatusProvider';
+import { ConnectionSetupDialog } from '@/components/ConnectionSetupDialog';
 import DashboardLayout from '@/layouts/DashboardLayout';
 import PiChat from '@/pages/PiChat';
 import Docs from '@/pages/Docs';
@@ -25,12 +27,23 @@ import KernelTop from '@/pages/KernelTop';
 import Symphony from '@/pages/Symphony';
 import Dock from '@/pages/Dock';
 
+const STORAGE_KEY = "rara_backend_url";
 const queryClient = new QueryClient();
 
 export default function App() {
+  const [needsSetup, setNeedsSetup] = useState(
+    () => !localStorage.getItem(STORAGE_KEY),
+  );
+
   return (
     <QueryClientProvider client={queryClient}>
       <ServerStatusProvider>
+        {needsSetup && (
+          <ConnectionSetupDialog
+            open={needsSetup}
+            onConnect={() => setNeedsSetup(false)}
+          />
+        )}
         <BrowserRouter>
           <Routes>
             {/* Fullscreen pi-web-ui chat */}

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -14,6 +14,43 @@
  * limitations under the License.
  */
 
+const STORAGE_KEY = "rara_backend_url";
+const DEFAULT_BACKEND_URL = "http://localhost:25555";
+
+/** Read the backend URL from localStorage, env, or fallback to default. */
+export function getBackendUrl(): string {
+  if (typeof window !== "undefined") {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    if (stored) return stored;
+  }
+  return import.meta.env.VITE_API_URL || DEFAULT_BACKEND_URL;
+}
+
+/** Persist backend URL and reload the page so all clients pick it up. */
+export function setBackendUrl(url: string) {
+  localStorage.setItem(STORAGE_KEY, url);
+  window.location.reload();
+}
+
+/** True when the user has explicitly set a custom backend URL. */
+function hasCustomBackendUrl(): boolean {
+  return typeof window !== "undefined" && localStorage.getItem(STORAGE_KEY) !== null;
+}
+
+/**
+ * Resolve the fetch URL for a given API path.
+ *
+ * When no custom URL is stored we use relative paths so the Vite dev proxy
+ * can forward `/api/...` requests.  When a custom URL is set we bypass the
+ * proxy and hit the backend directly.
+ */
+export function resolveUrl(path: string): string {
+  if (hasCustomBackendUrl()) {
+    return `${getBackendUrl()}${path}`;
+  }
+  return path;
+}
+
 export const BASE_URL = '';
 
 /** Build common request headers. */
@@ -47,7 +84,7 @@ async function request<T>(path: string, options?: RequestInit & { timeoutMs?: nu
   };
 
   try {
-    const res = await fetch(`${BASE_URL}${path}`, {
+    const res = await fetch(resolveUrl(path), {
       ...fetchOptions,
       headers,
       signal: controller.signal,
@@ -75,7 +112,7 @@ async function requestBlob(path: string, options?: RequestInit & { timeoutMs?: n
   const timer = setTimeout(() => controller.abort(), timeoutMs);
 
   try {
-    const res = await fetch(`${BASE_URL}${path}`, {
+    const res = await fetch(resolveUrl(path), {
       ...fetchOptions,
       signal: controller.signal,
     });

--- a/web/src/components/ConnectionSetupDialog.tsx
+++ b/web/src/components/ConnectionSetupDialog.tsx
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2025 Rararulab
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useState } from "react";
+import { setBackendUrl } from "@/api/client";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+
+interface ConnectionSetupDialogProps {
+  open: boolean;
+  onConnect: () => void;
+}
+
+/** First-launch dialog that prompts the user to enter their backend URL. */
+export function ConnectionSetupDialog({ open, onConnect }: ConnectionSetupDialogProps) {
+  const [url, setUrl] = useState("http://localhost:25555");
+  const [testing, setTesting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function testConnection() {
+    setTesting(true);
+    setError(null);
+    try {
+      const res = await fetch(`${url}/api/v1/settings`, {
+        signal: AbortSignal.timeout(5000),
+      });
+      if (res.ok) {
+        setBackendUrl(url);
+        onConnect();
+      } else {
+        setError(`Server returned ${res.status}`);
+      }
+    } catch (e) {
+      setError(`Cannot connect: ${e instanceof Error ? e.message : String(e)}`);
+    } finally {
+      setTesting(false);
+    }
+  }
+
+  return (
+    <Dialog open={open}>
+      <DialogContent
+        className="sm:max-w-md"
+        onInteractOutside={(e) => e.preventDefault()}
+      >
+        <DialogHeader>
+          <DialogTitle>Connect to Rara</DialogTitle>
+          <DialogDescription>
+            Enter the URL of your rara backend server.
+          </DialogDescription>
+        </DialogHeader>
+        <div className="space-y-4">
+          <Input
+            value={url}
+            onChange={(e) => setUrl(e.target.value)}
+            placeholder="http://localhost:25555"
+            className="font-mono text-sm"
+            onKeyDown={(e) => {
+              if (e.key === "Enter" && !testing) testConnection();
+            }}
+          />
+          {error && (
+            <p className="text-sm text-destructive">{error}</p>
+          )}
+          <Button
+            onClick={testConnection}
+            disabled={testing || !url.trim()}
+            className="w-full"
+          >
+            {testing ? "Testing..." : "Connect"}
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/web/src/components/ServerStatusProvider.tsx
+++ b/web/src/components/ServerStatusProvider.tsx
@@ -18,8 +18,7 @@ import { useEffect, useMemo, useState } from "react";
 import type { ReactNode } from "react";
 import { onlineManager } from "@tanstack/react-query";
 import { ServerStatusContext } from "@/hooks/use-server-status";
-
-const HEALTH_URL = "/api/v1/health";
+import { resolveUrl } from "@/api/client";
 const CHECK_INTERVAL_MS = 10_000;
 const TIMEOUT_MS = 5_000;
 
@@ -34,7 +33,7 @@ export function ServerStatusProvider({ children }: { children: ReactNode }) {
       const controller = new AbortController();
       const timer = setTimeout(() => controller.abort(), TIMEOUT_MS);
       try {
-        const res = await fetch(HEALTH_URL, { signal: controller.signal });
+        const res = await fetch(resolveUrl("/api/v1/health"), { signal: controller.signal });
         if (cancelled) return;
         const online = res.ok;
         setIsOnline(online);

--- a/web/src/layouts/DashboardLayout.tsx
+++ b/web/src/layouts/DashboardLayout.tsx
@@ -23,6 +23,7 @@ import { settingsApi } from '@/api/client';
 import { Button } from '@/components/ui/button';
 import OnboardingModal, { isOnboardingDismissed } from '@/components/OnboardingModal';
 import ThemeToggle from '@/components/ThemeToggle';
+import { useServerStatus } from '@/hooks/use-server-status';
 
 /** Routes that need zero padding in the main content area. */
 const FULL_BLEED_ROUTES = new Set(['/agent', '/docs', '/dock', '/settings']);
@@ -69,6 +70,23 @@ function hasConfiguredLlmProvider(settings: Record<string, string> | undefined):
   }
 }
 
+/** Small dot + label showing live backend connectivity. */
+function ConnectionStatus() {
+  const { isOnline, isChecking } = useServerStatus();
+  if (isChecking) return null;
+  return (
+    <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
+      <div
+        className={cn(
+          "h-2 w-2 rounded-full",
+          isOnline ? "bg-green-500" : "bg-red-500",
+        )}
+      />
+      <span>{isOnline ? "Connected" : "Disconnected"}</span>
+    </div>
+  );
+}
+
 export default function DashboardLayout() {
   const location = useLocation();
   const navigate = useNavigate();
@@ -99,6 +117,8 @@ export default function DashboardLayout() {
       <main className={cn('relative flex min-w-0 flex-1 flex-col', isFullBleed ? 'overflow-hidden' : 'overflow-auto')}>
         {/* Top bar */}
         <div className="flex shrink-0 items-center justify-end gap-2 border-b border-border/40 bg-background/30 px-4 py-1.5 backdrop-blur-sm">
+          <ConnectionStatus />
+          <div className="mx-1 h-4 w-px bg-border/60" />
           <Button
             variant="ghost"
             size="sm"

--- a/web/src/pages/Settings.tsx
+++ b/web/src/pages/Settings.tsx
@@ -57,10 +57,13 @@ import {
   Users,
   Sun,
   Palette,
+  Wifi,
 } from "lucide-react";
 
 import { cn } from "@/lib/utils";
 import { useTheme, type Theme } from "@/hooks/use-theme";
+import { useServerStatus } from "@/hooks/use-server-status";
+import { getBackendUrl, setBackendUrl } from "@/api/client";
 import Skills from "@/pages/Skills";
 import Agents from "@/pages/Agents";
 import McpServers from "@/pages/McpServers";
@@ -288,6 +291,78 @@ function KvGroup({
   );
 }
 
+/** Backend URL configuration card for the General settings tab. */
+function ConnectionCard() {
+  const { isOnline } = useServerStatus();
+  const [url, setUrl] = useState(() => getBackendUrl());
+  const [saving, setSaving] = useState(false);
+  const [result, setResult] = useState<{ kind: "success" | "error"; message: string } | null>(null);
+
+  async function saveAndReconnect() {
+    setSaving(true);
+    setResult(null);
+    try {
+      const res = await fetch(`${url}/api/v1/settings`, {
+        signal: AbortSignal.timeout(5000),
+      });
+      if (res.ok) {
+        setBackendUrl(url); // persists + reloads
+      } else {
+        setResult({ kind: "error", message: `Server returned ${res.status}` });
+      }
+    } catch (e) {
+      setResult({ kind: "error", message: `Cannot connect: ${e instanceof Error ? e.message : String(e)}` });
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <Card className="app-surface border-border/60">
+      <CardHeader>
+        <div className="flex items-center gap-3">
+          <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg border bg-muted/40 text-muted-foreground">
+            <Wifi className="h-4 w-4" />
+          </div>
+          <div className="flex-1">
+            <CardTitle className="text-base">Connection</CardTitle>
+            <CardDescription>Backend server URL</CardDescription>
+          </div>
+          <Badge variant={isOnline ? "secondary" : "destructive"} className="capitalize">
+            {isOnline ? "Connected" : "Disconnected"}
+          </Badge>
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <div className="flex items-center gap-2">
+          <Input
+            value={url}
+            onChange={(e) => { setUrl(e.target.value); setResult(null); }}
+            placeholder="http://localhost:25555"
+            className="h-9 font-mono text-sm"
+            onKeyDown={(e) => {
+              if (e.key === "Enter" && !saving) saveAndReconnect();
+            }}
+          />
+          <Button
+            onClick={saveAndReconnect}
+            disabled={saving || !url.trim()}
+            size="sm"
+          >
+            <Save className="mr-1.5 h-3.5 w-3.5" />
+            {saving ? "Testing..." : "Save & Reconnect"}
+          </Button>
+        </div>
+        {result && (
+          <p className={cn("text-sm", result.kind === "success" ? "text-green-600" : "text-destructive")}>
+            {result.message}
+          </p>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
 export default function Settings() {
   const [searchParams, setSearchParams] = useSearchParams();
   const { theme, setTheme } = useTheme();
@@ -477,6 +552,9 @@ export default function Settings() {
         {/* ── General ── */}
         {activeCategory === "general" && (
           <>
+            {/* Connection */}
+            <ConnectionCard />
+
             {/* Appearance */}
             <Card className="app-surface border-border/60">
               <CardHeader>


### PR DESCRIPTION
## Summary

- Add backend URL configuration with localStorage persistence (`rara_backend_url` key)
- Show `ConnectionSetupDialog` on first launch when no backend URL is stored — tests connectivity before saving
- Add connection status indicator (green/red dot) in the DashboardLayout top bar using existing `useServerStatus` hook
- Add "Connection" card in Settings > General tab for editing the backend URL with test-before-save
- Update `ServerStatusProvider` and API client to use `resolveUrl()` — custom URL bypasses Vite proxy, default uses relative paths

## Type of change

| Type | Label |
|------|-------|
| New feature | `enhancement` |

## Component

`ui`

## Closes

Closes #1264

## Test plan

- [x] `npm run build` passes
- [x] No Rust changes — frontend only
- [x] Vite proxy still works for default localhost:25555
- [x] Custom URL bypasses proxy and uses full URL directly