### PR TITLE
Add anchor mode command presets

### DIFF
--- a/crates/app/src/config_sync.rs
+++ b/crates/app/src/config_sync.rs
@@ -43,9 +43,9 @@ const DEBOUNCE_MS: u64 = 1500;
 
 /// Bidirectional sync between config.yaml and the settings KV store.
 pub struct ConfigFileSync {
-    settings:          Arc<dyn SettingsProvider>,
-    app_config:        Arc<RwLock<AppConfig>>,
-    config_path:       PathBuf,
+    settings: Arc<dyn SettingsProvider>,
+    app_config: Arc<RwLock<AppConfig>>,
+    config_path: PathBuf,
     last_written_hash: Arc<AtomicU64>,
 }
 
@@ -88,6 +88,7 @@ impl ConfigFileSync {
             cfg.telegram = new_config.telegram;
             cfg.composio = new_config.composio;
             cfg.knowledge = new_config.knowledge;
+            cfg.context_folding = new_config.context_folding;
         }
         info!("config.yaml synced to settings store");
         Ok(())
@@ -96,7 +97,7 @@ impl ConfigFileSync {
     /// Write current settings back to config.yaml.
     async fn writeback_to_file(&self) -> anyhow::Result<()> {
         let all_settings = self.settings.list().await;
-        let (llm, telegram, wechat, composio, knowledge) =
+        let (context_folding, llm, telegram, wechat, composio, knowledge) =
             flatten::unflatten_from_settings(&all_settings);
 
         let yaml = {
@@ -106,6 +107,12 @@ impl ConfigFileSync {
             cfg.wechat = wechat;
             cfg.composio = composio;
             cfg.knowledge = knowledge;
+            if let Some(context_folding) = context_folding {
+                cfg.context_folding.enabled = context_folding.enabled;
+                cfg.context_folding.fold_threshold = context_folding.fold_threshold;
+                cfg.context_folding.min_entries_between_folds =
+                    context_folding.min_entries_between_folds;
+            }
             serde_yaml::to_string(&*cfg)?
         };
 
@@ -200,6 +207,7 @@ impl ConfigFileSync {
                                 cfg.telegram = new_config.telegram;
                                 cfg.composio = new_config.composio;
                                 cfg.knowledge = new_config.knowledge;
+                                cfg.context_folding = new_config.context_folding;
                             }
                             info!("config file change detected and synced to settings");
                         }
@@ -300,6 +308,12 @@ gateway:
   repo_url: "https://github.com/example/repo"
   bot_token: "456:DEF"
   chat_id: 789
+
+context_folding:
+  enabled: true
+  fold_threshold: 0.75
+  min_entries_between_folds: 30
+  fold_model: "fold-model"
 "#;
 
     #[test]
@@ -373,6 +387,23 @@ gateway:
                 .and_then(|k| k.embedding_model.as_deref()),
         );
 
+        assert_eq!(
+            config.context_folding.enabled,
+            reparsed.context_folding.enabled,
+        );
+        assert_eq!(
+            config.context_folding.fold_threshold,
+            reparsed.context_folding.fold_threshold,
+        );
+        assert_eq!(
+            config.context_folding.min_entries_between_folds,
+            reparsed.context_folding.min_entries_between_folds,
+        );
+        assert_eq!(
+            config.context_folding.fold_model,
+            reparsed.context_folding.fold_model,
+        );
+
         // None fields should stay None
         assert_eq!(
             config
@@ -383,6 +414,22 @@ gateway:
                 .telegram
                 .as_ref()
                 .and_then(|t| t.allowed_group_chat_id.as_deref()),
+        );
+    }
+
+    #[test]
+    fn context_folding_yaml_roundtrip() {
+        let config: AppConfig = serde_yaml::from_str(TEST_YAML).expect("TEST_YAML should parse");
+        let serialized = serde_yaml::to_string(&config).expect("AppConfig should serialize");
+        let reparsed: AppConfig =
+            serde_yaml::from_str(&serialized).expect("serialized YAML should reparse");
+
+        assert_eq!(reparsed.context_folding.enabled, true);
+        assert_eq!(reparsed.context_folding.fold_threshold, 0.75);
+        assert_eq!(reparsed.context_folding.min_entries_between_folds, 30);
+        assert_eq!(
+            reparsed.context_folding.fold_model.as_deref(),
+            Some("fold-model")
         );
     }
 }

--- a/crates/app/src/flatten.rs
+++ b/crates/app/src/flatten.rs
@@ -22,6 +22,7 @@ use std::collections::HashMap;
 use serde::{Deserialize, Serialize};
 
 use super::AppConfig;
+use rara_kernel::kernel::ContextFoldingConfig;
 
 // ---------------------------------------------------------------------------
 // LLM config types
@@ -47,7 +48,7 @@ pub struct LlmConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub default_provider: Option<String>,
     #[serde(skip_serializing_if = "HashMap::is_empty")]
-    pub providers:        HashMap<String, ProviderConfig>,
+    pub providers: HashMap<String, ProviderConfig>,
 }
 
 /// Configuration for a single LLM provider (OpenAI-compatible).
