### PR TITLE
fix(kimi-oauth): clear frequency_penalty for Kimi code models (#1442)

### DIFF
--- a/crates/kernel/src/llm/kimi.rs
+++ b/crates/kernel/src/llm/kimi.rs
@@ -44,10 +44,14 @@ impl KimiCodeDriver {
 }
 
 /// Filter empty assistant messages that Kimi rejects with 400.
+/// Sanitize a request for Kimi API compatibility:
+/// - Remove empty assistant messages (400 on Kimi)
+/// - Clear frequency_penalty (only 0 allowed on code models)
 fn sanitize_request(mut request: CompletionRequest) -> CompletionRequest {
     request.messages.retain(|m| {
         !(m.role == Role::Assistant && m.tool_calls.is_empty() && m.content.as_text().is_empty())
     });
+    request.frequency_penalty = None;
     request
 }
 


### PR DESCRIPTION
## Summary

Kimi code models (K2.6-code-preview) only accept `frequency_penalty: 0`. Clear it in `sanitize_request` to avoid 400 Bad Request.

## Type of change

| Type | Label |
|------|-------|
| Bug fix | `bug` |

## Component

`core`

## Closes

Closes #1442

## Test plan

- [x] `cargo check` passes
- [x] All pre-commit hooks pass
- [ ] Manual test: send message to K2.6-code-preview