### PR TITLE
fix(kernel): return Err(Interrupted) for new-message interrupt path (#1372)

### DIFF
--- a/crates/kernel/src/agent/mod.rs
+++ b/crates/kernel/src/agent/mod.rs
@@ -2957,6 +2957,15 @@ pub(crate) async fn run_agent_loop(
         )
         .await;
 
+    // If interrupted by a new user message, return Interrupted so the
+    // kernel suppresses the empty-text fallback ("I wasn't able to
+    // generate a response") and drains the pause buffer cleanly.
+    // This aligns with the explicit /stop path which returns
+    // Err(Interrupted) via turn_cancel.
+    if was_interrupted {
+        return Err(KernelError::Interrupted);
+    }
+
     Ok(AgentTurnResult {
         text: last_accumulated_text,
         iterations: actual_iterations,


### PR DESCRIPTION
## Summary

When a new user message interrupts an active turn, the agent loop breaks with `was_interrupted = true` but returns `Ok(AgentTurnResult { text: "", ... })`. The kernel matches this as an empty-text success and sends **"I wasn't able to generate a response. Please try again."** — both for the interrupted turn and potentially for the re-injected buffered message.

The fix: return `Err(KernelError::Interrupted)` when `was_interrupted` is true, aligning the automatic interrupt path (new message during active turn) with the explicit `/stop` path (which already returns `Err(Interrupted)` via `turn_cancel`).

## Type of change

| Type | Label |
|------|-------|
| Bug fix | `bug` |

## Component

`core`

## Closes

Closes #1372

## Test plan

- [x] `cargo check -p rara-kernel` passes
- [x] `cargo clippy` passes
- [x] `cargo fmt` passes
- [x] `cargo doc` passes
- [x] Pre-commit hooks pass