### PR TITLE
fix(channels): use correct argument key for tool progress summary (#1357)

### DIFF
--- a/crates/channels/src/tool_display.rs
+++ b/crates/channels/src/tool_display.rs
@@ -267,10 +267,10 @@ pub fn tool_arguments_summary(tool_name: &str, arguments: &serde_json::Value) ->
         "shell_execute" => arguments.get("command").and_then(|v| v.as_str()),
         "web_search" => arguments.get("query").and_then(|v| v.as_str()),
         "web_fetch" => arguments.get("url").and_then(|v| v.as_str()),
-        "read-file" | "write-file" => arguments.get("path").and_then(|v| v.as_str()),
+        "read-file" | "write-file" => arguments.get("file_path").and_then(|v| v.as_str()),
         _ => {
             // Try common field names, then fall back to the first string value.
-            ["query", "command", "input", "path", "url"]
+            ["query", "command", "input", "file_path", "path", "url"]
                 .iter()
                 .find_map(|key| arguments.get(*key).and_then(|v| v.as_str()))
                 .or_else(|| first_string_value(arguments))
@@ -309,7 +309,9 @@ pub fn tool_display_info(tool_name: &str, arguments: &serde_json::Value) -> (Str
         "bash" => arguments.get("command").and_then(|v| v.as_str()),
         "web_search" => arguments.get("query").and_then(|v| v.as_str()),
         "web_fetch" | "http-fetch" => arguments.get("url").and_then(|v| v.as_str()),
-        "read-file" | "write-file" | "edit-file" => arguments.get("path").and_then(|v| v.as_str()),
+        "read-file" | "write-file" | "edit-file" => {
+            arguments.get("file_path").and_then(|v| v.as_str())
+        }
         "find-files" | "list-directory" => arguments.get("path").and_then(|v| v.as_str()),
         "grep" => arguments.get("pattern").and_then(|v| v.as_str()),
         "memory_search" => arguments.get("query").and_then(|v| v.as_str()),
@@ -328,10 +330,19 @@ pub fn tool_display_info(tool_name: &str, arguments: &serde_json::Value) -> (Str
         "read-tape" => arguments.get("session_id").and_then(|v| v.as_str()),
         "create-skill" | "delete-skill" => arguments.get("name").and_then(|v| v.as_str()),
         "settings" => arguments.get("action").and_then(|v| v.as_str()),
-        _ => ["query", "command", "input", "path", "url", "name", "key"]
-            .iter()
-            .find_map(|key| arguments.get(*key).and_then(|v| v.as_str()))
-            .or_else(|| first_string_value(arguments)),
+        _ => [
+            "query",
+            "command",
+            "input",
+            "file_path",
+            "path",
+            "url",
+            "name",
+            "key",
+        ]
+        .iter()
+        .find_map(|key| arguments.get(*key).and_then(|v| v.as_str()))
+        .or_else(|| first_string_value(arguments)),
     };
 
     let summary = raw.map(|s| first_line(s).to_owned()).unwrap_or_default();
@@ -527,5 +538,30 @@ mod tests {
         let (name, summary) = tool_display_info("web_search", &args);
         assert_eq!(name, "search");
         assert_eq!(summary, "rust async");
+    }
+
+    #[test]
+    fn summary_read_file() {
+        let args = json!({"file_path": "/home/user/main.rs"});
+        assert_eq!(
+            tool_arguments_summary("read-file", &args),
+            "/home/user/main.rs"
+        );
+    }
+
+    #[test]
+    fn display_info_read_file() {
+        let args = json!({"file_path": "/home/user/main.rs"});
+        let (name, summary) = tool_display_info("read-file", &args);
+        assert_eq!(name, "read");
+        assert_eq!(summary, "/home/user/main.rs");
+    }
+
+    #[test]
+    fn display_info_edit_file() {
+        let args = json!({"file_path": "/tmp/foo.rs", "old_string": "a", "new_string": "b"});
+        let (name, summary) = tool_display_info("edit-file", &args);
+        assert_eq!(name, "edit");
+        assert_eq!(summary, "/tmp/foo.rs");
     }
 }

--- a/crates/cmd/src/chat/ui.rs
+++ b/crates/cmd/src/chat/ui.rs
@@ -179,10 +179,10 @@ fn draw_progress_section(frame: &mut Frame, area: Rect, state: &ChatState) {
             .map(|d| format!(" ({})", format_tool_duration(d)))
             .unwrap_or_default();
 
-        let summary_part = if !entry.finished && !entry.summary.is_empty() {
-            format!(" \u{2014} {}", entry.summary)
-        } else {
+        let summary_part = if entry.summary.is_empty() {
             String::new()
+        } else {
+            format!(" \u{2014} {}", entry.summary)
         };
 
         lines.push(Line::from(vec![


### PR DESCRIPTION
## Summary

- Fix `tool_arguments_summary` and `tool_display_info` using wrong key `"path"` instead of `"file_path"` for read-file/write-file/edit-file tools — summary was always empty
- Show summary in CLI TUI for finished tools too, so fast-completing tools (read 0ms) still display the file path
- Add `"file_path"` to fallback key lists for unknown tools

## Type of change

| Type | Label |
|------|-------|
| Bug fix | `bug` |

## Component

`backend`

## Closes

Closes #1357

## Test plan

- [x] New tests: `summary_read_file`, `display_info_read_file`, `display_info_edit_file`
- [x] All 18 `tool_display` tests pass
- [x] `cargo check` / `cargo clippy` / `cargo fmt` pass
- [x] Pre-commit hooks pass