### PR TITLE
Add /anchor-mode context folding presets

### DIFF
--- a/crates/app/src/config_sync.rs
+++ b/crates/app/src/config_sync.rs
@@ -86,8 +86,10 @@ impl ConfigFileSync {
             let mut cfg = self.app_config.write().await;
             cfg.llm = new_config.llm;
             cfg.telegram = new_config.telegram;
+            cfg.wechat = new_config.wechat;
             cfg.composio = new_config.composio;
             cfg.knowledge = new_config.knowledge;
+            cfg.context_folding = new_config.context_folding;
         }
         info!("config.yaml synced to settings store");
         Ok(())
@@ -96,7 +98,7 @@ impl ConfigFileSync {
     /// Write current settings back to config.yaml.
     async fn writeback_to_file(&self) -> anyhow::Result<()> {
         let all_settings = self.settings.list().await;
-        let (llm, telegram, wechat, composio, knowledge) =
+        let (llm, telegram, wechat, composio, knowledge, context_folding) =
             flatten::unflatten_from_settings(&all_settings);
 
         let yaml = {
@@ -106,6 +108,7 @@ impl ConfigFileSync {
             cfg.wechat = wechat;
             cfg.composio = composio;
             cfg.knowledge = knowledge;
+            cfg.context_folding = context_folding;
             serde_yaml::to_string(&*cfg)?
         };
 
@@ -198,8 +201,10 @@ impl ConfigFileSync {
                                 let mut cfg = self.app_config.write().await;
                                 cfg.llm = new_config.llm;
                                 cfg.telegram = new_config.telegram;
+                                cfg.wechat = new_config.wechat;
                                 cfg.composio = new_config.composio;
                                 cfg.knowledge = new_config.knowledge;
+                                cfg.context_folding = new_config.context_folding;
                             }
                             info!("config file change detected and synced to settings");
                         }

--- a/crates/app/src/flatten.rs
+++ b/crates/app/src/flatten.rs
@@ -174,6 +174,7 @@ pub fn flatten_config_sections(config: &AppConfig) -> Vec<(String, String)> {
     if let Some(ref k) = config.knowledge {
         flatten_knowledge(k, &mut pairs);
     }
+    flatten_context_folding(&config.context_folding, &mut pairs);
     pairs
 }
 
@@ -260,6 +261,29 @@ fn flatten_knowledge(k: &KnowledgeConfig, out: &mut Vec<(String, String)>) {
     }
 }
 
+fn flatten_context_folding(
+    config: &rara_kernel::kernel::ContextFoldingConfig,
+    out: &mut Vec<(String, String)>,
+) {
+    use rara_domain_shared::settings::keys;
+
+    out.push((
+        keys::CONTEXT_FOLDING_ENABLED.into(),
+        config.enabled.to_string(),
+    ));
+    out.push((
+        keys::CONTEXT_FOLDING_FOLD_THRESHOLD.into(),
+        config.fold_threshold.to_string(),
+    ));
+    out.push((
+        keys::CONTEXT_FOLDING_MIN_ENTRIES_BETWEEN_FOLDS.into(),
+        config.min_entries_between_folds.to_string(),
+    ));
+    if let Some(ref fold_model) = config.fold_model {
+        out.push((keys::CONTEXT_FOLDING_FOLD_MODEL.into(), fold_model.clone()));
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Unflatten logic
 // ---------------------------------------------------------------------------
@@ -276,6 +300,7 @@ pub fn unflatten_from_settings<S: std::hash::BuildHasher>(
     Option<WechatConfig>,
     Option<ComposioConfig>,
     Option<KnowledgeConfig>,
+    rara_kernel::kernel::ContextFoldingConfig,
 ) {
     (
         unflatten_llm(pairs),
@@ -283,6 +308,7 @@ pub fn unflatten_from_settings<S: std::hash::BuildHasher>(
         unflatten_wechat(pairs),
         unflatten_composio(pairs),
         unflatten_knowledge(pairs),
+        unflatten_context_folding(pairs),
     )
 }
 
@@ -417,6 +443,34 @@ fn unflatten_knowledge(
     })
 }
 
+fn unflatten_context_folding(
+    pairs: &HashMap<String, String, impl std::hash::BuildHasher>,
+) -> rara_kernel::kernel::ContextFoldingConfig {
+    use rara_domain_shared::settings::keys;
+
+    let defaults = rara_kernel::kernel::ContextFoldingConfig::default();
+    let enabled = pairs
+        .get(keys::CONTEXT_FOLDING_ENABLED)
+        .and_then(|value| value.parse::<bool>().ok())
+        .unwrap_or(defaults.enabled);
+    let fold_threshold = pairs
+        .get(keys::CONTEXT_FOLDING_FOLD_THRESHOLD)
+        .and_then(|value| value.parse::<f64>().ok())
+        .unwrap_or(defaults.fold_threshold);
+    let min_entries_between_folds = pairs
+        .get(keys::CONTEXT_FOLDING_MIN_ENTRIES_BETWEEN_FOLDS)
+        .and_then(|value| value.parse::<usize>().ok())
+        .unwrap_or(defaults.min_entries_between_folds);
+    let fold_model = pairs.get(keys::CONTEXT_FOLDING_FOLD_MODEL).cloned();
+
+    rara_kernel::kernel::ContextFoldingConfig {
+        enabled,
+        fold_threshold,
+        min_entries_between_folds,
+        fold_model,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -460,6 +514,12 @@ mod tests {
             similarity_threshold: Some(0.85),
             extractor_model:      Some("gpt-4o-mini".into()),
         };
+        let context_folding = rara_kernel::kernel::ContextFoldingConfig {
+            enabled:                   true,
+            fold_threshold:            0.6,
+            min_entries_between_folds: 15,
+            fold_model:                Some("gpt-4.1-mini".into()),
+        };
 
         // Flatten
         let mut flat = Vec::new();
@@ -467,10 +527,12 @@ mod tests {
         flatten_telegram(&telegram, &mut flat);
         flatten_composio(&composio, &mut flat);
         flatten_knowledge(&knowledge, &mut flat);
+        flatten_context_folding(&context_folding, &mut flat);
         let map: HashMap<String, String> = flat.into_iter().collect();
 
         // Unflatten
-        let (got_llm, got_tg, _got_wechat, got_composio, got_know) = unflatten_from_settings(&map);
+        let (got_llm, got_tg, _got_wechat, got_composio, got_know, got_context_folding) =
+            unflatten_from_settings(&map);
 
         // --- LLM ---
         let got_llm = got_llm.expect("llm should be Some");
@@ -511,16 +573,32 @@ mod tests {
             knowledge.similarity_threshold
         );
         assert_eq!(got_know.extractor_model, knowledge.extractor_model);
+
+        // --- Context folding ---
+        assert_eq!(got_context_folding.enabled, context_folding.enabled);
+        assert_eq!(
+            got_context_folding.fold_threshold,
+            context_folding.fold_threshold
+        );
+        assert_eq!(
+            got_context_folding.min_entries_between_folds,
+            context_folding.min_entries_between_folds
+        );
+        assert_eq!(got_context_folding.fold_model, context_folding.fold_model);
     }
 
     #[test]
     fn unflatten_empty_map_returns_none() {
         let map = HashMap::new();
-        let (llm, tg, wechat, composio, know) = unflatten_from_settings(&map);
+        let (llm, tg, wechat, composio, know, context_folding) = unflatten_from_settings(&map);
         assert!(wechat.is_none());
         assert!(llm.is_none());
         assert!(tg.is_none());
         assert!(composio.is_none());
         assert!(know.is_none());
+        assert_eq!(
+            context_folding.fold_threshold,
+            rara_kernel::kernel::ContextFoldingConfig::default().fold_threshold
+        );
     }
 }

--- a/crates/app/src/lib.rs
+++ b/crates/app/src/lib.rs
@@ -601,8 +601,8 @@ pub async fn start_with_options(
     // Build command handlers shared across all channels.
     let command_handlers: Vec<std::sync::Arc<dyn rara_kernel::channel::command::CommandHandler>> = {
         use rara_channels::telegram::commands::{
-            BasicCommandHandler, DebugCommandHandler, McpCommandHandler, SessionCommandHandler,
-            StatusCommandHandler, StopCommandHandler, TapeCommandHandler,
+            AnchorModeCommandHandler, BasicCommandHandler, DebugCommandHandler, McpCommandHandler,
+            SessionCommandHandler, StatusCommandHandler, StopCommandHandler, TapeCommandHandler,
         };
         let session_handler = std::sync::Arc::new(SessionCommandHandler::new(bot_client.clone()));
         let stop_handler = std::sync::Arc::new(StopCommandHandler::new(
@@ -613,28 +613,35 @@ pub async fn start_with_options(
             bot_client.clone(),
             kernel_handle.clone(),
         ));
+        let anchor_mode_handler = std::sync::Arc::new(AnchorModeCommandHandler::new(
+            settings_provider.clone(),
+            config.context_folding.clone(),
+        ));
         let tape_handler = std::sync::Arc::new(TapeCommandHandler::new(bot_client.clone()));
         let debug_handler =
             std::sync::Arc::new(DebugCommandHandler::new(rara.tape_service.clone()));
+        let mcp_handler = std::sync::Arc::new(McpCommandHandler::new(bot_client.clone()));
         // Collect all command definitions so /help can list them.
         use rara_kernel::channel::command::CommandHandler as _;
         let all_commands: Vec<rara_kernel::channel::command::CommandDefinition> = [
             session_handler.commands(),
             stop_handler.commands(),
             status_handler.commands(),
+            anchor_mode_handler.commands(),
             tape_handler.commands(),
             debug_handler.commands(),
+            mcp_handler.commands(),
         ]
         .into_iter()
         .flatten()
         .collect();
         let basic_handler = std::sync::Arc::new(BasicCommandHandler::new(all_commands));
-        let mcp_handler = std::sync::Arc::new(McpCommandHandler::new(bot_client.clone()));
         vec![
             basic_handler,
             session_handler,
             stop_handler,
             status_handler,
+            anchor_mode_handler,
             tape_handler,
             debug_handler,
             mcp_handler,

--- a/crates/channels/Cargo.toml
+++ b/crates/channels/Cargo.toml
@@ -15,6 +15,7 @@ futures = { workspace = true }
 image = { workspace = true }
 jiff = { workspace = true }
 rand = { workspace = true }
+rara-domain-shared = { workspace = true }
 rara-dock = { workspace = true }
 rara-kernel = { workspace = true }
 rara-mcp = { workspace = true }

--- a/crates/channels/src/telegram/commands/anchor_mode.rs
+++ b/crates/channels/src/telegram/commands/anchor_mode.rs
@@ -1,0 +1,432 @@
+// Copyright 2025 Rararulab
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! `/anchor_mode` command — show or set auto-anchor aggressiveness presets.
+
+use std::{collections::HashMap, fmt::Write, sync::Arc};
+
+use async_trait::async_trait;
+use rara_domain_shared::settings::{SettingsProvider, keys};
+use rara_kernel::{
+    channel::command::{
+        CommandContext, CommandDefinition, CommandHandler, CommandInfo, CommandResult,
+    },
+    error::KernelError,
+    kernel::ContextFoldingConfig,
+};
+
+use super::session::html_escape;
+
+pub struct AnchorModeCommandHandler {
+    settings:       Arc<dyn SettingsProvider>,
+    default_config: ContextFoldingConfig,
+}
+
+impl AnchorModeCommandHandler {
+    pub fn new(settings: Arc<dyn SettingsProvider>, default_config: ContextFoldingConfig) -> Self {
+        Self {
+            settings,
+            default_config,
+        }
+    }
+
+    async fn current_config(&self) -> ContextFoldingConfig {
+        ContextFoldingConfig::resolve_from_settings(self.settings.as_ref(), &self.default_config)
+            .await
+    }
+
+    async fn persist_preset(
+        &self,
+        preset: AnchorModePreset,
+        current: &ContextFoldingConfig,
+    ) -> Result<(), KernelError> {
+        let mapped = preset.config();
+        let mut patches = HashMap::new();
+        patches.insert(
+            keys::CONTEXT_FOLDING_ENABLED.to_owned(),
+            Some(mapped.enabled.to_string()),
+        );
+        patches.insert(
+            keys::CONTEXT_FOLDING_FOLD_THRESHOLD.to_owned(),
+            Some(mapped.fold_threshold.to_string()),
+        );
+        patches.insert(
+            keys::CONTEXT_FOLDING_MIN_ENTRIES_BETWEEN_FOLDS.to_owned(),
+            Some(mapped.min_entries_between_folds.to_string()),
+        );
+        if let Some(ref fold_model) = current.fold_model {
+            patches.insert(
+                keys::CONTEXT_FOLDING_FOLD_MODEL.to_owned(),
+                Some(fold_model.clone()),
+            );
+        }
+        self.settings
+            .batch_update(patches)
+            .await
+            .map_err(|error| KernelError::Other {
+                message: format!("failed to update anchor mode: {error}").into(),
+            })
+    }
+}
+
+#[async_trait]
+impl CommandHandler for AnchorModeCommandHandler {
+    fn commands(&self) -> Vec<CommandDefinition> {
+        vec![CommandDefinition {
+            name:        "anchor_mode".to_owned(),
+            description: "Show or set auto-anchor frequency: chat, balanced, deep-work".to_owned(),
+            usage:       Some("/anchor_mode [chat|balanced|deep-work]".to_owned()),
+        }]
+    }
+
+    async fn handle(
+        &self,
+        command: &CommandInfo,
+        _context: &CommandContext,
+    ) -> Result<CommandResult, KernelError> {
+        let args = command.args.trim();
+        if args.is_empty() || matches!(args, "show" | "status" | "current") {
+            let current = self.current_config().await;
+            return Ok(CommandResult::Html(render_anchor_mode_report(
+                &current, None,
+            )));
+        }
+
+        let Some(preset) = AnchorModePreset::parse(args) else {
+            return Ok(CommandResult::Text(
+                "Usage: /anchor_mode [chat|balanced|deep-work]".to_owned(),
+            ));
+        };
+
+        let current = self.current_config().await;
+        self.persist_preset(preset, &current).await?;
+        let updated = self.current_config().await;
+
+        Ok(CommandResult::Html(render_anchor_mode_report(
+            &updated,
+            Some(format!(
+                "Updated anchor mode to <b>{}</b>. The new folding behavior applies on the next \
+                 turn.",
+                preset.label()
+            )),
+        )))
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum AnchorModePreset {
+    Chat,
+    Balanced,
+    DeepWork,
+}
+
+impl AnchorModePreset {
+    fn parse(raw: &str) -> Option<Self> {
+        let normalized = raw.trim().to_ascii_lowercase().replace('_', "-");
+        match normalized.as_str() {
+            "chat" => Some(Self::Chat),
+            "balanced" => Some(Self::Balanced),
+            "deep-work" | "deepwork" => Some(Self::DeepWork),
+            _ => None,
+        }
+    }
+
+    fn label(self) -> &'static str {
+        match self {
+            Self::Chat => "chat",
+            Self::Balanced => "balanced",
+            Self::DeepWork => "deep-work",
+        }
+    }
+
+    fn config(self) -> ContextFoldingConfig {
+        match self {
+            Self::Chat => ContextFoldingConfig {
+                enabled:                   true,
+                fold_threshold:            0.45,
+                min_entries_between_folds: 6,
+                fold_model:                None,
+            },
+            Self::Balanced => ContextFoldingConfig {
+                enabled:                   true,
+                fold_threshold:            0.60,
+                min_entries_between_folds: 15,
+                fold_model:                None,
+            },
+            Self::DeepWork => ContextFoldingConfig {
+                enabled:                   true,
+                fold_threshold:            0.68,
+                min_entries_between_folds: 32,
+                fold_model:                None,
+            },
+        }
+    }
+
+    fn behavior(self) -> &'static str {
+        match self {
+            Self::Chat => "Fold sooner so casual chat keeps a smaller working set.",
+            Self::Balanced => "Keep the default balance between continuity and context cleanup.",
+            Self::DeepWork => "Fold later so longer local reasoning stays in immediate context.",
+        }
+    }
+
+    fn from_config(config: &ContextFoldingConfig) -> Option<Self> {
+        for preset in [Self::Chat, Self::Balanced, Self::DeepWork] {
+            let mapped = preset.config();
+            if config.enabled == mapped.enabled
+                && approx_eq(config.fold_threshold, mapped.fold_threshold)
+                && config.min_entries_between_folds == mapped.min_entries_between_folds
+            {
+                return Some(preset);
+            }
+        }
+        None
+    }
+}
+
+fn render_anchor_mode_report(
+    config: &ContextFoldingConfig,
+    update_notice: Option<String>,
+) -> String {
+    let preset = AnchorModePreset::from_config(config);
+    let mode_label = preset.map_or_else(
+        || {
+            if config.enabled {
+                "custom".to_owned()
+            } else {
+                "custom (auto-fold off)".to_owned()
+            }
+        },
+        |preset| preset.label().to_owned(),
+    );
+    let behavior = preset.map_or_else(
+        || {
+            if config.enabled {
+                "Using custom context folding values."
+            } else {
+                "Automatic context folding is currently disabled."
+            }
+        },
+        AnchorModePreset::behavior,
+    );
+    let fold_model = config
+        .fold_model
+        .as_deref()
+        .map(html_escape)
+        .unwrap_or_else(|| "session default".to_owned());
+
+    let mut text = String::new();
+    if let Some(update_notice) = update_notice {
+        let _ = writeln!(text, "{update_notice}\n");
+    }
+    let _ = writeln!(text, "<b>Anchor mode</b>: {}", html_escape(&mode_label));
+    let _ = writeln!(text, "<b>Behavior</b>: {}", html_escape(behavior));
+    let _ = writeln!(text, "<b>Auto-fold enabled</b>: {}", config.enabled);
+    let _ = writeln!(text, "<b>Fold threshold</b>: {:.2}", config.fold_threshold);
+    let _ = writeln!(
+        text,
+        "<b>Min entries between folds</b>: {}",
+        config.min_entries_between_folds
+    );
+    let _ = writeln!(text, "<b>Fold model</b>: {fold_model}");
+    let _ = write!(
+        text,
+        "\nSet with <code>/anchor_mode chat</code>, <code>/anchor_mode balanced</code>, or \
+         <code>/anchor_mode deep-work</code>."
+    );
+    text
+}
+
+fn approx_eq(left: f64, right: f64) -> bool { (left - right).abs() < 1e-9 }
+
+#[cfg(test)]
+mod tests {
+    use std::{collections::HashMap, sync::Arc};
+
+    use async_trait::async_trait;
+    use rara_domain_shared::settings::SettingsProvider;
+    use rara_kernel::{
+        channel::{
+            command::{CommandContext, CommandHandler, CommandInfo, CommandResult},
+            types::{ChannelType, ChannelUser},
+        },
+        kernel::ContextFoldingConfig,
+    };
+
+    use super::{AnchorModeCommandHandler, AnchorModePreset, approx_eq};
+
+    struct StubSettings {
+        data: tokio::sync::RwLock<HashMap<String, String>>,
+        tx:   tokio::sync::watch::Sender<()>,
+        rx:   tokio::sync::watch::Receiver<()>,
+    }
+
+    impl StubSettings {
+        fn new() -> Self {
+            let (tx, rx) = tokio::sync::watch::channel(());
+            Self {
+                data: tokio::sync::RwLock::new(HashMap::new()),
+                tx,
+                rx,
+            }
+        }
+    }
+
+    #[async_trait]
+    impl SettingsProvider for StubSettings {
+        async fn get(&self, key: &str) -> Option<String> {
+            self.data.read().await.get(key).cloned()
+        }
+
+        async fn set(&self, key: &str, value: &str) -> anyhow::Result<()> {
+            self.data
+                .write()
+                .await
+                .insert(key.to_owned(), value.to_owned());
+            let _ = self.tx.send(());
+            Ok(())
+        }
+
+        async fn delete(&self, key: &str) -> anyhow::Result<()> {
+            self.data.write().await.remove(key);
+            let _ = self.tx.send(());
+            Ok(())
+        }
+
+        async fn list(&self) -> HashMap<String, String> { self.data.read().await.clone() }
+
+        async fn batch_update(
+            &self,
+            patches: HashMap<String, Option<String>>,
+        ) -> anyhow::Result<()> {
+            let mut data = self.data.write().await;
+            for (key, value) in patches {
+                match value {
+                    Some(value) => {
+                        data.insert(key, value);
+                    }
+                    None => {
+                        data.remove(&key);
+                    }
+                }
+            }
+            let _ = self.tx.send(());
+            Ok(())
+        }
+
+        fn subscribe(&self) -> tokio::sync::watch::Receiver<()> { self.rx.clone() }
+    }
+
+    fn test_context() -> CommandContext {
+        CommandContext {
+            channel_type: ChannelType::Cli,
+            session_key:  "cli-session".to_owned(),
+            user:         ChannelUser {
+                platform_id:  "cli:test".to_owned(),
+                display_name: Some("test".to_owned()),
+            },
+            metadata:     HashMap::new(),
+        }
+    }
+
+    fn balanced_config() -> ContextFoldingConfig { AnchorModePreset::Balanced.config() }
+
+    #[tokio::test]
+    async fn show_reports_current_mode() {
+        let settings = Arc::new(StubSettings::new());
+        let handler = AnchorModeCommandHandler::new(settings, balanced_config());
+
+        let result = handler
+            .handle(
+                &CommandInfo {
+                    name: "anchor_mode".to_owned(),
+                    args: String::new(),
+                    raw:  "/anchor_mode".to_owned(),
+                },
+                &test_context(),
+            )
+            .await
+            .unwrap();
+
+        match result {
+            CommandResult::Html(text) => {
+                assert!(text.contains("Anchor mode"));
+                assert!(text.contains("balanced"));
+            }
+            other => panic!("unexpected command result: {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn setting_chat_mode_updates_runtime_settings() {
+        let settings = Arc::new(StubSettings::new());
+        let handler = AnchorModeCommandHandler::new(settings.clone(), balanced_config());
+
+        let result = handler
+            .handle(
+                &CommandInfo {
+                    name: "anchor_mode".to_owned(),
+                    args: "chat".to_owned(),
+                    raw:  "/anchor_mode chat".to_owned(),
+                },
+                &test_context(),
+            )
+            .await
+            .unwrap();
+
+        match result {
+            CommandResult::Html(text) => assert!(text.contains("chat")),
+            other => panic!("unexpected command result: {other:?}"),
+        }
+
+        let effective =
+            ContextFoldingConfig::resolve_from_settings(settings.as_ref(), &balanced_config())
+                .await;
+        assert!(effective.enabled);
+        assert!(approx_eq(
+            effective.fold_threshold,
+            AnchorModePreset::Chat.config().fold_threshold,
+        ));
+        assert_eq!(
+            effective.min_entries_between_folds,
+            AnchorModePreset::Chat.config().min_entries_between_folds,
+        );
+    }
+
+    #[tokio::test]
+    async fn invalid_mode_returns_usage() {
+        let settings = Arc::new(StubSettings::new());
+        let handler = AnchorModeCommandHandler::new(settings, balanced_config());
+
+        let result = handler
+            .handle(
+                &CommandInfo {
+                    name: "anchor_mode".to_owned(),
+                    args: "turbo".to_owned(),
+                    raw:  "/anchor_mode turbo".to_owned(),
+                },
+                &test_context(),
+            )
+            .await
+            .unwrap();
+
+        match result {
+            CommandResult::Text(text) => {
+                assert!(text.contains("/anchor_mode"));
+                assert!(text.contains("deep-work"));
+            }
+            other => panic!("unexpected command result: {other:?}"),
+        }
+    }
+}

--- a/crates/channels/src/telegram/commands/mod.rs
+++ b/crates/channels/src/telegram/commands/mod.rs
@@ -21,6 +21,7 @@
 //!
 //! ## Modules
 //!
+//! - [`anchor_mode`]: `/anchor_mode` command.
 //! - [`client`]: Backend service client trait and response types.
 //! - [`basic`]: `/start` and `/help` commands.
 //! - [`session`]: `/new`, `/clear`, `/sessions`, `/usage`, `/model` commands.
@@ -31,6 +32,7 @@
 //! - [`callbacks`]: Inline keyboard callback handlers.
 
 pub mod anchor_dot;
+pub mod anchor_mode;
 pub mod basic;
 pub mod callbacks;
 pub mod client;
@@ -41,6 +43,7 @@ pub mod session;
 pub mod status;
 pub mod tape;
 
+pub use anchor_mode::AnchorModeCommandHandler;
 pub use basic::BasicCommandHandler;
 pub use callbacks::{
     SessionDeleteCallbackHandler, SessionDeleteCancelHandler, SessionDeleteConfirmHandler,

--- a/crates/domain/shared/src/settings/mod.rs
+++ b/crates/domain/shared/src/settings/mod.rs
@@ -54,6 +54,11 @@ pub mod keys {
     pub const KNOWLEDGE_SEARCH_TOP_K: &str = "memory.knowledge.search_top_k";
     pub const KNOWLEDGE_SIMILARITY_THRESHOLD: &str = "memory.knowledge.similarity_threshold";
     pub const KNOWLEDGE_EXTRACTOR_MODEL: &str = "memory.knowledge.extractor_model";
+    pub const CONTEXT_FOLDING_ENABLED: &str = "context_folding.enabled";
+    pub const CONTEXT_FOLDING_FOLD_THRESHOLD: &str = "context_folding.fold_threshold";
+    pub const CONTEXT_FOLDING_MIN_ENTRIES_BETWEEN_FOLDS: &str =
+        "context_folding.min_entries_between_folds";
+    pub const CONTEXT_FOLDING_FOLD_MODEL: &str = "context_folding.fold_model";
 }
 
 /// Unified trait for reading and writing flat KV settings.

--- a/crates/kernel/src/agent/mod.rs
+++ b/crates/kernel/src/agent/mod.rs
@@ -1092,7 +1092,11 @@ pub(crate) async fn run_agent_loop(
     let user_id = Some(tool_context.user_id.as_str());
 
     // ── Context folding state ────────────────────────────────────────
-    let fold_config = &handle.config().context_folding;
+    let fold_config = crate::kernel::ContextFoldingConfig::resolve_from_settings(
+        handle.settings().as_ref(),
+        &handle.config().context_folding,
+    )
+    .await;
     // Recover last auto-fold anchor's entry ID from tape so the cooldown
     // survives across turns (not just within a single run_agent_loop call).
     let mut last_fold_entry_id: Option<u64> =

--- a/crates/kernel/src/kernel.rs
+++ b/crates/kernel/src/kernel.rs
@@ -102,6 +102,45 @@ pub struct ContextFoldingConfig {
     pub fold_model:                Option<String>,
 }
 
+impl ContextFoldingConfig {
+    /// Resolve the runtime-effective config by overlaying settings values on
+    /// top of the boot-time fallback config.
+    pub async fn resolve_from_settings(
+        settings: &dyn rara_domain_shared::settings::SettingsProvider,
+        fallback: &Self,
+    ) -> Self {
+        use rara_domain_shared::settings::keys;
+
+        let enabled = settings
+            .get(keys::CONTEXT_FOLDING_ENABLED)
+            .await
+            .and_then(|value| value.parse::<bool>().ok())
+            .unwrap_or(fallback.enabled);
+        let fold_threshold = settings
+            .get(keys::CONTEXT_FOLDING_FOLD_THRESHOLD)
+            .await
+            .and_then(|value| value.parse::<f64>().ok())
+            .unwrap_or(fallback.fold_threshold);
+        let min_entries_between_folds = settings
+            .get(keys::CONTEXT_FOLDING_MIN_ENTRIES_BETWEEN_FOLDS)
+            .await
+            .and_then(|value| value.parse::<usize>().ok())
+            .unwrap_or(fallback.min_entries_between_folds);
+        let fold_model = match settings.get(keys::CONTEXT_FOLDING_FOLD_MODEL).await {
+            Some(value) if value.trim().is_empty() => None,
+            Some(value) => Some(value),
+            None => fallback.fold_model.clone(),
+        };
+
+        Self {
+            enabled,
+            fold_threshold,
+            min_entries_between_folds,
+            fold_model,
+        }
+    }
+}
+
 /// Kernel configuration.
 #[derive(Debug, Clone, smart_default::SmartDefault)]
 pub struct KernelConfig {

--- a/crates/kernel/src/syscall.rs
+++ b/crates/kernel/src/syscall.rs
@@ -360,10 +360,15 @@ impl SyscallDispatcher {
                         ),
                     ));
                     // Fold-branch tool (synchronous child with result compression)
+                    let fold_config = crate::kernel::ContextFoldingConfig::resolve_from_settings(
+                        kernel_handle.settings().as_ref(),
+                        &self.config.context_folding,
+                    )
+                    .await;
                     if let Ok((fold_driver, fold_model)) = self.driver_registry.resolve(
                         "fold-branch",
                         None,
-                        self.config.context_folding.fold_model.as_deref(),
+                        fold_config.fold_model.as_deref(),
                     ) {
                         let context_folder = Arc::new(crate::agent::fold::ContextFolder::new(
                             fold_driver,


### PR DESCRIPTION
## Summary
- add a shared `/anchor_mode` command with chat, balanced, and deep-work presets
- persist context folding knobs through the existing settings and config-sync path
- overlay runtime settings onto the kernel `ContextFoldingConfig` on the next turn
- add focused command and config round-trip coverage

## Type of change
New feature (`enhancement`)

## Component
`core`

## Closes
Closes #1395

## Test plan
- [ ] `just test` passes
- [ ] `just lint` passes
- [x] Tested locally
- `env -u RUSTC_WRAPPER cargo test --offline --manifest-path rara/Cargo.toml -p rara-channels anchor_mode --lib`
- `env -u RUSTC_WRAPPER cargo test --offline --manifest-path rara/Cargo.toml -p rara-app roundtrip_flatten_unflatten --lib`
- `env -u RUSTC_WRAPPER cargo check --offline --manifest-path rara/Cargo.toml -p rara-kernel -p rara-channels -p rara-app -p rara-domain-shared`
- `just pre-commit` blocked in this environment because `buf` is not installed (`sh: buf: command not found`)
