### PR TITLE
fix(agents): remove hardcoded max_iterations=25 from rara manifest (#1325)

### DIFF
--- a/crates/agents/src/lib.rs
+++ b/crates/agents/src/lib.rs
@@ -44,7 +44,7 @@ static RARA_MANIFEST: LazyLock<AgentManifest> = LazyLock::new(|| AgentManifest {
     system_prompt:          rara_system_prompt(),
     soul_prompt:            None,
     provider_hint:          None,
-    max_iterations:         Some(25),
+    max_iterations:         None,
     tools:                  vec![],
     excluded_tools:         vec![],
     max_children:           None,


### PR DESCRIPTION
## Summary

`RARA_MANIFEST` had `max_iterations: Some(25)` which overrode the `KernelConfig::default_max_iterations` (60). Changed to `None` so the primary agent uses the config default.

## Type of change

| Type | Label |
|------|-------|
| Bug fix | `bug` |

## Component

`core`

## Closes

Closes #1325

## Test plan

- [x] Pre-commit hooks pass