### PR TITLE
chore(kernel): increase default_max_iterations from 12 to 60 (#1313)

### DIFF
--- a/crates/kernel/src/kernel.rs
+++ b/crates/kernel/src/kernel.rs
@@ -105,8 +105,8 @@ pub struct KernelConfig {
     /// Default maximum number of children per agent.
     #[default = 8]
     pub default_child_limit:     usize,
-    /// Default max LLM iterations for spawned agents.
-    #[default = 12]
+    /// Default max LLM iterations per agent turn.
+    #[default = 60]
     pub default_max_iterations:  usize,
     /// Hard cap for one tool execution wave inside a turn.
     ///


### PR DESCRIPTION
## Summary

Increase `default_max_iterations` from 12 to 60. The primary agent needs more iterations for complex tasks. Sub-agents/tasks already set their own explicit limits (12-15).

## Type of change

| Type | Label |
|------|-------|
| Chore | `chore` |

## Component

`core`

## Closes

Closes #1314

## Test plan

- [x] Pre-commit hooks pass