### PR TITLE
fix(channels): route approval requests to originating chat (#1319)

### DIFF
--- a/crates/channels/src/telegram/adapter.rs
+++ b/crates/channels/src/telegram/adapter.rs
@@ -117,6 +117,7 @@ use rara_kernel::{
         RawPlatformMessage, ReplyContext, StreamHubRef,
     },
     security::{ApprovalDecision, ApprovalRequest, ResolveError},
+    session::SessionIndexRef,
     user_question::{UserQuestion, UserQuestionManagerRef},
 };
 use teloxide::{
@@ -1354,17 +1355,20 @@ impl ChannelAdapter for TelegramAdapter {
             }
         }
 
-        // Spawn approval request listener — sends inline keyboard to primary chat.
+        // Spawn approval request listener — sends inline keyboard to the
+        // originating chat (resolved via session binding).
         {
             let approval_rx = handle.security().approval().subscribe_requests();
             let approval_bot = self.bot.clone();
             let approval_config = Arc::clone(&self.config);
+            let approval_session_index = Arc::clone(handle.session_index());
             let mut approval_shutdown = self.shutdown_rx.clone();
             tokio::spawn(async move {
                 approval_listener(
                     approval_bot,
                     approval_rx,
                     approval_config,
+                    approval_session_index,
                     &mut approval_shutdown,
                 )
                 .await;
@@ -2087,11 +2091,15 @@ async fn handle_cascade_callback(
 }
 
 /// Listens for new approval requests and sends inline keyboard messages
-/// to the primary Telegram chat so the user can approve or deny.
+/// to the originating Telegram chat so the user can approve or deny.
+///
+/// The chat is resolved from the session's channel binding; falls back to
+/// `primary_chat_id` when no binding exists.
 async fn approval_listener(
     bot: teloxide::Bot,
     mut rx: tokio::sync::broadcast::Receiver<ApprovalRequest>,
     config: Arc<StdRwLock<TelegramConfig>>,
+    session_index: SessionIndexRef,
     shutdown_rx: &mut watch::Receiver<bool>,
 ) {
     loop {
@@ -2110,12 +2118,24 @@ async fn approval_listener(
                     }
                 };
 
-                let chat_id = {
+                // Resolve the originating chat from the session's channel
+                // binding; fall back to primary_chat_id when unavailable.
+                let binding_chat_id = session_index
+                    .get_channel_binding_by_session(&req.session_key)
+                    .await
+                    .ok()
+                    .flatten()
+                    .and_then(|b| b.chat_id.parse::<i64>().ok());
+
+                let chat_id = binding_chat_id.or_else(|| {
                     let cfg = config.read().unwrap_or_else(|e| e.into_inner());
                     cfg.primary_chat_id
-                };
+                });
                 let Some(chat_id) = chat_id else {
-                    warn!("telegram approval listener: no primary_chat_id configured, cannot send approval prompt");
+                    warn!(
+                        session_key = %req.session_key,
+                        "telegram approval listener: no channel binding and no primary_chat_id configured"
+                    );
                     continue;
                 };
 

--- a/crates/kernel/src/session/mod.rs
+++ b/crates/kernel/src/session/mod.rs
@@ -195,6 +195,18 @@ pub trait SessionIndex: Send + Sync + 'static {
         chat_id: &str,
     ) -> Result<Option<ChannelBinding>, SessionError>;
 
+    /// Resolve the first channel binding that points to the given session.
+    ///
+    /// Returns `Ok(None)` when no binding exists or the implementation does
+    /// not support reverse lookups. Channels use this to route responses
+    /// (e.g. approval prompts) back to the originating chat.
+    async fn get_channel_binding_by_session(
+        &self,
+        _key: &SessionKey,
+    ) -> Result<Option<ChannelBinding>, SessionError> {
+        Ok(None)
+    }
+
     /// Remove all channel bindings that point to the given session.
     async fn unbind_session(&self, key: &SessionKey) -> Result<(), SessionError>;
 }

--- a/crates/kernel/src/session/test_utils.rs
+++ b/crates/kernel/src/session/test_utils.rs
@@ -98,6 +98,18 @@ impl SessionIndex for InMemorySessionIndex {
             .map(|entry| entry.clone()))
     }
 
+    async fn get_channel_binding_by_session(
+        &self,
+        key: &SessionKey,
+    ) -> Result<Option<ChannelBinding>, SessionError> {
+        let key_str = key.to_string();
+        Ok(self
+            .bindings
+            .iter()
+            .find(|entry| entry.value().session_key.to_string() == key_str)
+            .map(|entry| entry.value().clone()))
+    }
+
     async fn unbind_session(&self, key: &SessionKey) -> Result<(), SessionError> {
         let key_str = key.to_string();
         let to_remove: Vec<_> = self

--- a/crates/sessions/src/file_index.rs
+++ b/crates/sessions/src/file_index.rs
@@ -210,6 +210,33 @@ impl SessionIndex for FileSessionIndex {
         self.read_json(&path).await
     }
 
+    async fn get_channel_binding_by_session(
+        &self,
+        key: &SessionKey,
+    ) -> Result<Option<ChannelBinding>, SessionError> {
+        let bindings_dir = self.index_dir.join("bindings");
+        let mut dir = fs::read_dir(&bindings_dir)
+            .await
+            .map_err(|source| SessionError::FileIo { source })?;
+
+        while let Some(entry) = dir
+            .next_entry()
+            .await
+            .map_err(|source| SessionError::FileIo { source })?
+        {
+            let path = entry.path();
+            if path.extension().and_then(|e| e.to_str()) != Some("json") {
+                continue;
+            }
+            if let Some(binding) = self.read_json::<ChannelBinding>(&path).await? {
+                if binding.session_key == *key {
+                    return Ok(Some(binding));
+                }
+            }
+        }
+        Ok(None)
+    }
+
     async fn unbind_session(&self, key: &SessionKey) -> Result<(), SessionError> {
         let bindings_dir = self.index_dir.join("bindings");
         let mut dir = fs::read_dir(&bindings_dir)


### PR DESCRIPTION
## Summary

- Fix approval prompts being sent to `primary_chat_id` (private DM) instead of the originating group chat
- Add `get_channel_binding_by_session()` to `SessionIndex` trait for reverse binding lookup
- `approval_listener` now resolves chat_id from session binding, falls back to `primary_chat_id`

## Type of change

| Type | Label |
|------|-------|
| Bug fix | `bug` |

## Component

`backend`

## Closes

Closes #1319

## Test plan

- [x] `cargo check` passes
- [x] `cargo clippy` passes (zero warnings)
- [x] `cargo fmt` passes
- [x] `cargo doc` passes
- [x] Pre-commit hooks all green
- [ ] Manual test: send message in group chat → trigger guard → verify approval appears in group chat