### PR TITLE
feat(kernel): add DataFeed trait + DataFeedRegistry + config types (#1366)

### DIFF
--- a/crates/kernel/src/data_feed/AGENT.md
+++ b/crates/kernel/src/data_feed/AGENT.md
@@ -8,24 +8,34 @@ External data ingestion subsystem: receives events from webhooks, WebSocket stre
 
 - `event.rs` — `FeedEvent` struct (the atomic event envelope) and `FeedEventId` (strongly-typed UUID).
 - `store.rs` — `FeedStore` async trait for persistence and `FeedFilter` for querying.
+- `config.rs` — `DataFeedConfig` (persisted feed registration) and `FeedType` enum (Webhook/WebSocket/Polling).
+- `feed.rs` — `DataFeed` trait: the abstraction each transport implements (`name`, `tags`, `run`).
+- `registry.rs` — `DataFeedRegistry`: in-memory CRUD for feed configs + cancellation token tracking for running tasks.
 - `mod.rs` — Re-exports only; no logic.
 
 Data flow: Transport layer (webhook/WS/polling) -> `FeedEvent` -> `FeedStore::append` -> subscription dispatch -> agent session.
+
+Registry flow: Caller loads configs from settings -> `DataFeedRegistry::restore` -> runtime `register`/`remove` -> caller persists via `configs()`.
 
 ## Critical Invariants
 
 - `FeedStore::append` MUST be idempotent on `event.id` — duplicate inserts must not create duplicate rows. Violation causes double-processing by subscribers.
 - `FeedEventId` uses `base::define_id!` (UUID v4, NonZeroU128) — never construct from arbitrary u128 without `from_uuid`.
 - Read cursors are per-subscriber per-source — do not conflate subscribers.
+- `DataFeedRegistry` does NOT own settings persistence — callers must read `configs()` and write to `SettingsProvider` after mutations. The registry is pure in-memory state.
+- Feed names are unique within the registry — `register` rejects duplicates.
 
 ## What NOT To Do
 
 - Do NOT put transport implementations (webhook HTTP handler, WS client) in this module — they belong in dedicated sub-modules or crates.
 - Do NOT add `Default` to `FeedFilter` with hardcoded limit — limit must be caller-specified or config-driven.
 - Do NOT store `FeedEvent::payload` as typed structs — it is intentionally `serde_json::Value` to support heterogeneous sources.
+- Do NOT call `SettingsProvider` from within `DataFeedRegistry` — persistence is the caller's responsibility to keep the registry sync-only and testable without async.
+- Do NOT hold `parking_lot::Mutex` guards across `.cancel()` or `tracing` calls — extract values from the lock first, then act on them.
 
 ## Dependencies
 
-- Upstream: `base` (for `define_id!` macro), `jiff` (timestamps), `crate::session` (for `SessionKey`).
-- Downstream: future `DataFeedRegistry`, `query-feed` tool, webhook HTTP handler.
+- Upstream: `base` (for `define_id!` macro), `jiff` (timestamps), `crate::session` (for `SessionKey`), `parking_lot`, `tokio_util` (CancellationToken).
+- Downstream: concrete transport implementations (Step 3+), `query-feed` tool, webhook HTTP handler, kernel startup (restore).
 - DB: `feed_events` + `feed_read_cursors` tables (migration in `crates/rara-model/migrations/`).
+- Settings: feed configs persisted via `SettingsProvider` KV store (key: `data_feeds.configs`).

--- a/crates/kernel/src/data_feed/config.rs
+++ b/crates/kernel/src/data_feed/config.rs
@@ -1,0 +1,56 @@
+// Copyright 2025 Rararulab
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Configuration types for data feed registration.
+
+use jiff::Timestamp;
+use serde::{Deserialize, Serialize};
+
+/// Persisted configuration for a registered data feed.
+///
+/// Each config represents a single external data source (webhook endpoint,
+/// WebSocket connection, or polling target). Configs are serialised to JSON
+/// and stored in the settings KV store for startup recovery.
+#[derive(Debug, Clone, Serialize, Deserialize, bon::Builder)]
+pub struct DataFeedConfig {
+    /// Unique name for this feed (e.g. `"github-rara"`, `"crypto-binance"`).
+    pub name: String,
+
+    /// Transport type that determines how events are ingested.
+    pub feed_type: FeedType,
+
+    /// Tags for subscription matching. Subscribers filter events by tag.
+    pub tags: Vec<String>,
+
+    /// Type-specific configuration (URL, auth, intervals, etc.).
+    ///
+    /// The schema depends on `feed_type` — each transport implementation
+    /// deserialises this into its own strongly-typed config struct.
+    pub config: serde_json::Value,
+
+    /// When this feed was registered.
+    pub created_at: Timestamp,
+}
+
+/// Transport type for a data feed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum FeedType {
+    /// HTTP POST receiver — external services push events to rara.
+    Webhook,
+    /// Outbound WebSocket client — rara connects to an external WS endpoint.
+    WebSocket,
+    /// Periodic HTTP GET — rara polls an external API at fixed intervals.
+    Polling,
+}

