### PR TITLE
feat(kernel): SkillNudge + MemoryNudge lifecycle hooks for closed learning loop (#1290)

### DIFF
--- a/crates/app/src/lib.rs
+++ b/crates/app/src/lib.rs
@@ -467,7 +467,7 @@ pub async fn start_with_options(
         })
     };
 
-    let kernel = rara_kernel::kernel::Kernel::new(
+    let mut kernel = rara_kernel::kernel::Kernel::new(
         kernel_config,
         rara.driver_registry.clone(),
         rara.tool_registry.clone(),
@@ -501,6 +501,14 @@ pub async fn start_with_options(
             config_file_sync.start(cancel).await;
         });
     }
+
+    // Register lifecycle hooks for the closed learning loop.
+    kernel.set_lifecycle_hooks(rara_kernel::lifecycle::LifecycleHookRegistry::with_hooks(
+        vec![
+            std::sync::Arc::new(rara_kernel::lifecycle::SkillNudgeHook),
+            std::sync::Arc::new(rara_kernel::lifecycle::MemoryNudgeHook::new(10)),
+        ],
+    ));
 
     let (_kernel_arc, kernel_handle) = kernel.start(cancellation_token.clone());
 

--- a/crates/kernel/src/kernel.rs
+++ b/crates/kernel/src/kernel.rs
@@ -209,6 +209,8 @@ pub struct Kernel {
     trace_service:         crate::trace::TraceService,
     /// Provider for generating the skills prompt block.
     skill_prompt_provider: crate::handle::SkillPromptProvider,
+    /// Lifecycle hook registry for turn/fold/delegation events.
+    lifecycle_hooks:       crate::lifecycle::LifecycleHookRegistry,
 }
 
 impl Kernel {
@@ -309,7 +311,13 @@ impl Kernel {
             hook_runner,
             trace_service,
             skill_prompt_provider,
+            lifecycle_hooks: crate::lifecycle::LifecycleHookRegistry::new(),
         }
+    }
+
+    /// Set the lifecycle hook registry (call before `start()`).
+    pub fn set_lifecycle_hooks(&mut self, hooks: crate::lifecycle::LifecycleHookRegistry) {
+        self.lifecycle_hooks = hooks;
     }
 
     /// List detailed runtime statistics for all processes.
@@ -998,6 +1006,16 @@ impl Kernel {
             output_len = result.output.len(),
             "child result received"
         );
+
+        self.lifecycle_hooks
+            .fire_delegation_done(&crate::lifecycle::DelegationResult {
+                parent_session: parent_id,
+                child_session:  child_id,
+                task:           String::new(),
+                success:        result.success,
+                output:         result.output.clone(),
+            })
+            .await;
 
         use crate::agent::CHILD_RESULT_SAFETY_LIMIT_BYTES;
         let output = &result.output;
