### PR TITLE
fix(kernel): classify SSE transport errors as retryable (#1422)

### DIFF
--- a/crates/kernel/src/llm/openai.rs
+++ b/crates/kernel/src/llm/openai.rs
@@ -979,7 +979,7 @@ async fn stream_chat_completions(
 
         match maybe_event {
             Ok(Some(event_result)) => {
-                let event = event_result.map_err(|e| KernelError::Provider {
+                let event = event_result.map_err(|e| KernelError::RetryableServer {
                     message: format!("SSE stream error: {}", crate::error::format_error_chain(&e))
                         .into(),
                 })?;
@@ -1311,7 +1311,7 @@ async fn stream_responses_api(
                 }
             }
             Ok(Some(Err(e))) => {
-                return Err(KernelError::Provider {
+                return Err(KernelError::RetryableServer {
                     message: format!("Responses API SSE error: {e}").into(),
                 });
             }


### PR DESCRIPTION
## Summary

SSE stream transport errors (e.g., `error decoding response body` from network glitches) were classified as hard `Provider` errors, causing immediate agent turn failure. Changed both `stream_chat_completions` and `stream_responses_api` to emit `RetryableServer` instead, enabling the agent loop's existing recovery logic at `agent/mod.rs:1607`.

## Type of change

| Type | Label |
|------|-------|
| Bug fix | `bug` |

## Component

`core`

## Closes

Closes #1422

## Test plan

- [x] `cargo check -p rara-kernel` passes
- [x] `cargo test -p rara-kernel` passes
- [x] Pre-commit hooks (check, fmt, clippy, doc) all pass