--- a/crates/kernel/src/data_feed/feed.rs
+++ b/crates/kernel/src/data_feed/feed.rs
@@ -1,0 +1,54 @@
+// Copyright 2025 Rararulab
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! DataFeed trait — abstraction for external data sources.
+
+use async_trait::async_trait;
+use tokio::sync::mpsc;
+use tokio_util::sync::CancellationToken;
+
+use super::FeedEvent;
+
+/// A registered external data feed.
+///
+/// Each implementation handles one transport protocol (webhook HTTP,
+/// WebSocket client, polling). Feeds produce [`FeedEvent`]s that are
+/// persisted to the feed store and dispatched to subscribing sessions.
+///
+/// The lifecycle is managed by [`DataFeedRegistry`](super::DataFeedRegistry):
+/// - `run` is called once when the feed is started.
+/// - The implementation owns its connection lifecycle (connect, reconnect with
+///   backoff, heartbeat, etc.).
+/// - When the `cancel` token is cancelled, the feed must shut down gracefully
+///   and return.
+#[async_trait]
+pub trait DataFeed: Send + Sync + 'static {
+    /// Human-readable name (e.g. `"crypto-binance"`, `"github-rara"`).
+    fn name(&self) -> &str;
+
+    /// Tags attached to all events from this feed.
+    fn tags(&self) -> &[String];
+
+    /// Start the feed, sending events through `tx` until `cancel` fires.
+    ///
+    /// The implementation owns its connection lifecycle (connect,
+    /// reconnect with backoff, heartbeat, etc.). When the cancellation
+    /// token is triggered, the feed must shut down gracefully and return
+    /// `Ok(())`.
+    async fn run(
+        &self,
+        tx: mpsc::Sender<FeedEvent>,
+        cancel: CancellationToken,
+    ) -> anyhow::Result<()>;
+}

--- a/crates/kernel/src/data_feed/mod.rs
+++ b/crates/kernel/src/data_feed/mod.rs
@@ -20,9 +20,18 @@
 //! - [`FeedEventId`] — strongly-typed UUID identifier for deduplication.
 //! - [`FeedStore`] — async persistence trait for events and read cursors.
 //! - [`FeedFilter`] — query criteria for filtered event retrieval.
+//! - [`DataFeed`] — trait for external data source implementations.
+//! - [`DataFeedConfig`] / [`FeedType`] — persisted configuration types.
+//! - [`DataFeedRegistry`] — runtime registry managing feed configs and tasks.
 
+mod config;
 mod event;
+mod feed;
+mod registry;
 mod store;
 
+pub use config::{DataFeedConfig, FeedType};
 pub use event::{FeedEvent, FeedEventId};
+pub use feed::DataFeed;
+pub use registry::DataFeedRegistry;
 pub use store::{FeedFilter, FeedStore};

