### PR TITLE
feat(web): add kimi-code to built-in provider list (#1427)

### DIFF
--- a/web/src/pages/Settings.tsx
+++ b/web/src/pages/Settings.tsx
@@ -177,6 +177,15 @@ const BUILTIN_PROVIDERS: ProviderDef[] = [
     enabledKey: KEYS.LLM_PROVIDERS_CODEX_ENABLED,
     fields: [],
   },
+  {
+    id: "kimi-code",
+    name: "Kimi Code",
+    description: "Kimi Code platform. Run `kimi auth login` first.",
+    enabledKey: "llm.providers.kimi-code.enabled",
+    fields: [
+      { key: "llm.providers.kimi-code.default_model", label: "Default Model", placeholder: "kimi-k2.5" },
+    ],
+  },
 ];
 
 const BUILTIN_PROVIDER_IDS = new Set(BUILTIN_PROVIDERS.map((p) => p.id));


### PR DESCRIPTION
## Summary

Add Kimi Code as a built-in provider in the Settings UI, following the same OAuth pattern as Codex. Includes a Default Model field so users can switch models (e.g. `kimi-k2.5`, `K2.6-code-preview`) from the UI.

Follow-up to #1420 / #1423.

## Type of change

| Type | Label |
|------|-------|
| New feature | `enhancement` |

## Component

`ui`

## Closes

Closes #1427

## Test plan

- [x] `npm run build` passes
- [x] Kimi Code appears in Settings provider list
- [x] Default Model field visible and editable