### PR TITLE
fix(channels): show file path in edit-file TG progress (#1401)

### DIFF
--- a/crates/channels/src/tool_display.rs
+++ b/crates/channels/src/tool_display.rs
@@ -267,10 +267,13 @@ pub fn tool_arguments_summary(tool_name: &str, arguments: &serde_json::Value) ->
         "shell_execute" => arguments.get("command").and_then(|v| v.as_str()),
         "web_search" => arguments.get("query").and_then(|v| v.as_str()),
         "web_fetch" => arguments.get("url").and_then(|v| v.as_str()),
-        "read-file" | "write-file" => arguments.get("path").and_then(|v| v.as_str()),
+        "read-file" | "write-file" | "edit-file" => arguments
+            .get("file_path")
+            .or_else(|| arguments.get("path"))
+            .and_then(|v| v.as_str()),
         _ => {
             // Try common field names, then fall back to the first string value.
-            ["query", "command", "input", "path", "url"]
+            ["query", "command", "input", "file_path", "path", "url"]
                 .iter()
                 .find_map(|key| arguments.get(*key).and_then(|v| v.as_str()))
                 .or_else(|| first_string_value(arguments))
@@ -309,7 +312,10 @@ pub fn tool_display_info(tool_name: &str, arguments: &serde_json::Value) -> (Str
         "bash" => arguments.get("command").and_then(|v| v.as_str()),
         "web_search" => arguments.get("query").and_then(|v| v.as_str()),
         "web_fetch" | "http-fetch" => arguments.get("url").and_then(|v| v.as_str()),
-        "read-file" | "write-file" | "edit-file" => arguments.get("path").and_then(|v| v.as_str()),
+        "read-file" | "write-file" | "edit-file" | "multi-edit" => arguments
+            .get("file_path")
+            .or_else(|| arguments.get("path"))
+            .and_then(|v| v.as_str()),
         "find-files" | "list-directory" => arguments.get("path").and_then(|v| v.as_str()),
         "grep" => arguments.get("pattern").and_then(|v| v.as_str()),
         "memory_search" => arguments.get("query").and_then(|v| v.as_str()),
@@ -328,10 +334,19 @@ pub fn tool_display_info(tool_name: &str, arguments: &serde_json::Value) -> (Str
         "read-tape" => arguments.get("session_id").and_then(|v| v.as_str()),
         "create-skill" | "delete-skill" => arguments.get("name").and_then(|v| v.as_str()),
         "settings" => arguments.get("action").and_then(|v| v.as_str()),
-        _ => ["query", "command", "input", "path", "url", "name", "key"]
-            .iter()
-            .find_map(|key| arguments.get(*key).and_then(|v| v.as_str()))
-            .or_else(|| first_string_value(arguments)),
+        _ => [
+            "query",
+            "command",
+            "input",
+            "file_path",
+            "path",
+            "url",
+            "name",
+            "key",
+        ]
+        .iter()
+        .find_map(|key| arguments.get(*key).and_then(|v| v.as_str()))
+        .or_else(|| first_string_value(arguments)),
     };
 
     let summary = raw.map(|s| first_line(s).to_owned()).unwrap_or_default();


### PR DESCRIPTION
## Summary

`tool_display_info()` looked up `arguments["path"]` but `edit-file`, `read-file`, `write-file`, and `multi-edit` all use `"file_path"` as the parameter name. Progress lines showed `🔧 edit 1ms` with no file context.

Fix: check `"file_path"` first, fall back to `"path"` for compatibility. Also add `"file_path"` to the generic fallback key list.

Before: `🔧 edit 1ms`
After: `🔧 edit src/main.rs 1ms`

## Type of change

| Type | Label |
|------|-------|
| Bug fix | `bug` |

## Component

`backend`

## Closes

Closes #1401

## Test plan

- [x] `cargo clippy` zero warnings
- [x] `cargo +nightly fmt --check` clean
- [x] Existing unit tests pass