### PR TITLE
fix(kernel): deliver scheduled task result to origin session (#1360)

### DIFF
--- a/crates/kernel/src/agent/scheduled.rs
+++ b/crates/kernel/src/agent/scheduled.rs
@@ -36,6 +36,8 @@ pub fn scheduled_job_manifest(
     trigger_summary: &str,
     message: &str,
     tags: &[String],
+    origin_session_key: &str,
+    principal_user_id: &str,
 ) -> AgentManifest {
     let tags_str = if tags.is_empty() {
         String::new()
@@ -71,6 +73,9 @@ pub fn scheduled_job_manifest(
         priority: Priority::default(),
         metadata: serde_json::json!({
             "scheduled_job_id": job_id,
+            "origin_session_key": origin_session_key,
+            "principal_user_id": principal_user_id,
+            "task_message": message,
         }),
         sandbox: None,
         default_execution_mode: None,

--- a/crates/kernel/src/kernel.rs
+++ b/crates/kernel/src/kernel.rs
@@ -1191,7 +1191,8 @@ impl Kernel {
             let state = rt.state();
             let parent_id = rt.parent_id;
 
-            // Clear in-flight ledger entry for scheduled job agents.
+            // Clear in-flight ledger entry for scheduled job agents and
+            // deliver the result to the origin session that created the job.
             if manifest_name == "scheduled_job" {
                 if let Some(job_id_str) = rt
                     .manifest
@@ -1204,6 +1205,45 @@ impl Kernel {
                         .and_then(crate::schedule::JobId::from_uuid)
                     {
                         self.syscall.job_wheel().lock().complete_in_flight(&job_id);
+                    }
+                }
+
+                // Inject task result into the origin session so the user's
+                // agent can present it through the normal delivery channel.
+                if let Some(result) = &rt.result {
+                    let origin_key = rt
+                        .manifest
+                        .metadata
+                        .get("origin_session_key")
+                        .and_then(|v| v.as_str())
+                        .and_then(|s| SessionKey::try_from_raw(s).ok());
+                    let task_msg = rt
+                        .manifest
+                        .metadata
+                        .get("task_message")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("scheduled task");
+
+                    if let Some(origin) = origin_key {
+                        let directive = format!(
+                            "[Scheduled Task Result]\nTask: {task_msg}\n\n{}",
+                            result.output
+                        );
+                        let user_id = crate::identity::UserId(
+                            rt.manifest
+                                .metadata
+                                .get("principal_user_id")
+                                .and_then(|v| v.as_str())
+                                .unwrap_or("system")
+                                .to_string(),
+                        );
+                        let msg = crate::io::InboundMessage::synthetic(directive, user_id, origin);
+                        if let Err(e) = self
+                            .event_queue
+                            .try_push(KernelEventEnvelope::user_message(msg))
+                        {
+                            warn!(%e, "failed to push scheduled task result");
+                        }
                     }
                 }
             }
@@ -1475,6 +1515,8 @@ impl Kernel {
             &trigger_summary,
             &job.message,
             &job.tags,
+            &session_key.to_string(),
+            &job.principal.user_id.0,
         );
 
         // 3. Spawn the agent.


### PR DESCRIPTION
## Summary

- Scheduled task agents run headlessly (`origin_endpoint: None`), so output was silently discarded
- Root cause: delivery relied on LLM calling `publish_report` + subscription tag matching (midlayer mistake for 1:1 delivery)
- Fix: `cleanup_process` now injects the result as a synthetic message into the origin session via `InboundMessage::synthetic` + `KernelEventEnvelope::user_message`
- The origin session's agent loop fires with `origin_endpoint` → message delivered through normal channel
- `publish_report` remains as optional structured enrichment

## Type of change

| Type | Label |
|------|-------|
| Bug fix | `bug` |

## Component

`core`

## Closes

Closes #1360

## Test plan

- [x] `cargo check -p rara-kernel` passes
- [x] `cargo test -p rara-kernel` — 452 tests pass
- [x] `cargo clippy` clean
- [x] `cargo +nightly fmt` clean
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)