### PR TITLE
fix(web): smart default URL, Settings in sidebar, fix onboarding detection (#1269)

### DIFF
--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -15,7 +15,12 @@
  */
 
 const STORAGE_KEY = "rara_backend_url";
-const DEFAULT_BACKEND_URL = "http://localhost:25555";
+
+/** Derive a sensible default backend URL from the current page hostname. */
+function defaultBackendUrl(): string {
+  const host = typeof window !== "undefined" ? window.location.hostname : "localhost";
+  return `http://${host}:25555`;
+}
 
 /** Read the backend URL from localStorage, env, or fallback to default. */
 export function getBackendUrl(): string {
@@ -23,7 +28,7 @@ export function getBackendUrl(): string {
     const stored = localStorage.getItem(STORAGE_KEY);
     if (stored) return stored;
   }
-  return import.meta.env.VITE_API_URL || DEFAULT_BACKEND_URL;
+  return import.meta.env.VITE_API_URL || defaultBackendUrl();
 }
 
 /** Persist backend URL and reload the page so all clients pick it up. */

--- a/web/src/components/ConnectionSetupDialog.tsx
+++ b/web/src/components/ConnectionSetupDialog.tsx
@@ -15,7 +15,7 @@
  */
 
 import { useState } from "react";
-import { setBackendUrl } from "@/api/client";
+import { setBackendUrl, getBackendUrl } from "@/api/client";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import {
@@ -33,7 +33,7 @@ interface ConnectionSetupDialogProps {
 
 /** First-launch dialog that prompts the user to enter their backend URL. */
 export function ConnectionSetupDialog({ open, onConnect }: ConnectionSetupDialogProps) {
-  const [url, setUrl] = useState("http://localhost:25555");
+  const [url, setUrl] = useState(() => getBackendUrl());
   const [testing, setTesting] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -73,7 +73,7 @@ export function ConnectionSetupDialog({ open, onConnect }: ConnectionSetupDialog
           <Input
             value={url}
             onChange={(e) => setUrl(e.target.value)}
-            placeholder="http://localhost:25555"
+            placeholder="http://hostname:25555"
             className="font-mono text-sm"
             onKeyDown={(e) => {
               if (e.key === "Enter" && !testing) testConnection();

--- a/web/src/layouts/DashboardLayout.tsx
+++ b/web/src/layouts/DashboardLayout.tsx
@@ -97,7 +97,9 @@ export default function DashboardLayout() {
     queryFn: () => settingsApi.list(),
   });
 
-  const shouldShowOnboarding = !isOnboardingDismissed();
+  // Skip onboarding entirely when dismissed or when providers are already configured.
+  const providerConfigured = hasConfiguredLlmProvider(settingsQuery.data);
+  const shouldShowOnboarding = !isOnboardingDismissed() && !providerConfigured;
   const [onboardingOpen, setOnboardingOpen] = useState(true);
 
   const handleOnboardingDismiss = () => {

--- a/web/src/pages/PiChat.tsx
+++ b/web/src/pages/PiChat.tsx
@@ -33,6 +33,7 @@ import { RaraStorageBackend } from "@/adapters/rara-storage";
 import { createRaraStreamFn } from "@/adapters/rara-stream";
 import { api } from "@/api/client";
 import type { ChatSession, ChatMessageData } from "@/api/types";
+import { useNavigate } from "react-router";
 import { VoiceRecorder } from "@/components/VoiceRecorder";
 
 /** Strip `<think>...</think>` blocks from assistant text. */
@@ -123,12 +124,14 @@ function SessionListPanel({
   onClose,
   onDelete,
   onNew,
+  onNavigate,
 }: {
   activeKey: string | undefined;
   onSelect: (s: ChatSession) => void;
   onClose: () => void;
   onDelete: (key: string) => void;
   onNew: () => void;
+  onNavigate: (path: string) => void;
 }) {
   const [sessions, setSessions] = useState<ChatSession[]>([]);
   const [loading, setLoading] = useState(true);
@@ -228,6 +231,19 @@ function SessionListPanel({
             ))
           )}
         </div>
+        {/* Settings link at the bottom */}
+        <div className="border-t border-border px-4 py-3">
+          <button
+            onClick={() => { onNavigate("/settings"); onClose(); }}
+            className="flex w-full items-center gap-2 rounded px-2 py-1.5 text-sm text-muted-foreground hover:bg-secondary hover:text-foreground transition-colors cursor-pointer"
+          >
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+              <circle cx="12" cy="12" r="3" />
+              <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z" />
+            </svg>
+            Settings
+          </button>
+        </div>
       </div>
     </>
   );
@@ -243,6 +259,7 @@ export default function PiChat() {
   const agentRef = useRef<Agent | null>(null);
   const chatPanelRef = useRef<import("@mariozechner/pi-web-ui").ChatPanel | null>(null);
   const [showSessionList, setShowSessionList] = useState(false);
+  const navigate = useNavigate();
 
   /** Switch the agent to a different session, loading its history. */
   const switchSession = useCallback(async (session: ChatSession) => {
@@ -405,6 +422,7 @@ export default function PiChat() {
           onClose={() => setShowSessionList(false)}
           onDelete={handleSessionDeleted}
           onNew={newSession}
+          onNavigate={navigate}
         />
       )}
     </div>


### PR DESCRIPTION
## Summary

- Use `window.location.hostname` for default backend URL instead of hardcoded `localhost` — fixes LAN access pre-filling wrong hostname
- Add Settings link (gear icon) at the bottom of PiChat session sidebar panel
- Skip onboarding modal when LLM providers are already configured in the settings API

## Type of change

| Type | Label |
|------|-------|
| Bug fix | `bug` |

## Component

`ui`

## Closes

Closes #1269

## Test plan

- [x] `npm run build` passes
- [x] Tested locally