### PR TITLE
fix(channels): harden ask-user — identity gate, sensitive DM routing, inline options (#1464)

### DIFF
--- a/crates/app/src/tools/ask_user.rs
+++ b/crates/app/src/tools/ask_user.rs
@@ -38,7 +38,21 @@ const DEFAULT_TIMEOUT_SECS: u64 = 300;
 pub struct AskUserParams {
     /// The question to ask the user. Be specific about what information you
     /// need and why.
-    question: String,
+    question:  String,
+    /// Set to `true` when the answer is sensitive (API keys, passwords,
+    /// tokens, 2FA codes, credentials, personal identifiers). Sensitive
+    /// prompts are forcibly routed to the user's private chat so the text
+    /// never appears in a shared group/topic, and a short notice is posted
+    /// in the originating chat instead. Default: `false`.
+    #[serde(default)]
+    sensitive: bool,
+    /// Pre-defined answer choices. When provided, channel adapters render
+    /// structured controls (e.g. inline keyboard buttons) and the user's
+    /// answer is guaranteed to be one of these strings. Use for
+    /// yes/no/enumerated questions to avoid free-text parsing. When `None`,
+    /// the user replies with free-form text.
+    #[serde(default)]
+    options:   Option<Vec<String>>,
 }
 
 /// Ask the user a question and wait for their response.
@@ -48,7 +62,10 @@ pub struct AskUserParams {
     description = "Ask the user a question and wait for their response. Use when you need \
                    information that only the user can provide (e.g. API keys, preferences, \
                    clarifications). The agent will pause until the user responds or the request \
-                   times out.",
+                   times out. Set `sensitive: true` when requesting secrets (keys, passwords, \
+                   tokens, 2FA codes) so the prompt is forced to a private channel. Provide \
+                   `options` for enumerated answers — the answer is guaranteed to be one of the \
+                   supplied strings, avoiding free-text ambiguity.",
     tier = "deferred",
     user_interaction
 )]
@@ -73,7 +90,93 @@ impl ToolExecute for AskUserTool {
         // question back to the same conversation surface (e.g. a Telegram
         // forum topic) instead of a default fallback like `primary_chat_id`.
         let endpoint = context.origin_endpoint.clone();
-        let answer = self.manager.ask(params.question, endpoint, timeout).await?;
+        // Propagate the platform-native user identifier so channel adapters
+        // can bind the pending question to the specific user who triggered
+        // the turn — other members of a shared chat must not be able to
+        // answer on their behalf.
+        let expected_platform_user_id = context.origin_platform_user_id.clone();
+        // Either the caller explicitly marked the prompt sensitive, or the
+        // question text matches common secret-request patterns. Heuristic
+        // detection is a defense-in-depth safety net, not a substitute for
+        // the explicit flag.
+        let sensitive = params.sensitive || looks_sensitive(&params.question);
+        let answer = self
+            .manager
+            .ask(
+                params.question,
+                endpoint,
+                expected_platform_user_id,
+                sensitive,
+                params.options,
+                timeout,
+            )
+            .await?;
         Ok(serde_json::json!({ "answer": answer }))
+    }
+}
+
+/// Heuristic detector for prompts that solicit sensitive material.
+///
+/// Pattern-matches common secret-request phrasings in English and Chinese.
+/// This is a best-effort safety net that complements — not replaces — the
+/// explicit `sensitive` flag that the caller can set. False positives are
+/// preferred over false negatives: the consequence of a false positive is
+/// that a mundane prompt gets routed to DM instead of the topic; the
+/// consequence of a false negative is a secret leaked to a shared chat.
+fn looks_sensitive(question: &str) -> bool {
+    /// Case-insensitive substring markers that strongly indicate a secret
+    /// is being requested. Keep this list conservative — broad words like
+    /// "auth" on their own trigger too often; pair them with a verb/noun
+    /// that implies "please provide X".
+    const NEEDLES: &[&str] = &[
+        "api key",
+        "api-key",
+        "apikey",
+        "access token",
+        "bearer token",
+        "refresh token",
+        "auth token",
+        "password",
+        "passphrase",
+        "secret key",
+        "private key",
+        "2fa",
+        "one-time code",
+        "one time code",
+        "otp",
+        "verification code",
+        "credentials",
+        "credential",
+        // Chinese
+        "密码",
+        "密钥",
+        "口令",
+        "验证码",
+        "令牌",
+        "私钥",
+    ];
+    let lower = question.to_lowercase();
+    NEEDLES.iter().any(|needle| lower.contains(needle))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::looks_sensitive;
+
+    #[test]
+    fn detects_common_secret_phrases() {
+        assert!(looks_sensitive("Please paste your API key here"));
+        assert!(looks_sensitive("What is the OTP code?"));
+        assert!(looks_sensitive("Enter your password"));
+        assert!(looks_sensitive("请输入密码"));
+        assert!(looks_sensitive("2FA code?"));
+        assert!(looks_sensitive("share your refresh token"));
+    }
+
+    #[test]
+    fn non_sensitive_prompts_pass_through() {
+        assert!(!looks_sensitive("Do you want A or B?"));
+        assert!(!looks_sensitive("Should I continue?"));
+        assert!(!looks_sensitive("What is your favorite color?"));
     }
 }