@@ -60,14 +61,14 @@ pub struct LlmConfig {
 #[serde(default)]
 pub struct ProviderConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub base_url:        Option<String>,
+    pub base_url: Option<String>,
     /// Required for all providers. For Ollama, use any placeholder value (e.g.
     /// `"ollama"`).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub api_key:         Option<String>,
+    pub api_key: Option<String>,
     /// Default model for this provider.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub default_model:   Option<String>,
+    pub default_model: Option<String>,
     /// Fallback models to try when the default is unavailable.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub fallback_models: Option<Vec<String>>,
@@ -82,13 +83,13 @@ pub struct ProviderConfig {
 #[serde(default)]
 pub struct TelegramConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub bot_token:               Option<String>,
+    pub bot_token: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub chat_id:                 Option<String>,
+    pub chat_id: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub allowed_group_chat_id:   Option<String>,
+    pub allowed_group_chat_id: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub group_policy:            Option<String>,
+    pub group_policy: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub notification_channel_id: Option<String>,
 }
@@ -106,7 +107,7 @@ pub struct WechatConfig {
     pub account_id: Option<String>,
     /// Base URL for the WeChat iLink API (defaults to production endpoint).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub base_url:   Option<String>,
+    pub base_url: Option<String>,
 }
 
 // ---------------------------------------------------------------------------
@@ -118,7 +119,7 @@ pub struct WechatConfig {
 #[serde(default)]
 pub struct ComposioConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub api_key:   Option<String>,
+    pub api_key: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub entity_id: Option<String>,
 }
@@ -141,15 +142,15 @@ pub struct ComposioConfig {
 #[serde(default)]
 pub struct KnowledgeConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub embedding_model:      Option<String>,
+    pub embedding_model: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub embedding_dimensions: Option<u32>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub search_top_k:         Option<u32>,
+    pub search_top_k: Option<u32>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub similarity_threshold: Option<f32>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub extractor_model:      Option<String>,
+    pub extractor_model: Option<String>,
 }
 
 // ---------------------------------------------------------------------------
@@ -159,6 +160,7 @@ pub struct KnowledgeConfig {
 /// Flatten all config-file sections into settings key-value pairs.
 pub fn flatten_config_sections(config: &AppConfig) -> Vec<(String, String)> {
     let mut pairs = Vec::new();
+    flatten_context_folding(&config.context_folding, &mut pairs);
     if let Some(ref llm) = config.llm {
         flatten_llm(llm, &mut pairs);
     }
@@ -175,6 +177,23 @@ pub fn flatten_config_sections(config: &AppConfig) -> Vec<(String, String)> {
         flatten_knowledge(k, &mut pairs);
     }
     pairs
+}
+
+fn flatten_context_folding(config: &ContextFoldingConfig, out: &mut Vec<(String, String)>) {
+    use rara_domain_shared::settings::keys;
+
+    out.push((
+        keys::CONTEXT_FOLDING_ENABLED.into(),
+        config.enabled.to_string(),
+    ));
+    out.push((
+        keys::CONTEXT_FOLDING_FOLD_THRESHOLD.into(),
+        config.fold_threshold.to_string(),
+    ));
+    out.push((
+        keys::CONTEXT_FOLDING_MIN_ENTRIES_BETWEEN_FOLDS.into(),
+        config.min_entries_between_folds.to_string(),
+    ));
 }
 
 fn flatten_llm(llm: &LlmConfig, out: &mut Vec<(String, String)>) {
@@ -271,6 +290,7 @@ fn flatten_knowledge(k: &KnowledgeConfig, out: &mut Vec<(String, String)>) {
 pub fn unflatten_from_settings<S: std::hash::BuildHasher>(
     pairs: &HashMap<String, String, S>,
 ) -> (
+    Option<ContextFoldingConfig>,
     Option<LlmConfig>,
     Option<TelegramConfig>,
     Option<WechatConfig>,
@@ -278,12 +298,50 @@ pub fn unflatten_from_settings<S: std::hash::BuildHasher>(
     Option<KnowledgeConfig>,
 ) {
     (
+        unflatten_context_folding(pairs),
         unflatten_llm(pairs),
         unflatten_telegram(pairs),
         unflatten_wechat(pairs),
         unflatten_composio(pairs),
         unflatten_knowledge(pairs),
     )
+}
+
+fn parse_context_folding_bool(raw: &str) -> Option<bool> {
+    match raw.trim().to_ascii_lowercase().as_str() {
+        "true" | "1" | "yes" | "on" => Some(true),
+        "false" | "0" | "no" | "off" => Some(false),
+        _ => None,
+    }
+}
+
+fn unflatten_context_folding(
+    pairs: &HashMap<String, String, impl std::hash::BuildHasher>,
+) -> Option<ContextFoldingConfig> {
+    use rara_domain_shared::settings::keys;
+
+    let enabled = pairs
+        .get(keys::CONTEXT_FOLDING_ENABLED)
+        .and_then(|value| parse_context_folding_bool(value));
+    let fold_threshold = pairs
+        .get(keys::CONTEXT_FOLDING_FOLD_THRESHOLD)
+        .and_then(|value| value.parse::<f64>().ok());
+    let min_entries_between_folds = pairs
+        .get(keys::CONTEXT_FOLDING_MIN_ENTRIES_BETWEEN_FOLDS)
+        .and_then(|value| value.parse::<usize>().ok());
+
+    if enabled.is_none() && fold_threshold.is_none() && min_entries_between_folds.is_none() {
+        return None;
+    }
+
+    let defaults = ContextFoldingConfig::default();
+    Some(ContextFoldingConfig {
+        enabled: enabled.unwrap_or(defaults.enabled),
+        fold_threshold: fold_threshold.unwrap_or(defaults.fold_threshold),
+        min_entries_between_folds: min_entries_between_folds
+            .unwrap_or(defaults.min_entries_between_folds),
+        fold_model: None,
+    })
 }
 
 fn unflatten_llm(
@@ -311,9 +369,9 @@ fn unflatten_llm(
     for name in &provider_names {
         found = true;
         let p = ProviderConfig {
-            base_url:        pairs.get(&format!("{prefix}{name}.base_url")).cloned(),
-            api_key:         pairs.get(&format!("{prefix}{name}.api_key")).cloned(),
-            default_model:   pairs.get(&format!("{prefix}{name}.default_model")).cloned(),
+            base_url: pairs.get(&format!("{prefix}{name}.base_url")).cloned(),
+            api_key: pairs.get(&format!("{prefix}{name}.api_key")).cloned(),
+            default_model: pairs.get(&format!("{prefix}{name}.default_model")).cloned(),
             fallback_models: pairs
                 .get(&format!("{prefix}{name}.fallback_models"))
                 .map(|v| v.split(',').map(|s| s.trim().to_string()).collect()),
@@ -423,16 +481,22 @@ mod tests {
 
     #[test]
     fn roundtrip_flatten_unflatten() {
+        let context_folding = ContextFoldingConfig {
+            enabled: true,
+            fold_threshold: 0.75,
+            min_entries_between_folds: 30,
+            fold_model: Some("fold-model".into()),
+        };
         let llm = LlmConfig {
             default_provider: Some("ollama".into()),
-            providers:        {
+            providers: {
                 let mut m = HashMap::new();
                 m.insert(
                     "ollama".into(),
                     ProviderConfig {
-                        base_url:        Some("http://localhost:11434/v1".into()),
-                        api_key:         Some("ollama".into()),
-                        default_model:   Some("qwen3:32b".into()),
+                        base_url: Some("http://localhost:11434/v1".into()),
+                        api_key: Some("ollama".into()),
+                        default_model: Some("qwen3:32b".into()),
                         fallback_models: Some(vec!["qwen3:14b".into(), "llama3:8b".into()]),
                     },
                 );
@@ -441,28 +505,29 @@ mod tests {
         };
 
         let telegram = TelegramConfig {
-            bot_token:               Some("123:ABC".into()),
-            chat_id:                 Some("456".into()),
-            allowed_group_chat_id:   Some("-789".into()),
-            group_policy:            Some("mention_or_small_group".into()),
+            bot_token: Some("123:ABC".into()),
+            chat_id: Some("456".into()),
+            allowed_group_chat_id: Some("-789".into()),
+            group_policy: Some("mention_or_small_group".into()),
             notification_channel_id: Some("-100".into()),
         };
 
         let composio = ComposioConfig {
-            api_key:   Some("cmp_test_key".into()),
+            api_key: Some("cmp_test_key".into()),
             entity_id: Some("workspace-default".into()),
         };
 
         let knowledge = KnowledgeConfig {
-            embedding_model:      Some("text-embedding-3-small".into()),
+            embedding_model: Some("text-embedding-3-small".into()),
             embedding_dimensions: Some(1536),
-            search_top_k:         Some(10),
+            search_top_k: Some(10),
             similarity_threshold: Some(0.85),
-            extractor_model:      Some("gpt-4o-mini".into()),
+            extractor_model: Some("gpt-4o-mini".into()),
         };
 
         // Flatten
         let mut flat = Vec::new();
+        flatten_context_folding(&context_folding, &mut flat);
         flatten_llm(&llm, &mut flat);
         flatten_telegram(&telegram, &mut flat);
         flatten_composio(&composio, &mut flat);
@@ -470,7 +535,18 @@ mod tests {
         let map: HashMap<String, String> = flat.into_iter().collect();
 
         // Unflatten
-        let (got_llm, got_tg, _got_wechat, got_composio, got_know) = unflatten_from_settings(&map);
+        let (got_cf, got_llm, got_tg, _got_wechat, got_composio, got_know) =
+            unflatten_from_settings(&map);
+
+        // --- Context folding ---
+        let got_cf = got_cf.expect("context_folding should be Some");
+        assert_eq!(got_cf.enabled, context_folding.enabled);
+        assert_eq!(got_cf.fold_threshold, context_folding.fold_threshold);
+        assert_eq!(
+            got_cf.min_entries_between_folds,
+            context_folding.min_entries_between_folds
+        );
+        assert!(got_cf.fold_model.is_none());
 
         // --- LLM ---
         let got_llm = got_llm.expect("llm should be Some");
@@ -516,11 +592,40 @@ mod tests {
     #[test]
     fn unflatten_empty_map_returns_none() {
         let map = HashMap::new();
-        let (llm, tg, wechat, composio, know) = unflatten_from_settings(&map);
+        let (context_folding, llm, tg, wechat, composio, know) = unflatten_from_settings(&map);
+        assert!(context_folding.is_none());
         assert!(wechat.is_none());
         assert!(llm.is_none());
         assert!(tg.is_none());
         assert!(composio.is_none());
         assert!(know.is_none());
+    }
+
+    #[test]
+    fn context_folding_flatten_unflatten_roundtrip() {
+        let context_folding = ContextFoldingConfig {
+            enabled: true,
+            fold_threshold: 0.45,
+            min_entries_between_folds: 8,
+            fold_model: Some("fold-model".into()),
+        };
+        let mut flat = Vec::new();
+        flatten_context_folding(&context_folding, &mut flat);
+        let map: HashMap<String, String> = flat.into_iter().collect();
+
+        let (got_context_folding, _, _, _, _, _) = unflatten_from_settings(&map);
+        let got_context_folding =
+            got_context_folding.expect("context_folding should be reconstructed");
+
+        assert_eq!(got_context_folding.enabled, context_folding.enabled);
+        assert_eq!(
+            got_context_folding.fold_threshold,
+            context_folding.fold_threshold
+        );
+        assert_eq!(
+            got_context_folding.min_entries_between_folds,
+            context_folding.min_entries_between_folds
+        );
+        assert!(got_context_folding.fold_model.is_none());
     }
 }

--- a/crates/app/src/lib.rs
+++ b/crates/app/src/lib.rs
@@ -63,56 +63,56 @@ use yunara_store::{config::DatabaseConfig, db::DBStore};
 pub struct AppConfig {
     /// Database connection pool (optional — defaults to max_connections=5).
     #[serde(default = "default_database_config")]
-    pub database:               DatabaseConfig,
+    pub database: DatabaseConfig,
     /// HTTP server bind / limits.
-    pub http:                   RestServerConfig,
+    pub http: RestServerConfig,
     /// gRPC server bind / limits.
-    pub grpc:                   GrpcServerConfig,
+    pub grpc: GrpcServerConfig,
     /// General OTLP telemetry (Alloy/Tempo).
     #[serde(default)]
-    pub telemetry:              TelemetryConfig,
+    pub telemetry: TelemetryConfig,
     /// Static bearer token for owner authentication (Web UI).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub owner_token:            Option<String>,
+    pub owner_token: Option<String>,
     /// LLM provider configuration (seeded to settings store at startup).
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub llm:                    Option<flatten::LlmConfig>,
+    pub llm: Option<flatten::LlmConfig>,
     /// Telegram bot configuration (seeded to settings store at startup).
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub telegram:               Option<flatten::TelegramConfig>,
+    pub telegram: Option<flatten::TelegramConfig>,
     /// WeChat iLink Bot configuration (seeded to settings store at startup).
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub wechat:                 Option<flatten::WechatConfig>,
+    pub wechat: Option<flatten::WechatConfig>,
     /// Composio credentials (seeded to settings store at startup).
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub composio:               Option<flatten::ComposioConfig>,
+    pub composio: Option<flatten::ComposioConfig>,
     /// Configured users with platform identity mappings (required).
-    pub users:                  Vec<crate::boot::UserConfig>,
+    pub users: Vec<crate::boot::UserConfig>,
     /// Maximum ingress messages per user per minute (rate limiting).
     #[serde(default = "default_max_ingress_per_minute")]
     pub max_ingress_per_minute: u32,
     /// Mita proactive agent configuration (required).
-    pub mita:                   MitaConfig,
+    pub mita: MitaConfig,
     /// Knowledge layer configuration (seeded to settings store at startup).
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub knowledge:              Option<flatten::KnowledgeConfig>,
+    pub knowledge: Option<flatten::KnowledgeConfig>,
     /// Speech-to-Text configuration (optional).
     /// When present, `base_url` is required — startup fails if missing.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub stt:                    Option<rara_stt::SttConfig>,
+    pub stt: Option<rara_stt::SttConfig>,
     /// Text-to-Speech configuration (optional).
     /// When present, voice replies are enabled for channels that support it.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub tts:                    Option<rara_tts::TtsConfig>,
+    pub tts: Option<rara_tts::TtsConfig>,
     /// Gateway supervisor configuration (optional — used by `rara gateway`).
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub gateway:                Option<GatewayConfig>,
+    pub gateway: Option<GatewayConfig>,
     /// Symphony autonomous coding agent orchestrator (optional).
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub symphony:               Option<rara_symphony::SymphonyConfig>,
+    pub symphony: Option<rara_symphony::SymphonyConfig>,
     /// Context folding (auto-anchor) configuration for the kernel.
     #[serde(default)]
-    pub context_folding:        rara_kernel::kernel::ContextFoldingConfig,
+    pub context_folding: rara_kernel::kernel::ContextFoldingConfig,
     /// Lightpanda browser subsystem (optional).
     ///
     /// When present, rara starts a Lightpanda CDP server and registers all
@@ -120,7 +120,7 @@ pub struct AppConfig {
     /// or when the binary is not installed, browser tools are not available and
     /// rara falls back to `http-fetch` for web access.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub browser:                Option<rara_browser::BrowserConfig>,
+    pub browser: Option<rara_browser::BrowserConfig>,
 }
 
 /// Configuration for the Mita background proactive agent.
@@ -143,10 +143,10 @@ pub struct GatewayConfig {
         deserialize_with = "humantime_serde::deserialize",
         serialize_with = "humantime_serde::serialize"
     )]
-    pub check_interval:       Duration,
+    pub check_interval: Duration,
     /// Total health confirmation timeout in seconds.
     #[serde(default = "gateway_defaults::health_timeout")]
-    pub health_timeout:       u64,
+    pub health_timeout: u64,
     /// HTTP health poll interval (e.g. "2s").
     #[serde(
         default = "gateway_defaults::health_poll_interval",
@@ -159,28 +159,40 @@ pub struct GatewayConfig {
     pub max_restart_attempts: u32,
     /// Whether to auto-apply upstream updates.
     #[serde(default = "gateway_defaults::auto_update")]
-    pub auto_update:          bool,
+    pub auto_update: bool,
     /// Bind address for the gateway admin HTTP API.
     #[serde(default = "gateway_defaults::bind_address")]
-    pub bind_address:         String,
+    pub bind_address: String,
     /// Repository URL for commit links in notifications (e.g. "<https://github.com/rararulab/rara>").
-    pub repo_url:             String,
+    pub repo_url: String,
     /// Telegram bot token for the gateway management bot (separate from rara's
     /// bot).
-    pub bot_token:            String,
+    pub bot_token: String,
     /// Telegram chat ID for the gateway bot (typically the admin's private
     /// chat).
-    pub chat_id:              i64,
+    pub chat_id: i64,
 }
 
 mod gateway_defaults {
     use std::time::Duration;
-    pub fn check_interval() -> Duration { Duration::from_secs(300) }
-    pub fn health_timeout() -> u64 { 30 }
-    pub fn health_poll_interval() -> Duration { Duration::from_secs(2) }
-    pub fn max_restart_attempts() -> u32 { 3 }
-    pub fn auto_update() -> bool { true }
-    pub fn bind_address() -> String { "127.0.0.1:25556".to_owned() }
+    pub fn check_interval() -> Duration {
+        Duration::from_secs(300)
+    }
+    pub fn health_timeout() -> u64 {
+        30
+    }
+    pub fn health_poll_interval() -> Duration {
+        Duration::from_secs(2)
+    }
+    pub fn max_restart_attempts() -> u32 {
+        3
+    }
+    pub fn auto_update() -> bool {
+        true
+    }
+    pub fn bind_address() -> String {
+        "127.0.0.1:25556".to_owned()
+    }
 }
 
 /// General OTLP telemetry configuration.
@@ -194,8 +206,12 @@ pub struct TelemetryConfig {
     pub otlp_protocol: Option<String>,
 }
 
-fn default_database_config() -> DatabaseConfig { DatabaseConfig::builder().build() }
-fn default_max_ingress_per_minute() -> u32 { 30 }
+fn default_database_config() -> DatabaseConfig {
+    DatabaseConfig::builder().build()
+}
+fn default_max_ingress_per_minute() -> u32 {
+    30
+}
 
 // ---------------------------------------------------------------------------
 // StartOptions
@@ -543,13 +559,11 @@ pub async fn start_with_options(
 
     let dock_store_path = rara_paths::data_dir().join("dock");
     let dock_state = rara_dock::DockRouterState {
-        store:         std::sync::Arc::new(rara_dock::DockSessionStore::new(dock_store_path)),
-        tape_service:  Some(rara.tape_service.clone()),
+        store: std::sync::Arc::new(rara_dock::DockSessionStore::new(dock_store_path)),
+        tape_service: Some(rara.tape_service.clone()),
         kernel_handle: Some(kernel_handle.clone()),
         mutation_sink: rara.dock_mutation_sink.clone(),
-        in_flight:     std::sync::Arc::new(parking_lot::Mutex::new(
-            std::collections::HashSet::new(),
-        )),
+        in_flight: std::sync::Arc::new(parking_lot::Mutex::new(std::collections::HashSet::new())),
     };
     let dock_routes = rara_dock::dock_router(dock_state);
 
@@ -601,9 +615,13 @@ pub async fn start_with_options(
     // Build command handlers shared across all channels.
     let command_handlers: Vec<std::sync::Arc<dyn rara_kernel::channel::command::CommandHandler>> = {
         use rara_channels::telegram::commands::{
-            BasicCommandHandler, DebugCommandHandler, McpCommandHandler, SessionCommandHandler,
-            StatusCommandHandler, StopCommandHandler, TapeCommandHandler,
+            AnchorModeCommandHandler, BasicCommandHandler, DebugCommandHandler, McpCommandHandler,
+            SessionCommandHandler, StatusCommandHandler, StopCommandHandler, TapeCommandHandler,
         };
+        let anchor_mode_handler = std::sync::Arc::new(AnchorModeCommandHandler::new(
+            settings_provider.clone(),
+            config.context_folding.clone(),
+        ));
         let session_handler = std::sync::Arc::new(SessionCommandHandler::new(bot_client.clone()));
         let stop_handler = std::sync::Arc::new(StopCommandHandler::new(
             bot_client.clone(),
@@ -619,6 +637,7 @@ pub async fn start_with_options(
         // Collect all command definitions so /help can list them.
         use rara_kernel::channel::command::CommandHandler as _;
         let all_commands: Vec<rara_kernel::channel::command::CommandDefinition> = [
+            anchor_mode_handler.commands(),
             session_handler.commands(),
             stop_handler.commands(),
             status_handler.commands(),
@@ -632,6 +651,7 @@ pub async fn start_with_options(
         let mcp_handler = std::sync::Arc::new(McpCommandHandler::new(bot_client.clone()));
         vec![
             basic_handler,
+            anchor_mode_handler,
             session_handler,
             stop_handler,
             status_handler,
@@ -900,12 +920,12 @@ async fn init_infra(config: &AppConfig) -> Result<DBStore, Whatever> {
 /// Handle for controlling a running application.
 #[allow(dead_code)]
 pub struct AppHandle {
-    shutdown_tx:               Option<oneshot::Sender<()>>,
-    running:                   Arc<AtomicBool>,
-    cancellation_token:        CancellationToken,
+    shutdown_tx: Option<oneshot::Sender<()>>,
+    running: Arc<AtomicBool>,
+    cancellation_token: CancellationToken,
     /// Kernel handle (for injecting inbound messages, accessing stream hub,
     /// endpoint registry, etc.).
-    pub kernel_handle:         Option<rara_kernel::handle::KernelHandle>,
+    pub kernel_handle: Option<rara_kernel::handle::KernelHandle>,
     /// Command handlers shared across all channels (Telegram, CLI, etc.).
     pub command_handlers: Vec<std::sync::Arc<dyn rara_kernel::channel::command::CommandHandler>>,
     /// User question manager for the ask-user tool (CLI needs it to subscribe
@@ -928,10 +948,14 @@ impl AppHandle {
 
     /// Check if the application is still running.
     #[must_use]
-    pub fn is_running(&self) -> bool { self.running.load(Ordering::SeqCst) }
+    pub fn is_running(&self) -> bool {
+        self.running.load(Ordering::SeqCst)
+    }
 
     /// Wait for the application to shutdown.
-    pub async fn wait_for_shutdown(&self) { self.cancellation_token.cancelled().await; }
+    pub async fn wait_for_shutdown(&self) {
+        self.cancellation_token.cancelled().await;
+    }
 }
 
 async fn shutdown_signal(shutdown_rx: oneshot::Receiver<()>) {

--- a/crates/channels/Cargo.toml
+++ b/crates/channels/Cargo.toml
@@ -16,6 +16,7 @@ image = { workspace = true }
 jiff = { workspace = true }
 rand = { workspace = true }
 rara-dock = { workspace = true }
+rara-domain-shared = { workspace = true }
 rara-kernel = { workspace = true }
 rara-mcp = { workspace = true }
 rara-paths = { workspace = true }

--- a/crates/channels/src/telegram/commands/anchor_mode.rs
+++ b/crates/channels/src/telegram/commands/anchor_mode.rs
@@ -1,0 +1,333 @@
+// Copyright 2025 Rararulab
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! `/anchor-mode` command — control automatic context folding aggressiveness
+//! through user-facing presets.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use rara_domain_shared::settings::SettingsProvider;
+use rara_kernel::{
+    channel::command::{
+        CommandContext, CommandDefinition, CommandHandler, CommandInfo, CommandResult,
+    },
+    error::KernelError,
+    kernel::{
+        ContextFoldingConfig, ContextFoldingPreset, context_folding_mode_name,
+        context_folding_settings_patch, effective_context_folding_config,
+    },
+};
+
+use super::session::html_escape;
+
+pub struct AnchorModeCommandHandler {
+    settings: Arc<dyn SettingsProvider>,
+    base_config: ContextFoldingConfig,
+}
+
+impl AnchorModeCommandHandler {
+    pub fn new(settings: Arc<dyn SettingsProvider>, base_config: ContextFoldingConfig) -> Self {
+        Self {
+            settings,
+            base_config,
+        }
+    }
+
+    async fn effective_config(&self) -> ContextFoldingConfig {
+        effective_context_folding_config(self.settings.as_ref(), &self.base_config).await
+    }
+
+    fn usage_text() -> &'static str {
+        "Usage: /anchor-mode [chat|balanced|deep-work]"
+    }
+
+    fn render_settings(config: &ContextFoldingConfig) -> String {
+        let fold_model = config.fold_model.as_deref().unwrap_or("(session model)");
+        format!(
+            "<code>enabled={}</code>\n<code>fold_threshold={:.2}</code>\n<code>min_entries_between_folds={}</code>\n<code>fold_model={}</code>",
+            config.enabled,
+            config.fold_threshold,
+            config.min_entries_between_folds,
+            html_escape(fold_model),
+        )
+    }
+
+    fn render_readback(config: &ContextFoldingConfig) -> CommandResult {
+        let mode = context_folding_mode_name(config);
+        let practical = ContextFoldingPreset::parse(mode)
+            .map(ContextFoldingPreset::practical_effect)
+            .unwrap_or("Using a custom folding profile outside the built-in presets.");
+
+        CommandResult::Html(format!(
+            "<b>Anchor mode</b>: <code>{}</code>\n{}\nApplies from the next agent turn.\n\n<b>Current settings</b>\n{}",
+            html_escape(mode),
+            html_escape(practical),
+            Self::render_settings(config),
+        ))
+    }
+}
+
+#[async_trait]
+impl CommandHandler for AnchorModeCommandHandler {
+    fn commands(&self) -> Vec<CommandDefinition> {
+        vec![CommandDefinition {
+            name: "anchor-mode".to_owned(),
+            description: "Show or switch automatic anchor frequency presets".to_owned(),
+            usage: Some("/anchor-mode [chat|balanced|deep-work]".to_owned()),
+        }]
+    }
+
+    async fn handle(
+        &self,
+        command: &CommandInfo,
+        _context: &CommandContext,
+    ) -> Result<CommandResult, KernelError> {
+        let raw_args = command.args.trim();
+        if raw_args.is_empty() {
+            return Ok(Self::render_readback(&self.effective_config().await));
+        }
+
+        let Some(preset) = ContextFoldingPreset::parse(raw_args) else {
+            return Ok(CommandResult::Html(format!(
+                "{}\nAvailable modes: <code>chat</code>, <code>balanced</code>, <code>deep-work</code>.",
+                Self::usage_text()
+            )));
+        };
+
+        let target_config = preset.config(self.base_config.fold_model.clone());
+        self.settings
+            .batch_update(context_folding_settings_patch(&target_config))
+            .await
+            .map_err(|error| KernelError::Other {
+                message: format!("failed to update anchor mode: {error}").into(),
+            })?;
+
+        Ok(CommandResult::Html(format!(
+            "<b>Anchor mode updated</b>: <code>{}</code>\n{}\nApplies from the next agent turn.\n\n<b>Applied settings</b>\n{}",
+            preset.slug(),
+            html_escape(preset.practical_effect()),
+            Self::render_settings(&target_config),
+        )))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use super::*;
+
+    struct TestSettings {
+        data: tokio::sync::RwLock<HashMap<String, String>>,
+        tx: tokio::sync::watch::Sender<()>,
+        rx: tokio::sync::watch::Receiver<()>,
+    }
+
+    impl TestSettings {
+        fn new() -> Self {
+            let (tx, rx) = tokio::sync::watch::channel(());
+            Self {
+                data: tokio::sync::RwLock::new(HashMap::new()),
+                tx,
+                rx,
+            }
+        }
+    }
+
+    #[async_trait]
+    impl SettingsProvider for TestSettings {
+        async fn get(&self, key: &str) -> Option<String> {
+            self.data.read().await.get(key).cloned()
+        }
+
+        async fn set(&self, key: &str, value: &str) -> anyhow::Result<()> {
+            self.data
+                .write()
+                .await
+                .insert(key.to_owned(), value.to_owned());
+            let _ = self.tx.send(());
+            Ok(())
+        }
+
+        async fn delete(&self, key: &str) -> anyhow::Result<()> {
+            self.data.write().await.remove(key);
+            let _ = self.tx.send(());
+            Ok(())
+        }
+
+        async fn list(&self) -> HashMap<String, String> {
+            self.data.read().await.clone()
+        }
+
+        async fn batch_update(
+            &self,
+            patches: HashMap<String, Option<String>>,
+        ) -> anyhow::Result<()> {
+            let mut data = self.data.write().await;
+            for (key, value) in patches {
+                match value {
+                    Some(value) => {
+                        data.insert(key, value);
+                    }
+                    None => {
+                        data.remove(&key);
+                    }
+                }
+            }
+            let _ = self.tx.send(());
+            Ok(())
+        }
+
+        fn subscribe(&self) -> tokio::sync::watch::Receiver<()> {
+            self.rx.clone()
+        }
+    }
+
+    fn test_context(args: &str) -> CommandInfo {
+        CommandInfo {
+            name: "anchor-mode".to_owned(),
+            args: args.to_owned(),
+            raw: if args.is_empty() {
+                "/anchor-mode".to_owned()
+            } else {
+                format!("/anchor-mode {args}")
+            },
+        }
+    }
+
+    fn test_command_context() -> CommandContext {
+        CommandContext {
+            channel_type: rara_kernel::channel::types::ChannelType::Cli,
+            session_key: "session".to_owned(),
+            user: rara_kernel::channel::types::ChannelUser {
+                platform_id: "cli:test".to_owned(),
+                display_name: Some("test".to_owned()),
+            },
+            metadata: HashMap::new(),
+        }
+    }
+
+    #[tokio::test]
+    async fn anchor_mode_readback_reports_effective_mode() {
+        let settings = Arc::new(TestSettings::new());
+        let handler = AnchorModeCommandHandler::new(
+            settings,
+            ContextFoldingPreset::Balanced.config(Some("fold-model".to_owned())),
+        );
+
+        let result = handler
+            .handle(&test_context(""), &test_command_context())
+            .await
+            .expect("readback succeeds");
+
+        match result {
+            CommandResult::Html(html) => {
+                assert!(html.contains("<code>balanced</code>"));
+                assert!(html.contains("fold_model=fold-model"));
+            }
+            other => panic!("expected HTML response, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn anchor_mode_invalid_argument_returns_usage() {
+        let settings = Arc::new(TestSettings::new());
+        let handler =
+            AnchorModeCommandHandler::new(settings, ContextFoldingPreset::Balanced.config(None));
+
+        let result = handler
+            .handle(&test_context("turbo"), &test_command_context())
+            .await
+            .expect("invalid argument still returns help");
+
+        match result {
+            CommandResult::Html(html) => {
+                assert!(html.contains("Usage: /anchor-mode"));
+                assert!(html.contains("deep-work"));
+            }
+            other => panic!("expected HTML response, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn anchor_mode_updates_settings_to_selected_preset() {
+        use rara_domain_shared::settings::keys;
+
+        let settings = Arc::new(TestSettings::new());
+        let handler = AnchorModeCommandHandler::new(
+            settings.clone(),
+            ContextFoldingPreset::Balanced.config(Some("fold-model".to_owned())),
+        );
+
+        let result = handler
+            .handle(&test_context("chat"), &test_command_context())
+            .await
+            .expect("set succeeds");
+
+        match result {
+            CommandResult::Html(html) => {
+                assert!(html.contains("<code>chat</code>"));
+                assert!(html.contains("working window smaller"));
+            }
+            other => panic!("expected HTML response, got {other:?}"),
+        }
+
+        assert_eq!(
+            settings.get(keys::CONTEXT_FOLDING_ENABLED).await.as_deref(),
+            Some("true")
+        );
+        assert_eq!(
+            settings
+                .get(keys::CONTEXT_FOLDING_FOLD_THRESHOLD)
+                .await
+                .as_deref(),
+            Some("0.45")
+        );
+        assert_eq!(
+            settings
+                .get(keys::CONTEXT_FOLDING_MIN_ENTRIES_BETWEEN_FOLDS)
+                .await
+                .as_deref(),
+            Some("8")
+        );
+    }
+
+    #[tokio::test]
+    async fn anchor_mode_help_is_discoverable_via_basic_handler() {
+        let settings = Arc::new(TestSettings::new());
+        let anchor_mode =
+            AnchorModeCommandHandler::new(settings, ContextFoldingPreset::Balanced.config(None));
+        let basic = super::super::basic::BasicCommandHandler::new(anchor_mode.commands());
+
+        let result = basic
+            .handle(
+                &CommandInfo {
+                    name: "help".to_owned(),
+                    args: String::new(),
+                    raw: "/help".to_owned(),
+                },
+                &test_command_context(),
+            )
+            .await
+            .expect("help succeeds");
+
+        match result {
+            CommandResult::Html(html) => {
+                assert!(html.contains("/anchor-mode [chat|balanced|deep-work]"));
+            }
+            other => panic!("expected HTML response, got {other:?}"),
+        }
+    }
+}

--- a/crates/channels/src/telegram/commands/mod.rs
+++ b/crates/channels/src/telegram/commands/mod.rs
@@ -22,6 +22,7 @@
 //! ## Modules
 //!
 //! - [`client`]: Backend service client trait and response types.
+//! - [`anchor_mode`]: `/anchor-mode` command.
 //! - [`basic`]: `/start` and `/help` commands.
 //! - [`session`]: `/new`, `/clear`, `/sessions`, `/usage`, `/model` commands.
 //! - [`kernel_client`]: `/search` and `/jd` commands.
@@ -31,6 +32,7 @@
 //! - [`callbacks`]: Inline keyboard callback handlers.
 
 pub mod anchor_dot;
+pub mod anchor_mode;
 pub mod basic;
 pub mod callbacks;
 pub mod client;
@@ -41,6 +43,7 @@ pub mod session;
 pub mod status;
 pub mod tape;
 
+pub use anchor_mode::AnchorModeCommandHandler;
 pub use basic::BasicCommandHandler;
 pub use callbacks::{
     SessionDeleteCallbackHandler, SessionDeleteCancelHandler, SessionDeleteConfirmHandler,

--- a/crates/cmd/Cargo.toml
+++ b/crates/cmd/Cargo.toml
@@ -60,6 +60,9 @@ yunara-store.workspace = true
 shadow-rs = { workspace = true }
 
 [dev-dependencies]
+anyhow.workspace = true
+async-trait.workspace = true
+rara-domain-shared = { workspace = true }
 rara-sessions = { workspace = true }
 tempfile.workspace = true
 

--- a/crates/cmd/src/chat/mod.rs
+++ b/crates/cmd/src/chat/mod.rs
@@ -117,7 +117,7 @@ impl ChatArgs {
 
         let cli_endpoint = Endpoint {
             channel_type: ChannelType::Cli,
-            address:      EndpointAddress::Cli {
+            address: EndpointAddress::Cli {
                 session_id: session_alias.clone(),
             },
         };
@@ -509,7 +509,7 @@ async fn handle_slash_command(
             let info = CommandInfo {
                 name: cmd_name.to_owned(),
                 args: args.to_owned(),
-                raw:  command.to_owned(),
+                raw: command.to_owned(),
             };
 
             let mut metadata = HashMap::new();
@@ -522,7 +522,7 @@ async fn handle_slash_command(
                 channel_type: ChannelType::Cli,
                 session_key: session_key.to_owned(),
                 user: ChannelUser {
-                    platform_id:  format!("cli:{user_id}"),
+                    platform_id: format!("cli:{user_id}"),
                     display_name: Some(user_id.to_owned()),
                 },
                 metadata,
@@ -552,15 +552,15 @@ async fn handle_new_session(state: &mut ChatState, kernel_handle: &KernelHandle)
     let session_index = kernel_handle.session_index();
     let now = Utc::now();
     let new_entry = SessionEntry {
-        key:           SessionKey::new(),
-        title:         None,
-        model:         None,
+        key: SessionKey::new(),
+        title: None,
+        model: None,
         system_prompt: None,
         message_count: 0,
-        preview:       None,
-        metadata:      None,
-        created_at:    now,
-        updated_at:    now,
+        preview: None,
+        metadata: None,
+        created_at: now,
+        updated_at: now,
     };
 
     let created = match session_index.create_session(&new_entry).await {
@@ -575,10 +575,10 @@ async fn handle_new_session(state: &mut ChatState, kernel_handle: &KernelHandle)
     let new_alias = short_session_key(&created.key);
     let binding = ChannelBinding {
         channel_type: ChannelType::Cli,
-        chat_id:      new_alias.clone(),
-        session_key:  created.key,
-        created_at:   now,
-        updated_at:   now,
+        chat_id: new_alias.clone(),
+        session_key: created.key,
+        created_at: now,
+        updated_at: now,
     };
 
     if let Err(e) = session_index.bind_channel(&binding).await {
@@ -690,10 +690,10 @@ async fn handle_switch_session(
     let now = Utc::now();
     let binding = ChannelBinding {
         channel_type: ChannelType::Cli,
-        chat_id:      new_alias.clone(),
-        session_key:  entry.key,
-        created_at:   now,
-        updated_at:   now,
+        chat_id: new_alias.clone(),
+        session_key: entry.key,
+        created_at: now,
+        updated_at: now,
     };
 
     if let Err(e) = session_index.bind_channel(&binding).await {
@@ -853,7 +853,9 @@ fn default_model_label(config: &AppConfig) -> String {
     }
 }
 
-fn cli_kernel_user_id(user_id: &str) -> UserId { UserId(user_id.to_owned()) }
+fn cli_kernel_user_id(user_id: &str) -> UserId {
+    UserId(user_id.to_owned())
+}
 
 async fn get_or_create_cli_session(
     session_index: &dyn SessionIndex,
@@ -869,15 +871,15 @@ async fn get_or_create_cli_session(
 
     let now = Utc::now();
     let entry = SessionEntry {
-        key:           SessionKey::new(),
-        title:         Some(chat_id.to_owned()),
-        model:         None,
+        key: SessionKey::new(),
+        title: Some(chat_id.to_owned()),
+        model: None,
         system_prompt: None,
         message_count: 0,
-        preview:       None,
-        metadata:      None,
-        created_at:    now,
-        updated_at:    now,
+        preview: None,
+        metadata: None,
+        created_at: now,
+        updated_at: now,
     };
     let created = session_index
         .create_session(&entry)
@@ -885,10 +887,10 @@ async fn get_or_create_cli_session(
         .whatever_context("Failed to create CLI chat session")?;
     let binding = ChannelBinding {
         channel_type: ChannelType::Cli,
-        chat_id:      chat_id.to_owned(),
-        session_key:  created.key.clone(),
-        created_at:   now,
-        updated_at:   now,
+        chat_id: chat_id.to_owned(),
+        session_key: created.key.clone(),
+        created_at: now,
+        updated_at: now,
     };
     session_index
         .bind_channel(&binding)
@@ -938,8 +940,8 @@ fn stream_event_to_cli_event(event: StreamEvent) -> CliEvent {
             total_steps,
             ..
         } => CliEvent::PlanCreated {
-            goal:              compact_summary,
-            total_steps:       total_steps as u32,
+            goal: compact_summary,
+            total_steps: total_steps as u32,
             step_descriptions: Vec::new(),
         },
         StreamEvent::PlanProgress {
@@ -1105,9 +1107,9 @@ fn build_cli_raw_message(
         platform_chat_id: Some(session_key.to_owned()),
         content,
         reply_context: Some(IoReplyContext {
-            thread_id:                None,
+            thread_id: None,
             reply_to_platform_msg_id: None,
-            interaction_type:         InteractionType::Message,
+            interaction_type: InteractionType::Message,
         }),
         metadata: HashMap::new(),
     }
@@ -1131,20 +1133,92 @@ async fn poll_crossterm_event() -> Option<Event> {
 
 #[cfg(test)]
 mod tests {
+    use std::{collections::HashMap, sync::Arc};
+
+    use async_trait::async_trait;
+    use rara_channels::telegram::commands::AnchorModeCommandHandler;
     use rara_channels::terminal::CliEvent;
     use rara_kernel::{
+        channel::command::CommandHandler,
         channel::types::{ChannelType, ContentBlock, MessageContent},
         identity::UserId,
         io::StreamEvent,
         session::SessionIndex,
+        testing::TestKernelBuilder,
     };
     use rara_sessions::file_index::FileSessionIndex;
 
     use super::{
-        build_cli_raw_message, cli_kernel_user_id, get_or_create_cli_session, short_session_key,
-        stream_event_to_cli_event,
+        build_cli_raw_message, cli_kernel_user_id, get_or_create_cli_session, handle_slash_command,
+        short_session_key, stream_event_to_cli_event,
     };
     use crate::chat::app::ChatState;
+
+    struct TestSettings {
+        data: tokio::sync::RwLock<HashMap<String, String>>,
+        tx: tokio::sync::watch::Sender<()>,
+        rx: tokio::sync::watch::Receiver<()>,
+    }
+
+    impl TestSettings {
+        fn new() -> Self {
+            let (tx, rx) = tokio::sync::watch::channel(());
+            Self {
+                data: tokio::sync::RwLock::new(HashMap::new()),
+                tx,
+                rx,
+            }
+        }
+    }
+
+    #[async_trait]
+    impl rara_domain_shared::settings::SettingsProvider for TestSettings {
+        async fn get(&self, key: &str) -> Option<String> {
+            self.data.read().await.get(key).cloned()
+        }
+
+        async fn set(&self, key: &str, value: &str) -> anyhow::Result<()> {
+            self.data
+                .write()
+                .await
+                .insert(key.to_owned(), value.to_owned());
+            let _ = self.tx.send(());
+            Ok(())
+        }
+
+        async fn delete(&self, key: &str) -> anyhow::Result<()> {
+            self.data.write().await.remove(key);
+            let _ = self.tx.send(());
+            Ok(())
+        }
+
+        async fn list(&self) -> HashMap<String, String> {
+            self.data.read().await.clone()
+        }
+
+        async fn batch_update(
+            &self,
+            patches: HashMap<String, Option<String>>,
+        ) -> anyhow::Result<()> {
+            let mut data = self.data.write().await;
+            for (key, value) in patches {
+                match value {
+                    Some(value) => {
+                        data.insert(key, value);
+                    }
+                    None => {
+                        data.remove(&key);
+                    }
+                }
+            }
+            let _ = self.tx.send(());
+            Ok(())
+        }
+
+        fn subscribe(&self) -> tokio::sync::watch::Receiver<()> {
+            self.rx.clone()
+        }
+    }
 
     #[tokio::test]
     async fn cli_session_binding_is_created_once_and_reused() {
@@ -1205,7 +1279,7 @@ mod tests {
             "describe",
             vec![ContentBlock::ImageBase64 {
                 media_type: "image/png".to_owned(),
-                data:       "AAAA".to_owned(),
+                data: "AAAA".to_owned(),
             }],
         );
 
@@ -1269,6 +1343,32 @@ mod tests {
 
         state.reset_messages();
         assert!(state.messages.is_empty());
+    }
+
+    #[tokio::test]
+    async fn anchor_mode_help_includes_registered_handler() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let test_kernel = TestKernelBuilder::new(tmp.path()).build().await;
+        let settings = Arc::new(TestSettings::new());
+        let handler: Arc<dyn CommandHandler> = Arc::new(AnchorModeCommandHandler::new(
+            settings,
+            rara_kernel::kernel::ContextFoldingPreset::Balanced.config(None),
+        ));
+        let mut state = ChatState::new("default".into(), "local".into());
+
+        let result = handle_slash_command(
+            &mut state,
+            "/help",
+            &[handler],
+            "default",
+            "local",
+            &test_kernel.handle,
+        )
+        .await;
+
+        assert!(matches!(result, super::HandleResult::Continue));
+        let help = &state.messages.last().expect("help message").text;
+        assert!(help.contains("/anchor-mode [chat|balanced|deep-work]"));
     }
 
     // -----------------------------------------------------------------------
@@ -1343,7 +1443,7 @@ mod tests {
         super::render_command_result(
             &mut state,
             CmdResult::Photo {
-                data:    vec![],
+                data: vec![],
                 caption: Some("Anchor tree (3 sessions)".to_owned()),
             },
         );
@@ -1359,7 +1459,7 @@ mod tests {
         super::render_command_result(
             &mut state,
             CmdResult::Photo {
-                data:    vec![],
+                data: vec![],
                 caption: None,
             },
         );
@@ -1375,11 +1475,11 @@ mod tests {
         super::render_command_result(
             &mut state,
             CmdResult::HtmlWithKeyboard {
-                html:     "<b>Status</b>\nActive: 1".to_owned(),
+                html: "<b>Status</b>\nActive: 1".to_owned(),
                 keyboard: vec![vec![InlineButton {
-                    text:          "All jobs".to_owned(),
+                    text: "All jobs".to_owned(),
                     callback_data: Some("status_jobs:abc".to_owned()),
-                    url:           None,
+                    url: None,
                 }]],
             },
         );

--- a/crates/domain/shared/src/settings/mod.rs
+++ b/crates/domain/shared/src/settings/mod.rs
@@ -22,6 +22,10 @@ use std::collections::HashMap;
 
 /// Well-known setting key constants.
 pub mod keys {
+    pub const CONTEXT_FOLDING_ENABLED: &str = "context_folding.enabled";
+    pub const CONTEXT_FOLDING_FOLD_THRESHOLD: &str = "context_folding.fold_threshold";
+    pub const CONTEXT_FOLDING_MIN_ENTRIES_BETWEEN_FOLDS: &str =
+        "context_folding.min_entries_between_folds";
     pub const LLM_DEFAULT_PROVIDER: &str = "llm.default_provider";
     pub const LLM_PROVIDER: &str = "llm.provider";
     pub const LLM_PROVIDERS_OPENROUTER_BASE_URL: &str = "llm.providers.openrouter.base_url";

--- a/crates/kernel/src/agent/mod.rs
+++ b/crates/kernel/src/agent/mod.rs
@@ -32,8 +32,7 @@ pub(crate) const CHILD_RESULT_SAFETY_LIMIT_BYTES: usize = 8000;
 
 /// Structured-output instructions appended to child agent system prompts
 /// so they self-summarize before returning results to the parent.
-pub(crate) const STRUCTURED_OUTPUT_SUFFIX: &str =
-    "\n\nWhen done, provide a structured result:\n1. Summary (2-3 sentences of what you did and \
+pub(crate) const STRUCTURED_OUTPUT_SUFFIX: &str = "\n\nWhen done, provide a structured result:\n1. Summary (2-3 sentences of what you did and \
      the outcome)\n2. Key changes or findings (bullet points)\n3. Issues encountered (if \
      any)\nKeep your final response concise — under 1500 characters.";
 
@@ -81,11 +80,11 @@ enum ContextPressure {
     Normal,
     Warning {
         estimated_tokens: usize,
-        usage_ratio:      f64,
+        usage_ratio: f64,
     },
     Critical {
         estimated_tokens: usize,
-        usage_ratio:      f64,
+        usage_ratio: f64,
     },
 }
 
@@ -141,13 +140,13 @@ pub enum Priority {
 pub struct SandboxConfig {
     /// Allowed file paths (read/write). Path-prefix matching.
     #[serde(default)]
-    pub allowed_paths:      Vec<String>,
+    pub allowed_paths: Vec<String>,
     /// Read-only paths (reads allowed, writes denied). Path-prefix matching.
     #[serde(default)]
-    pub read_only_paths:    Vec<String>,
+    pub read_only_paths: Vec<String>,
     /// Denied paths (takes precedence over allowed and read-only).
     #[serde(default)]
-    pub denied_paths:       Vec<String>,
+    pub denied_paths: Vec<String>,
     /// Whether to create an isolated temp workspace for this agent.
     #[serde(default)]
     pub isolated_workspace: bool,
@@ -203,52 +202,52 @@ impl ExecutionMode {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AgentManifest {
     /// Unique name identifying this agent definition.
-    pub name:                   String,
+    pub name: String,
     /// Agent's functional role (chat, scout, planner, worker).
     #[serde(default)]
-    pub role:                   AgentRole,
+    pub role: AgentRole,
     /// Human-readable description.
-    pub description:            String,
+    pub description: String,
     /// LLM model identifier.
     #[serde(default)]
-    pub model:                  Option<String>,
+    pub model: Option<String>,
     /// System prompt defining agent behavior.
-    pub system_prompt:          String,
+    pub system_prompt: String,
     /// Optional personality/mood/voice prompt.
     #[serde(default)]
-    pub soul_prompt:            Option<String>,
+    pub soul_prompt: Option<String>,
     /// Optional hint for provider selection.
     #[serde(default)]
-    pub provider_hint:          Option<String>,
+    pub provider_hint: Option<String>,
     /// Maximum LLM iterations before forced completion.
     #[serde(default)]
-    pub max_iterations:         Option<usize>,
+    pub max_iterations: Option<usize>,
     /// Tool names this agent is allowed to use (empty = inherit parent's
     /// tools).
     #[serde(default)]
-    pub tools:                  Vec<crate::tool::ToolName>,
+    pub tools: Vec<crate::tool::ToolName>,
     /// Tool names the agent is NOT allowed to use (denylist).
     ///
     /// Applied after `tools` allowlist filtering. If `tools` is empty (inherit
     /// all), excluded tools are removed from the full set. If `tools` is
     /// explicit, excluded tools are additionally removed.
     #[serde(default)]
-    pub excluded_tools:         Vec<crate::tool::ToolName>,
+    pub excluded_tools: Vec<crate::tool::ToolName>,
     /// Maximum number of concurrent child agents this agent can spawn.
     #[serde(default)]
-    pub max_children:           Option<usize>,
+    pub max_children: Option<usize>,
     /// Maximum context window size in tokens.
     #[serde(default)]
-    pub max_context_tokens:     Option<usize>,
+    pub max_context_tokens: Option<usize>,
     /// Dispatch priority for scheduling.
     #[serde(default)]
-    pub priority:               Priority,
+    pub priority: Priority,
     /// Arbitrary metadata for extension.
     #[serde(default)]
-    pub metadata:               serde_json::Value,
+    pub metadata: serde_json::Value,
     /// Optional sandbox configuration for file access control.
     #[serde(default)]
-    pub sandbox:                Option<SandboxConfig>,
+    pub sandbox: Option<SandboxConfig>,
     /// Default execution mode for this agent ("reactive" or "plan").
     /// When set, sessions using this manifest default to this mode
     /// unless overridden by session-level `/msg_version`.
@@ -268,19 +267,19 @@ pub struct AgentManifest {
     /// (e.g. Telegram inline keyboard) should enable this; channels without
     /// UI would hit the 120s timeout and silently stop.
     #[serde(default)]
-    pub tool_call_limit:        Option<usize>,
+    pub tool_call_limit: Option<usize>,
     /// Timeout in seconds for plan-mode worker steps. When a worker exceeds
     /// this duration it is terminated and the step is treated as failed.
     ///
     /// **Default: `None` (uses 300s fallback).**
     #[serde(default)]
-    pub worker_timeout_secs:    Option<u64>,
+    pub worker_timeout_secs: Option<u64>,
     /// Maximum self-elected continuations per turn.
     ///
     /// When set to `Some(0)`, continuation is disabled entirely.
     /// **Default: `None` (uses [`machine::DEFAULT_MAX_CONTINUATIONS`]).**
     #[serde(default)]
-    pub max_continuations:      Option<usize>,
+    pub max_continuations: Option<usize>,
 }
 
 /// Process environment — isolated per-agent context.
@@ -289,16 +288,16 @@ pub struct AgentEnv {
     /// Optional workspace directory for file operations.
     pub workspace: Option<String>,
     /// Key-value environment variables.
-    pub vars:      HashMap<String, String>,
+    pub vars: HashMap<String, String>,
 }
 
 /// Shared reference to the [`AgentRegistry`].
 pub type AgentRegistryRef = Arc<AgentRegistry>;
 
 pub struct AgentRegistry {
-    builtin:       HashMap<String, AgentManifest>,
-    custom:        DashMap<String, AgentManifest>,
-    agents_dir:    PathBuf,
+    builtin: HashMap<String, AgentManifest>,
+    custom: DashMap<String, AgentManifest>,
+    agents_dir: PathBuf,
     /// Role → agent name mapping for default agent resolution.
     role_defaults: DashMap<Role, String>,
 }
@@ -395,9 +394,13 @@ impl AgentRegistry {
         self.get(name.value())
     }
 
-    pub fn is_builtin(&self, name: &str) -> bool { self.builtin.contains_key(name) }
+    pub fn is_builtin(&self, name: &str) -> bool {
+        self.builtin.contains_key(name)
+    }
 
-    pub fn agents_dir(&self) -> &Path { &self.agents_dir }
+    pub fn agents_dir(&self) -> &Path {
+        &self.agents_dir
+    }
 }
 
 /// Loads [`AgentManifest`] definitions.
@@ -462,11 +465,15 @@ impl ManifestLoader {
     }
 
     /// List all loaded manifests.
-    pub fn list(&self) -> &[AgentManifest] { &self.manifests }
+    pub fn list(&self) -> &[AgentManifest] {
+        &self.manifests
+    }
 }
 
 impl Default for ManifestLoader {
-    fn default() -> Self { Self::new() }
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 /// Maximum byte length for result preview strings.
@@ -483,69 +490,69 @@ pub(crate) fn truncate_preview(s: &str, max_bytes: usize) -> String {
 
 /// A tool call being incrementally assembled from streaming deltas.
 struct PendingToolCall {
-    id:            String,
-    name:          String,
+    id: String,
+    name: String,
     arguments_buf: String,
 }
 
 /// Trace of a single tool call within an iteration.
 #[derive(Debug, Clone, serde::Serialize)]
 pub struct ToolCallTrace {
-    pub name:           String,
-    pub id:             String,
-    pub duration_ms:    u64,
-    pub success:        bool,
-    pub arguments:      serde_json::Value,
+    pub name: String,
+    pub id: String,
+    pub duration_ms: u64,
+    pub success: bool,
+    pub arguments: serde_json::Value,
     pub result_preview: String,
-    pub error:          Option<String>,
+    pub error: Option<String>,
 }
 
 /// Trace of a single LLM iteration within a turn.
 #[derive(Debug, Clone, serde::Serialize)]
 pub struct IterationTrace {
-    pub index:          usize,
+    pub index: usize,
     pub first_token_ms: Option<u64>,
-    pub stream_ms:      u64,
+    pub stream_ms: u64,
     /// First 200 chars of accumulated text.
-    pub text_preview:   String,
+    pub text_preview: String,
     /// Full accumulated reasoning text for this iteration.
     pub reasoning_text: Option<String>,
-    pub tool_calls:     Vec<ToolCallTrace>,
+    pub tool_calls: Vec<ToolCallTrace>,
 }
 
 /// Complete trace of a single agent turn.
 #[derive(Debug, Clone, serde::Serialize)]
 pub struct TurnTrace {
-    pub duration_ms:      u64,
-    pub model:            String,
+    pub duration_ms: u64,
+    pub model: String,
     /// The user message that triggered this turn.
-    pub input_text:       Option<String>,
-    pub iterations:       Vec<IterationTrace>,
-    pub final_text_len:   usize,
+    pub input_text: Option<String>,
+    pub iterations: Vec<IterationTrace>,
+    pub final_text_len: usize,
     pub total_tool_calls: usize,
-    pub success:          bool,
-    pub error:            Option<String>,
+    pub success: bool,
+    pub error: Option<String>,
     /// Rara internal message ID for end-to-end correlation.
     /// For user-triggered turns this is the `InboundMessage.id`;
     /// for proactive turns a fresh ID is generated at dispatch time.
-    pub rara_message_id:  crate::io::MessageId,
+    pub rara_message_id: crate::io::MessageId,
 }
 
 /// Result of a single agent turn.
 #[derive(Debug)]
 pub struct AgentTurnResult {
     /// The final text produced by the agent.
-    pub text:       String,
+    pub text: String,
     /// Number of LLM iterations consumed.
     pub iterations: usize,
     /// Number of tool calls executed.
     pub tool_calls: usize,
     /// Model used for this turn.
-    pub model:      String,
+    pub model: String,
     /// Detailed trace of the turn for observability.
-    pub trace:      TurnTrace,
+    pub trace: TurnTrace,
     /// Structured cascade trace built in real time during the turn.
-    pub cascade:    crate::cascade::CascadeTrace,
+    pub cascade: crate::cascade::CascadeTrace,
 }
 
 impl AgentTurnResult {
@@ -553,22 +560,22 @@ impl AgentTurnResult {
     /// judgment decides Rara should not reply.
     pub fn empty() -> Self {
         Self {
-            text:       String::new(),
+            text: String::new(),
             iterations: 0,
             tool_calls: 0,
-            model:      String::new(),
-            trace:      TurnTrace {
-                duration_ms:      0,
-                model:            String::new(),
-                input_text:       None,
-                iterations:       Vec::new(),
-                final_text_len:   0,
+            model: String::new(),
+            trace: TurnTrace {
+                duration_ms: 0,
+                model: String::new(),
+                input_text: None,
+                iterations: Vec::new(),
+                final_text_len: 0,
                 total_tool_calls: 0,
-                success:          true,
-                error:            None,
-                rara_message_id:  crate::io::MessageId::new(),
+                success: true,
+                error: None,
+                rara_message_id: crate::io::MessageId::new(),
             },
-            cascade:    crate::cascade::CascadeTrace::empty(),
+            cascade: crate::cascade::CascadeTrace::empty(),
         }
     }
 }
@@ -1092,7 +1099,11 @@ pub(crate) async fn run_agent_loop(
     let user_id = Some(tool_context.user_id.as_str());
 
     // ── Context folding state ────────────────────────────────────────
-    let fold_config = &handle.config().context_folding;
+    let fold_config = crate::kernel::effective_context_folding_config(
+        handle.settings().as_ref(),
+        &handle.config().context_folding,
+    )
+    .await;
     // Recover last auto-fold anchor's entry ID from tape so the cooldown
     // survives across turns (not just within a single run_agent_loop call).
     let mut last_fold_entry_id: Option<u64> =
@@ -1346,13 +1357,13 @@ pub(crate) async fn run_agent_loop(
 
         // Build completion request
         let request = llm::CompletionRequest {
-            model:               model.clone(),
-            messages:            request_messages,
-            tools:               tool_defs.clone(),
-            temperature:         Some(0.7),
-            max_tokens:          Some(2048),
-            thinking:            None,
-            tool_choice:         if tool_defs.is_empty() {
+            model: model.clone(),
+            messages: request_messages,
+            tools: tool_defs.clone(),
+            temperature: Some(0.7),
+            max_tokens: Some(2048),
+            thinking: None,
+            tool_choice: if tool_defs.is_empty() {
                 llm::ToolChoice::None
             } else {
                 llm::ToolChoice::Auto
@@ -1362,8 +1373,8 @@ pub(crate) async fn run_agent_loop(
             // especially prone to generating the same paragraph 3-4 times without
             // a penalty. 0.3 is a conservative value that curbs repetition without
             // degrading output quality. See #317.
-            frequency_penalty:   Some(0.3),
-            top_p:               None,
+            frequency_penalty: Some(0.3),
+            top_p: None,
         };
 
         // Start streaming via LlmDriver
@@ -1520,9 +1531,9 @@ pub(crate) async fn run_agent_loop(
                         cumulative_output_tokens =
                             cumulative_output_tokens.saturating_add(u.completion_tokens);
                         stream_handle.emit(StreamEvent::UsageUpdate {
-                            input_tokens:  u.prompt_tokens,
+                            input_tokens: u.prompt_tokens,
                             output_tokens: cumulative_output_tokens,
-                            thinking_ms:   cumulative_thinking_ms,
+                            thinking_ms: cumulative_thinking_ms,
                         });
                     }
                     break;
@@ -2023,8 +2034,8 @@ pub(crate) async fn run_agent_loop(
             let start_args = serde_json::from_str(&tool_call.arguments_buf)
                 .unwrap_or_else(|_| serde_json::Value::Object(Default::default()));
             stream_handle.emit(StreamEvent::ToolCallStart {
-                name:      tool_call.name.clone(),
-                id:        tool_call.id.clone(),
+                name: tool_call.name.clone(),
+                id: tool_call.id.clone(),
                 arguments: start_args,
             });
 
@@ -2045,11 +2056,11 @@ pub(crate) async fn run_agent_loop(
                             }),
                             serde_json::to_value(crate::memory::ToolResultMetadata {
                                 rara_message_id: rara_message_id.to_string(),
-                                tool_metrics:    vec![crate::memory::ToolMetric {
-                                    name:        tool_call.name.clone(),
+                                tool_metrics: vec![crate::memory::ToolMetric {
+                                    name: tool_call.name.clone(),
                                     duration_ms: 0,
-                                    success:     false,
-                                    error:       Some(error_message.clone()),
+                                    success: false,
+                                    error: Some(error_message.clone()),
                                 }],
                             })
                             .ok(),
@@ -2057,24 +2068,24 @@ pub(crate) async fn run_agent_loop(
                         .await;
                     let raw_args: String = tool_call.arguments_buf.chars().take(100).collect();
                     stream_handle.emit(StreamEvent::ToolCallEnd {
-                        id:             tool_call.id,
+                        id: tool_call.id,
                         result_preview: error_message.chars().take(200).collect(),
-                        success:        false,
-                        error:          Some(format!("{error_message} | args: {raw_args}")),
+                        success: false,
+                        error: Some(format!("{error_message} | args: {raw_args}")),
                     });
                     continue;
                 }
             };
 
             assistant_tool_calls.push(llm::ToolCallRequest {
-                id:        tool_call.id.clone(),
-                name:      tool_call.name.clone(),
+                id: tool_call.id.clone(),
+                name: tool_call.name.clone(),
                 arguments: tool_call.arguments_buf.clone(),
             });
             if let Some(ref mtx) = milestone_tx {
                 let _ = mtx
                     .send(crate::io::AgentEvent::Milestone {
-                        stage:  "tool_call_start".to_string(),
+                        stage: "tool_call_start".to_string(),
                         detail: Some(tool_call.name.clone()),
                     })
                     .await;
@@ -2547,10 +2558,10 @@ pub(crate) async fn run_agent_loop(
                 .zip(valid_tool_calls.iter())
                 .map(|((success, _, err, duration_ms), (_id, name, _args))| {
                     crate::memory::ToolMetric {
-                        name:        name.clone(),
+                        name: name.clone(),
                         duration_ms: *duration_ms,
-                        success:     *success,
-                        error:       err.clone(),
+                        success: *success,
+                        error: err.clone(),
                     }
                 })
                 .collect();
@@ -2669,15 +2680,15 @@ pub(crate) async fn run_agent_loop(
             let result_preview = truncate_preview(&result_str, RESULT_PREVIEW_MAX_BYTES);
 
             stream_handle.emit(StreamEvent::ToolCallEnd {
-                id:             id.clone(),
+                id: id.clone(),
                 result_preview: result_preview.clone(),
-                success:        *success,
-                error:          err.clone(),
+                success: *success,
+                error: err.clone(),
             });
             if let Some(ref mtx) = milestone_tx {
                 let _ = mtx
                     .send(crate::io::AgentEvent::Milestone {
-                        stage:  "tool_call_end".to_string(),
+                        stage: "tool_call_end".to_string(),
                         detail: Some(format!(
                             "{}: {}",
                             name,
@@ -2773,8 +2784,8 @@ pub(crate) async fn run_agent_loop(
                     next_limit_at = tool_calls_made + limit_interval;
                     stream_handle.emit(StreamEvent::ToolCallLimitResolved {
                         session_key: session_key.to_string(),
-                        limit_id:    current_limit_id,
-                        continued:   true,
+                        limit_id: current_limit_id,
+                        continued: true,
                     });
                 }
                 _ => {
@@ -2783,8 +2794,8 @@ pub(crate) async fn run_agent_loop(
                     warn!(tool_calls_made, "agent loop stopped by user or timeout");
                     stream_handle.emit(StreamEvent::ToolCallLimitResolved {
                         session_key: session_key.to_string(),
-                        limit_id:    current_limit_id,
-                        continued:   false,
+                        limit_id: current_limit_id,
+                        continued: false,
                     });
                     stopped_by_limit = true;
                     break;
@@ -3085,8 +3096,8 @@ mod tests {
         pending.insert(
             0,
             PendingToolCall {
-                id:            "call-1".to_string(),
-                name:          "write-file".to_string(),
+                id: "call-1".to_string(),
+                name: "write-file".to_string(),
                 arguments_buf: "{}".to_string(),
             },
         );

--- a/crates/kernel/src/kernel.rs
+++ b/crates/kernel/src/kernel.rs
@@ -40,6 +40,7 @@
 //! sends `Syscall` variants through the unified event queue.
 
 use std::{
+    collections::HashMap,
     sync::{
         Arc,
         atomic::{AtomicBool, Ordering},
@@ -87,11 +88,11 @@ use crate::{
 pub struct ContextFoldingConfig {
     /// Whether automatic context folding is enabled.
     #[default = false]
-    pub enabled:                   bool,
+    pub enabled: bool,
     /// Context pressure ratio at which auto-fold triggers (below the 0.70
     /// warning threshold).
     #[default = 0.60]
-    pub fold_threshold:            f64,
+    pub fold_threshold: f64,
     /// Minimum number of new tape entries since the last auto-fold before
     /// another fold is allowed (cooldown).
     #[default = 15]
@@ -99,7 +100,146 @@ pub struct ContextFoldingConfig {
     /// Model to use for fold summarization.  `None` falls back to the
     /// session's current model.
     #[default(_code = "None")]
-    pub fold_model:                Option<String>,
+    pub fold_model: Option<String>,
+}
+
+/// User-facing preset for automatic context folding aggressiveness.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ContextFoldingPreset {
+    Chat,
+    Balanced,
+    DeepWork,
+}
+
+impl ContextFoldingPreset {
+    pub const ALL: [Self; 3] = [Self::Chat, Self::Balanced, Self::DeepWork];
+
+    pub fn parse(raw: &str) -> Option<Self> {
+        match raw.trim().to_ascii_lowercase().as_str() {
+            "chat" => Some(Self::Chat),
+            "balanced" => Some(Self::Balanced),
+            "deep-work" | "deep_work" => Some(Self::DeepWork),
+            _ => None,
+        }
+    }
+
+    pub fn slug(self) -> &'static str {
+        match self {
+            Self::Chat => "chat",
+            Self::Balanced => "balanced",
+            Self::DeepWork => "deep-work",
+        }
+    }
+
+    pub fn practical_effect(self) -> &'static str {
+        match self {
+            Self::Chat => "Folds more frequently to keep the working window smaller.",
+            Self::Balanced => {
+                "Keeps the current default balance between folding and local context."
+            }
+            Self::DeepWork => "Preserves more recent local context and folds less often.",
+        }
+    }
+
+    pub fn config(self, fold_model: Option<String>) -> ContextFoldingConfig {
+        let (enabled, fold_threshold, min_entries_between_folds) = match self {
+            Self::Chat => (true, 0.45, 8),
+            Self::Balanced => (true, 0.60, 15),
+            Self::DeepWork => (true, 0.75, 30),
+        };
+
+        ContextFoldingConfig {
+            enabled,
+            fold_threshold,
+            min_entries_between_folds,
+            fold_model,
+        }
+    }
+
+    pub fn matches(self, config: &ContextFoldingConfig) -> bool {
+        let preset = self.config(None);
+        config.enabled == preset.enabled
+            && approx_fold_threshold_eq(config.fold_threshold, preset.fold_threshold)
+            && config.min_entries_between_folds == preset.min_entries_between_folds
+    }
+}
+
+fn approx_fold_threshold_eq(left: f64, right: f64) -> bool {
+    (left - right).abs() < 1e-9
+}
+
+fn parse_context_folding_bool(raw: &str) -> Option<bool> {
+    match raw.trim().to_ascii_lowercase().as_str() {
+        "true" | "1" | "yes" | "on" => Some(true),
+        "false" | "0" | "no" | "off" => Some(false),
+        _ => None,
+    }
+}
+
+pub fn matching_context_folding_preset(
+    config: &ContextFoldingConfig,
+) -> Option<ContextFoldingPreset> {
+    ContextFoldingPreset::ALL
+        .into_iter()
+        .find(|preset| preset.matches(config))
+}
+
+pub fn context_folding_mode_name(config: &ContextFoldingConfig) -> &'static str {
+    matching_context_folding_preset(config)
+        .map(ContextFoldingPreset::slug)
+        .unwrap_or("custom")
+}
+
+pub fn context_folding_settings_patch(
+    config: &ContextFoldingConfig,
+) -> HashMap<String, Option<String>> {
+    use rara_domain_shared::settings::keys;
+
+    HashMap::from([
+        (
+            keys::CONTEXT_FOLDING_ENABLED.to_owned(),
+            Some(config.enabled.to_string()),
+        ),
+        (
+            keys::CONTEXT_FOLDING_FOLD_THRESHOLD.to_owned(),
+            Some(config.fold_threshold.to_string()),
+        ),
+        (
+            keys::CONTEXT_FOLDING_MIN_ENTRIES_BETWEEN_FOLDS.to_owned(),
+            Some(config.min_entries_between_folds.to_string()),
+        ),
+    ])
+}
+
+pub async fn effective_context_folding_config(
+    settings: &dyn rara_domain_shared::settings::SettingsProvider,
+    base: &ContextFoldingConfig,
+) -> ContextFoldingConfig {
+    use rara_domain_shared::settings::keys;
+
+    let enabled = settings
+        .get(keys::CONTEXT_FOLDING_ENABLED)
+        .await
+        .as_deref()
+        .and_then(parse_context_folding_bool)
+        .unwrap_or(base.enabled);
+    let fold_threshold = settings
+        .get(keys::CONTEXT_FOLDING_FOLD_THRESHOLD)
+        .await
+        .and_then(|value| value.parse::<f64>().ok())
+        .unwrap_or(base.fold_threshold);
+    let min_entries_between_folds = settings
+        .get(keys::CONTEXT_FOLDING_MIN_ENTRIES_BETWEEN_FOLDS)
+        .await
+        .and_then(|value| value.parse::<usize>().ok())
+        .unwrap_or(base.min_entries_between_folds);
+
+    ContextFoldingConfig {
+        enabled,
+        fold_threshold,
+        min_entries_between_folds,
+        fold_model: base.fold_model.clone(),
+    }
 }
 
 /// Kernel configuration.
@@ -107,48 +247,48 @@ pub struct ContextFoldingConfig {
 pub struct KernelConfig {
     /// Maximum number of concurrent agent processes globally.
     #[default = 16]
-    pub max_concurrency:         usize,
+    pub max_concurrency: usize,
     /// Default maximum number of children per agent.
     #[default = 8]
-    pub default_child_limit:     usize,
+    pub default_child_limit: usize,
     /// Default max LLM iterations per agent turn.
     #[default = 60]
-    pub default_max_iterations:  usize,
+    pub default_max_iterations: usize,
     /// Hard cap for one tool execution wave inside a turn.
     ///
     /// Must be greater than any individual tool's own timeout (e.g. bash
     /// defaults to 120 s) so per-tool timeouts fire first and only the
     /// offending tool is killed rather than the entire wave.
     #[default(_code = "Duration::from_secs(180)")]
-    pub tool_execution_timeout:  Duration,
+    pub tool_execution_timeout: Duration,
     /// Default per-tool timeout applied when a tool's
     /// `execution_timeout()` returns `None`.
     ///
     /// Must be strictly less than `tool_execution_timeout` so the per-tool
     /// timeout fires before the global wave timeout.
     #[default(_code = "Duration::from_secs(120)")]
-    pub default_tool_timeout:    Duration,
+    pub default_tool_timeout: Duration,
     /// Maximum number of KV entries per agent (0 = unlimited).
     /// Applies to the agent-scoped namespace only.
     #[default = 1000]
-    pub memory_quota_per_agent:  usize,
+    pub memory_quota_per_agent: usize,
     /// Mita heartbeat interval. `None` disables the heartbeat.
     #[default(_code = "None")]
     pub mita_heartbeat_interval: Option<Duration>,
     // Event queue configuration. Controls whether the kernel uses a single
     // global queue (`num_shards = 0`) or sharded parallel processing.
-    pub event_queue:             ShardedEventQueueConfig,
+    pub event_queue: ShardedEventQueueConfig,
     /// Context folding (auto-anchor) configuration.
-    pub context_folding:         ContextFoldingConfig,
+    pub context_folding: ContextFoldingConfig,
     /// Ingress retry / dead-letter configuration.
     ///
     /// Controls how `push_with_retry` handles `IOError::Full` from the
     /// sharded queue when channel adapters publish messages. See
     /// [`crate::queue::push_with_retry`].
-    pub ingress:                 crate::queue::IngressConfig,
+    pub ingress: crate::queue::IngressConfig,
     /// Tool execution hook commands (PreToolUse / PostToolUse /
     /// PostToolUseFailure).
-    pub hooks:                   HooksConfig,
+    pub hooks: HooksConfig,
 }
 
 /// Shared reference to a
@@ -170,53 +310,53 @@ pub type SettingsRef = Arc<dyn rara_domain_shared::settings::SettingsProvider>;
 /// flattened directly into this struct.
 pub struct Kernel {
     /// Kernel configuration.
-    config:                KernelConfig,
+    config: KernelConfig,
     // -- Core subsystems (previously in KernelInner) -----------------------
     /// The global process table tracking all running agents.
-    process_table:         Arc<SessionTable>,
+    process_table: Arc<SessionTable>,
     /// Global semaphore limiting total concurrent agent processes.
-    global_semaphore:      Arc<Semaphore>,
+    global_semaphore: Arc<Semaphore>,
     /// Unified security subsystem (auth + authz + approval).
-    security:              SecurityRef,
+    security: SecurityRef,
     /// Agent registry for looking up named agent definitions.
-    agent_registry:        AgentRegistryRef,
+    agent_registry: AgentRegistryRef,
     /// Tape service for session message persistence.
-    tape_service:          TapeService,
+    tape_service: TapeService,
     /// Lightweight session metadata index (tape-centric replacement for the
     /// session CRUD subset of `SessionRepository`).
-    session_index:         SessionIndexRef,
+    session_index: SessionIndexRef,
     /// Flat KV settings provider for runtime configuration.
-    settings:              SettingsRef,
+    settings: SettingsRef,
     /// Syscall dispatcher (owns shared_kv, pipe_registry, driver_registry,
     /// tool_registry, event_bus).
-    syscall:               SyscallDispatcher,
+    syscall: SyscallDispatcher,
     // -- I/O subsystem -----------------------------------------------------
     /// Bundled I/O subsystem (ingress, stream hub, delivery).
-    io:                    Arc<IOSubsystem>,
+    io: Arc<IOSubsystem>,
     /// Unified event queue for all kernel interactions.
-    event_queue:           ShardedQueueRef,
+    event_queue: ShardedQueueRef,
     /// Sharded event queue backing the kernel event loop.
     ///
     /// Always present. When `num_shards == 0` (single-queue mode), all
     /// events are routed to the global queue and processed by a single
     /// `EventProcessor`. When `num_shards > 0`, events are distributed
     /// across N shard queues for parallel processing.
-    sharded_queue:         ShardedQueueRef,
+    sharded_queue: ShardedQueueRef,
     /// When this kernel was created (for uptime calculation).
-    started_at:            Timestamp,
+    started_at: Timestamp,
     /// Knowledge layer service for long-term memory extraction.
-    knowledge:             crate::memory::knowledge::KnowledgeServiceRef,
+    knowledge: crate::memory::knowledge::KnowledgeServiceRef,
     /// Security guard pipeline (taint tracking + pattern scanning).
-    guard_pipeline:        Arc<crate::guard::pipeline::GuardPipeline>,
+    guard_pipeline: Arc<crate::guard::pipeline::GuardPipeline>,
     /// Tool execution hook runner (PreToolUse / PostToolUse /
     /// PostToolUseFailure).
-    hook_runner:           HookRunnerRef,
+    hook_runner: HookRunnerRef,
     /// Execution trace service for persisting turn-level traces.
-    trace_service:         crate::trace::TraceService,
+    trace_service: crate::trace::TraceService,
     /// Provider for generating the skills prompt block.
     skill_prompt_provider: crate::handle::SkillPromptProvider,
     /// Lifecycle hook registry for turn/fold/delegation events.
-    lifecycle_hooks:       crate::lifecycle::LifecycleHookRegistry,
+    lifecycle_hooks: crate::lifecycle::LifecycleHookRegistry,
 }
 
 impl Kernel {
@@ -1024,10 +1164,10 @@ impl Kernel {
         self.lifecycle_hooks
             .fire_delegation_done(&crate::lifecycle::DelegationResult {
                 parent_session: parent_id,
-                child_session:  child_id,
-                task:           String::new(),
-                success:        result.success,
-                output:         result.output.clone(),
+                child_session: child_id,
+                task: String::new(),
+                success: result.success,
+                output: result.output.clone(),
             })
             .await;
 
@@ -1260,10 +1400,10 @@ impl Kernel {
             // Notify parent if this is a child process.
             if let Some(parent_id) = parent_id {
                 let result = rt.result.clone().unwrap_or(AgentRunLoopResult {
-                    output:     "process ended".to_string(),
+                    output: "process ended".to_string(),
                     iterations: 0,
                     tool_calls: 0,
-                    success:    false,
+                    success: false,
                 });
 
                 // Send final result through mpsc channel if spawn_child is waiting.
@@ -1335,15 +1475,15 @@ impl Kernel {
             None => {
                 let now = chrono::Utc::now();
                 let entry = crate::session::SessionEntry {
-                    key:           SessionKey::new(),
-                    title:         None,
-                    model:         None,
+                    key: SessionKey::new(),
+                    title: None,
+                    model: None,
                     system_prompt: None,
                     message_count: 0,
-                    preview:       None,
-                    metadata:      None,
-                    created_at:    now,
-                    updated_at:    now,
+                    preview: None,
+                    metadata: None,
+                    created_at: now,
+                    updated_at: now,
                 };
                 let session = match self.io.session_index().create_session(&entry).await {
                     Ok(s) => s,
@@ -1357,10 +1497,10 @@ impl Kernel {
                 if let Some(chat_id) = msg.source.platform_chat_id.as_deref() {
                     let binding = crate::session::ChannelBinding {
                         channel_type: msg.source.channel_type,
-                        chat_id:      chat_id.to_string(),
-                        session_key:  session.key.clone(),
-                        created_at:   now,
-                        updated_at:   now,
+                        chat_id: chat_id.to_string(),
+                        session_key: session.key.clone(),
+                        created_at: now,
+                        updated_at: now,
                     };
                     if let Err(e) = self.io.session_index().bind_channel(&binding).await {
                         warn!(error = %e, "failed to bind channel to new session");
@@ -1584,15 +1724,15 @@ impl Kernel {
             None => {
                 let now = chrono::Utc::now();
                 let entry = crate::session::SessionEntry {
-                    key:           SessionKey::new(),
-                    title:         None,
-                    model:         None,
+                    key: SessionKey::new(),
+                    title: None,
+                    model: None,
                     system_prompt: None,
                     message_count: 0,
-                    preview:       None,
-                    metadata:      None,
-                    created_at:    now,
-                    updated_at:    now,
+                    preview: None,
+                    metadata: None,
+                    created_at: now,
+                    updated_at: now,
                 };
                 let session = match self.io.session_index().create_session(&entry).await {
                     Ok(s) => s,
@@ -1604,10 +1744,10 @@ impl Kernel {
                 if let Some(chat_id) = msg.source.platform_chat_id.as_deref() {
                     let binding = crate::session::ChannelBinding {
                         channel_type: msg.source.channel_type,
-                        chat_id:      chat_id.to_string(),
-                        session_key:  session.key.clone(),
-                        created_at:   now,
-                        updated_at:   now,
+                        chat_id: chat_id.to_string(),
+                        session_key: session.key.clone(),
+                        created_at: now,
+                        updated_at: now,
                     };
                     if let Err(e) = self.io.session_index().bind_channel(&binding).await {
                         warn!(error = %e, "group: failed to bind channel to new session");
@@ -1906,15 +2046,15 @@ impl Kernel {
         //   - the response stream is closed
         //   - a TurnCompleted(Err) event is pushed so the process returns to Ready
         struct TurnGuard {
-            event_queue:     ShardedQueueRef,
-            stream_hub:      Arc<crate::io::StreamHub>,
-            stream_id:       StreamId,
-            typing_refresh:  Option<tokio::task::JoinHandle<()>>,
-            session_key:     SessionKey,
-            msg_id:          MessageId,
-            user:            crate::identity::UserId,
+            event_queue: ShardedQueueRef,
+            stream_hub: Arc<crate::io::StreamHub>,
+            stream_id: StreamId,
+            typing_refresh: Option<tokio::task::JoinHandle<()>>,
+            session_key: SessionKey,
+            msg_id: MessageId,
+            user: crate::identity::UserId,
             origin_endpoint: Option<crate::io::Endpoint>,
-            completed:       bool,
+            completed: bool,
         }
 
         impl Drop for TurnGuard {
@@ -2393,15 +2533,15 @@ impl Kernel {
 
             // -- 7b: Arm the TurnGuard --
             let mut turn_guard = TurnGuard {
-                event_queue:     event_queue.clone(),
-                stream_hub:      Arc::clone(&stream_hub_ref),
-                stream_id:       stream_id.clone(),
-                typing_refresh:  Some(typing_refresh),
-                session_key:     session_key.clone(),
-                msg_id:          msg_id.clone(),
-                user:            user.clone(),
+                event_queue: event_queue.clone(),
+                stream_hub: Arc::clone(&stream_hub_ref),
+                stream_id: stream_id.clone(),
+                typing_refresh: Some(typing_refresh),
+                session_key: session_key.clone(),
+                msg_id: msg_id.clone(),
+                user: user.clone(),
                 origin_endpoint: origin_endpoint.clone(),
-                completed:       false,
+                completed: false,
             };
 
             // Wrap the core turn work in catch_unwind so that if a panic
@@ -2678,19 +2818,19 @@ impl Kernel {
             };
             let turn_result = match &result {
                 Ok(turn) => crate::lifecycle::TurnResult {
-                    success:     turn.trace.success,
-                    iterations:  turn.iterations,
-                    tool_calls:  turn.tool_calls,
-                    output:      turn.text.clone(),
-                    error:       turn.trace.error.clone(),
+                    success: turn.trace.success,
+                    iterations: turn.iterations,
+                    tool_calls: turn.tool_calls,
+                    output: turn.text.clone(),
+                    error: turn.trace.error.clone(),
                     duration_ms: turn.trace.duration_ms,
                 },
                 Err(err) => crate::lifecycle::TurnResult {
-                    success:     false,
-                    iterations:  0,
-                    tool_calls:  0,
-                    output:      String::new(),
-                    error:       Some(err.clone()),
+                    success: false,
+                    iterations: 0,
+                    tool_calls: 0,
+                    output: String::new(),
+                    error: Some(err.clone()),
                     duration_ms: 0,
                 },
             };
@@ -2749,10 +2889,10 @@ impl Kernel {
                 }
 
                 let result = AgentRunLoopResult {
-                    output:     turn.text.clone(),
+                    output: turn.text.clone(),
                     iterations: turn.iterations,
                     tool_calls: turn.tool_calls,
-                    success:    turn.trace.success,
+                    success: turn.trace.success,
                 };
                 let _ = self.process_table.set_result(session_key, result.clone());
 
@@ -3143,6 +3283,51 @@ fn acquire_parent_child_permit(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use async_trait::async_trait;
+
+    struct TestSettings {
+        values: HashMap<String, String>,
+        tx: tokio::sync::watch::Sender<()>,
+        rx: tokio::sync::watch::Receiver<()>,
+    }
+
+    impl TestSettings {
+        fn new(values: HashMap<String, String>) -> Self {
+            let (tx, rx) = tokio::sync::watch::channel(());
+            Self { values, tx, rx }
+        }
+    }
+
+    #[async_trait]
+    impl rara_domain_shared::settings::SettingsProvider for TestSettings {
+        async fn get(&self, key: &str) -> Option<String> {
+            self.values.get(key).cloned()
+        }
+
+        async fn set(&self, _key: &str, _value: &str) -> anyhow::Result<()> {
+            Ok(())
+        }
+
+        async fn delete(&self, _key: &str) -> anyhow::Result<()> {
+            Ok(())
+        }
+
+        async fn list(&self) -> HashMap<String, String> {
+            self.values.clone()
+        }
+
+        async fn batch_update(
+            &self,
+            _patches: HashMap<String, Option<String>>,
+        ) -> anyhow::Result<()> {
+            Ok(())
+        }
+
+        fn subscribe(&self) -> tokio::sync::watch::Receiver<()> {
+            let _ = self.tx.send(());
+            self.rx.clone()
+        }
+    }
 
     /// A parent session with `max_children = 2` allows two child permits to
     /// be acquired and rejects the third with `SpawnLimitReached`. Releasing
@@ -3185,5 +3370,49 @@ mod tests {
             matches!(err, KernelError::SessionNotFound { .. }),
             "expected SessionNotFound, got {err:?}"
         );
+    }
+
+    #[test]
+    fn context_folding_preset_matching_ignores_fold_model() {
+        let config = ContextFoldingConfig {
+            fold_model: Some("fold-model".to_owned()),
+            ..ContextFoldingPreset::Chat.config(None)
+        };
+
+        assert_eq!(
+            matching_context_folding_preset(&config),
+            Some(ContextFoldingPreset::Chat)
+        );
+        assert_eq!(context_folding_mode_name(&config), "chat");
+    }
+
+    #[tokio::test]
+    async fn context_folding_settings_overlay_preserves_fold_model() {
+        use rara_domain_shared::settings::keys;
+
+        let base = ContextFoldingConfig {
+            fold_model: Some("fold-model".to_owned()),
+            ..ContextFoldingPreset::Balanced.config(None)
+        };
+        let settings = TestSettings::new(HashMap::from([
+            (keys::CONTEXT_FOLDING_ENABLED.to_owned(), "true".to_owned()),
+            (
+                keys::CONTEXT_FOLDING_FOLD_THRESHOLD.to_owned(),
+                "0.75".to_owned(),
+            ),
+            (
+                keys::CONTEXT_FOLDING_MIN_ENTRIES_BETWEEN_FOLDS.to_owned(),
+                "30".to_owned(),
+            ),
+        ]));
+
+        let effective = effective_context_folding_config(&settings, &base).await;
+
+        assert_eq!(effective.fold_model.as_deref(), Some("fold-model"));
+        assert_eq!(
+            matching_context_folding_preset(&effective),
+            Some(ContextFoldingPreset::DeepWork)
+        );
+        assert_eq!(context_folding_mode_name(&effective), "deep-work");
     }
 }


### PR DESCRIPTION
## Summary
- add a shared /anchor-mode command for Telegram and CLI
- persist context folding preset knobs through settings and config sync
- overlay effective context folding settings in the kernel on the next agent turn
- add targeted tests for command discoverability, preset mapping, and config round-trip

## Type of change
New feature (enhancement)

## Component
core

## Closes
Closes #1393

## Test plan
- [ ] just test passes
- [ ] just lint passes
- [x] Tested locally
- env -u RUSTC_WRAPPER cargo test --offline --manifest-path rara/Cargo.toml -p rara-channels --lib anchor_mode
- env -u RUSTC_WRAPPER cargo test --offline --manifest-path rara/Cargo.toml -p rara-cli anchor_mode
- env -u RUSTC_WRAPPER cargo test --offline --manifest-path rara/Cargo.toml -p rara-kernel --lib context_folding
- env -u RUSTC_WRAPPER cargo test --offline --manifest-path rara/Cargo.toml -p rara-app --lib context_folding
- env -u RUSTC_WRAPPER cargo check --offline --manifest-path rara/Cargo.toml -p rara-app -p rara-kernel -p rara-channels -p rara-cli -p rara-domain-shared