### PR TITLE
feat(channels): add inline message Dashboard for Telegram (#1389)

### DIFF
--- a/crates/channels/src/telegram/adapter.rs
+++ b/crates/channels/src/telegram/adapter.rs
@@ -2183,7 +2183,10 @@ async fn handle_cascade_callback(
 /// Handle a dashboard callback: render the requested tab and edit the
 /// message in-place.
 ///
-/// Callback data format: `"dash:{tab}:{chat_id}:{msg_id}"`
+/// Callback data format: `"dash:{tab}:{chat_id}:{msg_id}:{trace_id}"`
+///
+/// Sessions are scoped to the chat's bound session + children so that
+/// one chat cannot inspect another chat's sessions.
 async fn handle_dashboard_callback(
     bot: &teloxide::Bot,
     callback: &teloxide::types::CallbackQuery,
@@ -2192,8 +2195,8 @@ async fn handle_dashboard_callback(
 ) {
     let _ = bot.answer_callback_query(callback.id.clone()).await;
 
-    let parts: Vec<&str> = data.splitn(4, ':').collect();
-    if parts.len() != 4 {
+    let parts: Vec<&str> = data.splitn(5, ':').collect();
+    if parts.len() < 4 {
         return;
     }
 
@@ -2201,10 +2204,26 @@ async fn handle_dashboard_callback(
     let (Ok(cid), Ok(mid)) = (parts[2].parse::<i64>(), parts[3].parse::<i32>()) else {
         return;
     };
+    let trace_id = parts.get(4).filter(|t| **t != "-").copied();
 
-    let sessions = handle.list_processes();
-    let text = super::dashboard::render_dashboard(tab, &sessions);
-    let keyboard = super::dashboard::dashboard_keyboard(tab, cid, mid);
+    // Scope sessions to this chat's bound session + its children.
+    let chat_id_str = cid.to_string();
+    let all_sessions = handle.list_processes();
+    let scoped = if let Ok(Some(binding)) = handle
+        .session_index()
+        .get_channel_binding(
+            rara_kernel::channel::types::ChannelType::Telegram,
+            &chat_id_str,
+        )
+        .await
+    {
+        super::dashboard::scoped_sessions(&all_sessions, binding.session_key)
+    } else {
+        vec![]
+    };
+
+    let text = super::dashboard::render_dashboard(tab, &scoped);
+    let keyboard = super::dashboard::dashboard_keyboard(tab, cid, mid, trace_id);
 
     let _ = bot
         .edit_message_text(ChatId(cid), MessageId(mid), &text)
@@ -3668,9 +3687,10 @@ fn spawn_stream_forwarder(
                                             ),
                                         ];
                                         // Show Dashboard button when background tasks exist.
+                                        // Include trace_id so the dashboard can offer a Back button.
                                         if !progress.background_tasks.is_empty() {
                                             let dash_cb = format!(
-                                                "dash:tasks:{}:{}",
+                                                "dash:tasks:{}:{}:{trace_id}",
                                                 chat_id, mid.0,
                                             );
                                             buttons.push(InlineKeyboardButton::callback(

--- a/crates/channels/src/telegram/adapter.rs
+++ b/crates/channels/src/telegram/adapter.rs
@@ -2206,20 +2206,38 @@ async fn handle_dashboard_callback(
     };
     let trace_id = parts.get(4).filter(|t| **t != "-").copied();
 
-    // Scope sessions to this chat's bound session + its children.
-    let chat_id_str = cid.to_string();
+    // Scope sessions to the originating session (from trace_id) + its
+    // children.  This anchors the dashboard to the session that produced
+    // the message, not the chat's *current* binding — so `/new` or
+    // `/checkout` won't make old Dashboard buttons show the wrong session.
     let all_sessions = handle.list_processes();
-    let scoped = if let Ok(Some(binding)) = handle
-        .session_index()
-        .get_channel_binding(
-            rara_kernel::channel::types::ChannelType::Telegram,
-            &chat_id_str,
-        )
-        .await
-    {
-        super::dashboard::scoped_sessions(&all_sessions, binding.session_key)
-    } else {
-        vec![]
+    let root_key = match trace_id {
+        Some(tid) => handle
+            .trace_service()
+            .get_session_id(tid)
+            .await
+            .ok()
+            .flatten()
+            .and_then(|s| rara_kernel::session::SessionKey::try_from_raw(&s).ok()),
+        None => {
+            // Fallback for dashboards opened without a trace_id (e.g.
+            // future `/dashboard` command): use the chat's current binding.
+            let chat_id_str = cid.to_string();
+            handle
+                .session_index()
+                .get_channel_binding(
+                    rara_kernel::channel::types::ChannelType::Telegram,
+                    &chat_id_str,
+                )
+                .await
+                .ok()
+                .flatten()
+                .map(|b| b.session_key)
+        }
+    };
+    let scoped = match root_key {
+        Some(key) => super::dashboard::scoped_sessions(&all_sessions, key),
+        None => vec![],
     };
 
     let text = super::dashboard::render_dashboard(tab, &scoped);

--- a/crates/channels/src/telegram/adapter.rs
+++ b/crates/channels/src/telegram/adapter.rs
@@ -2180,6 +2180,39 @@ async fn handle_cascade_callback(
     }
 }
 
+/// Handle a dashboard callback: render the requested tab and edit the
+/// message in-place.
+///
+/// Callback data format: `"dash:{tab}:{chat_id}:{msg_id}"`
+async fn handle_dashboard_callback(
+    bot: &teloxide::Bot,
+    callback: &teloxide::types::CallbackQuery,
+    data: &str,
+    handle: &KernelHandle,
+) {
+    let _ = bot.answer_callback_query(callback.id.clone()).await;
+
+    let parts: Vec<&str> = data.splitn(4, ':').collect();
+    if parts.len() != 4 {
+        return;
+    }
+
+    let tab = super::dashboard::DashTab::from_str_prefix(parts[1]);
+    let (Ok(cid), Ok(mid)) = (parts[2].parse::<i64>(), parts[3].parse::<i32>()) else {
+        return;
+    };
+
+    let sessions = handle.list_processes();
+    let text = super::dashboard::render_dashboard(tab, &sessions);
+    let keyboard = super::dashboard::dashboard_keyboard(tab, cid, mid);
+
+    let _ = bot
+        .edit_message_text(ChatId(cid), MessageId(mid), &text)
+        .parse_mode(ParseMode::Html)
+        .reply_markup(keyboard)
+        .await;
+}
+
 /// Listens for new approval requests and sends inline keyboard messages
 /// to the originating Telegram chat so the user can approve or deny.
 ///
@@ -2483,6 +2516,10 @@ async fn handle_update(
             }
             if data.starts_with("cas:") {
                 handle_cascade_callback(bot, callback, data, handle).await;
+                return;
+            }
+            if data.starts_with("dash:") {
+                handle_dashboard_callback(bot, callback, data, handle).await;
                 return;
             }
 
@@ -3620,7 +3657,7 @@ fn spawn_stream_forwarder(
                                             "cas:show:{}:{}:{trace_id}",
                                             chat_id, mid.0,
                                         );
-                                        let keyboard = InlineKeyboardMarkup::new(vec![vec![
+                                        let mut buttons = vec![
                                             InlineKeyboardButton::callback(
                                                 "\u{1f4ca} \u{8be6}\u{60c5}",
                                                 callback_data,
@@ -3629,7 +3666,19 @@ fn spawn_stream_forwarder(
                                                 "\u{1f50d} Cascade",
                                                 cascade_cb,
                                             ),
-                                        ]]);
+                                        ];
+                                        // Show Dashboard button when background tasks exist.
+                                        if !progress.background_tasks.is_empty() {
+                                            let dash_cb = format!(
+                                                "dash:tasks:{}:{}",
+                                                chat_id, mid.0,
+                                            );
+                                            buttons.push(InlineKeyboardButton::callback(
+                                                "\u{1f4f1} Dashboard",
+                                                dash_cb,
+                                            ));
+                                        }
+                                        let keyboard = InlineKeyboardMarkup::new(vec![buttons]);
 
                                         let _ = bot
                                             .edit_message_text(ChatId(chat_id), mid, &compact)

--- a/crates/channels/src/telegram/dashboard.rs
+++ b/crates/channels/src/telegram/dashboard.rs
@@ -18,7 +18,7 @@
 //! `editMessageText` + `InlineKeyboardMarkup` for navigation.  No external
 //! URL or Mini App required — the entire UI lives in native Telegram messages.
 
-use rara_kernel::session::{SessionState, SessionStats};
+use rara_kernel::session::{SessionKey, SessionState, SessionStats};
 use teloxide::types::{InlineKeyboardButton, InlineKeyboardMarkup};
 
 // ── Tab enum ────────────────────────────────────────────────────────────
@@ -48,12 +48,26 @@ impl DashTab {
     }
 }
 
+// ── Session scoping ─────────────────────────────────────────────────────
+
+/// Filter `all_sessions` to only those belonging to `root` and its children.
+///
+/// This enforces per-chat isolation: a Telegram chat should only see the
+/// session it is bound to (the root) and any children spawned from it.
+pub fn scoped_sessions(all_sessions: &[SessionStats], root: SessionKey) -> Vec<&SessionStats> {
+    all_sessions
+        .iter()
+        .filter(|s| s.session_key == root || s.parent_id == Some(root))
+        .collect()
+}
+
 // ── Rendering ───────────────────────────────────────────────────────────
 
 /// Render the full dashboard message body (HTML) for the given tab.
 ///
-/// The `sessions` slice should come from `KernelHandle::list_processes()`.
-pub fn render_dashboard(tab: DashTab, sessions: &[SessionStats]) -> String {
+/// The `sessions` slice should already be scoped to the requesting chat
+/// via [`scoped_sessions`].
+pub fn render_dashboard(tab: DashTab, sessions: &[&SessionStats]) -> String {
     let mut out = String::with_capacity(1024);
 
     match tab {
@@ -61,17 +75,24 @@ pub fn render_dashboard(tab: DashTab, sessions: &[SessionStats]) -> String {
         DashTab::Sessions => render_sessions_tab(sessions, &mut out),
     }
 
-    // Hard-truncate to 4000 chars (Telegram limit is 4096; leave buffer for
-    // HTML entities that may expand during display).
-    out.truncate(4000);
+    truncate_html_safe(&mut out, 4000);
     out
 }
 
 /// Build the inline keyboard for the dashboard.
 ///
-/// Layout: `[📋 Tasks] [🖥 Sessions] [🔄]`
-/// The active tab gets a `·` suffix.
-pub fn dashboard_keyboard(active_tab: DashTab, chat_id: i64, msg_id: i32) -> InlineKeyboardMarkup {
+/// Layout row 1: `[📋 Tasks] [🖥 Sessions] [🔄]`
+/// Layout row 2 (if trace_id present): `[← Back]`
+///
+/// When `trace_id` is `Some`, a second row with a Back button is added so
+/// users can return to the execution trace view.  The active tab gets a `·`
+/// suffix.
+pub fn dashboard_keyboard(
+    active_tab: DashTab,
+    chat_id: i64,
+    msg_id: i32,
+    trace_id: Option<&str>,
+) -> InlineKeyboardMarkup {
     let tasks_label = if active_tab == DashTab::Tasks {
         "\u{1f4cb} Tasks \u{b7}"
     } else {
@@ -83,36 +104,52 @@ pub fn dashboard_keyboard(active_tab: DashTab, chat_id: i64, msg_id: i32) -> Inl
         "\u{1f5a5} Sessions"
     };
 
-    let tasks_cb = format!("dash:tasks:{chat_id}:{msg_id}");
-    let sess_cb = format!("dash:sess:{chat_id}:{msg_id}");
-    let refresh_cb = format!("dash:{}:{chat_id}:{msg_id}", active_tab.callback_key(),);
+    // Embed trace_id in tab callbacks so it survives tab switches.
+    let tid = trace_id.unwrap_or("-");
+    let tasks_cb = format!("dash:tasks:{chat_id}:{msg_id}:{tid}");
+    let sess_cb = format!("dash:sess:{chat_id}:{msg_id}:{tid}");
+    let refresh_cb = format!(
+        "dash:{}:{chat_id}:{msg_id}:{tid}",
+        active_tab.callback_key()
+    );
 
-    InlineKeyboardMarkup::new(vec![vec![
+    let mut rows = vec![vec![
         InlineKeyboardButton::callback(tasks_label, tasks_cb),
         InlineKeyboardButton::callback(sess_label, sess_cb),
         InlineKeyboardButton::callback("\u{1f504}", refresh_cb),
-    ]])
+    ]];
+
+    // Back button to restore trace view — only if we have a real trace_id.
+    if let Some(tid) = trace_id {
+        let back_cb = format!("trace:hide:{chat_id}:{msg_id}:{tid}");
+        rows.push(vec![InlineKeyboardButton::callback(
+            "\u{2190} Back",
+            back_cb,
+        )]);
+    }
+
+    InlineKeyboardMarkup::new(rows)
 }
 
 // ── Tasks tab ───────────────────────────────────────────────────────────
 
-fn render_tasks_tab(sessions: &[SessionStats], out: &mut String) {
+fn render_tasks_tab(sessions: &[&SessionStats], out: &mut String) {
     out.push_str("\u{1f4ca} <b>rara \u{b7} Tasks</b>\n");
     out.push_str("───────────────\n");
 
     // Background tasks = child sessions (parent_id.is_some()).
-    let children: Vec<&SessionStats> = sessions.iter().filter(|s| s.parent_id.is_some()).collect();
+    let children: Vec<&&SessionStats> = sessions.iter().filter(|s| s.parent_id.is_some()).collect();
 
     if children.is_empty() {
         out.push_str("\nNo background tasks.\n");
         return;
     }
 
-    let running: Vec<&&SessionStats> = children
+    let running: Vec<&&&SessionStats> = children
         .iter()
         .filter(|s| matches!(s.state, SessionState::Active | SessionState::Ready))
         .collect();
-    let done: Vec<&&SessionStats> = children
+    let done: Vec<&&&SessionStats> = children
         .iter()
         .filter(|s| matches!(s.state, SessionState::Suspended | SessionState::Paused))
         .collect();
@@ -157,7 +194,7 @@ fn push_task_line(s: &SessionStats, finished: bool, out: &mut String) {
 
 // ── Sessions tab ────────────────────────────────────────────────────────
 
-fn render_sessions_tab(sessions: &[SessionStats], out: &mut String) {
+fn render_sessions_tab(sessions: &[&SessionStats], out: &mut String) {
     out.push_str("\u{1f4ca} <b>rara \u{b7} Sessions</b>\n");
     out.push_str("───────────────\n");
 
@@ -227,6 +264,21 @@ fn html_escape(s: &str) -> String {
         .replace('>', "&gt;")
 }
 
+/// Truncate an HTML string at a safe boundary: on a char boundary that is
+/// not inside an HTML tag or entity.  Falls back to the last `\n` before
+/// `max_len` to avoid splitting a line mid-tag.
+fn truncate_html_safe(s: &mut String, max_len: usize) {
+    if s.len() <= max_len {
+        return;
+    }
+    // Find the last newline at or before max_len (char-safe since '\n' is ASCII).
+    let cut = s[..max_len]
+        .rfind('\n')
+        .unwrap_or_else(|| s.floor_char_boundary(max_len));
+    s.truncate(cut);
+    s.push_str("\n<i>… truncated</i>");
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -241,8 +293,10 @@ mod tests {
     #[test]
     fn keyboard_callback_data_within_64_bytes() {
         use teloxide::types::InlineKeyboardButtonKind;
-        // Worst case: supergroup chat_id is ~14 digits, msg_id ~10 digits.
-        let kb = dashboard_keyboard(DashTab::Tasks, -1001234567890, 2147483647);
+        // Worst case: supergroup chat_id ~14 digits, msg_id ~10 digits,
+        // trace_id = ULID (26 chars).
+        let tid = "01JRWQY1234567890ABCDEFGH";
+        let kb = dashboard_keyboard(DashTab::Tasks, -1001234567890, 2147483647, Some(tid));
         for row in &kb.inline_keyboard {
             for btn in row {
                 if let InlineKeyboardButtonKind::CallbackData(ref data) = btn.kind {
@@ -273,6 +327,22 @@ mod tests {
     fn render_empty_tasks() {
         let text = render_dashboard(DashTab::Tasks, &[]);
         assert!(text.contains("No background tasks"));
+    }
+
+    #[test]
+    fn truncate_html_safe_preserves_valid_html() {
+        let mut s = "line1\nline2\nline3\nline4".to_string();
+        truncate_html_safe(&mut s, 12);
+        // Should cut at newline before pos 12, not mid-line.
+        assert!(s.starts_with("line1\nline2"));
+        assert!(s.ends_with("truncated</i>"));
+    }
+
+    #[test]
+    fn truncate_html_safe_noop_when_short() {
+        let mut s = "short".to_string();
+        truncate_html_safe(&mut s, 4000);
+        assert_eq!(s, "short");
     }
 
     #[test]

--- a/crates/channels/src/telegram/dashboard.rs
+++ b/crates/channels/src/telegram/dashboard.rs
@@ -1,0 +1,283 @@
+// Copyright 2025 Rararulab
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Telegram inline-message Dashboard.
+//!
+//! Renders a tab-based status view inside a single Telegram message, using
+//! `editMessageText` + `InlineKeyboardMarkup` for navigation.  No external
+//! URL or Mini App required — the entire UI lives in native Telegram messages.
+
+use rara_kernel::session::{SessionState, SessionStats};
+use teloxide::types::{InlineKeyboardButton, InlineKeyboardMarkup};
+
+// ── Tab enum ────────────────────────────────────────────────────────────
+
+/// Dashboard tab.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DashTab {
+    Tasks,
+    Sessions,
+}
+
+impl DashTab {
+    /// Parse from the callback data segment (e.g. `"tasks"` / `"sess"`).
+    pub fn from_str_prefix(s: &str) -> Self {
+        match s {
+            "sess" => Self::Sessions,
+            _ => Self::Tasks,
+        }
+    }
+
+    /// Short string used in callback data (must be short — 64-byte limit).
+    fn callback_key(self) -> &'static str {
+        match self {
+            Self::Tasks => "tasks",
+            Self::Sessions => "sess",
+        }
+    }
+}
+
+// ── Rendering ───────────────────────────────────────────────────────────
+
+/// Render the full dashboard message body (HTML) for the given tab.
+///
+/// The `sessions` slice should come from `KernelHandle::list_processes()`.
+pub fn render_dashboard(tab: DashTab, sessions: &[SessionStats]) -> String {
+    let mut out = String::with_capacity(1024);
+
+    match tab {
+        DashTab::Tasks => render_tasks_tab(sessions, &mut out),
+        DashTab::Sessions => render_sessions_tab(sessions, &mut out),
+    }
+
+    // Hard-truncate to 4000 chars (Telegram limit is 4096; leave buffer for
+    // HTML entities that may expand during display).
+    out.truncate(4000);
+    out
+}
+
+/// Build the inline keyboard for the dashboard.
+///
+/// Layout: `[📋 Tasks] [🖥 Sessions] [🔄]`
+/// The active tab gets a `·` suffix.
+pub fn dashboard_keyboard(active_tab: DashTab, chat_id: i64, msg_id: i32) -> InlineKeyboardMarkup {
+    let tasks_label = if active_tab == DashTab::Tasks {
+        "\u{1f4cb} Tasks \u{b7}"
+    } else {
+        "\u{1f4cb} Tasks"
+    };
+    let sess_label = if active_tab == DashTab::Sessions {
+        "\u{1f5a5} Sessions \u{b7}"
+    } else {
+        "\u{1f5a5} Sessions"
+    };
+
+    let tasks_cb = format!("dash:tasks:{chat_id}:{msg_id}");
+    let sess_cb = format!("dash:sess:{chat_id}:{msg_id}");
+    let refresh_cb = format!("dash:{}:{chat_id}:{msg_id}", active_tab.callback_key(),);
+
+    InlineKeyboardMarkup::new(vec![vec![
+        InlineKeyboardButton::callback(tasks_label, tasks_cb),
+        InlineKeyboardButton::callback(sess_label, sess_cb),
+        InlineKeyboardButton::callback("\u{1f504}", refresh_cb),
+    ]])
+}
+
+// ── Tasks tab ───────────────────────────────────────────────────────────
+
+fn render_tasks_tab(sessions: &[SessionStats], out: &mut String) {
+    out.push_str("\u{1f4ca} <b>rara \u{b7} Tasks</b>\n");
+    out.push_str("───────────────\n");
+
+    // Background tasks = child sessions (parent_id.is_some()).
+    let children: Vec<&SessionStats> = sessions.iter().filter(|s| s.parent_id.is_some()).collect();
+
+    if children.is_empty() {
+        out.push_str("\nNo background tasks.\n");
+        return;
+    }
+
+    let running: Vec<&&SessionStats> = children
+        .iter()
+        .filter(|s| matches!(s.state, SessionState::Active | SessionState::Ready))
+        .collect();
+    let done: Vec<&&SessionStats> = children
+        .iter()
+        .filter(|s| matches!(s.state, SessionState::Suspended | SessionState::Paused))
+        .collect();
+
+    if !running.is_empty() {
+        out.push_str(&format!("\n\u{1f504} <b>Running ({})</b>\n", running.len()));
+        for s in &running {
+            push_task_line(s, false, out);
+        }
+    }
+
+    if !done.is_empty() {
+        out.push_str(&format!("\n\u{2705} <b>Done ({})</b>\n", done.len()));
+        // Show only the most recent 10 to stay within message limits.
+        for s in done.iter().rev().take(10) {
+            push_task_line(s, true, out);
+        }
+        if done.len() > 10 {
+            out.push_str(&format!("  <i>… and {} more</i>\n", done.len() - 10));
+        }
+    }
+}
+
+fn push_task_line(s: &SessionStats, finished: bool, out: &mut String) {
+    let icon = if finished {
+        "\u{2714}"
+    } else {
+        "\u{23f3} \u{1f916}"
+    };
+    let uptime = format_uptime(s.uptime_ms);
+    let name = html_escape(&s.manifest_name);
+
+    if finished {
+        out.push_str(&format!("{icon} {name} \u{2014} {uptime}\n"));
+    } else {
+        out.push_str(&format!(
+            "{icon} {name}\n   {uptime} \u{b7} {} tools\n",
+            s.tool_calls,
+        ));
+    }
+}
+
+// ── Sessions tab ────────────────────────────────────────────────────────
+
+fn render_sessions_tab(sessions: &[SessionStats], out: &mut String) {
+    out.push_str("\u{1f4ca} <b>rara \u{b7} Sessions</b>\n");
+    out.push_str("───────────────\n");
+
+    if sessions.is_empty() {
+        out.push_str("\nNo active sessions.\n");
+        return;
+    }
+
+    out.push('\n');
+    for s in sessions {
+        let (icon, state_label) = match s.state {
+            SessionState::Active => ("\u{25b6}", "Running"),
+            SessionState::Ready => ("\u{25b6}", "Idle"),
+            SessionState::Suspended => ("\u{23f8}\u{fe0f}", "Suspended"),
+            SessionState::Paused => ("\u{23f8}\u{fe0f}", "Paused"),
+        };
+        let name = html_escape(&s.manifest_name);
+        let uptime = format_uptime(s.uptime_ms);
+        let child_hint = if s.parent_id.is_some() {
+            " (child)"
+        } else {
+            ""
+        };
+
+        out.push_str(&format!(
+            "{icon} <b>{name}</b>{child_hint} \u{2014} {state_label} \u{b7} {uptime}\n",
+        ));
+        out.push_str(&format!(
+            "  \u{2191}{} \u{2193}{} \u{b7} {} tools\n",
+            format_tokens(s.tokens_consumed / 2), // rough split: half in half out
+            format_tokens(s.tokens_consumed / 2),
+            s.tool_calls,
+        ));
+    }
+}
+
+// ── Helpers ─────────────────────────────────────────────────────────────
+
+fn format_uptime(ms: u64) -> String {
+    let total_sec = ms / 1000;
+    let hours = total_sec / 3600;
+    let minutes = (total_sec % 3600) / 60;
+    let seconds = total_sec % 60;
+    if hours > 0 {
+        format!("{hours}h {minutes}m")
+    } else if minutes > 0 {
+        format!("{minutes}m {seconds}s")
+    } else {
+        format!("{seconds}s")
+    }
+}
+
+fn format_tokens(n: u64) -> String {
+    if n >= 1_000_000 {
+        format!("{:.1}M", n as f64 / 1_000_000.0)
+    } else if n >= 1_000 {
+        format!("{:.1}k", n as f64 / 1_000.0)
+    } else {
+        format!("{n}")
+    }
+}
+
+/// Escape HTML entities for Telegram HTML parse mode.
+fn html_escape(s: &str) -> String {
+    s.replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn dash_tab_roundtrip() {
+        assert_eq!(DashTab::from_str_prefix("tasks"), DashTab::Tasks);
+        assert_eq!(DashTab::from_str_prefix("sess"), DashTab::Sessions);
+        assert_eq!(DashTab::from_str_prefix("unknown"), DashTab::Tasks);
+    }
+
+    #[test]
+    fn keyboard_callback_data_within_64_bytes() {
+        use teloxide::types::InlineKeyboardButtonKind;
+        // Worst case: supergroup chat_id is ~14 digits, msg_id ~10 digits.
+        let kb = dashboard_keyboard(DashTab::Tasks, -1001234567890, 2147483647);
+        for row in &kb.inline_keyboard {
+            for btn in row {
+                if let InlineKeyboardButtonKind::CallbackData(ref data) = btn.kind {
+                    assert!(
+                        data.len() <= 64,
+                        "callback data too long ({} bytes): {data}",
+                        data.len(),
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn html_escape_special_chars() {
+        assert_eq!(html_escape("<b>&test</b>"), "&lt;b&gt;&amp;test&lt;/b&gt;");
+    }
+
+    #[test]
+    fn format_uptime_values() {
+        assert_eq!(format_uptime(500), "0s");
+        assert_eq!(format_uptime(5_000), "5s");
+        assert_eq!(format_uptime(65_000), "1m 5s");
+        assert_eq!(format_uptime(3_665_000), "1h 1m");
+    }
+
+    #[test]
+    fn render_empty_tasks() {
+        let text = render_dashboard(DashTab::Tasks, &[]);
+        assert!(text.contains("No background tasks"));
+    }
+
+    #[test]
+    fn render_empty_sessions() {
+        let text = render_dashboard(DashTab::Sessions, &[]);
+        assert!(text.contains("No active sessions"));
+    }
+}

--- a/crates/channels/src/telegram/mod.rs
+++ b/crates/channels/src/telegram/mod.rs
@@ -16,6 +16,7 @@
 
 pub mod adapter;
 pub mod commands;
+pub mod dashboard;
 pub mod latex;
 pub mod loading_hints;
 pub mod markdown;


### PR DESCRIPTION
## Summary

Add a message-driven Dashboard to the Telegram channel — a single editable message with inline keyboard tabs for real-time background task status and session overview.

- **New `dashboard.rs`**: `render_dashboard()` for Tasks/Sessions tabs, `dashboard_keyboard()` with tab switching + refresh button
- **Callback handler**: `dash:{tab}:{chat_id}:{msg_id}` prefix routing in adapter callback dispatch
- **Turn completion**: conditional `[📱 Dashboard]` button appears when background tasks exist
- Zero config/frontend/API changes — entirely within the TG adapter layer

No Mini App needed (rara doesn't expose a public HTTPS URL). Uses native Telegram `editMessageText` + `InlineKeyboardMarkup` callbacks.

## Type of change

| Type | Label |
|------|-------|
| New feature | `enhancement` |

## Component

`backend`

## Closes

Closes #1389

## Test plan

- [x] `cargo check -p rara-channels` passes
- [x] `cargo clippy` zero warnings
- [x] `cargo +nightly fmt --check` clean
- [x] `cargo doc` passes (no broken links)
- [x] Unit tests in `dashboard.rs` pass (tab roundtrip, callback data ≤64 bytes, HTML escape, uptime format, empty state rendering)