### PR TITLE
fix(kernel): wire DataFeed into kernel startup and mount webhook routes (#1416)

### DIFF
--- a/crates/app/src/lib.rs
+++ b/crates/app/src/lib.rs
@@ -375,6 +375,7 @@ pub async fn start_with_options(
         settings_provider.clone(),
         settings_svc.clone(),
         rara.model_lister.clone(),
+        pool.clone(),
     )
     .await
     .whatever_context("Failed to initialize BackendState")?;

--- a/crates/app/src/lib.rs
+++ b/crates/app/src/lib.rs
@@ -468,6 +468,16 @@ pub async fn start_with_options(
         })
     };
 
+    // -- Data feed subsystem ---------------------------------------------------
+    // Create the feed event channel and registry. The receiver will be
+    // consumed by a future feed-dispatch task; for now we hold it to keep
+    // the channel open.
+    let (feed_event_tx, _feed_event_rx) =
+        tokio::sync::mpsc::channel::<rara_kernel::data_feed::FeedEvent>(256);
+    let feed_registry = Arc::new(rara_kernel::data_feed::DataFeedRegistry::new(
+        feed_event_tx.clone(),
+    ));
+
     let mut kernel = rara_kernel::kernel::Kernel::new(
         kernel_config,
         rara.driver_registry.clone(),
@@ -487,6 +497,8 @@ pub async fn start_with_options(
         mcp_tool_provider,
         rara_kernel::trace::TraceService::new(pool.clone()),
         skill_prompt_provider,
+        Some(feed_registry.clone()),
+        None, // feed_store: queries go through backend SQL for now
     );
 
     let cancellation_token = CancellationToken::new();
@@ -554,13 +566,28 @@ pub async fn start_with_options(
     };
     let dock_routes = rara_dock::dock_router(dock_state);
 
-    let routes_fn: Box<dyn Fn(axum::Router) -> axum::Router + Send + Sync> =
+    // Webhook feed routes — receives HTTP POST from external services.
+    let webhook_state = Arc::new(rara_kernel::data_feed::webhook::WebhookState::new(
+        feed_registry.clone(),
+        feed_event_tx,
+    ));
+
+    let routes_fn: Box<dyn Fn(axum::Router) -> axum::Router + Send + Sync> = {
+        let wh = webhook_state;
         Box::new(move |router| {
+            let webhook_router = axum::Router::new()
+                .route(
+                    "/api/v1/webhooks/{feed_name}",
+                    axum::routing::post(rara_kernel::data_feed::webhook::webhook_handler),
+                )
+                .with_state(wh.clone());
             health_routes(router)
                 .merge(domain_routes.clone())
                 .merge(dock_routes.clone())
                 .nest("/api/v1/kernel/chat", web_router.clone())
-        });
+                .merge(webhook_router)
+        })
+    };
 
     info!("Application initialized successfully");
 

--- a/crates/extensions/backend-admin/src/data_feeds/mod.rs
+++ b/crates/extensions/backend-admin/src/data_feeds/mod.rs
@@ -12,17 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! # rara-backend-admin
+//! Data Feed management HTTP API.
 //!
-//! Unified HTTP admin routes for all backend subsystems: settings,
-//! models, MCP servers, skills, data feeds, and domain routes (chat).
+//! Provides CRUD endpoints for data feed configurations and paginated
+//! event history queries.
 
-pub mod agents;
-pub mod chat;
-pub mod data_feeds;
-pub mod kernel;
-pub mod mcp;
-pub mod settings;
-pub mod skills;
-pub mod state;
-pub mod system_routes;
+pub mod router;
+pub mod service;
+
+pub use router::data_feed_routes;
+pub use service::DataFeedSvc;

