### PR TITLE
fix(kernel): persist reasoning_content in Message for thinking mode (#1445)

### DIFF
--- a/crates/kernel/src/agent/mod.rs
+++ b/crates/kernel/src/agent/mod.rs
@@ -1774,10 +1774,17 @@ pub(crate) async fn run_agent_loop(
                 let _ = tape
                     .append_message(
                         tape_name,
-                        serde_json::json!({
-                            "role": "assistant",
-                            "content": &accumulated_text,
-                        }),
+                        {
+                            let mut payload = serde_json::json!({
+                                "role": "assistant",
+                                "content": &accumulated_text,
+                            });
+                            if !accumulated_reasoning.is_empty() {
+                                payload["reasoning_content"] =
+                                    serde_json::json!(&accumulated_reasoning);
+                            }
+                            payload
+                        },
                         None,
                     )
                     .await;
@@ -1853,10 +1860,17 @@ pub(crate) async fn run_agent_loop(
                 let _ = tape
                     .append_message(
                         tape_name,
-                        serde_json::json!({
-                            "role": "assistant",
-                            "content": &accumulated_text,
-                        }),
+                        {
+                            let mut payload = serde_json::json!({
+                                "role": "assistant",
+                                "content": &accumulated_text,
+                            });
+                            if !accumulated_reasoning.is_empty() {
+                                payload["reasoning_content"] =
+                                    serde_json::json!(&accumulated_reasoning);
+                            }
+                            payload
+                        },
                         meta,
                     )
                     .await;
@@ -1898,10 +1912,17 @@ pub(crate) async fn run_agent_loop(
             let _ = tape
                 .append_message(
                     tape_name,
-                    serde_json::json!({
-                        "role": "assistant",
-                        "content": &accumulated_text,
-                    }),
+                    {
+                        let mut payload = serde_json::json!({
+                            "role": "assistant",
+                            "content": &accumulated_text,
+                        });
+                        if !accumulated_reasoning.is_empty() {
+                            payload["reasoning_content"] =
+                                serde_json::json!(&accumulated_reasoning);
+                        }
+                        payload
+                    },
                     meta.clone(),
                 )
                 .await;
@@ -2101,10 +2122,17 @@ pub(crate) async fn run_agent_loop(
             let _ = tape
                 .append_message(
                     tape_name,
-                    serde_json::json!({
-                        "role": "assistant",
-                        "content": &accumulated_text,
-                    }),
+                    {
+                        let mut payload = serde_json::json!({
+                            "role": "assistant",
+                            "content": &accumulated_text,
+                        });
+                        if !accumulated_reasoning.is_empty() {
+                            payload["reasoning_content"] =
+                                serde_json::json!(&accumulated_reasoning);
+                        }
+                        payload
+                    },
                     serde_json::to_value(&meta).ok(),
                 )
                 .await;
@@ -2139,13 +2167,24 @@ pub(crate) async fn run_agent_loop(
                 iteration,
                 stream_ms,
                 first_token_ms,
-                reasoning_content: None,
+                reasoning_content: if accumulated_reasoning.is_empty() {
+                    None
+                } else {
+                    Some(accumulated_reasoning.clone())
+                },
             })
             .ok();
             let _ = tape
                 .append_tool_call(
                     tape_name,
-                    serde_json::json!({ "calls": calls_json }),
+                    {
+                        let mut payload = serde_json::json!({ "calls": calls_json });
+                        if !accumulated_reasoning.is_empty() {
+                            payload["reasoning_content"] =
+                                serde_json::json!(&accumulated_reasoning);
+                        }
+                        payload
+                    },
                     tool_call_meta,
                 )
                 .await;

--- a/crates/kernel/src/llm/openai.rs
+++ b/crates/kernel/src/llm/openai.rs
@@ -1892,14 +1892,16 @@ struct WireImageUrl<'a> {
 
 #[derive(Serialize)]
 struct WireMessage<'a> {
-    role:         &'static str,
+    role:              &'static str,
     /// Per OpenAI spec, assistant messages with tool_calls may have `content:
     /// null`.
-    content:      Option<WireContent<'a>>,
+    content:           Option<WireContent<'a>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    tool_calls:   Option<Vec<WireToolCallRef<'a>>>,
+    tool_calls:        Option<Vec<WireToolCallRef<'a>>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    tool_call_id: Option<&'a str>,
+    tool_call_id:      Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    reasoning_content: Option<&'a str>,
 }
 
 #[derive(Serialize)]
@@ -2078,6 +2080,7 @@ impl<'a> WireMessage<'a> {
             content,
             tool_calls,
             tool_call_id: msg.tool_call_id.as_deref(),
+            reasoning_content: msg.reasoning_content.as_deref(),
         }
     }
 }

--- a/crates/kernel/src/llm/types.rs
+++ b/crates/kernel/src/llm/types.rs
@@ -115,48 +115,56 @@ pub struct ToolCallRequest {
 /// A single message in a conversation.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Message {
-    pub role:         Role,
-    pub content:      MessageContent,
+    pub role:              Role,
+    pub content:           MessageContent,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub tool_calls:   Vec<ToolCallRequest>,
+    pub tool_calls:        Vec<ToolCallRequest>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub tool_call_id: Option<String>,
+    pub tool_call_id:      Option<String>,
+    /// Reasoning/thinking content from the LLM (e.g. Kimi, DeepSeek).
+    /// Persisted so it can be sent back on subsequent turns.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reasoning_content: Option<String>,
 }
 
 impl Message {
     pub fn system(text: impl Into<String>) -> Self {
         Self {
-            role:         Role::System,
-            content:      MessageContent::Text(text.into()),
-            tool_calls:   Vec::new(),
-            tool_call_id: None,
+            role:              Role::System,
+            content:           MessageContent::Text(text.into()),
+            tool_calls:        Vec::new(),
+            tool_call_id:      None,
+            reasoning_content: None,
         }
     }
 
     pub fn user(text: impl Into<String>) -> Self {
         Self {
-            role:         Role::User,
-            content:      MessageContent::Text(text.into()),
-            tool_calls:   Vec::new(),
-            tool_call_id: None,
+            role:              Role::User,
+            content:           MessageContent::Text(text.into()),
+            tool_calls:        Vec::new(),
+            tool_call_id:      None,
+            reasoning_content: None,
         }
     }
 
     pub fn user_multimodal(blocks: Vec<ContentBlock>) -> Self {
         Self {
-            role:         Role::User,
-            content:      MessageContent::Multimodal(blocks),
-            tool_calls:   Vec::new(),
-            tool_call_id: None,
+            role:              Role::User,
+            content:           MessageContent::Multimodal(blocks),
+            tool_calls:        Vec::new(),
+            tool_call_id:      None,
+            reasoning_content: None,
         }
     }
 
     pub fn assistant(text: impl Into<String>) -> Self {
         Self {
-            role:         Role::Assistant,
-            content:      MessageContent::Text(text.into()),
-            tool_calls:   Vec::new(),
-            tool_call_id: None,
+            role:              Role::Assistant,
+            content:           MessageContent::Text(text.into()),
+            tool_calls:        Vec::new(),
+            tool_call_id:      None,
+            reasoning_content: None,
         }
     }
 
@@ -169,15 +177,32 @@ impl Message {
             content: MessageContent::Text(text.into()),
             tool_calls,
             tool_call_id: None,
+            reasoning_content: None,
+        }
+    }
+
+    /// Create an assistant message with tool calls and optional reasoning.
+    pub fn assistant_with_tool_calls_and_reasoning(
+        text: impl Into<String>,
+        tool_calls: Vec<ToolCallRequest>,
+        reasoning: Option<String>,
+    ) -> Self {
+        Self {
+            role: Role::Assistant,
+            content: MessageContent::Text(text.into()),
+            tool_calls,
+            tool_call_id: None,
+            reasoning_content: reasoning,
         }
     }
 
     pub fn tool_result(tool_call_id: impl Into<String>, content: impl Into<String>) -> Self {
         Self {
-            role:         Role::Tool,
-            content:      MessageContent::Text(content.into()),
-            tool_calls:   Vec::new(),
-            tool_call_id: Some(tool_call_id.into()),
+            role:              Role::Tool,
+            content:           MessageContent::Text(content.into()),
+            tool_calls:        Vec::new(),
+            tool_call_id:      Some(tool_call_id.into()),
+            reasoning_content: None,
         }
     }
 
@@ -186,10 +211,11 @@ impl Message {
         blocks: Vec<ContentBlock>,
     ) -> Self {
         Self {
-            role:         Role::Tool,
-            content:      MessageContent::Multimodal(blocks),
-            tool_calls:   Vec::new(),
-            tool_call_id: Some(tool_call_id.into()),
+            role:              Role::Tool,
+            content:           MessageContent::Multimodal(blocks),
+            tool_calls:        Vec::new(),
+            tool_call_id:      Some(tool_call_id.into()),
+            reasoning_content: None,
         }
     }
 
@@ -590,8 +616,8 @@ mod tests {
     #[test]
     fn strip_images_replaces_image_blocks_with_notice() {
         let msg = Message {
-            role:         Role::User,
-            content:      MessageContent::Multimodal(vec![
+            role:              Role::User,
+            content:           MessageContent::Multimodal(vec![
                 ContentBlock::Text {
                     text: "look at this".into(),
                 },
@@ -600,8 +626,9 @@ mod tests {
                     data:       "AAAA".into(),
                 },
             ]),
-            tool_calls:   vec![],
-            tool_call_id: None,
+            tool_calls:        vec![],
+            tool_call_id:      None,
+            reasoning_content: None,
         };
         let stripped = msg.strip_images();
         match &stripped.content {

--- a/crates/kernel/src/memory/context.rs
+++ b/crates/kernel/src/memory/context.rs
@@ -119,7 +119,14 @@ fn append_tool_call_entry(messages: &mut Vec<Message>, entry: &TapEntry) -> Vec<
     }
 
     if !tool_calls.is_empty() {
-        messages.push(Message::assistant_with_tool_calls("", tool_calls));
+        let reasoning = entry
+            .payload
+            .get("reasoning_content")
+            .and_then(Value::as_str)
+            .map(String::from);
+        messages.push(Message::assistant_with_tool_calls_and_reasoning(
+            "", tool_calls, reasoning,
+        ));
     }
 
     pending


### PR DESCRIPTION
## Summary

Kimi API requires `reasoning_content` in assistant messages when thinking mode is enabled. rara was receiving reasoning_content from LLM responses but discarding it — the `Message` struct had no field for it. On subsequent turns, assistant messages (especially tool_call messages) were sent without reasoning_content, causing Kimi to reject with 400.

Changes:
- `Message` struct gains `reasoning_content: Option<String>` (serde-compatible)
- `WireMessage` serializes it in outbound HTTP requests
- Agent loop stores reasoning in tape entry payloads (both text and tool_call entries)
- Context rebuilder extracts reasoning from tape entries when reconstructing messages

## Type of change

| Type | Label |
|------|-------|
| Bug fix | `bug` |

## Component

`core`

## Closes

Closes #1445

## Test plan

- [x] `cargo check --all --all-targets` passes
- [x] `cargo clippy` passes
- [x] `cargo doc` passes
- [x] 448 unit tests pass
- [x] 10 e2e_scripted tests pass
- [ ] Manual test: multi-turn conversation with Kimi K2.6-code-preview thinking mode