### PR TITLE
feat(kernel): route FeedEvents to subscribers via SubscriptionRegistry (#1429)

### DIFF
--- a/crates/app/Cargo.toml
+++ b/crates/app/Cargo.toml
@@ -22,6 +22,7 @@ chrono.workspace = true
 common-runtime = { workspace = true }
 common-worker = { workspace = true }
 config = { workspace = true }
+futures.workspace = true
 glob = "0.3.3"
 globset = "0.4"
 humantime = "2"

--- a/crates/app/src/lib.rs
+++ b/crates/app/src/lib.rs
@@ -546,10 +546,11 @@ pub async fn start_with_options(
     let (_kernel_arc, kernel_handle) = kernel.start(cancellation_token.clone());
 
     // Spawn the feed dispatch task — consumes events from all transports,
-    // persists them to the feed_events table, and (future) distributes to
-    // subscribing sessions.
+    // persists them to the feed_events table, and routes matching events
+    // to subscribing sessions via SubscriptionRegistry.
     {
         let store = feed_store.clone();
+        let handle = kernel_handle.clone();
         tokio::spawn(async move {
             while let Some(event) = feed_event_rx.recv().await {
                 if let Err(e) = store.append(&event).await {
@@ -559,7 +560,88 @@ pub async fn start_with_options(
                         "failed to persist feed event"
                     );
                 }
-                // TODO: dispatch to subscriber sessions via notification bus
+
+                // Route to subscribers whose tags overlap with the event.
+                let matched = handle
+                    .subscription_registry()
+                    .match_tags_any_owner(&event.tags)
+                    .await;
+                if matched.is_empty() {
+                    continue;
+                }
+
+                let event_json = serde_json::to_value(&event).unwrap_or_default();
+                let payload_pretty =
+                    serde_json::to_string_pretty(&event.payload).unwrap_or_default();
+
+                use rara_kernel::notification::NotifyAction;
+
+                let futs: Vec<_> = matched
+                    .into_iter()
+                    .map(|sub| {
+                        let handle = handle.clone();
+                        let event_json = event_json.clone();
+                        let payload_pretty = payload_pretty.clone();
+                        let source_name = event.source_name.clone();
+                        let event_type = event.event_type.clone();
+                        let tags = event.tags.clone();
+                        async move {
+                            match sub.on_receive {
+                                NotifyAction::ProactiveTurn => {
+                                    if !handle.process_table().contains(&sub.subscriber) {
+                                        warn!(
+                                            subscriber = %sub.subscriber,
+                                            "feed ProactiveTurn downgraded to SilentAppend: \
+                                             subscriber session not in process table"
+                                        );
+                                        let sub_tape = sub.subscriber.to_string();
+                                        let _ = handle
+                                            .tape()
+                                            .store()
+                                            .append(
+                                                &sub_tape,
+                                                rara_kernel::memory::TapEntryKind::FeedEvent,
+                                                event_json,
+                                                None,
+                                            )
+                                            .await;
+                                        return;
+                                    }
+                                    let directive = format!(
+                                        "[FeedEvent] source={source_name} type={event_type} \
+                                         tags={tags:?}\n{payload_pretty}",
+                                    );
+                                    let msg = rara_kernel::io::InboundMessage::synthetic(
+                                        directive,
+                                        sub.owner.clone(),
+                                        sub.subscriber,
+                                    );
+                                    handle.deliver_internal(msg).await;
+                                }
+                                NotifyAction::SilentAppend => {
+                                    let sub_tape = sub.subscriber.to_string();
+                                    let _ = handle
+                                        .tape()
+                                        .store()
+                                        .append(
+                                            &sub_tape,
+                                            rara_kernel::memory::TapEntryKind::FeedEvent,
+                                            event_json,
+                                            None,
+                                        )
+                                        .await;
+                                }
+                            }
+                        }
+                    })
+                    .collect();
+                futures::future::join_all(futs).await;
+
+                info!(
+                    source = %event.source_name,
+                    event_type = %event.event_type,
+                    "feed event dispatched to subscribers"
+                );
             }
             info!("feed dispatch task stopped (channel closed)");
         });

--- a/crates/kernel/src/handle.rs
+++ b/crates/kernel/src/handle.rs
@@ -106,6 +106,8 @@ pub struct KernelHandle {
     /// Persistent store for feed events.
     /// `None` when the data feed subsystem is not configured.
     feed_store:            Option<crate::data_feed::FeedStoreRef>,
+    /// Tag-based subscription registry for routing notifications to sessions.
+    subscription_registry: crate::notification::SubscriptionRegistryRef,
 }
 
 impl KernelHandle {
@@ -129,6 +131,7 @@ impl KernelHandle {
         skill_prompt_provider: SkillPromptProvider,
         feed_registry: Option<Arc<crate::data_feed::DataFeedRegistry>>,
         feed_store: Option<crate::data_feed::FeedStoreRef>,
+        subscription_registry: crate::notification::SubscriptionRegistryRef,
     ) -> Self {
         Self {
             event_queue,
@@ -148,6 +151,7 @@ impl KernelHandle {
             skill_prompt_provider,
             feed_registry,
             feed_store,
+            subscription_registry,
         }
     }
 
@@ -404,6 +408,11 @@ impl KernelHandle {
 
     /// Access the feed event store (if configured).
     pub fn feed_store(&self) -> Option<&crate::data_feed::FeedStoreRef> { self.feed_store.as_ref() }
+
+    /// Access the tag-based subscription registry.
+    pub fn subscription_registry(&self) -> &crate::notification::SubscriptionRegistryRef {
+        &self.subscription_registry
+    }
 
     // -- Query methods ------------------------------------------------------
 

--- a/crates/kernel/src/kernel.rs
+++ b/crates/kernel/src/kernel.rs
@@ -403,6 +403,7 @@ impl Kernel {
             self.skill_prompt_provider.clone(),
             self.feed_registry.clone(),
             self.feed_store.clone(),
+            Arc::clone(self.syscall.subscription_registry()),
         )
     }
 

--- a/crates/kernel/src/memory/mod.rs
+++ b/crates/kernel/src/memory/mod.rs
@@ -228,6 +228,8 @@ pub enum TapEntryKind {
     Plan,
     /// Structured task report from background/scheduled tasks.
     TaskReport,
+    /// External data feed event appended via silent-append delivery.
+    FeedEvent,
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/kernel/src/notification/subscription.rs
+++ b/crates/kernel/src/notification/subscription.rs
@@ -119,11 +119,15 @@ pub struct SubscriptionRegistry {
 /// Interior state behind the `RwLock`.
 struct RegistryInner {
     /// Primary store: sub_id → Subscription.
-    subs:      HashMap<Uuid, Subscription>,
+    subs:             HashMap<Uuid, Subscription>,
     /// Inverted index: (owner, tag) → set of sub_ids.
-    tag_index: HashMap<(UserId, String), HashSet<Uuid>>,
+    tag_index:        HashMap<(UserId, String), HashSet<Uuid>>,
+    /// Owner-agnostic inverted index: tag → set of sub_ids.
+    /// Used by [`SubscriptionRegistry::match_tags_any_owner`] for O(M) lookup
+    /// on system-level events (e.g. data feed events).
+    global_tag_index: HashMap<String, HashSet<Uuid>>,
     /// Path to the JSON persistence file.
-    path:      PathBuf,
+    path:             PathBuf,
 }
 
 impl RegistryInner {
@@ -131,10 +135,15 @@ impl RegistryInner {
     fn from_entries(entries: Vec<Subscription>, path: PathBuf) -> Self {
         let mut subs = HashMap::new();
         let mut tag_index: HashMap<(UserId, String), HashSet<Uuid>> = HashMap::new();
+        let mut global_tag_index: HashMap<String, HashSet<Uuid>> = HashMap::new();
         for sub in entries {
             for tag in &sub.match_tags {
                 tag_index
                     .entry((sub.owner.clone(), tag.clone()))
+                    .or_default()
+                    .insert(sub.id);
+                global_tag_index
+                    .entry(tag.clone())
                     .or_default()
                     .insert(sub.id);
             }
@@ -143,22 +152,27 @@ impl RegistryInner {
         Self {
             subs,
             tag_index,
+            global_tag_index,
             path,
         }
     }
 
-    /// Insert a subscription into the primary store and inverted index.
+    /// Insert a subscription into the primary store and inverted indices.
     fn insert(&mut self, sub: Subscription) {
         for tag in &sub.match_tags {
             self.tag_index
                 .entry((sub.owner.clone(), tag.clone()))
                 .or_default()
                 .insert(sub.id);
+            self.global_tag_index
+                .entry(tag.clone())
+                .or_default()
+                .insert(sub.id);
         }
         self.subs.insert(sub.id, sub);
     }
 
-    /// Remove a subscription from the primary store and inverted index.
+    /// Remove a subscription from the primary store and inverted indices.
     fn remove(&mut self, id: Uuid) -> Option<Subscription> {
         if let Some(sub) = self.subs.remove(&id) {
             for tag in &sub.match_tags {
@@ -167,6 +181,12 @@ impl RegistryInner {
                     set.remove(&id);
                     if set.is_empty() {
                         self.tag_index.remove(&key);
+                    }
+                }
+                if let Some(set) = self.global_tag_index.get_mut(tag) {
+                    set.remove(&id);
+                    if set.is_empty() {
+                        self.global_tag_index.remove(tag);
                     }
                 }
             }
@@ -276,6 +296,31 @@ impl SubscriptionRegistry {
         let mut result = Vec::new();
         for tag in tags {
             if let Some(ids) = inner.tag_index.get(&(publisher.clone(), tag.clone())) {
+                for id in ids {
+                    if seen.insert(*id) {
+                        if let Some(sub) = inner.subs.get(id) {
+                            result.push(sub.clone());
+                        }
+                    }
+                }
+            }
+        }
+        result
+    }
+
+    /// Find all subscriptions matching any of the given tags across **all**
+    /// owners.
+    ///
+    /// Unlike [`match_tags`](Self::match_tags) which scopes to a single
+    /// publisher, this variant is used for system-level events (e.g. data feed
+    /// events) that are not owned by a specific user. Uses the
+    /// `global_tag_index` for O(M) lookup where M is the number of event tags.
+    pub async fn match_tags_any_owner(&self, tags: &[String]) -> Vec<Subscription> {
+        let inner = self.inner.read().await;
+        let mut seen = HashSet::new();
+        let mut result = Vec::new();
+        for tag in tags {
+            if let Some(ids) = inner.global_tag_index.get(tag) {
                 for id in ids {
                     if seen.insert(*id) {
                         if let Some(sub) = inner.subs.get(id) {


### PR DESCRIPTION
## Summary

- Wire the feed dispatch task to deliver persisted FeedEvents to subscribing sessions through SubscriptionRegistry tag matching
- Add `SubscriptionRegistry::match_tags_any_owner()` for system-level events (feed events have no specific publisher owner)
- Implement ProactiveTurn and SilentAppend delivery paths, mirroring the existing TaskNotification flow in `syscall.rs`

## Type of change

| Type | Label |
|------|-------|
| New feature | `enhancement` |

## Component

`core`

## Closes

Closes #1429

## Test plan

- [x] `cargo check --workspace` passes
- [x] `cargo +nightly fmt --all -- --check` passes
- [x] `cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings` passes
- [x] `RUSTDOCFLAGS="-D warnings" cargo +nightly doc --workspace --no-deps --document-private-items` passes
- [x] `cargo test -p rara-kernel` passes
- [x] Pre-commit hooks pass