--- a/crates/kernel/src/data_feed/registry.rs
+++ b/crates/kernel/src/data_feed/registry.rs
@@ -1,0 +1,259 @@
+// Copyright 2025 Rararulab
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! DataFeedRegistry — manages registered data feed configurations.
+//!
+//! The registry handles CRUD operations on [`DataFeedConfig`]s and tracks
+//! cancellation tokens for running feed tasks. It does **not** own the
+//! settings persistence layer — callers are responsible for reading
+//! [`configs`](DataFeedRegistry::configs) and writing to the settings
+//! store after mutations.
+//!
+//! # Lifecycle
+//!
+//! 1. On startup, the caller loads configs from settings and calls
+//!    [`restore`](DataFeedRegistry::restore).
+//! 2. At runtime, `register` / `remove` mutate the in-memory map. The caller
+//!    persists after each mutation.
+//! 3. Concrete feed tasks are started externally (Step 3) — the registry only
+//!    stores their [`CancellationToken`]s so that `remove` can cancel a running
+//!    feed.
+
+use std::{collections::HashMap, sync::Arc};
+
+use parking_lot::Mutex;
+use snafu::whatever;
+use tokio::sync::mpsc;
+use tokio_util::sync::CancellationToken;
+use tracing::info;
+
+use super::{DataFeedConfig, FeedEvent};
+
+/// Manages registered data feeds and their runtime state.
+///
+/// Thread-safe: all interior state is behind `parking_lot::Mutex`.
+/// The struct itself is cheaply clonable via the inner `Arc`s.
+pub struct DataFeedRegistry {
+    /// Registered feed configs keyed by name.
+    configs:  Arc<Mutex<HashMap<String, DataFeedConfig>>>,
+    /// Event sender shared by all running feeds.
+    event_tx: mpsc::Sender<FeedEvent>,
+    /// Cancel tokens for running feed tasks, keyed by feed name.
+    /// Populated externally when a concrete feed task is spawned.
+    running:  Arc<Mutex<HashMap<String, CancellationToken>>>,
+}
+
+impl DataFeedRegistry {
+    /// Create a new empty registry.
+    ///
+    /// `event_tx` is the channel sender that all feeds will use to emit
+    /// events. The receiving end is owned by the kernel's event dispatcher.
+    pub fn new(event_tx: mpsc::Sender<FeedEvent>) -> Self {
+        Self {
+            configs: Arc::new(Mutex::new(HashMap::new())),
+            event_tx,
+            running: Arc::new(Mutex::new(HashMap::new())),
+        }
+    }
+
+    /// Register a new data feed configuration.
+    ///
+    /// Returns an error if a feed with the same name is already registered.
+    /// The caller is responsible for persisting configs to settings after
+    /// this call.
+    pub fn register(&self, config: DataFeedConfig) -> crate::Result<()> {
+        let mut configs = self.configs.lock();
+        if configs.contains_key(&config.name) {
+            whatever!("data feed already registered: {}", config.name);
+        }
+        info!(name = %config.name, feed_type = ?config.feed_type, "registered data feed");
+        configs.insert(config.name.clone(), config);
+        Ok(())
+    }
+
+    /// Remove a registered data feed by name.
+    ///
+    /// If the feed has a running task, its cancellation token is triggered
+    /// before the config is removed. Returns an error if no feed with
+    /// the given name exists.
+    pub fn remove(&self, name: &str) -> crate::Result<()> {
+        // Cancel running task first (if any). Extract from lock before
+        // acting on it to avoid holding the guard across cancel/log.
+        let token = self.running.lock().remove(name);
+        if let Some(token) = token {
+            token.cancel();
+            info!(name, "cancelled running data feed task");
+        }
+
+        let mut configs = self.configs.lock();
+        if configs.remove(name).is_none() {
+            whatever!("data feed not found: {name}");
+        }
+        info!(name, "removed data feed");
+        Ok(())
+    }
+
+    /// List all registered feed configurations.
+    pub fn list(&self) -> Vec<DataFeedConfig> { self.configs.lock().values().cloned().collect() }
+
+    /// Get a single feed configuration by name.
+    pub fn get(&self, name: &str) -> Option<DataFeedConfig> {
+        self.configs.lock().get(name).cloned()
+    }
+
+    /// Return all configs for external persistence.
+    ///
+    /// This is the serialisation companion to [`restore`](Self::restore) —
+    /// the caller serialises the returned vec to JSON and writes it to the
+    /// settings store.
+    pub fn configs(&self) -> Vec<DataFeedConfig> { self.configs.lock().values().cloned().collect() }
+
+    /// Bulk-load configs from a previously persisted state.
+    ///
+    /// Called once at kernel startup after reading the settings store.
+    /// Any existing configs are replaced.
+    pub fn restore(&self, configs: Vec<DataFeedConfig>) {
+        let mut map = self.configs.lock();
+        map.clear();
+        let count = configs.len();
+        for config in configs {
+            map.insert(config.name.clone(), config);
+        }
+        info!(count, "restored data feed configs from settings");
+    }
+
+    /// Return a clone of the shared event sender.
+    ///
+    /// Concrete feed implementations need a sender to emit events.
+    pub fn event_tx(&self) -> mpsc::Sender<FeedEvent> { self.event_tx.clone() }
+
+    /// Register a cancellation token for a running feed task.
+    ///
+    /// Called by the feed spawner (Step 3) after `tokio::spawn`-ing the
+    /// feed's `run` future.
+    pub fn set_running(&self, name: String, token: CancellationToken) {
+        self.running.lock().insert(name, token);
+    }
+
+    /// Check whether a feed has a running task.
+    pub fn is_running(&self, name: &str) -> bool { self.running.lock().contains_key(name) }
+
+    /// Remove the cancellation token for a feed that has stopped.
+    ///
+    /// Called when a feed task completes (either normally or due to error).
+    pub fn clear_running(&self, name: &str) { self.running.lock().remove(name); }
+}
+
+#[cfg(test)]
+mod tests {
+    use jiff::Timestamp;
+    use tokio::sync::mpsc;
+
+    use super::*;
+    use crate::data_feed::FeedType;
+
+    fn make_config(name: &str) -> DataFeedConfig {
+        DataFeedConfig {
+            name:       name.to_owned(),
+            feed_type:  FeedType::Webhook,
+            tags:       vec!["test".to_owned()],
+            config:     serde_json::json!({}),
+            created_at: Timestamp::UNIX_EPOCH,
+        }
+    }
+
+    #[test]
+    fn register_and_list() {
+        let (tx, _rx) = mpsc::channel(16);
+        let registry = DataFeedRegistry::new(tx);
+
+        registry.register(make_config("alpha")).unwrap();
+        registry.register(make_config("beta")).unwrap();
+
+        let configs = registry.list();
+        assert_eq!(configs.len(), 2);
+    }
+
+    #[test]
+    fn register_duplicate_fails() {
+        let (tx, _rx) = mpsc::channel(16);
+        let registry = DataFeedRegistry::new(tx);
+
+        registry.register(make_config("alpha")).unwrap();
+        let result = registry.register(make_config("alpha"));
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn remove_nonexistent_fails() {
+        let (tx, _rx) = mpsc::channel(16);
+        let registry = DataFeedRegistry::new(tx);
+
+        let result = registry.remove("ghost");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn remove_cancels_running_task() {
+        let (tx, _rx) = mpsc::channel(16);
+        let registry = DataFeedRegistry::new(tx);
+
+        registry.register(make_config("alpha")).unwrap();
+
+        let token = CancellationToken::new();
+        let token_clone = token.clone();
+        registry.set_running("alpha".to_owned(), token);
+
+        assert!(registry.is_running("alpha"));
+
+        registry.remove("alpha").unwrap();
+
+        // Token should have been cancelled.
+        assert!(token_clone.is_cancelled());
+        assert!(!registry.is_running("alpha"));
+    }
+
+    #[test]
+    fn get_returns_none_for_missing() {
+        let (tx, _rx) = mpsc::channel(16);
+        let registry = DataFeedRegistry::new(tx);
+
+        assert!(registry.get("nope").is_none());
+    }
+
+    #[test]
+    fn restore_replaces_existing_configs() {
+        let (tx, _rx) = mpsc::channel(16);
+        let registry = DataFeedRegistry::new(tx);
+
+        registry.register(make_config("old")).unwrap();
+
+        let new_configs = vec![make_config("new-a"), make_config("new-b")];
+        registry.restore(new_configs);
+
+        assert!(registry.get("old").is_none());
+        assert!(registry.get("new-a").is_some());
+        assert!(registry.get("new-b").is_some());
+        assert_eq!(registry.list().len(), 2);
+    }
+
+    #[test]
+    fn configs_matches_list() {
+        let (tx, _rx) = mpsc::channel(16);
+        let registry = DataFeedRegistry::new(tx);
+
+        registry.register(make_config("x")).unwrap();
+        assert_eq!(registry.configs().len(), registry.list().len());
+    }
+}


### PR DESCRIPTION
## Summary

Part of #1364 (Data Feed epic). Stacked on #1369 (Step 1: FeedEvent + FeedStore).

Adds the second layer of the data feed subsystem:

- **`DataFeed` trait** — async abstraction for external data sources with `name`/`tags`/`run` contract. Each transport (webhook, WebSocket, polling) implements this trait.
- **`DataFeedConfig` + `FeedType`** — persisted configuration types for registered feeds. `bon::Builder` + `Serialize`/`Deserialize` for settings storage.
- **`DataFeedRegistry`** — thread-safe in-memory registry managing feed configs and cancellation tokens for running tasks. Provides `register`/`remove`/`list`/`get`/`restore`/`configs` API. Persistence is delegated to the caller via `SettingsProvider`.
- **Updated AGENT.md** with new module documentation, invariants, and anti-patterns.

## Type of change

| Type | Label |
|------|-------|
| New feature | `enhancement` |

## Component

`core`

## Closes

Closes #1366

## Test plan

- [x] 7 unit tests for `DataFeedRegistry` (register, duplicate rejection, remove, cancel on remove, get, restore, configs)
- [x] `cargo check -p rara-kernel` passes
- [x] `cargo clippy -p rara-kernel --all-targets --all-features --no-deps -- -D warnings` passes
- [x] `cargo +nightly fmt --all -- --check` passes
- [x] `RUSTDOCFLAGS="-D warnings" cargo +nightly doc -p rara-kernel --no-deps --document-private-items` passes