### PR TITLE
fix(channels): route guard approval back to origin topic + identity gate (#1466)

### DIFF
--- a/crates/channels/src/telegram/adapter.rs
+++ b/crates/channels/src/telegram/adapter.rs
@@ -53,6 +53,41 @@ use uuid::Uuid;
 /// cancelled when the user resolves an approval before the timeout fires.
 static GUARD_EXPIRY_HANDLES: LazyLock<DashMap<Uuid, AbortHandle>> = LazyLock::new(DashMap::new);
 
+/// Per-question identity gate state for a pending guard approval prompt.
+///
+/// Inserted by [`approval_listener`] after the inline-keyboard prompt has
+/// been rendered, removed by [`handle_guard_callback`] (on resolve) or by
+/// the per-request expiry task spawned alongside the prompt. When
+/// `expected_platform_user_id` is set, [`handle_guard_callback`] rejects
+/// approve/deny presses from any other user — strictly narrower than the
+/// chat-level `allowed_user_ids` gate so the original asker (and only them)
+/// can resolve a guard prompt that was raised inside a shared chat.
+// `_id` postfix on `request_id`/`prompt_chat_id`/`prompt_msg_id` is the
+// established naming for kernel/Telegram identifiers across the adapter
+// (see `PendingUserQuestion`); renaming would obscure the meaning.
+#[allow(clippy::struct_field_names)]
+struct PendingGuardApproval {
+    request_id:                Uuid,
+    /// Telegram `from.id` (as a string) of the user who triggered the turn
+    /// that produced this approval request. `None` when the originating
+    /// turn carries no platform identity (synthetic re-entry, background
+    /// jobs, syscall path); in that case identity-gate enforcement is
+    /// skipped and only the chat-level gate applies.
+    expected_platform_user_id: Option<String>,
+    /// Chat where the approval prompt was rendered. Kept for the expiry
+    /// task and for parity with [`PendingUserQuestion::prompt_location`].
+    prompt_chat_id:            i64,
+    /// Telegram message id of the rendered prompt — combined with
+    /// `prompt_chat_id` to form a stable address for the expiry task.
+    prompt_msg_id:             MessageId,
+}
+
+/// Pending guard-approval index keyed by the kernel-generated approval
+/// request UUID. Mirrors [`PENDING_USER_QUESTIONS`] in spirit: the kernel
+/// owns the UUID, the adapter owns the per-platform identity gate.
+static PENDING_GUARD_APPROVALS: LazyLock<DashMap<Uuid, PendingGuardApproval>> =
+    LazyLock::new(DashMap::new);
+
 /// Pending user-question entry stored in [`PENDING_USER_QUESTIONS`].
 struct PendingUserQuestion {
     question_id:               Uuid,
@@ -1872,6 +1907,34 @@ async fn handle_guard_callback(
         }
     };
 
+    // Per-request identity gate: reject presses from anyone but the user
+    // who triggered the turn that produced this approval request, so other
+    // members of a shared chat (who already passed the chat-level gate
+    // above) cannot resolve a guard prompt meant for the original asker.
+    //
+    // The gate is enforced only when the kernel recorded an expected
+    // identity — `None` falls through to chat-level auth (preserves
+    // pre-existing behavior for syscall-driven approvals and synthetic
+    // re-entries that have no platform user identity).
+    let caller_pid = callback.from.id.0.to_string();
+    if let Some(entry) = PENDING_GUARD_APPROVALS.get(&request_id) {
+        if let Some(expected) = entry.expected_platform_user_id.as_deref() {
+            if expected != caller_pid {
+                warn!(
+                    request_id = %request_id,
+                    caller_pid,
+                    "guard callback: identity gate rejected non-asker"
+                );
+                let _ = bot
+                    .answer_callback_query(callback.id.clone())
+                    .text("⚠️ Only the originator can approve this prompt")
+                    .show_alert(true)
+                    .await;
+                return;
+            }
+        }
+    }
+
     let decided_by = callback
         .from
         .username
@@ -1880,10 +1943,13 @@ async fn handle_guard_callback(
         .to_string();
 
     // Cancel the auto-expiry task before resolving so it cannot race with the
-    // message edit below.
+    // message edit below. Identity-gate state is removed here too — once we
+    // commit to resolving, no further presses should be accepted for this
+    // request.
     if let Some((_, abort_handle)) = GUARD_EXPIRY_HANDLES.remove(&request_id) {
         abort_handle.abort();
     }
+    PENDING_GUARD_APPROVALS.remove(&request_id);
 
     let result =
         handle
@@ -2441,25 +2507,48 @@ async fn approval_listener(
                     }
                 };
 
-                // Resolve the originating chat from the session's channel
-                // binding; fall back to primary_chat_id when unavailable.
-                let binding_chat_id = session_index
-                    .get_channel_binding_by_session(&req.session_key)
-                    .await
-                    .ok()
-                    .flatten()
-                    .and_then(|b| b.chat_id.parse::<i64>().ok());
+                // Resolve the destination in priority order:
+                //
+                //   1. `req.origin_endpoint` when it points at Telegram —
+                //      preserves `(chat_id, thread_id)` so the prompt
+                //      surfaces in the same forum topic the user was
+                //      chatting in (mirrors the routing fix in #1462 for
+                //      ask-user prompts).
+                //   2. Session channel binding (chat-level fallback when
+                //      the originating turn carried no Telegram endpoint,
+                //      e.g. heartbeat-driven background turns).
+                //   3. `primary_chat_id` (config-level fallback for
+                //      web/cli/synthetic origins).
+                //
+                // `thread_id` is preserved only on the (1) path; the
+                // chat-level fallbacks have no per-thread context.
+                let (chat_id, thread_id) = match &req.origin_endpoint {
+                    Some(Endpoint {
+                        address: EndpointAddress::Telegram { chat_id, thread_id },
+                        ..
+                    }) => (*chat_id, *thread_id),
+                    _ => {
+                        let binding_chat_id = session_index
+                            .get_channel_binding_by_session(&req.session_key)
+                            .await
+                            .ok()
+                            .flatten()
+                            .and_then(|b| b.chat_id.parse::<i64>().ok());
 
-                let chat_id = binding_chat_id.or_else(|| {
-                    let cfg = config.read().unwrap_or_else(|e| e.into_inner());
-                    cfg.primary_chat_id
-                });
-                let Some(chat_id) = chat_id else {
-                    warn!(
-                        session_key = %req.session_key,
-                        "telegram approval listener: no channel binding and no primary_chat_id configured"
-                    );
-                    continue;
+                        let chat_id = binding_chat_id.or_else(|| {
+                            let cfg = config.read().unwrap_or_else(|e| e.into_inner());
+                            cfg.primary_chat_id
+                        });
+                        let Some(chat_id) = chat_id else {
+                            warn!(
+                                session_key = %req.session_key,
+                                request_id = %req.id,
+                                "telegram approval listener: no Telegram origin, no channel binding, no primary_chat_id configured"
+                            );
+                            continue;
+                        };
+                        (chat_id, None)
+                    }
                 };
 
                 let (_display, args_summary_raw) = tool_display_info(&req.tool_name, &req.tool_args);
@@ -2510,14 +2599,33 @@ async fn approval_listener(
                     InlineKeyboardButton::callback("❌ Deny", format!("guard:deny:{}", req.id)),
                 ]]);
 
