### PR TITLE
feat(kernel): self-continuation signal to prevent GPT stop-and-ask (#1301)

### DIFF
--- a/crates/agents/src/lib.rs
+++ b/crates/agents/src/lib.rs
@@ -55,6 +55,7 @@ static RARA_MANIFEST: LazyLock<AgentManifest> = LazyLock::new(|| AgentManifest {
     default_execution_mode: None,
     tool_call_limit:        None,
     worker_timeout_secs:    None,
+    max_continuations:      Some(10),
 });
 
 /// Build the **rara** agent manifest — the default user-facing chat agent.
@@ -83,6 +84,7 @@ static NANA_MANIFEST: LazyLock<AgentManifest> = LazyLock::new(|| AgentManifest {
     default_execution_mode: None,
     tool_call_limit:        None,
     worker_timeout_secs:    None,
+    max_continuations:      Some(0),
 });
 
 /// Build the **nana** agent manifest — a chat-only companion for regular users.
@@ -112,6 +114,7 @@ static WORKER_MANIFEST: LazyLock<AgentManifest> = LazyLock::new(|| AgentManifest
     default_execution_mode: None,
     tool_call_limit:        None,
     worker_timeout_secs:    None,
+    max_continuations:      Some(0),
 });
 
 /// Build the **worker** agent manifest — a lightweight sub-agent for task
@@ -153,6 +156,7 @@ static MITA_MANIFEST: LazyLock<AgentManifest> = LazyLock::new(|| AgentManifest {
     default_execution_mode: None,
     tool_call_limit:        None,
     worker_timeout_secs:    None,
+    max_continuations:      Some(0),
 });
 
 /// Build the **mita** agent manifest — a background proactive agent that
@@ -195,6 +199,7 @@ pub fn scheduled_job(job_id: &str, trigger_summary: &str, message: &str) -> Agen
         default_execution_mode: None,
         tool_call_limit:        None,
         worker_timeout_secs:    None,
+        max_continuations:      Some(0),
     }
 }
 
@@ -256,6 +261,27 @@ For actions that affect external systems or are hard to reverse, confirm with th
 When blocked, do not brute-force past the obstacle. Investigate root causes, consider
 alternatives, or ask the user."#;
 
+/// Self-continuation — signal when you have more work to do.
+const RARA_CONTINUATION_FRAGMENT: &str = r#"## Continuation
+
+When a task has obvious next steps, keep going — do not stop to ask "should I continue?"
+
+If you are about to produce a text-only response mid-task (no tool calls), call the
+`continue-work` tool first to signal you have more work. The system will automatically
+give you another turn.
+
+Use continue-work when:
+- You completed one phase of a multi-step task and the next step is obvious
+- You started a setup process and need to verify it worked
+- The user gave you a destination; you should drive there, not stop at each intersection
+
+Do NOT use continue-work when:
+- You genuinely finished the task
+- You hit a real ambiguity requiring user input
+- You need the user to perform an action (login, approve, etc.)
+
+Fallback: end your response with CONTINUE_WORK (exact text) if tool calling fails."#;
+
 /// Anti-narration — prevent common LLM chattiness patterns.
 const RARA_ANTI_NARRATION_FRAGMENT: &str = r#"## Anti-patterns
 
@@ -265,7 +291,8 @@ Do NOT:
 - Repeat the user's question back to them
 - Add disclaimers or hedging ("I think...", "It seems like...")
 - Over-explain simple actions
-- Ask for confirmation on routine operations"#;
+- Ask for confirmation on routine operations
+- Stop mid-task to ask "should I continue?" when the next step is obvious"#;
 
 /// Rara prompt fragment: skill maintenance and draft handling.
 const RARA_SKILL_MAINTENANCE_FRAGMENT: &str = r#"## Skill Maintenance
@@ -289,6 +316,7 @@ fn rara_system_prompt() -> String {
         RARA_TOOL_FRAGMENT,
         RARA_DELEGATION_FRAGMENT,
         RARA_SAFETY_FRAGMENT,
+        RARA_CONTINUATION_FRAGMENT,
         RARA_SKILL_MAINTENANCE_FRAGMENT,
         RARA_ANTI_NARRATION_FRAGMENT,
     ]

--- a/crates/extensions/backend-admin/src/agents/router.rs
+++ b/crates/extensions/backend-admin/src/agents/router.rs
@@ -174,6 +174,7 @@ async fn create_agent(
         default_execution_mode: None,
         tool_call_limit:        None,
         worker_timeout_secs:    None,
+        max_continuations:      None,
     };
 
     registry

--- a/crates/kernel/AGENT.md
+++ b/crates/kernel/AGENT.md
@@ -265,3 +265,23 @@ includes `task`, `spawn-background`, and `create-plan`.
 - Do NOT publish TaskReport without going through the syscall — `exec_publish_report` enforces `source_session` and `tags` invariants
 - Do NOT use `UserId("system")` in synthetic messages for ProactiveTurn — always use the subscription owner's identity to prevent privilege escalation on session restore
 - Do NOT construct `TaskNotification` outside `handle_publish_task_report` — it builds the `TaskReportRef` and coordinates result persistence
