### PR TITLE
feat(channels): forum topic naming — deep-link, LLM title sync, /rename (#1460)

### DIFF
--- a/crates/app/src/lib.rs
+++ b/crates/app/src/lib.rs
@@ -751,8 +751,8 @@ pub async fn start_with_options(
     // Build command handlers shared across all channels.
     let command_handlers: Vec<std::sync::Arc<dyn rara_kernel::channel::command::CommandHandler>> = {
         use rara_channels::telegram::commands::{
-            BasicCommandHandler, DebugCommandHandler, McpCommandHandler, SessionCommandHandler,
-            StatusCommandHandler, StopCommandHandler, TapeCommandHandler,
+            BasicCommandHandler, DebugCommandHandler, McpCommandHandler, RenameCommandHandler,
+            SessionCommandHandler, StatusCommandHandler, StopCommandHandler, TapeCommandHandler,
         };
         let tg_bot = telegram_adapter.as_ref().map(|a| a.bot());
         let session_handler =
@@ -765,6 +765,7 @@ pub async fn start_with_options(
             bot_client.clone(),
             kernel_handle.clone(),
         ));
+        let rename_handler = std::sync::Arc::new(RenameCommandHandler::new(bot_client.clone()));
         let tape_handler = std::sync::Arc::new(TapeCommandHandler::new(bot_client.clone()));
         let debug_handler =
             std::sync::Arc::new(DebugCommandHandler::new(rara.tape_service.clone()));
@@ -774,6 +775,7 @@ pub async fn start_with_options(
             session_handler.commands(),
             stop_handler.commands(),
             status_handler.commands(),
+            rename_handler.commands(),
             tape_handler.commands(),
             debug_handler.commands(),
         ]
@@ -787,6 +789,7 @@ pub async fn start_with_options(
             session_handler,
             stop_handler,
             status_handler,
+            rename_handler,
             tape_handler,
             debug_handler,
             mcp_handler,

--- a/crates/channels/src/telegram/adapter.rs
+++ b/crates/channels/src/telegram/adapter.rs
@@ -123,9 +123,9 @@ use rara_kernel::{
 };
 use teloxide::{
     payloads::{
-        AnswerCallbackQuerySetters, EditMessageTextSetters, GetUpdatesSetters,
-        SendChatActionSetters, SendDocumentSetters, SendMessageSetters, SendPhotoSetters,
-        SendVoiceSetters,
+        AnswerCallbackQuerySetters, EditForumTopicSetters, EditMessageTextSetters,
+        GetUpdatesSetters, SendChatActionSetters, SendDocumentSetters, SendMessageSetters,
+        SendPhotoSetters, SendVoiceSetters,
     },
     requests::{Request, Requester},
     types::{
@@ -148,6 +148,48 @@ fn to_thread_id(thread_id: Option<i64>) -> Option<teloxide::types::ThreadId> {
         #[allow(clippy::cast_possible_truncation)]
         teloxide::types::ThreadId(MessageId(tid as i32))
     })
+}
+
+/// Build a public `t.me/c/…` deep-link for a forum topic.
+///
+/// Private supergroups use chat IDs below `-1_000_000_000_000`; Telegram's
+/// web client links use the "short" chat ID form which strips the `-100`
+/// prefix. The returned URL opens the client directly in the given topic.
+fn forum_topic_link(chat_id: i64, thread_id: i64) -> String {
+    // Telegram supergroup IDs are always negative; make them positive and
+    // strip the `100` prefix (1_000_000_000_000) to get the short form.
+    let short = (-chat_id) - 1_000_000_000_000;
+    format!("https://t.me/c/{short}/{thread_id}")
+}
+
+/// Derive a forum topic name from the user's first message text.
+///
+/// Strips noise that would make a bad topic label: the bot `@mention` and a
+/// leading `/command` token. Truncates the result to 30 characters. Falls
+/// back to `"New chat"` when the message has no usable text.
+fn derive_initial_topic_name(text: Option<&str>, bot_username: Option<&str>) -> String {
+    let Some(raw) = text.map(str::trim).filter(|s| !s.is_empty()) else {
+        return "New chat".to_owned();
+    };
+
+    let without_mention = strip_group_mention(raw, bot_username);
+
+    // Drop the leading `/command` token if present (e.g. `/new hello`
+    // → `hello`). Only strip when the whole first whitespace-delimited
+    // token starts with `/` so plain messages containing a mid-sentence
+    // slash are preserved.
+    let stripped = match without_mention.split_once(char::is_whitespace) {
+        Some((head, rest)) if head.starts_with('/') => rest.trim_start().to_owned(),
+        _ if without_mention.starts_with('/') => String::new(),
+        _ => without_mention,
+    };
+
+    let trimmed = stripped.trim();
+    if trimmed.is_empty() {
+        return "New chat".to_owned();
+    }
+
+    trimmed.chars().take(30).collect()
 }
 
 /// Apply forum topic `thread_id` to a teloxide request builder if present.
@@ -1595,6 +1637,37 @@ impl ChannelAdapter for TelegramAdapter {
             })?;
         Ok(())
     }
+
+    async fn rename_session_label(
+        &self,
+        binding: &rara_kernel::session::ChannelBinding,
+        title: &str,
+    ) -> Result<(), KernelError> {
+        let Some(thread_id_str) = binding.thread_id.as_deref() else {
+            // No thread — nothing to rename at the Telegram topic level.
+            return Ok(());
+        };
+        let Ok(chat_id) = binding.chat_id.parse::<i64>() else {
+            tracing::warn!(chat_id = %binding.chat_id, "rename: invalid chat_id");
+            return Ok(());
+        };
+        let Ok(tid) = thread_id_str.parse::<i32>() else {
+            tracing::warn!(thread_id = %thread_id_str, "rename: invalid thread_id");
+            return Ok(());
+        };
+        let thread_id = teloxide::types::ThreadId(teloxide::types::MessageId(tid));
+        // Telegram caps topic name at 128 chars.
+        let name: String = title.chars().take(128).collect();
+        if let Err(e) = self
+            .bot
+            .edit_forum_topic(teloxide::types::ChatId(chat_id), thread_id)
+            .name(name)
+            .await
+        {
+            tracing::warn!(error = %e, chat_id, tid, "edit_forum_topic failed");
+        }
+        Ok(())
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -2737,6 +2810,9 @@ async fn handle_update(
     // Capture message text before the teloxide `msg` is shadowed by
     // `handle.resolve()` — used as the forum topic name.
     let topic_text: Option<String> = msg.text().map(|t| t.to_owned());
+    // Capture the user's original message id before the teloxide `msg`
+    // is shadowed — used to reply-link the General notification below.
+    let original_msg_id = msg.id;
 
     // Check if this chat is allowed.
     if !allowed_chat_ids.is_empty() && !allowed_chat_ids.contains(&chat_id) {
@@ -3077,16 +3153,30 @@ async fn handle_update(
     // and then the post-ingest binding rewrite silently pointed the new
     // topic at General's session — leaking context across conversations.
     let raw = if is_forum_chat && tg_thread_id.is_none() {
-        let topic_name = topic_text
-            .as_deref()
-            .filter(|t| !t.is_empty())
-            .map(|t| t.chars().take(30).collect::<String>())
-            .unwrap_or_else(|| "New chat".to_owned());
+        // Acquire bot username once so we can sanitize the initial topic
+        // name (strip @mentions and /command prefixes).
+        let bot_username_snapshot = bot_username.read().await.clone();
+        let topic_name =
+            derive_initial_topic_name(topic_text.as_deref(), bot_username_snapshot.as_deref());
 
         match bot.create_forum_topic(ChatId(chat_id), &topic_name).await {
             Ok(topic) => {
                 let new_tid = i64::from(topic.thread_id.0.0);
                 tg_thread_id = Some(new_tid);
+
+                // Notify the user in General with a clickable deep-link to
+                // the newly created topic. Replying to the original message
+                // keeps the notification threaded to their request.
+                let link = forum_topic_link(chat_id, new_tid);
+                let notice = format!(
+                    "\u{1f4ac} New topic: <a href=\"{link}\">{name}</a>",
+                    name = guard_html_escape(&topic_name),
+                );
+                let _ = bot
+                    .send_message(ChatId(chat_id), notice)
+                    .parse_mode(ParseMode::Html)
+                    .reply_parameters(ReplyParameters::new(original_msg_id))
+                    .await;
 
                 // Send a brief intro in the new topic so the user sees
                 // activity there (the original message stays in General —
@@ -4730,5 +4820,52 @@ mod stream_suffix_tests {
     fn slice_after_char_prefix_handles_multibyte_chars() {
         let content = "你好世界abc";
         assert_eq!(slice_after_char_prefix(content, 4), "abc");
+    }
+}
+
+#[cfg(test)]
+mod forum_topic_tests {
+    use super::{derive_initial_topic_name, forum_topic_link};
+
+    #[test]
+    fn forum_topic_link_strips_100_prefix_from_supergroup_chat_id() {
+        let link = forum_topic_link(-1001234567890, 5);
+        assert_eq!(link, "https://t.me/c/1234567890/5");
+    }
+
+    #[test]
+    fn derive_initial_topic_name_falls_back_when_text_missing() {
+        assert_eq!(derive_initial_topic_name(None, None), "New chat");
+    }
+
+    #[test]
+    fn derive_initial_topic_name_falls_back_on_empty_text() {
+        assert_eq!(derive_initial_topic_name(Some(""), None), "New chat");
+    }
+
+    #[test]
+    fn derive_initial_topic_name_keeps_plain_text_verbatim() {
+        assert_eq!(derive_initial_topic_name(Some("hello"), None), "hello");
+    }
+
+    #[test]
+    fn derive_initial_topic_name_strips_bot_mention() {
+        assert_eq!(
+            derive_initial_topic_name(Some("@rarabot hello world"), Some("rarabot")),
+            "hello world"
+        );
+    }
+
+    #[test]
+    fn derive_initial_topic_name_strips_leading_slash_command() {
+        assert_eq!(
+            derive_initial_topic_name(Some("/new my task"), None),
+            "my task"
+        );
+    }
+
+    #[test]
+    fn derive_initial_topic_name_falls_back_when_only_command() {
+        assert_eq!(derive_initial_topic_name(Some("/new"), None), "New chat");
     }
 }

--- a/crates/channels/src/telegram/commands/client.rs
+++ b/crates/channels/src/telegram/commands/client.rs
@@ -183,6 +183,14 @@ pub trait BotServiceClient: Send + Sync {
         model: Option<&str>,
     ) -> Result<SessionDetail, BotServiceError>;
 
+    /// Rename a session — updates `SessionEntry.title` and propagates the
+    /// change to the channel layer (e.g. renames the Telegram forum topic).
+    async fn rename_session(
+        &self,
+        key: &str,
+        title: &str,
+    ) -> Result<SessionDetail, BotServiceError>;
+
     // -- Tape / anchor tree -------------------------------------------------
 
     /// Build the full anchor tree for the given session.

--- a/crates/channels/src/telegram/commands/kernel_client.rs
+++ b/crates/channels/src/telegram/commands/kernel_client.rs
@@ -230,6 +230,38 @@ impl BotServiceClient for KernelBotServiceClient {
         Ok(entry_to_detail(&updated))
     }
 
+    async fn rename_session(
+        &self,
+        key: &str,
+        title: &str,
+    ) -> Result<SessionDetail, BotServiceError> {
+        let sk = SessionKey::try_from_raw(key).map_err(|e| BotServiceError::Service {
+            message: format!("invalid session key: {e}"),
+        })?;
+        let mut entry = self
+            .sessions
+            .get_session(&sk)
+            .await
+            .context(SessionSnafu)?
+            .ok_or_else(|| BotServiceError::Service {
+                message: format!("session not found: {key}"),
+            })?;
+        entry.title = Some(title.to_owned());
+        entry.updated_at = Utc::now();
+        let updated = self
+            .sessions
+            .update_session(&entry)
+            .await
+            .context(SessionSnafu)?;
+        // Propagate the new title to the channel layer (e.g. rename the
+        // Telegram forum topic). Silent no-op when no KernelHandle is
+        // wired in (e.g. unit tests).
+        if let Some(ref handle) = self.handle {
+            handle.io().rename_session_label(&sk, title).await;
+        }
+        Ok(entry_to_detail(&updated))
+    }
+
     async fn anchor_tree(
         &self,
         session_key: &str,

--- a/crates/channels/src/telegram/commands/mod.rs
+++ b/crates/channels/src/telegram/commands/mod.rs
@@ -23,7 +23,8 @@
 //!
 //! - [`client`]: Backend service client trait and response types.
 //! - [`basic`]: `/start` and `/help` commands.
-//! - [`session`]: `/new`, `/clear`, `/sessions`, `/usage`, `/model` commands.
+//! - [`session`]: `/new`, `/clear`, `/sessions`, `/usage`, `/model`, `/rename`
+//!   commands.
 //! - [`kernel_client`]: `/search` and `/jd` commands.
 //! - [`mcp`]: `/mcp` command.
 //! - [`status`]: `/status` command.
@@ -50,7 +51,7 @@ pub use client::BotServiceClient;
 pub use debug::DebugCommandHandler;
 pub use kernel_client::KernelBotServiceClient;
 pub use mcp::McpCommandHandler;
-pub use session::{SessionCommandHandler, StopCommandHandler};
+pub use session::{RenameCommandHandler, SessionCommandHandler, StopCommandHandler};
 pub use status::{StatusCommandHandler, StatusJobsCallbackHandler};
 pub use tape::TapeCommandHandler;
 

--- a/crates/channels/src/telegram/commands/session.rs
+++ b/crates/channels/src/telegram/commands/session.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 //! Session management commands: `/new`, `/clear`, `/sessions`, `/usage`,
-//! `/model`.
+//! `/model`, `/rename`.
 
 use std::{fmt::Write, sync::Arc};
 
@@ -438,6 +438,83 @@ impl CommandHandler for StopCommandHandler {
                 Ok(CommandResult::Text("已中断当前操作。".to_owned()))
             }
             Err(_) => Ok(CommandResult::Text("当前没有活跃的会话。".to_owned())),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// RenameCommandHandler
+// ---------------------------------------------------------------------------
+
+/// Maximum length (in Unicode scalar values) for a renamed session title.
+///
+/// Matches Telegram's `editForumTopic` 128-character topic name cap so the
+/// two layers stay consistent.
+const RENAME_TITLE_MAX_CHARS: usize = 128;
+
+/// Handles the `/rename <name>` command — sets the session title and
+/// propagates the new label to the channel layer (e.g. renames the
+/// Telegram forum topic).
+pub struct RenameCommandHandler {
+    client: Arc<dyn BotServiceClient>,
+}
+
+impl RenameCommandHandler {
+    pub fn new(client: Arc<dyn BotServiceClient>) -> Self { Self { client } }
+}
+
+#[async_trait]
+impl CommandHandler for RenameCommandHandler {
+    fn commands(&self) -> Vec<CommandDefinition> {
+        vec![CommandDefinition {
+            name:        "rename".to_owned(),
+            description: "Rename the current session (and its forum topic)".to_owned(),
+            usage:       Some("/rename <name>".to_owned()),
+        }]
+    }
+
+    async fn handle(
+        &self,
+        command: &CommandInfo,
+        context: &CommandContext,
+    ) -> Result<CommandResult, KernelError> {
+        let title = command.args.trim();
+        if title.is_empty() {
+            return Ok(CommandResult::Text(
+                "Usage: /rename <name>\nExample: /rename Project planning".to_owned(),
+            ));
+        }
+
+        // Clip to the Telegram topic-name cap — both layers agree on the
+        // same limit so the DB title matches the rendered topic name.
+        let title: String = title.chars().take(RENAME_TITLE_MAX_CHARS).collect();
+
+        let (channel_type, chat_id, thread_id) = extract_channel_info(context);
+
+        let session_key = match self
+            .client
+            .get_channel_session(channel_type, &chat_id, thread_id.as_deref())
+            .await
+        {
+            Ok(Some(binding)) => binding.session_key,
+            Ok(None) => {
+                return Ok(CommandResult::Text(
+                    "No active session. Send a message to create one.".to_owned(),
+                ));
+            }
+            Err(e) => {
+                return Ok(CommandResult::Text(format!(
+                    "Failed to resolve session: {e}"
+                )));
+            }
+        };
+
+        match self.client.rename_session(&session_key, &title).await {
+            Ok(_) => Ok(CommandResult::Html(format!(
+                "\u{2705} Session renamed to \"{}\"",
+                html_escape(&title),
+            ))),
+            Err(e) => Ok(CommandResult::Text(format!("Failed to rename: {e}"))),
         }
     }
 }

--- a/crates/kernel/src/channel/adapter.rs
+++ b/crates/kernel/src/channel/adapter.rs
@@ -43,9 +43,10 @@ use crate::{
 /// # Optional hooks
 ///
 /// [`start`](Self::start), [`stop`](Self::stop),
-/// [`typing_indicator`](Self::typing_indicator), and
-/// [`set_phase`](Self::set_phase) have default no-op implementations.
-/// Egress-only adapters (e.g. CLI) only need to implement
+/// [`typing_indicator`](Self::typing_indicator),
+/// [`set_phase`](Self::set_phase), and
+/// [`rename_session_label`](Self::rename_session_label) have default no-op
+/// implementations. Egress-only adapters (e.g. CLI) only need to implement
 /// [`channel_type`](Self::channel_type) and [`send`](Self::send).
 #[async_trait]
 pub trait ChannelAdapter: Send + Sync + 'static {
@@ -75,6 +76,23 @@ pub trait ChannelAdapter: Send + Sync + 'static {
     ///
     /// No-op by default; override for platforms that support reactions.
     async fn set_phase(&self, _session_key: &str, _phase: AgentPhase) -> Result<(), KernelError> {
+        Ok(())
+    }
+
+    /// Update the channel-level label for this session (e.g. rename a
+    /// Telegram forum topic). Called after session title is generated
+    /// or manually updated.
+    ///
+    /// Receives the [`ChannelBinding`](crate::session::ChannelBinding) so
+    /// platform adapters can extract their own identifiers (chat_id,
+    /// thread_id, etc).
+    ///
+    /// No-op by default; override for platforms that support it.
+    async fn rename_session_label(
+        &self,
+        _binding: &crate::session::ChannelBinding,
+        _title: &str,
+    ) -> Result<(), KernelError> {
         Ok(())
     }
 }

--- a/crates/kernel/src/handle.rs
+++ b/crates/kernel/src/handle.rs
@@ -383,6 +383,12 @@ impl KernelHandle {
     /// Access the session index for session and channel binding lookups.
     pub fn session_index(&self) -> &Arc<dyn SessionIndex> { self.io.session_index() }
 
+    /// Access the bundled I/O subsystem.
+    ///
+    /// Exposed so channel command handlers can invoke cross-cutting hooks
+    /// like [`IOSubsystem::rename_session_label`].
+    pub fn io(&self) -> &Arc<IOSubsystem> { &self.io }
+
     /// Access the agent registry for looking up named manifests.
     pub fn agent_registry(&self) -> &AgentRegistryRef { &self.agent_registry }
 

--- a/crates/kernel/src/io.rs
+++ b/crates/kernel/src/io.rs
@@ -1721,6 +1721,35 @@ impl IOSubsystem {
         self.endpoint_registry.register(&msg.user, endpoint);
     }
 
+    /// Propagate a session title change to the channel layer (e.g.
+    /// rename the Telegram forum topic). Silent no-op if the session
+    /// has no channel binding or the adapter does not implement rename.
+    #[tracing::instrument(skip(self), fields(%session_key, title))]
+    pub async fn rename_session_label(
+        &self,
+        session_key: &crate::session::SessionKey,
+        title: &str,
+    ) {
+        let binding = match self
+            .session_index
+            .get_channel_binding_by_session(session_key)
+            .await
+        {
+            Ok(Some(b)) => b,
+            Ok(None) => return,
+            Err(e) => {
+                tracing::warn!(%e, "rename_session_label: binding lookup failed");
+                return;
+            }
+        };
+        let Some(adapter) = self.adapters.get(&binding.channel_type).cloned() else {
+            return;
+        };
+        if let Err(e) = adapter.rename_session_label(&binding, title).await {
+            tracing::warn!(%e, "rename_session_label: adapter returned error");
+        }
+    }
+
     // -- Accessors (external consumers) ---------------------------------------
 
     /// Access the session index.

--- a/crates/kernel/src/io.rs
+++ b/crates/kernel/src/io.rs
@@ -1724,29 +1724,46 @@ impl IOSubsystem {
     /// Propagate a session title change to the channel layer (e.g.
     /// rename the Telegram forum topic). Silent no-op if the session
     /// has no channel binding or the adapter does not implement rename.
+    ///
+    /// Fans out to **every** binding pointing at the session: a single
+    /// session can be reachable from multiple forum topics (e.g. when a
+    /// topic has been re-targeted via `/sessions`), and propagating to
+    /// only the first one returned by the index leaves stale topic names
+    /// in place. Per-binding errors are logged but never propagated so
+    /// one bad topic does not block the others.
     #[tracing::instrument(skip(self), fields(%session_key, title))]
     pub async fn rename_session_label(
         &self,
         session_key: &crate::session::SessionKey,
         title: &str,
     ) {
-        let binding = match self
+        let bindings = match self
             .session_index
-            .get_channel_binding_by_session(session_key)
+            .list_channel_bindings_by_session(session_key)
             .await
         {
-            Ok(Some(b)) => b,
-            Ok(None) => return,
+            Ok(bs) => bs,
             Err(e) => {
                 tracing::warn!(%e, "rename_session_label: binding lookup failed");
                 return;
             }
         };
-        let Some(adapter) = self.adapters.get(&binding.channel_type).cloned() else {
+        if bindings.is_empty() {
             return;
-        };
-        if let Err(e) = adapter.rename_session_label(&binding, title).await {
-            tracing::warn!(%e, "rename_session_label: adapter returned error");
+        }
+        for binding in &bindings {
+            let Some(adapter) = self.adapters.get(&binding.channel_type).cloned() else {
+                continue;
+            };
+            if let Err(e) = adapter.rename_session_label(binding, title).await {
+                tracing::warn!(
+                    %e,
+                    channel_type = %binding.channel_type,
+                    chat_id = %binding.chat_id,
+                    thread_id = ?binding.thread_id,
+                    "rename_session_label: adapter returned error"
+                );
+            }
         }
     }
 

--- a/crates/kernel/src/kernel.rs
+++ b/crates/kernel/src/kernel.rs
@@ -2981,6 +2981,7 @@ impl Kernel {
             if needs_title {
                 let tape_service = self.tape_service.clone();
                 let driver_registry = Arc::clone(self.syscall.driver_registry());
+                let io = Arc::clone(&self.io);
                 let sk = session_key;
                 let tape_name = sk.to_string();
                 tokio::spawn(async move {
@@ -2989,6 +2990,7 @@ impl Kernel {
                         &tape_name,
                         &driver_registry,
                         session_index.as_ref(),
+                        &io,
                         &sk,
                     )
                     .await
@@ -3040,6 +3042,7 @@ async fn generate_session_title(
     tape_name: &str,
     driver_registry: &crate::llm::DriverRegistry,
     session_index: &dyn crate::session::SessionIndex,
+    io: &Arc<crate::io::IOSubsystem>,
     session_key: &SessionKey,
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     use crate::memory::TapEntryKind;
@@ -3137,6 +3140,9 @@ async fn generate_session_title(
                 tracing::warn!(%e, session_key = %session_key, "title gen: failed to persist title");
             } else {
                 tracing::info!(session_key = %session_key, title = %title, "session title generated");
+                // Propagate the new title to the channel layer so the
+                // forum topic (if any) gets renamed to match.
+                io.rename_session_label(session_key, &title).await;
             }
         }
         Ok(None) => {

--- a/crates/kernel/src/kernel.rs
+++ b/crates/kernel/src/kernel.rs
@@ -3134,6 +3134,21 @@ async fn generate_session_title(
 
     match session_index.get_session(session_key).await {
         Ok(Some(mut entry)) => {
+            // Re-check the title under the current read: a concurrent
+            // `/rename` or another auto-title task may have landed while
+            // the LLM call was in flight, and overwriting a manual title
+            // with a stale generated one is user-visible damage. The
+            // up-front `entry.title.is_none()` gate at the call site is
+            // advisory — this is the authoritative compare-and-persist.
+            if entry.title.is_some() {
+                tracing::info!(
+                    session_key = %session_key,
+                    existing_title = ?entry.title,
+                    generated_title = %title,
+                    "title gen: title already set (concurrent update), skipping"
+                );
+                return Ok(());
+            }
             entry.title = Some(title.clone());
             entry.updated_at = chrono::Utc::now();
             if let Err(e) = session_index.update_session(&entry).await {

--- a/crates/kernel/src/session/mod.rs
+++ b/crates/kernel/src/session/mod.rs
@@ -213,6 +213,26 @@ pub trait SessionIndex: Send + Sync + 'static {
         Ok(None)
     }
 
+    /// Enumerate every channel binding that points to the given session.
+    ///
+    /// A session can accumulate multiple bindings when a topic has been
+    /// re-targeted (e.g. via `/sessions`) or when the same session is
+    /// reachable from several chats. Callers that need to propagate state
+    /// across every bound channel (e.g. renaming all forum topics that
+    /// reflect this session) should use this instead of
+    /// [`get_channel_binding_by_session`](Self::get_channel_binding_by_session),
+    /// whose single-result contract is stable but arbitrary when multiple
+    /// bindings exist.
+    ///
+    /// Returns an empty `Vec` when no bindings exist or the implementation
+    /// does not support reverse lookups.
+    async fn list_channel_bindings_by_session(
+        &self,
+        _key: &SessionKey,
+    ) -> Result<Vec<ChannelBinding>, SessionError> {
+        Ok(Vec::new())
+    }
+
     /// Remove all channel bindings that point to the given session.
     async fn unbind_session(&self, key: &SessionKey) -> Result<(), SessionError>;
 }

--- a/crates/kernel/src/session/test_utils.rs
+++ b/crates/kernel/src/session/test_utils.rs
@@ -119,6 +119,19 @@ impl SessionIndex for InMemorySessionIndex {
             .map(|entry| entry.value().clone()))
     }
 
+    async fn list_channel_bindings_by_session(
+        &self,
+        key: &SessionKey,
+    ) -> Result<Vec<ChannelBinding>, SessionError> {
+        let key_str = key.to_string();
+        Ok(self
+            .bindings
+            .iter()
+            .filter(|entry| entry.value().session_key.to_string() == key_str)
+            .map(|entry| entry.value().clone())
+            .collect())
+    }
+
     async fn unbind_session(&self, key: &SessionKey) -> Result<(), SessionError> {
         let key_str = key.to_string();
         let to_remove: Vec<_> = self

--- a/crates/sessions/src/file_index.rs
+++ b/crates/sessions/src/file_index.rs
@@ -256,6 +256,34 @@ impl SessionIndex for FileSessionIndex {
         Ok(None)
     }
 
+    async fn list_channel_bindings_by_session(
+        &self,
+        key: &SessionKey,
+    ) -> Result<Vec<ChannelBinding>, SessionError> {
+        let bindings_dir = self.index_dir.join("bindings");
+        let mut dir = fs::read_dir(&bindings_dir)
+            .await
+            .map_err(|source| SessionError::FileIo { source })?;
+
+        let mut results = Vec::new();
+        while let Some(entry) = dir
+            .next_entry()
+            .await
+            .map_err(|source| SessionError::FileIo { source })?
+        {
+            let path = entry.path();
+            if path.extension().and_then(|e| e.to_str()) != Some("json") {
+                continue;
+            }
+            if let Some(binding) = self.read_json::<ChannelBinding>(&path).await? {
+                if binding.session_key == *key {
+                    results.push(binding);
+                }
+            }
+        }
+        Ok(results)
+    }
+
     async fn unbind_session(&self, key: &SessionKey) -> Result<(), SessionError> {
         let bindings_dir = self.index_dir.join("bindings");
         let mut dir = fs::read_dir(&bindings_dir)


### PR DESCRIPTION
## Summary

Follow-up to #1456. Four coordinated UX improvements for Telegram forum topics:

- **A — Deep-link in General**: when a topic is auto-created from a General message, reply in General with a tappable HTML link to the new topic (`https://t.me/c/<short>/<tid>`). User is no longer stranded in General wondering where Rara went.
- **B — Initial topic name robustness**: strip `@botname` mentions and leading `/command` tokens before truncating to 30 chars. Fallback `"New chat"` preserved for voice/photo/sticker with no text.
- **C — LLM title → topic name sync**: `generate_session_title` (kernel) now calls new `IOSubsystem::rename_session_label` after persisting; Telegram adapter implements `rename_session_label` via `editForumTopic`. Matches ChatGPT-style sidebar UX.
- **D — `/rename <name>` command**: manual override. Updates `SessionEntry.title` and renames the forum topic.

Infra changes:
- New optional UX hook `ChannelAdapter::rename_session_label` (no-op default, same pattern as `typing_indicator` / `set_phase`).
- New `IOSubsystem::rename_session_label` — binding lookup + adapter dispatch.
- New helpers in `telegram/adapter.rs`: `forum_topic_link`, `derive_initial_topic_name` (7 unit tests).

## Type of change

| Type | Label |
|------|-------|
| New feature | `enhancement` |

## Component

`core` (channels + kernel)

## Closes

Closes #1460

## Test plan

- [x] `cargo check --workspace` passes
- [x] `cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings` passes with zero warnings
- [x] `cargo test -p rara-kernel` — 450 passed
- [x] `cargo test -p rara-channels` — 125 passed
- [x] New unit tests for `forum_topic_link` and `derive_initial_topic_name` (7 cases)
- [ ] Manual smoke test: send message to General → receive deep-link in General + intro in new topic
- [ ] Manual smoke test: after first LLM turn completes, forum topic is renamed to LLM-generated title
- [ ] Manual smoke test: `/rename my topic` renames both session title and forum topic