### PR TITLE
feat(channels): show tool name in progress phase line (#1298)

### DIFF
--- a/crates/channels/src/telegram/adapter.rs
+++ b/crates/channels/src/telegram/adapter.rs
@@ -344,6 +344,8 @@ struct Phase {
     all_success:    bool,
     total_duration: Option<std::time::Duration>,
     first_error:    Option<String>,
+    /// Display name of the first tool (e.g. "shell", "ctx_execute").
+    first_name:     String,
     /// Summary of the first tool in this phase (e.g. file path, command).
     first_summary:  String,
 }
@@ -378,6 +380,7 @@ fn aggregate_phases(tools: &[ToolProgress]) -> Vec<Phase> {
                 all_success:    tool.success,
                 total_duration: tool.duration,
                 first_error:    tool.error.clone(),
+                first_name:     tool.name.clone(),
                 first_summary:  tool.summary.clone(),
             });
         }
@@ -394,10 +397,12 @@ fn aggregate_phases(tools: &[ToolProgress]) -> Vec<Phase> {
 fn format_phase_line(phase: &Phase, loading_hint: &str) -> String {
     use crate::tool_display::truncate_summary;
 
-    // Truncate at 60 chars for Telegram's narrow viewport; the full text
-    // is preserved in the trace detail accessible via the "📊 详情" button.
+    // Show what the tool is doing: prefer summary (command, path, query),
+    // fall back to display name so the user always sees *something*.
     let suffix = if phase.count == 1 && !phase.first_summary.is_empty() {
         format!(" — {}", truncate_summary(&phase.first_summary, 60))
+    } else if phase.count == 1 && !phase.first_name.is_empty() {
+        format!(" — {}", phase.first_name)
     } else {
         String::new()
     };


### PR DESCRIPTION
## Summary

When a tool's argument summary is empty (common for MCP tools like `ctx_execute`), the Telegram progress phase line only showed the activity label (e.g. "正在执行命令…") with no indication of which tool was running.

Now falls back to the tool display name so the user always sees something meaningful:
- With summary: `正在执行命令… — git status`
- Without summary (before): `正在执行命令…`
- Without summary (after): `正在执行命令… — ctx_execute`

## Type of change

| Type | Label |
|------|-------|
| New feature | `enhancement` |

## Component

`ui`

## Closes

Closes #1298

## Test plan

- [x] `cargo check -p rara-channels` passes
- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy` passes
- [x] `cargo doc` passes
- [x] Pre-commit hooks all green