### PR TITLE
fix(kernel): close spawn_child race that leaks child semaphore permits (#1376)

### DIFF
--- a/crates/kernel/src/event.rs
+++ b/crates/kernel/src/event.rs
@@ -297,6 +297,14 @@ pub enum KernelEvent {
         #[debug(skip)]
         #[serde(skip_serializing)]
         reply_tx:            oneshot::Sender<crate::error::Result<SessionKey>>,
+        /// Pre-created channel for streaming `AgentEvent`s back to the
+        /// spawner.  Passed through so that `handle_spawn_agent` can store
+        /// it on the `Session` atomically at creation time, closing the
+        /// race window where a fast-completing child turn could miss a
+        /// late-set `result_tx`.
+        #[debug(skip)]
+        #[serde(skip_serializing)]
+        child_result_tx:     Option<tokio::sync::mpsc::Sender<crate::io::AgentEvent>>,
     },
 
     /// Send a control signal to a session.
@@ -462,6 +470,7 @@ impl KernelEventEnvelope {
         parent_id: Option<SessionKey>,
         desired_session_key: Option<SessionKey>,
         reply_tx: oneshot::Sender<crate::error::Result<SessionKey>>,
+        child_result_tx: Option<tokio::sync::mpsc::Sender<crate::io::AgentEvent>>,
     ) -> Self {
         Self {
             base: EventBase::from(desired_session_key.unwrap_or_default()),
@@ -472,6 +481,7 @@ impl KernelEventEnvelope {
                 parent_id,
                 desired_session_key,
                 reply_tx,
+                child_result_tx,
             },
         }
     }
@@ -484,6 +494,7 @@ impl KernelEventEnvelope {
         parent_id: Option<SessionKey>,
         desired_session_key: Option<SessionKey>,
         reply_tx: oneshot::Sender<crate::error::Result<SessionKey>>,
+        child_result_tx: Option<tokio::sync::mpsc::Sender<crate::io::AgentEvent>>,
     ) -> Self {
         Self::create_session(
             manifest,
@@ -492,6 +503,7 @@ impl KernelEventEnvelope {
             parent_id,
             desired_session_key,
             reply_tx,
+            child_result_tx,
         )
     }
 

--- a/crates/kernel/src/handle.rs
+++ b/crates/kernel/src/handle.rs
@@ -165,6 +165,7 @@ impl KernelHandle {
             parent_id,
             desired_session_key,
             reply_tx,
+            None, // no child_result_tx for top-level spawns
         );
         self.event_queue
             .push(event)
@@ -467,6 +468,13 @@ impl KernelHandle {
         manifest: AgentManifest,
         input: String,
     ) -> Result<AgentHandle> {
+        // Create the result channel BEFORE pushing the event so that
+        // handle_spawn_agent stores it on the Session at creation time.
+        // This closes the race window where a fast-completing child turn
+        // could find result_tx = None and skip cleanup_process, leaking
+        // the parent's child_semaphore permit.
+        let (result_tx, result_rx) = tokio::sync::mpsc::channel(64);
+
         let (reply_tx, reply_rx) = tokio::sync::oneshot::channel();
         let event = KernelEventEnvelope::spawn_agent(
             manifest,
@@ -475,20 +483,13 @@ impl KernelHandle {
             Some(session_key),
             None,
             reply_tx,
+            Some(result_tx),
         );
         self.syscall_push(event).await?;
 
         let child_key = reply_rx.await.map_err(|_| KernelError::SpawnFailed {
             message: "spawn reply channel closed".to_string(),
         })??;
-
-        let (result_tx, result_rx) = tokio::sync::mpsc::channel(64);
-
-        // Store result_tx in the child session so cleanup_process can send
-        // the result back to the awaiting parent.
-        self.process_table.with_mut(&child_key, |session| {
-            session.result_tx = Some(result_tx);
-        });
 
         Ok(AgentHandle {
             session_key: child_key,

--- a/crates/kernel/src/kernel.rs
+++ b/crates/kernel/src/kernel.rs
@@ -676,8 +676,9 @@ impl Kernel {
                 parent_id,
                 desired_session_key,
                 reply_tx,
+                child_result_tx,
             } => {
-                // CreateSession from SessionHandle::create_child() — subagent.
+                // CreateSession from SessionHandle — subagent or top-level.
                 let result = self
                     .handle_spawn_agent(
                         manifest,
@@ -687,6 +688,7 @@ impl Kernel {
                         None,
                         desired_session_key,
                         None,
+                        child_result_tx,
                     )
                     .await;
                 let _ = reply_tx.send(result);
@@ -780,6 +782,10 @@ impl Kernel {
         // The originating channel endpoint, stored in the session so that
         // reply routing works even for synthetic re-entry messages.
         origin_endpoint: Option<crate::io::Endpoint>,
+        // Pre-created channel for streaming AgentEvents back to the spawner.
+        // Set at creation time to avoid the race where a fast-completing child
+        // turn checks result_tx before the spawner has a chance to set it.
+        child_result_tx: Option<tokio::sync::mpsc::Sender<crate::io::AgentEvent>>,
     ) -> crate::Result<SessionKey> {
         // Validate principal.
         let principal = self.security.resolve_principal(&principal).await?;
@@ -841,7 +847,7 @@ impl Kernel {
             created_at: jiff::Timestamp::now(),
             finished_at: None,
             result: None,
-            result_tx: None,
+            result_tx: child_result_tx,
             created_files: vec![],
             metrics,
             turn_traces: vec![],
@@ -1471,6 +1477,7 @@ impl Kernel {
                 resume_session_id,
                 Some(session_id.clone()),
                 origin_endpoint.clone(),
+                None, // no child_result_tx for user-initiated sessions
             )
             .await;
         match spawn_result {
@@ -1530,6 +1537,7 @@ impl Kernel {
                 None, // no resume
                 None, // independent session, don't pollute the original tape
                 None, // no origin endpoint
+                None, // no child_result_tx for scheduled tasks
             )
             .await
         {
@@ -1760,6 +1768,7 @@ impl Kernel {
                     None,
                     Some(session_key),
                     None,
+                    None, // no child_result_tx for Mita
                 )
                 .await
             {


### PR DESCRIPTION
## Summary

- Fix race condition where `spawn_child` created the `result_tx` channel **after** pushing the `SpawnAgent` event, allowing a fast-completing child turn to find `result_tx = None` and skip `cleanup_process` — leaking the parent's `child_semaphore` permit permanently
- Thread `child_result_tx` through `CreateSession` event → `handle_spawn_agent` → `Session` construction so the channel is present from session creation
- All non-`spawn_child` callers pass `None` for the new parameter (no behavioral change)

## Type of change

| Type | Label |
|------|-------|
| Bug fix | `bug` |

## Component

`core`

## Closes

Closes #1376

## Test plan

- [x] `cargo check -p rara-kernel` passes
- [x] All pre-commit hooks pass (check, fmt, clippy, doc, AGENT.md)
- [x] Race timeline verified: `result_tx` is now on Session from creation → turn completion always finds it → `cleanup_process` always runs → permit always released