--- a/crates/channels/src/telegram/adapter.rs
+++ b/crates/channels/src/telegram/adapter.rs
@@ -55,19 +55,35 @@ static GUARD_EXPIRY_HANDLES: LazyLock<DashMap<Uuid, AbortHandle>> = LazyLock::ne
 
 /// Pending user-question entry stored in [`PENDING_USER_QUESTIONS`].
 struct PendingUserQuestion {
-    question_id:   Uuid,
-    question_text: String,
-    manager:       UserQuestionManagerRef,
+    question_id:               Uuid,
+    question_text:             String,
+    manager:                   UserQuestionManagerRef,
+    /// Platform-native id of the user who asked — incoming answers are
+    /// rejected unless `msg.from.id`/`callback.from.id` matches this value.
+    /// `None` when the origin had no platform identity (web/cli).
+    expected_platform_user_id: Option<String>,
+    /// Pre-defined answer options. When `Some`, the prompt was rendered as
+    /// an inline keyboard; callback resolution maps the pressed index into
+    /// this list.
+    options:                   Option<Vec<String>>,
+    /// The `(chat_id, prompt_message_id)` where the prompt was rendered.
+    /// Kept so the timeout cleanup task can remove both index entries.
+    prompt_location:           (i64, i32),
 }
 
-/// Maps `(chat_id, message_id)` of sent user-question prompts to their
-/// pending state, so reply-to-question messages can resolve them.
+/// Primary pending-question index keyed by the kernel-generated question
+/// UUID, so both reply-to and inline-keyboard callbacks can find the entry
+/// by a single stable identifier.
 ///
-/// Entries are inserted by [`question_listener`] and removed either by
-/// `handle_update` (user replies) or by the timeout cleanup task spawned
-/// alongside each question.
-static PENDING_USER_QUESTIONS: LazyLock<DashMap<(i64, i32), PendingUserQuestion>> =
+/// Entries are inserted by [`question_listener`] and removed by
+/// `handle_update` (on resolve) or by the per-question timeout cleanup task.
+static PENDING_USER_QUESTIONS: LazyLock<DashMap<Uuid, PendingUserQuestion>> =
     LazyLock::new(DashMap::new);
+
+/// Secondary index: `(chat_id, prompt_message_id) → question_id`, used to
+/// locate a pending question from a user's reply-to-message. Kept in sync
+/// with [`PENDING_USER_QUESTIONS`].
+static PROMPT_MSG_TO_QID: LazyLock<DashMap<(i64, i32), Uuid>> = LazyLock::new(DashMap::new);
 
 /// Matches complete tool-call XML blocks (open + close, possibly mismatched
 /// names).
@@ -2565,74 +2581,285 @@ async fn question_listener(
                     }
                 };
 
-                // Route the question back to the originating Telegram surface
-                // when possible (e.g. the forum topic the user was chatting
-                // in). Fall back to `primary_chat_id` when the question
-                // originated off-Telegram (web/cli) or carries no endpoint.
-                let (chat_id, thread_id) = match &question.endpoint {
-                    Some(Endpoint {
-                        address: EndpointAddress::Telegram { chat_id, thread_id },
-                        ..
-                    }) => (*chat_id, *thread_id),
-                    _ => {
-                        let fallback = {
-                            let cfg = config.read().unwrap_or_else(|e| e.into_inner());
-                            cfg.primary_chat_id
-                        };
-                        let Some(fallback_chat) = fallback else {
-                            warn!(
-                                question_id = %question.id,
-                                "telegram question listener: no primary_chat_id \
-                                 configured and question carries no Telegram endpoint",
-                            );
-                            continue;
-                        };
-                        (fallback_chat, None)
-                    }
-                };
-
-                let text = format!(
-                    "<b>❓ Agent Question</b>\n\n{}\n\n<i>Reply to this message to answer.</i>",
-                    guard_html_escape(&question.question),
-                );
-
-                let req = with_thread_id!(
-                    bot.send_message(ChatId(chat_id), &text)
-                        .parse_mode(ParseMode::Html),
-                    thread_id
-                );
-                match req.await {
-                    Ok(sent_msg) => {
-                        let key = (chat_id, sent_msg.id.0);
-                        PENDING_USER_QUESTIONS.insert(
-                            key,
-                            PendingUserQuestion {
-                                question_id:   question.id,
-                                question_text: question.question.clone(),
-                                manager:       Arc::clone(&mgr),
-                            },
-                        );
-                        info!(
-                            question_id = %question.id,
-                            message_id = sent_msg.id.0,
-                            "telegram question listener: sent question to chat"
-                        );
-
-                        // Spawn a cleanup task that removes the entry after
-                        // the ask-user timeout (5 min) plus a small grace
-                        // period, preventing unbounded map growth when
-                        // questions time out and the user never replies.
-                        let cleanup_key = key;
-                        tokio::spawn(async move {
-                            tokio::time::sleep(std::time::Duration::from_secs(330)).await;
-                            PENDING_USER_QUESTIONS.remove(&cleanup_key);
-                        });
-                    }
-                    Err(e) => {
-                        warn!(error = %e, "telegram question listener: failed to send question");
-                    }
+                if let Err(e) = dispatch_user_question(&bot, &config, &mgr, question).await {
+                    warn!(error = %e, "telegram question listener: dispatch failed");
                 }
             }
