### PR TITLE
fix(kernel): ack detector now catches mid-turn planning responses (#1332)

### DIFF
--- a/crates/kernel/src/agent/ack_detector.rs
+++ b/crates/kernel/src/agent/ack_detector.rs
@@ -19,7 +19,7 @@
 //! a nudge forcing the model to act. The ack message is kept in context
 //! (marked as intermediate) so the model sees its own plan.
 //!
-//! Aligned with hermes-agent `_looks_like_codex_intermediate_ack`.
+//! Pattern sources: hermes-agent, Logos (GregsGreyCode), Mullet (tomgould).
 
 use std::sync::OnceLock;
 
@@ -33,15 +33,21 @@ use crate::llm;
 const MAX_ACK_LENGTH_CHARS: usize = 1200;
 
 /// Compiled regex for English future-ack phrases with word boundaries.
-/// Aligned with hermes: `re.search(r"\b(i['']ll|i will|let me|i can do that|i
-/// can help with that)\b", text)`
+/// Sources: hermes original + Logos (`i'm going to`) + Mullet (`i need to`,
+/// `i should`, `allow me to`). `let's` is checked via substring (below)
+/// because the apostrophe breaks `\b` matching.
 fn future_ack_regex() -> &'static Regex {
     static RE: OnceLock<Regex> = OnceLock::new();
     RE.get_or_init(|| {
-        Regex::new(r"(?i)\b(i[''\u{2019}]ll|i will|let me|i can do that|i can help with that)\b")
-            .expect("ack regex must compile")
+        Regex::new(
+            r"(?i)\b(i[''\u{2019}]ll|i will|let me|i can do that|i can help with that|i[''\u{2019}]m going to|i need to|i should|allow me to)\b",
+        )
+        .expect("ack regex must compile")
     })
 }
