### PR TITLE
test(web): add DataFeed Playwright e2e tests (#1407)

### DIFF
--- a/web/e2e/data-feeds.spec.ts
+++ b/web/e2e/data-feeds.spec.ts
@@ -1,0 +1,564 @@
+/*
+ * Copyright 2025 Rararulab
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { test, expect } from "@playwright/test";
+
+// ---------------------------------------------------------------------------
+// Types — mirrors web/src/api/data-feeds.ts
+// ---------------------------------------------------------------------------
+
+interface DataFeedConfig {
+  id: string;
+  name: string;
+  feed_type: "webhook" | "websocket" | "polling";
+  tags: string[];
+  transport: Record<string, unknown>;
+  auth: { type: string; [key: string]: unknown } | null;
+  enabled: boolean;
+  status: "idle" | "running" | "error";
+  last_error: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+interface FeedEvent {
+  id: string;
+  source_name: string;
+  event_type: string;
+  tags: string[];
+  payload: unknown;
+  received_at: string;
+}
+
+// ---------------------------------------------------------------------------
+// Shared mock data
+// ---------------------------------------------------------------------------
+
+/** Yahoo Finance payload — fetched once in beforeAll, or falls back to static fixture. */
+let yahooPayload: unknown;
+
+const YAHOO_API_URL =
+  "https://query1.finance.yahoo.com/v8/finance/chart/AAPL?interval=1d&range=1d";
+
+/** Static fallback when Yahoo Finance API is unreachable. */
+const YAHOO_FALLBACK = {
+  chart: {
+    result: [
+      {
+        meta: {
+          currency: "USD",
+          symbol: "AAPL",
+          exchangeName: "NMS",
+          fullExchangeName: "NasdaqGS",
+          regularMarketPrice: 195.89,
+        },
+        timestamp: [1713100200],
+        indicators: {
+          quote: [
+            {
+              open: [194.5],
+              high: [196.12],
+              low: [193.87],
+              close: [195.89],
+              volume: [54_321_000],
+            },
+          ],
+        },
+      },
+    ],
+    error: null,
+  },
+};
+
+/** Fake settings that satisfy hasConfiguredLlmProvider so onboarding is skipped. */
+const MOCK_SETTINGS: Record<string, string> = {
+  "llm.default_provider": "openrouter",
+  "llm.providers.openrouter.enabled": "true",
+  "llm.providers.openrouter.api_key": "sk-fake-key-for-e2e",
+};
+
+function makeFeed(overrides: Partial<DataFeedConfig> = {}): DataFeedConfig {
+  const now = new Date().toISOString();
+  return {
+    id: "feed-1",
+    name: "yahoo-aapl",
+    feed_type: "polling",
+    tags: ["stock", "yahoo", "aapl"],
+    transport: {
+      url: YAHOO_API_URL,
+      interval_secs: 60,
+      headers: {},
+      method: "GET",
+    },
+    auth: null,
+    enabled: true,
+    status: "running",
+    last_error: null,
+    created_at: now,
+    updated_at: now,
+    ...overrides,
+  };
+}
+
+function makeEvent(overrides: Partial<FeedEvent> = {}): FeedEvent {
+  return {
+    id: "evt-1",
+    source_name: "yahoo-aapl",
+    event_type: "poll_response",
+    tags: ["stock", "yahoo", "aapl"],
+    payload: yahooPayload,
+    received_at: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Setup — fetch real Yahoo Finance data once for realistic payloads
+// ---------------------------------------------------------------------------
+
+test.beforeAll(async () => {
+  try {
+    const res = await fetch(YAHOO_API_URL, {
+      headers: { "User-Agent": "Mozilla/5.0" },
+      signal: AbortSignal.timeout(5_000),
+    });
+    if (res.ok) {
+      yahooPayload = await res.json();
+    } else {
+      yahooPayload = YAHOO_FALLBACK;
+    }
+  } catch {
+    yahooPayload = YAHOO_FALLBACK;
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Install API route mocks and suppress UI dialogs that block interaction.
+ *
+ * - Sets localStorage entries to prevent the ConnectionSetupDialog (needs
+ *   rara_backend_url) and OnboardingModal (needs onboarding_dismissed).
+ * - Mocks /health, /settings, and all /data-feeds endpoints.
+ *
+ * IMPORTANT: The rara_backend_url is set to the Vite dev server origin so
+ * that resolveUrl() produces absolute URLs pointing back at the same origin.
+ * Playwright's page.route() then intercepts these before they hit the network.
+ */
+async function setupRoutes(
+  page: import("@playwright/test").Page,
+  state: {
+    feeds: DataFeedConfig[];
+    events: FeedEvent[];
+  },
+) {
+  // Suppress onboarding & connection dialogs via localStorage.
+  // Using the Vite dev server URL keeps resolveUrl() pointing at same origin.
+  await page.addInitScript(() => {
+    // Use empty string so resolveUrl returns relative paths that page.route can intercept.
+    // hasCustomBackendUrl() needs a truthy value to suppress ConnectionSetupDialog.
+    localStorage.setItem("rara_backend_url", "http://localhost:5173");
+    localStorage.setItem("onboarding_dismissed", "true");
+  });
+
+  // Health check.
+  await page.route("**/api/v1/health", (route) =>
+    route.fulfill({ status: 200, json: { status: "ok" } }),
+  );
+
+  // Settings — return a configured provider so onboarding is suppressed.
+  await page.route("**/api/v1/settings", (route) =>
+    route.fulfill({ status: 200, json: MOCK_SETTINGS }),
+  );
+
+  // Data feeds list + create.
+  await page.route("**/api/v1/data-feeds", async (route, request) => {
+    const method = request.method();
+    if (method === "GET") {
+      await route.fulfill({ json: state.feeds });
+    } else if (method === "POST") {
+      const body = request.postDataJSON();
+      const now = new Date().toISOString();
+      const created: DataFeedConfig = {
+        id: `feed-${Date.now()}`,
+        name: body.name,
+        feed_type: body.feed_type,
+        tags: body.tags ?? [],
+        transport: body.transport ?? {},
+        auth: body.auth ?? null,
+        enabled: true,
+        status: "running",
+        last_error: null,
+        created_at: now,
+        updated_at: now,
+      };
+      state.feeds.push(created);
+      await route.fulfill({ json: created });
+    } else {
+      await route.continue();
+    }
+  });
+
+  // Toggle feed.
+  await page.route("**/api/v1/data-feeds/*/toggle", async (route, request) => {
+    if (request.method() === "PUT") {
+      const url = request.url();
+      const idMatch = url.match(/data-feeds\/([^/]+)\/toggle/);
+      const id = idMatch?.[1];
+      const feed = state.feeds.find((f) => f.id === id);
+      if (feed) {
+        feed.enabled = !feed.enabled;
+        feed.status = feed.enabled ? "running" : "idle";
+        await route.fulfill({ json: feed });
+      } else {
+        await route.fulfill({ status: 404, json: { error: "not found" } });
+      }
+    } else {
+      await route.continue();
+    }
+  });
+
+  // Feed events — must be registered before the single-feed catch-all.
+  await page.route("**/api/v1/data-feeds/*/events*", async (route) => {
+    await route.fulfill({
+      json: {
+        events: state.events,
+        total: state.events.length,
+        has_more: false,
+      },
+    });
+  });
+
+  // Single feed operations (GET/PUT/DELETE by id).
+  await page.route(
+    /\/api\/v1\/data-feeds\/[^/]+$/,
+    async (route, request) => {
+      const method = request.method();
+      const url = request.url();
+      const idMatch = url.match(/data-feeds\/([^/]+)$/);
+      const id = idMatch?.[1];
+
+      if (method === "DELETE") {
+        state.feeds = state.feeds.filter((f) => f.id !== id);
+        await route.fulfill({ status: 204 });
+      } else if (method === "PUT") {
+        const feed = state.feeds.find((f) => f.id === id);
+        if (feed) {
+          const body = request.postDataJSON();
+          Object.assign(feed, body, { updated_at: new Date().toISOString() });
+          await route.fulfill({ json: feed });
+        } else {
+          await route.fulfill({ status: 404, json: { error: "not found" } });
+        }
+      } else if (method === "GET") {
+        const feed = state.feeds.find((f) => f.id === id);
+        if (feed) {
+          await route.fulfill({ json: feed });
+        } else {
+          await route.fulfill({ status: 404, json: { error: "not found" } });
+        }
+      } else {
+        await route.continue();
+      }
+    },
+  );
+}
+
+/** Navigate directly to the Data Feeds settings tab. */
+async function goToDataFeeds(page: import("@playwright/test").Page) {
+  await page.goto("/settings?section=data-feeds");
+  await page.waitForLoadState("networkidle");
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+test.describe("Data Feeds Management", () => {
+
+  // -----------------------------------------------------------------------
+  // 1. Navigate to Data Feeds tab
+  // -----------------------------------------------------------------------
+
+  test("navigate to Data Feeds tab in settings", async ({ page }) => {
+    await setupRoutes(page, { feeds: [], events: [] });
+    await page.goto("/settings");
+
+    // Click the Data Feeds sidebar button.
+    const navButton = page.locator("button", { hasText: "Data Feeds" });
+    await expect(navButton).toBeVisible({ timeout: 10_000 });
+    await navButton.click();
+
+    // The Data Feeds panel should render.
+    await expect(
+      page.getByText("External data sources that push events into rara."),
+    ).toBeVisible();
+  });
+
+  // -----------------------------------------------------------------------
+  // 2. Empty state
+  // -----------------------------------------------------------------------
+
+  test("shows empty state when no feeds configured", async ({ page }) => {
+    await setupRoutes(page, { feeds: [], events: [] });
+    await goToDataFeeds(page);
+
+    await expect(
+      page.getByText("No data feeds configured"),
+    ).toBeVisible({ timeout: 10_000 });
+    await expect(page.getByText("Create Feed")).toBeVisible();
+  });
+
+  // -----------------------------------------------------------------------
+  // 3. Create a polling feed
+  // -----------------------------------------------------------------------
+
+  test("create a polling feed", async ({ page }) => {
+    await setupRoutes(page, { feeds: [], events: [] });
+    await goToDataFeeds(page);
+
+    // Click "Create Feed" button in the empty state.
+    await page.getByRole("button", { name: /Create Feed/ }).click();
+
+    // Dialog should open.
+    await expect(page.getByText("New Data Feed")).toBeVisible({ timeout: 5_000 });
+
+    // Fill name.
+    const nameInput = page.locator('input[placeholder="e.g. github-rara"]');
+    await nameInput.fill("yahoo-aapl");
+
+    // Type defaults to Polling — verify it is selected.
+    await expect(page.getByText("Polling")).toBeVisible();
+
+    // Fill URL.
+    const urlInput = page.locator(
+      'input[placeholder="https://api.example.com/data"]',
+    );
+    await urlInput.fill(YAHOO_API_URL);
+
+    // Fill tags.
+    const tagsInput = page.locator('input[placeholder="stock, yahoo, aapl"]');
+    await tagsInput.fill("stock, yahoo, aapl");
+
+    // Click Create.
+    await page.getByRole("button", { name: "Create" }).click();
+
+    // Dialog should close and the feed should appear in the list.
+    await expect(page.getByText("yahoo-aapl")).toBeVisible({ timeout: 5_000 });
+
+    // Verify status badge shows Running.
+    await expect(page.getByText("Running")).toBeVisible();
+  });
+
+  // -----------------------------------------------------------------------
+  // 4. Feed list renders existing feeds
+  // -----------------------------------------------------------------------
+
+  test("feed list renders existing feeds with correct columns", async ({
+    page,
+  }) => {
+    const feed = makeFeed();
+    await setupRoutes(page, { feeds: [feed], events: [] });
+    await goToDataFeeds(page);
+
+    // Name column.
+    await expect(page.getByText("yahoo-aapl")).toBeVisible({ timeout: 10_000 });
+
+    // Type badge.
+    await expect(page.getByText("Polling")).toBeVisible();
+
+    // Status badge.
+    await expect(page.getByText("Running")).toBeVisible();
+
+    // Tags.
+    await expect(page.getByText("stock")).toBeVisible();
+    await expect(page.getByText("yahoo", { exact: true })).toBeVisible();
+    await expect(page.getByText("aapl", { exact: true })).toBeVisible();
+  });
+
+  // -----------------------------------------------------------------------
+  // 5. View event history for a feed
+  // -----------------------------------------------------------------------
+
+  test("view event history for a feed", async ({ page }) => {
+    const feed = makeFeed();
+    const events = [makeEvent()];
+    await setupRoutes(page, { feeds: [feed], events });
+    await goToDataFeeds(page);
+
+    // Click the feed name to navigate to event history.
+    await page.getByText("yahoo-aapl").click();
+
+    // Should see the Back button.
+    await expect(
+      page.getByRole("button", { name: "Back" }),
+    ).toBeVisible({ timeout: 5_000 });
+
+    // Should see the feed info card with name and status.
+    await expect(page.getByText("yahoo-aapl")).toBeVisible();
+    await expect(page.getByText("Running")).toBeVisible();
+
+    // Should see event table headers.
+    await expect(page.getByRole("columnheader", { name: "Time" })).toBeVisible();
+    await expect(page.getByRole("columnheader", { name: "Type" })).toBeVisible();
+    await expect(page.getByRole("columnheader", { name: "Size" })).toBeVisible();
+
+    // Should see the event type badge.
+    await expect(page.getByText("poll_response")).toBeVisible();
+  });
+
+  // -----------------------------------------------------------------------
+  // 6. View event detail with JSON payload
+  // -----------------------------------------------------------------------
+
+  test("view event detail with JSON payload", async ({ page }) => {
+    const feed = makeFeed();
+    const events = [makeEvent()];
+    await setupRoutes(page, { feeds: [feed], events });
+    await goToDataFeeds(page);
+
+    // Navigate to event history.
+    await page.getByText("yahoo-aapl").click();
+    await expect(
+      page.getByRole("button", { name: "Back" }),
+    ).toBeVisible({ timeout: 5_000 });
+
+    // Click the event row to open the detail sheet.
+    const eventRow = page.locator("tr.cursor-pointer").first();
+    await eventRow.click();
+
+    // The Sheet should open — look for the event ID in the sheet header.
+    await expect(page.getByText("evt-1")).toBeVisible({ timeout: 5_000 });
+
+    // Payload section should show the JsonTree with Yahoo Finance keys.
+    await expect(page.getByText("Payload")).toBeVisible();
+
+    // The JsonTree renders top-level keys visible, nested ones are collapsed.
+    // "chart:" and "result:" are visible at their respective nesting levels.
+    await expect(page.getByText(/chart:/)).toBeVisible();
+    await expect(page.getByText(/result:/)).toBeVisible();
+
+    // "error: null" is visible at the second level of the tree.
+    await expect(page.getByText(/error.*null/)).toBeVisible();
+
+    // Copy button should be present.
+    await expect(page.getByRole("button", { name: "Copy" })).toBeVisible();
+  });
+
+  // -----------------------------------------------------------------------
+  // 7. Toggle feed enabled/disabled
+  // -----------------------------------------------------------------------
+
+  test("toggle feed enabled/disabled", async ({ page }) => {
+    const feed = makeFeed({ enabled: true, status: "running" });
+    await setupRoutes(page, { feeds: [feed], events: [] });
+    await goToDataFeeds(page);
+
+    // Feed should show Running initially.
+    await expect(page.getByText("Running")).toBeVisible({ timeout: 10_000 });
+
+    // Click the toggle switch.
+    const toggle = page.getByRole("switch");
+    await toggle.click();
+
+    // After toggle, the status should change to Disabled.
+    await expect(page.getByText("Disabled")).toBeVisible({ timeout: 5_000 });
+  });
+
+  // -----------------------------------------------------------------------
+  // 8. Delete a feed
+  // -----------------------------------------------------------------------
+
+  test("delete a feed", async ({ page }) => {
+    const feed = makeFeed();
+    await setupRoutes(page, { feeds: [feed], events: [] });
+    await goToDataFeeds(page);
+
+    // Feed should be visible.
+    await expect(page.getByText("yahoo-aapl")).toBeVisible({ timeout: 10_000 });
+
+    // Click the delete button (Trash2 icon button with destructive styling).
+    const deleteButton = page.locator("button.text-destructive");
+    await deleteButton.click();
+
+    // Confirmation dialog should appear.
+    await expect(page.getByText("Delete Feed")).toBeVisible({ timeout: 5_000 });
+    await expect(
+      page.getByText("This will permanently remove this feed"),
+    ).toBeVisible();
+
+    // Click the destructive Delete button in the confirmation dialog.
+    const confirmDelete = page
+      .locator('[role="dialog"]')
+      .getByRole("button", { name: "Delete" });
+    await confirmDelete.click();
+
+    // Feed should disappear and empty state should show.
+    await expect(page.getByText("No data feeds configured")).toBeVisible({
+      timeout: 5_000,
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // 9. Navigate back from event history to feed list
+  // -----------------------------------------------------------------------
+
+  test("navigate back from event history to feed list", async ({ page }) => {
+    const feed = makeFeed();
+    await setupRoutes(page, { feeds: [feed], events: [makeEvent()] });
+    await goToDataFeeds(page);
+
+    // Go to event history.
+    await page.getByText("yahoo-aapl").click();
+    await expect(
+      page.getByRole("button", { name: "Back" }),
+    ).toBeVisible({ timeout: 5_000 });
+
+    // Click Back.
+    await page.getByRole("button", { name: "Back" }).click();
+
+    // Should return to the feed list with the "New Feed" button visible.
+    await expect(
+      page.getByRole("button", { name: "New Feed" }),
+    ).toBeVisible({ timeout: 5_000 });
+
+    // Feed should still be in the list.
+    await expect(page.getByText("yahoo-aapl")).toBeVisible();
+  });
+
+  // -----------------------------------------------------------------------
+  // 10. Event history shows empty state for no events
+  // -----------------------------------------------------------------------
+
+  test("event history shows empty state when no events", async ({ page }) => {
+    const feed = makeFeed();
+    await setupRoutes(page, { feeds: [feed], events: [] });
+    await goToDataFeeds(page);
+
+    // Navigate to event history.
+    await page.getByText("yahoo-aapl").click();
+    await expect(
+      page.getByRole("button", { name: "Back" }),
+    ).toBeVisible({ timeout: 5_000 });
+
+    // Should show "No events in this time range".
+    await expect(
+      page.getByText("No events in this time range"),
+    ).toBeVisible({ timeout: 5_000 });
+  });
+});

--- a/web/src/api/data-feeds.ts
+++ b/web/src/api/data-feeds.ts
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2025 Rararulab
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { api } from "./client";
+
+// ---------------------------------------------------------------------------
+// Types — mirrors kernel::data_feed::config
+// ---------------------------------------------------------------------------
+
+export interface DataFeedConfig {
+  id: string;
+  name: string;
+  feed_type: "webhook" | "websocket" | "polling";
+  tags: string[];
+  transport: Record<string, unknown>;
+  auth: AuthConfig | null;
+  enabled: boolean;
+  status: "idle" | "running" | "error";
+  last_error: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export type AuthType = "header" | "query" | "bearer" | "basic" | "hmac";
+
+export interface AuthConfig {
+  type: AuthType;
+  [key: string]: unknown;
+}
+
+export interface FeedEvent {
+  id: string;
+  source_name: string;
+  event_type: string;
+  tags: string[];
+  payload: unknown;
+  received_at: string;
+}
+
+export interface FeedEventsResponse {
+  events: FeedEvent[];
+  total: number;
+  has_more: boolean;
+}
+
+export interface CreateFeedRequest {
+  name: string;
+  feed_type: "webhook" | "websocket" | "polling";
+  tags: string[];
+  transport: Record<string, unknown>;
+  auth: AuthConfig | null;
+}
+
+// ---------------------------------------------------------------------------
+// API client
+// ---------------------------------------------------------------------------
+
+export const dataFeedsApi = {
+  list: () => api.get<DataFeedConfig[]>("/api/v1/data-feeds"),
+
+  get: (id: string) => api.get<DataFeedConfig>(`/api/v1/data-feeds/${id}`),
+
+  create: (feed: CreateFeedRequest) =>
+    api.post<DataFeedConfig>("/api/v1/data-feeds", feed),
+
+  update: (id: string, feed: Partial<CreateFeedRequest>) =>
+    api.put<DataFeedConfig>(`/api/v1/data-feeds/${id}`, feed),
+
+  delete: (id: string) => api.del(`/api/v1/data-feeds/${id}`),
+
+  toggle: (id: string) =>
+    api.put<DataFeedConfig>(`/api/v1/data-feeds/${id}/toggle`),
+
+  events: (
+    id: string,
+    params?: { since?: string; limit?: number; offset?: number },
+  ) => {
+    const query = new URLSearchParams();
+    if (params?.since) query.set("since", params.since);
+    if (params?.limit) query.set("limit", String(params.limit));
+    if (params?.offset) query.set("offset", String(params.offset));
+    const qs = query.toString();
+    return api.get<FeedEventsResponse>(
+      `/api/v1/data-feeds/${id}/events${qs ? `?${qs}` : ""}`,
+    );
+  },
+};

--- a/web/src/components/DataFeedsPanel.tsx
+++ b/web/src/components/DataFeedsPanel.tsx
@@ -1,0 +1,1186 @@
+/*
+ * Copyright 2025 Rararulab
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useState, useMemo, useCallback } from "react";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import {
+  dataFeedsApi,
+  type DataFeedConfig,
+  type FeedEvent,
+  type CreateFeedRequest,
+  type AuthType,
+} from "@/api/data-feeds";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Switch } from "@/components/ui/switch";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+} from "@/components/ui/sheet";
+import { JsonTree } from "@/components/JsonTree";
+import {
+  AlertTriangle,
+  ArrowLeft,
+  ChevronRight,
+  Clock,
+  Copy,
+  Pencil,
+  Plus,
+  Radio,
+  Trash2,
+} from "lucide-react";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Convert an ISO timestamp to a human-readable relative time string. */
+function timeAgo(dateStr: string): string {
+  const now = Date.now();
+  const then = new Date(dateStr).getTime();
+  const diffSec = Math.floor((now - then) / 1000);
+
+  if (diffSec < 0) return "just now";
+  if (diffSec < 60) return `${diffSec}s ago`;
+
+  const diffMin = Math.floor(diffSec / 60);
+  if (diffMin < 60) return `${diffMin}m ago`;
+
+  const diffHour = Math.floor(diffMin / 60);
+  if (diffHour < 24) return `${diffHour}h ago`;
+
+  const diffDay = Math.floor(diffHour / 24);
+  return `${diffDay}d ago`;
+}
+
+/** Estimate byte-size of a JSON payload. */
+function payloadSize(payload: unknown): string {
+  const bytes = new Blob([JSON.stringify(payload)]).size;
+  if (bytes < 1024) return `${bytes}B`;
+  return `${(bytes / 1024).toFixed(1)}K`;
+}
+
+/** Format type badge label. */
+function typeLabel(t: DataFeedConfig["feed_type"]): string {
+  switch (t) {
+    case "polling":
+      return "Polling";
+    case "webhook":
+      return "Webhook";
+    case "websocket":
+      return "WebSocket";
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Status badge
+// ---------------------------------------------------------------------------
+
+function StatusBadge({
+  status,
+  enabled,
+}: {
+  status: DataFeedConfig["status"];
+  enabled: boolean;
+}) {
+  if (!enabled) {
+    return (
+      <Badge variant="secondary" className="text-muted-foreground">
+        Disabled
+      </Badge>
+    );
+  }
+  switch (status) {
+    case "running":
+      return (
+        <Badge className="border-green-200 bg-green-50 text-green-700 dark:border-green-900 dark:bg-green-950 dark:text-green-400">
+          Running
+        </Badge>
+      );
+    case "idle":
+      return (
+        <Badge className="border-yellow-200 bg-yellow-50 text-yellow-700 dark:border-yellow-900 dark:bg-yellow-950 dark:text-yellow-400">
+          Idle
+        </Badge>
+      );
+    case "error":
+      return (
+        <Badge variant="destructive">
+          Error
+        </Badge>
+      );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Time filter options
+// ---------------------------------------------------------------------------
+
+const TIME_FILTERS = [
+  { value: "1h", label: "Last 1 hour" },
+  { value: "24h", label: "Last 24 hours" },
+  { value: "7d", label: "Last 7 days" },
+  { value: "30d", label: "Last 30 days" },
+] as const;
+
+function sinceFromFilter(filter: string): string {
+  const now = new Date();
+  switch (filter) {
+    case "1h":
+      return new Date(now.getTime() - 3600_000).toISOString();
+    case "24h":
+      return new Date(now.getTime() - 86400_000).toISOString();
+    case "7d":
+      return new Date(now.getTime() - 7 * 86400_000).toISOString();
+    case "30d":
+      return new Date(now.getTime() - 30 * 86400_000).toISOString();
+    default:
+      return new Date(now.getTime() - 86400_000).toISOString();
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Empty auth/transport helpers
+// ---------------------------------------------------------------------------
+
+function emptyTransport(
+  feedType: CreateFeedRequest["feed_type"],
+): Record<string, unknown> {
+  switch (feedType) {
+    case "polling":
+      return { url: "", interval_secs: 60, headers: {}, method: "GET" };
+    case "webhook":
+      return { events: [], body_size_limit: 1048576 };
+    case "websocket":
+      return {
+        url: "",
+        reconnect_backoff: [5, 10, 30, 60],
+        heartbeat_secs: 30,
+      };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Feed Form Dialog
+// ---------------------------------------------------------------------------
+
+interface FeedFormState {
+  name: string;
+  feed_type: CreateFeedRequest["feed_type"];
+  tags: string;
+  transport: Record<string, unknown>;
+  authType: "none" | AuthType;
+  authFields: Record<string, string>;
+}
+
+const INITIAL_FORM: FeedFormState = {
+  name: "",
+  feed_type: "polling",
+  tags: "",
+  transport: emptyTransport("polling"),
+  authType: "none",
+  authFields: {},
+};
+
+function feedToForm(feed: DataFeedConfig): FeedFormState {
+  const authType: FeedFormState["authType"] = feed.auth
+    ? (feed.auth.type as AuthType)
+    : "none";
+  const authFields: Record<string, string> = {};
+  if (feed.auth) {
+    for (const [k, v] of Object.entries(feed.auth)) {
+      if (k !== "type") authFields[k] = String(v ?? "");
+    }
+  }
+  return {
+    name: feed.name,
+    feed_type: feed.feed_type,
+    tags: feed.tags.join(", "),
+    transport: { ...feed.transport },
+    authType,
+    authFields,
+  };
+}
+
+function formToRequest(form: FeedFormState): CreateFeedRequest {
+  const tags = form.tags
+    .split(",")
+    .map((t) => t.trim())
+    .filter(Boolean);
+
+  let auth = null;
+  if (form.authType !== "none") {
+    auth = { type: form.authType, ...form.authFields };
+  }
+
+  return {
+    name: form.name,
+    feed_type: form.feed_type,
+    tags,
+    transport: form.transport,
+    auth,
+  };
+}
+
+function TransportFields({
+  feedType,
+  transport,
+  onChange,
+}: {
+  feedType: CreateFeedRequest["feed_type"];
+  transport: Record<string, unknown>;
+  onChange: (t: Record<string, unknown>) => void;
+}) {
+  const set = (key: string, value: unknown) =>
+    onChange({ ...transport, [key]: value });
+
+  switch (feedType) {
+    case "polling":
+      return (
+        <div className="space-y-3">
+          <div className="space-y-1.5">
+            <Label className="text-sm font-medium">URL</Label>
+            <Input
+              value={String(transport.url ?? "")}
+              onChange={(e) => set("url", e.target.value)}
+              placeholder="https://api.example.com/data"
+              className="h-9 font-mono text-sm"
+            />
+          </div>
+          <div className="space-y-1.5">
+            <Label className="text-sm font-medium">Interval (seconds)</Label>
+            <Input
+              type="number"
+              min={1}
+              value={String(transport.interval_secs ?? 60)}
+              onChange={(e) => set("interval_secs", Number(e.target.value))}
+              className="h-9 w-32 text-sm"
+            />
+          </div>
+        </div>
+      );
+    case "webhook":
+      return (
+        <p className="text-sm text-muted-foreground">
+          A unique webhook URL will be generated after creation. Configure your
+          external service to POST events to that URL.
+        </p>
+      );
+    case "websocket":
+      return (
+        <div className="space-y-3">
+          <div className="space-y-1.5">
+            <Label className="text-sm font-medium">WebSocket URL</Label>
+            <Input
+              value={String(transport.url ?? "")}
+              onChange={(e) => set("url", e.target.value)}
+              placeholder="wss://stream.example.com/ws"
+              className="h-9 font-mono text-sm"
+            />
+          </div>
+        </div>
+      );
+  }
+}
+
+function AuthFields({
+  authType,
+  fields,
+  onChange,
+}: {
+  authType: AuthType;
+  fields: Record<string, string>;
+  onChange: (f: Record<string, string>) => void;
+}) {
+  const set = (key: string, value: string) =>
+    onChange({ ...fields, [key]: value });
+
+  switch (authType) {
+    case "header":
+      return (
+        <div className="space-y-3">
+          <div className="space-y-1.5">
+            <Label className="text-sm font-medium">Header Name</Label>
+            <Input
+              value={fields.name ?? ""}
+              onChange={(e) => set("name", e.target.value)}
+              placeholder="X-API-Key"
+              className="h-9 text-sm"
+            />
+          </div>
+          <div className="space-y-1.5">
+            <Label className="text-sm font-medium">Header Value</Label>
+            <Input
+              type="password"
+              value={fields.value ?? ""}
+              onChange={(e) => set("value", e.target.value)}
+              placeholder="sk-..."
+              className="h-9 font-mono text-sm"
+            />
+          </div>
+        </div>
+      );
+    case "query":
+      return (
+        <div className="space-y-3">
+          <div className="space-y-1.5">
+            <Label className="text-sm font-medium">Query Parameter</Label>
+            <Input
+              value={fields.name ?? ""}
+              onChange={(e) => set("name", e.target.value)}
+              placeholder="apikey"
+              className="h-9 text-sm"
+            />
+          </div>
+          <div className="space-y-1.5">
+            <Label className="text-sm font-medium">Value</Label>
+            <Input
+              type="password"
+              value={fields.value ?? ""}
+              onChange={(e) => set("value", e.target.value)}
+              placeholder="sk-..."
+              className="h-9 font-mono text-sm"
+            />
+          </div>
+        </div>
+      );
+    case "bearer":
+      return (
+        <div className="space-y-1.5">
+          <Label className="text-sm font-medium">Bearer Token</Label>
+          <Input
+            type="password"
+            value={fields.token ?? ""}
+            onChange={(e) => set("token", e.target.value)}
+            placeholder="eyJ..."
+            className="h-9 font-mono text-sm"
+          />
+        </div>
+      );
+    case "basic":
+      return (
+        <div className="space-y-3">
+          <div className="space-y-1.5">
+            <Label className="text-sm font-medium">Username</Label>
+            <Input
+              value={fields.username ?? ""}
+              onChange={(e) => set("username", e.target.value)}
+              className="h-9 text-sm"
+            />
+          </div>
+          <div className="space-y-1.5">
+            <Label className="text-sm font-medium">Password</Label>
+            <Input
+              type="password"
+              value={fields.password ?? ""}
+              onChange={(e) => set("password", e.target.value)}
+              className="h-9 font-mono text-sm"
+            />
+          </div>
+        </div>
+      );
+    case "hmac":
+      return (
+        <div className="space-y-3">
+          <div className="space-y-1.5">
+            <Label className="text-sm font-medium">HMAC Secret</Label>
+            <Input
+              type="password"
+              value={fields.secret ?? ""}
+              onChange={(e) => set("secret", e.target.value)}
+              placeholder="whsec_..."
+              className="h-9 font-mono text-sm"
+            />
+          </div>
+          <div className="space-y-1.5">
+            <Label className="text-sm font-medium">Signature Header</Label>
+            <Input
+              value={fields.header ?? ""}
+              onChange={(e) => set("header", e.target.value)}
+              placeholder="X-Hub-Signature-256"
+              className="h-9 text-sm"
+            />
+          </div>
+        </div>
+      );
+  }
+}
+
+function FeedFormDialog({
+  open,
+  onOpenChange,
+  editFeed,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  editFeed?: DataFeedConfig;
+}) {
+  const queryClient = useQueryClient();
+  const [form, setForm] = useState<FeedFormState>(
+    editFeed ? feedToForm(editFeed) : INITIAL_FORM,
+  );
+  const [error, setError] = useState<string | null>(null);
+
+  const isEdit = !!editFeed;
+
+  const createMutation = useMutation({
+    mutationFn: (req: CreateFeedRequest) => dataFeedsApi.create(req),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["data-feeds"] });
+      onOpenChange(false);
+    },
+    onError: (err: Error) => setError(err.message),
+  });
+
+  const updateMutation = useMutation({
+    mutationFn: (req: Partial<CreateFeedRequest>) =>
+      dataFeedsApi.update(editFeed!.id, req),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["data-feeds"] });
+      onOpenChange(false);
+    },
+    onError: (err: Error) => setError(err.message),
+  });
+
+  const handleSubmit = () => {
+    setError(null);
+    const req = formToRequest(form);
+    if (!req.name.trim()) {
+      setError("Name is required");
+      return;
+    }
+    if (isEdit) {
+      updateMutation.mutate(req);
+    } else {
+      createMutation.mutate(req);
+    }
+  };
+
+  const saving = createMutation.isPending || updateMutation.isPending;
+
+  // Reset form when dialog opens with a new feed
+  const handleOpenChange = (next: boolean) => {
+    if (next) {
+      setForm(editFeed ? feedToForm(editFeed) : INITIAL_FORM);
+      setError(null);
+    }
+    onOpenChange(next);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent className="max-h-[85vh] overflow-y-auto sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle>{isEdit ? "Edit Feed" : "New Data Feed"}</DialogTitle>
+          <DialogDescription>
+            {isEdit
+              ? "Update the data feed configuration."
+              : "Configure an external data source to ingest events."}
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4 py-2">
+          {/* Name */}
+          <div className="space-y-1.5">
+            <Label className="text-sm font-medium">Name</Label>
+            <Input
+              value={form.name}
+              onChange={(e) => setForm({ ...form, name: e.target.value })}
+              placeholder="e.g. github-rara"
+              className="h-9 font-mono text-sm"
+              disabled={isEdit}
+            />
+          </div>
+
+          {/* Feed Type */}
+          <div className="space-y-1.5">
+            <Label className="text-sm font-medium">Type</Label>
+            <Select
+              value={form.feed_type}
+              onValueChange={(v) => {
+                const ft = v as CreateFeedRequest["feed_type"];
+                setForm({
+                  ...form,
+                  feed_type: ft,
+                  transport: emptyTransport(ft),
+                });
+              }}
+              disabled={isEdit}
+            >
+              <SelectTrigger className="h-9 w-48">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="polling">Polling</SelectItem>
+                <SelectItem value="webhook">Webhook</SelectItem>
+                <SelectItem value="websocket">WebSocket</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+
+          {/* Transport */}
+          <div className="space-y-1.5">
+            <Label className="text-sm font-medium">Transport</Label>
+            <TransportFields
+              feedType={form.feed_type}
+              transport={form.transport}
+              onChange={(t) => setForm({ ...form, transport: t })}
+            />
+          </div>
+
+          {/* Auth */}
+          <div className="space-y-1.5">
+            <Label className="text-sm font-medium">Authentication</Label>
+            <Select
+              value={form.authType}
+              onValueChange={(v) => {
+                setForm({
+                  ...form,
+                  authType: v as FeedFormState["authType"],
+                  authFields: {},
+                });
+              }}
+            >
+              <SelectTrigger className="h-9 w-48">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="none">None</SelectItem>
+                <SelectItem value="header">API Key (Header)</SelectItem>
+                <SelectItem value="query">API Key (Query)</SelectItem>
+                <SelectItem value="bearer">Bearer Token</SelectItem>
+                <SelectItem value="basic">Basic Auth</SelectItem>
+                <SelectItem value="hmac">HMAC Signature</SelectItem>
+              </SelectContent>
+            </Select>
+            {form.authType !== "none" && (
+              <div className="mt-3">
+                <AuthFields
+                  authType={form.authType}
+                  fields={form.authFields}
+                  onChange={(f) => setForm({ ...form, authFields: f })}
+                />
+              </div>
+            )}
+          </div>
+
+          {/* Tags */}
+          <div className="space-y-1.5">
+            <Label className="text-sm font-medium">Tags</Label>
+            <Input
+              value={form.tags}
+              onChange={(e) => setForm({ ...form, tags: e.target.value })}
+              placeholder="stock, yahoo, aapl"
+              className="h-9 text-sm"
+            />
+            <p className="text-xs text-muted-foreground">
+              Comma-separated. Used for subscription matching.
+            </p>
+          </div>
+
+          {/* Error */}
+          {error && (
+            <div className="flex items-center gap-2 rounded-lg border border-destructive/30 bg-destructive/5 px-3 py-2 text-sm text-destructive">
+              <AlertTriangle className="h-4 w-4 shrink-0" />
+              {error}
+            </div>
+          )}
+        </div>
+
+        <DialogFooter>
+          <Button
+            variant="outline"
+            onClick={() => onOpenChange(false)}
+            disabled={saving}
+          >
+            Cancel
+          </Button>
+          <Button onClick={handleSubmit} disabled={saving}>
+            {saving ? "Saving..." : isEdit ? "Update" : "Create"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Event Detail Sheet
+// ---------------------------------------------------------------------------
+
+function EventDetailSheet({
+  event,
+  open,
+  onOpenChange,
+}: {
+  event: FeedEvent | null;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}) {
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = useCallback(() => {
+    if (!event) return;
+    navigator.clipboard
+      .writeText(JSON.stringify(event.payload, null, 2))
+      .then(() => {
+        setCopied(true);
+        setTimeout(() => setCopied(false), 2000);
+      });
+  }, [event]);
+
+  return (
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent side="right" className="overflow-y-auto sm:max-w-lg">
+        <SheetHeader>
+          <SheetTitle className="font-mono text-sm">
+            {event?.id ?? "Event Detail"}
+          </SheetTitle>
+          <SheetDescription>
+            {event ? timeAgo(event.received_at) : ""}
+            {event && (
+              <span
+                className="ml-2 text-xs text-muted-foreground"
+                title={event.received_at}
+              >
+                ({new Date(event.received_at).toLocaleString()})
+              </span>
+            )}
+          </SheetDescription>
+        </SheetHeader>
+
+        {event && (
+          <div className="mt-6 space-y-4">
+            {/* Meta */}
+            <div className="space-y-2">
+              <div className="flex items-center gap-2">
+                <span className="text-xs font-medium text-muted-foreground">
+                  Type
+                </span>
+                <Badge variant="outline">{event.event_type}</Badge>
+              </div>
+              {event.tags.length > 0 && (
+                <div className="flex flex-wrap items-center gap-1.5">
+                  <span className="text-xs font-medium text-muted-foreground">
+                    Tags
+                  </span>
+                  {event.tags.map((tag) => (
+                    <Badge key={tag} variant="secondary" className="text-xs">
+                      {tag}
+                    </Badge>
+                  ))}
+                </div>
+              )}
+            </div>
+
+            {/* Payload */}
+            <div className="space-y-2">
+              <div className="flex items-center justify-between">
+                <span className="text-xs font-medium text-muted-foreground">
+                  Payload
+                </span>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className="h-7 gap-1 text-xs"
+                  onClick={handleCopy}
+                >
+                  <Copy className="h-3 w-3" />
+                  {copied ? "Copied" : "Copy"}
+                </Button>
+              </div>
+              <div className="rounded-lg border bg-muted/30 p-3 font-mono text-xs">
+                <JsonTree data={event.payload} />
+              </div>
+            </div>
+          </div>
+        )}
+      </SheetContent>
+    </Sheet>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Event History View
+// ---------------------------------------------------------------------------
+
+function EventHistoryView({
+  feed,
+  onBack,
+}: {
+  feed: DataFeedConfig;
+  onBack: () => void;
+}) {
+  const [timeFilter, setTimeFilter] = useState("24h");
+  const [selectedEvent, setSelectedEvent] = useState<FeedEvent | null>(null);
+  const [offset, setOffset] = useState(0);
+  const limit = 50;
+
+  const since = useMemo(() => sinceFromFilter(timeFilter), [timeFilter]);
+
+  const eventsQuery = useQuery({
+    queryKey: ["data-feed-events", feed.id, since, offset],
+    queryFn: () => dataFeedsApi.events(feed.id, { since, limit, offset }),
+  });
+
+  const events = eventsQuery.data?.events ?? [];
+  const hasMore = eventsQuery.data?.has_more ?? false;
+  const total = eventsQuery.data?.total ?? 0;
+
+  return (
+    <div className="space-y-4">
+      {/* Header */}
+      <div className="flex items-center gap-3">
+        <Button
+          variant="outline"
+          size="sm"
+          className="h-8 gap-1"
+          onClick={onBack}
+        >
+          <ArrowLeft className="h-3.5 w-3.5" />
+          Back
+        </Button>
+      </div>
+
+      {/* Feed info card */}
+      <div className="rounded-lg border bg-muted/20 px-4 py-3">
+        <div className="flex items-center gap-3">
+          <Radio className="h-5 w-5 text-muted-foreground" />
+          <div className="min-w-0 flex-1">
+            <div className="flex items-center gap-2">
+              <span className="font-semibold">{feed.name}</span>
+              <Badge variant="outline" className="text-xs">
+                {typeLabel(feed.feed_type)}
+              </Badge>
+              <StatusBadge status={feed.status} enabled={feed.enabled} />
+            </div>
+            <div className="mt-0.5 flex items-center gap-3 text-xs text-muted-foreground">
+              {feed.feed_type === "polling" && !!feed.transport.url && (
+                <span className="truncate font-mono">
+                  {String(feed.transport.url)}
+                </span>
+              )}
+              {feed.feed_type === "polling" && !!feed.transport.interval_secs && (
+                <span>{String(feed.transport.interval_secs)}s interval</span>
+              )}
+              <span>{total} events</span>
+            </div>
+          </div>
+        </div>
+        {feed.last_error && (
+          <div className="mt-2 flex items-center gap-2 text-xs text-destructive">
+            <AlertTriangle className="h-3.5 w-3.5 shrink-0" />
+            {feed.last_error}
+          </div>
+        )}
+      </div>
+
+      {/* Filters */}
+      <div className="flex items-center gap-3">
+        <Select
+          value={timeFilter}
+          onValueChange={(v) => {
+            setTimeFilter(v);
+            setOffset(0);
+          }}
+        >
+          <SelectTrigger className="h-8 w-44 text-xs">
+            <Clock className="mr-1.5 h-3.5 w-3.5" />
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {TIME_FILTERS.map((f) => (
+              <SelectItem key={f.value} value={f.value}>
+                {f.label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+
+      {/* Events table */}
+      {eventsQuery.isLoading ? (
+        <div className="space-y-2">
+          {Array.from({ length: 5 }).map((_, i) => (
+            <Skeleton key={i} className="h-10 w-full" />
+          ))}
+        </div>
+      ) : events.length === 0 ? (
+        <div className="flex flex-col items-center justify-center py-12 text-muted-foreground">
+          <Clock className="mb-2 h-8 w-8" />
+          <p className="text-sm">No events in this time range</p>
+        </div>
+      ) : (
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead className="w-32">Time</TableHead>
+              <TableHead>Type</TableHead>
+              <TableHead className="w-20 text-right">Size</TableHead>
+              <TableHead className="w-8" />
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {events.map((evt) => (
+              <TableRow
+                key={evt.id}
+                className="cursor-pointer"
+                onClick={() => setSelectedEvent(evt)}
+              >
+                <TableCell
+                  className="font-mono text-xs"
+                  title={new Date(evt.received_at).toLocaleString()}
+                >
+                  {timeAgo(evt.received_at)}
+                </TableCell>
+                <TableCell>
+                  <Badge variant="outline" className="text-xs">
+                    {evt.event_type}
+                  </Badge>
+                </TableCell>
+                <TableCell className="text-right text-xs text-muted-foreground">
+                  {payloadSize(evt.payload)}
+                </TableCell>
+                <TableCell>
+                  <ChevronRight className="h-4 w-4 text-muted-foreground" />
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      )}
+
+      {/* Load more */}
+      {hasMore && (
+        <div className="flex justify-center">
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => setOffset((prev) => prev + limit)}
+            disabled={eventsQuery.isFetching}
+          >
+            {eventsQuery.isFetching ? "Loading..." : "Load more"}
+          </Button>
+        </div>
+      )}
+
+      {/* Event detail drawer */}
+      <EventDetailSheet
+        event={selectedEvent}
+        open={!!selectedEvent}
+        onOpenChange={(open) => {
+          if (!open) setSelectedEvent(null);
+        }}
+      />
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Feed List View
+// ---------------------------------------------------------------------------
+
+function FeedListView({
+  feeds,
+  onSelectFeed,
+}: {
+  feeds: DataFeedConfig[];
+  onSelectFeed: (feed: DataFeedConfig) => void;
+}) {
+  const queryClient = useQueryClient();
+  const [formOpen, setFormOpen] = useState(false);
+  const [editFeed, setEditFeed] = useState<DataFeedConfig | undefined>();
+  const [deleteId, setDeleteId] = useState<string | null>(null);
+
+  const toggleMutation = useMutation({
+    mutationFn: (id: string) => dataFeedsApi.toggle(id),
+    onSuccess: () =>
+      queryClient.invalidateQueries({ queryKey: ["data-feeds"] }),
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: (id: string) => dataFeedsApi.delete(id),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["data-feeds"] });
+      setDeleteId(null);
+    },
+  });
+
+  const handleEdit = (feed: DataFeedConfig) => {
+    setEditFeed(feed);
+    setFormOpen(true);
+  };
+
+  const handleNew = () => {
+    setEditFeed(undefined);
+    setFormOpen(true);
+  };
+
+  return (
+    <>
+      {/* Toolbar */}
+      <div className="flex items-center justify-between">
+        <div>
+          <h2 className="text-base font-semibold">Data Feeds</h2>
+          <p className="text-xs text-muted-foreground">
+            External data sources that push events into rara.
+          </p>
+        </div>
+        <Button size="sm" className="h-8 gap-1" onClick={handleNew}>
+          <Plus className="h-3.5 w-3.5" />
+          New Feed
+        </Button>
+      </div>
+
+      {/* Table */}
+      {feeds.length === 0 ? (
+        <div className="flex flex-col items-center justify-center rounded-lg border border-dashed py-12 text-muted-foreground">
+          <Radio className="mb-2 h-8 w-8" />
+          <p className="text-sm">No data feeds configured</p>
+          <p className="text-xs">
+            Create a feed to start ingesting external events.
+          </p>
+          <Button
+            size="sm"
+            variant="outline"
+            className="mt-4 gap-1"
+            onClick={handleNew}
+          >
+            <Plus className="h-3.5 w-3.5" />
+            Create Feed
+          </Button>
+        </div>
+      ) : (
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Name</TableHead>
+              <TableHead className="w-24">Type</TableHead>
+              <TableHead className="w-24">Status</TableHead>
+              <TableHead className="w-24 text-right">Updated</TableHead>
+              <TableHead className="w-32 text-right">Actions</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {feeds.map((feed) => (
+              <TableRow key={feed.id}>
+                <TableCell>
+                  <button
+                    className="font-medium text-primary hover:underline"
+                    onClick={() => onSelectFeed(feed)}
+                  >
+                    {feed.name}
+                  </button>
+                  {feed.tags.length > 0 && (
+                    <div className="mt-0.5 flex flex-wrap gap-1">
+                      {feed.tags.slice(0, 3).map((tag) => (
+                        <Badge
+                          key={tag}
+                          variant="secondary"
+                          className="text-[10px] px-1.5 py-0"
+                        >
+                          {tag}
+                        </Badge>
+                      ))}
+                      {feed.tags.length > 3 && (
+                        <span className="text-[10px] text-muted-foreground">
+                          +{feed.tags.length - 3}
+                        </span>
+                      )}
+                    </div>
+                  )}
+                </TableCell>
+                <TableCell>
+                  <Badge variant="outline" className="text-xs">
+                    {typeLabel(feed.feed_type)}
+                  </Badge>
+                </TableCell>
+                <TableCell>
+                  <StatusBadge status={feed.status} enabled={feed.enabled} />
+                </TableCell>
+                <TableCell
+                  className="text-right text-xs text-muted-foreground"
+                  title={new Date(feed.updated_at).toLocaleString()}
+                >
+                  {timeAgo(feed.updated_at)}
+                </TableCell>
+                <TableCell className="text-right">
+                  <div className="flex items-center justify-end gap-2">
+                    <Switch
+                      checked={feed.enabled}
+                      onCheckedChange={() => toggleMutation.mutate(feed.id)}
+                      disabled={toggleMutation.isPending}
+                    />
+                    <Button
+                      variant="outline"
+                      size="icon"
+                      className="h-7 w-7"
+                      onClick={() => handleEdit(feed)}
+                    >
+                      <Pencil className="h-3 w-3" />
+                    </Button>
+                    <Button
+                      variant="outline"
+                      size="icon"
+                      className="h-7 w-7 text-destructive hover:bg-destructive/10"
+                      onClick={() => setDeleteId(feed.id)}
+                    >
+                      <Trash2 className="h-3 w-3" />
+                    </Button>
+                  </div>
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      )}
+
+      {/* Create/Edit Dialog */}
+      <FeedFormDialog
+        open={formOpen}
+        onOpenChange={setFormOpen}
+        editFeed={editFeed}
+      />
+
+      {/* Delete Confirmation */}
+      <Dialog
+        open={!!deleteId}
+        onOpenChange={(open) => {
+          if (!open) setDeleteId(null);
+        }}
+      >
+        <DialogContent className="sm:max-w-sm">
+          <DialogHeader>
+            <DialogTitle>Delete Feed</DialogTitle>
+            <DialogDescription>
+              This will permanently remove this feed and stop all event
+              ingestion. This action cannot be undone.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setDeleteId(null)}>
+              Cancel
+            </Button>
+            <Button
+              variant="destructive"
+              onClick={() => deleteId && deleteMutation.mutate(deleteId)}
+              disabled={deleteMutation.isPending}
+            >
+              {deleteMutation.isPending ? "Deleting..." : "Delete"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Root Component
+// ---------------------------------------------------------------------------
+
+type View =
+  | { kind: "list" }
+  | { kind: "events"; feed: DataFeedConfig };
+
+export default function DataFeedsPanel() {
+  const [view, setView] = useState<View>({ kind: "list" });
+
+  const feedsQuery = useQuery({
+    queryKey: ["data-feeds"],
+    queryFn: () => dataFeedsApi.list(),
+  });
+
+  if (feedsQuery.isLoading) {
+    return (
+      <div className="space-y-3">
+        <Skeleton className="h-8 w-48" />
+        {Array.from({ length: 3 }).map((_, i) => (
+          <Skeleton key={i} className="h-14 w-full" />
+        ))}
+      </div>
+    );
+  }
+
+  if (feedsQuery.isError) {
+    return (
+      <div className="flex flex-col items-center justify-center py-12 text-muted-foreground">
+        <AlertTriangle className="mb-2 h-8 w-8 text-destructive" />
+        <p className="text-sm">Failed to load data feeds</p>
+        <p className="text-xs">Check the backend connection and try again.</p>
+        <Button
+          variant="outline"
+          size="sm"
+          className="mt-3"
+          onClick={() => feedsQuery.refetch()}
+        >
+          Retry
+        </Button>
+      </div>
+    );
+  }
+
+  const feeds = feedsQuery.data ?? [];
+
+  if (view.kind === "events") {
+    // When we navigate to events, refresh the feed object from the list
+    // so toggling status is reflected.
+    const freshFeed =
+      feeds.find((f) => f.id === view.feed.id) ?? view.feed;
+    return (
+      <EventHistoryView
+        feed={freshFeed}
+        onBack={() => setView({ kind: "list" })}
+      />
+    );
+  }
+
+  return (
+    <FeedListView
+      feeds={feeds}
+      onSelectFeed={(feed) => setView({ kind: "events", feed })}
+    />
+  );
+}

--- a/web/src/components/ui/sheet.tsx
+++ b/web/src/components/ui/sheet.tsx
@@ -1,0 +1,152 @@
+/*
+ * Copyright 2025 Rararulab
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as React from "react";
+import * as DialogPrimitive from "@radix-ui/react-dialog";
+import { X } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+
+const Sheet = DialogPrimitive.Root;
+
+const SheetTrigger = DialogPrimitive.Trigger;
+
+const SheetClose = DialogPrimitive.Close;
+
+const SheetPortal = DialogPrimitive.Portal;
+
+const SheetOverlay = React.forwardRef<
+  React.ComponentRef<typeof DialogPrimitive.Overlay>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Overlay
+    className={cn(
+      "fixed inset-0 z-50 bg-black/80 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      className,
+    )}
+    {...props}
+    ref={ref}
+  />
+));
+SheetOverlay.displayName = DialogPrimitive.Overlay.displayName;
+
+interface SheetContentProps
+  extends React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content> {
+  side?: "top" | "bottom" | "left" | "right";
+}
+
+const sheetSideVariants: Record<string, string> = {
+  top: "inset-x-0 top-0 border-b data-[state=closed]:slide-out-to-top data-[state=open]:slide-in-from-top",
+  bottom:
+    "inset-x-0 bottom-0 border-t data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom",
+  left: "inset-y-0 left-0 h-full w-3/4 border-r data-[state=closed]:slide-out-to-left data-[state=open]:slide-in-from-left sm:max-w-sm",
+  right:
+    "inset-y-0 right-0 h-full w-3/4 border-l data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right sm:max-w-md",
+};
+
+const SheetContent = React.forwardRef<
+  React.ComponentRef<typeof DialogPrimitive.Content>,
+  SheetContentProps
+>(({ side = "right", className, children, ...props }, ref) => (
+  <SheetPortal>
+    <SheetOverlay />
+    <DialogPrimitive.Content
+      ref={ref}
+      className={cn(
+        "fixed z-50 gap-4 bg-background p-6 shadow-lg transition ease-in-out data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:duration-300 data-[state=open]:duration-500",
+        sheetSideVariants[side],
+        className,
+      )}
+      {...props}
+    >
+      {children}
+      <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-secondary">
+        <X className="h-4 w-4" />
+        <span className="sr-only">Close</span>
+      </DialogPrimitive.Close>
+    </DialogPrimitive.Content>
+  </SheetPortal>
+));
+SheetContent.displayName = DialogPrimitive.Content.displayName;
+
+function SheetHeader({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div
+      className={cn(
+        "flex flex-col space-y-2 text-center sm:text-left",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+SheetHeader.displayName = "SheetHeader";
+
+function SheetFooter({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div
+      className={cn(
+        "flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+SheetFooter.displayName = "SheetFooter";
+
+const SheetTitle = React.forwardRef<
+  React.ComponentRef<typeof DialogPrimitive.Title>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Title>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Title
+    ref={ref}
+    className={cn("text-lg font-semibold text-foreground", className)}
+    {...props}
+  />
+));
+SheetTitle.displayName = DialogPrimitive.Title.displayName;
+
+const SheetDescription = React.forwardRef<
+  React.ComponentRef<typeof DialogPrimitive.Description>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Description>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Description
+    ref={ref}
+    className={cn("text-sm text-muted-foreground", className)}
+    {...props}
+  />
+));
+SheetDescription.displayName = DialogPrimitive.Description.displayName;
+
+export {
+  Sheet,
+  SheetPortal,
+  SheetOverlay,
+  SheetTrigger,
+  SheetClose,
+  SheetContent,
+  SheetHeader,
+  SheetFooter,
+  SheetTitle,
+  SheetDescription,
+};

--- a/web/src/pages/Settings.tsx
+++ b/web/src/pages/Settings.tsx
@@ -60,6 +60,7 @@ import {
   Sun,
   Palette,
   Wifi,
+  Radio,
 } from "lucide-react";
 import {
   Dialog,
@@ -77,8 +78,9 @@ import { getBackendUrl, setBackendUrl } from "@/api/client";
 import Skills from "@/pages/Skills";
 import Agents from "@/pages/Agents";
 import McpServers from "@/pages/McpServers";
+import DataFeedsPanel from "@/components/DataFeedsPanel";
 
-type SettingsPage = "general" | "providers" | "agents" | "skills" | "mcp" | "channels" | "tools" | "security";
+type SettingsPage = "general" | "providers" | "agents" | "skills" | "mcp" | "channels" | "tools" | "security" | "data-feeds";
 type ToastState = { kind: "success" | "error"; message: string } | null;
 
 // Well-known setting keys (must match backend keys module)
@@ -498,7 +500,7 @@ export default function Settings() {
   const queryClient = useQueryClient();
   const [activeCategory, setActiveCategory] = useState<SettingsPage>(() => {
     const section = searchParams.get("section");
-    const allowed: SettingsPage[] = ["general", "providers", "agents", "skills", "mcp", "channels", "tools", "security"];
+    const allowed: SettingsPage[] = ["general", "providers", "agents", "skills", "mcp", "channels", "tools", "security", "data-feeds"];
     return allowed.includes(section as SettingsPage) ? (section as SettingsPage) : "general";
   });
   const [toast, setToast] = useState<ToastState>(null);
@@ -620,6 +622,7 @@ export default function Settings() {
     { id: "channels", label: "Channels", icon: <MessageSquare className="h-4 w-4" />, summary: "Telegram, Gmail" },
     { id: "tools", label: "Tools", icon: <Settings2 className="h-4 w-4" />, summary: "Composio, memory integrations" },
     { id: "security", label: "Security", icon: <Shield className="h-4 w-4" />, summary: "Filesystem sandbox" },
+    { id: "data-feeds", label: "Data Feeds", icon: <Radio className="h-4 w-4" />, summary: "External event sources" },
   ];
 
   return (
@@ -1201,6 +1204,13 @@ export default function Settings() {
               </CardContent>
             </Card>
           </>
+        )}
+
+        {/* ── Data Feeds ── */}
+        {activeCategory === "data-feeds" && (
+          <div className="data-panel p-4">
+            <DataFeedsPanel />
+          </div>
         )}
 
       </div>


### PR DESCRIPTION
## Summary

- Add 10 Playwright e2e tests for the DataFeed management UI covering full CRUD lifecycle
- Uses `page.route()` to mock all backend API endpoints (`/api/v1/data-feeds*`, `/api/v1/settings`, `/api/v1/health`)
- Fetches real Yahoo Finance data in `beforeAll` for realistic JSON payload rendering (with static fallback)
- Suppresses onboarding/connection dialogs via localStorage initialization

## Type of change

| Type | Label |
|------|-------|
| New feature | `enhancement` |

## Component

`ui`

## Closes

Closes #1407

## Test plan

- [x] `npx playwright test e2e/data-feeds.spec.ts` — 10/10 passed (16.2s)
- [x] TypeScript `tsc --noEmit` passes
- [x] All tests independent via per-test mock state