### PR TITLE
feat(kernel): interrupt agent turn on new user message (#1317)

### DIFF
--- a/crates/kernel/src/agent/mod.rs
+++ b/crates/kernel/src/agent/mod.rs
@@ -38,7 +38,10 @@ pub(crate) const STRUCTURED_OUTPUT_SUFFIX: &str =
 use std::{
     collections::HashMap,
     path::{Path, PathBuf},
-    sync::Arc,
+    sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    },
     time::Instant,
 };
 
@@ -871,7 +874,8 @@ call `discover-tools` to load it first.{tool_list}
         tape,
         tape_name,
         guard_pipeline,
-        notification_bus
+        notification_bus,
+        interrupted
     ),
     fields(
         session_key = %session_key,
@@ -891,6 +895,7 @@ pub(crate) async fn run_agent_loop(
     hook_runner: crate::hooks::HookRunnerRef,
     notification_bus: NotificationBusRef,
     rara_message_id: crate::io::MessageId,
+    interrupted: &AtomicBool,
 ) -> crate::error::Result<AgentTurnResult> {
     // Query context via syscalls.
     let manifest =
@@ -1077,6 +1082,16 @@ pub(crate) async fn run_agent_loop(
     };
 
     for iteration in 0..max_iterations {
+        // Check interrupt flag — a new user message arrived while this turn
+        // was running. Break early so the kernel can drain the pause buffer
+        // and start a new turn with the latest message.
+        if interrupted.load(Ordering::Relaxed) {
+            info!("agent turn interrupted by new user message at iteration start");
+            stream_handle.emit(StreamEvent::Progress {
+                stage: "interrupted".to_string(),
+            });
+            break;
+        }
         // ── Auto-fold: pressure-driven context compression ───────────
         // Runs BEFORE rebuild so the new anchor (if created) takes effect
         // in this iteration's context.  Disabled for the remainder of this
@@ -2621,6 +2636,15 @@ pub(crate) async fn run_agent_loop(
                     break;
                 }
             }
+        }
+
+        // Check interrupt flag after tool wave completes.
+        if interrupted.load(Ordering::Relaxed) {
+            info!("agent turn interrupted after tool wave");
+            stream_handle.emit(StreamEvent::Progress {
+                stage: "interrupted".to_string(),
+            });
+            break;
         }
 
         // ── Runtime context guard ──────────────────────────────────────

--- a/crates/kernel/src/agent/mod.rs
+++ b/crates/kernel/src/agent/mod.rs
@@ -1052,6 +1052,9 @@ pub(crate) async fn run_agent_loop(
     // Distinguishes "user stopped via limit" from "max iterations exhausted"
     // in the post-loop exit logic — they produce different user messages.
     let mut stopped_by_limit = false;
+    // Set when a new user message interrupts the turn — the turn should
+    // exit quietly without emitting exhaustion warnings or fallback text.
+    let mut was_interrupted = false;
     // ── Token & thinking metrics for UsageUpdate (#303) ──────────────
     // These are *cumulative* across all iterations within the turn.
     // `cumulative_output_tokens` sums completion_tokens from every iteration;
@@ -1090,6 +1093,7 @@ pub(crate) async fn run_agent_loop(
             stream_handle.emit(StreamEvent::Progress {
                 stage: "interrupted".to_string(),
             });
+            was_interrupted = true;
             break;
         }
         // ── Auto-fold: pressure-driven context compression ───────────
@@ -2644,6 +2648,7 @@ pub(crate) async fn run_agent_loop(
             stream_handle.emit(StreamEvent::Progress {
                 stage: "interrupted".to_string(),
             });
+            was_interrupted = true;
             break;
         }
 
@@ -2668,7 +2673,16 @@ pub(crate) async fn run_agent_loop(
     }
 
     // Determine exit reason and build appropriate error/message.
-    let exhaustion_error = if stopped_by_limit {
+    let exhaustion_error = if was_interrupted {
+        // Turn interrupted by a new user message — exit quietly.
+        // No warning, no fallback text. The buffered message will
+        // trigger a fresh turn with full context.
+        info!(
+            tool_calls_made,
+            "agent turn interrupted, yielding to new message"
+        );
+        format!("interrupted after {tool_calls_made} tool calls")
+    } else if stopped_by_limit {
         // User clicked "stop" or tool call limit timed out — not an exhaustion error.
         let msg = format!("agent stopped by user/timeout after {tool_calls_made} tool calls");
         warn!(

--- a/crates/kernel/src/kernel.rs
+++ b/crates/kernel/src/kernel.rs
@@ -39,7 +39,13 @@
 //! Each spawned agent receives a `ProcessHandle` — a thin event pusher that
 //! sends `Syscall` variants through the unified event queue.
 
-use std::{sync::Arc, time::Duration};
+use std::{
+    sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    },
+    time::Duration,
+};
 
 use futures::FutureExt;
 use jiff::Timestamp;
@@ -846,6 +852,7 @@ impl Kernel {
             paused: false,
             origin_endpoint,
             pause_buffer: Vec::new(),
+            interrupted: Arc::new(AtomicBool::new(false)),
             background_tasks: Vec::new(),
             pending_tool_call_limit: None,
             activated_deferred: std::collections::HashSet::new(),
@@ -1750,6 +1757,8 @@ impl Kernel {
             if is_active {
                 rt.pause_buffer
                     .push(KernelEventEnvelope::user_message(msg.clone()));
+                // Signal the agent loop to break at next checkpoint.
+                rt.interrupted.store(true, Ordering::Relaxed);
                 return true;
             }
             false
@@ -2240,6 +2249,12 @@ impl Kernel {
             .flatten();
         let parent_span = tracing::Span::current();
 
+        // Clone the interrupt flag so the spawned agent task can check it.
+        let interrupted = self
+            .process_table
+            .with(&session_key, |p| Arc::clone(&p.interrupted))
+            .expect("session must exist when starting turn");
+
         // -- Phase 6b: Resolve execution mode ------------------------------------
         //
         // Determine whether this turn uses reactive (v1) or plan-execute (v2).
@@ -2409,6 +2424,7 @@ impl Kernel {
                         hook_runner,
                         notification_bus,
                         rara_message_id,
+                        &interrupted,
                     )
                     .await
                 } else {
@@ -2426,6 +2442,7 @@ impl Kernel {
                         hook_runner,
                         notification_bus,
                         rara_message_id,
+                        &interrupted,
                     )
                     .await
                 };
@@ -2895,6 +2912,11 @@ impl Kernel {
                 });
             }
         }
+
+        // Reset interrupt flag before draining so the next turn starts clean.
+        self.process_table.with_mut(&session_key, |rt| {
+            rt.interrupted.store(false, Ordering::Relaxed);
+        });
 
         // Drain pause buffer — if the user sent messages while the turn was
         // running, re-inject them so they start a new turn on this session.

--- a/crates/kernel/src/plan.rs
+++ b/crates/kernel/src/plan.rs
@@ -23,7 +23,10 @@
 //! The entry point is `run_plan_loop`, which has the same signature as
 //! `run_agent_loop` so the kernel can route to either.
 
-use std::{sync::Arc, time::Instant};
+use std::{
+    sync::{Arc, atomic::AtomicBool},
+    time::Instant,
+};
 
 use serde::{Deserialize, Serialize};
 use tokio_util::sync::CancellationToken;
@@ -251,6 +254,7 @@ pub(crate) async fn run_plan_loop(
     hook_runner: crate::hooks::HookRunnerRef,
     notification_bus: NotificationBusRef,
     rara_message_id: crate::io::MessageId,
+    interrupted: &AtomicBool,
 ) -> Result<AgentTurnResult> {
     info!(session_key = %session_key, "plan executor: starting v2 plan-execute loop");
     let start = Instant::now();
@@ -399,6 +403,7 @@ pub(crate) async fn run_plan_loop(
                     hook_runner.clone(),
                     notification_bus.clone(),
                     rara_message_id,
+                    interrupted,
                     &mut total_iterations,
                     &mut total_tool_calls,
                     &mut last_model,
@@ -1327,6 +1332,7 @@ async fn execute_inline_step(
     hook_runner: crate::hooks::HookRunnerRef,
     notification_bus: NotificationBusRef,
     rara_message_id: crate::io::MessageId,
+    interrupted: &AtomicBool,
     total_iterations: &mut usize,
     total_tool_calls: &mut usize,
     last_model: &mut String,
@@ -1390,6 +1396,7 @@ async fn execute_inline_step(
         hook_runner,
         notification_bus,
         rara_message_id,
+        interrupted,
     )
     .await;
 

--- a/crates/kernel/src/plan.rs
+++ b/crates/kernel/src/plan.rs
@@ -24,7 +24,10 @@
 //! `run_agent_loop` so the kernel can route to either.
 
 use std::{
-    sync::{Arc, atomic::AtomicBool},
+    sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    },
     time::Instant,
 };
 
@@ -344,8 +347,8 @@ pub(crate) async fn run_plan_loop(
     // Use an index-based loop so we can replace plan.steps on replan.
     let mut step_idx = 0;
     while step_idx < plan.steps.len() {
-        if turn_cancel.is_cancelled() {
-            warn!(session_key = %session_key, step = step_idx, "plan executor: cancelled");
+        if turn_cancel.is_cancelled() || interrupted.load(Ordering::Relaxed) {
+            warn!(session_key = %session_key, step = step_idx, "plan executor: cancelled/interrupted");
             break;
         }
 
@@ -449,9 +452,9 @@ pub(crate) async fn run_plan_loop(
             status_text: end_status,
         });
 
-        // If interrupted during step execution, exit immediately
+        // If cancelled or interrupted during step execution, exit immediately
         // without replan or further processing.
-        if turn_cancel.is_cancelled() {
+        if turn_cancel.is_cancelled() || interrupted.load(Ordering::Relaxed) {
             break;
         }
 

--- a/crates/kernel/src/session/mod.rs
+++ b/crates/kernel/src/session/mod.rs
@@ -23,7 +23,7 @@ use std::{
     path::PathBuf,
     sync::{
         Arc,
-        atomic::{AtomicI64, AtomicU64, Ordering},
+        atomic::{AtomicBool, AtomicI64, AtomicU64, Ordering},
     },
 };
 
@@ -344,6 +344,9 @@ pub struct Session {
     pub paused: bool,
     /// Buffered events received while the session was paused or busy.
     pub pause_buffer: Vec<KernelEventEnvelope>,
+    /// Flag set when a new user message arrives during an active turn.
+    /// The agent loop checks this between iterations and breaks if set.
+    pub interrupted: Arc<AtomicBool>,
     /// Active background tasks spawned by this session.
     pub background_tasks: Vec<BackgroundTaskEntry>,
     /// Pending tool call limit oneshot sender keyed by limit_id. When the
@@ -937,6 +940,7 @@ impl Session {
             execution_mode: None,
             paused: false,
             pause_buffer: Vec::new(),
+            interrupted: Arc::new(AtomicBool::new(false)),
             background_tasks: Vec::new(),
             pending_tool_call_limit: None,
             origin_endpoint: None,
@@ -1013,6 +1017,7 @@ mod state_transition_tests {
             execution_mode: None,
             paused: false,
             pause_buffer: vec![],
+            interrupted: Arc::new(AtomicBool::new(false)),
             background_tasks: vec![],
             pending_tool_call_limit: None,
             origin_endpoint: None,


### PR DESCRIPTION
## Summary

Add cooperative interrupt mechanism for agent turns, aligned with hermes-agent's approach.

When a user sends a new message while the agent is executing, the agent breaks at the next safe checkpoint (between iterations / after tool wave). The buffered message then triggers a new turn.

**Mechanism:** `Arc<AtomicBool>` flag on `SessionRuntime`
- Set by `deliver_to_session` when buffering during active turn
- Checked by agent loop at iteration start + after tool wave
- Reset before draining pause_buffer on turn completion

**Before:** User waits minutes with no way to redirect the agent
**After:** Agent stops within one iteration, new message processed immediately

Design: `docs/plans/2026-04-13-message-interrupt.md`

## Type of change

| Type | Label |
|------|-------|
| New feature | `enhancement` |

## Component

`core`

## Closes

Closes #1317

## Test plan

- [x] `cargo check -p rara-kernel` passes
- [x] `cargo clippy` passes
- [x] Pre-commit hooks all green
- [ ] Manual: send message during active turn, verify agent interrupts