### PR TITLE
feat(channels): add pinned message status bar for Telegram (#1415)

### DIFF
--- a/crates/app/src/lib.rs
+++ b/crates/app/src/lib.rs
@@ -799,12 +799,17 @@ async fn try_build_telegram(
     tg_config.group_policy = group_policy;
 
     let adapter = Arc::new(
-        rara_channels::telegram::TelegramAdapter::with_proxy(&token, vec![], proxy.as_deref())
-            .whatever_context("failed to build telegram adapter")?
-            .with_config(tg_config)
-            .with_user_question_manager(user_question_manager)
-            .with_stt_service(stt_service)
-            .with_tts_service(tts_service),
+        rara_channels::telegram::TelegramAdapter::with_proxy(
+            &token,
+            vec![],
+            proxy.as_deref(),
+            Arc::clone(&settings),
+        )
+        .whatever_context("failed to build telegram adapter")?
+        .with_config(tg_config)
+        .with_user_question_manager(user_question_manager)
+        .with_stt_service(stt_service)
+        .with_tts_service(tts_service),
     );
 
     let config_handle = adapter.config_handle();

--- a/crates/channels/Cargo.toml
+++ b/crates/channels/Cargo.toml
@@ -16,6 +16,7 @@ image = { workspace = true }
 jiff = { workspace = true }
 rand = { workspace = true }
 rara-dock = { workspace = true }
+rara-domain-shared = { workspace = true }
 rara-kernel = { workspace = true }
 rara-mcp = { workspace = true }
 rara-paths = { workspace = true }

--- a/crates/channels/src/telegram/adapter.rs
+++ b/crates/channels/src/telegram/adapter.rs
@@ -101,6 +101,7 @@ static TOOL_CALL_TAG_RE: LazyLock<regex::Regex> = LazyLock::new(|| {
 
 use async_trait::async_trait;
 use dashmap::{DashMap, DashSet};
+use rara_domain_shared::settings::SettingsProvider;
 use rara_kernel::{
     channel::{
         adapter::ChannelAdapter,
@@ -316,7 +317,7 @@ impl ProgressMessage {
 use rara_kernel::trace::{ExecutionTrace, ToolTraceEntry};
 
 /// Format a duration as a compact human-readable string.
-fn format_duration_compact(d: std::time::Duration) -> String {
+pub(super) fn format_duration_compact(d: std::time::Duration) -> String {
     let secs = d.as_secs();
     if secs < 1 {
         format!("{}ms", d.as_millis())
@@ -591,7 +592,7 @@ fn render_background_tasks(tasks: &[BackgroundTaskState], lines: &mut Vec<String
     }
 }
 
-fn format_token_count(tokens: u32) -> String {
+pub(super) fn format_token_count(tokens: u32) -> String {
     if tokens >= 1_000_000 {
         format!("{:.1}M", tokens as f64 / 1_000_000.0)
     } else if tokens >= 1_000 {
@@ -928,6 +929,8 @@ pub struct TelegramAdapter {
     /// Chat IDs whose most recent inbound message was a voice note.
     /// Checked at egress to decide whether to reply with a voice note.
     voice_chat_ids:        Arc<DashSet<i64>>,
+    /// Settings provider for persisting pinned message IDs across restarts.
+    settings:              Arc<dyn SettingsProvider>,
 }
 
 impl TelegramAdapter {
@@ -938,7 +941,11 @@ impl TelegramAdapter {
     /// - `bot` — a configured [`teloxide::Bot`] instance
     /// - `allowed_chat_ids` — list of Telegram chat IDs that are permitted to
     ///   interact with the adapter. Pass an empty vec to allow all chats.
-    pub fn new(bot: teloxide::Bot, allowed_chat_ids: Vec<i64>) -> Self {
+    pub fn new(
+        bot: teloxide::Bot,
+        allowed_chat_ids: Vec<i64>,
+        settings: Arc<dyn SettingsProvider>,
+    ) -> Self {
         let (shutdown_tx, shutdown_rx) = watch::channel(false);
         Self {
             bot,
@@ -956,6 +963,7 @@ impl TelegramAdapter {
             stt_service: None,
             tts_service: None,
             voice_chat_ids: Arc::new(DashSet::new()),
+            settings,
         }
     }
 
@@ -968,9 +976,10 @@ impl TelegramAdapter {
         token: &str,
         allowed_chat_ids: Vec<i64>,
         proxy: Option<&str>,
+        settings: Arc<dyn SettingsProvider>,
     ) -> Result<Self, anyhow::Error> {
         let bot = build_bot(token, proxy)?;
-        Ok(Self::new(bot, allowed_chat_ids))
+        Ok(Self::new(bot, allowed_chat_ids, settings))
     }
 
     /// Create a new Telegram adapter with a custom polling timeout.
@@ -1425,6 +1434,7 @@ impl ChannelAdapter for TelegramAdapter {
             .into();
         let stt_service = self.stt_service.clone();
         let voice_chat_ids = Arc::clone(&self.voice_chat_ids);
+        let settings = Arc::clone(&self.settings);
 
         // Register slash-menu with Telegram so '/' shows available commands.
         {
@@ -1501,6 +1511,7 @@ impl ChannelAdapter for TelegramAdapter {
                 callback_handlers,
                 stt_service,
                 voice_chat_ids,
+                settings,
             )
             .await;
         });
@@ -1555,6 +1566,7 @@ async fn polling_loop(
     callback_handlers: Arc<[Arc<dyn CallbackHandler>]>,
     stt_service: Option<rara_stt::SttService>,
     voice_chat_ids: Arc<DashSet<i64>>,
+    settings: Arc<dyn SettingsProvider>,
 ) {
     let mut offset: Option<i32> = None;
     let mut retry_delay = INITIAL_RETRY_DELAY;
@@ -1613,6 +1625,7 @@ async fn polling_loop(
                     let callback_handlers = Arc::clone(&callback_handlers);
                     let stt = stt_service.clone();
                     let voice_ids = Arc::clone(&voice_chat_ids);
+                    let stg = Arc::clone(&settings);
                     tokio::spawn(async move {
                         handle_update(
                             update,
@@ -1627,6 +1640,7 @@ async fn polling_loop(
                             &callback_handlers,
                             &stt,
                             &voice_ids,
+                            &stg,
                         )
                         .await;
                     });
@@ -2485,6 +2499,7 @@ async fn handle_update(
     callback_handlers: &[Arc<dyn CallbackHandler>],
     stt_service: &Option<rara_stt::SttService>,
     voice_chat_ids: &Arc<DashSet<i64>>,
+    settings: &Arc<dyn SettingsProvider>,
 ) {
     // Read a snapshot of the runtime config for this update.
     let cfg = match config.read() {
@@ -3017,6 +3032,7 @@ async fn handle_update(
                     sid,
                     handle.trace_service().clone(),
                     rara_message_id.clone(),
+                    Arc::clone(settings),
                 );
             }
         }
@@ -3113,6 +3129,7 @@ fn spawn_stream_forwarder(
     session_id: rara_kernel::session::SessionKey,
     trace_service: rara_kernel::trace::TraceService,
     rara_message_id: String,
+    settings: Arc<dyn SettingsProvider>,
 ) {
     use rara_kernel::io::{PlanStepStatus, StreamEvent};
 
@@ -3160,6 +3177,21 @@ fn spawn_stream_forwarder(
 
         let mut progress = ProgressMessage::new(rara_message_id);
         let mut progress_dirty = false;
+
+        // Pinned session card — a stable summary pinned to the chat top.
+        // Restore persisted message ID so we can continue editing after restart.
+        let session_label = session_id.to_string();
+        let mut pinned = super::pinned_status::PinnedSessionCard::new(
+            chat_id,
+            session_label.clone(),
+            session_label,
+        );
+        let pinned_settings_key = format!("telegram.pinned_message.{chat_id}");
+        if let Some(raw) = settings.get(&pinned_settings_key).await {
+            if let Ok(id) = raw.parse::<i32>() {
+                pinned.message_id = Some(MessageId(id));
+            }
+        }
 
         loop {
             tokio::select! {
@@ -3215,6 +3247,7 @@ fn spawn_stream_forwarder(
                         Ok(StreamEvent::ToolCallStart { name, id, arguments }) => {
                             // Transition out of thinking phase.
                             progress.thinking = false;
+                            pinned.on_tool_start();
 
                             let (display, summary) = tool_display_info(&name, &arguments);
                             let activity = tool_activity_label(&name).to_owned();
@@ -3268,6 +3301,7 @@ fn spawn_stream_forwarder(
                                 tp.duration = Some(tp.started_at.elapsed());
                                 tp.error = error;
                             }
+                            pinned.on_tool_end();
 
                             let text = progress.render_text();
                             if progress.last_edit.elapsed() >= MIN_EDIT_INTERVAL {
@@ -3473,6 +3507,7 @@ fn spawn_stream_forwarder(
                             progress.input_tokens = input_tokens;
                             progress.output_tokens = output_tokens;
                             progress.thinking_ms = thinking_ms;
+                            pinned.on_usage_update(input_tokens, output_tokens, thinking_ms);
                             // Trigger a progress re-render if we have a message
                             if progress.message_id.is_some() || !progress.tools.is_empty() {
                                 let text = progress.render_text();
@@ -3537,6 +3572,7 @@ fn spawn_stream_forwarder(
                             // TurnMetrics arrives just before stream close —
                             // stash for the ExecutionTrace built in RecvError::Closed.
                             progress.model = model;
+                            pinned.on_turn_metrics(progress.model.clone());
                             progress.iterations = iterations;
                         }
                         // Tool call limit: send inline keyboard with continue/stop
@@ -3575,6 +3611,7 @@ fn spawn_stream_forwarder(
                         // messages cannot be updated fast enough for streaming.
                         Ok(StreamEvent::ToolOutput { .. }) => {}
                         Ok(StreamEvent::BackgroundTaskStarted { task_id, agent_name, description }) => {
+                            pinned.on_background_task_started(task_id.clone(), agent_name.clone());
                             progress.background_tasks.push(BackgroundTaskState {
                                 task_id,
                                 agent_name,
@@ -3586,6 +3623,7 @@ fn spawn_stream_forwarder(
                             progress_dirty = true;
                         }
                         Ok(StreamEvent::BackgroundTaskDone { task_id, status }) => {
+                            pinned.on_background_task_done(&task_id);
                             if let Some(task) = progress.background_tasks.iter_mut().find(|t| t.task_id == task_id) {
                                 task.finished = true;
                                 task.status = Some(status);
@@ -3634,6 +3672,10 @@ fn spawn_stream_forwarder(
                                 let result = flush_edit(&bot, chat_id, &req).await;
                                 apply_flush_result(&active_streams, chat_id, result);
                             }
+
+                            // ── Pinned status bar: final flush ──
+                            pinned.on_stream_close();
+                            flush_pinned_status(&bot, chat_id, &mut pinned, &settings, &pinned_settings_key).await;
 
                             // ── Finalize: always create trace + compact summary ──
                             // Every agent turn (including pure text replies) gets a
@@ -3796,6 +3838,11 @@ fn spawn_stream_forwarder(
                         progress.last_edit = Instant::now();
                         progress_dirty = false;
                     }
+
+                    // ── Pinned session card: flush on state change only ──
+                    if pinned.needs_flush() {
+                        flush_pinned_status(&bot, chat_id, &mut pinned, &settings, &pinned_settings_key).await;
+                    }
                 }
                 _ = typing_interval.tick() => {
                     let _ = bot
@@ -3882,6 +3929,54 @@ enum FlushResult {
     RateLimited,
     /// Send failed.
     SendFailed,
+}
+
+/// Flush the pinned session card to Telegram.
+///
+/// Three scenarios, in priority order:
+///
+/// 1. **`message_id` is `Some` and edit succeeds** — normal path; the existing
+///    pinned message is updated in-place.
+///
+/// 2. **`message_id` is `Some` but edit fails** — the persisted message was
+///    deleted by the user or expired. We fall through to scenario 3.
+///
+/// 3. **`message_id` is `None`** (first flush of this turn, or fallback from
+///    scenario 2) — send a new message, pin it silently, and persist the new ID
+///    so subsequent turns reuse it instead of accumulating orphan messages.
+async fn flush_pinned_status(
+    bot: &teloxide::Bot,
+    chat_id: i64,
+    pinned: &mut super::pinned_status::PinnedSessionCard,
+    settings: &Arc<dyn SettingsProvider>,
+    settings_key: &str,
+) {
+    use teloxide::payloads::PinChatMessageSetters;
+
+    let html = pinned.render();
+    let need_new_msg = match pinned.message_id {
+        Some(mid) => bot
+            .edit_message_text(ChatId(chat_id), mid, &html)
+            .parse_mode(ParseMode::Html)
+            .await
+            .is_err(),
+        None => true,
+    };
+    if need_new_msg {
+        if let Ok(msg) = bot
+            .send_message(ChatId(chat_id), &html)
+            .parse_mode(ParseMode::Html)
+            .await
+        {
+            pinned.message_id = Some(msg.id);
+            let _ = bot
+                .pin_chat_message(ChatId(chat_id), msg.id)
+                .disable_notification(true)
+                .await;
+            let _ = settings.set(settings_key, &msg.id.0.to_string()).await;
+        }
+    }
+    pinned.mark_flushed();
 }
 
 /// Flush accumulated text to Telegram via `sendMessage` (first time) or

--- a/crates/channels/src/telegram/mod.rs
+++ b/crates/channels/src/telegram/mod.rs
@@ -20,6 +20,7 @@ pub mod dashboard;
 pub mod latex;
 pub mod loading_hints;
 pub mod markdown;
+pub mod pinned_status;
 pub mod spinner_verbs;
 
 pub use adapter::{TelegramAdapter, TelegramConfig, build_bot, telegram_to_raw_platform_message};

--- a/crates/channels/src/telegram/pinned_status.rs
+++ b/crates/channels/src/telegram/pinned_status.rs
@@ -1,0 +1,412 @@
+// Copyright 2025 Rararulab
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Pinned session summary card for Telegram chats.
+//!
+//! `PinnedSessionCard` renders an HTML session overview pinned to the top of
+//! the chat, modeled after opencode-telegram-bot's session summary card.
+//!
+//! Updates only on meaningful state changes, with skip-unchanged optimization
+//! to avoid redundant Telegram API calls.
+
+use teloxide::types::MessageId;
+
+use super::adapter::format_token_count;
+
+// ---------------------------------------------------------------------------
+// Model metadata — context window sizes and per-token pricing
+// ---------------------------------------------------------------------------
+
+/// Known model context window size.
+struct ModelInfo {
+    context_window: u32,
+}
+
+/// Best-effort lookup of model metadata by name substring.
+///
+/// Matches the most specific substring first. Returns `None` for unknown
+/// models — the card gracefully omits context % and cost when unavailable.
+fn lookup_model_info(model: &str) -> Option<ModelInfo> {
+    let m = model.to_lowercase();
+
+    // Claude family — 200K context
+    if m.contains("opus") || m.contains("sonnet") || m.contains("haiku") {
+        return Some(ModelInfo {
+            context_window: 200_000,
+        });
+    }
+    // OpenAI o-series — 200K context
+    if m.contains("o3") || m.contains("o4-mini") {
+        return Some(ModelInfo {
+            context_window: 200_000,
+        });
+    }
+    // GPT-4o family — 128K context
+    if m.contains("gpt-4o") {
+        return Some(ModelInfo {
+            context_window: 128_000,
+        });
+    }
+    // Gemini — 1M context
+    if m.contains("gemini-2") || m.contains("gemini-1.5") {
+        return Some(ModelInfo {
+            context_window: 1_000_000,
+        });
+    }
+    // DeepSeek — 128K context
+    if m.contains("deepseek") {
+        return Some(ModelInfo {
+            context_window: 128_000,
+        });
+    }
+
+    None
+}
+
+// ---------------------------------------------------------------------------
+// Session card
+// ---------------------------------------------------------------------------
+
+/// Agent execution state shown in the card header.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum State {
+    Running,
+    Idle,
+}
+
+impl std::fmt::Display for State {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Running => f.write_str("Running"),
+            Self::Idle => f.write_str("Idle"),
+        }
+    }
+}
+
+/// A background sub-agent tracked in the session card.
+#[derive(Debug, Clone)]
+pub(super) struct BackgroundTaskEntry {
+    pub task_id:    String,
+    pub agent_name: String,
+    pub finished:   bool,
+}
+
+/// Pinned session summary card.
+///
+/// The first line is an **identity bar** — shown in Telegram's floating pin
+/// preview — containing session title, agent name, and optional channel tag.
+/// Metrics (model, context, cost) go in the card body, visible on tap.
+///
+/// This matches the opencode-telegram-bot pattern where the pin preview
+/// answers "where am I?" rather than "what's happening?".
+#[derive(Debug)]
+pub(super) struct PinnedSessionCard {
+    /// Telegram chat ID this card belongs to.
+    pub chat_id:      i64,
+    /// Message ID of the pinned message, `None` until first send.
+    pub message_id:   Option<MessageId>,
+    /// Session identifier used for detecting session switches.
+    pub session_id:   String,
+    session_title:    String,
+    model:            String,
+    state:            State,
+    input_tokens:     u32,
+    output_tokens:    u32,
+    thinking_ms:      u64,
+    tool_calls:       u32,
+    background_tasks: Vec<BackgroundTaskEntry>,
+    dirty:            bool,
+    /// Last rendered HTML — skip-unchanged optimization.
+    last_rendered:    String,
+}
+
+impl PinnedSessionCard {
+    /// Create a new session card.
+    ///
+    /// - `session_title` — human-readable session label (topic or ID)
+    pub fn new(chat_id: i64, session_id: String, session_title: String) -> Self {
+        Self {
+            chat_id,
+            message_id: None,
+            session_id,
+            session_title,
+            model: String::new(),
+            state: State::Running,
+            input_tokens: 0,
+            output_tokens: 0,
+            thinking_ms: 0,
+            tool_calls: 0,
+            background_tasks: Vec::new(),
+            dirty: true,
+            last_rendered: String::new(),
+        }
+    }
+
+    /// Render the session summary card as HTML.
+    ///
+    /// **Line 1 — Identity bar** (visible in Telegram's floating pin preview):
+    /// `🟢 {session_title} · {agent_name}`
+    /// Answers "where am I?" — session context, not telemetry.
+    ///
+    /// **Body — Metrics** (visible when user taps the pinned message):
+    /// Model, Context %, Cost, Thinking, Tools, Background.
+    pub fn render(&self) -> String {
+        let mut lines = Vec::with_capacity(8);
+
+        // Line 1: Identity bar — status emoji + session title + agent name.
+        // This is what shows in the floating pin preview at the chat top.
+        let status_emoji = match self.state {
+            State::Running => "\u{1f7e2}", // 🟢
+            State::Idle => "\u{26aa}",     // ⚪
+        };
+        lines.push(format!("{status_emoji} <b>{}</b>", self.session_title));
+
+        let model_info = if self.model.is_empty() {
+            None
+        } else {
+            lookup_model_info(&self.model)
+        };
+
+        // Model.
+        if !self.model.is_empty() {
+            lines.push(format!("Model: <code>{}</code>", self.model));
+        }
+
+        // Context: input_tokens is the current prompt/context size in our
+        // stream protocol. output_tokens is cumulative completion — must NOT
+        // be mixed into the context meter.
+        if self.input_tokens > 0 {
+            let used_str = format_token_count(self.input_tokens);
+            let context_line = if let Some(ref info) = model_info {
+                let limit_str = format_token_count(info.context_window);
+                let pct = (self.input_tokens as f64 / info.context_window as f64 * 100.0) as u32;
+                format!("Context: {used_str} / {limit_str} ({pct}%)")
+            } else {
+                format!("Context: {used_str}")
+            };
+            lines.push(context_line);
+        }
+
+        // Thinking time (rara-specific, shown when non-zero).
+        if self.thinking_ms > 0 {
+            let secs = self.thinking_ms / 1000;
+            if secs > 0 {
+                lines.push(format!("Thinking: {secs}s"));
+            }
+        }
+
+        // Tool calls (rara-specific, shown when non-zero).
+        if self.tool_calls > 0 {
+            lines.push(format!("\u{1f527} {} tool calls", self.tool_calls));
+        }
+
+        // Active background tasks (rara-specific).
+        let active: Vec<&BackgroundTaskEntry> = self
+            .background_tasks
+            .iter()
+            .filter(|t| !t.finished)
+            .collect();
+        if !active.is_empty() {
+            lines.push(String::new());
+            lines.push(format!("\u{1f504} <b>Background ({})</b>", active.len()));
+            for task in &active {
+                lines.push(format!("\u{23f3} {}", task.agent_name));
+            }
+        }
+
+        lines.join("\n")
+    }
+
+    // ── Event callbacks ──
+    // Each sets dirty=true. The forwarder calls needs_flush() which compares
+    // render() output against last_rendered to skip no-op API calls.
+
+    /// Called when cumulative usage counters are updated.
+    pub fn on_usage_update(&mut self, input_tokens: u32, output_tokens: u32, thinking_ms: u64) {
+        self.input_tokens = input_tokens;
+        self.output_tokens = output_tokens;
+        self.thinking_ms = thinking_ms;
+        self.dirty = true;
+    }
+
+    /// Called when a tool call begins.
+    pub fn on_tool_start(&mut self) {
+        self.tool_calls += 1;
+        self.dirty = true;
+    }
+
+    /// Called when a tool call finishes.
+    pub fn on_tool_end(&mut self) { self.dirty = true; }
+
+    /// Called when turn metrics arrive (resolves the model name).
+    pub fn on_turn_metrics(&mut self, model: String) {
+        self.model = model;
+        self.dirty = true;
+    }
+
+    /// Called when a background sub-agent is spawned.
+    pub fn on_background_task_started(&mut self, task_id: String, agent_name: String) {
+        self.background_tasks.push(BackgroundTaskEntry {
+            task_id,
+            agent_name,
+            finished: false,
+        });
+        self.dirty = true;
+    }
+
+    /// Called when a background sub-agent finishes.
+    pub fn on_background_task_done(&mut self, task_id: &str) {
+        if let Some(task) = self
+            .background_tasks
+            .iter_mut()
+            .find(|t| t.task_id == task_id)
+        {
+            task.finished = true;
+            self.dirty = true;
+        }
+    }
+
+    /// Transition to idle state on stream close.
+    pub fn on_stream_close(&mut self) {
+        self.state = State::Idle;
+        self.dirty = true;
+    }
+
+    /// Whether the card has pending changes worth flushing.
+    ///
+    /// Returns `true` only when both conditions hold:
+    /// 1. An event callback set the dirty flag.
+    /// 2. The rendered HTML differs from the last flush.
+    ///
+    /// This skip-unchanged check avoids hitting the Telegram API when
+    /// repeated events produce identical rendered output.
+    pub fn needs_flush(&mut self) -> bool {
+        if !self.dirty {
+            return false;
+        }
+        let current = self.render();
+        if current == self.last_rendered {
+            self.dirty = false;
+            return false;
+        }
+        true
+    }
+
+    /// Record the flushed HTML and clear the dirty flag.
+    pub fn mark_flushed(&mut self) {
+        self.last_rendered = self.render();
+        self.dirty = false;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn render_with_model_and_context() {
+        let mut card = PinnedSessionCard::new(123, "s1".into(), "mita".into());
+        card.model = "claude-sonnet-4".to_string();
+        card.input_tokens = 45_000;
+        card.output_tokens = 12_000;
+        card.thinking_ms = 5_000;
+        card.tool_calls = 8;
+
+        let text = card.render();
+        // Identity bar: 🟢 mita
+        assert!(text.contains("\u{1f7e2}"));
+        assert!(text.contains("<b>mita</b>"));
+        assert!(text.contains("<code>claude-sonnet-4</code>"));
+        // Context uses input_tokens only (not input+output).
+        assert!(text.contains("45.0k / 200.0k"));
+        assert!(text.contains('%'));
+        assert!(!text.contains("Cost:"));
+        assert!(text.contains("Thinking: 5s"));
+        assert!(text.contains("8 tool calls"));
+    }
+
+    #[test]
+    fn render_unknown_model_omits_limit() {
+        let mut card = PinnedSessionCard::new(123, "s1".into(), "mita".into());
+        card.model = "some-unknown-model".to_string();
+        card.input_tokens = 10_000;
+        card.output_tokens = 5_000;
+
+        let text = card.render();
+        // Context uses input_tokens only, no limit/percent for unknown model.
+        assert!(text.contains("Context: 10.0k"));
+        assert!(!text.contains('%'));
+    }
+
+    #[test]
+    fn render_idle_state() {
+        let mut card = PinnedSessionCard::new(123, "s1".into(), "mita".into());
+        card.on_stream_close();
+        let text = card.render();
+        // Idle uses ⚪ emoji, no "Idle" text in identity bar.
+        assert!(text.contains("\u{26aa}"));
+        assert!(text.contains("<b>mita</b>"));
+    }
+
+    #[test]
+    fn skip_unchanged_render() {
+        let mut card = PinnedSessionCard::new(123, "s1".into(), "mita".into());
+        assert!(card.needs_flush());
+        card.mark_flushed();
+
+        card.dirty = true;
+        assert!(!card.needs_flush());
+    }
+
+    #[test]
+    fn dirty_flag_lifecycle() {
+        let mut card = PinnedSessionCard::new(123, "s1".into(), "mita".into());
+        card.mark_flushed();
+        assert!(!card.needs_flush());
+
+        card.on_tool_start();
+        assert!(card.needs_flush());
+
+        card.mark_flushed();
+        assert!(!card.needs_flush());
+    }
+
+    #[test]
+    fn background_tasks_render() {
+        let mut card = PinnedSessionCard::new(123, "s1".into(), "mita".into());
+        card.on_background_task_started("task-1".into(), "Researcher".into());
+        let text = card.render();
+        assert!(text.contains("<b>Background (1)</b>"));
+        assert!(text.contains("Researcher"));
+    }
+
+    #[test]
+    fn background_task_done_hides_from_render() {
+        let mut card = PinnedSessionCard::new(123, "s1".into(), "mita".into());
+        card.on_background_task_started("task-1".into(), "Researcher".into());
+        card.on_background_task_done("task-1");
+        let text = card.render();
+        assert!(!text.contains("Background"));
+    }
+
+    #[test]
+    fn omits_empty_sections() {
+        let card = PinnedSessionCard::new(123, "s1".into(), "mita".into());
+        let text = card.render();
+        assert!(!text.contains("Model:"));
+        assert!(!text.contains("Context:"));
+        assert!(!text.contains("Cost:"));
+        assert!(!text.contains("tool calls"));
+    }
+}


### PR DESCRIPTION
## Summary

- Add `PinnedStatusBar` struct that renders a plain-text status line pinned to the top of Telegram chats
- Shows agent state (Running/Idle), model name, token usage (↑/↓), thinking time, elapsed time, tool count, and active background tasks
- Integrated into `spawn_stream_forwarder` with throttled updates (reuses existing `MIN_EDIT_INTERVAL` 1.5s tick)
- Uses `pin_chat_message(disable_notification: true)` so the pin appears silently

## Type of change

| Type | Label |
|------|-------|
| New feature | `enhancement` |

## Component

`backend`

## Closes

Closes #1415

## Test plan

- [x] `cargo clippy` passes (zero warnings)
- [x] `cargo +nightly fmt` passes
- [x] `cargo doc` passes (no rustdoc warnings)
- [x] Unit tests for render, dirty flag lifecycle, background task display
- [ ] Manual: send message → verify floating pin bar appears at chat top
- [ ] Manual: trigger tool calls → verify tool count updates
- [ ] Manual: turn ends → status changes to Idle