-                let result = bot
-                    .send_message(ChatId(chat_id), &display_text)
-                    .parse_mode(ParseMode::Html)
-                    .reply_markup(keyboard)
-                    .await;
+                let send_req = with_thread_id!(
+                    bot.send_message(ChatId(chat_id), &display_text)
+                        .parse_mode(ParseMode::Html)
+                        .reply_markup(keyboard),
+                    thread_id
+                );
+                let result = send_req.await;
 
                 match result {
                     Ok(sent_msg) => {
+                        // Install identity-gate state so `handle_guard_callback`
+                        // can reject approve/deny presses from anyone but the
+                        // user who triggered the turn. Recorded BEFORE the
+                        // expiry task is spawned so a fast user press cannot
+                        // race the insert.
+                        PENDING_GUARD_APPROVALS.insert(
+                            req.id,
+                            PendingGuardApproval {
+                                request_id:                req.id,
+                                expected_platform_user_id: req
+                                    .origin_platform_user_id
+                                    .clone(),
+                                prompt_chat_id:            chat_id,
+                                prompt_msg_id:             sent_msg.id,
+                            },
+                        );
+
                         // Spawn a delayed task to auto-expire the message when
                         // the approval timeout elapses. The abort handle is
                         // stored so `handle_guard_callback` can cancel it if
@@ -2530,8 +2638,12 @@ async fn approval_listener(
                         let handle = tokio::spawn(async move {
                             tokio::time::sleep(std::time::Duration::from_secs(timeout_secs)).await;
 
-                            // Remove our own entry from the map.
+                            // Remove our own entry from the maps. Both
+                            // GUARD_EXPIRY_HANDLES and PENDING_GUARD_APPROVALS
+                            // are cleaned up here so timed-out requests do
+                            // not leak identity-gate state.
                             GUARD_EXPIRY_HANDLES.remove(&request_id);
+                            PENDING_GUARD_APPROVALS.remove(&request_id);
 
                             // Collapse to compact one-liner on expiry.
                             let expired_text = "🛡 <b>Guard</b> ⏰ timed out".to_string();

--- a/crates/kernel/src/agent/mod.rs
+++ b/crates/kernel/src/agent/mod.rs
@@ -2287,16 +2287,26 @@ pub(crate) async fn run_agent_loop(
                         );
 
                         let risk_level = crate::security::ApprovalManager::classify_risk(blocked_tool.as_str());
+                        // Carry the originating endpoint and platform user
+                        // identity through the approval request so the
+                        // channel adapter can route the prompt back to the
+                        // exact chat surface the user was in (e.g. the same
+                        // Telegram forum topic) and reject approve/deny
+                        // presses from anyone but the original asker. Both
+                        // already live on `ToolContext`, populated at
+                        // turn-start from the inbound message.
                         let approval_req = crate::security::ApprovalRequest {
-                            id:           uuid::Uuid::new_v4(),
-                            session_key:  session_key_for_guard,
-                            tool_name:    blocked_tool.to_string(),
-                            tool_args:    args.clone(),
-                            summary:      format!("Guard blocked ({layer}): {reason}"),
+                            id:                      uuid::Uuid::new_v4(),
+                            session_key:             session_key_for_guard,
+                            tool_name:               blocked_tool.to_string(),
+                            tool_args:               args.clone(),
+                            summary:                 format!("Guard blocked ({layer}): {reason}"),
                             risk_level,
-                            requested_at: jiff::Timestamp::now(),
-                            timeout_secs: 120,
-                            context:      None,
+                            requested_at:            jiff::Timestamp::now(),
+                            timeout_secs:            120,
+                            context:                 None,
+                            origin_endpoint:         tc.origin_endpoint.clone(),
+                            origin_platform_user_id: tc.origin_platform_user_id.clone(),
                         };
 
                         let decision = approval_manager.request_approval(approval_req).await;

--- a/crates/kernel/src/kernel.rs
+++ b/crates/kernel/src/kernel.rs
@@ -2463,7 +2463,20 @@ impl Kernel {
                     // Carry the platform-native user id (e.g. Telegram
                     // `msg.from.id`) so interactive tools can bind pending
                     // prompts to the actual responder in shared chats.
-                    origin_platform_user_id: Some(msg.source.platform_user_id.clone()),
+                    //
+                    // Suppress for `ChannelType::Internal` synthetic
+                    // re-entry (e.g. `handle_spawn_agent` bootstrap
+                    // turns), where `platform_user_id` carries the
+                    // kernel `UserId.0` instead of a real platform id.
+                    // Surfacing that string would make the Telegram
+                    // identity gate compare `callback.from.id` against
+                    // a kernel username, locking out the real
+                    // originator on a session's first guarded turn
+                    // (Codex review of #1467).
+                    origin_platform_user_id: match msg.source.channel_type {
+                        crate::channel::types::ChannelType::Internal => None,
+                        _ => Some(msg.source.platform_user_id.clone()),
+                    },
                     event_queue: event_queue.clone(),
                     rara_message_id: msg_id.clone(),
                     context_window_tokens: 0,

--- a/crates/kernel/src/security.rs
+++ b/crates/kernel/src/security.rs
@@ -60,16 +60,38 @@ pub enum ApprovalDecision {
 /// An approval request submitted by an agent before executing a tool.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ApprovalRequest {
-    pub id:           Uuid,
-    pub session_key:  SessionKey,
-    pub tool_name:    String,
-    pub tool_args:    serde_json::Value,
-    pub summary:      String,
-    pub risk_level:   RiskLevel,
+    pub id: Uuid,
+    pub session_key: SessionKey,
+    pub tool_name: String,
+    pub tool_args: serde_json::Value,
+    pub summary: String,
+    pub risk_level: RiskLevel,
     pub requested_at: Timestamp,
     pub timeout_secs: u64,
     /// Optional context explaining why the agent wants to call this tool.
-    pub context:      Option<String>,
+    pub context: Option<String>,
+    /// Originating endpoint of the agent turn that raised this approval
+    /// request.
+    ///
+    /// Channel adapters route the rendered approval prompt back to this
+    /// endpoint (e.g. the same Telegram forum topic the user was chatting
+    /// in) so the user does not have to leave the topic to approve. `None`
+    /// when the originating turn has no platform endpoint (synthetic
+    /// re-entry, background jobs) or the source channel cannot be inferred,
+    /// in which case adapters fall back to the session's channel binding or
+    /// `primary_chat_id`.
+    #[serde(default)]
+    pub origin_endpoint: Option<crate::io::Endpoint>,
+    /// Platform-native user identifier of the user who triggered the turn
+    /// that raised this approval request (e.g. Telegram `msg.from.id` as a
+    /// string).
+    ///
+    /// Channel adapters MUST compare incoming approve/deny presses against
+    /// this value when set, so other members of a shared chat cannot
+    /// resolve a guard prompt meant for the original asker. `None` when the
+    /// origin has no platform-level identity (CLI, background jobs).
+    #[serde(default)]
+    pub origin_platform_user_id: Option<String>,
 }
 
 /// Response after an approval request is resolved.

--- a/crates/kernel/src/syscall.rs
+++ b/crates/kernel/src/syscall.rs
@@ -267,6 +267,16 @@ impl SyscallDispatcher {
             } => {
                 let approval = Arc::clone(security.approval());
                 let policy = approval.policy();
+                // The Session carries `origin_endpoint` set by the most
+                // recent platform message; use it so channel adapters can
+                // route the approval prompt back to the originating chat
+                // surface (e.g. the same Telegram forum topic). Returns
+                // `None` for synthetic/background turns with no inbound
+                // endpoint, in which case adapters fall back to the
+                // session's channel binding or `primary_chat_id`.
+                let origin_endpoint = process_table
+                    .with(&syscall_sender, |p| p.origin_endpoint.clone())
+                    .flatten();
                 let req = crate::security::ApprovalRequest {
                     id: uuid::Uuid::new_v4(),
                     session_key: syscall_sender,
@@ -277,6 +287,13 @@ impl SyscallDispatcher {
                     requested_at: Timestamp::now(),
                     timeout_secs: policy.timeout_secs,
                     context: None,
+                    origin_endpoint,
+                    // Syscall-driven approval requests are not bound to a
+                    // single platform user — `KernelHandle::request_approval`
+                    // does not carry the inbound message identity. Setting
+                    // `None` falls back to chat-level authorization, which
+                    // is the pre-existing behavior.
+                    origin_platform_user_id: None,
                 };
 
                 // Spawn a task so the event loop is not blocked while waiting


### PR DESCRIPTION
## Summary

Same class of bug as #1461 (ask-user routing) and #1464 (ask-user hardening), but for guard approval. Mirrors the patterns from #1462 + #1465.

- **Routing**: `ApprovalRequest` now carries `origin_endpoint: Option<Endpoint>`, populated from `Session.origin_endpoint` (kernel) and `ToolContext.origin_endpoint` (agent loop). `approval_listener` reads it and routes to `(chat_id, thread_id)` via `with_thread_id!`. Falls back to binding lookup → `primary_chat_id` only when origin is missing or non-Telegram.
- **Identity gate**: new `PendingGuardApproval` + `PENDING_GUARD_APPROVALS` map (mirroring `PendingUserQuestion` from #1465) carries the originator's `expected_platform_user_id` from `ToolContext.origin_platform_user_id`. `handle_guard_callback` rejects presses where `callback.from.id` does not match: `"⚠️ Only the originator can approve this prompt"`. Bot-level `allowed_user_ids` retained as outer gate (defense in depth).

### Deviation noted in commit

`Syscall::RequestApproval` sets `origin_platform_user_id = None` because `KernelHandle::request_approval` (the only entry point producing this syscall) currently has zero callers — the live guard path goes through the agent loop where `tc.origin_platform_user_id` is available. If the syscall API gains real callers, threading the id through `Session` is the cleanest follow-up.

## Type of change

| Type | Label |
|------|-------|
| Bug fix | `bug` |

## Component

`core` (channels + kernel)

## Closes

Closes #1466

## Test plan

- [x] `cargo check --workspace --all-targets` passes
- [x] `cargo +nightly fmt --all` applied
- [x] `cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings` passes (zero warnings)
- [x] `cargo test -p rara-kernel -p rara-channels` passes
- [x] `cargo +nightly doc --workspace --no-deps --document-private-items` passes
- [ ] Manual smoke test: trigger a guard-blocked tool inside a forum topic → approval prompt appears in the same topic, not in DM
- [ ] Manual smoke test: another authorized user tries to approve someone else's prompt → callback returns "Only the originator can approve"