### PR TITLE
fix(web): fix toggle body and since format in DataFeed API calls (#1425)

### DIFF
--- a/crates/extensions/backend-admin/src/data_feeds/router.rs
+++ b/crates/extensions/backend-admin/src/data_feeds/router.rs
@@ -77,12 +77,6 @@ struct UpdateFeedRequest {
     auth:      Option<serde_json::Value>,
 }
 
-/// Request body for toggling feed enabled state.
-#[derive(Debug, Deserialize)]
-struct ToggleFeedRequest {
-    enabled: bool,
-}
-
 /// Query parameters for event listing.
 #[derive(Debug, Deserialize)]
 struct EventQueryParams {
@@ -230,10 +224,9 @@ async fn delete_feed(
 async fn toggle_feed(
     State(svc): State<DataFeedSvc>,
     Path(id): Path<String>,
-    Json(body): Json<ToggleFeedRequest>,
 ) -> Result<Json<DataFeedConfig>, ProblemDetails> {
     let toggled = svc
-        .toggle_feed(&id, body.enabled)
+        .toggle_feed(&id)
         .await
         .map_err(|e| ProblemDetails::internal(e.to_string()))?;
 

--- a/crates/extensions/backend-admin/src/data_feeds/service.rs
+++ b/crates/extensions/backend-admin/src/data_feeds/service.rs
@@ -148,15 +148,15 @@ impl DataFeedSvc {
 
     /// Toggle the enabled flag for a feed. Returns `true` if updated.
     #[instrument(skip(self))]
-    pub async fn toggle_feed(&self, id: &str, enabled: bool) -> anyhow::Result<bool> {
+    pub async fn toggle_feed(&self, id: &str) -> anyhow::Result<bool> {
         let now = Timestamp::now().to_string();
-        let result =
-            sqlx::query("UPDATE data_feeds SET enabled = ?1, updated_at = ?2 WHERE id = ?3")
-                .bind(enabled)
-                .bind(&now)
-                .bind(id)
-                .execute(&self.pool)
-                .await?;
+        let result = sqlx::query(
+            "UPDATE data_feeds SET enabled = NOT enabled, updated_at = ?1 WHERE id = ?2",
+        )
+        .bind(&now)
+        .bind(id)
+        .execute(&self.pool)
+        .await?;
         Ok(result.rows_affected() > 0)
     }
 

--- a/web/src/components/DataFeedsPanel.tsx
+++ b/web/src/components/DataFeedsPanel.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { useState, useMemo, useCallback } from "react";
+import { useState, useCallback } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import {
   dataFeedsApi,
@@ -165,21 +165,7 @@ const TIME_FILTERS = [
   { value: "30d", label: "Last 30 days" },
 ] as const;
 
-function sinceFromFilter(filter: string): string {
-  const now = new Date();
-  switch (filter) {
-    case "1h":
-      return new Date(now.getTime() - 3600_000).toISOString();
-    case "24h":
-      return new Date(now.getTime() - 86400_000).toISOString();
-    case "7d":
-      return new Date(now.getTime() - 7 * 86400_000).toISOString();
-    case "30d":
-      return new Date(now.getTime() - 30 * 86400_000).toISOString();
-    default:
-      return new Date(now.getTime() - 86400_000).toISOString();
-  }
-}
+
 
 // ---------------------------------------------------------------------------
 // Empty auth/transport helpers
@@ -758,7 +744,7 @@ function EventHistoryView({
   const [offset, setOffset] = useState(0);
   const limit = 50;
 
-  const since = useMemo(() => sinceFromFilter(timeFilter), [timeFilter]);
+  const since = timeFilter;
 
   const eventsQuery = useQuery({
     queryKey: ["data-feed-events", feed.id, since, offset],


### PR DESCRIPTION
## Summary

- **Toggle endpoint**: Backend `toggle_feed` handler no longer requires a JSON body with `{ enabled: bool }`. Instead, it uses `SET enabled = NOT enabled` in SQL to atomically flip the state server-side. This matches the frontend which already sends an empty-body PUT (true toggle semantics).
- **Since parameter**: Frontend `DataFeedsPanel` no longer converts time filter values to ISO timestamps. It passes duration strings (`1h`, `24h`, `7d`, `30d`) directly to the backend, which already expects this format in `parse_duration_ago`.

## Type of change

| Type | Label |
|------|-------|
| Bug fix | `bug` |

## Component

`ui`, `backend`

## Closes

Closes #1425

## Test plan

- [x] `cargo check -p rara-backend-admin` passes
- [x] `cargo clippy` passes (zero warnings)
- [x] `cargo +nightly fmt --all -- --check` passes
- [x] `npm run build` passes
- [x] Pre-commit hooks all green (check, fmt, clippy, doc, AGENT.md)