@@ -2208,6 +2226,13 @@ impl Kernel {
         let guard_pipeline = self.guard_pipeline.clone();
         let hook_runner = self.hook_runner.clone();
         let notification_bus = self.syscall.event_bus().clone();
+        let lifecycle_hooks = self.lifecycle_hooks.clone();
+        let model_name = self
+            .process_table
+            .with(&session_key, |p| {
+                p.manifest.model.clone().unwrap_or_default()
+            })
+            .unwrap_or_default();
 
         let milestone_tx = self
             .process_table
@@ -2359,6 +2384,15 @@ impl Kernel {
                 // Use the inbound message ID as the turn's rara_message_id
                 // for end-to-end correlation.
                 let rara_message_id = msg_id.clone();
+
+                // Fire pre_turn lifecycle hooks.
+                lifecycle_hooks
+                    .fire_pre_turn(&crate::lifecycle::TurnContext {
+                        session_key: rt_session_key,
+                        user_text:   effective_user_text.clone(),
+                        model:       model_name.clone(),
+                    })
+                    .await;
 
                 let turn_result = if use_plan_executor {
                     run_plan_loop(
@@ -2554,6 +2588,61 @@ impl Kernel {
             .process_table
             .with(&session_key, |p| p.manifest.name.clone())
             .unwrap_or_else(|| "unknown".to_string());
+
+        // Fire post_turn lifecycle hooks and persist nudge messages.
+        {
+            let model = self
+                .process_table
+                .with(&session_key, |p| {
+                    p.manifest.model.clone().unwrap_or_default()
+                })
+                .unwrap_or_default();
+            let turn_ctx = crate::lifecycle::TurnContext {
+                session_key,
+                user_text: String::new(),
+                model,
+            };
+            let turn_result = match &result {
+                Ok(turn) => crate::lifecycle::TurnResult {
+                    success:     turn.trace.success,
+                    iterations:  turn.iterations,
+                    tool_calls:  turn.tool_calls,
+                    output:      turn.text.clone(),
+                    error:       turn.trace.error.clone(),
+                    duration_ms: turn.trace.duration_ms,
+                },
+                Err(err) => crate::lifecycle::TurnResult {
+                    success:     false,
+                    iterations:  0,
+                    tool_calls:  0,
+                    output:      String::new(),
+                    error:       Some(err.clone()),
+                    duration_ms: 0,
+                },
+            };
+            let nudges = self
+                .lifecycle_hooks
+                .fire_post_turn(&turn_ctx, &turn_result)
+                .await;
+            if !nudges.is_empty() {
+                let tape_name = session_key.to_string();
+                for nudge in &nudges {
+                    let _ = self
+                        .tape_service
+                        .append_message(
+                            &tape_name,
+                            serde_json::json!({ "role": "system", "content": nudge }),
+                            None,
+                        )
+                        .await;
+                }
+                tracing::debug!(
+                    count = nudges.len(),
+                    session_key = %session_key,
+                    "persisted lifecycle nudges to tape"
+                );
+            }
+        }
 
         match result {
             Ok(turn) if !turn.text.is_empty() => {

--- a/crates/kernel/src/lifecycle.rs
+++ b/crates/kernel/src/lifecycle.rs
@@ -110,9 +110,11 @@ pub trait LifecycleHook: Send + Sync + 'static {
 
     /// Called after the agent loop completes a turn.
     ///
-    /// Use this for post-processing: persist memories, check whether to
-    /// suggest skill creation, update analytics.
-    async fn post_turn(&self, _ctx: &TurnContext, _result: &TurnResult) {}
+    /// Return an optional nudge message. The kernel persists it to the
+    /// session tape as a system message so the LLM sees it on the next
+    /// turn. Hooks never write to tape directly — all writes go through
+    /// the kernel event pipeline.
+    async fn post_turn(&self, _ctx: &TurnContext, _result: &TurnResult) -> Option<String> { None }
 
     /// Called before tape auto-fold compresses context.
     ///
@@ -163,18 +165,27 @@ impl LifecycleHookRegistry {
         }
     }
 
-    /// Fire `post_turn` on all registered hooks.
-    pub async fn fire_post_turn(&self, ctx: &TurnContext, result: &TurnResult) {
+    /// Fire `post_turn` on all registered hooks and collect nudge messages.
+    ///
+    /// The kernel writes returned nudges to the session tape so the LLM
+    /// sees them on the next turn.
+    pub async fn fire_post_turn(&self, ctx: &TurnContext, result: &TurnResult) -> Vec<String> {
+        let mut nudges = Vec::new();
         for hook in self.hooks.iter() {
-            if let Err(e) = tokio::time::timeout(
+            match tokio::time::timeout(
                 std::time::Duration::from_secs(5),
                 hook.post_turn(ctx, result),
             )
             .await
             {
-                tracing::warn!(hook = hook.name(), "post_turn hook timed out: {e}");
+                Ok(Some(msg)) => nudges.push(msg),
+                Ok(None) => {}
+                Err(e) => {
+                    tracing::warn!(hook = hook.name(), "post_turn hook timed out: {e}");
+                }
             }
         }
+        nudges
     }
 
     /// Fire `pre_fold` on all registered hooks.
@@ -225,6 +236,76 @@ impl std::fmt::Debug for LifecycleHookRegistry {
     }
 }
 
+// ---------------------------------------------------------------------------
+// Built-in hooks
+// ---------------------------------------------------------------------------
+
+/// Nudges the agent to create a skill after complex turns (5+ tool calls).
+pub struct SkillNudgeHook;
+
+#[async_trait]
+impl LifecycleHook for SkillNudgeHook {
+    fn name(&self) -> &str { "skill-nudge" }
+
+    async fn post_turn(&self, _ctx: &TurnContext, result: &TurnResult) -> Option<String> {
+        if !result.success || result.tool_calls < 5 {
+            return None;
+        }
+        Some(
+            "[System nudge] You just completed a complex task with multiple tool calls. If you \
+             discovered a non-trivial workflow, solved a tricky problem, or built something \
+             reusable, save the approach as a skill with `create-skill` so you can reuse it next \
+             time. Only create skills for genuinely reusable patterns — not for one-off tasks."
+                .to_owned(),
+        )
+    }
+}
+
+/// Periodically nudges the agent to persist durable facts to memory.
+///
+/// Uses a simple turn counter — fires every `interval` successful turns.
+pub struct MemoryNudgeHook {
+    interval: std::sync::atomic::AtomicUsize,
+    counter:  std::sync::atomic::AtomicUsize,
+}
+
+impl MemoryNudgeHook {
+    /// Create a nudge hook that fires every `every_n_turns` successful turns.
+    pub fn new(every_n_turns: usize) -> Self {
+        Self {
+            interval: std::sync::atomic::AtomicUsize::new(every_n_turns),
+            counter:  std::sync::atomic::AtomicUsize::new(0),
+        }
+    }
+}
+
+#[async_trait]
+impl LifecycleHook for MemoryNudgeHook {
+    fn name(&self) -> &str { "memory-nudge" }
+
+    async fn post_turn(&self, _ctx: &TurnContext, result: &TurnResult) -> Option<String> {
+        if !result.success {
+            return None;
+        }
+        let count = self
+            .counter
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed)
+            + 1;
+        let interval = self.interval.load(std::sync::atomic::Ordering::Relaxed);
+        if interval == 0 || count % interval != 0 {
+            return None;
+        }
+        Some(
+            "[System nudge] Periodic memory check: review what you learned in recent turns. Save \
+             durable facts using the memory tool — user preferences, environment details, tool \
+             quirks, stable conventions. Prioritize what reduces future user corrections. Do NOT \
+             save task progress or session outcomes — only facts that will still matter in future \
+             sessions."
+                .to_owned(),
+        )
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::sync::atomic::{AtomicUsize, Ordering};
@@ -253,8 +334,9 @@ mod tests {
             self.pre_count.fetch_add(1, Ordering::Relaxed);
         }
 
-        async fn post_turn(&self, _ctx: &TurnContext, _result: &TurnResult) {
+        async fn post_turn(&self, _ctx: &TurnContext, _result: &TurnResult) -> Option<String> {
             self.post_count.fetch_add(1, Ordering::Relaxed);
+            None
         }
     }
 


### PR DESCRIPTION
## Summary

Closes the self-learning loop inspired by Hermes Agent. Three layers:

**1. post_turn returns nudge messages**
- \`LifecycleHook::post_turn\` now returns \`Option<String>\`
- Kernel collects nudges and persists them to session tape as system messages
- Hooks never write to tape directly — all through kernel event pipeline

**2. SkillNudgeHook**
- Fires when \`tool_calls >= 5\` and turn succeeded
- Nudges: \"save the approach as a skill with create-skill\"

**3. MemoryNudgeHook**
- Fires every 10 successful turns
- Nudges: \"review and persist durable facts to memory\"

**4. Kernel wiring**
- \`pre_turn\` fires before run_agent_loop
- \`post_turn\` fires in handle_turn_completed, writes nudges to tape
- \`delegation_done\` fires in handle_child_completed

## Type of change

| Type | Label |
|------|-------|
| New feature | \`enhancement\` |

## Component

\`core\`

## Closes

Closes #1290

## Test plan

- [x] 3 lifecycle unit tests pass
- [x] \`prek run --all-files\` passes
- [x] Hooks registered at app startup with SkillNudge + MemoryNudge(10)