### PR TITLE
feat(channels): show line-change stats in edit-file TG progress (#1404)

### DIFF
--- a/crates/app/Cargo.toml
+++ b/crates/app/Cargo.toml
@@ -72,6 +72,7 @@ tracing = { workspace = true }
 uuid.workspace = true
 walkdir = "2.5.0"
 yunara-store = { workspace = true }
+similar = "3.1.0"
 
 [dev-dependencies]
 common-telemetry.workspace = true

--- a/crates/app/src/tools/edit_file.rs
+++ b/crates/app/src/tools/edit_file.rs
@@ -35,8 +35,12 @@ pub struct EditFileParams {
 
 #[derive(Debug, Clone, Serialize)]
 pub struct EditFileResult {
-    pub replacements: usize,
-    pub file_path:    String,
+    pub replacements:  usize,
+    pub file_path:     String,
+    /// Net lines added (0 when lines were only removed).
+    pub lines_added:   usize,
+    /// Net lines removed (0 when lines were only added).
+    pub lines_removed: usize,
 }
 
 /// Layer 1 primitive: edit a file by exact string replacement.
@@ -92,9 +96,14 @@ impl ToolExecute for EditFileTool {
         tokio::fs::write(&file_path, &new_content)
             .await
             .context(format!("failed to write file {}", file_path.display()))?;
+        let old_lines = content.lines().count();
+        let new_lines = new_content.lines().count();
+
         Ok(EditFileResult {
-            replacements: if replace_all { count } else { 1 },
-            file_path:    file_path.display().to_string(),
+            replacements:  if replace_all { count } else { 1 },
+            file_path:     file_path.display().to_string(),
+            lines_added:   new_lines.saturating_sub(old_lines),
+            lines_removed: old_lines.saturating_sub(new_lines),
         })
     }
 }

--- a/crates/app/src/tools/edit_file.rs
+++ b/crates/app/src/tools/edit_file.rs
@@ -96,14 +96,21 @@ impl ToolExecute for EditFileTool {
         tokio::fs::write(&file_path, &new_content)
             .await
             .context(format!("failed to write file {}", file_path.display()))?;
-        let old_lines = content.lines().count();
-        let new_lines = new_content.lines().count();
+        let diff = similar::TextDiff::from_lines(&content, &new_content);
+        let (mut added, mut removed) = (0usize, 0usize);
+        for change in diff.iter_all_changes() {
+            match change.tag() {
+                similar::ChangeTag::Insert => added += 1,
+                similar::ChangeTag::Delete => removed += 1,
+                similar::ChangeTag::Equal => {}
+            }
+        }
 
         Ok(EditFileResult {
             replacements:  if replace_all { count } else { 1 },
             file_path:     file_path.display().to_string(),
-            lines_added:   new_lines.saturating_sub(old_lines),
-            lines_removed: old_lines.saturating_sub(new_lines),
+            lines_added:   added,
+            lines_removed: removed,
         })
     }
 }

--- a/crates/channels/src/telegram/adapter.rs
+++ b/crates/channels/src/telegram/adapter.rs
@@ -184,17 +184,19 @@ pub fn build_bot(token: &str, proxy: Option<&str>) -> Result<teloxide::Bot, anyh
 
 /// Single tool's progress state within a streaming turn.
 struct ToolProgress {
-    id:         String,
+    id:          String,
     /// Raw tool name from the LLM (e.g. "shell_execute", "read-file").
-    raw_name:   String,
-    name:       String,
-    activity:   String,
-    summary:    String,
-    started_at: Instant,
-    finished:   bool,
-    success:    bool,
-    duration:   Option<std::time::Duration>,
-    error:      Option<String>,
+    raw_name:    String,
+    name:        String,
+    activity:    String,
+    summary:     String,
+    started_at:  Instant,
+    finished:    bool,
+    success:     bool,
+    duration:    Option<std::time::Duration>,
+    error:       Option<String>,
+    /// Compact result hint extracted from `ToolCallEnd::result_preview`.
+    result_hint: Option<String>,
 }
 
 /// Status of a single plan step.