+        }
+    }
+}
+
+/// Render and route a single [`UserQuestion`] to Telegram, applying
+/// sensitivity-based routing, optional inline-keyboard rendering, and
+/// installing the pending-question bookkeeping that later resolution paths
+/// (reply-to or callback press) depend on.
+///
+/// Returns `Err` only for unrecoverable dispatch failures (e.g. no target
+/// chat available, send_message rejected by Telegram). Identity validation
+/// happens at *resolve* time, not dispatch time.
+async fn dispatch_user_question(
+    bot: &teloxide::Bot,
+    config: &Arc<StdRwLock<TelegramConfig>>,
+    mgr: &UserQuestionManagerRef,
+    question: UserQuestion,
+) -> anyhow::Result<()> {
+    let primary_chat_id = {
+        let cfg = config.read().unwrap_or_else(|e| e.into_inner());
+        cfg.primary_chat_id
+    };
+
+    // Extract the originating Telegram coordinates (if any). Questions
+    // raised from web/cli turns carry a non-Telegram endpoint or none at
+    // all — those always route to `primary_chat_id`.
+    let origin_tg = match &question.endpoint {
+        Some(Endpoint {
+            address: EndpointAddress::Telegram { chat_id, thread_id },
+            ..
+        }) => Some((*chat_id, *thread_id)),
+        _ => None,
+    };
+
+    // Resolve the destination (route_chat_id, route_thread_id).
+    //
+    // Sensitive prompts ALWAYS go to `primary_chat_id` (assumed to be the
+    // user's DM) and never leak into a shared group/topic. If the prompt
+    // originated in a different chat, we post a breadcrumb there so the
+    // user knows to check their DM.
+    let (route_chat_id, route_thread_id) = if question.sensitive {
+        let Some(pm) = primary_chat_id else {
+            anyhow::bail!(
+                "sensitive question {} dropped — no primary_chat_id configured",
+                question.id
+            );
+        };
+        if let Some((origin_chat, origin_thread)) = origin_tg {
+            if origin_chat != pm {
+                let notice =
+                    "🔒 I sent a private question to your DM. Please check there to answer.";
+                let breadcrumb =
+                    with_thread_id!(bot.send_message(ChatId(origin_chat), notice), origin_thread);
+                if let Err(e) = breadcrumb.await {
+                    // Breadcrumb failure is non-fatal — the real question still
+                    // reaches the user via DM.
+                    warn!(
+                        error = %e,
+                        question_id = %question.id,
+                        "telegram: failed to post sensitive-question breadcrumb",
+                    );
+                }
+            }
+        }
+        (pm, None)
+    } else {
+        match origin_tg {
+            Some(loc) => loc,
+            None => {
+                let Some(pm) = primary_chat_id else {
+                    anyhow::bail!(
+                        "question {} dropped — non-Telegram endpoint and no primary_chat_id",
+                        question.id
+                    );
+                };
+                (pm, None)
+            }
+        }
+    };
+
+    // Compose the visible prompt. When options are present we will render
+    // an inline keyboard below, so the "reply to this message" hint would
+    // be misleading — suppress it.
+    let body = guard_html_escape(&question.question);
+    let text = if question.options.is_some() {
+        format!("<b>❓ Agent Question</b>\n\n{body}")
+    } else {
+        format!("<b>❓ Agent Question</b>\n\n{body}\n\n<i>Reply to this message to answer.</i>",)
+    };
+
+    let send_result = if let Some(ref options) = question.options {
+        // Inline keyboard: one button per option. `callback_data` encodes
+        // the question UUID plus the option index; identity is re-checked
+        // on the callback path using `callback.from.id`.
+        let keyboard: Vec<Vec<InlineKeyboardButton>> = options
+            .iter()
+            .enumerate()
+            .map(|(idx, label)| {
+                vec![InlineKeyboardButton::callback(
+                    label.clone(),
+                    format!("au:{}:{}", question.id, idx),
+                )]
+            })
+            .collect();
+        let markup = InlineKeyboardMarkup::new(keyboard);
+        let req = with_thread_id!(
+            bot.send_message(ChatId(route_chat_id), &text)
+                .parse_mode(ParseMode::Html)
+                .reply_markup(markup),
+            route_thread_id
+        );
+        req.await
+    } else {
+        let req = with_thread_id!(
+            bot.send_message(ChatId(route_chat_id), &text)
+                .parse_mode(ParseMode::Html),
+            route_thread_id
+        );
+        req.await
+    };
+
+    let sent_msg = send_result.map_err(|e| anyhow::anyhow!("send_message failed: {e}"))?;
+    let prompt_location = (route_chat_id, sent_msg.id.0);
+
+    PENDING_USER_QUESTIONS.insert(
+        question.id,
+        PendingUserQuestion {
+            question_id: question.id,
+            question_text: question.question.clone(),
+            manager: Arc::clone(mgr),
+            expected_platform_user_id: question.expected_platform_user_id.clone(),
+            options: question.options.clone(),
+            prompt_location,
+        },
+    );
+    PROMPT_MSG_TO_QID.insert(prompt_location, question.id);
+
+    info!(
+        question_id = %question.id,
+        chat_id = route_chat_id,
+        message_id = sent_msg.id.0,
+        sensitive = question.sensitive,
+        has_options = question.options.is_some(),
+        "telegram question listener: sent question",
+    );
+
+    // Timeout cleanup (5 min ask-user timeout + grace period) prevents the
+    // pending-question maps from growing unbounded when the user never
+    // answers.
+    let cleanup_qid = question.id;
+    let cleanup_loc = prompt_location;
+    tokio::spawn(async move {
+        tokio::time::sleep(std::time::Duration::from_secs(330)).await;
+        PENDING_USER_QUESTIONS.remove(&cleanup_qid);
+        PROMPT_MSG_TO_QID.remove(&cleanup_loc);
+    });
+
+    Ok(())
+}
+
+/// Handle `au:<question_id>:<option_index>` inline-keyboard callbacks
+/// emitted by [`dispatch_user_question`] when a question has options.
+///
+/// Validates `callback.from.id` against the pending question's expected
+/// platform user id and rejects mismatches, preventing other group members
+/// from pressing answer buttons on behalf of the original asker.
+async fn handle_ask_user_callback(
+    bot: &teloxide::Bot,
+    callback: &teloxide::types::CallbackQuery,
+    data: &str,
+) {
+    // `au:<uuid>:<idx>`
+    let rest = match data.strip_prefix("au:") {
+        Some(r) => r,
+        None => return,
+    };
+    let Some((qid_str, idx_str)) = rest.split_once(':') else {
+        let _ = bot
+            .answer_callback_query(callback.id.clone())
+            .text("Malformed callback data")
+            .await;
+        return;
+    };
+    let Ok(qid) = Uuid::parse_str(qid_str) else {
+        let _ = bot
+            .answer_callback_query(callback.id.clone())
+            .text("Invalid question id")
+            .await;
+        return;
+    };
+    let Ok(idx) = idx_str.parse::<usize>() else {
+        let _ = bot
+            .answer_callback_query(callback.id.clone())
+            .text("Invalid option index")
+            .await;
+        return;
+    };
+
+    // Identity check against the asker recorded at dispatch time. We use
+    // `callback.from.id` which Telegram guarantees to be the user who
+    // pressed the button (platform-level attestation — cannot be spoofed
+    // by another group member).
+    let caller_pid = callback.from.id.0.to_string();
+    {
+        let Some(entry) = PENDING_USER_QUESTIONS.get(&qid) else {
+            let _ = bot
+                .answer_callback_query(callback.id.clone())
+                .text("This question is no longer pending.")
+                .await;
+            return;
+        };
+        if let Some(ref expected) = entry.expected_platform_user_id {
+            if expected != &caller_pid {
+                let _ = bot
+                    .answer_callback_query(callback.id.clone())
+                    .text("Only the original asker can answer this question.")
+                    .show_alert(true)
+                    .await;
+                return;
+            }
+        }
+    }
+
+    // Remove and resolve.
+    let Some((_, pending)) = PENDING_USER_QUESTIONS.remove(&qid) else {
+        let _ = bot
+            .answer_callback_query(callback.id.clone())
+            .text("This question was already answered.")
+            .await;
+        return;
+    };
+    PROMPT_MSG_TO_QID.remove(&pending.prompt_location);
+
+    let Some(options) = pending.options.as_ref() else {
+        warn!(question_id = %qid, "ask-user callback without options on pending entry");
+        let _ = bot
+            .answer_callback_query(callback.id.clone())
+            .text("No options recorded for this question.")
+            .await;
+        return;
+    };
+    let Some(answer) = options.get(idx).cloned() else {
+        // Put it back so the user can retry with a valid button.
+        PENDING_USER_QUESTIONS.insert(qid, pending);
+        let _ = bot
+            .answer_callback_query(callback.id.clone())
+            .text("Option index out of range.")
+            .await;
+        return;
+    };
+
+    match pending.manager.resolve(qid, answer.clone()) {
+        Ok(()) => {
+            info!(question_id = %qid, "telegram: resolved user question via inline callback");
+            let (chat_id, msg_id) = pending.prompt_location;
+            let answered_text = format!(
+                "<b>✅ Answered</b>\n\n<s>{}</s>\n\n<i>→ {}</i>",
+                guard_html_escape(&pending.question_text),
+                guard_html_escape(&answer),
+            );
+            // Edit the prompt to strike through and append the selected
+            // answer; also strips the inline keyboard by not re-attaching
+            // a reply_markup.
+            let _ = bot
+                .edit_message_text(ChatId(chat_id), MessageId(msg_id), answered_text)
+                .parse_mode(ParseMode::Html)
+                .await;
+            let _ = bot.answer_callback_query(callback.id.clone()).await;
+        }
+        Err(e) => {
+            warn!(error = %e, question_id = %qid, "telegram: failed to resolve ask-user callback");
+            let _ = bot
+                .answer_callback_query(callback.id.clone())
+                .text("Failed to record answer.")
+                .await;
         }
     }
 }
