### PR TITLE
feat(kimi-oauth): add Kimi Code OAuth provider via kimi-cli token sharing (#1420)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -122,6 +122,7 @@ members = [
     "crates/skills",
     "crates/integrations/mcp",
     "crates/integrations/codex-oauth",
+    "crates/integrations/kimi-oauth",
     "crates/integrations/keyring-store",
     "crates/integrations/pg-credential-store",
     "crates/agents",
@@ -254,6 +255,7 @@ rara-tts = { path = "crates/drivers/tts" }
 rara-channels = { path = "crates/channels" }
 rara-cli = { path = "crates/cmd" }
 rara-codex-oauth = { path = "crates/integrations/codex-oauth" }
+rara-kimi-oauth = { path = "crates/integrations/kimi-oauth" }
 rara-composio = { path = "crates/integrations/composio" }
 rara-dock = { path = "crates/rara-dock" }
 rara-domain-shared = { path = "crates/domain/shared" }

--- a/crates/app/Cargo.toml
+++ b/crates/app/Cargo.toml
@@ -38,6 +38,7 @@ rara-backend-admin = { workspace = true }
 rara-browser = { workspace = true }
 rara-channels = { workspace = true }
 rara-codex-oauth = { workspace = true }
+rara-kimi-oauth = { workspace = true }
 rara-composio.workspace = true
 rara-dock = { workspace = true }
 rara-domain-shared = { workspace = true }

--- a/crates/app/src/boot.rs
+++ b/crates/app/src/boot.rs
@@ -350,20 +350,24 @@ async fn build_driver_registry(
         .collect();
 
     for &name in &provider_names {
-        let base_url_key = format!("llm.providers.{name}.base_url");
-        let no_proxy = all_settings
-            .get(&base_url_key)
-            .map_or(false, |url| rara_kernel::llm::is_local_url(url));
-        registry.register_driver(
-            name,
-            Arc::new(OpenAiDriver::from_settings(
-                settings.clone(),
+        // kimi-code uses a dedicated OAuth driver — skip OpenAiDriver registration.
+        if name != "kimi-code" {
+            let base_url_key = format!("llm.providers.{name}.base_url");
+            let no_proxy = all_settings
+                .get(&base_url_key)
+                .map_or(false, |url| rara_kernel::llm::is_local_url(url));
+            registry.register_driver(
                 name,
-                OpenAiDriver::DEFAULT_SSE_IDLE_TIMEOUT,
-                no_proxy,
-            )),
-        );
+                Arc::new(OpenAiDriver::from_settings(
+                    settings.clone(),
+                    name,
+                    OpenAiDriver::DEFAULT_SSE_IDLE_TIMEOUT,
+                    no_proxy,
+                )),
+            );
+        }
 
+        // Model config applies to ALL providers including kimi-code.
         // Read per-provider default_model and fallback_models
         let model_key = format!("llm.providers.{name}.default_model");
         if let Some(default_model) = all_settings
@@ -440,6 +444,24 @@ async fn build_driver_registry(
         }
         Ok(None) => {} // No tokens configured — skip
         Err(e) => tracing::warn!("failed to load codex OAuth tokens: {e}"),
+    }
+
+    // -- kimi-code (Kimi Code platform via shared kimi-cli OAuth) ---------------
+
+    match rara_kimi_oauth::load_tokens().await {
+        Ok(Some(_)) => {
+            registry.register_driver(
+                "kimi-code",
+                Arc::new(rara_kernel::llm::kimi::KimiCodeDriver::new(Arc::new(
+                    rara_kimi_oauth::KimiCredentialResolver,
+                ))),
+            );
+            info!("kimi-code driver registered (OAuth tokens found)");
+        }
+        Ok(None) => {
+            tracing::debug!("kimi-code: no OAuth tokens found, skipping");
+        }
+        Err(e) => tracing::warn!("failed to load kimi OAuth tokens: {e}"),
     }
 
     info!(

--- a/crates/app/src/boot.rs
+++ b/crates/app/src/boot.rs
@@ -261,6 +261,10 @@ pub(crate) async fn boot(
     let agent_registry = Arc::new(load_default_registry());
 
     // -- default provider model lister / embedder ----------------------------
+    //
+    // OAuth-based providers (kimi-code, codex) don't have base_url/api_key in
+    // settings — they resolve credentials dynamically.  Build the appropriate
+    // OpenAiDriver variant so model listing and embedding work end-to-end.
 
     let default_provider = {
         use rara_domain_shared::settings::keys;
@@ -269,19 +273,30 @@ pub(crate) async fn boot(
             .await
             .unwrap_or_else(|| "openrouter".to_owned())
     };
-    let default_base_url_key = format!("llm.providers.{default_provider}.base_url");
-    let default_no_proxy = settings_provider
-        .get(&default_base_url_key)
-        .await
-        .as_deref()
-        .map_or(false, rara_kernel::llm::is_local_url);
-    let default_driver: Arc<rara_kernel::llm::OpenAiDriver> =
-        Arc::new(rara_kernel::llm::OpenAiDriver::from_settings(
-            settings_provider.clone(),
-            &default_provider,
+    let default_driver: Arc<rara_kernel::llm::OpenAiDriver> = match default_provider.as_str() {
+        "kimi-code" => Arc::new(rara_kernel::llm::OpenAiDriver::with_credential_resolver(
+            Arc::new(rara_kimi_oauth::KimiCredentialResolver),
             rara_kernel::llm::OpenAiDriver::DEFAULT_SSE_IDLE_TIMEOUT,
-            default_no_proxy,
-        ));
+        )),
+        "codex" => Arc::new(rara_kernel::llm::OpenAiDriver::with_credential_resolver(
+            Arc::new(rara_codex_oauth::CodexCredentialResolver),
+            rara_kernel::llm::OpenAiDriver::DEFAULT_SSE_IDLE_TIMEOUT,
+        )),
+        _ => {
+            let base_url_key = format!("llm.providers.{default_provider}.base_url");
+            let no_proxy = settings_provider
+                .get(&base_url_key)
+                .await
+                .as_deref()
+                .map_or(false, rara_kernel::llm::is_local_url);
+            Arc::new(rara_kernel::llm::OpenAiDriver::from_settings(
+                settings_provider.clone(),
+                &default_provider,
+                rara_kernel::llm::OpenAiDriver::DEFAULT_SSE_IDLE_TIMEOUT,
+                no_proxy,
+            ))
+        }
+    };
     let model_lister: rara_kernel::llm::LlmModelListerRef = default_driver.clone();
     let embedder: rara_kernel::llm::LlmEmbedderRef = default_driver;
 

--- a/crates/integrations/kimi-oauth/AGENT.md
+++ b/crates/integrations/kimi-oauth/AGENT.md
@@ -1,0 +1,28 @@
+# rara-kimi-oauth — Agent Guidelines
+
+## Purpose
+Read OAuth tokens from kimi-cli's `~/.kimi/credentials/kimi-code.json` and provide
+a `LlmCredentialResolver` for the Kimi Code platform API.
+
+## Architecture
+- `StoredKimiTokens` — serde struct matching kimi-cli's token JSON format
+- `load_tokens()` / `should_refresh_token()` — file I/O + expiry check
+- `refresh_tokens()` — POST to `auth.kimi.com/api/oauth/token`
+- `KimiCredentialResolver` — implements `LlmCredentialResolver`, returns `LlmCredential` with `X-Msh-*` headers
+- `kimi_common_headers()` — builds the 6 required metadata headers
+
+## Critical Invariants
+- Token file format MUST match kimi-cli's `OAuthToken.to_dict()` — field names are `expires_at` (float), not `expires_at_unix` (u64).
+- `X-Msh-Platform` MUST be `"kimi_cli"` (not `"rara"`) — the server validates this.
+- Device ID is read from `~/.kimi/device_id`, NOT generated — must share with kimi-cli.
+- Refreshed tokens MUST be written back to the same file so kimi-cli stays in sync.
+
+## What NOT To Do
+- Do NOT generate a new device ID — must read kimi-cli's existing one.
+- Do NOT change `X-Msh-Platform` to `"rara"` — Kimi server may reject unknown platforms.
+- Do NOT use `rara_paths::config_dir()` for token storage — tokens live in `~/.kimi/`.
+
+## Dependencies
+- Upstream: `rara-kernel` (for `LlmCredentialResolver` trait)
+- Downstream: `rara-app` (registers the driver in `boot.rs`)
+- External: kimi-cli must be installed and `kimi auth login` completed

--- a/crates/integrations/kimi-oauth/Cargo.toml
+++ b/crates/integrations/kimi-oauth/Cargo.toml
@@ -15,6 +15,7 @@ workspace = true
 
 [dependencies]
 async-trait.workspace = true
+dirs.workspace = true
 rara-kernel.workspace = true
 reqwest.workspace = true
 serde.workspace = true

--- a/crates/integrations/kimi-oauth/Cargo.toml
+++ b/crates/integrations/kimi-oauth/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "rara-kimi-oauth"
+version = "0.0.1"
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+repository.workspace = true
+homepage.workspace = true
+readme.workspace = true
+keywords.workspace = true
+categories.workspace = true
+
+[lints]
+workspace = true
+
+[dependencies]
+async-trait.workspace = true
+rara-kernel.workspace = true
+reqwest.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+snafu.workspace = true
+tokio = { workspace = true, features = ["fs"] }
+tracing.workspace = true

--- a/crates/integrations/kimi-oauth/src/lib.rs
+++ b/crates/integrations/kimi-oauth/src/lib.rs
@@ -270,11 +270,11 @@ pub async fn refresh_tokens(current: &StoredKimiTokens) -> Result<StoredKimiToke
 // ---------------------------------------------------------------------------
 
 /// Build the `X-Msh-*` metadata headers required by Kimi Code platform.
-async fn kimi_common_headers() -> Vec<(String, String)> {
-    let device_id = read_device_id().await.unwrap_or_else(|e| {
-        tracing::warn!("failed to read kimi device_id, using fallback: {e}");
-        "unknown".into()
-    });
+///
+/// Fails if `~/.kimi/device_id` is unreadable — requests with a
+/// placeholder device ID would be rejected by the server anyway.
+async fn kimi_common_headers() -> Result<Vec<(String, String)>> {
+    let device_id = read_device_id().await?;
 
     // Best-effort hostname — no extra crate dependency.
     let device_name = std::process::Command::new("hostname")
@@ -286,14 +286,14 @@ async fn kimi_common_headers() -> Vec<(String, String)> {
 
     let device_model = format!("{} {}", std::env::consts::OS, std::env::consts::ARCH);
 
-    vec![
+    Ok(vec![
         ("X-Msh-Platform".into(), "kimi_cli".into()),
         ("X-Msh-Version".into(), "0.0.1".into()),
         ("X-Msh-Device-Name".into(), device_name),
         ("X-Msh-Device-Model".into(), device_model),
         ("X-Msh-Os-Version".into(), std::env::consts::OS.into()),
         ("X-Msh-Device-Id".into(), device_id),
-    ]
+    ])
 }
 
 // ---------------------------------------------------------------------------
@@ -334,8 +334,15 @@ impl LlmCredentialResolver for KimiCredentialResolver {
             }
         }
 
+        let headers =
+            kimi_common_headers()
+                .await
+                .map_err(|e| rara_kernel::error::KernelError::Provider {
+                    message: e.to_string().into(),
+                })?;
+
         let mut cred = LlmCredential::new(KIMI_CODE_BASE_URL, &tokens.access_token);
-        for (name, value) in kimi_common_headers().await {
+        for (name, value) in headers {
             cred = cred.with_header(name, value);
         }
         Ok(cred)

--- a/crates/integrations/kimi-oauth/src/lib.rs
+++ b/crates/integrations/kimi-oauth/src/lib.rs
@@ -1,0 +1,101 @@
+//! Kimi Code OAuth integration — reads tokens from kimi-cli.
+//!
+//! This crate reads OAuth tokens persisted by
+//! [kimi-cli](https://github.com/nicepkg/kimi-cli) at
+//! `~/.kimi/credentials/kimi-code.json` and provides a
+//! `LlmCredentialResolver` that injects the required
+//! `Authorization` + `X-Msh-*` headers for the Kimi Code platform.
+//!
+//! Users authenticate via `kimi auth login` in kimi-cli; rara
+//! piggybacks on those credentials with automatic refresh.
+
+use serde::{Deserialize, Serialize};
+use snafu::Snafu;
+
+/// Kimi Code platform API base URL.
+pub const KIMI_CODE_BASE_URL: &str = "https://api.kimi.com/coding/v1";
+
+/// OAuth token endpoint for refresh.
+const KIMI_AUTH_TOKEN_ENDPOINT: &str = "https://auth.kimi.com/api/oauth/token";
+
+/// Kimi Code public OAuth client ID (same as kimi-cli).
+const KIMI_CODE_CLIENT_ID: &str = "17e5f671-d194-4dfb-9706-5516cb48c098";
+
+/// Refresh skew — attempt refresh this many seconds before expiry.
+const REFRESH_SKEW_SECS: f64 = 300.0;
+
+/// Token file name within `~/.kimi/credentials/`.
+const TOKEN_FILENAME: &str = "kimi-code.json";
+
+/// Device ID file within `~/.kimi/`.
+const DEVICE_ID_FILENAME: &str = "device_id";
+
+// ---------------------------------------------------------------------------
+// Error types
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Snafu)]
+#[snafu(visibility(pub))]
+pub enum KimiOauthError {
+    #[snafu(display("failed to read token file {path}: {source}"))]
+    TokenFileRead {
+        path:   String,
+        source: std::io::Error,
+    },
+
+    #[snafu(display("failed to parse token file {path}: {source}"))]
+    TokenFileParse {
+        path:   String,
+        source: serde_json::Error,
+    },
+
+    #[snafu(display("failed to read device ID from {path}: {source}"))]
+    DeviceIdRead {
+        path:   String,
+        source: std::io::Error,
+    },
+
+    #[snafu(display("{context} request failed: {source}"))]
+    TokenRequest {
+        context: String,
+        source:  reqwest::Error,
+    },
+
+    #[snafu(display("{context} failed: {status} {body}"))]
+    TokenRequestStatus {
+        context: String,
+        status:  reqwest::StatusCode,
+        body:    String,
+    },
+
+    #[snafu(display("failed to parse {context} response: {source}"))]
+    TokenResponseParse {
+        context: String,
+        source:  reqwest::Error,
+    },
+
+    #[snafu(display("{message}"))]
+    Validation { message: String },
+}
+
+pub type Result<T> = std::result::Result<T, KimiOauthError>;
+
+// ---------------------------------------------------------------------------
+// Token data types
+// ---------------------------------------------------------------------------
+
+/// Persisted Kimi OAuth token (matches kimi-cli's file format).
+///
+/// Field names and types match kimi-cli's `OAuthToken.to_dict()` output
+/// exactly — `expires_at` is a float unix timestamp, not integer.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct StoredKimiTokens {
+    pub access_token:  String,
+    pub refresh_token: String,
+    /// Absolute expiry time as unix timestamp (seconds, float).
+    pub expires_at:    f64,
+    pub scope:         String,
+    pub token_type:    String,
+    /// Original `expires_in` value from the OAuth response.
+    pub expires_in:    f64,
+}

--- a/crates/integrations/kimi-oauth/src/lib.rs
+++ b/crates/integrations/kimi-oauth/src/lib.rs
@@ -3,14 +3,16 @@
 //! This crate reads OAuth tokens persisted by
 //! [kimi-cli](https://github.com/nicepkg/kimi-cli) at
 //! `~/.kimi/credentials/kimi-code.json` and provides a
-//! `LlmCredentialResolver` that injects the required
+//! [`KimiCredentialResolver`] that injects the required
 //! `Authorization` + `X-Msh-*` headers for the Kimi Code platform.
 //!
 //! Users authenticate via `kimi auth login` in kimi-cli; rara
 //! piggybacks on those credentials with automatic refresh.
 
+use async_trait::async_trait;
+use rara_kernel::llm::{LlmCredential, LlmCredentialResolver};
 use serde::{Deserialize, Serialize};
-use snafu::Snafu;
+use snafu::{OptionExt as _, ResultExt as _, Snafu};
 
 /// Kimi Code platform API base URL.
 pub const KIMI_CODE_BASE_URL: &str = "https://api.kimi.com/coding/v1";
@@ -34,33 +36,46 @@ const DEVICE_ID_FILENAME: &str = "device_id";
 // Error types
 // ---------------------------------------------------------------------------
 
+/// Crate-level error type for Kimi OAuth operations.
 #[derive(Debug, Snafu)]
 #[snafu(visibility(pub))]
 pub enum KimiOauthError {
+    /// Failed to read the token file from disk.
     #[snafu(display("failed to read token file {path}: {source}"))]
     TokenFileRead {
         path:   String,
         source: std::io::Error,
     },
 
+    /// Failed to deserialize the token file contents.
     #[snafu(display("failed to parse token file {path}: {source}"))]
     TokenFileParse {
         path:   String,
         source: serde_json::Error,
     },
 
+    /// Failed to write the token file to disk.
+    #[snafu(display("failed to write token file {path}: {source}"))]
+    TokenFileWrite {
+        path:   String,
+        source: std::io::Error,
+    },
+
+    /// Failed to read the device ID file.
     #[snafu(display("failed to read device ID from {path}: {source}"))]
     DeviceIdRead {
         path:   String,
         source: std::io::Error,
     },
 
+    /// HTTP request to the token endpoint failed.
     #[snafu(display("{context} request failed: {source}"))]
     TokenRequest {
         context: String,
         source:  reqwest::Error,
     },
 
+    /// Token endpoint returned a non-success HTTP status.
     #[snafu(display("{context} failed: {status} {body}"))]
     TokenRequestStatus {
         context: String,
@@ -68,16 +83,19 @@ pub enum KimiOauthError {
         body:    String,
     },
 
+    /// Failed to parse the JSON response from the token endpoint.
     #[snafu(display("failed to parse {context} response: {source}"))]
     TokenResponseParse {
         context: String,
         source:  reqwest::Error,
     },
 
+    /// Generic validation error.
     #[snafu(display("{message}"))]
     Validation { message: String },
 }
 
+/// Crate-level result alias.
 pub type Result<T> = std::result::Result<T, KimiOauthError>;
 
 // ---------------------------------------------------------------------------
@@ -98,4 +116,228 @@ pub struct StoredKimiTokens {
     pub token_type:    String,
     /// Original `expires_in` value from the OAuth response.
     pub expires_in:    f64,
+}
+
+// ---------------------------------------------------------------------------
+// Token file paths
+// ---------------------------------------------------------------------------
+
+/// Kimi CLI share directory (`~/.kimi`).
+///
+/// Respects the `KIMI_SHARE_DIR` environment variable for testing
+/// and non-standard installations.
+fn kimi_share_dir() -> std::path::PathBuf {
+    if let Ok(dir) = std::env::var("KIMI_SHARE_DIR") {
+        return std::path::PathBuf::from(dir);
+    }
+    dirs::home_dir()
+        .expect("cannot determine home directory")
+        .join(".kimi")
+}
+
+fn token_file_path() -> std::path::PathBuf {
+    kimi_share_dir().join("credentials").join(TOKEN_FILENAME)
+}
+
+fn device_id_path() -> std::path::PathBuf { kimi_share_dir().join(DEVICE_ID_FILENAME) }
+
+// ---------------------------------------------------------------------------
+// Token I/O
+// ---------------------------------------------------------------------------
+
+/// Load kimi-cli's persisted OAuth tokens.
+///
+/// Returns `Ok(None)` if the token file does not exist.
+pub async fn load_tokens() -> Result<Option<StoredKimiTokens>> {
+    let path = token_file_path();
+    let path_str = path.display().to_string();
+    let raw = match tokio::fs::read_to_string(&path).await {
+        Ok(raw) => raw,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(e) => return Err(e).context(TokenFileReadSnafu { path: path_str }),
+    };
+    serde_json::from_str(&raw)
+        .context(TokenFileParseSnafu { path: path_str })
+        .map(Some)
+}
+
+/// Save refreshed tokens back to kimi-cli's token file.
+async fn save_tokens(tokens: &StoredKimiTokens) -> Result<()> {
+    let path = token_file_path();
+    let path_str = path.display().to_string();
+    if let Some(parent) = path.parent() {
+        tokio::fs::create_dir_all(parent)
+            .await
+            .context(TokenFileWriteSnafu {
+                path: parent.display().to_string(),
+            })?;
+    }
+    let raw =
+        serde_json::to_string_pretty(tokens).expect("StoredKimiTokens is always serializable");
+    tokio::fs::write(&path, raw)
+        .await
+        .context(TokenFileWriteSnafu { path: path_str })?;
+
+    // Restrict to owner-only read/write — tokens are sensitive credentials.
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let perms = std::fs::Permissions::from_mode(0o600);
+        let _ = tokio::fs::set_permissions(&path, perms).await;
+    }
+
+    Ok(())
+}
+
+/// Read device ID from kimi-cli's `device_id` file.
+async fn read_device_id() -> Result<String> {
+    let path = device_id_path();
+    let path_str = path.display().to_string();
+    tokio::fs::read_to_string(&path)
+        .await
+        .map(|s| s.trim().to_owned())
+        .context(DeviceIdReadSnafu { path: path_str })
+}
+
+/// Whether token is close enough to expiry that refresh should be attempted.
+pub fn should_refresh_token(tokens: &StoredKimiTokens) -> bool {
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map_or(0.0, |d| d.as_secs_f64());
+    tokens.expires_at - now < REFRESH_SKEW_SECS
+}
+
+// ---------------------------------------------------------------------------
+// Token refresh
+// ---------------------------------------------------------------------------
+
+/// Raw token response from the Kimi OAuth token endpoint.
+#[derive(Debug, Deserialize)]
+struct TokenResponse {
+    access_token:  String,
+    refresh_token: String,
+    expires_in:    f64,
+    scope:         String,
+    token_type:    String,
+}
+
+/// Refresh the access token using kimi-cli's refresh token.
+pub async fn refresh_tokens(current: &StoredKimiTokens) -> Result<StoredKimiTokens> {
+    let form = [
+        ("client_id", KIMI_CODE_CLIENT_ID),
+        ("grant_type", "refresh_token"),
+        ("refresh_token", current.refresh_token.as_str()),
+    ];
+    let response = reqwest::Client::new()
+        .post(KIMI_AUTH_TOKEN_ENDPOINT)
+        .form(&form)
+        .send()
+        .await
+        .context(TokenRequestSnafu {
+            context: "kimi token refresh",
+        })?;
+    if !response.status().is_success() {
+        let status = response.status();
+        let body = response
+            .text()
+            .await
+            .unwrap_or_else(|_| "<unavailable>".into());
+        return TokenRequestStatusSnafu {
+            context: "kimi token refresh",
+            status,
+            body,
+        }
+        .fail();
+    }
+    let token: TokenResponse = response.json().await.context(TokenResponseParseSnafu {
+        context: "kimi token refresh",
+    })?;
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map_or(0.0, |d| d.as_secs_f64());
+    Ok(StoredKimiTokens {
+        access_token:  token.access_token,
+        refresh_token: token.refresh_token,
+        expires_at:    now + token.expires_in,
+        scope:         token.scope,
+        token_type:    token.token_type,
+        expires_in:    token.expires_in,
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Common headers
+// ---------------------------------------------------------------------------
+
+/// Build the `X-Msh-*` metadata headers required by Kimi Code platform.
+async fn kimi_common_headers() -> Vec<(String, String)> {
+    let device_id = read_device_id().await.unwrap_or_else(|e| {
+        tracing::warn!("failed to read kimi device_id, using fallback: {e}");
+        "unknown".into()
+    });
+
+    // Best-effort hostname — no extra crate dependency.
+    let device_name = std::process::Command::new("hostname")
+        .output()
+        .ok()
+        .and_then(|o| String::from_utf8(o.stdout).ok())
+        .map(|s| s.trim().to_owned())
+        .unwrap_or_else(|| "unknown".into());
+
+    let device_model = format!("{} {}", std::env::consts::OS, std::env::consts::ARCH);
+
+    vec![
+        ("X-Msh-Platform".into(), "kimi_cli".into()),
+        ("X-Msh-Version".into(), "0.0.1".into()),
+        ("X-Msh-Device-Name".into(), device_name),
+        ("X-Msh-Device-Model".into(), device_model),
+        ("X-Msh-Os-Version".into(), std::env::consts::OS.into()),
+        ("X-Msh-Device-Id".into(), device_id),
+    ]
+}
+
+// ---------------------------------------------------------------------------
+// KimiCredentialResolver
+// ---------------------------------------------------------------------------
+
+/// Dynamic credential resolver for the Kimi Code platform.
+///
+/// On each call to [`resolve`](LlmCredentialResolver::resolve), loads the
+/// current token from disk, refreshes it if near expiry, and returns a
+/// fresh [`LlmCredential`] with the required `X-Msh-*` headers.
+pub struct KimiCredentialResolver;
+
+#[async_trait]
+impl LlmCredentialResolver for KimiCredentialResolver {
+    async fn resolve(&self) -> rara_kernel::error::Result<LlmCredential> {
+        let mut tokens = load_tokens()
+            .await
+            .map_err(|e| rara_kernel::error::KernelError::Provider {
+                message: e.to_string().into(),
+            })?
+            .context(rara_kernel::error::ProviderNotConfiguredSnafu)?;
+
+        if should_refresh_token(&tokens) {
+            match refresh_tokens(&tokens).await {
+                Ok(refreshed) => {
+                    if let Err(e) = save_tokens(&refreshed).await {
+                        tracing::warn!("failed to persist refreshed kimi tokens: {e}");
+                    }
+                    tokens = refreshed;
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        expires_at = tokens.expires_at,
+                        "kimi token refresh failed, using existing token: {e}",
+                    );
+                }
+            }
+        }
+
+        let mut cred = LlmCredential::new(KIMI_CODE_BASE_URL, &tokens.access_token);
+        for (name, value) in kimi_common_headers().await {
+            cred = cred.with_header(name, value);
+        }
+        Ok(cred)
+    }
 }

--- a/crates/integrations/kimi-oauth/src/lib.rs
+++ b/crates/integrations/kimi-oauth/src/lib.rs
@@ -3,7 +3,7 @@
 //! This crate reads OAuth tokens persisted by
 //! [kimi-cli](https://github.com/nicepkg/kimi-cli) at
 //! `~/.kimi/credentials/kimi-code.json` and provides a
-//! [`KimiCredentialResolver`] that injects the required
+//! `KimiCredentialResolver` that injects the required
 //! `Authorization` + `X-Msh-*` headers for the Kimi Code platform.
 //!
 //! Users authenticate via `kimi auth login` in kimi-cli; rara

--- a/crates/kernel/src/llm/kimi.rs
+++ b/crates/kernel/src/llm/kimi.rs
@@ -1,0 +1,63 @@
+// Copyright 2025 Rararulab
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Kimi Code backend driver — thin wrapper around [`OpenAiDriver`]
+//! configured with the Kimi Code platform base URL.
+//!
+//! Authentication uses shared OAuth tokens from kimi-cli, resolved via
+//! [`LlmCredentialResolverRef`].  Kimi Code uses the standard OpenAI
+//! chat completions API format, so all request/response handling is
+//! delegated to `OpenAiDriver`.
+
+use async_trait::async_trait;
+use tokio::sync::mpsc;
+
+use super::{
+    CompletionRequest, CompletionResponse, LlmCredentialResolverRef, StreamDelta,
+    driver::LlmDriver, openai::OpenAiDriver,
+};
+use crate::error::Result;
+
+/// Kimi Code driver that calls the Kimi Code chat completions API.
+pub struct KimiCodeDriver {
+    inner: OpenAiDriver,
+}
+
+impl KimiCodeDriver {
+    /// Create a new Kimi Code driver with a credential resolver.
+    pub fn new(resolver: LlmCredentialResolverRef) -> Self {
+        let inner =
+            OpenAiDriver::with_credential_resolver(resolver, std::time::Duration::from_secs(120));
+        Self { inner }
+    }
+}
+
+#[async_trait]
+impl LlmDriver for KimiCodeDriver {
+    async fn complete(&self, request: CompletionRequest) -> Result<CompletionResponse> {
+        self.inner.complete(request).await
+    }
+
+    async fn stream(
+        &self,
+        request: CompletionRequest,
+        tx: mpsc::Sender<StreamDelta>,
+    ) -> Result<CompletionResponse> {
+        self.inner.stream(request, tx).await
+    }
+
+    async fn model_context_length(&self, _model: &str) -> Option<usize> { Some(128_000) }
+
+    async fn model_supports_vision(&self, _model: &str) -> Option<bool> { Some(true) }
+}

--- a/crates/kernel/src/llm/mod.rs
+++ b/crates/kernel/src/llm/mod.rs
@@ -24,6 +24,7 @@
 pub mod codex;
 pub mod driver;
 pub mod image;
+pub mod kimi;
 pub mod openai;
 pub mod registry;
 pub mod scripted;


### PR DESCRIPTION
## Summary

Add `rara-kimi-oauth` crate that reads OAuth tokens from kimi-cli's `~/.kimi/credentials/kimi-code.json`, enabling rara to use Kimi Code platform models (kimi-k2.5, K2.6-code-preview) that require OAuth authentication.

- **`rara-kimi-oauth`** — token loading, refresh via `auth.kimi.com`, `KimiCredentialResolver` with `X-Msh-*` headers
- **`KimiCodeDriver`** — thin `OpenAiDriver` wrapper in kernel, mirroring `CodexDriver` pattern
- **boot.rs** — auto-registers `kimi-code` driver when `~/.kimi/credentials/kimi-code.json` exists; skips `OpenAiDriver` for `kimi-code` in auto-discover loop while preserving model config

### Usage

```yaml
llm:
  default_provider: "kimi-code"
  providers:
    kimi-code:
      default_model: "kimi-k2.5"
      fallback_models: "K2.6-code-preview"
```

Prerequisites: run `kimi auth login` once via kimi-cli.

## Type of change

| Type | Label |
|------|-------|
| New feature | `enhancement` |

## Component

`core`

## Closes

Closes #1420

## Test plan

- [x] `cargo check --all --all-targets` passes
- [x] `cargo +nightly fmt --all -- --check` passes
- [x] `cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings` passes
- [x] `RUSTDOCFLAGS="-D warnings" cargo +nightly doc --workspace --no-deps --document-private-items` passes
- [ ] Manual test: `kimi auth login` + configure `kimi-code` provider + send request