+
+/// English ack phrases that contain apostrophes and can't use `\b` reliably.
+const ENGLISH_ACK_SUBSTRINGS: &[&str] = &["let's", "let\u{2019}s"];
 
 /// Chinese future-ack phrases (no word boundaries needed — CJK has no spaces).
 const CHINESE_ACK_PATTERNS: &[&str] = &[
@@ -59,8 +65,11 @@ const CHINESE_ACK_PATTERNS: &[&str] = &[
     "接下来我",
 ];
 
-/// Action verbs confirming described future work. Aligned with hermes.
+/// Action verbs confirming described future work.
+/// Sources: hermes (19) + Logos (`try`, `attempt`) + Mullet + common LLM
+/// patterns.
 const ACTION_MARKERS: &[&str] = &[
+    // hermes original
     "look into",
     "look at",
     "inspect",
@@ -80,8 +89,25 @@ const ACTION_MARKERS: &[&str] = &[
     "walkthrough",
     "report back",
     "summarize",
+    // Logos additions
+    "try",
+    "attempt",
     "investigate",
     "examine",
+    // Common LLM output patterns
+    "modify",
+    "update",
+    "create",
+    "write",
+    "implement",
+    "diagnose",
+    "verify",
+    "build",
+    "execute",
+    "set up",
+    "trace",
+    "refactor",
+    "compile",
     // Chinese — rara extension
     "查看",
     "查实",
@@ -92,6 +118,38 @@ const ACTION_MARKERS: &[&str] = &[
     "搜索",
     "修复",
     "测试",
+    "编写",
+    "构建",
+    "实现",
+    "排查",
+    "验证",
+];
+
+/// Result phrases that indicate the model is giving an answer, not planning.
+/// Adapted from Mullet's result_phrases — if any of these appear, the
+/// response is genuine even if it also contains ack/action words.
+const RESULT_PHRASES: &[&str] = &[
+    // English
+    "here is",
+    "here are",
+    "the answer",
+    "the result",
+    "i found",
+    "it shows",
+    "the output is",
+    "the error is",
+    "the issue is",
+    "the problem is",
+    "the fix is",
+    // Chinese
+    "结果是",
+    "问题是",
+    "原因是",
+    "找到了",
+    "已经",
+    "完成了",
+    "成功了",
+    "错误是",
 ];
 
 /// Strip `<think>...</think>` blocks from assistant text before detection.
@@ -108,22 +166,18 @@ fn strip_think_blocks(text: &str) -> String {
 /// Check whether an assistant response is an intermediate ack that should
 /// be nudged instead of ending the turn.
 ///
-/// Based on hermes-agent `_looks_like_codex_intermediate_ack`, adapted for
-/// rara's tape-driven architecture:
+/// Based on hermes-agent `_looks_like_codex_intermediate_ack`, with patterns
+/// expanded from Logos and Mullet forks, and adapted for rara:
+///
 /// 1. Strip `<think>` blocks (reasoning shouldn't trigger detection).
 /// 2. If the last message is a tool result, the model is summarizing tool
 ///    output — that's a genuine answer, not laziness.
-/// 3. Short text (≤1200 chars) with a future-tense phrase (word-boundary
+/// 3. If response contains result phrases ("here is", "i found"), it's a
+///    genuine answer even if it also mentions future actions.
+/// 4. Short text (≤1200 chars) with a future-tense phrase (word-boundary
 ///    matched for English, substring for Chinese) + action verb = lazy ack.
 ///
-/// **Divergence from hermes**: hermes checks `any(role == "tool")` which
-/// disables detection after the first tool call ever. This misses the common
-/// scenario where the agent calls tools for several iterations then produces
-/// a planning response instead of continuing. We check the *last* message
-/// instead: tool result at tail = genuine summary; anything else = may be lazy.
-///
-/// Workspace markers from hermes are omitted because rara always operates
-/// in a workspace context (personal agent, not general chat).
+/// Workspace markers from hermes are omitted (rara is always in workspace).
 pub fn looks_like_intermediate_ack(assistant_text: &str, messages: &[llm::Message]) -> bool {
     // If the last message is a tool result, the model is responding to tool
     // output — that's a genuine summary, not laziness. Skip detection.
@@ -133,7 +187,7 @@ pub fn looks_like_intermediate_ack(assistant_text: &str, messages: &[llm::Messag
         }
     }
 
-    // hermes: `self._strip_think_blocks(assistant_content or "").strip().lower()`
+    // Strip think blocks, then check length.
     let stripped = strip_think_blocks(assistant_text);
     let text = stripped.trim();
     if text.is_empty() || text.chars().count() > MAX_ACK_LENGTH_CHARS {
@@ -142,21 +196,25 @@ pub fn looks_like_intermediate_ack(assistant_text: &str, messages: &[llm::Messag
 
     let lower = text.to_lowercase();
 
-    // hermes: `re.search(r"\b(i['']ll|i will|let me|...)\b", assistant_text)`
-    // Word-boundary regex for English, substring match for Chinese.
+    // Result phrase exclusion (Mullet): if the response already contains
+    // result indicators, it's a genuine answer — not a lazy ack.
+    if RESULT_PHRASES.iter().any(|rp| lower.contains(rp)) {
+        return false;
+    }
+
+    // Future-ack detection: word-boundary regex for English, substring for Chinese.
     let has_future_ack = future_ack_regex().is_match(&lower)
+        || ENGLISH_ACK_SUBSTRINGS.iter().any(|p| lower.contains(p))
         || CHINESE_ACK_PATTERNS.iter().any(|p| lower.contains(p));
     if !has_future_ack {
         return false;
     }
 
-    // hermes: `any(marker in assistant_text for marker in action_markers)`
+    // Action marker: confirms the model is describing future work.
     ACTION_MARKERS.iter().any(|marker| lower.contains(marker))
 }
 
 /// Nudge message injected after an ack is detected.
-/// Aligned with hermes: `"[System: Continue now. Execute the required tool
-/// calls and only send your final answer after completing the task.]"`
 pub const ACK_NUDGE_MESSAGE: &str = "[System: Continue now. Execute the required tool calls and \
                                      only send your final answer after completing the task.]";
 
@@ -169,7 +227,6 @@ mod tests {
 
     fn empty_messages() -> Vec<llm::Message> { vec![] }
 
-    /// Last message is a tool result — model is summarizing.
     fn messages_ending_with_tool_result() -> Vec<llm::Message> {
         vec![
             llm::Message::user("hello".to_string()),
@@ -177,7 +234,6 @@ mod tests {
         ]
     }
 
-    /// Tool results exist but last message is user text — model may be lazy.
     fn messages_with_tools_then_user() -> Vec<llm::Message> {
         vec![
             llm::Message::user("hello".to_string()),
@@ -186,6 +242,8 @@ mod tests {
             llm::Message::user("ok now fix it".to_string()),
         ]
     }
+
+    // --- Positive detections ---
 
     #[test]
     fn detects_english_planning_ack() {
@@ -204,20 +262,76 @@ mod tests {
     }
 
     #[test]
-    fn ignores_when_last_msg_is_tool_result() {
-        assert!(!looks_like_intermediate_ack(
-            "I'll look into the build failure.",
-            &messages_ending_with_tool_result(),
+    fn detects_ack_after_tools_when_last_msg_is_user() {
+        assert!(looks_like_intermediate_ack(
+            "I'll look into the build failure and check the logs.",
+            &messages_with_tools_then_user(),
         ));
     }
 
     #[test]
-    fn detects_ack_after_tools_when_last_msg_is_user() {
-        // Tools were called earlier, but last message is user text.
-        // Model should act, not plan.
+    fn detects_hermes_style_ack() {
         assert!(looks_like_intermediate_ack(
-            "I'll look into the build failure and check the logs.",
-            &messages_with_tools_then_user(),
+            "I can help with that. Let me search the codebase and report back.",
+            &empty_messages(),
+        ));
+    }
+
+    #[test]
+    fn detects_polite_ack() {
+        assert!(looks_like_intermediate_ack(
+            "好的，我来帮你查看一下这个问题",
+            &empty_messages(),
+        ));
+    }
+
+    #[test]
+    fn detects_next_step_chinese_ack() {
+        assert!(looks_like_intermediate_ack(
+            "我下一步会直接从这些官方文档里把触发机制查实",
+            &empty_messages(),
+        ));
+    }
+
+    #[test]
+    fn detects_logos_going_to_pattern() {
+        assert!(looks_like_intermediate_ack(
+            "I'm going to investigate the test failures.",
+            &empty_messages(),
+        ));
+    }
+
+    #[test]
+    fn detects_mullet_need_to_pattern() {
+        assert!(looks_like_intermediate_ack(
+            "I need to check the configuration file first.",
+            &empty_messages(),
+        ));
+    }
+
+    #[test]
+    fn detects_lets_pattern() {
+        assert!(looks_like_intermediate_ack(
+            "Let's examine the build logs and trace the deployment.",
+            &empty_messages(),
+        ));
+    }
+
+    #[test]
+    fn strip_think_preserves_visible_ack() {
+        assert!(looks_like_intermediate_ack(
+            "<think>reasoning here</think>Let me check the build logs.",
+            &empty_messages(),
+        ));
+    }
+
+    // --- Negative detections (should NOT trigger) ---
+
+    #[test]
+    fn ignores_when_last_msg_is_tool_result() {
+        assert!(!looks_like_intermediate_ack(
+            "I'll look into the build failure.",
+            &messages_ending_with_tool_result(),
         ));
     }
 
@@ -241,23 +355,6 @@ mod tests {
     }
 
     #[test]
-    fn detects_polite_ack() {
-        assert!(looks_like_intermediate_ack(
-            "好的，我来帮你查看一下这个问题",
-            &empty_messages(),
-        ));
-    }
-
-    #[test]
-    fn detects_hermes_style_ack() {
-        assert!(looks_like_intermediate_ack(
-            "I can help with that. Let me search the codebase and report back.",
-            &empty_messages(),
-        ));
-    }
-
-    // Word boundary: "filled" should NOT match "i'll"
-    #[test]
     fn word_boundary_no_false_positive() {
         assert!(!looks_like_intermediate_ack(
             "I filled the test report and checked the results.",
@@ -265,7 +362,6 @@ mod tests {
         ));
     }
 
-    // Think blocks stripped before detection
     #[test]
     fn ignores_ack_inside_think_block() {
         assert!(!looks_like_intermediate_ack(
@@ -274,18 +370,19 @@ mod tests {
         ));
     }
 
+    // Result phrase exclusion (Mullet)
     #[test]
-    fn detects_next_step_chinese_ack() {
-        assert!(looks_like_intermediate_ack(
-            "我下一步会直接从这些官方文档里把触发机制查实",
+    fn ignores_response_with_result_phrase() {
+        assert!(!looks_like_intermediate_ack(
+            "I'll summarize what I found. Here is the configuration issue.",
             &empty_messages(),
         ));
     }
 
     #[test]
-    fn strip_think_preserves_visible_ack() {
-        assert!(looks_like_intermediate_ack(
-            "<think>reasoning here</think>Let me check the build logs.",
+    fn ignores_chinese_result_response() {
+        assert!(!looks_like_intermediate_ack(
+            "让我总结一下，问题是配置文件缺少必要字段",
             &empty_messages(),
         ));
     }

--- a/crates/kernel/src/agent/ack_detector.rs
+++ b/crates/kernel/src/agent/ack_detector.rs
@@ -12,14 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Runtime detection of lazy LLM "ack" responses.
+//! Runtime detection of lazy LLM responses.
 //!
-//! When the LLM produces a planning message ("I'll look into this...",
-//! "让我检查一下...") instead of calling tools, the agent loop injects
-//! a nudge forcing the model to act. The ack message is kept in context
-//! (marked as intermediate) so the model sees its own plan.
+//! Catches 4 categories of laziness:
+//! 1. **Planning ack** — "I'll look into it..." (hermes/Logos/Mullet)
+//! 2. **Permission seeking** — "Would you like me to..." "Should I..."
+//! 3. **Self-narration** — "Here's my plan..." "The approach is..."
+//! 4. **Deferral** — "In the next step..." "After that..."
 //!
-//! Pattern sources: hermes-agent, Logos (GregsGreyCode), Mullet (tomgould).
+//! Pattern sources: hermes-agent, Logos, Mullet, Omegon, aider, Cursor,
+//! SLOP_Detector, stop-slop, and real-world rara logs.
 
 use std::sync::OnceLock;
 
@@ -29,28 +31,99 @@ use crate::llm;
 
 /// Maximum assistant response length (chars) to consider.
 /// Longer responses are likely substantive, not lazy acks.
-/// Aligned with hermes (1200 chars).
 const MAX_ACK_LENGTH_CHARS: usize = 1200;
 
-/// Compiled regex for English future-ack phrases with word boundaries.
-/// Sources: hermes original + Logos (`i'm going to`) + Mullet (`i need to`,
-/// `i should`, `allow me to`). `let's` is checked via substring (below)
-/// because the apostrophe breaks `\b` matching.
+// ---------------------------------------------------------------------------
+// Category 1: Future-tense planning ("I'll...", "Let me...")
+// Sources: hermes, Logos, Mullet
+// ---------------------------------------------------------------------------
+
+/// English future-ack regex with word boundaries.
 fn future_ack_regex() -> &'static Regex {
     static RE: OnceLock<Regex> = OnceLock::new();
     RE.get_or_init(|| {
-        Regex::new(
-            r"(?i)\b(i[''\u{2019}]ll|i will|let me|i can do that|i can help with that|i[''\u{2019}]m going to|i need to|i should|allow me to)\b",
-        )
-        .expect("ack regex must compile")
+        Regex::new(concat!(
+            r"(?i)\b(",
+            // hermes original
+            r"i[''\u{2019}]ll",
+            r"|i will",
+            r"|let me",
+            r"|i can do that",
+            r"|i can help with that",
+            // Logos
+            r"|i[''\u{2019}]m going to",
+            // Mullet
+            r"|i need to",
+            r"|i should",
+            r"|allow me to",
+            // Common LLM patterns
+            r"|i[''\u{2019}]d like to",
+            r"|i[''\u{2019}]d want to",
+            r"|to start,? i",
+            r"|first,? i",
+            r")\b",
+        ))
+        .expect("future_ack regex must compile")
     })
 }
 
-/// English ack phrases that contain apostrophes and can't use `\b` reliably.
+// ---------------------------------------------------------------------------
+// Category 2: Permission seeking ("Should I...", "Would you like me to...")
+// Sources: Cursor anti-patterns, real-world rara/GPT logs
+// ---------------------------------------------------------------------------
+
+fn permission_regex() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| {
+        Regex::new(concat!(
+            r"(?i)\b(",
+            r"would you like me to",
+            r"|shall i",
+            r"|should i",
+            r"|do you want me to",
+            r"|want me to",
+            r"|if you[''\u{2019}]d like,? i",
+            r"|if you want,? i",
+            r"|i can .{0,30} if you",
+            r")\b",
+        ))
+        .expect("permission regex must compile")
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Category 3: Self-narration / plan description
+// Sources: Omegon "stop narrating", Cursor, real-world logs
+// ---------------------------------------------------------------------------
+
+fn narration_regex() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| {
+        Regex::new(concat!(
+            r"(?i)\b(",
+            r"here[''\u{2019}]s my plan",
+            r"|here[''\u{2019}]s what i[''\u{2019}]ll do",
+            r"|here[''\u{2019}]s my approach",
+            r"|my plan is to",
+            r"|my approach (is|will be) to",
+            r"|the strategy (is|would be) to",
+            r"|the approach (is|would be) to",
+            r"|the next step (is|would be) to",
+            r"|i[''\u{2019}]m planning to",
+            r"|i plan to",
+            r")\b",
+        ))
+        .expect("narration regex must compile")
+    })
+}
+
+/// English ack phrases that contain apostrophes (can't use `\b` reliably).
 const ENGLISH_ACK_SUBSTRINGS: &[&str] = &["let's", "let\u{2019}s"];
 
-/// Chinese future-ack phrases (no word boundaries needed — CJK has no spaces).
-const CHINESE_ACK_PATTERNS: &[&str] = &[
+/// Chinese lazy patterns — all categories combined.
+/// No word boundaries needed for CJK.
+const CHINESE_LAZY_PATTERNS: &[&str] = &[
+    // Category 1: Future planning
     "让我",
     "我来",
     "我去",
@@ -63,11 +136,39 @@ const CHINESE_ACK_PATTERNS: &[&str] = &[
     "我接下来",
     "下一步我",
     "接下来我",
+    "我打算",
+    "我准备",
+    "我会去",
+    "首先我",
+    // Category 2: Permission seeking
+    "要不要我",
+    "需要我",
+    "要我帮你",
+    "你要我",
+    "你希望我",
+    "你需要我",
+    // Category 3: Self-narration
+    "我的方案是",
+    "我的思路是",
+    "我的计划是",
+    "具体步骤",
+    "方案如下",
+    "思路如下",
+    "计划如下",
+    "步骤如下",
+    // Category 4: Deferral
+    "之后我",
+    "然后我",
+    "接着我",
+    "等一下我",
+    "后续我",
 ];
 
-/// Action verbs confirming described future work.
-/// Sources: hermes (19) + Logos (`try`, `attempt`) + Mullet + common LLM
-/// patterns.
+// ---------------------------------------------------------------------------
+// Action markers — confirms the model is describing work, not giving results
+// ---------------------------------------------------------------------------
+
+/// Action verbs. Sources: hermes (19) + Logos (2) + Mullet + common LLM + CJK.
 const ACTION_MARKERS: &[&str] = &[
     // hermes original
     "look into",
@@ -89,12 +190,12 @@ const ACTION_MARKERS: &[&str] = &[
     "walkthrough",
     "report back",
     "summarize",
-    // Logos additions
+    // Logos
     "try",
     "attempt",
     "investigate",
     "examine",
-    // Common LLM output patterns
+    // Common LLM patterns
     "modify",
     "update",
     "create",
@@ -108,7 +209,21 @@ const ACTION_MARKERS: &[&str] = &[
     "trace",
     "refactor",
     "compile",
-    // Chinese — rara extension
+    "deploy",
+    "configure",
+    "install",
+    "migrate",
+    "resolve",
+    "troubleshoot",
+    "address",
+    "handle",
+    "patch",
+    "adjust",
+    "optimize",
+    "clean up",
+    "restructure",
+    "rewrite",
+    // Chinese
     "查看",
     "查实",
     "检查",
@@ -123,38 +238,69 @@ const ACTION_MARKERS: &[&str] = &[
     "实现",
     "排查",
     "验证",
+    "部署",
+    "配置",
+    "迁移",
+    "优化",
+    "重构",
+    "处理",
+    "解决",
+    "调整",
+    "梳理",
+    "整理",
 ];
 
-/// Result phrases that indicate the model is giving an answer, not planning.
-/// Adapted from Mullet's result_phrases — if any of these appear, the
-/// response is genuine even if it also contains ack/action words.
+// ---------------------------------------------------------------------------
+// Result phrases — genuine answers, NOT laziness (Mullet pattern)
+// ---------------------------------------------------------------------------
+
 const RESULT_PHRASES: &[&str] = &[
     // English
     "here is",
     "here are",
-    "the answer",
-    "the result",
-    "i found",
+    "the answer is",
+    "the result is",
+    "i found that",
+    "i found the",
     "it shows",
     "the output is",
     "the error is",
     "the issue is",
     "the problem is",
     "the fix is",
+    "the root cause",
+    "this is because",
+    "this happens because",
+    "the reason is",
+    "i've completed",
+    "i've finished",
+    "i've fixed",
+    "i've updated",
+    "done.",
+    "done!",
+    "all set",
+    "successfully",
     // Chinese
     "结果是",
     "问题是",
     "原因是",
     "找到了",
-    "已经",
+    "已经完成",
+    "已经修复",
+    "已经更新",
     "完成了",
     "成功了",
+    "搞定了",
     "错误是",
+    "根因是",
+    "这是因为",
+    "弄好了",
 ];
 
-/// Strip `<think>...</think>` blocks from assistant text before detection.
-/// Aligned with hermes `_strip_think_blocks` — reasoning content should
-/// not trigger ack detection.
+// ---------------------------------------------------------------------------
+// Think-block stripping
+// ---------------------------------------------------------------------------
+
 fn strip_think_blocks(text: &str) -> String {
     static RE: OnceLock<Regex> = OnceLock::new();
     let re = RE.get_or_init(|| {
@@ -163,31 +309,28 @@ fn strip_think_blocks(text: &str) -> String {
     re.replace_all(text, "").to_string()
 }
 
-/// Check whether an assistant response is an intermediate ack that should
-/// be nudged instead of ending the turn.
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/// Check whether an assistant response is a lazy ack/hedge/narration that
+/// should be nudged instead of ending the turn.
 ///
-/// Based on hermes-agent `_looks_like_codex_intermediate_ack`, with patterns
-/// expanded from Logos and Mullet forks, and adapted for rara:
-///
-/// 1. Strip `<think>` blocks (reasoning shouldn't trigger detection).
-/// 2. If the last message is a tool result, the model is summarizing tool
-///    output — that's a genuine answer, not laziness.
-/// 3. If response contains result phrases ("here is", "i found"), it's a
-///    genuine answer even if it also mentions future actions.
-/// 4. Short text (≤1200 chars) with a future-tense phrase (word-boundary
-///    matched for English, substring for Chinese) + action verb = lazy ack.
-///
-/// Workspace markers from hermes are omitted (rara is always in workspace).
+/// Detection flow:
+/// 1. Skip if last message is a tool result (model is summarizing — genuine).
+/// 2. Strip `<think>` blocks. Check length ≤ 1200 chars.
+/// 3. Skip if response contains result phrases (genuine answer).
+/// 4. Match against 4 laziness categories (future-ack, permission, narration,
+///    CJK).
+/// 5. Require an action marker to confirm the model is describing work.
 pub fn looks_like_intermediate_ack(assistant_text: &str, messages: &[llm::Message]) -> bool {
-    // If the last message is a tool result, the model is responding to tool
-    // output — that's a genuine summary, not laziness. Skip detection.
+    // Genuine summary: last message is a tool result.
     if let Some(last) = messages.last() {
         if matches!(last.role, llm::Role::Tool) {
             return false;
         }
     }
 
-    // Strip think blocks, then check length.
     let stripped = strip_think_blocks(assistant_text);
     let text = stripped.trim();
     if text.is_empty() || text.chars().count() > MAX_ACK_LENGTH_CHARS {
@@ -196,169 +339,253 @@ pub fn looks_like_intermediate_ack(assistant_text: &str, messages: &[llm::Messag
 
     let lower = text.to_lowercase();
 
-    // Result phrase exclusion (Mullet): if the response already contains
-    // result indicators, it's a genuine answer — not a lazy ack.
+    // Result phrase exclusion: genuine answers pass through.
     if RESULT_PHRASES.iter().any(|rp| lower.contains(rp)) {
         return false;
     }
 
-    // Future-ack detection: word-boundary regex for English, substring for Chinese.
-    let has_future_ack = future_ack_regex().is_match(&lower)
+    // Match any laziness category.
+    let is_lazy = future_ack_regex().is_match(&lower)
+        || permission_regex().is_match(&lower)
+        || narration_regex().is_match(&lower)
         || ENGLISH_ACK_SUBSTRINGS.iter().any(|p| lower.contains(p))
-        || CHINESE_ACK_PATTERNS.iter().any(|p| lower.contains(p));
-    if !has_future_ack {
+        || CHINESE_LAZY_PATTERNS.iter().any(|p| lower.contains(p));
+    if !is_lazy {
         return false;
     }
 
-    // Action marker: confirms the model is describing future work.
+    // Require action marker to confirm it's about work, not small talk.
     ACTION_MARKERS.iter().any(|marker| lower.contains(marker))
 }
 
-/// Nudge message injected after an ack is detected.
-pub const ACK_NUDGE_MESSAGE: &str = "[System: Continue now. Execute the required tool calls and \
-                                     only send your final answer after completing the task.]";
+/// Nudge message injected after laziness is detected.
+pub const ACK_NUDGE_MESSAGE: &str = "[System: You described what you intend to do but did not \
+                                     call any tools. Use your tools now to complete the task. Do \
+                                     not narrate — act.]";
 
-/// Maximum ack nudges per turn (hermes: `codex_ack_continuations < 2`).
+/// Maximum nudges per turn.
 pub const MAX_ACK_NUDGES: usize = 2;
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    fn empty_messages() -> Vec<llm::Message> { vec![] }
+    fn empty() -> Vec<llm::Message> { vec![] }
 
-    fn messages_ending_with_tool_result() -> Vec<llm::Message> {
+    fn after_tool() -> Vec<llm::Message> {
         vec![
             llm::Message::user("hello".to_string()),
-            llm::Message::tool_result("call_1", "result"),
+            llm::Message::tool_result("c1", "result"),
         ]
     }
 
-    fn messages_with_tools_then_user() -> Vec<llm::Message> {
+    fn after_user() -> Vec<llm::Message> {
         vec![
             llm::Message::user("hello".to_string()),
-            llm::Message::tool_result("call_1", "result"),
+            llm::Message::tool_result("c1", "result"),
             llm::Message::assistant("I found the file.".to_string()),
             llm::Message::user("ok now fix it".to_string()),
         ]
     }
 
-    // --- Positive detections ---
+    // ── Category 1: Future-tense planning ──
 
     #[test]
-    fn detects_english_planning_ack() {
+    fn hermes_ill_look() {
         assert!(looks_like_intermediate_ack(
             "I'll look into the build failure and check the logs.",
-            &empty_messages(),
+            &empty(),
         ));
     }
 
     #[test]
-    fn detects_chinese_planning_ack() {
-        assert!(looks_like_intermediate_ack(
-            "让我检查一下构建日志",
-            &empty_messages()
-        ));
-    }
-
-    #[test]
-    fn detects_ack_after_tools_when_last_msg_is_user() {
-        assert!(looks_like_intermediate_ack(
-            "I'll look into the build failure and check the logs.",
-            &messages_with_tools_then_user(),
-        ));
-    }
-
-    #[test]
-    fn detects_hermes_style_ack() {
+    fn hermes_let_me() {
         assert!(looks_like_intermediate_ack(
             "I can help with that. Let me search the codebase and report back.",
-            &empty_messages(),
+            &empty(),
         ));
     }
 
     #[test]
-    fn detects_polite_ack() {
-        assert!(looks_like_intermediate_ack(
-            "好的，我来帮你查看一下这个问题",
-            &empty_messages(),
-        ));
-    }
-
-    #[test]
-    fn detects_next_step_chinese_ack() {
-        assert!(looks_like_intermediate_ack(
-            "我下一步会直接从这些官方文档里把触发机制查实",
-            &empty_messages(),
-        ));
-    }
-
-    #[test]
-    fn detects_logos_going_to_pattern() {
+    fn logos_going_to() {
         assert!(looks_like_intermediate_ack(
             "I'm going to investigate the test failures.",
-            &empty_messages(),
+            &empty(),
         ));
     }
 
     #[test]
-    fn detects_mullet_need_to_pattern() {
+    fn mullet_need_to() {
         assert!(looks_like_intermediate_ack(
             "I need to check the configuration file first.",
-            &empty_messages(),
+            &empty(),
         ));
     }
 
     #[test]
-    fn detects_lets_pattern() {
+    fn mullet_lets() {
         assert!(looks_like_intermediate_ack(
             "Let's examine the build logs and trace the deployment.",
-            &empty_messages(),
+            &empty(),
         ));
     }
 
     #[test]
-    fn strip_think_preserves_visible_ack() {
+    fn id_like_to() {
         assert!(looks_like_intermediate_ack(
-            "<think>reasoning here</think>Let me check the build logs.",
-            &empty_messages(),
+            "I'd like to review the database migrations first.",
+            &empty(),
         ));
     }
 
-    // --- Negative detections (should NOT trigger) ---
+    #[test]
+    fn chinese_let_me() {
+        assert!(looks_like_intermediate_ack(
+            "让我检查一下构建日志",
+            &empty()
+        ));
+    }
+
+    #[test]
+    fn chinese_next_step() {
+        assert!(looks_like_intermediate_ack(
+            "我下一步会直接从这些官方文档里把触发机制查实",
+            &empty(),
+        ));
+    }
+
+    #[test]
+    fn chinese_polite() {
+        assert!(looks_like_intermediate_ack(
+            "好的，我来帮你查看一下这个问题",
+            &empty(),
+        ));
+    }
+
+    #[test]
+    fn chinese_plan_to() {
+        assert!(looks_like_intermediate_ack(
+            "我打算先检查一下配置文件",
+            &empty()
+        ));
+    }
+
+    // ── Category 2: Permission seeking ──
+
+    #[test]
+    fn would_you_like() {
+        assert!(looks_like_intermediate_ack(
+            "Would you like me to check the error logs?",
+            &empty(),
+        ));
+    }
+
+    #[test]
+    fn shall_i() {
+        assert!(looks_like_intermediate_ack(
+            "Shall I investigate the test failure?",
+            &empty(),
+        ));
+    }
+
+    #[test]
+    fn should_i() {
+        assert!(looks_like_intermediate_ack(
+            "Should I run the tests to verify?",
+            &empty(),
+        ));
+    }
+
+    #[test]
+    fn chinese_permission() {
+        assert!(looks_like_intermediate_ack(
+            "要不要我帮你检查一下这个问题？",
+            &empty(),
+        ));
+    }
+
+    // ── Category 3: Self-narration ──
+
+    #[test]
+    fn heres_my_plan() {
+        assert!(looks_like_intermediate_ack(
+            "Here's my plan: first I'll read the config, then run the tests.",
+            &empty(),
+        ));
+    }
+
+    #[test]
+    fn my_approach_is() {
+        assert!(looks_like_intermediate_ack(
+            "My approach is to investigate the failing module and fix the imports.",
+            &empty(),
+        ));
+    }
+
+    #[test]
+    fn chinese_approach() {
+        assert!(looks_like_intermediate_ack(
+            "我的思路是先排查配置文件的问题",
+            &empty(),
+        ));
+    }
+
+    #[test]
+    fn chinese_steps() {
+        assert!(looks_like_intermediate_ack(
+            "具体步骤如下：第一步检查日志，第二步修复配置",
+            &empty(),
+        ));
+    }
+
+    // ── Mid-turn detection (tools called earlier, model still lazy) ──
+
+    #[test]
+    fn detects_after_tools_when_last_msg_is_user() {
+        assert!(looks_like_intermediate_ack(
+            "I'll look into the build failure and check the logs.",
+            &after_user(),
+        ));
+    }
+
+    // ── Negative: should NOT trigger ──
 
     #[test]
     fn ignores_when_last_msg_is_tool_result() {
         assert!(!looks_like_intermediate_ack(
             "I'll look into the build failure.",
-            &messages_ending_with_tool_result(),
+            &after_tool(),
         ));
     }
 
     #[test]
-    fn ignores_long_substantive_response() {
-        let long_text = "I'll analyze this. ".repeat(200);
-        assert!(!looks_like_intermediate_ack(&long_text, &empty_messages()));
+    fn ignores_long_response() {
+        let long = "I'll analyze this. ".repeat(200);
+        assert!(!looks_like_intermediate_ack(&long, &empty()));
     }
 
     #[test]
     fn ignores_genuine_answer() {
         assert!(!looks_like_intermediate_ack(
             "The build succeeded. All 42 tests passed.",
-            &empty_messages(),
+            &empty(),
         ));
     }
 
     #[test]
     fn ignores_empty() {
-        assert!(!looks_like_intermediate_ack("", &empty_messages()));
+        assert!(!looks_like_intermediate_ack("", &empty()));
     }
 
     #[test]
     fn word_boundary_no_false_positive() {
         assert!(!looks_like_intermediate_ack(
             "I filled the test report and checked the results.",
-            &empty_messages(),
+            &empty(),
         ));
     }
 
@@ -366,24 +593,49 @@ mod tests {
     fn ignores_ack_inside_think_block() {
         assert!(!looks_like_intermediate_ack(
             "<think>I'll look into this and check the logs.</think>The answer is 42.",
-            &empty_messages(),
+            &empty(),
         ));
     }
 
-    // Result phrase exclusion (Mullet)
     #[test]
-    fn ignores_response_with_result_phrase() {
+    fn think_strip_preserves_visible_ack() {
+        assert!(looks_like_intermediate_ack(
+            "<think>reasoning</think>Let me check the build logs.",
+            &empty(),
+        ));
+    }
+
+    // ── Result phrase exclusion ──
+
+    #[test]
+    fn ignores_response_with_result() {
         assert!(!looks_like_intermediate_ack(
             "I'll summarize what I found. Here is the configuration issue.",
-            &empty_messages(),
+            &empty(),
         ));
     }
 
     #[test]
-    fn ignores_chinese_result_response() {
+    fn ignores_chinese_result() {
         assert!(!looks_like_intermediate_ack(
             "让我总结一下，问题是配置文件缺少必要字段",
-            &empty_messages(),
+            &empty(),
+        ));
+    }
+
+    #[test]
+    fn ignores_completed_action() {
+        assert!(!looks_like_intermediate_ack(
+            "I've fixed the import error and updated the config.",
+            &empty(),
+        ));
+    }
+
+    #[test]
+    fn ignores_chinese_completed() {
+        assert!(!looks_like_intermediate_ack(
+            "已经完成了配置文件的修复，搞定了",
+            &empty(),
         ));
     }
 }

--- a/crates/kernel/src/agent/ack_detector.rs
+++ b/crates/kernel/src/agent/ack_detector.rs
@@ -53,6 +53,10 @@ const CHINESE_ACK_PATTERNS: &[&str] = &[
     "我先",
     "我看看",
     "我查一下",
+    "我下一步",
+    "我接下来",
+    "下一步我",
+    "接下来我",
 ];
 
 /// Action verbs confirming described future work. Aligned with hermes.
@@ -80,7 +84,9 @@ const ACTION_MARKERS: &[&str] = &[
     "examine",
     // Chinese — rara extension
     "查看",
+    "查实",
     "检查",
+    "确认",
     "分析",
     "调试",
     "搜索",
@@ -102,19 +108,29 @@ fn strip_think_blocks(text: &str) -> String {
 /// Check whether an assistant response is an intermediate ack that should
 /// be nudged instead of ending the turn.
 ///
-/// Mirrors hermes-agent `_looks_like_codex_intermediate_ack`:
+/// Based on hermes-agent `_looks_like_codex_intermediate_ack`, adapted for
+/// rara's tape-driven architecture:
 /// 1. Strip `<think>` blocks (reasoning shouldn't trigger detection).
-/// 2. If the conversation already contains tool results, the model has started
-///    working — a text-only follow-up is a genuine answer.
+/// 2. If the last message is a tool result, the model is summarizing tool
+///    output — that's a genuine answer, not laziness.
 /// 3. Short text (≤1200 chars) with a future-tense phrase (word-boundary
 ///    matched for English, substring for Chinese) + action verb = lazy ack.
+///
+/// **Divergence from hermes**: hermes checks `any(role == "tool")` which
+/// disables detection after the first tool call ever. This misses the common
+/// scenario where the agent calls tools for several iterations then produces
+/// a planning response instead of continuing. We check the *last* message
+/// instead: tool result at tail = genuine summary; anything else = may be lazy.
 ///
 /// Workspace markers from hermes are omitted because rara always operates
 /// in a workspace context (personal agent, not general chat).
 pub fn looks_like_intermediate_ack(assistant_text: &str, messages: &[llm::Message]) -> bool {
-    // hermes: `if any(msg.get("role") == "tool" for msg in messages): return False`
-    if messages.iter().any(|m| matches!(m.role, llm::Role::Tool)) {
-        return false;
+    // If the last message is a tool result, the model is responding to tool
+    // output — that's a genuine summary, not laziness. Skip detection.
+    if let Some(last) = messages.last() {
+        if matches!(last.role, llm::Role::Tool) {
+            return false;
+        }
     }
 
     // hermes: `self._strip_think_blocks(assistant_content or "").strip().lower()`
@@ -153,10 +169,21 @@ mod tests {
 
     fn empty_messages() -> Vec<llm::Message> { vec![] }
 
-    fn messages_with_tool_result() -> Vec<llm::Message> {
+    /// Last message is a tool result — model is summarizing.
+    fn messages_ending_with_tool_result() -> Vec<llm::Message> {
         vec![
             llm::Message::user("hello".to_string()),
             llm::Message::tool_result("call_1", "result"),
+        ]
+    }
+
+    /// Tool results exist but last message is user text — model may be lazy.
+    fn messages_with_tools_then_user() -> Vec<llm::Message> {
+        vec![
+            llm::Message::user("hello".to_string()),
+            llm::Message::tool_result("call_1", "result"),
+            llm::Message::assistant("I found the file.".to_string()),
+            llm::Message::user("ok now fix it".to_string()),
         ]
     }
 
@@ -177,10 +204,20 @@ mod tests {
     }
 
     #[test]
-    fn ignores_when_tools_already_called() {
+    fn ignores_when_last_msg_is_tool_result() {
         assert!(!looks_like_intermediate_ack(
             "I'll look into the build failure.",
-            &messages_with_tool_result(),
+            &messages_ending_with_tool_result(),
+        ));
+    }
+
+    #[test]
+    fn detects_ack_after_tools_when_last_msg_is_user() {
+        // Tools were called earlier, but last message is user text.
+        // Model should act, not plan.
+        assert!(looks_like_intermediate_ack(
+            "I'll look into the build failure and check the logs.",
+            &messages_with_tools_then_user(),
         ));
     }
 
@@ -233,6 +270,14 @@ mod tests {
     fn ignores_ack_inside_think_block() {
         assert!(!looks_like_intermediate_ack(
             "<think>I'll look into this and check the logs.</think>The answer is 42.",
+            &empty_messages(),
+        ));
+    }
+
+    #[test]
+    fn detects_next_step_chinese_ack() {
+        assert!(looks_like_intermediate_ack(
+            "我下一步会直接从这些官方文档里把触发机制查实",
             &empty_messages(),
         ));
     }


### PR DESCRIPTION
## Summary

The ack detector from #1329 checked `any(role == tool)` which disabled detection after the first tool call ever. This missed the most common laziness scenario: agent calls tools for several iterations, then produces a planning response ("我下一步会从文档里查实...") instead of continuing.

Changes:
- Check last message role instead of any — tool result at tail = genuine summary, anything else = may be lazy
- Added Chinese ack patterns: 我下一步会, 我接下来, 下一步我, 接下来我
- Added action markers: 查实, 确认

## Type of change

| Type | Label |
|------|-------|
| Bug fix | `bug` |

## Component

`core`

## Closes

Closes #1332

## Test plan

- [x] 13 ack detector unit tests pass (including new mid-turn scenario)
- [x] `cargo test -p rara-kernel` all 411 tests pass
- [x] Pre-commit hooks pass