@@ -2659,9 +2886,11 @@ async fn handle_update(
     };
 
     // Handle callback queries by prefix routing:
-    //   "guard:*"  → guard approval (approve/deny)
-    //   "trace:*"  → execution trace toggle (show/hide detail view)
-    //   other      → TODO: convert to RawPlatformMessage for kernel processing
+    //   "guard:*"   → guard approval (approve/deny)
+    //   "limit:*"   → tool-call limit continue/stop
+    //   "au:*"      → ask-user inline option press
+    //   "trace:*"   → execution trace toggle (show/hide detail view)
+    //   other       → TODO: convert to RawPlatformMessage for kernel processing
     if let UpdateKind::CallbackQuery(callback) = &update.kind {
         if let Some(data) = &callback.data {
             // guard: callbacks do their own user-level auth internally,
@@ -2674,6 +2903,15 @@ async fn handle_update(
             if data.starts_with("limit:") {
                 handle_tool_call_limit_callback(handle, bot, callback, data, allowed_chat_ids)
                     .await;
+                return;
+            }
+            // au: (ask-user option press) enforces per-question identity
+            // (expected_platform_user_id) on its own, which is strictly
+            // narrower than the shared chat-level auth below. Route it
+            // before the chat gate so a legitimate asker in a shared but
+            // unlisted chat can still answer their own prompt.
+            if data.starts_with("au:") {
+                handle_ask_user_callback(bot, callback, data).await;
                 return;
             }
 
@@ -2846,12 +3084,39 @@ async fn handle_update(
     // normal message processing so the reply text isn't ingested as a new
     // conversation turn.
     if let Some(reply) = msg.reply_to_message() {
-        let key = (chat_id, reply.id.0);
-        if let Some((_, pending)) = PENDING_USER_QUESTIONS.remove(&key) {
+        let lookup_key = (chat_id, reply.id.0);
+        if let Some((_, qid)) = PROMPT_MSG_TO_QID.remove(&lookup_key) {
+            let Some((_, pending)) = PENDING_USER_QUESTIONS.remove(&qid) else {
+                // Primary entry gone (timed out or already answered); drop
+                // the reply and fall through to normal processing.
+                return;
+            };
+
+            // Identity gate: only the asker may answer. Other members of a
+            // shared group/topic see the prompt but must not be able to
+            // unblock the agent by replying with, say, a fabricated API
+            // key. Re-insert the pending state on rejection so the real
+            // asker can still answer later.
+            let actual_pid = msg.from.as_ref().map(|u| u.id.0.to_string());
+            if let Some(ref expected) = pending.expected_platform_user_id {
+                if actual_pid.as_deref() != Some(expected.as_str()) {
+                    PENDING_USER_QUESTIONS.insert(qid, pending);
+                    PROMPT_MSG_TO_QID.insert(lookup_key, qid);
+                    let _ = bot
+                        .send_message(
+                            ChatId(chat_id),
+                            "⚠️ Only the original asker can answer this question.",
+                        )
+                        .reply_parameters(ReplyParameters::new(msg.id))
+                        .await;
+                    return;
+                }
+            }
+
             // Reject non-text replies — prompt user to reply with text.
             let Some(answer_text) = msg.text() else {
-                // Re-insert so the user can try again with a text reply.
-                PENDING_USER_QUESTIONS.insert(key, pending);
+                PENDING_USER_QUESTIONS.insert(qid, pending);
+                PROMPT_MSG_TO_QID.insert(lookup_key, qid);
                 let _ = bot
                     .send_message(ChatId(chat_id), "⚠️ Please reply with a text message.")
                     .reply_parameters(ReplyParameters::new(msg.id))
@@ -2860,11 +3125,10 @@ async fn handle_update(
             };
 
             let answer = answer_text.to_string();
-            let question_id = pending.question_id;
-            match pending.manager.resolve(question_id, answer) {
+            match pending.manager.resolve(qid, answer) {
                 Ok(()) => {
                     info!(
-                        question_id = %question_id,
+                        question_id = %qid,
                         "telegram: resolved user question via reply"
                     );
                     // Edit the original question message to show it was answered.
@@ -2878,7 +3142,7 @@ async fn handle_update(
                         .await;
                 }
                 Err(e) => {
-                    warn!(error = %e, question_id = %question_id, "telegram: failed to resolve question");
+                    warn!(error = %e, question_id = %qid, "telegram: failed to resolve question");
                 }
             }
             return;

--- a/crates/kernel/src/kernel.rs
+++ b/crates/kernel/src/kernel.rs
@@ -2460,6 +2460,10 @@ impl Kernel {
                     user_id: user.0.clone(),
                     session_key: session_key.clone(),
                     origin_endpoint: origin_endpoint.clone(),
+                    // Carry the platform-native user id (e.g. Telegram
+                    // `msg.from.id`) so interactive tools can bind pending
+                    // prompts to the actual responder in shared chats.
+                    origin_platform_user_id: Some(msg.source.platform_user_id.clone()),
                     event_queue: event_queue.clone(),
                     rara_message_id: msg_id.clone(),
                     context_window_tokens: 0,

--- a/crates/kernel/src/tool/mod.rs
+++ b/crates/kernel/src/tool/mod.rs
@@ -336,26 +336,35 @@ pub type ToolRegistryRef = Arc<ToolRegistry>;
 #[derive(Clone)]
 pub struct ToolContext {
     /// The authenticated user identifier for the current session.
-    pub user_id:               String,
+    pub user_id:                 String,
     /// The session key for the current conversation turn.
-    pub session_key:           crate::session::SessionKey,
+    pub session_key:             crate::session::SessionKey,
     /// The originating endpoint (e.g. Telegram chat) for routing replies.
-    pub origin_endpoint:       Option<crate::io::Endpoint>,
+    pub origin_endpoint:         Option<crate::io::Endpoint>,
+    /// Platform-native user identifier of the user who triggered this turn
+    /// (e.g. the Telegram `msg.from.id` as a string).
+    ///
+    /// Tools that raise interactive prompts (`ask-user`) use this to bind
+    /// pending requests to the expected responder, so that other members of a
+    /// shared group chat cannot resolve a question meant for one specific
+    /// user. `None` for origins that have no platform-level identity (CLI,
+    /// background jobs, synthetic re-entry).
+    pub origin_platform_user_id: Option<String>,
     /// Event queue for pushing outbound events.
-    pub event_queue:           crate::queue::ShardedQueueRef,
+    pub event_queue:             crate::queue::ShardedQueueRef,
     /// The inbound message ID that triggered the current turn.
-    pub rara_message_id:       crate::io::MessageId,
+    pub rara_message_id:         crate::io::MessageId,
     /// Context window size in tokens for the current model.
-    pub context_window_tokens: usize,
+    pub context_window_tokens:   usize,
     /// Live tool registry for the current session (includes dynamic MCP tools).
     /// Used by `discover-tools` to query the deferred catalog at runtime.
-    pub tool_registry:         Option<ToolRegistryRef>,
+    pub tool_registry:           Option<ToolRegistryRef>,
     /// Stream handle for emitting real-time output during execution.
     /// `None` when streaming is not available (e.g. background tasks).
-    pub stream_handle:         Option<crate::io::StreamHandle>,
+    pub stream_handle:           Option<crate::io::StreamHandle>,
     /// The tool call ID assigned by the LLM for this invocation.
     /// Used to correlate streaming output with the tool call.
-    pub tool_call_id:          Option<String>,
+    pub tool_call_id:            Option<String>,
 }
 
 impl std::fmt::Debug for ToolContext {
@@ -364,6 +373,7 @@ impl std::fmt::Debug for ToolContext {
             .field("user_id", &self.user_id)
             .field("session_key", &self.session_key)
             .field("origin_endpoint", &self.origin_endpoint)
+            .field("origin_platform_user_id", &self.origin_platform_user_id)
             .field("event_queue", &"...")
             .field("rara_message_id", &self.rara_message_id)
             .field("context_window_tokens", &self.context_window_tokens)

--- a/crates/kernel/src/tool/schedule.rs
+++ b/crates/kernel/src/tool/schedule.rs
@@ -366,15 +366,16 @@ mod tests {
 
     fn build_context() -> ToolContext {
         ToolContext {
-            user_id:               "test-user".into(),
-            session_key:           SessionKey::new(),
-            origin_endpoint:       None,
-            event_queue:           build_queue(),
-            rara_message_id:       MessageId::new(),
-            context_window_tokens: 0,
-            tool_registry:         None,
-            stream_handle:         None,
-            tool_call_id:          None,
+            user_id:                 "test-user".into(),
+            session_key:             SessionKey::new(),
+            origin_endpoint:         None,
+            origin_platform_user_id: None,
+            event_queue:             build_queue(),
+            rara_message_id:         MessageId::new(),
+            context_window_tokens:   0,
+            tool_registry:           None,
+            stream_handle:           None,
+            tool_call_id:            None,
         }
     }
 

--- a/crates/kernel/src/user_question.rs
+++ b/crates/kernel/src/user_question.rs
@@ -34,9 +34,23 @@ use crate::io::Endpoint;
 #[derive(Debug, Clone, Serialize)]
 pub struct UserQuestion {
     /// Unique identifier for this question.
-    pub id:       Uuid,
+    pub id: Uuid,
     /// The question text to present to the user.
     pub question: String,
+    /// Whether the question is sensitive (e.g. asks for API keys, passwords,
+    /// tokens).
+    ///
+    /// Channel adapters MUST route sensitive prompts to a private surface
+    /// (e.g. Telegram DM via `primary_chat_id`) and avoid leaking the text
+    /// into shared chats, even when the endpoint points at a group/topic.
+    pub sensitive: bool,
+    /// Optional pre-defined answer choices.
+    ///
+    /// When `Some`, adapters SHOULD render structured controls (e.g. Telegram
+    /// inline keyboard) so the user can pick without typing, and the answer
+    /// returned to the agent is the exact selected option string. When
+    /// `None`, adapters fall back to free-form reply-to-message input.
+    pub options: Option<Vec<String>>,
     /// Originating endpoint of the agent turn that raised this question.
     ///
     /// Channel adapters route the rendered prompt back to this endpoint (e.g.
@@ -45,6 +59,14 @@ pub struct UserQuestion {
     /// legacy callers), in which case adapters fall back to a default
     /// destination such as Telegram's `primary_chat_id`.
     pub endpoint: Option<Endpoint>,
+    /// Platform-native user identifier of the user who triggered this
+    /// question (e.g. Telegram `msg.from.id` as a string).
+    ///
+    /// Channel adapters MUST compare incoming answers (reply text or
+    /// callback press) against this value and reject mismatches, so that
+    /// other members of a shared chat cannot answer on behalf of the asker.
+    /// `None` when the origin has no platform-level identity.
+    pub expected_platform_user_id: Option<String>,
 }
 
 /// Error from user question operations.
@@ -113,12 +135,29 @@ impl UserQuestionManager {
     /// question back to the same conversation surface (e.g. a Telegram forum
     /// topic) rather than a default destination.
     ///
+    /// `expected_platform_user_id` identifies the user who triggered the
+    /// turn (typically `ToolContext::origin_platform_user_id`). Adapters
+    /// MUST validate incoming answers against it to prevent hijacking in
+    /// shared chats.
+    ///
+    /// When `sensitive` is `true`, adapters MUST route the prompt to a
+    /// private surface (e.g. the user's DM) rather than to `endpoint` if it
+    /// is a shared chat, so secret material never surfaces publicly.
+    ///
+    /// `options` optionally supplies pre-defined answer choices; adapters
+    /// that support structured input (e.g. inline keyboards) render them
+    /// instead of a free-text reply prompt.
+    ///
     /// Fails immediately with [`NoSubscribersSnafu`] if no channel adapter is
     /// listening, avoiding a silent 5-minute hang.
+    #[allow(clippy::too_many_arguments)]
     pub async fn ask(
         &self,
         question: String,
         endpoint: Option<Endpoint>,
+        expected_platform_user_id: Option<String>,
+        sensitive: bool,
+        options: Option<Vec<String>>,
         timeout: std::time::Duration,
     ) -> std::result::Result<String, UserQuestionError> {
         let id = Uuid::new_v4();
@@ -126,7 +165,10 @@ impl UserQuestionManager {
         let uq = UserQuestion {
             id,
             question: question.clone(),
+            sensitive,
+            options,
             endpoint,
+            expected_platform_user_id,
         };
 
         let (tx, rx) = tokio::sync::oneshot::channel();
@@ -212,6 +254,9 @@ mod tests {
                 .ask(
                     "What is your API key?".into(),
                     None,
+                    None,
+                    false,
+                    None,
                     std::time::Duration::from_secs(5),
                 )
                 .await
@@ -239,6 +284,9 @@ mod tests {
             .ask(
                 "question".into(),
                 None,
+                None,
+                false,
+                None,
                 std::time::Duration::from_millis(10),
             )
             .await;
@@ -251,7 +299,14 @@ mod tests {
         let mgr = UserQuestionManager::new();
         // No subscriber — should fail immediately.
         let result = mgr
-            .ask("question".into(), None, std::time::Duration::from_secs(5))
+            .ask(
+                "question".into(),
+                None,
+                None,
+                false,
+                None,
+                std::time::Duration::from_secs(5),
+            )
             .await;
         assert!(matches!(result, Err(UserQuestionError::NoSubscribers)));
     }


### PR DESCRIPTION
## Summary

Follow-up to #1462. Codex review of #1462 surfaced a P1 authorization gap that must be fixed before forum-topic routing is safe in shared chats: the reply handler at `crates/channels/src/telegram/adapter.rs` resolves `PENDING_USER_QUESTIONS` purely on `(chat_id, reply_message_id)` without checking `msg.from`, so any group member who can see the prompt can answer — including prompts that solicit secret material like API keys.

This PR lands three hardening layers in one change set.

### Layer 1 — identity gate (P1, blocks safe deployment in shared chats)

- `ToolContext` carries a new `origin_platform_user_id`, populated from `InboundMessage.source.platform_user_id` (kernel.rs build site).
- `UserQuestion` and `UserQuestionManager::ask` propagate it end-to-end.
- The Telegram adapter stores the expected platform user id on each pending question and rejects:
  - reply-to-message answers from `msg.from.id != expected` — re-inserts pending state, posts `⚠️ Only the original asker can answer this question.`
  - inline-keyboard `callback.from.id != expected` — `show_alert: true` rejection.

### Layer 2 — sensitive prompts forced to DM

- `AskUserParams.sensitive: bool` lets the agent explicitly mark secret-soliciting prompts.
- A conservative heuristic (`looks_sensitive`) matches common patterns in EN + ZH (`api key`, `password`, `token`, `2FA`, `OTP`, `密码`, `密钥`, `验证码`, `令牌`, `私钥`, …) — false positives strongly preferred over false negatives.
- Sensitive questions always route to `primary_chat_id` (DM) regardless of origin endpoint; a breadcrumb (`🔒 I sent a private question to your DM. Please check there to answer.`) is posted in the originating chat.

### Layer 3 — inline keyboard for enumerated answers

- `AskUserParams.options: Option<Vec<String>>` lets the agent supply pre-defined choices.
- The adapter renders Telegram inline-keyboard buttons with `callback_data = au:<question_uuid>:<option_index>`.
- New `handle_ask_user_callback` parses the prefix, validates `callback.from.id` (Telegram-attested platform identity), maps the index back through stored options, resolves, and edits the prompt in place to `✅ Answered ... → <selected>`.
- Routed before chat-level auth because per-question identity is strictly narrower.

### Internal restructuring

- `PENDING_USER_QUESTIONS` re-keyed on `Uuid` (stable across reply-to and callback paths).
- `PROMPT_MSG_TO_QID: DashMap<(chat_id, msg_id), Uuid>` secondary index keeps reply-to lookup O(1).
- `dispatch_user_question` extracted from `question_listener` for testability and to keep the select loop thin.
- Cleanup task removes both index entries on the 5-min ask-user timeout.

## Type of change

| Type | Label |
|------|-------|
| Bug fix + hardening | `bug` |

## Component

`backend` (kernel `user_question` / `tool::ToolContext`, app `ask_user` tool, Telegram adapter)

## Closes

Closes #1464

## Test plan

- [x] `cargo check --all --all-targets` passes
- [x] `cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings` passes (zero warnings)
- [x] `RUSTDOCFLAGS=\"-D warnings\" cargo +nightly doc --workspace --no-deps --document-private-items` passes
- [x] `cargo +nightly fmt --all -- --check` passes
- [x] `cargo test -p rara-kernel --lib user_question::` — 4/4 pass (call sites updated for new `ask` signature)
- [x] `cargo test -p rara-app --lib tools::ask_user::` — 2/2 pass (`looks_sensitive` heuristic coverage)
- [ ] Manual: Telegram forum topic, trigger plain `ask-user` → prompt appears in topic, only asker can reply-to
- [ ] Manual: Telegram forum topic, trigger `ask-user(sensitive: true)` → prompt routed to DM, breadcrumb in topic
- [ ] Manual: Telegram forum topic, trigger `ask-user(options: ["A", "B"])` → inline keyboard, only asker's button press resolves; other members get "Only the original asker..." alert