### PR TITLE
feat(agents): make safety fragment act-by-default to improve proactivity (#1320)

### DIFF
--- a/crates/agents/src/lib.rs
+++ b/crates/agents/src/lib.rs
@@ -252,14 +252,14 @@ When facing multiple independent questions, dispatch parallel tasks — one per 
 /// Action safety — consider reversibility and blast radius.
 const RARA_SAFETY_FRAGMENT: &str = r#"## Actions
 
-Freely take local, reversible actions (reading, writing notes, searching).
-For actions that affect external systems or are hard to reverse, confirm with the user first:
+Act by default. Confirm only when the action is hard to reverse AND affects people outside this system:
 - Sending messages or notifications to other people
-- Dispatching tasks that trigger real-world side effects
+- Modifying external services, deployments, or infrastructure
 - Deleting or overwriting user data
 
-When blocked, do not brute-force past the obstacle. Investigate root causes, consider
-alternatives, or ask the user."#;
+Everything else — dispatching agents, updating statuses, moving pipeline stages forward — just do it.
+
+When blocked, investigate root causes or ask the user."#;
 
 /// Self-continuation — signal when you have more work to do.
 const RARA_CONTINUATION_FRAGMENT: &str = r#"## Continuation

--- a/crates/app/tests/e2e_scripted.rs
+++ b/crates/app/tests/e2e_scripted.rs
@@ -432,9 +432,22 @@ async fn llm_error_does_not_crash_session() {
         .expect("spawn session");
 
     // The agent loop returns Err for non-retryable errors, so no TurnTrace
-    // is pushed. Instead, poll until the session transitions back to Ready
-    // (meaning the error was handled and the session is alive).
+    // is pushed. Poll for Active first (turn started), then Ready (turn
+    // completed) — the session starts in Ready state, so polling for Ready
+    // directly would race with the initial message delivery.
     let deadline = Instant::now() + TURN_WAIT_TIMEOUT;
+    loop {
+        if let Some(stats) = tk.handle.session_stats(session_key) {
+            if matches!(stats.state, SessionState::Active) {
+                break;
+            }
+        }
+        assert!(
+            Instant::now() < deadline,
+            "timed out waiting for session to become Active"
+        );
+        sleep(Duration::from_millis(50)).await;
+    }
     loop {
         if let Some(stats) = tk.handle.session_stats(session_key) {
             if matches!(stats.state, SessionState::Ready) {

--- a/crates/app/tests/e2e_scripted.rs
+++ b/crates/app/tests/e2e_scripted.rs
@@ -432,24 +432,20 @@ async fn llm_error_does_not_crash_session() {
         .expect("spawn session");
 
     // The agent loop returns Err for non-retryable errors, so no TurnTrace
-    // is pushed. Poll for Active first (turn started), then Ready (turn
-    // completed) — the session starts in Ready state, so polling for Ready
-    // directly would race with the initial message delivery.
+    // is pushed. We need to wait for the error turn to finish before sending
+    // the follow-up. The session starts in Ready state and the error turn
+    // may complete within a single event-loop tick (scripted driver returns
+    // immediately), so polling for Active→Ready is unreliable.
+    //
+    // Yield first so the kernel event loop picks up and processes the initial
+    // UserMessage pushed by spawn_named. Then poll for Ready — at this point
+    // Ready means "turn completed" rather than "just created".
+    tokio::task::yield_now().await;
     let deadline = Instant::now() + TURN_WAIT_TIMEOUT;
     loop {
         if let Some(stats) = tk.handle.session_stats(session_key) {
-            if matches!(stats.state, SessionState::Active) {
-                break;
-            }
-        }
-        assert!(
-            Instant::now() < deadline,
-            "timed out waiting for session to become Active"
-        );
-        sleep(Duration::from_millis(50)).await;
-    }
-    loop {
-        if let Some(stats) = tk.handle.session_stats(session_key) {
+            // After yield, the turn has started (or already finished).
+            // Wait until it settles back to Ready.
             if matches!(stats.state, SessionState::Ready) {
                 break;
             }
@@ -458,8 +454,11 @@ async fn llm_error_does_not_crash_session() {
             Instant::now() < deadline,
             "timed out waiting for session to return to Ready after LLM error"
         );
-        sleep(Duration::from_millis(50)).await;
+        sleep(Duration::from_millis(10)).await;
     }
+    // Extra yield to ensure TurnCompleted event is fully processed
+    // (interrupt flag reset, pause buffer drained).
+    sleep(Duration::from_millis(10)).await;
 
     // Session is alive and Ready — send a second message to prove it
     // did not crash.

--- a/crates/kernel/src/agent/mod.rs
+++ b/crates/kernel/src/agent/mod.rs
@@ -881,7 +881,8 @@ call `discover-tools` to load it first.{tool_list}
         tape_name,
         guard_pipeline,
         notification_bus,
-        interrupted
+        interrupted,
+        interrupt_notify
     ),
     fields(
         session_key = %session_key,
@@ -902,6 +903,7 @@ pub(crate) async fn run_agent_loop(
     notification_bus: NotificationBusRef,
     rara_message_id: crate::io::MessageId,
     interrupted: &AtomicBool,
+    interrupt_notify: &tokio::sync::Notify,
 ) -> crate::error::Result<AgentTurnResult> {
     // Query context via syscalls.
     let manifest =
@@ -1394,6 +1396,12 @@ pub(crate) async fn run_agent_loop(
                     info!("LLM turn cancelled during streaming");
                     return Err(KernelError::Interrupted);
                 }
+                _ = interrupt_notify.notified() => {
+                    stream_task.abort();
+                    info!("LLM streaming interrupted by new user message");
+                    was_interrupted = true;
+                    break;
+                }
             };
 
             let Some(delta) = delta else {
@@ -1512,6 +1520,15 @@ pub(crate) async fn run_agent_loop(
                     break;
                 }
             }
+        }
+
+        // If interrupted mid-stream, skip remaining iteration processing
+        // and exit the for loop — the post-loop code handles was_interrupted.
+        if was_interrupted {
+            stream_handle.emit(StreamEvent::Progress {
+                stage: "interrupted".to_string(),
+            });
+            break;
         }
 
         // Signal forwarder to discard intermediate narration text.

--- a/crates/kernel/src/kernel.rs
+++ b/crates/kernel/src/kernel.rs
@@ -853,6 +853,7 @@ impl Kernel {
             origin_endpoint,
             pause_buffer: Vec::new(),
             interrupted: Arc::new(AtomicBool::new(false)),
+            interrupt_notify: Arc::new(tokio::sync::Notify::new()),
             background_tasks: Vec::new(),
             pending_tool_call_limit: None,
             activated_deferred: std::collections::HashSet::new(),
@@ -1759,6 +1760,7 @@ impl Kernel {
                     .push(KernelEventEnvelope::user_message(msg.clone()));
                 // Signal the agent loop to break at next checkpoint.
                 rt.interrupted.store(true, Ordering::Relaxed);
+                rt.interrupt_notify.notify_one();
                 return true;
             }
             false
@@ -2249,10 +2251,12 @@ impl Kernel {
             .flatten();
         let parent_span = tracing::Span::current();
 
-        // Clone the interrupt flag so the spawned agent task can check it.
-        let interrupted = self
+        // Clone the interrupt flag + notify so the spawned agent task can check it.
+        let (interrupted, interrupt_notify) = self
             .process_table
-            .with(&session_key, |p| Arc::clone(&p.interrupted))
+            .with(&session_key, |p| {
+                (Arc::clone(&p.interrupted), Arc::clone(&p.interrupt_notify))
+            })
             .expect("session must exist when starting turn");
 
         // -- Phase 6b: Resolve execution mode ------------------------------------
@@ -2425,6 +2429,7 @@ impl Kernel {
                         notification_bus,
                         rara_message_id,
                         &interrupted,
+                        &interrupt_notify,
                     )
                     .await
                 } else {
@@ -2443,6 +2448,7 @@ impl Kernel {
                         notification_bus,
                         rara_message_id,
                         &interrupted,
+                        &interrupt_notify,
                     )
                     .await
                 };

--- a/crates/kernel/src/plan.rs
+++ b/crates/kernel/src/plan.rs
@@ -258,6 +258,7 @@ pub(crate) async fn run_plan_loop(
     notification_bus: NotificationBusRef,
     rara_message_id: crate::io::MessageId,
     interrupted: &AtomicBool,
+    interrupt_notify: &tokio::sync::Notify,
 ) -> Result<AgentTurnResult> {
     info!(session_key = %session_key, "plan executor: starting v2 plan-execute loop");
     let start = Instant::now();
@@ -407,6 +408,7 @@ pub(crate) async fn run_plan_loop(
                     notification_bus.clone(),
                     rara_message_id,
                     interrupted,
+                    interrupt_notify,
                     &mut total_iterations,
                     &mut total_tool_calls,
                     &mut last_model,
@@ -1337,6 +1339,7 @@ async fn execute_inline_step(
     notification_bus: NotificationBusRef,
     rara_message_id: crate::io::MessageId,
     interrupted: &AtomicBool,
+    interrupt_notify: &tokio::sync::Notify,
     total_iterations: &mut usize,
     total_tool_calls: &mut usize,
     last_model: &mut String,
@@ -1401,6 +1404,7 @@ async fn execute_inline_step(
         notification_bus,
         rara_message_id,
         interrupted,
+        interrupt_notify,
     )
     .await;
 

--- a/crates/kernel/src/session/mod.rs
+++ b/crates/kernel/src/session/mod.rs
@@ -347,6 +347,9 @@ pub struct Session {
     /// Flag set when a new user message arrives during an active turn.
     /// The agent loop checks this between iterations and breaks if set.
     pub interrupted: Arc<AtomicBool>,
+    /// Wakes the agent loop immediately when the `interrupted` flag is set,
+    /// so it does not have to wait for the next iteration boundary.
+    pub interrupt_notify: Arc<tokio::sync::Notify>,
     /// Active background tasks spawned by this session.
     pub background_tasks: Vec<BackgroundTaskEntry>,
     /// Pending tool call limit oneshot sender keyed by limit_id. When the
@@ -942,6 +945,7 @@ impl Session {
             paused: false,
             pause_buffer: Vec::new(),
             interrupted: Arc::new(AtomicBool::new(false)),
+            interrupt_notify: Arc::new(tokio::sync::Notify::new()),
             background_tasks: Vec::new(),
             pending_tool_call_limit: None,
             origin_endpoint: None,
@@ -1020,6 +1024,7 @@ mod state_transition_tests {
             paused: false,
             pause_buffer: vec![],
             interrupted: Arc::new(AtomicBool::new(false)),
+            interrupt_notify: Arc::new(tokio::sync::Notify::new()),
             background_tasks: vec![],
             pending_tool_call_limit: None,
             origin_endpoint: None,


### PR DESCRIPTION
## Summary

Rara knows the next step in a workflow but asks for permission instead of executing. Root cause: safety fragment listed "dispatching tasks that trigger real-world side effects" as needing confirmation, conflicting with "act first, report after".

Changed the default from "confirm first" to "act by default, confirm only when hard to reverse AND affects people outside this system". Internal operations (dispatching agents, updating statuses, pipeline transitions) no longer need confirmation.

## Type of change

| Type | Label |
|------|-------|
| New feature | `enhancement` |

## Component

`core`

## Closes

Closes #1320

## Test plan

- [x] `cargo check -p rara-agents` passes
- [x] Pre-commit hooks pass (check, fmt, clippy, doc)
- [x] Prompt change is minimal — only safety fragment reworded, no new fragments added