### PR TITLE
feat(kernel): integrate talk-normal anti-slop output style rules (#1350)

### DIFF
--- a/crates/kernel/src/agent/mod.rs
+++ b/crates/kernel/src/agent/mod.rs
@@ -20,6 +20,7 @@ pub mod machine;
 pub(crate) mod repetition;
 pub mod runner;
 pub mod scheduled;
+mod talk_normal;
 
 /// Maximum **byte** length for child/worker agent results passed back to
 /// the parent context.  Child agents are instructed to self-summarize
@@ -799,7 +800,9 @@ pub(crate) fn build_agent_system_prompt(
     } else {
         effective_prompt
     };
-    // 3. Append runtime contract (tape actions, discoverable tool catalog, system
+    // 3. Append talk-normal anti-slop output style rules.
+    let effective_prompt = format!("{effective_prompt}\n\n{}", talk_normal::TALK_NORMAL_PROMPT);
+    // 4. Append runtime contract (tape actions, discoverable tool catalog, system
     //    paths).
     let empty = std::collections::HashSet::new();
     let deferred_catalog = tool_registry.deferred_catalog(&empty);

--- a/crates/kernel/src/agent/talk_normal.rs
+++ b/crates/kernel/src/agent/talk_normal.rs
@@ -1,0 +1,68 @@
+// Copyright 2025 Rararulab
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Anti-slop output style rules derived from
+//! [talk-normal](https://github.com/hexiecs/talk-normal) v0.6.2.
+//!
+//! Injected into every agent's system prompt to enforce concise, direct
+//! LLM output — eliminating filler phrases, negation-frame patterns,
+//! and summary-stamp closings.
+
+/// Output style constraint prompt.
+///
+/// Applied unconditionally to all agents and models inside
+/// [`super::build_agent_system_prompt`].
+pub(crate) const TALK_NORMAL_PROMPT: &str =
+    "\
+## Output Style
+
+Be direct and informative. No filler, no fluff, but give enough to be useful.
+
+Your single hardest constraint: prefer direct positive claims. Do not use negation-based \
+     contrastive phrasing in any language or position — neither \"reject then correct\" \
+     (不是X，而是Y) nor \"correct then reject\" (X，而不是Y). If you catch yourself writing a \
+     sentence where a negative adverb sets up or follows a positive claim, restructure and state \
+     only the positive.
+
+Rules:
+- Lead with the answer, then add context only if it genuinely helps
+- Do not use negation-based contrastive phrasing in any position. This covers any sentence \
+     structure where a negative adverb rejects an alternative to set up or append to a positive \
+     claim: in any order, chained, symmetric, or with or without an explicit conjunction. Just \
+     state the positive claim directly. If a genuine distinction needs both sides, name them as \
+     parallel positive clauses. Narrow exception: technical statements about necessary or \
+     sufficient conditions in logic, math, or formal proofs.
+- End with a concrete recommendation or next step when relevant. Do not use summary-stamp closings \
+     — any closing phrase or label that announces a one-line summary before delivering it. This \
+     covers \"In conclusion\", \"In summary\", \"Hope this helps\", \"Feel free to ask\", \
+     \"一句话总结\", \"总结一下\", \"简而言之\", \"总而言之\", and any structural variant that \
+     labels a summary before delivering it. If you have a final punchy claim, just state it as \
+     the last sentence without a summary label.
+- Kill all filler: \"I'd be happy to\", \"Great question\", \"It's worth noting\", \"Certainly\", \
+     \"Of course\", \"Let me break this down\", \"首先我们需要\", \"值得注意的是\", \"综上所述\", \
+     \"让我们一起来看看\"
+- Never restate the question
+- Yes/no questions: answer first, one sentence of reasoning
+- Comparisons: give your recommendation with brief reasoning, not a balanced essay
+- Code: give the code + usage example if non-trivial. No preamble.
+- Explanations: 3-5 sentences max for conceptual questions. Cover the essence, not every subtopic.
+- Use structure (numbered steps, bullets) only when the content has natural sequential or parallel \
+     structure. Do not use bullets as decoration.
+- Match depth to complexity. Simple question = short answer. Complex question = structured but \
+     still tight.
+- Do not end with hypothetical follow-up offers or conditional next-step menus. Answer what was \
+     asked, give the recommendation, stop.
+- Do not restate the same point in plain language after already explaining it. Say it once clearly.
+- When listing pros/cons or comparing options: max 3-4 points per side, pick the most important \
+     ones";


### PR DESCRIPTION
## Summary

- Integrate [talk-normal](https://github.com/hexiecs/talk-normal) v0.6.2 anti-slop prompt rules into rara's system prompt pipeline
- Rules injected as step 3 in `build_agent_system_prompt()`, between agent.md and runtime contract
- Applied unconditionally to all agents and all models — eliminates filler phrases, negation-frame patterns, and summary-stamp closings

## Type of change

| Type | Label |
|------|-------|
| New feature | `enhancement` |

## Component

`core`

## Closes

Closes #1350

## Test plan

- [x] `cargo check -p rara-kernel` passes
- [x] `cargo test -p rara-kernel` passes
- [x] `cargo +nightly fmt --all -- --check` passes
- [x] `cargo clippy -p rara-kernel` passes
- [x] Pre-commit hooks (cargo check, fmt, clippy, doc, AGENT.md) all pass