### PR TITLE
feat(channels): Telegram reply keyboard with session status + forum topic lifecycle (#1454)

### DIFF
--- a/crates/channels/src/telegram/adapter.rs
+++ b/crates/channels/src/telegram/adapter.rs
@@ -2951,6 +2951,73 @@ async fn handle_update(
         }
     }
 
+    // ── Reply Keyboard button interception ──
+    // When the user taps a Reply Keyboard button, Telegram sends the
+    // button label as a plain text message. Intercept these before they
+    // reach the kernel so they don't get ingested as conversation turns.
+    if let Some(text) = msg.text() {
+        if super::reply_keyboard::is_new_session_button(text) {
+            // Create a fresh session and bind this chat to it, mirroring
+            // the `/new` command logic.
+            let now = chrono::Utc::now();
+            let new_key = rara_kernel::session::SessionKey::new();
+            let entry = rara_kernel::session::SessionEntry {
+                key:           new_key,
+                title:         None,
+                model:         None,
+                system_prompt: None,
+                message_count: 0,
+                preview:       None,
+                metadata:      None,
+                created_at:    now,
+                updated_at:    now,
+            };
+            let session_index = handle.session_index();
+            match session_index.create_session(&entry).await {
+                Ok(_) => {
+                    let thread_str = tg_thread_id.map(|t| t.to_string());
+                    let binding = rara_kernel::session::ChannelBinding {
+                        channel_type: ChannelType::Telegram,
+                        chat_id:      chat_id.to_string(),
+                        thread_id:    thread_str,
+                        session_key:  new_key,
+                        created_at:   now,
+                        updated_at:   now,
+                    };
+                    let _ = session_index.bind_channel(&binding).await;
+                    // Send confirmation with a fresh Reply Keyboard (reset
+                    // token counters to zero for the new session).
+                    let kb = super::reply_keyboard::build_main_keyboard(0, None, "");
+                    let req = with_thread_id!(
+                        bot.send_message(ChatId(chat_id), "\u{1f195} New session started.")
+                            .reply_markup(kb),
+                        tg_thread_id
+                    );
+                    let _ = req.await;
+                }
+                Err(e) => {
+                    warn!(error = %e, "reply keyboard: failed to create new session");
+                    let req = with_thread_id!(
+                        bot.send_message(
+                            ChatId(chat_id),
+                            format!("Failed to create session: {e}"),
+                        ),
+                        tg_thread_id
+                    );
+                    let _ = req.await;
+                }
+            }
+            return;
+        }
+        // Context and model buttons are informational — tapping them
+        // sends their label text but there is nothing to act on.
+        if super::reply_keyboard::is_context_button(text)
+            || super::reply_keyboard::is_model_button(text)
+        {
+            return;
+        }
+    }
+
     // Convert to RawPlatformMessage.
     let username_guard = bot_username.read().await;
     let username_ref = username_guard.as_deref().unwrap_or("");
