### PR TITLE
feat(kernel): Yahoo Finance stock data feed integration test (#1383)

### DIFF
--- a/crates/kernel/src/data_feed/AGENT.md
+++ b/crates/kernel/src/data_feed/AGENT.md
@@ -12,11 +12,17 @@ External data ingestion subsystem: receives events from webhooks, WebSocket stre
 - `feed.rs` — `DataFeed` trait: the abstraction each transport implements (`name`, `tags`, `run`).
 - `registry.rs` — `DataFeedRegistry`: in-memory CRUD for feed configs + cancellation token tracking for running tasks.
 - `webhook.rs` — `WebhookState`, `webhook_handler` (axum POST handler), HMAC-SHA256 verification, idempotency cache, `webhook_routes` for server registration, `WebhookConfig` for per-feed webhook settings.
+- `polling.rs` — `PollingSource`: generic HTTP polling feed with pluggable `ResponseParser` trait. Periodically GETs a URL, passes the response body to the parser, and sends resulting `FeedEvent`s. Resilient: logs warnings on errors but continues polling.
+- `yahoo.rs` — `YahooStockFeed`: Yahoo Finance v8 chart API polling feed. Tracks multiple stock symbols, emits `price_update` events. `parse_chart_response` is the public parsing function, unit-testable with JSON fixtures. Integration tests are `#[ignore]` (require network).
 - `mod.rs` — Re-exports only; no logic.
 
 Data flow: Transport layer (webhook/WS/polling) -> `FeedEvent` -> `FeedStore::append` -> subscription dispatch -> agent session.
 
 Webhook flow: External POST -> `/api/v1/webhooks/{feed_name}` -> `webhook_handler` -> registry lookup -> HMAC verify -> dedup check -> `FeedEvent` -> `event_tx` channel -> kernel.
+
+Polling flow: `PollingSource::run` loop -> `tokio::select!` (cancel vs sleep) -> HTTP GET -> `ResponseParser::parse` -> `FeedEvent`s -> `event_tx` channel.
+
+Yahoo flow: `YahooStockFeed::run` loop -> per-symbol `fetch_symbol` -> Yahoo v8 API -> `parse_chart_response` -> `FeedEvent` with `event_type = "price_update"`.
 
 Registry flow: Caller loads configs from settings -> `DataFeedRegistry::restore` -> runtime `register`/`remove` -> caller persists via `configs()`.
 
@@ -50,6 +56,8 @@ These operate directly on `DataFeedRegistry` via `KernelHandle` — no event que
 - Webhook HMAC verification uses constant-time comparison (`subtle::ConstantTimeEq`) — never use `==` for signature comparison. Violation enables timing attacks.
 - Webhook idempotency cache is in-memory with 1h TTL — process restarts reset it. This is acceptable because `FeedStore::append` is also idempotent on `event.id`.
 - `KernelHandle` fields `feed_registry` and `feed_store` are `Option` — both are `None` until the data feed subsystem is fully wired into kernel bootstrap.
+- `PollingSource` and `YahooStockFeed` must gracefully handle transient HTTP errors — log and continue, never crash the poll loop.
+- Yahoo integration tests MUST be `#[ignore]` — they require network access and must not block CI.
 
 ## What NOT To Do
 
@@ -60,10 +68,12 @@ These operate directly on `DataFeedRegistry` via `KernelHandle` — no event que
 - Do NOT use `==` for HMAC signature comparison in webhook.rs — use `subtle::ConstantTimeEq` to prevent timing attacks.
 - Do NOT add webhook-specific config fields to `DataFeedConfig` — webhook settings go in `WebhookConfig` and are stored inside `DataFeedConfig::config` as JSON.
 - Do NOT add new `Syscall` enum variants for data feed operations — they operate directly on `DataFeedRegistry` (synchronous) via `KernelHandle`, not through the event queue.
+- Do NOT make Yahoo integration tests run in CI — always mark with `#[ignore]` since Yahoo Finance API may rate-limit or change without notice.
+- Do NOT embed API keys in `YahooStockFeed` — the v8 chart endpoint is keyless; if future endpoints need auth, use the credential store.
 
 ## Dependencies
 
-- Upstream: `base` (for `define_id!` macro), `jiff` (timestamps), `crate::session` (for `SessionKey`), `parking_lot`, `tokio_util` (CancellationToken), `axum` (webhook handler types), `hmac`/`sha2`/`subtle`/`hex` (signature verification).
+- Upstream: `base` (for `define_id!` macro), `jiff` (timestamps), `crate::session` (for `SessionKey`), `parking_lot`, `tokio_util` (CancellationToken), `axum` (webhook handler types), `hmac`/`sha2`/`subtle`/`hex` (signature verification), `reqwest` (polling HTTP client).
 - Downstream: `query-feed` tool (in `tool/data_feed.rs`), kernel syscall actions (in `syscall.rs`), kernel startup (restore), server route registration (via `webhook_routes`).
 - DB: `feed_events` + `feed_read_cursors` tables (migration in `crates/rara-model/migrations/`).
 - Settings: feed configs persisted via `SettingsProvider` KV store (key: `data_feeds.configs`).

--- a/crates/kernel/src/data_feed/mod.rs
+++ b/crates/kernel/src/data_feed/mod.rs
@@ -24,13 +24,17 @@
 //! - [`DataFeedConfig`] / [`FeedType`] — persisted configuration types.
 //! - [`DataFeedRegistry`] — runtime registry managing feed configs and tasks.
 //! - [`webhook`] — HTTP POST receiver with HMAC verification and dedup.
+//! - [`polling`] — generic HTTP polling source with pluggable response parser.
+//! - [`yahoo`] — Yahoo Finance stock price polling feed.
 
 mod config;
 mod event;
 mod feed;
+pub mod polling;
 mod registry;
 mod store;
 pub mod webhook;
+pub mod yahoo;
 
 pub use config::{DataFeedConfig, FeedType};
 pub use event::{FeedEvent, FeedEventId};

--- a/crates/kernel/src/data_feed/polling.rs
+++ b/crates/kernel/src/data_feed/polling.rs
@@ -1,0 +1,200 @@
+// Copyright 2025 Rararulab
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Generic polling data feed — periodically fetches data from an HTTP endpoint.
+//!
+//! [`PollingSource`] pairs a URL + interval with a caller-supplied
+//! [`ResponseParser`] that converts each HTTP response body into zero or more
+//! [`FeedEvent`]s. The poll loop runs until the cancellation token fires,
+//! logging warnings on transient errors without crashing.
+
+use std::time::Duration;
+
+use async_trait::async_trait;
+use tokio::sync::mpsc;
+use tokio_util::sync::CancellationToken;
+use tracing::{instrument, warn};
+
+use super::{DataFeed, FeedEvent};
+
+// ---------------------------------------------------------------------------
+// ResponseParser — pluggable response-to-event conversion
+// ---------------------------------------------------------------------------
+
+/// Converts a raw HTTP response body into feed events.
+///
+/// Implementations are source-specific: a Yahoo Finance parser extracts price
+/// data, a weather parser extracts forecasts, etc. The parser receives the
+/// source name and base tags so it can populate the [`FeedEvent`] envelope
+/// fields without duplicating that knowledge.
+#[async_trait]
+pub trait ResponseParser: Send + Sync + 'static {
+    /// Parse `body` into zero or more [`FeedEvent`]s.
+    ///
+    /// Returning an empty vec is valid (e.g. no new data since last poll).
+    /// Errors are logged but do not stop the poll loop.
+    fn parse(
+        &self,
+        body: &[u8],
+        source_name: &str,
+        base_tags: &[String],
+    ) -> anyhow::Result<Vec<FeedEvent>>;
+}
+
+// ---------------------------------------------------------------------------
+// PollingSource
+// ---------------------------------------------------------------------------
+
+/// A polling data feed that periodically HTTP-GETs a URL and converts the
+/// response into [`FeedEvent`]s via a [`ResponseParser`].
+#[derive(bon::Builder)]
+pub struct PollingSource {
+    /// Human-readable feed name.
+    name:     String,
+    /// Tags inherited by every event from this source.
+    tags:     Vec<String>,
+    /// Endpoint to poll.
+    url:      String,
+    /// Time between successive polls.
+    interval: Duration,
+    /// HTTP client (shared across polls).
+    client:   reqwest::Client,
+    /// Pluggable response-to-event converter.
+    parser:   Box<dyn ResponseParser>,
+}
+
+#[async_trait]
+impl DataFeed for PollingSource {
+    fn name(&self) -> &str { &self.name }
+
+    fn tags(&self) -> &[String] { &self.tags }
+
+    #[instrument(skip_all, fields(feed = %self.name))]
+    async fn run(
+        &self,
+        tx: mpsc::Sender<FeedEvent>,
+        cancel: CancellationToken,
+    ) -> anyhow::Result<()> {
+        tracing::info!(url = %self.url, interval = ?self.interval, "polling feed started");
+
+        loop {
+            tokio::select! {
+                () = cancel.cancelled() => {
+                    tracing::info!("polling feed cancelled, shutting down");
+                    break;
+                }
+                () = tokio::time::sleep(self.interval) => {
+                    self.poll_once(&tx).await;
+                }
+            }
+        }
+
+        Ok(())
+    }
+}
+
+impl PollingSource {
+    /// Execute a single poll cycle: fetch URL, parse response, send events.
+    async fn poll_once(&self, tx: &mpsc::Sender<FeedEvent>) {
+        let response = match self.client.get(&self.url).send().await {
+            Ok(r) => r,
+            Err(e) => {
+                warn!(error = %e, "poll fetch failed");
+                return;
+            }
+        };
+
+        let status = response.status();
+        if !status.is_success() {
+            warn!(%status, "poll received non-success status");
+            return;
+        }
+
+        let body = match response.bytes().await {
+            Ok(b) => b,
+            Err(e) => {
+                warn!(error = %e, "failed to read poll response body");
+                return;
+            }
+        };
+
+        let events = match self.parser.parse(&body, &self.name, &self.tags) {
+            Ok(evts) => evts,
+            Err(e) => {
+                warn!(error = %e, "response parsing failed");
+                return;
+            }
+        };
+
+        for event in events {
+            if tx.send(event).await.is_err() {
+                // Channel closed — receiver dropped; stop polling.
+                tracing::info!("event channel closed, stopping poll loop");
+                return;
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use tokio::sync::mpsc;
+    use tokio_util::sync::CancellationToken;
+
+    use super::*;
+
+    /// Trivial parser that always returns an empty vec.
+    struct NoopParser;
+
+    #[async_trait]
+    impl ResponseParser for NoopParser {
+        fn parse(
+            &self,
+            _body: &[u8],
+            _source_name: &str,
+            _base_tags: &[String],
+        ) -> anyhow::Result<Vec<FeedEvent>> {
+            Ok(vec![])
+        }
+    }
+
+    #[tokio::test]
+    async fn cancel_stops_polling() {
+        let cancel = CancellationToken::new();
+        let (tx, _rx) = mpsc::channel(16);
+
+        let source = PollingSource::builder()
+            .name("test-poll".to_owned())
+            .tags(vec!["test".to_owned()])
+            .url("http://localhost:99999/nonexistent".to_owned())
+            .interval(Duration::from_secs(3600))
+            .client(reqwest::Client::new())
+            .parser(Box::new(NoopParser))
+            .build();
+
+        let cancel_clone = cancel.clone();
+        let handle = tokio::spawn(async move { source.run(tx, cancel_clone).await });
+
+        // Cancel immediately — should return Ok(()).
+        cancel.cancel();
+        let result = tokio::time::timeout(Duration::from_secs(5), handle)
+            .await
+            .expect("task should complete within timeout")
+            .expect("task should not panic");
+
+        assert!(result.is_ok());
+    }
+}

--- a/crates/kernel/src/data_feed/yahoo.rs
+++ b/crates/kernel/src/data_feed/yahoo.rs
@@ -1,0 +1,487 @@
+// Copyright 2025 Rararulab
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Yahoo Finance stock data feed.
+//!
+//! Polls the Yahoo Finance v8 chart API for real-time stock prices and
+//! emits [`FeedEvent`]s with `event_type = "price_update"`. Each tracked
+//! symbol produces one event per poll cycle.
+//!
+//! # API endpoint
+//!
+//! ```text
+//! GET https://query1.finance.yahoo.com/v8/finance/chart/{symbol}?interval=1d&range=1d
+//! ```
+//!
+//! No API key is required for this endpoint.
+
+use std::time::Duration;
+
+use async_trait::async_trait;
+use jiff::Timestamp;
+use serde::Deserialize;
+use tokio::sync::mpsc;
+use tokio_util::sync::CancellationToken;
+use tracing::{instrument, warn};
+
+use super::{DataFeed, FeedEvent, FeedEventId};
+
+/// Base URL for Yahoo Finance v8 chart API.
+const YAHOO_CHART_BASE: &str = "https://query1.finance.yahoo.com/v8/finance/chart";
+
+// ---------------------------------------------------------------------------
+// Config
+// ---------------------------------------------------------------------------
+
+/// Configuration for the Yahoo Finance stock polling feed.
+pub struct YahooStockConfig {
+    /// Stock symbols to track (e.g. `["AAPL", "GOOGL", "MSFT"]`).
+    pub symbols:  Vec<String>,
+    /// Polling interval between successive fetches.
+    pub interval: Duration,
+}
+
+// ---------------------------------------------------------------------------
+// YahooStockFeed
+// ---------------------------------------------------------------------------
+
+/// A data feed that polls Yahoo Finance for stock price updates.
+///
+/// Iterates over configured symbols each poll cycle, fetching the v8 chart
+/// endpoint for each symbol and emitting a `price_update` [`FeedEvent`].
+#[derive(bon::Builder)]
+pub struct YahooStockFeed {
+    /// Human-readable feed name.
+    name:     String,
+    /// Tags inherited by every event.
+    tags:     Vec<String>,
+    /// Stock symbols to track.
+    symbols:  Vec<String>,
+    /// Polling interval.
+    interval: Duration,
+    /// Shared HTTP client.
+    client:   reqwest::Client,
+}
+
+impl YahooStockFeed {
+    /// Create a feed from a [`YahooStockConfig`].
+    pub fn from_config(name: impl Into<String>, config: YahooStockConfig) -> Self {
+        Self {
+            name:     name.into(),
+            tags:     vec!["stock".to_owned(), "yahoo".to_owned()],
+            symbols:  config.symbols,
+            interval: config.interval,
+            client:   reqwest::Client::new(),
+        }
+    }
+}
+
+#[async_trait]
+impl DataFeed for YahooStockFeed {
+    fn name(&self) -> &str { &self.name }
+
+    fn tags(&self) -> &[String] { &self.tags }
+
+    #[instrument(skip_all, fields(feed = %self.name))]
+    async fn run(
+        &self,
+        tx: mpsc::Sender<FeedEvent>,
+        cancel: CancellationToken,
+    ) -> anyhow::Result<()> {
+        tracing::info!(
+            symbols = ?self.symbols,
+            interval = ?self.interval,
+            "yahoo stock feed started"
+        );
+
+        loop {
+            tokio::select! {
+                () = cancel.cancelled() => {
+                    tracing::info!("yahoo stock feed cancelled, shutting down");
+                    break;
+                }
+                () = tokio::time::sleep(self.interval) => {
+                    self.poll_all_symbols(&tx).await;
+                }
+            }
+        }
+
+        Ok(())
+    }
+}
+
+impl YahooStockFeed {
+    /// Poll all configured symbols and send events.
+    async fn poll_all_symbols(&self, tx: &mpsc::Sender<FeedEvent>) {
+        for symbol in &self.symbols {
+            match self.fetch_symbol(symbol).await {
+                Ok(events) => {
+                    for event in events {
+                        if tx.send(event).await.is_err() {
+                            tracing::info!("event channel closed, stopping yahoo feed");
+                            return;
+                        }
+                    }
+                }
+                Err(e) => {
+                    warn!(symbol, error = %e, "failed to fetch yahoo stock data");
+                }
+            }
+        }
+    }
+
+    /// Fetch chart data for a single symbol and convert to events.
+    async fn fetch_symbol(&self, symbol: &str) -> anyhow::Result<Vec<FeedEvent>> {
+        let url = format!("{YAHOO_CHART_BASE}/{symbol}?interval=1d&range=1d");
+        let response = self
+            .client
+            .get(&url)
+            .header("User-Agent", "Mozilla/5.0")
+            .send()
+            .await?;
+
+        let status = response.status();
+        if !status.is_success() {
+            anyhow::bail!("yahoo API returned {status} for {symbol}");
+        }
+
+        let body = response.bytes().await?;
+        parse_chart_response(&body, symbol, &self.name, &self.tags)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Yahoo v8 chart response types (subset)
+// ---------------------------------------------------------------------------
+
+/// Top-level response envelope.
+#[derive(Debug, Deserialize)]
+struct ChartResponse {
+    chart: ChartResult,
+}
+
+/// Contains the result array.
+#[derive(Debug, Deserialize)]
+struct ChartResult {
+    result: Option<Vec<ChartData>>,
+}
+
+/// A single chart result entry.
+#[derive(Debug, Deserialize)]
+struct ChartData {
+    meta:       ChartMeta,
+    indicators: ChartIndicators,
+}
+
+/// Metadata for the chart (contains current price info).
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct ChartMeta {
+    symbol:               String,
+    regular_market_price: Option<f64>,
+    previous_close:       Option<f64>,
+}
+
+/// Contains quote indicators.
+#[derive(Debug, Deserialize)]
+struct ChartIndicators {
+    quote: Option<Vec<QuoteData>>,
+}
+
+/// Volume and price arrays from the quote indicator.
+#[derive(Debug, Deserialize)]
+struct QuoteData {
+    volume: Option<Vec<Option<u64>>>,
+}
+
+// ---------------------------------------------------------------------------
+// Response parsing
+// ---------------------------------------------------------------------------
+
+/// Parse a Yahoo Finance v8 chart API response into [`FeedEvent`]s.
+///
+/// Each chart result entry produces one `price_update` event. Returns an
+/// empty vec if the response contains no usable data (e.g. market closed
+/// with no `regularMarketPrice`).
+pub fn parse_chart_response(
+    body: &[u8],
+    symbol: &str,
+    source_name: &str,
+    base_tags: &[String],
+) -> anyhow::Result<Vec<FeedEvent>> {
+    let resp: ChartResponse = serde_json::from_slice(body)?;
+
+    let results = match resp.chart.result {
+        Some(r) if !r.is_empty() => r,
+        _ => return Ok(vec![]),
+    };
+
+    let mut events = Vec::with_capacity(results.len());
+
+    for data in &results {
+        let price = match data.meta.regular_market_price {
+            Some(p) => p,
+            None => continue,
+        };
+
+        let previous_close = data.meta.previous_close.unwrap_or(price);
+        let change = price - previous_close;
+        let change_percent = if previous_close.abs() > f64::EPSILON {
+            (change / previous_close) * 100.0
+        } else {
+            0.0
+        };
+
+        // Extract latest volume from the quote indicator arrays.
+        let volume = data
+            .indicators
+            .quote
+            .as_ref()
+            .and_then(|quotes| quotes.first())
+            .and_then(|q| q.volume.as_ref())
+            .and_then(|vols| vols.iter().rev().find_map(|v| *v))
+            .unwrap_or(0);
+
+        let now = Timestamp::now();
+        let sym_upper = data.meta.symbol.to_uppercase();
+
+        let mut tags = base_tags.to_vec();
+        let sym_lower = sym_upper.to_lowercase();
+        if !tags.contains(&sym_lower) {
+            tags.push(sym_lower);
+        }
+
+        let payload = serde_json::json!({
+            "symbol": sym_upper,
+            "price": price,
+            "change": (change * 100.0).round() / 100.0,
+            "change_percent": (change_percent * 100.0).round() / 100.0,
+            "volume": volume,
+            "timestamp": now.to_string(),
+        });
+
+        let event = FeedEvent::builder()
+            .id(FeedEventId::deterministic(&format!(
+                "{source_name}:{symbol}:{}",
+                now.as_millisecond()
+            )))
+            .source_name(source_name.to_owned())
+            .event_type("price_update".to_owned())
+            .tags(tags)
+            .payload(payload)
+            .received_at(now)
+            .build();
+
+        events.push(event);
+    }
+
+    Ok(events)
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use tokio::sync::mpsc;
+    use tokio_util::sync::CancellationToken;
+
+    use super::*;
+
+    /// Fixture: minimal Yahoo Finance v8 chart API response.
+    const YAHOO_RESPONSE_FIXTURE: &str = r#"{
+        "chart": {
+            "result": [{
+                "meta": {
+                    "symbol": "AAPL",
+                    "regularMarketPrice": 185.50,
+                    "previousClose": 183.25
+                },
+                "indicators": {
+                    "quote": [{
+                        "volume": [null, 45123456, 52345678]
+                    }]
+                }
+            }]
+        }
+    }"#;
+
+    #[test]
+    fn parse_chart_response_extracts_price_event() {
+        let events = parse_chart_response(
+            YAHOO_RESPONSE_FIXTURE.as_bytes(),
+            "AAPL",
+            "test-yahoo",
+            &["stock".to_owned(), "yahoo".to_owned()],
+        )
+        .expect("parse should succeed");
+
+        assert_eq!(events.len(), 1);
+
+        let event = &events[0];
+        assert_eq!(event.source_name, "test-yahoo");
+        assert_eq!(event.event_type, "price_update");
+        assert!(event.tags.contains(&"stock".to_owned()));
+        assert!(event.tags.contains(&"yahoo".to_owned()));
+        assert!(event.tags.contains(&"aapl".to_owned()));
+
+        let payload = &event.payload;
+        assert_eq!(payload["symbol"], "AAPL");
+        assert_eq!(payload["price"], 185.50);
+        assert_eq!(payload["volume"], 52345678);
+
+        // change = 185.50 - 183.25 = 2.25
+        assert_eq!(payload["change"], 2.25);
+
+        // change_percent = (2.25 / 183.25) * 100 = ~1.23%
+        let pct = payload["change_percent"].as_f64().expect("change_percent");
+        assert!((pct - 1.23).abs() < 0.01, "expected ~1.23, got {pct}");
+    }
+
+    #[test]
+    fn parse_chart_response_handles_empty_result() {
+        let body = br#"{"chart": {"result": []}}"#;
+        let events = parse_chart_response(body, "AAPL", "test-yahoo", &["stock".to_owned()])
+            .expect("parse should succeed");
+
+        assert!(events.is_empty());
+    }
+
+    #[test]
+    fn parse_chart_response_handles_null_result() {
+        let body = br#"{"chart": {"result": null}}"#;
+        let events = parse_chart_response(body, "AAPL", "test-yahoo", &["stock".to_owned()])
+            .expect("parse should succeed");
+
+        assert!(events.is_empty());
+    }
+
+    #[test]
+    fn parse_chart_response_skips_missing_price() {
+        let body = br#"{
+            "chart": {
+                "result": [{
+                    "meta": {
+                        "symbol": "AAPL",
+                        "previousClose": 183.25
+                    },
+                    "indicators": { "quote": [] }
+                }]
+            }
+        }"#;
+        let events = parse_chart_response(body, "AAPL", "test-yahoo", &["stock".to_owned()])
+            .expect("parse should succeed");
+
+        assert!(events.is_empty());
+    }
+
+    #[test]
+    fn parse_chart_response_handles_missing_volume() {
+        let body = br#"{
+            "chart": {
+                "result": [{
+                    "meta": {
+                        "symbol": "MSFT",
+                        "regularMarketPrice": 420.10,
+                        "previousClose": 418.00
+                    },
+                    "indicators": { "quote": [] }
+                }]
+            }
+        }"#;
+        let events = parse_chart_response(body, "MSFT", "test-yahoo", &["stock".to_owned()])
+            .expect("parse should succeed");
+
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].payload["volume"], 0);
+    }
+
+    #[test]
+    fn parse_chart_response_rejects_invalid_json() {
+        let body = b"not json at all";
+        let result = parse_chart_response(body, "AAPL", "test-yahoo", &["stock".to_owned()]);
+
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn yahoo_feed_cancel_stops_immediately() {
+        let cancel = CancellationToken::new();
+        let (tx, _rx) = mpsc::channel(16);
+
+        let feed = YahooStockFeed::builder()
+            .name("test-yahoo".to_owned())
+            .tags(vec!["stock".to_owned(), "yahoo".to_owned()])
+            .symbols(vec!["AAPL".to_owned()])
+            .interval(Duration::from_secs(3600))
+            .client(reqwest::Client::new())
+            .build();
+
+        let cancel_clone = cancel.clone();
+        let handle = tokio::spawn(async move { feed.run(tx, cancel_clone).await });
+
+        cancel.cancel();
+        let result = tokio::time::timeout(Duration::from_secs(5), handle)
+            .await
+            .expect("task should complete within timeout")
+            .expect("task should not panic");
+
+        assert!(result.is_ok());
+    }
+
+    // ----- Integration tests (require network) -----
+
+    #[tokio::test]
+    #[ignore = "requires network access — run with `cargo test -- --ignored`"]
+    async fn yahoo_feed_receives_real_price_event() {
+        let cancel = CancellationToken::new();
+        let (tx, mut rx) = mpsc::channel(16);
+
+        let feed = YahooStockFeed::builder()
+            .name("integration-test".to_owned())
+            .tags(vec!["stock".to_owned(), "yahoo".to_owned()])
+            .symbols(vec!["AAPL".to_owned()])
+            // Poll immediately by using a very short interval; we only need
+            // one cycle.
+            .interval(Duration::from_millis(100))
+            .client(reqwest::Client::new())
+            .build();
+
+        let cancel_clone = cancel.clone();
+        tokio::spawn(async move {
+            let _ = feed.run(tx, cancel_clone).await;
+        });
+
+        // Wait for at least one event (with generous timeout).
+        let event = tokio::time::timeout(Duration::from_secs(30), rx.recv())
+            .await
+            .expect("should receive event within timeout")
+            .expect("channel should not be closed");
+
+        assert_eq!(event.source_name, "integration-test");
+        assert_eq!(event.event_type, "price_update");
+        assert_eq!(event.payload["symbol"], "AAPL");
+
+        let price = event.payload["price"]
+            .as_f64()
+            .expect("price should be a number");
+        assert!(price > 0.0, "price should be positive, got {price}");
+
+        // Cleanup.
+        cancel.cancel();
+    }
+}


### PR DESCRIPTION
## Summary

- Add generic `PollingSource` with pluggable `ResponseParser` trait for reusable HTTP polling feeds
- Add `YahooStockFeed` that polls Yahoo Finance v8 chart API for real-time stock prices (`price_update` events)
- Comprehensive unit tests for JSON parsing edge cases (empty result, null result, missing price, missing volume, invalid JSON)
- `#[ignore]` integration test for live Yahoo Finance API validation
- Update `AGENT.md` with polling and yahoo module documentation

## Type of change

| Type | Label |
|------|-------|
| New feature | `enhancement` |

## Component

`core`

## Closes

Part of #1364. Closes #1383

## Test plan

- [x] `cargo check -p rara-kernel` passes
- [x] `cargo test -p rara-kernel -- data_feed` — 30 passed, 1 ignored
- [x] `cargo +nightly fmt --all -- --check` passes
- [x] `cargo clippy -p rara-kernel --all-targets --all-features --no-deps -- -D warnings` passes
- [x] `RUSTDOCFLAGS="-D warnings" cargo +nightly doc -p rara-kernel --no-deps --document-private-items` passes
- [x] All pre-commit hooks pass