### PR TITLE
fix(kernel): session title stuck as Untitled after switching (#1433)

### DIFF
--- a/crates/channels/src/telegram/commands/callbacks.rs
+++ b/crates/channels/src/telegram/commands/callbacks.rs
@@ -52,24 +52,35 @@ impl CallbackHandler for SessionSwitchCallbackHandler {
         let session_key = &context.data["switch:".len()..];
         let chat_id = super::extract_chat_id(&context.metadata)?;
 
-        // Verify session still exists before binding to prevent ghost bindings.
-        if self.client.get_session(session_key).await.is_err() {
-            return Ok(CallbackResult::SendMessage {
-                text: "Session no longer exists.".to_owned(),
-            });
-        }
+        // Fetch session — also serves as an existence check.
+        let detail = match self.client.get_session(session_key).await {
+            Ok(d) => d,
+            Err(_) => {
+                return Ok(CallbackResult::SendMessage {
+                    text: "Session no longer exists.".to_owned(),
+                });
+            }
+        };
 
         match self
             .client
             .bind_channel("telegram", &chat_id, session_key)
             .await
         {
-            Ok(_) => Ok(CallbackResult::SendMessage {
-                text: format!(
-                    "Switched to session: <code>{}</code>",
-                    html_escape(session_key)
-                ),
-            }),
+            Ok(_) => {
+                let title = detail
+                    .title
+                    .as_deref()
+                    .or(detail.preview.as_deref())
+                    .unwrap_or("Untitled");
+                Ok(CallbackResult::SendMessage {
+                    text: format!(
+                        "Switched to session: <b>{}</b>\n<code>{}</code>",
+                        html_escape(title),
+                        html_escape(session_key),
+                    ),
+                })
+            }
             Err(e) => Ok(CallbackResult::SendMessage {
                 text: format!("Failed to switch session: {e}"),
             }),
@@ -101,7 +112,11 @@ impl CallbackHandler for SessionDetailCallbackHandler {
 
         match self.client.get_session(session_key).await {
             Ok(detail) => {
-                let title = detail.title.as_deref().unwrap_or("Untitled");
+                let title = detail
+                    .title
+                    .as_deref()
+                    .or(detail.preview.as_deref())
+                    .unwrap_or("Untitled");
                 let model = detail.model.as_deref().unwrap_or("(default)");
                 let text = format!(
                     "<b>{}</b>\nKey: <code>{}</code>\nModel: {}\nCreated: {}\nLast active: {}",

--- a/crates/channels/src/telegram/commands/session.rs
+++ b/crates/channels/src/telegram/commands/session.rs
@@ -239,7 +239,11 @@ impl SessionCommandHandler {
         match self.client.get_session(&session_key).await {
             Ok(detail) => {
                 let mut text = String::new();
-                let title = detail.title.as_deref().unwrap_or("Untitled");
+                let title = detail
+                    .title
+                    .as_deref()
+                    .or(detail.preview.as_deref())
+                    .unwrap_or("Untitled");
                 let _ = writeln!(text, "<b>Session:</b> {}", html_escape(title));
                 let _ = writeln!(
                     text,

--- a/crates/channels/src/telegram/commands/status.rs
+++ b/crates/channels/src/telegram/commands/status.rs
@@ -100,7 +100,11 @@ impl CommandHandler for StatusCommandHandler {
         // -- Section 1: Session metadata ------------------------------------
         match self.client.get_session(&session_key_str).await {
             Ok(detail) => {
-                let title = detail.title.as_deref().unwrap_or("Untitled");
+                let title = detail
+                    .title
+                    .as_deref()
+                    .or(detail.preview.as_deref())
+                    .unwrap_or("Untitled");
                 let short_key = &detail.key[..8];
                 let _ = writeln!(text, "<b>Session</b>");
                 let _ = writeln!(text, "Title: {}", html_escape(title));

--- a/crates/kernel/src/kernel.rs
+++ b/crates/kernel/src/kernel.rs
@@ -3048,7 +3048,7 @@ async fn generate_session_title(
         .find_map(|e| {
             let p = &e.payload;
             if p.get("role")?.as_str()? == "user" {
-                p.get("content")?.as_str().map(String::from)
+                extract_text_content(p.get("content")?)
             } else {
                 None
             }
@@ -3065,7 +3065,7 @@ async fn generate_session_title(
         .find_map(|e| {
             let p = &e.payload;
             if p.get("role")?.as_str()? == "assistant" {
-                p.get("content")?.as_str().map(String::from)
+                extract_text_content(p.get("content")?)
             } else {
                 None
             }
@@ -3142,6 +3142,23 @@ async fn generate_session_title(
     }
 
     Ok(())
+}
+
+/// Extract text from a tape entry's `content` field, handling both plain
+/// strings and multimodal content-block arrays
+/// (`[{"type":"text","text":"…"}]`).
+fn extract_text_content(value: &serde_json::Value) -> Option<String> {
+    match value {
+        serde_json::Value::String(s) => Some(s.clone()),
+        serde_json::Value::Array(blocks) => blocks.iter().find_map(|b| {
+            if b.get("type")?.as_str()? == "text" {
+                b.get("text")?.as_str().map(String::from)
+            } else {
+                None
+            }
+        }),
+        _ => None,
+    }
 }
 
 /// Acquire a permit from the parent session's `child_semaphore` to enforce


### PR DESCRIPTION
## Summary

Fix sessions showing "Untitled" when switching via Telegram. Two root causes:

- `generate_session_title()` used `as_str()` on tape content — silently fails for multimodal messages (image+text) where content is a JSON array. Added `extract_text_content()` to handle both string and array formats.
- Telegram detail/switch/status callbacks lacked preview fallback. Now uses title → preview → "Untitled" degradation, matching the existing `session_display_name()` logic.

## Type of change

| Type | Label |
|------|-------|
| Bug fix | `bug` |

## Component

`core`

## Closes

Closes #1433

## Test plan

- [x] `cargo check` passes
- [x] `cargo clippy` passes
- [x] `cargo fmt` passes
- [x] `cargo doc` passes