@@ -3867,9 +3934,20 @@ fn spawn_stream_forwarder(
                                 let mid = if let Some(mid) = progress.message_id {
                                     mid
                                 } else {
+                                    // Attach Reply Keyboard with updated session
+                                    // status (tokens, model). The keyboard is
+                                    // persistent — Telegram keeps it visible until
+                                    // a new ReplyMarkup replaces it.
+                                    let ctx_limit = super::pinned_status::context_window_for_model(&trace.model);
+                                    let reply_kb = super::reply_keyboard::build_main_keyboard(
+                                        trace.input_tokens,
+                                        ctx_limit,
+                                        &trace.model,
+                                    );
                                     let req = with_thread_id!(bot
                                         .send_message(ChatId(chat_id), &compact)
-                                        .parse_mode(ParseMode::Html), thread_id);
+                                        .parse_mode(ParseMode::Html)
+                                        .reply_markup(reply_kb), thread_id);
                                     match req.await
                                     {
                                         Ok(msg) => msg.id,

--- a/crates/channels/src/telegram/adapter.rs
+++ b/crates/channels/src/telegram/adapter.rs
@@ -2956,64 +2956,87 @@ async fn handle_update(
     // button label as a plain text message. Intercept these before they
     // reach the kernel so they don't get ingested as conversation turns.
     if let Some(text) = msg.text() {
+        // "🆕 New Session" — delegate to the registered `/new` command
+        // handler so this path stays aligned with `/new`: same session
+        // defaults, same guard/kernel hooks, same error surface. Avoids
+        // having two divergent session-creation code paths.
         if super::reply_keyboard::is_new_session_button(text) {
-            // Create a fresh session and bind this chat to it, mirroring
-            // the `/new` command logic.
-            let now = chrono::Utc::now();
-            let new_key = rara_kernel::session::SessionKey::new();
-            let entry = rara_kernel::session::SessionEntry {
-                key:           new_key,
-                title:         None,
-                model:         None,
-                system_prompt: None,
-                message_count: 0,
-                preview:       None,
-                metadata:      None,
-                created_at:    now,
-                updated_at:    now,
-            };
-            let session_index = handle.session_index();
-            match session_index.create_session(&entry).await {
-                Ok(_) => {
-                    let thread_str = tg_thread_id.map(|t| t.to_string());
-                    let binding = rara_kernel::session::ChannelBinding {
-                        channel_type: ChannelType::Telegram,
-                        chat_id:      chat_id.to_string(),
-                        thread_id:    thread_str,
-                        session_key:  new_key,
-                        created_at:   now,
-                        updated_at:   now,
-                    };
-                    let _ = session_index.bind_channel(&binding).await;
-                    // Send confirmation with a fresh Reply Keyboard (reset
-                    // token counters to zero for the new session).
-                    let kb = super::reply_keyboard::build_main_keyboard(0, None, "");
-                    let req = with_thread_id!(
-                        bot.send_message(ChatId(chat_id), "\u{1f195} New session started.")
-                            .reply_markup(kb),
-                        tg_thread_id
+            let matched = command_handlers
+                .iter()
+                .find(|h| h.commands().iter().any(|def| def.name == "new"));
+            if let Some(handler) = matched {
+                let user_id = msg
+                    .from
+                    .as_ref()
+                    .map(|u| u.id.0.to_string())
+                    .unwrap_or_default();
+                let display_name = msg
+                    .from
+                    .as_ref()
+                    .and_then(|u| u.username.clone().or_else(|| Some(u.first_name.clone())));
+                let mut metadata = HashMap::new();
+                metadata.insert(
+                    "telegram_chat_id".to_owned(),
+                    serde_json::Value::Number(chat_id.into()),
+                );
+                if let Some(tid) = tg_thread_id {
+                    metadata.insert(
+                        "telegram_thread_id".to_owned(),
+                        serde_json::Value::Number(tid.into()),
                     );
-                    let _ = req.await;
                 }
-                Err(e) => {
-                    warn!(error = %e, "reply keyboard: failed to create new session");
-                    let req = with_thread_id!(
-                        bot.send_message(
-                            ChatId(chat_id),
-                            format!("Failed to create session: {e}"),
-                        ),
-                        tg_thread_id
-                    );
-                    let _ = req.await;
+                let info = CommandInfo {
+                    name: "new".to_owned(),
+                    args: String::new(),
+                    raw:  "/new".to_owned(),
+                };
+                let ctx = CommandContext {
+                    channel_type: ChannelType::Telegram,
+                    session_key: String::new(),
+                    user: ChannelUser {
+                        platform_id: user_id,
+                        display_name,
+                    },
+                    metadata,
+                };
+                match handler.handle(&info, &ctx).await {
+                    Ok(result) => {
+                        dispatch_command_result(bot, chat_id, tg_thread_id, result).await;
+                    }
+                    Err(e) => {
+                        warn!(error = %e, "reply keyboard: `/new` handler failed");
+                        let req = with_thread_id!(
+                            bot.send_message(
+                                ChatId(chat_id),
+                                format!("Failed to create session: {e}"),
+                            ),
+                            tg_thread_id
+                        );
+                        let _ = req.await;
+                    }
                 }
+            } else {
+                warn!("reply keyboard: no `/new` handler registered");
             }
             return;
         }
-        // Context and model buttons are informational — tapping them
-        // sends their label text but there is nothing to act on.
-        if super::reply_keyboard::is_context_button(text)
-            || super::reply_keyboard::is_model_button(text)
-        {
+        // Context / model buttons are informational. Echo the current
+        // value so the tap feels responsive instead of being silently
+        // swallowed (which can look like the bot hung).
+        if super::reply_keyboard::is_context_button(text) {
+            let req = with_thread_id!(
+                bot.send_message(ChatId(chat_id), format!("Context usage: {text}")),
+                tg_thread_id
+            );
+            let _ = req.await;
+            return;
+        }
+        if super::reply_keyboard::is_model_button(text) {
+            let req = with_thread_id!(
+                bot.send_message(ChatId(chat_id), format!("Active model: {text}")),
+                tg_thread_id
+            );
+            let _ = req.await;
             return;
         }
     }
@@ -3206,6 +3229,27 @@ async fn handle_update(
                             };
                             if let Err(e) = handle.session_index().bind_channel(&binding).await {
                                 warn!(error = %e, "failed to update channel binding for new forum topic");
+                            }
+
+                            // Also refresh the session's stored origin endpoint
+                            // so that reply routing for synthetic re-entry
+                            // messages (background task completions, Mita
+                            // directives) targets the new topic instead of
+                            // General — the first user message was ingested
+                            // before the topic existed, so the endpoint stored
+                            // at session creation has `thread_id = None`.
+                            let topic_endpoint = rara_kernel::io::Endpoint {
+                                channel_type: ChannelType::Telegram,
+                                address:      rara_kernel::io::EndpointAddress::Telegram {
+                                    chat_id,
+                                    thread_id: Some(new_tid),
+                                },
+                            };
+                            if !handle.update_session_origin_endpoint(sid, topic_endpoint) {
+                                warn!(
+                                    session_key = %sid,
+                                    "auto-create topic: session not found in process table when updating origin endpoint"
+                                );
                             }
                         }
 

--- a/crates/channels/src/telegram/mod.rs
+++ b/crates/channels/src/telegram/mod.rs
@@ -21,6 +21,7 @@ pub mod latex;
 pub mod loading_hints;
 pub mod markdown;
 pub mod pinned_status;
+pub mod reply_keyboard;
 pub mod spinner_verbs;
 
 pub use adapter::{TelegramAdapter, TelegramConfig, build_bot, telegram_to_raw_platform_message};

--- a/crates/channels/src/telegram/pinned_status.rs
+++ b/crates/channels/src/telegram/pinned_status.rs
@@ -74,6 +74,14 @@ fn lookup_model_info(model: &str) -> Option<ModelInfo> {
     None
 }
 
+/// Look up the context window size (in tokens) for a known model.
+///
+/// Thin wrapper around [`lookup_model_info`] exposed to sibling modules
+/// so that [`super::reply_keyboard`] can compute the context usage gauge.
+pub(super) fn context_window_for_model(model: &str) -> Option<u32> {
+    lookup_model_info(model).map(|info| info.context_window)
+}
+
 // ---------------------------------------------------------------------------
 // Session card
 // ---------------------------------------------------------------------------

--- a/crates/channels/src/telegram/reply_keyboard.rs
+++ b/crates/channels/src/telegram/reply_keyboard.rs
@@ -1,0 +1,170 @@
+// Copyright 2025 Rararulab
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Reply Keyboard for Telegram — persistent buttons below the input field.
+//!
+//! Provides a two-row keyboard layout:
+//! - Row 1: context usage gauge + active model name
+//! - Row 2: "New Session" quick action
+//!
+//! The keyboard is attached via [`build_main_keyboard`] and remains visible
+//! (sticky) until replaced by another `ReplyMarkup`.  Button presses arrive
+//! as regular text messages; the `is_*_button` helpers detect them so the
+//! adapter can intercept before ingesting.
+
+use teloxide::types::{KeyboardButton, KeyboardMarkup};
+
+/// Build the main Reply Keyboard with session status buttons.
+///
+/// Layout:
+/// ```text
+/// [ 📊 context_usage ]  [ 🤖 model_name ]
+/// [ 🆕 New Session ]
+/// ```
+pub fn build_main_keyboard(
+    input_tokens: u32,
+    context_limit: Option<u32>,
+    model: &str,
+) -> KeyboardMarkup {
+    let context_text = format_context_button(input_tokens, context_limit);
+    let model_text = format_model_button(model);
+
+    KeyboardMarkup::new(vec![
+        vec![
+            KeyboardButton::new(context_text),
+            KeyboardButton::new(model_text),
+        ],
+        vec![KeyboardButton::new("\u{1f195} New Session")],
+    ])
+    .resize_keyboard()
+    .persistent()
+}
+
+// ── Formatting helpers ──────────────────────────────────────────────────
+
+fn format_context_button(input_tokens: u32, context_limit: Option<u32>) -> String {
+    let used = format_token_count(input_tokens);
+    match context_limit {
+        Some(limit) => {
+            let limit_str = format_token_count(limit);
+            let pct = if limit > 0 {
+                (f64::from(input_tokens) / f64::from(limit) * 100.0) as u32
+            } else {
+                0
+            };
+            format!("\u{1f4ca} {used}/{limit_str} ({pct}%)")
+        }
+        None => format!("\u{1f4ca} {used}"),
+    }
+}
+
+fn format_model_button(model: &str) -> String {
+    let display: String = model.chars().take(25).collect();
+    if display.is_empty() {
+        "\u{1f916} (no model)".to_string()
+    } else {
+        format!("\u{1f916} {display}")
+    }
+}
+
+/// Format a token count as a compact human-readable string.
+///
+/// Duplicated from `adapter::format_token_count` because that function is
+/// `pub(super)` and cannot be called from a sibling module.
+fn format_token_count(tokens: u32) -> String {
+    if tokens >= 1_000_000 {
+        format!("{:.1}M", f64::from(tokens) / 1_000_000.0)
+    } else if tokens >= 1_000 {
+        format!("{:.1}k", f64::from(tokens) / 1_000.0)
+    } else {
+        format!("{tokens}")
+    }
+}
+
+// ── Button press detection ──────────────────────────────────────────────
+
+/// Returns `true` if the message text matches a context-usage button press.
+pub fn is_context_button(text: &str) -> bool { text.starts_with("\u{1f4ca} ") }
+
+/// Returns `true` if the message text matches a model-name button press.
+pub fn is_model_button(text: &str) -> bool { text.starts_with("\u{1f916} ") }
+
+/// Returns `true` if the message text matches the "New Session" button press.
+pub fn is_new_session_button(text: &str) -> bool { text.contains("New Session") }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn keyboard_layout_has_two_rows() {
+        let kb = build_main_keyboard(1500, Some(200_000), "claude-sonnet-4");
+        assert_eq!(kb.keyboard.len(), 2);
+        assert_eq!(kb.keyboard[0].len(), 2);
+        assert_eq!(kb.keyboard[1].len(), 1);
+    }
+
+    #[test]
+    fn context_button_formatting() {
+        let kb = build_main_keyboard(0, Some(200_000), "claude-sonnet-4");
+        assert_eq!(kb.keyboard[0][0].text, "\u{1f4ca} 0/200.0k (0%)");
+
+        let kb = build_main_keyboard(150_000, Some(200_000), "claude-sonnet-4");
+        assert_eq!(kb.keyboard[0][0].text, "\u{1f4ca} 150.0k/200.0k (75%)");
+    }
+
+    #[test]
+    fn model_button_formatting() {
+        let kb = build_main_keyboard(0, None, "claude-sonnet-4");
+        assert_eq!(kb.keyboard[0][1].text, "\u{1f916} claude-sonnet-4");
+    }
+
+    #[test]
+    fn model_button_truncation() {
+        let long_model = "a]".repeat(20);
+        let kb = build_main_keyboard(0, None, &long_model);
+        // 25 chars max + emoji prefix
+        assert!(kb.keyboard[0][1].text.chars().count() <= 25 + 3);
+    }
+
+    #[test]
+    fn empty_model_shows_placeholder() {
+        let kb = build_main_keyboard(0, None, "");
+        assert_eq!(kb.keyboard[0][1].text, "\u{1f916} (no model)");
+    }
+
+    #[test]
+    fn button_detection() {
+        assert!(is_context_button("\u{1f4ca} 0/200.0k (0%)"));
+        assert!(is_model_button("\u{1f916} claude-sonnet-4"));
+        assert!(is_new_session_button("\u{1f195} New Session"));
+        // Negative cases
+        assert!(!is_context_button("hello"));
+        assert!(!is_model_button("hello"));
+        assert!(!is_new_session_button("hello"));
+    }
+
+    #[test]
+    fn keyboard_is_persistent_and_resized() {
+        let kb = build_main_keyboard(0, None, "test");
+        assert!(kb.is_persistent);
+        assert!(kb.resize_keyboard);
+    }
+
+    #[test]
+    fn no_context_limit() {
+        let kb = build_main_keyboard(5000, None, "test");
+        assert_eq!(kb.keyboard[0][0].text, "\u{1f4ca} 5.0k");
+    }
+}

--- a/crates/channels/src/telegram/reply_keyboard.rs
+++ b/crates/channels/src/telegram/reply_keyboard.rs
@@ -25,6 +25,18 @@
 
 use teloxide::types::{KeyboardButton, KeyboardMarkup};
 
+use super::adapter::format_token_count;
+
+/// Label emitted by the "New Session" Reply Keyboard button.
+///
+/// Exposed so the adapter can send it as-is and so detection logic can use
+/// exact-match comparison instead of substring search.
+pub const NEW_SESSION_BUTTON: &str = "\u{1f195} New Session";
+
+const CONTEXT_BUTTON_PREFIX: &str = "\u{1f4ca} ";
+const MODEL_BUTTON_PREFIX: &str = "\u{1f916} ";
+const MODEL_NAME_MAX_CHARS: usize = 25;
+
 /// Build the main Reply Keyboard with session status buttons.
 ///
 /// Layout:
@@ -45,7 +57,7 @@ pub fn build_main_keyboard(
             KeyboardButton::new(context_text),
             KeyboardButton::new(model_text),
         ],
-        vec![KeyboardButton::new("\u{1f195} New Session")],
+        vec![KeyboardButton::new(NEW_SESSION_BUTTON)],
     ])
     .resize_keyboard()
     .persistent()
@@ -58,50 +70,45 @@ fn format_context_button(input_tokens: u32, context_limit: Option<u32>) -> Strin
     match context_limit {
         Some(limit) => {
             let limit_str = format_token_count(limit);
+            // Clamp to 0..=100 so over-quota turns do not surface odd values
+            // like "(142%)" in the button label.
             let pct = if limit > 0 {
-                (f64::from(input_tokens) / f64::from(limit) * 100.0) as u32
+                ((f64::from(input_tokens) / f64::from(limit) * 100.0).round() as u32).min(100)
             } else {
                 0
             };
-            format!("\u{1f4ca} {used}/{limit_str} ({pct}%)")
+            format!("{CONTEXT_BUTTON_PREFIX}{used}/{limit_str} ({pct}%)")
         }
-        None => format!("\u{1f4ca} {used}"),
+        None => format!("{CONTEXT_BUTTON_PREFIX}{used}"),
     }
 }
 
+/// Truncate to [`MODEL_NAME_MAX_CHARS`] code points. Model identifiers in
+/// practice are ASCII (e.g. `claude-sonnet-4`, `openai/gpt-5-codex`), so
+/// `chars().take(...)` is safe — no grapheme-cluster concerns.
 fn format_model_button(model: &str) -> String {
-    let display: String = model.chars().take(25).collect();
+    let display: String = model.chars().take(MODEL_NAME_MAX_CHARS).collect();
     if display.is_empty() {
-        "\u{1f916} (no model)".to_string()
+        format!("{MODEL_BUTTON_PREFIX}(no model)")
     } else {
-        format!("\u{1f916} {display}")
-    }
-}
-
-/// Format a token count as a compact human-readable string.
-///
-/// Duplicated from `adapter::format_token_count` because that function is
-/// `pub(super)` and cannot be called from a sibling module.
-fn format_token_count(tokens: u32) -> String {
-    if tokens >= 1_000_000 {
-        format!("{:.1}M", f64::from(tokens) / 1_000_000.0)
-    } else if tokens >= 1_000 {
-        format!("{:.1}k", f64::from(tokens) / 1_000.0)
-    } else {
-        format!("{tokens}")
+        format!("{MODEL_BUTTON_PREFIX}{display}")
     }
 }
 
 // ── Button press detection ──────────────────────────────────────────────
 
 /// Returns `true` if the message text matches a context-usage button press.
-pub fn is_context_button(text: &str) -> bool { text.starts_with("\u{1f4ca} ") }
+pub fn is_context_button(text: &str) -> bool { text.starts_with(CONTEXT_BUTTON_PREFIX) }
 
 /// Returns `true` if the message text matches a model-name button press.
-pub fn is_model_button(text: &str) -> bool { text.starts_with("\u{1f916} ") }
+pub fn is_model_button(text: &str) -> bool { text.starts_with(MODEL_BUTTON_PREFIX) }
 
-/// Returns `true` if the message text matches the "New Session" button press.
-pub fn is_new_session_button(text: &str) -> bool { text.contains("New Session") }
+/// Returns `true` if the message text is exactly the "New Session" button.
+///
+/// Uses exact match (not `contains`) so free-form user messages that happen
+/// to contain the phrase "New Session" do not get intercepted as button
+/// presses and silently swallowed.
+pub fn is_new_session_button(text: &str) -> bool { text == NEW_SESSION_BUTTON }
 
 #[cfg(test)]
 mod tests {
@@ -125,6 +132,13 @@ mod tests {
     }
 
     #[test]
+    fn context_percent_clamped_to_100() {
+        // Over-quota should not produce (142%) or similar.
+        let kb = build_main_keyboard(300_000, Some(200_000), "m");
+        assert!(kb.keyboard[0][0].text.ends_with("(100%)"));
+    }
+
+    #[test]
     fn model_button_formatting() {
         let kb = build_main_keyboard(0, None, "claude-sonnet-4");
         assert_eq!(kb.keyboard[0][1].text, "\u{1f916} claude-sonnet-4");
@@ -134,8 +148,9 @@ mod tests {
     fn model_button_truncation() {
         let long_model = "a]".repeat(20);
         let kb = build_main_keyboard(0, None, &long_model);
-        // 25 chars max + emoji prefix
-        assert!(kb.keyboard[0][1].text.chars().count() <= 25 + 3);
+        // Content chars capped at MODEL_NAME_MAX_CHARS; the emoji + space
+        // prefix is 2 chars.
+        assert!(kb.keyboard[0][1].text.chars().count() <= MODEL_NAME_MAX_CHARS + 2);
     }
 
     #[test]
@@ -148,11 +163,23 @@ mod tests {
     fn button_detection() {
         assert!(is_context_button("\u{1f4ca} 0/200.0k (0%)"));
         assert!(is_model_button("\u{1f916} claude-sonnet-4"));
-        assert!(is_new_session_button("\u{1f195} New Session"));
+        assert!(is_new_session_button(NEW_SESSION_BUTTON));
         // Negative cases
         assert!(!is_context_button("hello"));
         assert!(!is_model_button("hello"));
         assert!(!is_new_session_button("hello"));
+    }
+
+    #[test]
+    fn new_session_button_is_exact_match() {
+        // Regression: free-form user text containing the phrase must not
+        // be misclassified as a button press.
+        assert!(!is_new_session_button(
+            "Can we start a New Session about X?"
+        ));
+        assert!(!is_new_session_button("New Session"));
+        assert!(!is_new_session_button("\u{1f195} New Session please"));
+        assert!(is_new_session_button(NEW_SESSION_BUTTON));
     }
 
     #[test]

--- a/crates/kernel/src/handle.rs
+++ b/crates/kernel/src/handle.rs
@@ -29,8 +29,8 @@ use crate::{
     event::{KernelEventEnvelope, Syscall},
     identity::Principal,
     io::{
-        AgentHandle, EndpointRegistryRef, IOError, IOSubsystem, InboundMessage, PipeReader,
-        PipeWriter, RawPlatformMessage, StreamHubRef,
+        AgentHandle, Endpoint, EndpointRegistryRef, IOError, IOSubsystem, InboundMessage,
+        PipeReader, PipeWriter, RawPlatformMessage, StreamHubRef,
     },
     kernel::{KernelConfig, SettingsRef},
     kv::KvScope,
@@ -333,6 +333,24 @@ impl KernelHandle {
             .map_err(|_| KernelError::Other {
                 message: "event queue full for shutdown".into(),
             })
+    }
+
+    /// Update the session's stored originating endpoint used as the reply
+    /// target fallback for synthetic re-entry messages (background tasks,
+    /// Mita directives, etc.).
+    ///
+    /// Channel adapters call this after learning a more specific endpoint for
+    /// an existing session. The Telegram adapter, for example, auto-creates
+    /// a forum topic when the first user message lands in the General chat;
+    /// it then calls this method so that subsequent replies route to the new
+    /// topic instead of General.
+    ///
+    /// Returns `true` when the session was found and updated, `false` when no
+    /// session with that key exists.
+    pub fn update_session_origin_endpoint(&self, key: &SessionKey, endpoint: Endpoint) -> bool {
+        self.process_table
+            .with_mut(key, |p| p.origin_endpoint = Some(endpoint))
+            .is_some()
     }
 
     // -- Read-only accessors ------------------------------------------------

--- a/crates/kernel/src/session/mod.rs
+++ b/crates/kernel/src/session/mod.rs
@@ -1111,4 +1111,54 @@ mod state_transition_tests {
         assert_eq!(err.from, SessionState::Active);
         assert_eq!(err.to, SessionState::Suspended);
     }
+
+    #[test]
+    fn session_table_updates_origin_endpoint_via_with_mut() {
+        use crate::{
+            channel::types::ChannelType,
+            io::{Endpoint, EndpointAddress},
+        };
+
+        let table = SessionTable::new();
+        let session = make_session(SessionState::Ready);
+        let key = session.session_key;
+        table.insert(session);
+
+        // Simulate the Telegram adapter auto-creating a forum topic and then
+        // updating the session's stored origin endpoint. This mirrors the call
+        // made by `KernelHandle::update_session_origin_endpoint`, which
+        // delegates to `SessionTable::with_mut`.
+        let updated = Endpoint {
+            channel_type: ChannelType::Telegram,
+            address:      EndpointAddress::Telegram {
+                chat_id:   42,
+                thread_id: Some(99),
+            },
+        };
+        let applied = table
+            .with_mut(&key, |p| p.origin_endpoint = Some(updated.clone()))
+            .is_some();
+        assert!(applied, "session must exist for update to succeed");
+
+        let stored = table
+            .with(&key, |p| p.origin_endpoint.clone())
+            .flatten()
+            .expect("origin endpoint must be stored");
+        match stored.address {
+            EndpointAddress::Telegram { chat_id, thread_id } => {
+                assert_eq!(chat_id, 42);
+                assert_eq!(thread_id, Some(99));
+            }
+            other => panic!("unexpected endpoint variant: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn session_table_update_origin_endpoint_missing_session() {
+        let table = SessionTable::new();
+        let missing = SessionKey::new();
+        // No session inserted → with_mut returns None, mirroring the handle
+        // method returning `false` for a not-found session.
+        assert!(table.with_mut(&missing, |_| ()).is_none());
+    }
 }


### PR DESCRIPTION
## Summary

Builds on #1440 (merged). Adds:
- **Reply Keyboard** (new): persistent buttons below input field — context%, model, New Session
- **Auto-create topics**: forum group → auto `create_forum_topic` on new conversation
- **/clear in topic**: deletes topic + session fully

## Type of change

| Type | Label |
|------|-------|
| New feature | `enhancement` |

## Component

`backend`

## Closes

Closes #1454

## Test plan

- [x] `cargo clippy` passes
- [x] 8 unit tests for reply_keyboard
- [ ] Manual: forum group new message → auto topic created
- [ ] Manual: /clear in topic → topic deleted
- [ ] Manual: reply keyboard shows context% and model after turn
- [ ] Manual: press New Session button → fresh session starts