### PR TITLE
feat(app): auto-start web frontend server alongside Gateway (#1266)

### DIFF
--- a/crates/app/src/lib.rs
+++ b/crates/app/src/lib.rs
@@ -20,6 +20,7 @@ pub mod gateway;
 // `crate::tool::AgentTool` in derived impls.
 pub(crate) use rara_kernel::tool;
 mod tools;
+mod web_server;
 
 use std::{
     path::{Path, PathBuf},
@@ -692,6 +693,15 @@ pub async fn start_with_options(
             });
             info!("Symphony service started");
         }
+    }
+
+    // Start web frontend server if web/dist/ exists and web_port is configured.
+    if let Some(web_port) = config.http.web_port {
+        let web_dist = PathBuf::from("web/dist");
+        let web_cancel = cancellation_token.clone();
+        tokio::spawn(async move {
+            web_server::start_web_server(web_dist, web_port, web_cancel).await;
+        });
     }
 
     info!("Application started successfully");

--- a/crates/app/src/web_server.rs
+++ b/crates/app/src/web_server.rs
@@ -1,0 +1,115 @@
+// Copyright 2025 Rararulab
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Lightweight static file server for the web frontend.
+//!
+//! When `web/dist/` exists (pre-built frontend), spawns a child process to
+//! serve it on a separate port. Tries `npx serve` first (SPA-friendly with
+//! `--single`), falls back to `python3 -m http.server`.
+
+use std::{path::PathBuf, process::Stdio};
+
+use tokio::process::Command;
+use tokio_util::sync::CancellationToken;
+use tracing::{error, info, warn};
+
+/// Spawn a static file server for the web frontend.
+///
+/// Serves `dist_dir` on the given port. Uses `npx serve` if available,
+/// falls back to Python's `http.server`. The child process is killed when
+/// `cancel` fires (`kill_on_drop`).
+///
+/// Returns immediately (no-op) when `dist_dir/index.html` does not exist.
+pub async fn start_web_server(dist_dir: PathBuf, port: u16, cancel: CancellationToken) {
+    if !dist_dir.join("index.html").exists() {
+        info!(
+            path = %dist_dir.display(),
+            "web/dist not found, skipping frontend server"
+        );
+        return;
+    }
+
+    info!(port, path = %dist_dir.display(), "starting web frontend server");
+
+    let dist_str = dist_dir.to_str().unwrap_or(".");
+
+    // Try `npx serve` first — better SPA support with --single flag.
+    let mut child = match Command::new("npx")
+        .args([
+            "serve",
+            "--single",
+            "--listen",
+            &format!("tcp://0.0.0.0:{port}"),
+            dist_str,
+        ])
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped())
+        .kill_on_drop(true)
+        .spawn()
+    {
+        Ok(child) => {
+            info!(
+                port,
+                "Web UI available at http://0.0.0.0:{port} (npx serve)"
+            );
+            child
+        }
+        Err(_) => {
+            // Fallback: python3 -m http.server (no SPA routing).
+            match Command::new("python3")
+                .args([
+                    "-m",
+                    "http.server",
+                    &port.to_string(),
+                    "--directory",
+                    dist_str,
+                ])
+                .stdout(Stdio::null())
+                .stderr(Stdio::piped())
+                .kill_on_drop(true)
+                .spawn()
+            {
+                Ok(child) => {
+                    warn!(
+                        port,
+                        "Web UI available at http://0.0.0.0:{port} (python3 http.server, no SPA \
+                         fallback)"
+                    );
+                    child
+                }
+                Err(e) => {
+                    error!(
+                        %e,
+                        "failed to start web frontend server — neither 'npx serve' nor 'python3' available"
+                    );
+                    return;
+                }
+            }
+        }
+    };
+
+    // Wait for cancellation or unexpected child exit.
+    tokio::select! {
+        () = cancel.cancelled() => {
+            info!("shutting down web frontend server");
+            child.kill().await.ok();
+        }
+        status = child.wait() => {
+            match status {
+                Ok(s) => warn!(code = ?s.code(), "web frontend server exited unexpectedly"),
+                Err(e) => error!(%e, "web frontend server error"),
+            }
+        }
+    }
+}

--- a/crates/server/src/http.rs
+++ b/crates/server/src/http.rs
@@ -97,6 +97,11 @@ pub struct RestServerConfig {
     /// Request timeout in seconds
     #[default(DEFAULT_REQUEST_TIMEOUT_SECS)]
     pub request_timeout: u64,
+    /// Port for the static web frontend server (optional).
+    ///
+    /// When set, the app spawns a child process (`npx serve` or `python3
+    /// http.server`) to serve `web/dist/` on this port.
+    pub web_port:        Option<u16>,
 }
 
 /// Starts the REST server and returns a handle for managing its lifecycle.

--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -125,6 +125,7 @@ just consul-keys   # list current keys
 | `max_body_size` | `RARA__HTTP__MAX_BODY_SIZE` | `100MB` | Max request body |
 | `enable_cors` | `RARA__HTTP__ENABLE_CORS` | `true` | CORS headers |
 | `request_timeout` | `RARA__HTTP__REQUEST_TIMEOUT` | `60` | Timeout in seconds |
+| `web_port` | `RARA__HTTP__WEB_PORT` | *(none)* | Static frontend server port (spawns `npx serve` or `python3 http.server` for `web/dist/`) |
 
 #### gRPC Server (`grpc.*`)
 


### PR DESCRIPTION
## Summary

- When `http.web_port` is configured and `web/dist/index.html` exists, spawn a child process to serve the pre-built web frontend on a separate port
- Uses `npx serve --single` (SPA routing) with `python3 http.server` fallback
- Child process is killed on app shutdown via `kill_on_drop(true)` + `CancellationToken`
- Silently skips if `web/dist/` is absent or `web_port` is not configured

## Type of change

| Type | Label |
|------|-------|
| New feature | `enhancement` |

## Component

`backend`

## Closes

Closes #1266

## Test plan

- [x] `cargo check -p rara-app` passes
- [x] `cargo clippy -p rara-app -- -D warnings` passes
- [x] `cargo +nightly fmt -p rara-app -- --check` passes
- [x] All pre-commit hooks pass
- [x] Verified: no web server spawned when `web_port` is `None` (default)
- [x] Verified: no web server spawned when `web/dist/index.html` is absent