### PR TITLE
feat(channels): move spinner verb from phase line to footer (#1295)

### DIFF
--- a/crates/channels/src/telegram/adapter.rs
+++ b/crates/channels/src/telegram/adapter.rs
@@ -422,11 +422,7 @@ fn format_phase_line(phase: &Phase, loading_hint: &str) -> String {
     } else if phase.activity == rara_kernel::io::stages::THINKING {
         loading_hint.to_string()
     } else {
-        // Append a randomly-sampled spinner verb on each render so the
-        // message visibly changes during long tool runs — the static
-        // "正在{activity}…" looked frozen for 2+ minutes.
-        let verb = super::spinner_verbs::random_verb();
-        format!("正在{}… ({verb}){suffix}", phase.activity)
+        format!("正在{}…{suffix}", phase.activity)
     }
 }
 
@@ -464,8 +460,12 @@ fn render_progress(
         if !progress.thinking {
             return String::new();
         }
+        let verb = super::spinner_verbs::random_verb().to_lowercase();
         let mut lines = vec![thinking_hint(progress)];
-        lines.push(format!("✳️ {}", format_duration_compact(turn_elapsed)));
+        lines.push(format!(
+            "✳️ {verb}... {}",
+            format_duration_compact(turn_elapsed)
+        ));
         return lines.join("\n");
     }
 
@@ -522,8 +522,11 @@ fn render_progress(
         lines.push(thinking_hint(progress));
     }
 
-    // Footer: elapsed + tokens + thinking
+    // Footer: spinner verb + elapsed + tokens + thinking.
+    // The verb was previously on the phase line as "(Verb)" — moved here
+    // so the phase line stays clean for the command summary.
     {
+        let verb = super::spinner_verbs::random_verb().to_lowercase();
         let mut parts = vec![format_duration_compact(turn_elapsed)];
 
         if progress.input_tokens > 0 || progress.output_tokens > 0 {
@@ -539,7 +542,7 @@ fn render_progress(
             }
         }
 
-        lines.push(format!("✳️ {}", parts.join(" · ")));
+        lines.push(format!("✳️ {verb}... {}", parts.join(" · ")));
     }
 
     lines.join("\n")


### PR DESCRIPTION
## Summary

Move the spinner verb (e.g. "Billowing") from the phase line to the footer line in Telegram progress display.

- **Before**: `正在执行命令… (Billowing)` + `✳️ 1m3s · ↑31.6k ↓281 · thought 2`
- **After**: `正在执行命令…` + `✳️ billowing... 1m3s · ↑31.6k ↓281 · thought 2`

This keeps the phase line clean for showing what command is being executed (via the summary suffix), and the spinner verb provides visual freshness in the footer instead.

## Type of change

| Type | Label |
|------|-------|
| New feature | `enhancement` |

## Component

`ui`

## Closes

Closes #1295

## Test plan

- [x] `cargo check -p rara-channels` passes
- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy` passes
- [x] `cargo doc` passes
- [x] Pre-commit hooks all green