### PR TITLE
feat(kernel): GPT-specific anti-narration prompt + raise ack length to 2000 (#1340)

### DIFF
--- a/crates/kernel/src/agent/ack_detector.rs
+++ b/crates/kernel/src/agent/ack_detector.rs
@@ -30,8 +30,8 @@ use regex::Regex;
 use crate::llm;
 
 /// Maximum assistant response length (chars) to consider.
-/// Longer responses are likely substantive, not lazy acks.
-const MAX_ACK_LENGTH_CHARS: usize = 1200;
+/// GPT models produce verbose planning responses that exceed 1200 chars.
+const MAX_ACK_LENGTH_CHARS: usize = 2000;
 
 // ---------------------------------------------------------------------------
 // Category 1: Future-tense planning ("I'll...", "Let me...")

--- a/crates/kernel/src/agent/mod.rs
+++ b/crates/kernel/src/agent/mod.rs
@@ -987,6 +987,24 @@ pub(crate) async fn run_agent_loop(
 
     tracing::Span::current().record("model", model.as_str());
 
+    // GPT models narrate plans instead of acting. Inject a stronger
+    // constraint when the resolved model is GPT-family.
+    let effective_prompt = if model.contains("gpt") || model.contains("o3") || model.contains("o4")
+    {
+        format!(
+            "{effective_prompt}\n\n## GPT Anti-Narration\n\nCRITICAL: You tend to describe what \
+             you plan to do instead of doing it.\n\nWRONG: \"I'll look into the build failure and \
+             check the logs.\"\nRIGHT: [call read-file on the log file]\n\nWRONG: \"Let me \
+             analyze the configuration...\"\nRIGHT: [call read-file on config.yaml]\n\nWRONG: \
+             \"Here's my plan: 1. Check X  2. Fix Y  3. Test Z\"\nRIGHT: [call the first tool \
+             immediately]\n\nEvery response MUST contain at least one tool call unless you are \
+             directly answering a question. If you catch yourself writing a plan, stop and call a \
+             tool."
+        )
+    } else {
+        effective_prompt
+    };
+
     let mut capabilities = ModelCapabilities::detect(provider_hint, &model);
 
     // Context window priority: manifest override > provider API > default.


### PR DESCRIPTION
## Summary

1. Raise ack detection length from 1200 to 2000 chars — GPT's verbose planning responses bypassed detection.
2. Inject GPT-specific anti-narration into system prompt at runtime (only for gpt/o3/o4 models). Uses WRONG/RIGHT examples. Claude is unaffected.

## Type of change

| Type | Label |
|------|-------|
| New feature | `enhancement` |

## Component

`core`

## Closes

Closes #1340

## Test plan

- [x] `cargo check -p rara-kernel` passes
- [x] Pre-commit hooks pass
- [x] Injection only triggers when model name contains gpt/o3/o4