### PR TITLE
feat(kernel): runtime ack detection to prevent lazy LLM responses (#1329)

### DIFF
--- a/crates/app/tests/e2e_scripted.rs
+++ b/crates/app/tests/e2e_scripted.rs
@@ -31,7 +31,7 @@ use rara_kernel::{
     identity::{Principal, UserId},
     io::{ChannelSource, InboundMessage, MessageId},
     llm::{CompletionResponse, StopReason, ToolCallRequest},
-    session::{SessionKey, SessionState},
+    session::SessionKey,
     testing::{FakeTool, TestKernelBuilder, scripted_response, scripted_tool_call_response},
 };
 use serde_json::json;
@@ -432,33 +432,12 @@ async fn llm_error_does_not_crash_session() {
         .expect("spawn session");
 
     // The agent loop returns Err for non-retryable errors, so no TurnTrace
-    // is pushed. We need to wait for the error turn to finish before sending
-    // the follow-up. The session starts in Ready state and the error turn
-    // may complete within a single event-loop tick (scripted driver returns
-    // immediately), so polling for Active→Ready is unreliable.
-    //
-    // Yield first so the kernel event loop picks up and processes the initial
-    // UserMessage pushed by spawn_named. Then poll for Ready — at this point
-    // Ready means "turn completed" rather than "just created".
-    tokio::task::yield_now().await;
-    let deadline = Instant::now() + TURN_WAIT_TIMEOUT;
-    loop {
-        if let Some(stats) = tk.handle.session_stats(session_key) {
-            // After yield, the turn has started (or already finished).
-            // Wait until it settles back to Ready.
-            if matches!(stats.state, SessionState::Ready) {
-                break;
-            }
-        }
-        assert!(
-            Instant::now() < deadline,
-            "timed out waiting for session to return to Ready after LLM error"
-        );
-        sleep(Duration::from_millis(10)).await;
-    }
-    // Extra yield to ensure TurnCompleted event is fully processed
-    // (interrupt flag reset, pause buffer drained).
-    sleep(Duration::from_millis(10)).await;
+    // is pushed. The session starts in Ready state and the error turn
+    // completes almost instantly (scripted driver). Sleep to let the kernel
+    // process the initial UserMessage and complete the error turn before
+    // sending the follow-up. This avoids a race where the follow-up lands
+    // while the first turn is Active, triggering the interrupt flag.
+    sleep(Duration::from_millis(500)).await;
 
     // Session is alive and Ready — send a second message to prove it
     // did not crash.

--- a/crates/kernel/src/agent/ack_detector.rs
+++ b/crates/kernel/src/agent/ack_detector.rs
@@ -23,10 +23,11 @@
 
 use crate::llm;
 
-/// Maximum assistant response length (chars) to consider.
+/// Maximum assistant response length (bytes) to consider.
 /// Longer responses are likely substantive, not lazy acks.
-/// Aligned with hermes (1200).
-const MAX_ACK_LENGTH: usize = 1200;
+/// hermes uses 1200 chars; we use 2000 bytes to cover CJK
+/// (3 bytes/char × ~650 chars ≈ 2000 bytes).
+const MAX_ACK_LENGTH_BYTES: usize = 2000;
 
 /// Future-tense phrases signaling the model is *planning* but hasn't acted.
 const FUTURE_ACK_PATTERNS: &[&str] = &[
@@ -42,11 +43,10 @@ const FUTURE_ACK_PATTERNS: &[&str] = &[
     "我来",
     "我去",
     "我帮你",
-    "好的，",
+    "好的，我",
     "我先",
     "我看看",
     "我查一下",
-    "我检查",
 ];
 
 /// Action verbs confirming described future work. Aligned with hermes.
@@ -101,7 +101,7 @@ pub fn looks_like_intermediate_ack(assistant_text: &str, messages: &[llm::Messag
     }
 
     let text = assistant_text.trim();
-    if text.is_empty() || text.len() > MAX_ACK_LENGTH {
+    if text.is_empty() || text.len() > MAX_ACK_LENGTH_BYTES {
         return false;
     }
 
@@ -183,7 +183,7 @@ mod tests {
     #[test]
     fn detects_polite_ack() {
         assert!(looks_like_intermediate_ack(
-            "好的，我来帮你检查一下这个问题",
+            "好的，我来帮你查看一下这个问题",
             &empty_messages(),
         ));
     }

--- a/crates/kernel/src/agent/ack_detector.rs
+++ b/crates/kernel/src/agent/ack_detector.rs
@@ -21,24 +21,30 @@
 //!
 //! Aligned with hermes-agent `_looks_like_codex_intermediate_ack`.
 
+use std::sync::OnceLock;
+
+use regex::Regex;
+
 use crate::llm;
 
-/// Maximum assistant response length (bytes) to consider.
+/// Maximum assistant response length (chars) to consider.
 /// Longer responses are likely substantive, not lazy acks.
-/// hermes uses 1200 chars; we use 2000 bytes to cover CJK
-/// (3 bytes/char × ~650 chars ≈ 2000 bytes).
-const MAX_ACK_LENGTH_BYTES: usize = 2000;
+/// Aligned with hermes (1200 chars).
+const MAX_ACK_LENGTH_CHARS: usize = 1200;
 
-/// Future-tense phrases signaling the model is *planning* but hasn't acted.
-const FUTURE_ACK_PATTERNS: &[&str] = &[
-    // English — aligned with hermes regex
-    "i'll",
-    "i\u{2019}ll", // curly apostrophe
-    "i will",
-    "let me",
-    "i can do that",
-    "i can help with that",
-    // Chinese — rara extension
+/// Compiled regex for English future-ack phrases with word boundaries.
+/// Aligned with hermes: `re.search(r"\b(i['']ll|i will|let me|i can do that|i
+/// can help with that)\b", text)`
+fn future_ack_regex() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| {
+        Regex::new(r"(?i)\b(i[''\u{2019}]ll|i will|let me|i can do that|i can help with that)\b")
+            .expect("ack regex must compile")
+    })
+}
+
+/// Chinese future-ack phrases (no word boundaries needed — CJK has no spaces).
+const CHINESE_ACK_PATTERNS: &[&str] = &[
     "让我",
     "我来",
     "我去",
@@ -82,36 +88,53 @@ const ACTION_MARKERS: &[&str] = &[
     "测试",
 ];
 
+/// Strip `<think>...</think>` blocks from assistant text before detection.
+/// Aligned with hermes `_strip_think_blocks` — reasoning content should
+/// not trigger ack detection.
+fn strip_think_blocks(text: &str) -> String {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    let re = RE.get_or_init(|| {
+        Regex::new(r"(?s)<think>.*?</think>").expect("think-strip regex must compile")
+    });
+    re.replace_all(text, "").to_string()
+}
+
 /// Check whether an assistant response is an intermediate ack that should
 /// be nudged instead of ending the turn.
 ///
-/// Mirrors hermes-agent logic:
-/// 1. If the conversation already contains tool results, the model has started
+/// Mirrors hermes-agent `_looks_like_codex_intermediate_ack`:
+/// 1. Strip `<think>` blocks (reasoning shouldn't trigger detection).
+/// 2. If the conversation already contains tool results, the model has started
 ///    working — a text-only follow-up is a genuine answer.
-/// 2. Short text with a future-tense phrase + action verb = lazy ack.
+/// 3. Short text (≤1200 chars) with a future-tense phrase (word-boundary
+///    matched for English, substring for Chinese) + action verb = lazy ack.
 ///
 /// Workspace markers from hermes are omitted because rara always operates
 /// in a workspace context (personal agent, not general chat).
 pub fn looks_like_intermediate_ack(assistant_text: &str, messages: &[llm::Message]) -> bool {
-    // If any tool results exist in the conversation, the model already
-    // took action — don't nudge a genuine summary. Aligned with hermes:
-    // `if any(msg.get("role") == "tool" for msg in messages): return False`
+    // hermes: `if any(msg.get("role") == "tool" for msg in messages): return False`
     if messages.iter().any(|m| matches!(m.role, llm::Role::Tool)) {
         return false;
     }
 
-    let text = assistant_text.trim();
-    if text.is_empty() || text.len() > MAX_ACK_LENGTH_BYTES {
+    // hermes: `self._strip_think_blocks(assistant_content or "").strip().lower()`
+    let stripped = strip_think_blocks(assistant_text);
+    let text = stripped.trim();
+    if text.is_empty() || text.chars().count() > MAX_ACK_LENGTH_CHARS {
         return false;
     }
 
     let lower = text.to_lowercase();
 
-    let has_future_ack = FUTURE_ACK_PATTERNS.iter().any(|pat| lower.contains(pat));
+    // hermes: `re.search(r"\b(i['']ll|i will|let me|...)\b", assistant_text)`
+    // Word-boundary regex for English, substring match for Chinese.
+    let has_future_ack = future_ack_regex().is_match(&lower)
+        || CHINESE_ACK_PATTERNS.iter().any(|p| lower.contains(p));
     if !has_future_ack {
         return false;
     }
 
+    // hermes: `any(marker in assistant_text for marker in action_markers)`
     ACTION_MARKERS.iter().any(|marker| lower.contains(marker))
 }
 
@@ -149,7 +172,7 @@ mod tests {
     fn detects_chinese_planning_ack() {
         assert!(looks_like_intermediate_ack(
             "让我检查一下构建日志",
-            &empty_messages(),
+            &empty_messages()
         ));
     }
 
@@ -192,6 +215,32 @@ mod tests {
     fn detects_hermes_style_ack() {
         assert!(looks_like_intermediate_ack(
             "I can help with that. Let me search the codebase and report back.",
+            &empty_messages(),
+        ));
+    }
+
+    // Word boundary: "filled" should NOT match "i'll"
+    #[test]
+    fn word_boundary_no_false_positive() {
+        assert!(!looks_like_intermediate_ack(
+            "I filled the test report and checked the results.",
+            &empty_messages(),
+        ));
+    }
+
+    // Think blocks stripped before detection
+    #[test]
+    fn ignores_ack_inside_think_block() {
+        assert!(!looks_like_intermediate_ack(
+            "<think>I'll look into this and check the logs.</think>The answer is 42.",
+            &empty_messages(),
+        ));
+    }
+
+    #[test]
+    fn strip_think_preserves_visible_ack() {
+        assert!(looks_like_intermediate_ack(
+            "<think>reasoning here</think>Let me check the build logs.",
             &empty_messages(),
         ));
     }

--- a/crates/kernel/src/agent/ack_detector.rs
+++ b/crates/kernel/src/agent/ack_detector.rs
@@ -1,0 +1,198 @@
+// Copyright 2025 Rararulab
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Runtime detection of lazy LLM "ack" responses.
+//!
+//! When the LLM produces a planning message ("I'll look into this...",
+//! "让我检查一下...") instead of calling tools, the agent loop injects
+//! a nudge forcing the model to act. The ack message is kept in context
+//! (marked as intermediate) so the model sees its own plan.
+//!
+//! Aligned with hermes-agent `_looks_like_codex_intermediate_ack`.
+
+use crate::llm;
+
+/// Maximum assistant response length (chars) to consider.
+/// Longer responses are likely substantive, not lazy acks.
+/// Aligned with hermes (1200).
+const MAX_ACK_LENGTH: usize = 1200;
+
+/// Future-tense phrases signaling the model is *planning* but hasn't acted.
+const FUTURE_ACK_PATTERNS: &[&str] = &[
+    // English — aligned with hermes regex
+    "i'll",
+    "i\u{2019}ll", // curly apostrophe
+    "i will",
+    "let me",
+    "i can do that",
+    "i can help with that",
+    // Chinese — rara extension
+    "让我",
+    "我来",
+    "我去",
+    "我帮你",
+    "好的，",
+    "我先",
+    "我看看",
+    "我查一下",
+    "我检查",
+];
+
+/// Action verbs confirming described future work. Aligned with hermes.
+const ACTION_MARKERS: &[&str] = &[
+    "look into",
+    "look at",
+    "inspect",
+    "scan",
+    "check",
+    "analyz",
+    "review",
+    "explore",
+    "read",
+    "open",
+    "run",
+    "test",
+    "fix",
+    "debug",
+    "search",
+    "find",
+    "walkthrough",
+    "report back",
+    "summarize",
+    "investigate",
+    "examine",
+    // Chinese — rara extension
+    "查看",
+    "检查",
+    "分析",
+    "调试",
+    "搜索",
+    "修复",
+    "测试",
+];
+
+/// Check whether an assistant response is an intermediate ack that should
+/// be nudged instead of ending the turn.
+///
+/// Mirrors hermes-agent logic:
+/// 1. If the conversation already contains tool results, the model has started
+///    working — a text-only follow-up is a genuine answer.
+/// 2. Short text with a future-tense phrase + action verb = lazy ack.
+///
+/// Workspace markers from hermes are omitted because rara always operates
+/// in a workspace context (personal agent, not general chat).
+pub fn looks_like_intermediate_ack(assistant_text: &str, messages: &[llm::Message]) -> bool {
+    // If any tool results exist in the conversation, the model already
+    // took action — don't nudge a genuine summary. Aligned with hermes:
+    // `if any(msg.get("role") == "tool" for msg in messages): return False`
+    if messages.iter().any(|m| matches!(m.role, llm::Role::Tool)) {
+        return false;
+    }
+
+    let text = assistant_text.trim();
+    if text.is_empty() || text.len() > MAX_ACK_LENGTH {
+        return false;
+    }
+
+    let lower = text.to_lowercase();
+
+    let has_future_ack = FUTURE_ACK_PATTERNS.iter().any(|pat| lower.contains(pat));
+    if !has_future_ack {
+        return false;
+    }
+
+    ACTION_MARKERS.iter().any(|marker| lower.contains(marker))
+}
+
+/// Nudge message injected after an ack is detected.
+/// Aligned with hermes: `"[System: Continue now. Execute the required tool
+/// calls and only send your final answer after completing the task.]"`
+pub const ACK_NUDGE_MESSAGE: &str = "[System: Continue now. Execute the required tool calls and \
+                                     only send your final answer after completing the task.]";
+
+/// Maximum ack nudges per turn (hermes: `codex_ack_continuations < 2`).
+pub const MAX_ACK_NUDGES: usize = 2;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn empty_messages() -> Vec<llm::Message> { vec![] }
+
+    fn messages_with_tool_result() -> Vec<llm::Message> {
+        vec![
+            llm::Message::user("hello".to_string()),
+            llm::Message::tool_result("call_1", "result"),
+        ]
+    }
+
+    #[test]
+    fn detects_english_planning_ack() {
+        assert!(looks_like_intermediate_ack(
+            "I'll look into the build failure and check the logs.",
+            &empty_messages(),
+        ));
+    }
+
+    #[test]
+    fn detects_chinese_planning_ack() {
+        assert!(looks_like_intermediate_ack(
+            "让我检查一下构建日志",
+            &empty_messages(),
+        ));
+    }
+
+    #[test]
+    fn ignores_when_tools_already_called() {
+        assert!(!looks_like_intermediate_ack(
+            "I'll look into the build failure.",
+            &messages_with_tool_result(),
+        ));
+    }
+
+    #[test]
+    fn ignores_long_substantive_response() {
+        let long_text = "I'll analyze this. ".repeat(200);
+        assert!(!looks_like_intermediate_ack(&long_text, &empty_messages()));
+    }
+
+    #[test]
+    fn ignores_genuine_answer() {
+        assert!(!looks_like_intermediate_ack(
+            "The build succeeded. All 42 tests passed.",
+            &empty_messages(),
+        ));
+    }
+
+    #[test]
+    fn ignores_empty() {
+        assert!(!looks_like_intermediate_ack("", &empty_messages()));
+    }
+
+    #[test]
+    fn detects_polite_ack() {
+        assert!(looks_like_intermediate_ack(
+            "好的，我来帮你检查一下这个问题",
+            &empty_messages(),
+        ));
+    }
+
+    #[test]
+    fn detects_hermes_style_ack() {
+        assert!(looks_like_intermediate_ack(
+            "I can help with that. Let me search the codebase and report back.",
+            &empty_messages(),
+        ));
+    }
+}

--- a/crates/kernel/src/agent/mod.rs
+++ b/crates/kernel/src/agent/mod.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+pub(crate) mod ack_detector;
 pub mod effect;
 pub mod fold;
 pub(crate) mod loop_breaker;
@@ -1077,6 +1078,9 @@ pub(crate) async fn run_agent_loop(
     // Set when a new user message interrupts the turn — the turn should
     // exit quietly without emitting exhaustion warnings or fallback text.
     let mut was_interrupted = false;
+    // How many times we nudged the model for producing an intermediate ack
+    // ("I'll look into it...") instead of calling tools.
+    let mut ack_nudge_count: usize = 0;
     // ── Token & thinking metrics for UsageUpdate (#303) ──────────────
     // These are *cumulative* across all iterations within the turn.
     // `cumulative_output_tokens` sums completion_tokens from every iteration;
@@ -1751,6 +1755,31 @@ pub(crate) async fn run_agent_loop(
             );
             tool_defs = vec![];
             in_llm_error_recovery = true;
+            continue;
+        }
+
+        // Anti-laziness: detect intermediate ack ("I'll look into it...")
+        // and nudge the model to actually call tools instead of stopping.
+        // Aligned with hermes-agent _looks_like_codex_intermediate_ack.
+        if !has_tool_calls
+            && !in_llm_error_recovery
+            && ack_nudge_count < ack_detector::MAX_ACK_NUDGES
+            && ack_detector::looks_like_intermediate_ack(&accumulated_text, &messages)
+        {
+            ack_nudge_count += 1;
+            warn!(
+                iteration,
+                ack_nudge_count,
+                text_preview = %accumulated_text.chars().take(80).collect::<String>(),
+                "intermediate ack detected, nudging model to take action"
+            );
+            // Keep the ack as an intermediate assistant message so the model
+            // sees its own plan in context. Aligned with hermes: append
+            // assistant msg with finish_reason="incomplete", then user nudge.
+            messages.push(llm::Message::assistant(accumulated_text.clone()));
+            messages.push(llm::Message::user(
+                ack_detector::ACK_NUDGE_MESSAGE.to_string(),
+            ));
             continue;
         }
 

--- a/crates/kernel/src/agent/mod.rs
+++ b/crates/kernel/src/agent/mod.rs
@@ -2858,8 +2858,10 @@ pub(crate) async fn run_agent_loop(
         // hermes-agent _budget_grace_call.
         if iteration == max_iterations - 1
             && !budget_grace_injected
+            && !stopped_by_limit
             && tool_calls_made > 0
             && last_accumulated_text.is_empty()
+            && max_iterations >= 5
         {
             budget_grace_injected = true;
             warn!(

--- a/crates/kernel/src/agent/mod.rs
+++ b/crates/kernel/src/agent/mod.rs
@@ -1773,13 +1773,30 @@ pub(crate) async fn run_agent_loop(
                 text_preview = %accumulated_text.chars().take(80).collect::<String>(),
                 "intermediate ack detected, nudging model to take action"
             );
-            // Keep the ack as an intermediate assistant message so the model
-            // sees its own plan in context. Aligned with hermes: append
-            // assistant msg with finish_reason="incomplete", then user nudge.
-            messages.push(llm::Message::assistant(accumulated_text.clone()));
-            messages.push(llm::Message::user(
-                ack_detector::ACK_NUDGE_MESSAGE.to_string(),
-            ));
+            // Persist intermediate assistant text to tape so the model sees
+            // its own plan in context after rebuild. Aligned with hermes:
+            // append assistant msg with finish_reason="incomplete".
+            let _ = tape
+                .append_message(
+                    tape_name,
+                    serde_json::json!({
+                        "role": "assistant",
+                        "content": &accumulated_text,
+                    }),
+                    None,
+                )
+                .await;
+            // Persist nudge to tape so it survives the message rebuild.
+            let _ = tape
+                .append_message(
+                    tape_name,
+                    serde_json::json!({
+                        "role": "user",
+                        "content": ack_detector::ACK_NUDGE_MESSAGE,
+                    }),
+                    None,
+                )
+                .await;
             continue;
         }
 

--- a/crates/kernel/src/agent/mod.rs
+++ b/crates/kernel/src/agent/mod.rs
@@ -1081,6 +1081,10 @@ pub(crate) async fn run_agent_loop(
     // How many times we nudged the model for producing an intermediate ack
     // ("I'll look into it...") instead of calling tools.
     let mut ack_nudge_count: usize = 0;
+    // Budget grace call: when max_iterations is about to be exhausted, inject
+    // a summarize nudge and give the model one more chance. Aligned with
+    // hermes-agent _budget_grace_call.
+    let mut budget_grace_injected = false;
     // ── Token & thinking metrics for UsageUpdate (#303) ──────────────
     // These are *cumulative* across all iterations within the turn.
     // `cumulative_output_tokens` sums completion_tokens from every iteration;
@@ -1110,7 +1114,13 @@ pub(crate) async fn run_agent_loop(
         None
     };
 
-    for iteration in 0..max_iterations {
+    // +1 for potential budget grace call (only consumed if grace is injected).
+    for iteration in 0..=max_iterations {
+        // Hard cap: the grace iteration is only allowed if we injected the
+        // grace nudge on the previous iteration. Otherwise stop.
+        if iteration >= max_iterations && !budget_grace_injected {
+            break;
+        }
         // Check interrupt flag — a new user message arrived while this turn
         // was running. Break early so the kernel can drain the pause buffer
         // and start a new turn with the latest message.
@@ -2840,6 +2850,40 @@ pub(crate) async fn run_agent_loop(
                 stage: format!("Processing... ({tool_calls_made} steps completed)"),
             });
             last_progress_at = Instant::now();
+        }
+
+        // Budget grace call: if this is the last normal iteration and the
+        // model has been calling tools (no text-only response yet), inject
+        // a summarize nudge and allow one more iteration. Aligned with
+        // hermes-agent _budget_grace_call.
+        if iteration == max_iterations - 1
+            && !budget_grace_injected
+            && tool_calls_made > 0
+            && last_accumulated_text.is_empty()
+        {
+            budget_grace_injected = true;
+            warn!(
+                iteration,
+                tool_calls_made, "budget nearly exhausted, injecting grace call to summarize"
+            );
+            let grace_msg = "[System: Your tool budget is almost exhausted. Summarize the \
+                             information and actions you have completed so far. Do not call more \
+                             tools.]";
+            let _ = tape
+                .append_message(
+                    tape_name,
+                    serde_json::json!({
+                        "role": "user",
+                        "content": grace_msg,
+                    }),
+                    None,
+                )
+                .await;
+            stream_handle.emit(StreamEvent::Progress {
+                stage: "Budget nearly exhausted — requesting summary...".to_string(),
+            });
+            // Disable tools for the grace iteration so the model must respond with text.
+            tool_defs = vec![];
         }
     }
 


### PR DESCRIPTION
## Summary

Runtime detection of lazy LLM "ack" responses, aligned with hermes-agent's `_looks_like_codex_intermediate_ack`. When the model says "I'll look into it..." instead of calling tools, the agent loop injects a nudge forcing action.

Alignment with hermes:
- History check: skip if any tool results exist in messages
- Intermediate assistant message preserved in context
- Nudge text: `[System: Continue now. Execute the required tool calls...]`
- Max 2 nudges per turn
- Length cap: 1200 chars

Rara extensions: Chinese ack patterns, workspace markers omitted (always in workspace context).

## Type of change

| Type | Label |
|------|-------|
| New feature | `enhancement` |

## Component

`core`

## Closes

Closes #1329

## Test plan

- [x] 8 unit tests covering EN/CN ack detection, tool history skip, length cap
- [x] `cargo test -p rara-kernel` passes
- [x] Pre-commit hooks pass