### PR TITLE
fix(channels): guard streamed_visible_prefix behind actual TG message send (#1334)

### DIFF
--- a/crates/channels/src/telegram/adapter.rs
+++ b/crates/channels/src/telegram/adapter.rs
@@ -1221,8 +1221,18 @@ impl ChannelAdapter for TelegramAdapter {
                     }
 
                     if let Some((_, stream_state)) = self.active_streams.remove(&chat_id) {
-                        streamed_visible_prefix =
-                            Some(strip_tool_call_xml(&stream_state.accumulated));
+                        // Only treat accumulated text as "already displayed" when a
+                        // Telegram message was actually sent. Fast text-only turns
+                        // may close before the throttle tick fires, leaving
+                        // accumulated content that was never shown to the user.
+                        let msg_was_sent = stream_state
+                            .message_ids
+                            .last()
+                            .map_or(false, |id| *id != MessageId(0));
+                        if msg_was_sent {
+                            streamed_visible_prefix =
+                                Some(strip_tool_call_xml(&stream_state.accumulated));
+                        }
                         if let Some(&last_msg_id) = stream_state.message_ids.last() {
                             if last_msg_id != MessageId(0) {
                                 let html =


### PR DESCRIPTION
## Summary

When the agent produces a fast text-only response (common after #1330 ack detection
changes the response rhythm), the Telegram stream forwarder accumulates `TextDelta`
events but the throttle tick never fires — no Telegram message is actually sent.

The Reply handler at `adapter.rs:1224` unconditionally set `streamed_visible_prefix`
from the accumulated buffer, then `slice_after_prefix_if_matches` (line 1273) stripped
the reply content to empty, silently dropping the response. Web channel is unaffected
because it doesn't use the streaming prefix dedup mechanism.

**Fix:** Only set `streamed_visible_prefix` when `message_ids` contains a real
(non-sentinel) message ID, proving the text was actually displayed to the user.

## Type of change

| Type | Label |
|------|-------|
| Bug fix | `bug` |

## Component

`ui`

## Closes

Closes #1334

## Test plan

- [x] `cargo check -p rara-channels` passes
- [x] `cargo clippy` passes
- [x] `cargo fmt` passes
- [x] All pre-commit hooks pass
- [ ] Manual test: send message via Telegram, verify reply arrives