### PR TITLE
fix(kernel): add deferred tier to task and spawn-background tools (#1375)

### DIFF
--- a/crates/app/src/tools/mod.rs
+++ b/crates/app/src/tools/mod.rs
@@ -125,6 +125,9 @@ pub fn rara_tool_names() -> Vec<rara_kernel::tool::ToolName> {
         // Tape memory (2 Core; info/anchors/entries/between/checkout are Deferred)
         tool_names::TAPE_ANCHOR.clone(),
         tool_names::TAPE_SEARCH.clone(),
+        // Background task delegation
+        tool_names::TASK.clone(),
+        tool_names::SPAWN_BACKGROUND.clone(),
         // Discovery
         ToolName::new(DiscoverToolsTool::TOOL_NAME),
     ]
@@ -292,7 +295,14 @@ mod tests {
         let names = rara_tool_names();
         // Only Core tools appear in the manifest; deferred tools (kernel,
         // marketplace, schedule-*, etc.) are discovered on demand.
-        for expected in ["bash", "tape-anchor", "tape-search", "discover-tools"] {
+        for expected in [
+            "bash",
+            "tape-anchor",
+            "tape-search",
+            "task",
+            "spawn-background",
+            "discover-tools",
+        ] {
             assert!(names.iter().any(|n| n == expected), "missing: {expected}");
         }
         // Verify deferred tools are NOT in the core list.
@@ -323,8 +333,8 @@ mod tests {
     fn rara_core_tool_count_stays_slim() {
         let names = rara_tool_names();
         assert!(
-            names.len() <= 10,
-            "Core tool set has {} tools — keep it under 10 to control token costs. Use tier = \
+            names.len() <= 12,
+            "Core tool set has {} tools — keep it under 12 to control token costs. Use tier = \
              \"deferred\" for non-essential tools.",
             names.len()
         );

--- a/crates/kernel/src/tool/spawn_background.rs
+++ b/crates/kernel/src/tool/spawn_background.rs
@@ -36,7 +36,7 @@ use crate::{
                    instruction), `description` (short status label), and `system_prompt` (agent \
                    behavior). Optional: `name`, `tools`, `model`, `max_iterations`. The agent \
                    runs independently and results are delivered when complete.",
-    tier = "core"
+    tier = "deferred"
 )]
 pub struct SpawnBackgroundTool {
     handle:      KernelHandle,

--- a/crates/kernel/src/tool/spawn_background.rs
+++ b/crates/kernel/src/tool/spawn_background.rs
@@ -36,7 +36,7 @@ use crate::{
                    instruction), `description` (short status label), and `system_prompt` (agent \
                    behavior). Optional: `name`, `tools`, `model`, `max_iterations`. The agent \
                    runs independently and results are delivered when complete.",
-    tier = "deferred"
+    tier = "core"
 )]
 pub struct SpawnBackgroundTool {
     handle:      KernelHandle,

--- a/crates/kernel/src/tool/task/mod.rs
+++ b/crates/kernel/src/tool/task/mod.rs
@@ -49,7 +49,7 @@ use crate::{
                    tool directly\n- Tasks needing user interaction — child agents cannot ask the \
                    user\n\nIMPORTANT: The child agent has NO memory of your conversation. Pass \
                    ALL relevant context (file paths, error messages, constraints) in the prompt.",
-    tier = "deferred"
+    tier = "core"
 )]
 pub struct TaskTool {
     handle:      KernelHandle,

--- a/crates/kernel/src/tool/task/mod.rs
+++ b/crates/kernel/src/tool/task/mod.rs
@@ -48,7 +48,8 @@ use crate::{
                    code review, analysis)\n\nWHEN NOT TO USE:\n- Single tool call — just call the \
                    tool directly\n- Tasks needing user interaction — child agents cannot ask the \
                    user\n\nIMPORTANT: The child agent has NO memory of your conversation. Pass \
-                   ALL relevant context (file paths, error messages, constraints) in the prompt."
+                   ALL relevant context (file paths, error messages, constraints) in the prompt.",
+    tier = "deferred"
 )]
 pub struct TaskTool {
     handle:      KernelHandle,


### PR DESCRIPTION
## Summary

Both `task` and `spawn-background` tools were invisible to the agent because they fell through both the Core manifest filter and the Deferred discovery filter. `task` had no `tier` attribute (defaulting to Core) and `spawn-background` had `tier = "core"`, but neither was in `rara_tool_names()`. Setting `tier = "deferred"` ensures they are discoverable via `deferred_catalog()`.

## Type of change

| Type | Label |
|------|-------|
| Bug fix | `bug` |

## Component

`core`

## Closes

Closes #1375

## Test plan

- [x] `cargo check -p rara-kernel` passes
- [x] `cargo test -p rara-kernel` passes
- [x] Pre-commit hooks pass (check, fmt, clippy, doc, AGENT.md)