+
+---
+
+## Self-Continuation Signal
+
+Dual-channel mechanism to prevent GPT from stopping mid-task to ask "should I continue?":
+
+1. **Tool channel (primary):** Agent calls `continue-work` tool → `ToolHint::ContinueWork`
+   → agent loop injects `[continuation:wake]` message → re-enters LLM call
+2. **Text channel (fallback):** Agent ends response with `CONTINUE_WORK` → stripped from
+   output → same wake injection
+
+Safety: bounded by `max_continuations` (default 10 per turn, configurable per `AgentManifest`).
+Child/worker agents have continuation disabled (`max_continuations: Some(0)`).
+
+### What NOT To Do
+
+- Do NOT increase `max_continuations` above 20 — runaway continuation loops waste tokens and produce incoherent output
+- Do NOT enable continuation for worker/child agents — only the root user-facing agent should self-continue
+- Do NOT bypass the text-token stripping — `CONTINUE_WORK` must never reach the user

--- a/crates/kernel/src/agent/effect.rs
+++ b/crates/kernel/src/agent/effect.rs
@@ -102,6 +102,14 @@ pub enum Effect {
         /// Reason the machine reached a terminal state.
         reason:     FinishReason,
     },
+    /// Inject a continuation wake system message into the conversation
+    /// before the next LLM call. The runner constructs the message.
+    InjectContinuationWake {
+        /// Current continuation turn number (1-based).
+        turn: usize,
+        /// Maximum continuations allowed.
+        max:  usize,
+    },
     /// Terminate the loop with a failure.
     Fail {
         /// Free-form failure description.

--- a/crates/kernel/src/agent/machine.rs
+++ b/crates/kernel/src/agent/machine.rs
@@ -60,16 +60,25 @@ pub enum Phase {
 /// `MAX_LLM_ERROR_RECOVERIES` constant in `agent::mod`).
 pub const MAX_LLM_RECOVERIES: u32 = 3;
 
+/// Default maximum self-elected continuations per turn.
+pub const DEFAULT_MAX_CONTINUATIONS: usize = 10;
+
 /// Mutable state carried across machine transitions for one turn.
 #[derive(Debug, Clone)]
 pub struct AgentMachine {
-    phase:               Phase,
-    iteration:           usize,
-    max_iterations:      usize,
-    tool_calls_made:     usize,
-    last_assistant_text: String,
-    tools_enabled:       bool,
-    llm_recoveries:      u32,
+    phase:                Phase,
+    iteration:            usize,
+    max_iterations:       usize,
+    tool_calls_made:      usize,
+    last_assistant_text:  String,
+    tools_enabled:        bool,
+    llm_recoveries:       u32,
+    /// Whether the most recent tool wave included a continue-work signal.
+    continuation_pending: bool,
+    /// How many self-elected continuations have been consumed this turn.
+    continuation_count:   usize,
+    /// Maximum allowed continuations per turn.
+    max_continuations:    usize,
 }
 
 impl AgentMachine {
@@ -83,6 +92,17 @@ impl AgentMachine {
             last_assistant_text: String::new(),
             tools_enabled: true,
             llm_recoveries: 0,
+            continuation_pending: false,
+            continuation_count: 0,
+            max_continuations: DEFAULT_MAX_CONTINUATIONS,
+        }
+    }
+
+    /// Construct a machine with custom iteration and continuation limits.
+    pub fn with_max_continuations(max_iterations: usize, max_continuations: usize) -> Self {
+        Self {
+            max_continuations,
+            ..Self::new(max_iterations)
         }
     }
 
@@ -94,6 +114,9 @@ impl AgentMachine {
 
     /// Cumulative tool calls executed in the turn so far.
     pub fn tool_calls_made(&self) -> usize { self.tool_calls_made }
+
+    /// How many self-elected continuations have been consumed this turn.
+    pub fn continuation_count(&self) -> usize { self.continuation_count }
 
     /// Whether the machine has reached a terminal state.
     pub fn is_terminal(&self) -> bool { matches!(self.phase, Phase::Done | Phase::Failed) }
@@ -125,6 +148,29 @@ impl AgentMachine {
             ) if !has_tool_calls => {
                 self.last_assistant_text = text.clone();
                 debug_assert!(tool_calls.is_empty());
+
+                // If a previous tool wave signaled continue-work AND budget remains,
+                // loop back instead of stopping.
+                if self.continuation_pending && self.continuation_count < self.max_continuations {
+                    self.continuation_pending = false;
+                    self.continuation_count += 1;
+                    self.phase = Phase::AwaitingLlm;
+                    return vec![
+                        Effect::AppendTape {
+                            kind: TapeAppendKind::AssistantIntermediate,
+                        },
+                        Effect::InjectContinuationWake {
+                            turn: self.continuation_count,
+                            max:  self.max_continuations,
+                        },
+                        Effect::CallLlm {
+                            iteration:     self.iteration,
+                            tools_enabled: self.tools_enabled,
+                        },
+                    ];
+                }
+
+                self.continuation_pending = false;
                 self.phase = Phase::Done;
                 vec![
                     Effect::AppendTape {
@@ -179,7 +225,11 @@ impl AgentMachine {
             }
 
             // ── Tool wave finished ───────────────────────────────────────
-            (Phase::ExecutingTools, Event::ToolsCompleted { results: _ }) => {
+            (Phase::ExecutingTools, Event::ToolsCompleted { results }) => {
+                // Check if any tool in this wave signaled continuation.
+                self.continuation_pending = results
+                    .iter()
+                    .any(|r| r.name == "continue-work" && r.success);
                 self.iteration += 1;
                 if self.iteration >= self.max_iterations {
                     self.phase = Phase::Done;
@@ -516,6 +566,124 @@ mod tests {
                 ..
             })
         ));
+    }
+
+    #[test]
+    fn continuation_signal_loops_back_to_llm() {
+        let mut m = AgentMachine::new(8);
+        let _ = m.step(Event::TurnStarted);
+
+        // LLM calls continue-work tool
+        let _ = m.step(Event::LlmCompleted {
+            text:           "working on it".into(),
+            tool_calls:     vec![tool_call("c1", "continue-work")],
+            has_tool_calls: true,
+        });
+        let _ = m.step(Event::ToolsCompleted {
+            results: vec![tool_result("c1", "continue-work", true)],
+        });
+
+        // LLM responds with text only — BUT continuation was signaled
+        let effects = m.step(Event::LlmCompleted {
+            text:           "still working...".into(),
+            tool_calls:     vec![],
+            has_tool_calls: false,
+        });
+
+        // Should NOT terminate — should inject wake and loop back
+        assert_eq!(m.phase(), Phase::AwaitingLlm);
+        assert!(
+            effects
+                .iter()
+                .any(|e| matches!(e, Effect::InjectContinuationWake { .. }))
+        );
+        assert!(effects.iter().any(|e| matches!(e, Effect::CallLlm { .. })));
+        assert_eq!(m.continuation_count(), 1);
+    }
+
+    #[test]
+    fn continuation_respects_max_limit() {
+        let mut m = AgentMachine::with_max_continuations(20, 2);
+        let _ = m.step(Event::TurnStarted);
+
+        // Use up 2 continuations
+        for i in 0..2 {
+            let _ = m.step(Event::LlmCompleted {
+                text:           String::new(),
+                tool_calls:     vec![tool_call(&format!("c{i}"), "continue-work")],
+                has_tool_calls: true,
+            });
+            let _ = m.step(Event::ToolsCompleted {
+                results: vec![tool_result(&format!("c{i}"), "continue-work", true)],
+            });
+            // Text-only response — continuation kicks in
+            let _ = m.step(Event::LlmCompleted {
+                text:           format!("working {i}"),
+                tool_calls:     vec![],
+                has_tool_calls: false,
+            });
+            assert_eq!(
+                m.phase(),
+                Phase::AwaitingLlm,
+                "should continue at round {i}"
+            );
+        }
+
+        // 3rd continue-work call
+        let _ = m.step(Event::LlmCompleted {
+            text:           String::new(),
+            tool_calls:     vec![tool_call("c3", "continue-work")],
+            has_tool_calls: true,
+        });
+        let _ = m.step(Event::ToolsCompleted {
+            results: vec![tool_result("c3", "continue-work", true)],
+        });
+        // Text-only — but limit reached, should stop
+        let effects = m.step(Event::LlmCompleted {
+            text:           "done".into(),
+            tool_calls:     vec![],
+            has_tool_calls: false,
+        });
+        assert_eq!(m.phase(), Phase::Done);
+        assert!(matches!(
+            effects.last(),
+            Some(Effect::Finish {
+                reason: FinishReason::Stopped,
+                ..
+            })
+        ));
+    }
+
+    #[test]
+    fn continuation_not_triggered_without_signal() {
+        let mut m = AgentMachine::new(8);
+        let _ = m.step(Event::TurnStarted);
+
+        // Regular tool call (not continue-work)
+        let _ = m.step(Event::LlmCompleted {
+            text:           String::new(),
+            tool_calls:     vec![tool_call("c1", "search")],
+            has_tool_calls: true,
+        });
+        let _ = m.step(Event::ToolsCompleted {
+            results: vec![tool_result("c1", "search", true)],
+        });
+
+        // Text-only — should stop normally
+        let effects = m.step(Event::LlmCompleted {
+            text:           "here are the results".into(),
+            tool_calls:     vec![],
+            has_tool_calls: false,
+        });
+        assert_eq!(m.phase(), Phase::Done);
+        assert!(matches!(
+            effects.last(),
+            Some(Effect::Finish {
+                reason: FinishReason::Stopped,
+                ..
+            })
+        ));
+        assert_eq!(m.continuation_count(), 0);
     }
 
     #[test]

--- a/crates/kernel/src/agent/mod.rs
+++ b/crates/kernel/src/agent/mod.rs
@@ -279,6 +279,12 @@ pub struct AgentManifest {
     /// **Default: `None` (uses 300s fallback).**
     #[serde(default)]
     pub worker_timeout_secs:    Option<u64>,
+    /// Maximum self-elected continuations per turn.
+    ///
+    /// When set to `Some(0)`, continuation is disabled entirely.
+    /// **Default: `None` (uses [`machine::DEFAULT_MAX_CONTINUATIONS`]).**
+    #[serde(default)]
+    pub max_continuations:      Option<usize>,
 }
 
 /// Process environment — isolated per-agent context.
@@ -1049,7 +1055,9 @@ pub(crate) async fn run_agent_loop(
     // ── Self-continuation signal state ──────────────────────────────
     // Tracks whether the most recent tool wave included a continue-work
     // call, and how many continuations have been consumed this turn.
-    let max_continuations: usize = 10;
+    let max_continuations = manifest
+        .max_continuations
+        .unwrap_or(crate::agent::machine::DEFAULT_MAX_CONTINUATIONS);
     let mut continuation_count: usize = 0;
     let mut continuation_pending = false;
 

--- a/crates/kernel/src/agent/mod.rs
+++ b/crates/kernel/src/agent/mod.rs
@@ -1715,10 +1715,11 @@ pub(crate) async fn run_agent_loop(
         // but subsequent iterations (after tool restoration) can resume
         // normal tool-calling flow.
         if !has_tool_calls {
-            // ── Text-token fallback: detect CONTINUE_WORK at response tail ──
-            // Always strip the sentinel to prevent it from leaking to the user,
-            // regardless of whether continuation budget remains.
-            if !continuation_pending {
+            // ── Text-token fallback: strip CONTINUE_WORK from response tail ──
+            // Always strip to prevent leaking the sentinel to the user, even
+            // when continuation_pending is already set (dual-channel case) or
+            // the budget is exhausted.
+            {
                 let trimmed = accumulated_text.trim();
                 if trimmed.ends_with("CONTINUE_WORK") {
                     let end = accumulated_text
@@ -1726,7 +1727,7 @@ pub(crate) async fn run_agent_loop(
                         .expect("CONTINUE_WORK confirmed present by ends_with check");
                     accumulated_text.truncate(end);
                     accumulated_text = accumulated_text.trim_end().to_string();
-                    if continuation_count < max_continuations {
+                    if !continuation_pending && continuation_count < max_continuations {
                         continuation_pending = true;
                     }
                     info!(

--- a/crates/kernel/src/agent/mod.rs
+++ b/crates/kernel/src/agent/mod.rs
@@ -1716,19 +1716,23 @@ pub(crate) async fn run_agent_loop(
         // normal tool-calling flow.
         if !has_tool_calls {
             // ── Text-token fallback: detect CONTINUE_WORK at response tail ──
-            if !continuation_pending && continuation_count < max_continuations {
+            // Always strip the sentinel to prevent it from leaking to the user,
+            // regardless of whether continuation budget remains.
+            if !continuation_pending {
                 let trimmed = accumulated_text.trim();
                 if trimmed.ends_with("CONTINUE_WORK") {
-                    // Strip the token from displayed text
                     let end = accumulated_text
                         .rfind("CONTINUE_WORK")
                         .expect("CONTINUE_WORK confirmed present by ends_with check");
                     accumulated_text.truncate(end);
                     accumulated_text = accumulated_text.trim_end().to_string();
-                    continuation_pending = true;
+                    if continuation_count < max_continuations {
+                        continuation_pending = true;
+                    }
                     info!(
                         iteration,
-                        "CONTINUE_WORK text token detected at response tail"
+                        continuation_pending,
+                        "CONTINUE_WORK text token stripped from response tail"
                     );
                 }
             }
@@ -1770,12 +1774,23 @@ pub(crate) async fn run_agent_loop(
                     )
                     .await;
 
-                // Inject wake message
-                messages.push(llm::Message::user(format!(
+                // Persist wake message to tape so it survives the message
+                // rebuild at the top of the next iteration.
+                let wake_text = format!(
                     "[continuation:wake] Turn {}/{}. You elected to continue working. Resume your \
                      task.",
                     continuation_count, max_continuations
-                )));
+                );
+                let _ = tape
+                    .append_message(
+                        tape_name,
+                        serde_json::json!({
+                            "role": "user",
+                            "content": &wake_text,
+                        }),
+                        None,
+                    )
+                    .await;
                 continue;
             }
             // Persist final assistant message to tape.

--- a/crates/kernel/src/agent/mod.rs
+++ b/crates/kernel/src/agent/mod.rs
@@ -1046,6 +1046,13 @@ pub(crate) async fn run_agent_loop(
         loop_breaker::ToolCallLoopBreaker::new(loop_breaker::LoopBreakerConfig::builder().build());
     let mut loop_breaker_warning: Option<String> = None;
 
+    // ── Self-continuation signal state ──────────────────────────────
+    // Tracks whether the most recent tool wave included a continue-work
+    // call, and how many continuations have been consumed this turn.
+    let max_continuations: usize = 10;
+    let mut continuation_count: usize = 0;
+    let mut continuation_pending = false;
+
     // ── Session length reminder state ─────────────────────────────────
     // Count user turns since the last anchor to detect long sessions that
     // may benefit from a handoff.  Queried once from the tape at turn
@@ -1743,6 +1750,69 @@ pub(crate) async fn run_agent_loop(
         // but subsequent iterations (after tool restoration) can resume
         // normal tool-calling flow.
         if !has_tool_calls {
+            // ── Text-token fallback: detect CONTINUE_WORK at response tail ──
+            if !continuation_pending && continuation_count < max_continuations {
+                let trimmed = accumulated_text.trim();
+                if trimmed.ends_with("CONTINUE_WORK") {
+                    // Strip the token from displayed text
+                    let end = accumulated_text
+                        .rfind("CONTINUE_WORK")
+                        .expect("CONTINUE_WORK confirmed present by ends_with check");
+                    accumulated_text.truncate(end);
+                    accumulated_text = accumulated_text.trim_end().to_string();
+                    continuation_pending = true;
+                    info!(
+                        iteration,
+                        "CONTINUE_WORK text token detected at response tail"
+                    );
+                }
+            }
+
+            // ── Self-continuation: intercept premature stop ─────────────
+            if continuation_pending && continuation_count < max_continuations {
+                continuation_pending = false;
+                continuation_count += 1;
+                info!(
+                    iteration,
+                    continuation_count,
+                    max_continuations,
+                    "continuation signal: injecting wake message instead of stopping"
+                );
+
+                // Persist intermediate text to tape (not as final).
+                let meta = serde_json::to_value(crate::memory::LlmEntryMetadata {
+                    rara_message_id: rara_message_id.to_string(),
+                    usage: last_usage,
+                    model: model.clone(),
+                    iteration,
+                    stream_ms,
+                    first_token_ms,
+                    reasoning_content: if accumulated_reasoning.is_empty() {
+                        None
+                    } else {
+                        Some(accumulated_reasoning.clone())
+                    },
+                })
+                .ok();
+                let _ = tape
+                    .append_message(
+                        tape_name,
+                        serde_json::json!({
+                            "role": "assistant",
+                            "content": &accumulated_text,
+                        }),
+                        meta,
+                    )
+                    .await;
+
+                // Inject wake message
+                messages.push(llm::Message::user(format!(
+                    "[continuation:wake] Turn {}/{}. You elected to continue working. Resume your \
+                     task.",
+                    continuation_count, max_continuations
+                )));
+                continue;
+            }
             // Persist final assistant message to tape.
             let meta = serde_json::to_value(crate::memory::LlmEntryMetadata {
                 rara_message_id: rara_message_id.to_string(),
@@ -2481,6 +2551,17 @@ pub(crate) async fn run_agent_loop(
                     force_fold_next_iteration = true;
                     info!(tool = %name, "setting force_fold_next_iteration via ToolHint");
                 }
+            }
+
+            // Check for ContinueWork hint from continue-work tool.
+            if results.iter().any(|(_success, output, _err, _dur)| {
+                output
+                    .hints
+                    .iter()
+                    .any(|h| matches!(h, crate::tool::ToolHint::ContinueWork { .. }))
+            }) {
+                continuation_pending = true;
+                info!(iteration, "continue-work signal detected in tool wave");
             }
 
             // Reset session-length counter when the agent creates an anchor.

--- a/crates/kernel/src/agent/runner.rs
+++ b/crates/kernel/src/agent/runner.rs
@@ -95,6 +95,11 @@ pub trait Subsystems: Send + Sync {
 
     /// Forward a stream event to the user-facing transport.
     async fn emit_stream(&mut self, kind: String);
+
+    /// Inject a system/user message into the conversation context so the
+    /// LLM sees it on the next `call_llm`.  Used by continuation wake.
+    /// Default: no-op (test stubs that don't model message history).
+    async fn inject_user_message(&mut self, _text: String) {}
 }
 
 /// Drive the [`AgentMachine`] to completion against `subsys`.
@@ -127,12 +132,14 @@ pub async fn drive<S: Subsystems>(machine: &mut AgentMachine, subsys: &mut S) ->
                 }
                 Effect::AppendTape { kind } => subsys.append_tape(kind).await,
                 Effect::InjectContinuationWake { turn, max } => {
-                    subsys
-                        .emit_stream(format!(
-                            "[continuation:wake] Turn {turn}/{max}. The agent elected to continue \
-                             working."
-                        ))
-                        .await;
+                    let wake_msg = format!(
+                        "[continuation:wake] Turn {turn}/{max}. The agent elected to continue \
+                         working."
+                    );
+                    // Inject into conversation context so the LLM sees it.
+                    subsys.inject_user_message(wake_msg.clone()).await;
+                    // Also emit to stream for observability.
+                    subsys.emit_stream(wake_msg).await;
                 }
                 Effect::EmitStream { kind } => subsys.emit_stream(kind).await,
                 Effect::Finish {

--- a/crates/kernel/src/agent/runner.rs
+++ b/crates/kernel/src/agent/runner.rs
@@ -126,6 +126,14 @@ pub async fn drive<S: Subsystems>(machine: &mut AgentMachine, subsys: &mut S) ->
                     follow_up = Some(subsys.run_tools(calls).await);
                 }
                 Effect::AppendTape { kind } => subsys.append_tape(kind).await,
+                Effect::InjectContinuationWake { turn, max } => {
+                    subsys
+                        .emit_stream(format!(
+                            "[continuation:wake] Turn {turn}/{max}. The agent elected to continue \
+                             working."
+                        ))
+                        .await;
+                }
                 Effect::EmitStream { kind } => subsys.emit_stream(kind).await,
                 Effect::Finish {
                     text,
@@ -272,6 +280,62 @@ mod tests {
                 TapeAppendKind::ToolResults,
                 TapeAppendKind::AssistantFinal,
             ]
+        );
+    }
+
+    #[tokio::test]
+    async fn drive_handles_continuation_wake() {
+        let tc = Tc {
+            id:        ToolCallId::new("c1"),
+            name:      ToolName::new("continue-work"),
+            arguments: r#"{"reason":"checking services"}"#.into(),
+        };
+        let mut subsys = ScriptedSubsys {
+            llm_script:     vec![
+                // Iteration 0: call continue-work
+                Event::LlmCompleted {
+                    text:           "checking...".into(),
+                    tool_calls:     vec![tc.clone()],
+                    has_tool_calls: true,
+                },
+                // Iteration 1: text-only (continuation fires, wake injected, another LLM call)
+                Event::LlmCompleted {
+                    text:           "still working".into(),
+                    tool_calls:     vec![],
+                    has_tool_calls: false,
+                },
+                // After wake: finishes for real
+                Event::LlmCompleted {
+                    text:           "all done".into(),
+                    tool_calls:     vec![],
+                    has_tool_calls: false,
+                },
+            ],
+            next_llm:       0,
+            tool_responses: vec![vec![Tr {
+                id:          ToolCallId::new("c1"),
+                name:        ToolName::new("continue-work"),
+                success:     true,
+                duration_ms: 1,
+                error:       None,
+            }]],
+            next_tool:      0,
+            tape_log:       vec![],
+            stream_log:     vec![],
+        };
+        let mut machine = AgentMachine::with_max_continuations(8, 3);
+        let outcome = drive(&mut machine, &mut subsys).await;
+        assert!(outcome.success);
+        assert_eq!(outcome.text, "all done");
+        assert_eq!(machine.continuation_count(), 1);
+        // Verify wake message was emitted
+        assert!(
+            subsys
+                .stream_log
+                .iter()
+                .any(|s| s.contains("[continuation:wake]")),
+            "expected continuation wake in stream log: {:?}",
+            subsys.stream_log
         );
     }
 

--- a/crates/kernel/src/agent/scheduled.rs
+++ b/crates/kernel/src/agent/scheduled.rs
@@ -76,5 +76,6 @@ pub fn scheduled_job_manifest(
         default_execution_mode: None,
         tool_call_limit: None,
         worker_timeout_secs: None,
+        max_continuations: Some(0),
     }
 }

--- a/crates/kernel/src/lib.rs
+++ b/crates/kernel/src/lib.rs
@@ -123,6 +123,9 @@ pub mod tool_names {
     // ACP delegation
     tool!(ACP_DELEGATE, "acp-delegate");
 
+    // Continuation signal
+    tool!(CONTINUE_WORK, "continue-work");
+
     // User interaction
     tool!(ASK_USER, "ask-user");
 }

--- a/crates/kernel/src/plan.rs
+++ b/crates/kernel/src/plan.rs
@@ -1035,6 +1035,7 @@ async fn execute_worker_step(
         default_execution_mode: None,
         tool_call_limit:        None,
         worker_timeout_secs:    None,
+        max_continuations:      Some(0),
     };
 
     info!(

--- a/crates/kernel/src/session/mod.rs
+++ b/crates/kernel/src/session/mod.rs
@@ -921,6 +921,7 @@ impl Session {
                 default_execution_mode: None,
                 tool_call_limit:        None,
                 worker_timeout_secs:    None,
+                max_continuations:      None,
             },
             principal,
             env: AgentEnv::default(),
@@ -981,6 +982,7 @@ mod state_transition_tests {
             default_execution_mode: None,
             tool_call_limit:        None,
             worker_timeout_secs:    None,
+            max_continuations:      None,
         }
     }
 

--- a/crates/kernel/src/syscall.rs
+++ b/crates/kernel/src/syscall.rs
@@ -377,6 +377,8 @@ impl SyscallDispatcher {
                     }
                     // Plan tools
                     registry.register(Arc::new(crate::tool::create_plan::CreatePlanTool));
+                    // Self-continuation signal
+                    registry.register(Arc::new(crate::tool::continue_work::ContinueWorkTool));
                 }
                 // Inject dynamic tools (e.g. MCP server tools).
                 if let Some(ref provider) = self.dynamic_tool_provider {

--- a/crates/kernel/src/testing.rs
+++ b/crates/kernel/src/testing.rs
@@ -343,6 +343,7 @@ impl TestKernelBuilder {
             default_execution_mode: None,
             tool_call_limit:        None,
             worker_timeout_secs:    None,
+            max_continuations:      None,
         });
         let manifest_name = manifest.name.clone();
 

--- a/crates/kernel/src/tool/continue_work.rs
+++ b/crates/kernel/src/tool/continue_work.rs
@@ -1,0 +1,97 @@
+// Copyright 2025 Rararulab
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Self-continuation signal tool.
+//!
+//! When the agent calls `continue-work`, it signals that the current task
+//! is not yet complete and the agent loop should inject a continuation
+//! wake message instead of terminating the turn.
+//!
+//! This is the structured (tool-call) channel of the dual-channel
+//! continuation signal. The text-token fallback (`CONTINUE_WORK` at
+//! response tail) is handled separately in the agent loop.
+//!
+//! Inspired by OpenClaw's CONTINUE_WORK signal.
+
+use async_trait::async_trait;
+use rara_tool_macro::ToolDef;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+use crate::tool::{ToolContext, ToolExecute, ToolHint};
+
+/// Tool that signals the agent wants another turn to continue working.
+///
+/// The tool itself does nothing — its effect is communicated via
+/// [`ToolHint::ContinueWork`] which the agent loop inspects after
+/// tool execution.
+#[derive(ToolDef)]
+#[tool(
+    name = "continue-work",
+    description = "Signal that you have more work to do on the current task. Call this instead of \
+                   stopping to ask the user 'should I continue?' — the system will automatically \
+                   give you another turn. Only use when you have concrete next steps, not to seem \
+                   busy.",
+    tier = "core"
+)]
+pub struct ContinueWorkTool;
+
+/// Parameters for the `continue-work` tool.
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct ContinueWorkParams {
+    /// Brief description of what you will do next (for logging and context).
+    reason: String,
+}
+
+/// Result returned to the LLM.
+#[derive(Debug, Serialize)]
+pub struct ContinueWorkResult {
+    status: &'static str,
+}
+
+#[async_trait]
+impl ToolExecute for ContinueWorkTool {
+    type Output = ContinueWorkResult;
+    type Params = ContinueWorkParams;
+
+    fn hints(&self) -> Vec<ToolHint> {
+        vec![ToolHint::ContinueWork {
+            reason: String::new(),
+        }]
+    }
+
+    async fn run(
+        &self,
+        params: ContinueWorkParams,
+        _context: &ToolContext,
+    ) -> anyhow::Result<ContinueWorkResult> {
+        tracing::info!(reason = %params.reason, "agent elected to continue working");
+        Ok(ContinueWorkResult {
+            status: "continuing",
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn hints_returns_continue_work() {
+        let tool = ContinueWorkTool;
+        let hints = tool.hints();
+        assert_eq!(hints.len(), 1);
+        assert!(matches!(&hints[0], ToolHint::ContinueWork { .. }));
+    }
+}

--- a/crates/kernel/src/tool/fold_branch.rs
+++ b/crates/kernel/src/tool/fold_branch.rs
@@ -170,6 +170,7 @@ impl ToolExecute for FoldBranchTool {
             sandbox: None,
             default_execution_mode: None,
             tool_call_limit: None,
+            max_continuations: Some(0),
             worker_timeout_secs: None,
         };
 

--- a/crates/kernel/src/tool/mod.rs
+++ b/crates/kernel/src/tool/mod.rs
@@ -14,6 +14,7 @@
 
 pub mod browser;
 pub(crate) mod cancel_background;
+pub(crate) mod continue_work;
 pub(crate) mod create_plan;
 pub(crate) mod fold_branch;
 pub(crate) mod schedule;
@@ -153,6 +154,14 @@ pub enum ToolHint {
     SuggestFold {
         /// Optional human-readable reason for logging/diagnostics.
         reason: Option<String>,
+    },
+
+    /// Signal that the agent wants another turn to continue working.
+    /// The agent loop should inject a continuation wake message and
+    /// re-enter the LLM call instead of terminating.
+    ContinueWork {
+        /// Why the agent wants to continue (for logging and the wake message).
+        reason: String,
     },
 }
 

--- a/crates/kernel/src/tool/mod.rs
+++ b/crates/kernel/src/tool/mod.rs
@@ -82,6 +82,7 @@ pub(crate) fn recursive_tool_denylist() -> Vec<ToolName> {
         crate::tool_names::SPAWN_BACKGROUND.clone(),
         crate::tool_names::CREATE_PLAN.clone(),
         crate::tool_names::ASK_USER.clone(),
+        crate::tool_names::CONTINUE_WORK.clone(),
     ]
 }
 

--- a/crates/kernel/src/tool/spawn_background.rs
+++ b/crates/kernel/src/tool/spawn_background.rs
@@ -114,6 +114,7 @@ impl ToolExecute for SpawnBackgroundTool {
             default_execution_mode: None,
             tool_call_limit: None,
             worker_timeout_secs: Some(p.max_iterations.unwrap_or(15) as u64 * 60),
+            max_continuations: Some(0),
         };
 
         super::background_common::spawn_and_register_background(

--- a/crates/kernel/src/tool/task/mod.rs
+++ b/crates/kernel/src/tool/task/mod.rs
@@ -107,6 +107,7 @@ impl ToolExecute for TaskTool {
             default_execution_mode: None,
             tool_call_limit:        None,
             worker_timeout_secs:    Some(preset.max_iterations as u64 * 60),
+            max_continuations:      Some(0),
         };
 
         let mut result = super::background_common::spawn_and_register_background(
@@ -178,6 +179,7 @@ mod tests {
             default_execution_mode: None,
             tool_call_limit:        None,
             worker_timeout_secs:    Some(preset.max_iterations as u64 * 60),
+            max_continuations:      Some(0),
         };
         assert_eq!(manifest.role, AgentRole::Worker);
         assert_eq!(manifest.max_children, Some(0));

--- a/docs/guides/anti-patterns.md
+++ b/docs/guides/anti-patterns.md
@@ -13,6 +13,7 @@ Every entry has a **why** — the reasoning generalizes better than the rule alo
 - Do NOT hardcode database URLs or config defaults in Rust — **why:** config must be explicit and auditable in YAML; hidden defaults cause "works on my machine" failures
 - Do NOT modify already-applied migration files — **why:** SQLx tracks checksums; any change breaks startup on every deployed instance
 - Do NOT write code comments in any language other than English — **why:** non-English comments fragment search and break tooling for international contributors
+- Do NOT enable continuation for worker/child agents — **why:** child agents run in bounded context; self-continuation would break the parent's timeout and resource accounting
 
 ## Workflow
 


### PR DESCRIPTION
## Summary

Dual-channel self-continuation signal, inspired by OpenClaw's CONTINUE_WORK pattern:

- **Tool channel (primary):** `continue-work` tool → `ToolHint::ContinueWork` → agent loop injects `[continuation:wake]` message → re-enters LLM call
- **Text channel (fallback):** Agent ends response with `CONTINUE_WORK` → stripped from output → same wake injection
- **Safety:** bounded by `max_continuations` (default 10, configurable per `AgentManifest`); child/worker agents disabled (`Some(0)`)

### Changes

1. `ToolHint::ContinueWork` variant + `CONTINUE_WORK` tool name constant
2. `ContinueWorkTool` implementation (tier = core, zero dependencies)
3. `AgentMachine`: `continuation_pending`, `continuation_count`, `max_continuations` + `Effect::InjectContinuationWake`
4. `runner::drive`: handles wake effect
5. Legacy `run_agent_loop`: tool hint detection + text token fallback + wake injection
6. `RARA_CONTINUATION_FRAGMENT` in system prompt
7. Boot registration + recursive tool denylist
8. `AgentManifest.max_continuations` field (rara=10, others=0)

## Type of change

| Type | Label |
|------|-------|
| New feature | `enhancement` |

## Component

`core`

## Closes

Closes #1301

## Test plan

- [x] 3 new machine tests (continuation loops, max limit, no false positive)
- [x] 1 new runner integration test (drive_handles_continuation_wake)
- [x] 1 new tool unit test (hints_returns_continue_work)
- [x] All existing tests pass (`cargo test -p rara-kernel`, `cargo test -p rara-agents`)
- [x] `cargo check --workspace` clean
- [x] Pre-commit hooks pass (clippy, fmt, doc, AGENT.md)