### PR TITLE
fix(ci): use zlob feature for fff-search to fix CI build (#1304)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -273,7 +273,7 @@ rara-symphony = { path = "crates/symphony" }
 rara-vault = { path = "crates/rara-vault" }
 
 # fff (Fast File Finder) — Cargo git dependencies (not vendored)
-fff-search = { git = "https://github.com/dmtrKovalenko/fff.nvim", default-features = false }
+fff-search = { git = "https://github.com/dmtrKovalenko/fff.nvim", features = ["zlob"] }
 fff-grep = { git = "https://github.com/dmtrKovalenko/fff.nvim" }
 fff-query-parser = { git = "https://github.com/dmtrKovalenko/fff.nvim", default-features = false }
 


### PR DESCRIPTION
## Summary

Fix all Rust CI jobs (clippy, test, doc) that fail because `fff-search` build script fails on runners. Change `default-features = false` to `features = ["zlob"]`.

## Type of change

| Type | Label |
|------|-------|
| Bug fix | `bug` |

## Component

`ci`

## Closes

Closes #1304

## Test plan

- [x] `cargo check -p rara-app` passes locally
- [x] Pre-commit hooks all green
- [ ] CI Rust jobs should pass after this merge