### PR TITLE
feat(kernel): DataFeed step 1 — FeedEvent + FeedStore + DB migration (#1365)

### DIFF
--- a/crates/kernel/src/data_feed/AGENT.md
+++ b/crates/kernel/src/data_feed/AGENT.md
@@ -1,0 +1,31 @@
+# data_feed — Agent Guidelines
+
+## Purpose
+
+External data ingestion subsystem: receives events from webhooks, WebSocket streams, and polling sources, persists them, and dispatches to subscribing agent sessions.
+
+## Architecture
+
+- `event.rs` — `FeedEvent` struct (the atomic event envelope) and `FeedEventId` (strongly-typed UUID).
+- `store.rs` — `FeedStore` async trait for persistence and `FeedFilter` for querying.
+- `mod.rs` — Re-exports only; no logic.
+
+Data flow: Transport layer (webhook/WS/polling) -> `FeedEvent` -> `FeedStore::append` -> subscription dispatch -> agent session.
+
+## Critical Invariants
+
+- `FeedStore::append` MUST be idempotent on `event.id` — duplicate inserts must not create duplicate rows. Violation causes double-processing by subscribers.
+- `FeedEventId` uses `base::define_id!` (UUID v4, NonZeroU128) — never construct from arbitrary u128 without `from_uuid`.
+- Read cursors are per-subscriber per-source — do not conflate subscribers.
+
+## What NOT To Do
+
+- Do NOT put transport implementations (webhook HTTP handler, WS client) in this module — they belong in dedicated sub-modules or crates.
+- Do NOT add `Default` to `FeedFilter` with hardcoded limit — limit must be caller-specified or config-driven.
+- Do NOT store `FeedEvent::payload` as typed structs — it is intentionally `serde_json::Value` to support heterogeneous sources.
+
+## Dependencies
+
+- Upstream: `base` (for `define_id!` macro), `jiff` (timestamps), `crate::session` (for `SessionKey`).
+- Downstream: future `DataFeedRegistry`, `query-feed` tool, webhook HTTP handler.
+- DB: `feed_events` + `feed_read_cursors` tables (migration in `crates/rara-model/migrations/`).

--- a/crates/kernel/src/data_feed/event.rs
+++ b/crates/kernel/src/data_feed/event.rs
@@ -1,0 +1,53 @@
+// Copyright 2025 Rararulab
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Feed event type — the atomic unit of external data ingestion.
+
+use jiff::Timestamp;
+use serde::{Deserialize, Serialize};
+
+base::define_id!(
+    /// Unique identifier for a feed event (UUID v4).
+    ///
+    /// Used for deduplication and read-cursor tracking across subscribers.
+    FeedEventId
+);
+
+/// An event received from an external data source.
+///
+/// Each `FeedEvent` represents a single datum (webhook delivery, WebSocket
+/// message, polled record) that has been normalised into a common envelope.
+/// Events are persisted to the [`FeedStore`](super::FeedStore) and dispatched
+/// to subscribing agent sessions.
+#[derive(Debug, Clone, Serialize, Deserialize, bon::Builder)]
+pub struct FeedEvent {
+    /// Unique event identifier for deduplication and cursor tracking.
+    pub id: FeedEventId,
+
+    /// Name of the source that produced this event (e.g. `"github-rara"`).
+    pub source_name: String,
+
+    /// Discriminator within a source (e.g. `"push"`, `"price_update"`).
+    pub event_type: String,
+
+    /// Tags for subscription matching — inherited from the source plus any
+    /// event-specific tags added by the transport layer.
+    pub tags: Vec<String>,
+
+    /// Raw event payload as a JSON value.
+    pub payload: serde_json::Value,
+
+    /// Wall-clock time when the event was received by rara.
+    pub received_at: Timestamp,
+}

--- a/crates/kernel/src/data_feed/mod.rs
+++ b/crates/kernel/src/data_feed/mod.rs
@@ -1,0 +1,28 @@
+// Copyright 2025 Rararulab
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Data Feed — external data ingestion for agent perception.
+//!
+//! This module defines the core types for the data feed subsystem:
+//!
+//! - [`FeedEvent`] — the atomic event envelope received from external sources.
+//! - [`FeedEventId`] — strongly-typed UUID identifier for deduplication.
+//! - [`FeedStore`] — async persistence trait for events and read cursors.
+//! - [`FeedFilter`] — query criteria for filtered event retrieval.
+
+mod event;
+mod store;
+
+pub use event::{FeedEvent, FeedEventId};
+pub use store::{FeedFilter, FeedStore};

--- a/crates/kernel/src/data_feed/store.rs
+++ b/crates/kernel/src/data_feed/store.rs
@@ -1,0 +1,67 @@
+// Copyright 2025 Rararulab
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Persistent store trait for feed events.
+
+use async_trait::async_trait;
+use jiff::Timestamp;
+
+use super::event::{FeedEvent, FeedEventId};
+use crate::session::SessionKey;
+
+/// Persistent store for external feed events.
+///
+/// Implementations handle event persistence, filtered queries, and
+/// per-subscriber read-cursor tracking. The kernel owns one shared `FeedStore`
+/// instance; transport layers call [`append`](Self::append) on ingestion and
+/// agent sessions call [`query`](Self::query) /
+/// [`unread_count`](Self::unread_count) to consume events.
+#[async_trait]
+pub trait FeedStore: Send + Sync {
+    /// Persist a new event.
+    ///
+    /// Implementations must be idempotent on `event.id` — inserting an event
+    /// whose ID already exists should succeed without duplicating the row.
+    async fn append(&self, event: &FeedEvent) -> crate::Result<()>;
+
+    /// Query events matching `filter`, returned in chronological order.
+    async fn query(&self, filter: FeedFilter) -> crate::Result<Vec<FeedEvent>>;
+
+    /// Mark all events up to (and including) `up_to` as read for `subscriber`.
+    ///
+    /// The read cursor is per-subscriber, per-source so that multiple agent
+    /// sessions can independently track their consumption progress.
+    async fn mark_read(&self, subscriber: &SessionKey, up_to: FeedEventId) -> crate::Result<()>;
+
+    /// Return the number of unread events for `subscriber` across all sources.
+    async fn unread_count(&self, subscriber: &SessionKey) -> crate::Result<usize>;
+}
+
+/// Filter criteria for [`FeedStore::query`].
+#[derive(Debug, Clone)]
+pub struct FeedFilter {
+    /// Only return events from this source. `None` means all sources.
+    pub source_name: Option<String>,
+
+    /// Only return events that carry *all* of these tags. Empty means no tag
+    /// filter.
+    pub tags: Vec<String>,
+
+    /// Only return events received at or after this timestamp.
+    pub since: Option<Timestamp>,
+
+    /// Maximum number of events to return. Implementations should clamp this
+    /// to a sane upper bound.
+    pub limit: usize,
+}

--- a/crates/kernel/src/lib.rs
+++ b/crates/kernel/src/lib.rs
@@ -31,6 +31,7 @@
 pub mod agent;
 pub mod cascade;
 pub mod channel;
+pub mod data_feed;
 pub mod debug;
 pub mod error;
 pub mod event;

--- a/crates/rara-model/migrations/20260414125453_feed_events.down.sql
+++ b/crates/rara-model/migrations/20260414125453_feed_events.down.sql
@@ -1,0 +1,4 @@
+DROP TABLE IF EXISTS feed_read_cursors;
+DROP INDEX IF EXISTS idx_feed_events_received;
+DROP INDEX IF EXISTS idx_feed_events_source;
+DROP TABLE IF EXISTS feed_events;

--- a/crates/rara-model/migrations/20260414125453_feed_events.up.sql
+++ b/crates/rara-model/migrations/20260414125453_feed_events.up.sql
@@ -1,0 +1,22 @@
+-- Feed events: external data ingested by the data feed subsystem.
+CREATE TABLE IF NOT EXISTS feed_events (
+    id          TEXT PRIMARY KEY NOT NULL,
+    source_name TEXT NOT NULL,
+    event_type  TEXT NOT NULL,
+    tags        TEXT NOT NULL DEFAULT '[]',
+    payload     TEXT NOT NULL DEFAULT '{}',
+    received_at TEXT NOT NULL,
+    created_at  TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+);
+
+CREATE INDEX idx_feed_events_source ON feed_events(source_name);
+CREATE INDEX idx_feed_events_received ON feed_events(received_at);
+
+-- Per-subscriber read cursors for tracking consumption progress.
+CREATE TABLE IF NOT EXISTS feed_read_cursors (
+    subscriber_id TEXT NOT NULL,
+    source_name   TEXT NOT NULL,
+    last_read_id  TEXT NOT NULL,
+    updated_at    TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+    PRIMARY KEY (subscriber_id, source_name)
+);


### PR DESCRIPTION
## Summary

Part of #1360. Introduce the `data_feed` kernel module with the foundational types for external data ingestion:

- `FeedEvent` struct with strongly-typed `FeedEventId` (UUID v4 via `define_id!`)
- `FeedStore` async trait: `append`, `query`, `mark_read`, `unread_count`
- `FeedFilter` query criteria (source, tags, since, limit)
- Database migration: `feed_events` + `feed_read_cursors` tables with indexes
- `AGENT.md` for the new module

## Type of change

| Type | Label |
|------|-------|
| New feature | `enhancement` |

## Component

`core`

## Closes

Closes #1365

## Test plan

- [x] `cargo check -p rara-kernel` passes
- [x] `cargo test -p rara-kernel` passes
- [x] `cargo clippy` passes (zero warnings)
- [x] `cargo +nightly fmt --check` passes
- [x] `RUSTDOCFLAGS="-D warnings" cargo +nightly doc` passes
- [x] All pre-commit hooks pass