@@ -349,8 +351,13 @@ fn format_tool_line(t: &ToolProgress) -> String {
             .duration
             .map(|d| format!(" {}", format_duration_compact(d)))
             .unwrap_or_default();
+        let hint = t
+            .result_hint
+            .as_ref()
+            .map(|h| format!(" {h}"))
+            .unwrap_or_default();
         if t.success {
-            format!("\u{2705} {emoji} {verb}{summary_part}{dur}")
+            format!("\u{2705} {emoji} {verb}{summary_part}{hint}{dur}")
         } else {
             let err_suffix = t
                 .error
@@ -3155,6 +3162,7 @@ fn spawn_stream_forwarder(
                                 success: false,
                                 duration: None,
                                 error: None,
+                                result_hint: None,
                             });
 
                             // Send typing indicator before the first progress message.
@@ -3187,12 +3195,14 @@ fn spawn_stream_forwarder(
                                 progress_dirty = true;
                             }
                         }
-                        Ok(StreamEvent::ToolCallEnd { id, success, error, .. }) => {
+                        Ok(StreamEvent::ToolCallEnd { id, result_preview, success, error }) => {
                             if let Some(tp) = progress.tools.iter_mut().find(|t| t.id == id) {
                                 tp.finished = true;
                                 tp.success = success;
                                 tp.duration = Some(tp.started_at.elapsed());
                                 tp.error = error;
+                                tp.result_hint =
+                                    crate::tool_display::tool_result_hint(&tp.raw_name, &result_preview);
                             }
 
                             let text = progress.render_text();
@@ -4274,16 +4284,17 @@ mod render_progress_tests {
     /// something to display.
     fn finished_tool(name: &str) -> ToolProgress {
         ToolProgress {
-            id:         "tool-1".into(),
-            raw_name:   name.into(),
-            name:       name.into(),
-            activity:   name.into(),
-            summary:    String::new(),
-            started_at: Instant::now(),
-            finished:   true,
-            success:    true,
-            duration:   Some(std::time::Duration::from_millis(100)),
-            error:      None,
+            id:          "tool-1".into(),
+            raw_name:    name.into(),
+            name:        name.into(),
+            activity:    name.into(),
+            summary:     String::new(),
+            started_at:  Instant::now(),
+            finished:    true,
+            success:     true,
+            duration:    Some(std::time::Duration::from_millis(100)),
+            error:       None,
+            result_hint: None,
         }
     }
 

--- a/crates/channels/src/tool_display.rs
+++ b/crates/channels/src/tool_display.rs
@@ -377,6 +377,31 @@ fn first_string_value(value: &serde_json::Value) -> Option<&str> {
         .and_then(|obj| obj.values().find_map(|v| v.as_str()))
 }
 
+/// Extract a compact result hint from a tool's `result_preview` JSON.
+///
+/// Returns `None` when no useful hint can be produced.  Currently supports:
+/// - `edit-file` / `multi-edit`: `"(+3 -1)"` line-change stats
+/// - `write-file`: `"(wrote N lines)"`
+pub fn tool_result_hint(tool_name: &str, result_preview: &str) -> Option<String> {
+    let v: serde_json::Value = serde_json::from_str(result_preview).ok()?;
+    match tool_name {
+        "edit-file" | "multi-edit" => {
+            let added = v.get("lines_added").and_then(|n| n.as_u64()).unwrap_or(0);
+            let removed = v.get("lines_removed").and_then(|n| n.as_u64()).unwrap_or(0);
+            if added > 0 || removed > 0 {
+                Some(format!("(+{added} -{removed})"))
+            } else {
+                None
+            }
+        }
+        "write-file" => {
+            let lines = v.get("lines_written").and_then(|n| n.as_u64())?;
+            Some(format!("({lines} lines)"))
+        }
+        _ => None,
+    }
+}
+
 /// Take only the first line of `s`, truncating to `max_chars` with an ellipsis
 /// if needed.
 pub fn truncate_summary(s: &str, max_chars: usize) -> String {


### PR DESCRIPTION
## Summary

- `EditFileResult` gains `lines_added` / `lines_removed` fields (computed from line count delta)
- `ToolProgress` captures `result_preview` from `ToolCallEnd` (previously ignored via `..`)
- New `tool_result_hint()` in `tool_display.rs` extracts compact stats from result JSON
- `format_tool_line()` appends result hint for finished tools

Before: `✅ 🔧 edit 1ms`
After:  `✅ 🔧 edit src/main.rs (+3 -1) 1ms`

## Type of change

| Type | Label |
|------|-------|
| New feature | `enhancement` |

## Component

`backend`

## Closes

Closes #1404

## Test plan

- [x] `cargo clippy` zero warnings
- [x] `cargo +nightly fmt --check` clean
- [x] `cargo doc` passes
- [x] Pre-commit hooks pass