### PR TITLE
fix(kernel): simplify context contract following bub's approach (#1309)

### DIFF
--- a/crates/kernel/src/agent/mod.rs
+++ b/crates/kernel/src/agent/mod.rs
@@ -843,25 +843,23 @@ fn build_runtime_contract_prompt(
 <context_contract>
 ## Context Management
 
-**Tape tools**: `tape-anchor` (checkpoint + trim), `tape-search` (recall old context).
+**Tape tools** (always available — no `discover-tools` needed):
+- `tape-anchor` — checkpoint + trim context
+- `tape-search` — recall earlier context and past conversations
 
-**MANDATORY: On-demand tool activation**: You MUST call `discover-tools` BEFORE using any tool \
-from the list below. These names are search keywords, NOT callable tools. \
-Example: `discover-tools({{"query":"marketplace"}})` — this loads the real tools so you can call them. \
+Excessively long context may cause model call failures. When context is long or \
+[Context Usage Warning] appears, use `tape-anchor` to checkpoint and trim. \
+When you need to recall something from before an anchor, or the user references \
+a project/task/concept from a previous session, use `tape-search` before asking \
+the user — they likely already told you. \
+Always include `summary` and `next_steps` in anchors.
+
+**On-demand tool activation**: Call `discover-tools` BEFORE using any tool from \
+the discoverable list below. These are search keywords, NOT callable tools. \
+Example: `discover-tools({{"query":"marketplace"}})`. \
 NEVER call a listed name directly. NEVER tell the user a tool is unavailable — \
 call `discover-tools` to load it first.{tool_list}
 {system_paths}
-
-**MUST anchor when:**
-- Context is long or [Context Usage Warning] appears
-- Tool result exceeds ~2000 chars (anchor the key findings, not the raw output)
-- User switches topic or starts a new task
-
-**MUST search when:**
-- Question refers to content before an anchor
-- You need exact details from earlier in the conversation
-
-Always include `summary` and `next_steps` in anchors — they are your future self's entry point.
 </context_contract>"#
     )
 }


### PR DESCRIPTION
## Summary

Rewrite the `context_contract` prompt following bub's simpler approach instead of rigid MUST/MUST NOT lists.

**Before:** Exhaustive rules like "MUST anchor when tool result >2000 chars", "MUST search when question refers to content before anchor" — caused agent to anchor too aggressively (KV cache thrash, context shrinkage) and not search when it should.

**After:** Natural-language description of when to use tape-anchor and tape-search, similar to bub's `"you MAY use tape.info... you SHOULD use tape.handoff"` pattern. Tape tools explicitly marked as always available (no discover-tools needed).

## Type of change

| Type | Label |
|------|-------|
| Bug fix | `bug` |

## Component

`core`

## Closes

Closes #1309

## Test plan

- [x] `cargo check -p rara-kernel` passes
- [x] Pre-commit hooks all green
- [ ] Manual validation: agent should anchor less frequently, search more proactively