### PR TITLE
fix(kernel): emit reasoning_content only for providers that require it (#1451)

### DIFF
--- a/crates/kernel/src/agent/fold.rs
+++ b/crates/kernel/src/agent/fold.rs
@@ -110,6 +110,7 @@ impl ContextFolder {
             parallel_tool_calls: false,
             frequency_penalty:   None,
             top_p:               None,
+            emit_reasoning:      false,
         };
 
         let response = self.driver.complete(request).await?;
@@ -142,6 +143,7 @@ impl ContextFolder {
             parallel_tool_calls: false,
             frequency_penalty:   None,
             top_p:               None,
+            emit_reasoning:      false,
         };
 
         let response = self.driver.complete(request).await?;

--- a/crates/kernel/src/agent/mod.rs
+++ b/crates/kernel/src/agent/mod.rs
@@ -1364,6 +1364,7 @@ pub(crate) async fn run_agent_loop(
             // degrading output quality. See #317.
             frequency_penalty:   Some(0.3),
             top_p:               None,
+            emit_reasoning:      false,
         };
 
         // Start streaming via LlmDriver

--- a/crates/kernel/src/kernel.rs
+++ b/crates/kernel/src/kernel.rs
@@ -3098,6 +3098,7 @@ async fn generate_session_title(
         parallel_tool_calls: false,
         frequency_penalty: None,
         top_p: None,
+        emit_reasoning: false,
     };
 
     let response = driver.complete(request).await?;

--- a/crates/kernel/src/llm/codex.rs
+++ b/crates/kernel/src/llm/codex.rs
@@ -106,6 +106,7 @@ mod tests {
             parallel_tool_calls: false,
             frequency_penalty:   None,
             top_p:               None,
+            emit_reasoning:      false,
         };
 
         let body = build_responses_request(&request, ApiFormat::Responses);
@@ -135,6 +136,7 @@ mod tests {
             parallel_tool_calls: false,
             frequency_penalty:   None,
             top_p:               None,
+            emit_reasoning:      false,
         };
 
         let body = build_responses_request(&request, ApiFormat::Responses);
@@ -159,6 +161,7 @@ mod tests {
             parallel_tool_calls: false,
             frequency_penalty:   None,
             top_p:               None,
+            emit_reasoning:      false,
         };
 
         let body = build_responses_request(&request, ApiFormat::Responses);
@@ -185,6 +188,7 @@ mod tests {
             parallel_tool_calls: true,
             frequency_penalty:   None,
             top_p:               None,
+            emit_reasoning:      false,
         };
 
         let body = build_responses_request(&request, ApiFormat::Responses);
@@ -209,6 +213,7 @@ mod tests {
             parallel_tool_calls: false,
             frequency_penalty:   None,
             top_p:               None,
+            emit_reasoning:      false,
         };
 
         let body = build_responses_request(&request, ApiFormat::Responses);
@@ -238,6 +243,7 @@ mod tests {
             parallel_tool_calls: false,
             frequency_penalty:   None,
             top_p:               None,
+            emit_reasoning:      false,
         };
 
         let body = build_responses_request(&request, ApiFormat::Responses);

--- a/crates/kernel/src/llm/kimi.rs
+++ b/crates/kernel/src/llm/kimi.rs
@@ -47,11 +47,13 @@ impl KimiCodeDriver {
 /// Sanitize a request for Kimi API compatibility:
 /// - Remove empty assistant messages (400 on Kimi)
 /// - Clear frequency_penalty (only 0 allowed on code models)
+/// - Enable reasoning_content round-trip (required by Kimi thinking mode)
 fn sanitize_request(mut request: CompletionRequest) -> CompletionRequest {
     request.messages.retain(|m| {
         !(m.role == Role::Assistant && m.tool_calls.is_empty() && m.content.as_text().is_empty())
     });
     request.frequency_penalty = None;
+    request.emit_reasoning = true;
     request
 }
 

--- a/crates/kernel/src/llm/openai.rs
+++ b/crates/kernel/src/llm/openai.rs
@@ -1921,15 +1921,10 @@ impl<'a> ChatRequest<'a> {
     fn from_completion(request: &'a CompletionRequest, stream: bool) -> Self {
         let provider = detect_provider_family(None, &request.model);
 
-        // Kimi requires reasoning_content on assistant messages when thinking
-        // mode is active.  Most other providers ignore or reject it, so only
-        // emit for models known to need it.
-        let emit_reasoning = request.model.starts_with("kimi-");
-
         let messages: Vec<WireMessage<'a>> = request
             .messages
             .iter()
-            .map(|m| WireMessage::from_message(m, emit_reasoning))
+            .map(|m| WireMessage::from_message(m, request.emit_reasoning))
             .collect();
 
         let (tools, tool_choice, parallel_tool_calls) = if request.tools.is_empty() {
@@ -2294,6 +2289,7 @@ mod tests {
             parallel_tool_calls: false,
             frequency_penalty:   None,
             top_p:               None,
+            emit_reasoning:      false,
         };
 
         let body = build_responses_request(&request, ApiFormat::Responses);
@@ -2323,6 +2319,7 @@ mod tests {
             parallel_tool_calls: false,
             frequency_penalty:   None,
             top_p:               None,
+            emit_reasoning:      false,
         };
 
         let body = build_responses_request(&request, ApiFormat::Responses);
@@ -2347,6 +2344,7 @@ mod tests {
             parallel_tool_calls: false,
             frequency_penalty:   None,
             top_p:               None,
+            emit_reasoning:      false,
         };
 
         let body = build_responses_request(&request, ApiFormat::Responses);
@@ -2373,6 +2371,7 @@ mod tests {
             parallel_tool_calls: true,
             frequency_penalty:   None,
             top_p:               None,
+            emit_reasoning:      false,
         };
 
         let body = build_responses_request(&request, ApiFormat::Responses);
@@ -2397,6 +2396,7 @@ mod tests {
             parallel_tool_calls: false,
             frequency_penalty:   None,
             top_p:               None,
+            emit_reasoning:      false,
         };
 
         let body = build_responses_request(&request, ApiFormat::Responses);
@@ -2426,6 +2426,7 @@ mod tests {
             parallel_tool_calls: false,
             frequency_penalty:   None,
             top_p:               None,
+            emit_reasoning:      false,
         };
 
         let body = build_responses_request(&request, ApiFormat::Responses);

--- a/crates/kernel/src/llm/scripted.rs
+++ b/crates/kernel/src/llm/scripted.rs
@@ -194,6 +194,7 @@ mod tests {
             parallel_tool_calls: false,
             frequency_penalty:   None,
             top_p:               None,
+            emit_reasoning:      false,
         };
 
         let r1 = driver.complete(request.clone()).await.unwrap();
@@ -220,6 +221,7 @@ mod tests {
             parallel_tool_calls: false,
             frequency_penalty:   None,
             top_p:               None,
+            emit_reasoning:      false,
         };
         let result = driver.complete(request).await;
         assert!(result.is_err(), "should return error when exhausted");
@@ -241,6 +243,7 @@ mod tests {
             parallel_tool_calls: false,
             frequency_penalty:   None,
             top_p:               None,
+            emit_reasoning:      false,
         };
 
         let response = driver.stream(request, tx).await.unwrap();

--- a/crates/kernel/src/llm/types.rs
+++ b/crates/kernel/src/llm/types.rs
@@ -342,6 +342,10 @@ pub struct CompletionRequest {
     /// Nucleus sampling threshold. GLM defaults to 0.95; pass through for all
     /// providers.
     pub top_p:               Option<f32>,
+    /// Whether to include `reasoning_content` on assistant messages in the
+    /// outbound wire format.  Only providers that require thinking round-trip
+    /// (e.g. Kimi) should set this to `true`.
+    pub emit_reasoning:      bool,
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/kernel/src/memory/knowledge/extractor.rs
+++ b/crates/kernel/src/memory/knowledge/extractor.rs
@@ -225,6 +225,7 @@ Output ONLY the JSON array, no markdown fences or explanation."#;
         parallel_tool_calls: false,
         frequency_penalty:   None,
         top_p:               None,
+        emit_reasoning:      false,
     };
 
     let response = driver.complete(request).await.context(LlmSnafu)?;
@@ -297,6 +298,7 @@ async fn update_category_files(
             parallel_tool_calls: false,
             frequency_penalty:   None,
             top_p:               None,
+            emit_reasoning:      false,
         };
 
         let response = driver.complete(request).await.context(LlmSnafu)?;

--- a/crates/kernel/src/plan.rs
+++ b/crates/kernel/src/plan.rs
@@ -777,6 +777,7 @@ async fn create_plan_via_llm(
         parallel_tool_calls: false,
         frequency_penalty: None,
         top_p: None,
+        emit_reasoning: false,
     };
 
     info!(session_key = %session_key, "plan executor: calling LLM for plan creation");
@@ -920,6 +921,7 @@ async fn replan_via_llm(
         parallel_tool_calls: false,
         frequency_penalty: None,
         top_p: None,
+        emit_reasoning: false,
     };
 
     info!(session_key = %session_key, "plan executor: calling LLM for replan");

--- a/crates/kernel/src/proactive.rs
+++ b/crates/kernel/src/proactive.rs
@@ -133,6 +133,7 @@ pub async fn should_reply(
         parallel_tool_calls: false,
         frequency_penalty:   None,
         top_p:               None,
+        emit_reasoning:      false,
     };
 
     let response = match driver.complete(request).await {


### PR DESCRIPTION
## Summary

Follow-up to #1452. Adds `emit_reasoning: bool` flag to `CompletionRequest` so only providers that need reasoning round-trip (Kimi) emit `reasoning_content` in outbound wire format. Other providers default to `false`.

- `CompletionRequest` gains `emit_reasoning: bool` (default `false`)
- `KimiCodeDriver::sanitize_request` sets `emit_reasoning = true`
- `WireMessage::from_message` respects the flag
- Removes model-name-based detection (`starts_with("kimi-")`) which missed `K2.6-code-preview`
- Deletes unused `assistant_with_reasoning()` constructor

## Type of change

| Type | Label |
|------|-------|
| Bug fix | `bug` |

## Component

`core`

## Closes

Closes #1451

## Test plan

- [x] `cargo check --all --all-targets` passes
- [x] `cargo clippy` passes  
- [x] 10/10 e2e tests pass
- [ ] Manual test: Kimi K2.6-code-preview multi-turn with thinking