--- a/crates/extensions/backend-admin/src/data_feeds/router.rs
+++ b/crates/extensions/backend-admin/src/data_feeds/router.rs
@@ -1,0 +1,349 @@
+// Copyright 2025 Rararulab
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Data Feed REST API handlers.
+//!
+//! | Method | Path                                        | Description         |
+//! |--------|---------------------------------------------|---------------------|
+//! | GET    | `/api/v1/data-feeds`                        | list all feeds      |
+//! | POST   | `/api/v1/data-feeds`                        | create feed         |
+//! | GET    | `/api/v1/data-feeds/{id}`                   | get feed detail     |
+//! | PUT    | `/api/v1/data-feeds/{id}`                   | update feed         |
+//! | DELETE | `/api/v1/data-feeds/{id}`                   | delete feed         |
+//! | PUT    | `/api/v1/data-feeds/{id}/toggle`             | enable/disable feed |
+//! | GET    | `/api/v1/data-feeds/{id}/events`             | query feed events   |
+//! | GET    | `/api/v1/data-feeds/{id}/events/{event_id}` | get single event    |
+
+use axum::{
+    Json, Router,
+    extract::{Path, Query, State},
+    http::StatusCode,
+    routing::{get, put},
+};
+use jiff::{Timestamp, ToSpan};
+use rara_kernel::data_feed::{DataFeedConfig, FeedStatus, FeedType};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use super::service::DataFeedSvc;
+use crate::kernel::problem::ProblemDetails;
+
+/// Build the `/api/v1/data-feeds/...` router.
+pub fn data_feed_routes(svc: DataFeedSvc) -> Router {
+    Router::new()
+        .route("/api/v1/data-feeds", get(list_feeds).post(create_feed))
+        .route(
+            "/api/v1/data-feeds/{id}",
+            get(get_feed).put(update_feed).delete(delete_feed),
+        )
+        .route("/api/v1/data-feeds/{id}/toggle", put(toggle_feed))
+        .route("/api/v1/data-feeds/{id}/events", get(query_events))
+        .route("/api/v1/data-feeds/{id}/events/{event_id}", get(get_event))
+        .with_state(svc)
+}
+
+// ---------------------------------------------------------------------------
+// Request / response types
+// ---------------------------------------------------------------------------
+
+/// Request body for creating a new data feed.
+#[derive(Debug, Deserialize)]
+struct CreateFeedRequest {
+    name:      String,
+    feed_type: FeedType,
+    tags:      Vec<String>,
+    transport: serde_json::Value,
+    auth:      Option<serde_json::Value>,
+}
+
+/// Request body for updating an existing data feed.
+#[derive(Debug, Deserialize)]
+struct UpdateFeedRequest {
+    name:      String,
+    feed_type: FeedType,
+    tags:      Vec<String>,
+    transport: serde_json::Value,
+    auth:      Option<serde_json::Value>,
+}
+
+/// Request body for toggling feed enabled state.
+#[derive(Debug, Deserialize)]
+struct ToggleFeedRequest {
+    enabled: bool,
+}
+
+/// Query parameters for event listing.
+#[derive(Debug, Deserialize)]
+struct EventQueryParams {
+    /// Duration string: `"1h"`, `"24h"`, `"7d"`, etc.
+    since:  Option<String>,
+    /// Maximum events to return (default: 50, max: 200).
+    limit:  Option<i64>,
+    /// Offset for pagination (default: 0).
+    offset: Option<i64>,
+}
+
+/// Paginated event response.
+#[derive(Debug, Serialize)]
+struct EventListResponse {
+    events:   Vec<rara_kernel::data_feed::FeedEvent>,
+    total:    i64,
+    has_more: bool,
+}
+
+// ---------------------------------------------------------------------------
+// Handlers
+// ---------------------------------------------------------------------------
+
+/// `GET /api/v1/data-feeds` — list all feeds.
+async fn list_feeds(
+    State(svc): State<DataFeedSvc>,
+) -> Result<Json<Vec<DataFeedConfig>>, ProblemDetails> {
+    let feeds = svc
+        .list_feeds()
+        .await
+        .map_err(|e| ProblemDetails::internal(e.to_string()))?;
+    Ok(Json(feeds))
+}
+
+/// `POST /api/v1/data-feeds` — create a new feed.
+async fn create_feed(
+    State(svc): State<DataFeedSvc>,
+    Json(body): Json<CreateFeedRequest>,
+) -> Result<(StatusCode, Json<DataFeedConfig>), ProblemDetails> {
+    let auth = body
+        .auth
+        .map(serde_json::from_value)
+        .transpose()
+        .map_err(|e| ProblemDetails::bad_request(format!("invalid auth config: {e}")))?;
+
+    let now = Timestamp::now();
+    let config = DataFeedConfig::builder()
+        .id(Uuid::new_v4().to_string())
+        .name(body.name)
+        .feed_type(body.feed_type)
+        .tags(body.tags)
+        .transport(body.transport)
+        .maybe_auth(auth)
+        .enabled(true)
+        .status(FeedStatus::Idle)
+        .created_at(now)
+        .updated_at(now)
+        .build();
+
+    svc.create_feed(&config)
+        .await
+        .map_err(|e| ProblemDetails::internal(e.to_string()))?;
+
+    Ok((StatusCode::CREATED, Json(config)))
+}
+
+/// `GET /api/v1/data-feeds/{id}` — get a single feed.
+async fn get_feed(
+    State(svc): State<DataFeedSvc>,
+    Path(id): Path<String>,
+) -> Result<Json<DataFeedConfig>, ProblemDetails> {
+    let feed = svc
+        .get_feed(&id)
+        .await
+        .map_err(|e| ProblemDetails::internal(e.to_string()))?
+        .ok_or_else(|| {
+            ProblemDetails::not_found("Feed Not Found", format!("no feed with id: {id}"))
+        })?;
+    Ok(Json(feed))
+}
+
+/// `PUT /api/v1/data-feeds/{id}` — update an existing feed.
+async fn update_feed(
+    State(svc): State<DataFeedSvc>,
+    Path(id): Path<String>,
+    Json(body): Json<UpdateFeedRequest>,
+) -> Result<Json<DataFeedConfig>, ProblemDetails> {
+    // Fetch existing to preserve status / timestamps / enabled.
+    let existing = svc
+        .get_feed(&id)
+        .await
+        .map_err(|e| ProblemDetails::internal(e.to_string()))?
+        .ok_or_else(|| {
+            ProblemDetails::not_found("Feed Not Found", format!("no feed with id: {id}"))
+        })?;
+
+    let auth = body
+        .auth
+        .map(serde_json::from_value)
+        .transpose()
+        .map_err(|e| ProblemDetails::bad_request(format!("invalid auth config: {e}")))?;
+
+    let updated = DataFeedConfig::builder()
+        .id(id)
+        .name(body.name)
+        .feed_type(body.feed_type)
+        .tags(body.tags)
+        .transport(body.transport)
+        .maybe_auth(auth)
+        .enabled(existing.enabled)
+        .status(existing.status)
+        .maybe_last_error(existing.last_error)
+        .created_at(existing.created_at)
+        .updated_at(Timestamp::now())
+        .build();
+
+    svc.update_feed(&updated)
+        .await
+        .map_err(|e| ProblemDetails::internal(e.to_string()))?;
+
+    Ok(Json(updated))
+}
+
+/// `DELETE /api/v1/data-feeds/{id}` — delete a feed.
+async fn delete_feed(
+    State(svc): State<DataFeedSvc>,
+    Path(id): Path<String>,
+) -> Result<StatusCode, ProblemDetails> {
+    let deleted = svc
+        .delete_feed(&id)
+        .await
+        .map_err(|e| ProblemDetails::internal(e.to_string()))?;
+
+    if deleted {
+        Ok(StatusCode::NO_CONTENT)
+    } else {
+        Err(ProblemDetails::not_found(
+            "Feed Not Found",
+            format!("no feed with id: {id}"),
+        ))
+    }
+}
+
+/// `PUT /api/v1/data-feeds/{id}/toggle` — enable or disable a feed.
+async fn toggle_feed(
+    State(svc): State<DataFeedSvc>,
+    Path(id): Path<String>,
+    Json(body): Json<ToggleFeedRequest>,
+) -> Result<Json<DataFeedConfig>, ProblemDetails> {
+    let toggled = svc
+        .toggle_feed(&id, body.enabled)
+        .await
+        .map_err(|e| ProblemDetails::internal(e.to_string()))?;
+
+    if !toggled {
+        return Err(ProblemDetails::not_found(
+            "Feed Not Found",
+            format!("no feed with id: {id}"),
+        ));
+    }
+
+    // Return the updated config.
+    let feed = svc
+        .get_feed(&id)
+        .await
+        .map_err(|e| ProblemDetails::internal(e.to_string()))?
+        .ok_or_else(|| {
+            ProblemDetails::not_found("Feed Not Found", format!("no feed with id: {id}"))
+        })?;
+
+    Ok(Json(feed))
+}
+
+/// `GET /api/v1/data-feeds/{id}/events` — query events for a feed.
+async fn query_events(
+    State(svc): State<DataFeedSvc>,
+    Path(id): Path<String>,
+    Query(params): Query<EventQueryParams>,
+) -> Result<Json<EventListResponse>, ProblemDetails> {
+    // Resolve the feed to get its source_name.
+    let feed = svc
+        .get_feed(&id)
+        .await
+        .map_err(|e| ProblemDetails::internal(e.to_string()))?
+        .ok_or_else(|| {
+            ProblemDetails::not_found("Feed Not Found", format!("no feed with id: {id}"))
+        })?;
+
+    let since = params
+        .since
+        .as_deref()
+        .map(parse_duration_ago)
+        .transpose()
+        .map_err(|e| ProblemDetails::bad_request(format!("invalid 'since' parameter: {e}")))?;
+
+    let limit = params.limit.unwrap_or(50).clamp(1, 200);
+    let offset = params.offset.unwrap_or(0).max(0);
+
+    let page = svc
+        .query_events(&feed.name, since, limit, offset)
+        .await
+        .map_err(|e| ProblemDetails::internal(e.to_string()))?;
+
+    Ok(Json(EventListResponse {
+        events:   page.events,
+        total:    page.total,
+        has_more: page.has_more,
+    }))
+}
+
+/// `GET /api/v1/data-feeds/{id}/events/{event_id}` — get a single event.
+async fn get_event(
+    State(svc): State<DataFeedSvc>,
+    Path((id, event_id)): Path<(String, String)>,
+) -> Result<Json<rara_kernel::data_feed::FeedEvent>, ProblemDetails> {
+    // Resolve feed name first.
+    let feed = svc
+        .get_feed(&id)
+        .await
+        .map_err(|e| ProblemDetails::internal(e.to_string()))?
+        .ok_or_else(|| {
+            ProblemDetails::not_found("Feed Not Found", format!("no feed with id: {id}"))
+        })?;
+
+    let event = svc
+        .get_event(&feed.name, &event_id)
+        .await
+        .map_err(|e| ProblemDetails::internal(e.to_string()))?
+        .ok_or_else(|| {
+            ProblemDetails::not_found("Event Not Found", format!("no event with id: {event_id}"))
+        })?;
+
+    Ok(Json(event))
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Parse a human-friendly duration string (e.g. `"1h"`, `"24h"`, `"7d"`)
+/// and return the timestamp that many units ago from now.
+fn parse_duration_ago(s: &str) -> anyhow::Result<Timestamp> {
+    let s = s.trim();
+    if s.is_empty() {
+        anyhow::bail!("empty duration string");
+    }
+
+    let (num_str, unit) = s.split_at(s.len() - 1);
+    let n: i64 = num_str
+        .parse()
+        .map_err(|_| anyhow::anyhow!("invalid number in duration: {s}"))?;
+
+    let span = match unit {
+        "s" => n.seconds(),
+        "m" => n.minutes(),
+        "h" => n.hours(),
+        "d" => n.days(),
+        _ => anyhow::bail!("unsupported duration unit '{unit}', expected s/m/h/d"),
+    };
+
+    let now = Timestamp::now();
+    let past = now.checked_sub(span)?;
+    Ok(past)
+}

--- a/crates/extensions/backend-admin/src/data_feeds/service.rs
+++ b/crates/extensions/backend-admin/src/data_feeds/service.rs
@@ -1,0 +1,333 @@
+// Copyright 2025 Rararulab
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Persistence layer for data feed CRUD and event queries.
+//!
+//! [`DataFeedSvc`] operates directly on the `data_feeds` and `feed_events`
+//! SQLite tables. It does not depend on [`DataFeedRegistry`] — the registry
+//! manages in-memory runtime state while this service manages persistence.
+//!
+//! [`DataFeedRegistry`]: rara_kernel::data_feed::DataFeedRegistry
+
+use jiff::Timestamp;
+use rara_kernel::data_feed::{
+    AuthConfig, DataFeedConfig, FeedEvent, FeedEventId, FeedStatus, FeedType,
+};
+use sqlx::SqlitePool;
+use tracing::instrument;
+
+/// Service for data feed persistence operations.
+///
+/// Holds a SQLite connection pool and provides CRUD on the `data_feeds`
+/// table plus paginated queries on the `feed_events` table.
+#[derive(Clone)]
+pub struct DataFeedSvc {
+    pool: SqlitePool,
+}
+
+impl DataFeedSvc {
+    /// Create a new service backed by the given pool.
+    pub fn new(pool: SqlitePool) -> Self { Self { pool } }
+
+    // -- Feed config CRUD ---------------------------------------------------
+
+    /// List all registered data feed configurations.
+    #[instrument(skip_all)]
+    pub async fn list_feeds(&self) -> anyhow::Result<Vec<DataFeedConfig>> {
+        let rows: Vec<FeedRow> = sqlx::query_as(
+            "SELECT id, name, feed_type, tags, transport, auth, enabled, status, last_error, \
+             created_at, updated_at FROM data_feeds ORDER BY created_at DESC",
+        )
+        .fetch_all(&self.pool)
+        .await?;
+
+        rows.into_iter().map(FeedRow::into_config).collect()
+    }
+
+    /// Get a single feed by ID.
+    #[instrument(skip(self))]
+    pub async fn get_feed(&self, id: &str) -> anyhow::Result<Option<DataFeedConfig>> {
+        let row: Option<FeedRow> = sqlx::query_as(
+            "SELECT id, name, feed_type, tags, transport, auth, enabled, status, last_error, \
+             created_at, updated_at FROM data_feeds WHERE id = ?1",
+        )
+        .bind(id)
+        .fetch_optional(&self.pool)
+        .await?;
+
+        row.map(FeedRow::into_config).transpose()
+    }
+
+    /// Insert a new feed configuration.
+    #[instrument(skip_all)]
+    pub async fn create_feed(&self, config: &DataFeedConfig) -> anyhow::Result<()> {
+        let tags_json = serde_json::to_string(&config.tags)?;
+        let transport_json = serde_json::to_string(&config.transport)?;
+        let auth_json = config
+            .auth
+            .as_ref()
+            .map(serde_json::to_string)
+            .transpose()?;
+
+        sqlx::query(
+            "INSERT INTO data_feeds (id, name, feed_type, tags, transport, auth, enabled, status, \
+             last_error, created_at, updated_at) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, \
+             ?11)",
+        )
+        .bind(&config.id)
+        .bind(&config.name)
+        .bind(config.feed_type.to_string())
+        .bind(&tags_json)
+        .bind(&transport_json)
+        .bind(&auth_json)
+        .bind(config.enabled)
+        .bind(config.status.to_string())
+        .bind(&config.last_error)
+        .bind(config.created_at.to_string())
+        .bind(config.updated_at.to_string())
+        .execute(&self.pool)
+        .await?;
+
+        Ok(())
+    }
+
+    /// Update an existing feed configuration.
+    ///
+    /// Returns `true` if a row was updated.
+    #[instrument(skip_all)]
+    pub async fn update_feed(&self, config: &DataFeedConfig) -> anyhow::Result<bool> {
+        let tags_json = serde_json::to_string(&config.tags)?;
+        let transport_json = serde_json::to_string(&config.transport)?;
+        let auth_json = config
+            .auth
+            .as_ref()
+            .map(serde_json::to_string)
+            .transpose()?;
+        let now = Timestamp::now().to_string();
+
+        let result = sqlx::query(
+            "UPDATE data_feeds SET name = ?1, feed_type = ?2, tags = ?3, transport = ?4, auth = \
+             ?5, enabled = ?6, status = ?7, last_error = ?8, updated_at = ?9 WHERE id = ?10",
+        )
+        .bind(&config.name)
+        .bind(config.feed_type.to_string())
+        .bind(&tags_json)
+        .bind(&transport_json)
+        .bind(&auth_json)
+        .bind(config.enabled)
+        .bind(config.status.to_string())
+        .bind(&config.last_error)
+        .bind(&now)
+        .bind(&config.id)
+        .execute(&self.pool)
+        .await?;
+
+        Ok(result.rows_affected() > 0)
+    }
+
+    /// Delete a feed by ID. Returns `true` if a row was deleted.
+    #[instrument(skip(self))]
+    pub async fn delete_feed(&self, id: &str) -> anyhow::Result<bool> {
+        let result = sqlx::query("DELETE FROM data_feeds WHERE id = ?1")
+            .bind(id)
+            .execute(&self.pool)
+            .await?;
+        Ok(result.rows_affected() > 0)
+    }
+
+    /// Toggle the enabled flag for a feed. Returns `true` if updated.
+    #[instrument(skip(self))]
+    pub async fn toggle_feed(&self, id: &str, enabled: bool) -> anyhow::Result<bool> {
+        let now = Timestamp::now().to_string();
+        let result =
+            sqlx::query("UPDATE data_feeds SET enabled = ?1, updated_at = ?2 WHERE id = ?3")
+                .bind(enabled)
+                .bind(&now)
+                .bind(id)
+                .execute(&self.pool)
+                .await?;
+        Ok(result.rows_affected() > 0)
+    }
+
+    // -- Event queries ------------------------------------------------------
+
+    /// Query events for a specific feed, with pagination.
+    #[instrument(skip(self))]
+    pub async fn query_events(
+        &self,
+        source_name: &str,
+        since: Option<Timestamp>,
+        limit: i64,
+        offset: i64,
+    ) -> anyhow::Result<EventPage> {
+        // Count total matching events for pagination metadata.
+        let total: (i64,) = if let Some(ref ts) = since {
+            sqlx::query_as(
+                "SELECT COUNT(*) FROM feed_events WHERE source_name = ?1 AND received_at >= ?2",
+            )
+            .bind(source_name)
+            .bind(ts.to_string())
+            .fetch_one(&self.pool)
+            .await?
+        } else {
+            sqlx::query_as("SELECT COUNT(*) FROM feed_events WHERE source_name = ?1")
+                .bind(source_name)
+                .fetch_one(&self.pool)
+                .await?
+        };
+
+        let rows: Vec<EventRow> = if let Some(ref ts) = since {
+            sqlx::query_as(
+                "SELECT id, source_name, event_type, tags, payload, received_at FROM feed_events \
+                 WHERE source_name = ?1 AND received_at >= ?2 ORDER BY received_at DESC LIMIT ?3 \
+                 OFFSET ?4",
+            )
+            .bind(source_name)
+            .bind(ts.to_string())
+            .bind(limit)
+            .bind(offset)
+            .fetch_all(&self.pool)
+            .await?
+        } else {
+            sqlx::query_as(
+                "SELECT id, source_name, event_type, tags, payload, received_at FROM feed_events \
+                 WHERE source_name = ?1 ORDER BY received_at DESC LIMIT ?2 OFFSET ?3",
+            )
+            .bind(source_name)
+            .bind(limit)
+            .bind(offset)
+            .fetch_all(&self.pool)
+            .await?
+        };
+
+        let events: Vec<FeedEvent> = rows
+            .into_iter()
+            .map(EventRow::into_event)
+            .collect::<anyhow::Result<Vec<_>>>()?;
+
+        let has_more = (offset + limit) < total.0;
+
+        Ok(EventPage {
+            events,
+            total: total.0,
+            has_more,
+        })
+    }
+
+    /// Get a single event by ID within a feed.
+    #[instrument(skip(self))]
+    pub async fn get_event(
+        &self,
+        source_name: &str,
+        event_id: &str,
+    ) -> anyhow::Result<Option<FeedEvent>> {
+        let row: Option<EventRow> = sqlx::query_as(
+            "SELECT id, source_name, event_type, tags, payload, received_at FROM feed_events \
+             WHERE id = ?1 AND source_name = ?2",
+        )
+        .bind(event_id)
+        .bind(source_name)
+        .fetch_optional(&self.pool)
+        .await?;
+
+        row.map(EventRow::into_event).transpose()
+    }
+}
+
+/// Paginated event query result.
+#[derive(Debug, serde::Serialize)]
+pub struct EventPage {
+    /// Events on this page.
+    pub events:   Vec<FeedEvent>,
+    /// Total number of matching events.
+    pub total:    i64,
+    /// Whether more events exist beyond this page.
+    pub has_more: bool,
+}
+
+// ---------------------------------------------------------------------------
+// Internal row types for SQLite <-> domain mapping
+// ---------------------------------------------------------------------------
+
+#[derive(sqlx::FromRow)]
+struct FeedRow {
+    id:         String,
+    name:       String,
+    feed_type:  String,
+    tags:       String,
+    transport:  String,
+    auth:       Option<String>,
+    enabled:    bool,
+    status:     String,
+    last_error: Option<String>,
+    created_at: String,
+    updated_at: String,
+}
+
+impl FeedRow {
+    fn into_config(self) -> anyhow::Result<DataFeedConfig> {
+        let feed_type: FeedType =
+            serde_json::from_value(serde_json::Value::String(self.feed_type))?;
+        let status: FeedStatus = serde_json::from_value(serde_json::Value::String(self.status))?;
+        let tags: Vec<String> = serde_json::from_str(&self.tags)?;
+        let transport: serde_json::Value = serde_json::from_str(&self.transport)?;
+        let auth: Option<AuthConfig> =
+            self.auth.as_deref().map(serde_json::from_str).transpose()?;
+        let created_at: Timestamp = self.created_at.parse()?;
+        let updated_at: Timestamp = self.updated_at.parse()?;
+
+        Ok(DataFeedConfig::builder()
+            .id(self.id)
+            .name(self.name)
+            .feed_type(feed_type)
+            .tags(tags)
+            .transport(transport)
+            .maybe_auth(auth)
+            .enabled(self.enabled)
+            .status(status)
+            .maybe_last_error(self.last_error)
+            .created_at(created_at)
+            .updated_at(updated_at)
+            .build())
+    }
+}
+
+#[derive(sqlx::FromRow)]
+struct EventRow {
+    id:          String,
+    source_name: String,
+    event_type:  String,
+    tags:        String,
+    payload:     String,
+    received_at: String,
+}
+
+impl EventRow {
+    fn into_event(self) -> anyhow::Result<FeedEvent> {
+        let id = FeedEventId::try_from_raw(&self.id)
+            .map_err(|e| anyhow::anyhow!("invalid event id: {e}"))?;
+        let tags: Vec<String> = serde_json::from_str(&self.tags)?;
+        let payload: serde_json::Value = serde_json::from_str(&self.payload)?;
+        let received_at: Timestamp = self.received_at.parse()?;
+
+        Ok(FeedEvent::builder()
+            .id(id)
+            .source_name(self.source_name)
+            .event_type(self.event_type)
+            .tags(tags)
+            .payload(payload)
+            .received_at(received_at)
+            .build())
+    }
+}

--- a/crates/extensions/backend-admin/src/state.rs
+++ b/crates/extensions/backend-admin/src/state.rs
@@ -15,11 +15,12 @@
 //! Backend domain-service state — holds all HTTP admin services and routes.
 //!
 //! [`BackendState`] is the domain-service half of the old `AppState` god
-//! object.  It wires session (chat) and settings.
+//! object.  It wires session (chat), settings, and data feeds.
 
 use std::sync::Arc;
 
 use snafu::Whatever;
+use sqlx::SqlitePool;
 use tracing::info;
 
 /// Backend domain-service state.
@@ -29,6 +30,7 @@ use tracing::info;
 pub struct BackendState {
     pub session_service: crate::chat::service::SessionService,
     pub settings_svc:    crate::settings::SettingsSvc,
+    pub data_feed_svc:   crate::data_feeds::DataFeedSvc,
 }
 
 impl BackendState {
@@ -42,6 +44,7 @@ impl BackendState {
         settings_provider: Arc<dyn rara_domain_shared::settings::SettingsProvider>,
         settings_svc: crate::settings::SettingsSvc,
         model_lister: rara_kernel::llm::LlmModelListerRef,
+        pool: SqlitePool,
     ) -> Result<Self, Whatever> {
         // -- domain services -------------------------------------------------
 
@@ -55,9 +58,13 @@ impl BackendState {
         );
         info!("Session service initialized");
 
+        let data_feed_svc = crate::data_feeds::DataFeedSvc::new(pool);
+        info!("DataFeed service initialized");
+
         Ok(Self {
             session_service,
             settings_svc,
+            data_feed_svc,
         })
     }
 
@@ -100,6 +107,11 @@ impl BackendState {
         // Kernel observability routes (stats, sessions, approvals, audit).
         router = router.merge(crate::kernel::router::kernel_routes(kernel_handle.clone()));
 
+        // Data feed management routes.
+        router = router.merge(crate::data_feeds::data_feed_routes(
+            self.data_feed_svc.clone(),
+        ));
+
         (router, api)
     }
 
@@ -115,7 +127,8 @@ impl BackendState {
             tags(
                 (name = "chat", description = "Chat sessions and messaging"),
                 (name = "settings", description = "Runtime settings"),
-                (name = "system", description = "System utilities")
+                (name = "system", description = "System utilities"),
+                (name = "data-feeds", description = "Data feed management")
             )
         )]
         struct ApiDoc;

--- a/crates/kernel/src/kernel.rs
+++ b/crates/kernel/src/kernel.rs
@@ -217,6 +217,12 @@ pub struct Kernel {
     skill_prompt_provider: crate::handle::SkillPromptProvider,
     /// Lifecycle hook registry for turn/fold/delegation events.
     lifecycle_hooks:       crate::lifecycle::LifecycleHookRegistry,
+    /// Data feed registry for managing external data sources.
+    /// `None` when the data feed subsystem is not configured.
+    feed_registry:         Option<Arc<crate::data_feed::DataFeedRegistry>>,
+    /// Persistent store for feed events.
+    /// `None` when the data feed subsystem is not configured.
+    feed_store:            Option<crate::data_feed::FeedStoreRef>,
 }
 
 impl Kernel {
@@ -237,6 +243,8 @@ impl Kernel {
         dynamic_tool_provider: Option<DynamicToolProviderRef>,
         trace_service: crate::trace::TraceService,
         skill_prompt_provider: crate::handle::SkillPromptProvider,
+        feed_registry: Option<Arc<crate::data_feed::DataFeedRegistry>>,
+        feed_store: Option<crate::data_feed::FeedStoreRef>,
     ) -> Self {
         let event_bus: NotificationBusRef = Arc::new(BroadcastNotificationBus::default());
         // Clamp default_tool_timeout so it never exceeds the global wave timeout.
@@ -318,6 +326,8 @@ impl Kernel {
             trace_service,
             skill_prompt_provider,
             lifecycle_hooks: crate::lifecycle::LifecycleHookRegistry::new(),
+            feed_registry,
+            feed_store,
         }
     }
 
@@ -379,8 +389,8 @@ impl Kernel {
             self.trace_service.clone(),
             self.syscall.job_wheel().clone(),
             self.skill_prompt_provider.clone(),
-            None, // feed_registry: wired during data feed integration
-            None, // feed_store: wired during data feed integration
+            self.feed_registry.clone(),
+            self.feed_store.clone(),
         )
     }
 

--- a/crates/kernel/src/syscall.rs
+++ b/crates/kernel/src/syscall.rs
@@ -1293,20 +1293,15 @@ impl SyscallTool {
         &self,
         source_name: &str,
     ) -> anyhow::Result<serde_json::Value> {
-        // Verify the feed exists.
+        // Verify the feed exists so the error message is specific.
         let registry = self.feed_registry()?;
         if registry.get(source_name).is_none() {
             return Err(anyhow::anyhow!("data feed not found: '{source_name}'"));
         }
-        info!(
-            source = source_name,
-            "unsubscribe_data_feed requested (subscription lookup not yet implemented)"
+        anyhow::bail!(
+            "unsubscribe_data_feed is not yet implemented (feed '{source_name}' exists but \
+             subscription management is pending)"
         );
-        Ok(serde_json::json!({
-            "ok": true,
-            "source_name": source_name,
-            "message": "Unsubscribe noted. Full subscription lookup will be available after integration.",
-        }))
     }
 
     async fn exec_list_data_feeds(&self) -> anyhow::Result<serde_json::Value> {

--- a/crates/kernel/src/testing.rs
+++ b/crates/kernel/src/testing.rs
@@ -405,6 +405,8 @@ impl TestKernelBuilder {
             None, // no dynamic tool provider
             trace_service,
             skill_prompt_provider,
+            None, // feed_registry: not needed in tests
+            None, // feed_store: not needed in tests
         );
 
         let cancel_token = CancellationToken::new();


### PR DESCRIPTION
## Summary

- Cherry-pick REST API endpoints (PR #1402) that were mistakenly merged to `issue-1388-feed-config` instead of `feat/data-feed`
- Wire `feed_registry` and `feed_store` into `Kernel` struct and pass through to `KernelHandle` — previously hardcoded as `None`, making syscall and query-feed tool non-functional at runtime
- Mount `webhook_routes()` into the HTTP server at `/api/v1/webhooks/{feed_name}` so webhook feeds can receive traffic
- Fix `unsubscribe_data_feed` syscall to return an error instead of silently returning `ok: true` (was a no-op violating the anti-pattern rule against noop impls)

## Type of change

| Type | Label |
|------|-------|
| Bug fix | `bug` |

## Component

`core`

## Closes

Closes #1416

## Test plan

- [x] `cargo check --workspace` passes
- [x] `cargo +nightly fmt --all -- --check` passes
- [x] `cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings` passes
- [x] `RUSTDOCFLAGS="-D warnings" cargo +nightly doc --workspace --no-deps --document-private-items` passes
- [x] `cargo test -p rara-kernel --lib -- data_feed` — 28 tests pass
- [x] Pre-commit hooks pass