### PR TITLE
refactor(web): unified TimelineItem + useSessionTimeline hook (#1470)

### DIFF
--- a/web/src/api/kernel-types.ts
+++ b/web/src/api/kernel-types.ts
@@ -1,0 +1,256 @@
+/*
+ * Copyright 2025 Rararulab
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Shared types between the kernel REST/WS API and the UI.
+ *
+ * The kernel emits two data shapes for an agent's execution:
+ *   1. Historical turns via `GET /api/v1/kernel/sessions/{key}/turns`
+ *      — structured `TurnTrace[]` with completed iterations and tool calls.
+ *   2. Live incremental events via WebSocket
+ *      `/api/v1/kernel/sessions/{key}/stream` — `StreamEvent` deltas.
+ *
+ * The UI should not care which source an event came from. This module
+ * defines the unified {@link TimelineItem} shape and the helpers that
+ * project the two backend shapes into it.
+ */
+
+// ---------------------------------------------------------------------------
+// Backend-mirrored types
+// ---------------------------------------------------------------------------
+
+/** A single tool invocation recorded on a completed iteration. */
+export interface ToolCallTrace {
+  name: string;
+  id: string;
+  duration_ms: number;
+  success: boolean;
+  arguments: Record<string, unknown>;
+  result_preview: string;
+  error: string | null;
+}
+
+/** One iteration of the agent loop (an LLM call + its resulting tool calls). */
+export interface IterationTrace {
+  index: number;
+  first_token_ms: number | null;
+  stream_ms: number;
+  text_preview: string;
+  reasoning_text: string | null;
+  tool_calls: ToolCallTrace[];
+}
+
+/** Trace data for a single completed agent turn. */
+export interface TurnTrace {
+  duration_ms: number;
+  model: string;
+  input_text: string | null;
+  iterations: IterationTrace[];
+  final_text_len: number;
+  total_tool_calls: number;
+  success: boolean;
+  error: string | null;
+}
+
+/**
+ * Narrow subset of kernel `StreamEvent` the UI consumes today.
+ *
+ * The kernel emits more variants (PlanCreated, UsageUpdate,
+ * BackgroundTaskStarted, etc.); we parse defensively — unknown variants
+ * are ignored by the hook.
+ */
+export type StreamEvent =
+  | { type: "text_delta"; text: string }
+  | { type: "reasoning_delta"; text: string }
+  | {
+      type: "tool_call_start";
+      name: string;
+      id: string;
+      arguments: Record<string, unknown>;
+    }
+  | {
+      type: "tool_call_end";
+      id: string;
+      result_preview: string;
+      success: boolean;
+      error: string | null;
+    }
+  | {
+      type: "turn_metrics";
+      duration_ms: number;
+      iterations: number;
+      tool_calls: number;
+      model: string;
+      rara_message_id: string;
+    }
+  | { type: "done" }
+  | { type: string; [k: string]: unknown };
+
+// ---------------------------------------------------------------------------
+// Unified timeline model
+// ---------------------------------------------------------------------------
+
+/** Semantic category of a timeline item — drives icon/color/layout. */
+export type EventKind =
+  | "agent"
+  | "thinking"
+  | "tool_use"
+  | "tool_result"
+  | "error";
+
+/**
+ * One renderable row in the session timeline.
+ *
+ * `seq` is monotonic **within its source** (historical or live). Keys for
+ * React reconciliation should combine source + seq (e.g. `h-3`, `l-7`),
+ * never compare seqs across sources.
+ */
+export interface TimelineItem {
+  seq: number;
+  /** 0-based turn index this item belongs to. */
+  turn: number;
+  kind: EventKind;
+  /** Tool name for `tool_use` / `tool_result`. */
+  tool?: string;
+  /** Body for `agent` / `thinking` / `error`. */
+  content?: string;
+  /** Tool call arguments for `tool_use`. */
+  input?: Record<string, unknown>;
+  /** Tool result preview for `tool_result`. */
+  output?: string;
+  /** Tool execution duration (historical only). */
+  durationMs?: number;
+  /** Tool success flag (`tool_use` / `tool_result`). */
+  success?: boolean;
+  /** Still receiving WS deltas — callers may show a cursor/pulse. */
+  streaming?: boolean;
+}
+
+/**
+ * Flatten an array of `TurnTrace` into timeline items.
+ *
+ * Order within a turn: `thinking?` → per tool `[tool_use, tool_result|error]` → `agent?`.
+ * A turn-level error is appended last.
+ */
+export function turnsToTimeline(turns: TurnTrace[]): TimelineItem[] {
+  const items: TimelineItem[] = [];
+  let seq = 0;
+
+  turns.forEach((turn, turnIdx) => {
+    for (const iter of turn.iterations) {
+      if (iter.reasoning_text && iter.reasoning_text.trim().length > 0) {
+        items.push({
+          seq: seq++,
+          turn: turnIdx,
+          kind: "thinking",
+          content: iter.reasoning_text,
+        });
+      }
+
+      for (const tc of iter.tool_calls) {
+        items.push({
+          seq: seq++,
+          turn: turnIdx,
+          kind: "tool_use",
+          tool: tc.name,
+          input: tc.arguments,
+          durationMs: tc.duration_ms,
+          success: tc.success,
+        });
+        if (tc.error) {
+          items.push({
+            seq: seq++,
+            turn: turnIdx,
+            kind: "error",
+            tool: tc.name,
+            content: tc.error,
+          });
+        } else if (tc.result_preview) {
+          items.push({
+            seq: seq++,
+            turn: turnIdx,
+            kind: "tool_result",
+            tool: tc.name,
+            output: tc.result_preview,
+            success: tc.success,
+          });
+        }
+      }
+
+      if (iter.text_preview && iter.text_preview.trim().length > 0) {
+        items.push({
+          seq: seq++,
+          turn: turnIdx,
+          kind: "agent",
+          content: iter.text_preview,
+        });
+      }
+    }
+
+    if (turn.error) {
+      items.push({
+        seq: seq++,
+        turn: turnIdx,
+        kind: "error",
+        content: turn.error,
+      });
+    }
+  });
+
+  return items;
+}
+
+// ---------------------------------------------------------------------------
+// Session state helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Concrete states produced by `rara_kernel::session::SessionState`.
+ *
+ * See `crates/kernel/src/session/mod.rs:243`. Sessions are **never
+ * terminal** (`is_terminal()` always returns false), so `Completed`,
+ * `Failed`, or `Cancelled` never appear — do not branch on them.
+ */
+export type KernelSessionState = "Active" | "Ready" | "Suspended" | "Paused";
+
+/** UI grouping for the session list. */
+export type SessionGroup = "active" | "dormant";
+
+/**
+ * Bucket a kernel session state into an IA group.
+ *
+ * - `active` — currently processing (`Active`) or idle-but-alive (`Ready`).
+ * - `dormant` — temporarily offline (`Suspended` / `Paused`).
+ */
+export function sessionGroup(state: string): SessionGroup {
+  switch (state.toLowerCase()) {
+    case "active":
+    case "ready":
+      return "active";
+    default:
+      return "dormant";
+  }
+}
+
+/**
+ * Whether a session is expected to emit live stream events and should be
+ * subscribed to via WebSocket.
+ */
+export function isLiveState(state: string | null): boolean {
+  if (!state) return false;
+  const s = state.toLowerCase();
+  return s === "active" || s === "ready";
+}

--- a/web/src/hooks/use-session-timeline.ts
+++ b/web/src/hooks/use-session-timeline.ts
@@ -1,0 +1,319 @@
+/*
+ * Copyright 2025 Rararulab
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useEffect, useMemo, useRef, useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { api } from "@/api/client";
+import {
+  isLiveState,
+  turnsToTimeline,
+  type StreamEvent,
+  type TimelineItem,
+  type TurnTrace,
+} from "@/api/kernel-types";
+
+const TURNS_REFETCH_MS = 5_000;
+
+/** Result returned by {@link useSessionTimeline}. */
+export interface SessionTimelineState {
+  /** Merged timeline: historical turns followed by in-flight live events. */
+  items: TimelineItem[];
+  /** Items projected from completed historical turns. */
+  historicalItems: TimelineItem[];
+  /** Items from the in-flight WS stream (empty when not streaming). */
+  liveItems: TimelineItem[];
+  /** True while a WebSocket stream is actively receiving events. */
+  isStreaming: boolean;
+  /** Raw turns for callers that need turn-level metadata (duration, model). */
+  turns: TurnTrace[];
+  isLoading: boolean;
+  isError: boolean;
+  refetch: () => void;
+}
+
+/**
+ * Unified session execution timeline — merges historical turns from
+ * `/kernel/sessions/{key}/turns` with live WS events into a single
+ * ordered `TimelineItem[]`.
+ *
+ * The caller is agnostic to data source: historical and live items are
+ * indistinguishable beyond the `streaming` flag on items still receiving
+ * deltas. When the backend's `done` event fires, live items are cleared;
+ * the next turns-query refetch will surface them as historical items.
+ */
+export function useSessionTimeline(
+  sessionKey: string | null,
+  sessionState: string | null,
+): SessionTimelineState {
+  const turnsQuery = useQuery({
+    queryKey: ["session-turns", sessionKey],
+    queryFn: () =>
+      api.get<TurnTrace[]>(`/api/v1/kernel/sessions/${sessionKey}/turns`),
+    enabled: !!sessionKey,
+    refetchInterval: TURNS_REFETCH_MS,
+  });
+
+  const turns = useMemo(() => turnsQuery.data ?? [], [turnsQuery.data]);
+  const historicalItems = useMemo(() => turnsToTimeline(turns), [turns]);
+
+  const [liveItems, setLiveItems] = useState<TimelineItem[]>([]);
+  const [isStreaming, setIsStreaming] = useState(false);
+
+  // Read through a ref so the WS effect does not re-subscribe every time
+  // the 5s turns refetch mutates turn count. The value is sampled when the
+  // WS opens and captured into `liveTurnIdx` below.
+  const turnsLenRef = useRef(0);
+  turnsLenRef.current = turns.length;
+
+  // Depending only on (sessionKey, sessionState) prevents the WS from
+  // reconnecting whenever the 5s turns refetch mutates historical data.
+  useEffect(() => {
+    if (!sessionKey || !isLiveState(sessionState)) {
+      setLiveItems([]);
+      setIsStreaming(false);
+      return;
+    }
+
+    const host = window.location.host;
+    const protocol = window.location.protocol === "https:" ? "wss:" : "ws:";
+    const token = localStorage.getItem("access_token") ?? "";
+    const ws = new WebSocket(
+      `${protocol}//${host}/api/v1/kernel/sessions/${sessionKey}/stream?token=${token}`,
+    );
+
+    // Live seq is an independent monotonic counter; combine with the "l-"
+    // prefix on React keys to avoid any collision with historical seqs.
+    let liveSeq = 0;
+    const nextSeq = () => liveSeq++;
+
+    // Track the in-flight text/thinking item's seq so deltas can be appended
+    // in place, and the tool_use seq per tool id so tool_call_end finalizes
+    // the correct row.
+    let currentTextSeq: number | null = null;
+    let currentThinkSeq: number | null = null;
+    const toolSeqById = new Map<string, number>();
+
+    // Live events belong to the turn after the last one already recorded.
+    // Captured at WS-open time; not refreshed mid-stream. `done` clears
+    // live state, so drift between this value and turnsQuery is bounded.
+    const liveTurnIdx = turnsLenRef.current;
+
+    ws.onopen = () => {
+      setIsStreaming(true);
+      setLiveItems([]);
+    };
+
+    ws.onmessage = (ev) => {
+      let event: StreamEvent;
+      try {
+        event = JSON.parse(ev.data) as StreamEvent;
+      } catch {
+        return;
+      }
+
+      switch (event.type) {
+        case "text_delta": {
+          const delta = (event as { text?: string }).text ?? "";
+          if (!delta) break;
+          setLiveItems((prev) => {
+            if (currentTextSeq !== null) {
+              const target = currentTextSeq;
+              return prev.map((it) =>
+                it.seq === target && it.kind === "agent"
+                  ? { ...it, content: (it.content ?? "") + delta }
+                  : it,
+              );
+            }
+            const seq = nextSeq();
+            currentTextSeq = seq;
+            return [
+              ...prev,
+              {
+                seq,
+                turn: liveTurnIdx,
+                kind: "agent",
+                content: delta,
+                streaming: true,
+              },
+            ];
+          });
+          break;
+        }
+
+        case "reasoning_delta": {
+          const delta = (event as { text?: string }).text ?? "";
+          if (!delta) break;
+          setLiveItems((prev) => {
+            if (currentThinkSeq !== null) {
+              const target = currentThinkSeq;
+              return prev.map((it) =>
+                it.seq === target && it.kind === "thinking"
+                  ? { ...it, content: (it.content ?? "") + delta }
+                  : it,
+              );
+            }
+            const seq = nextSeq();
+            currentThinkSeq = seq;
+            return [
+              ...prev,
+              {
+                seq,
+                turn: liveTurnIdx,
+                kind: "thinking",
+                content: delta,
+                streaming: true,
+              },
+            ];
+          });
+          break;
+        }
+
+        case "tool_call_start": {
+          const e = event as {
+            name: string;
+            id: string;
+            arguments: Record<string, unknown>;
+          };
+          const closedTextSeq = currentTextSeq;
+          const closedThinkSeq = currentThinkSeq;
+          currentTextSeq = null;
+          currentThinkSeq = null;
+
+          const seq = nextSeq();
+          toolSeqById.set(e.id, seq);
+
+          setLiveItems((prev) => {
+            const finalized = prev.map((it) => {
+              if (
+                (closedTextSeq !== null && it.seq === closedTextSeq) ||
+                (closedThinkSeq !== null && it.seq === closedThinkSeq)
+              ) {
+                return { ...it, streaming: false };
+              }
+              return it;
+            });
+            return [
+              ...finalized,
+              {
+                seq,
+                turn: liveTurnIdx,
+                kind: "tool_use",
+                tool: e.name,
+                input: e.arguments,
+                streaming: true,
+              },
+            ];
+          });
+          break;
+        }
+
+        case "tool_call_end": {
+          const e = event as {
+            id: string;
+            result_preview: string;
+            success: boolean;
+            error: string | null;
+          };
+          const usedSeq = toolSeqById.get(e.id);
+          toolSeqById.delete(e.id);
+
+          setLiveItems((prev) => {
+            const finalized =
+              usedSeq !== undefined
+                ? prev.map((it) =>
+                    it.seq === usedSeq && it.kind === "tool_use"
+                      ? { ...it, streaming: false, success: e.success }
+                      : it,
+                  )
+                : prev;
+
+            if (e.error) {
+              return [
+                ...finalized,
+                {
+                  seq: nextSeq(),
+                  turn: liveTurnIdx,
+                  kind: "error",
+                  content: e.error,
+                },
+              ];
+            }
+            if (e.result_preview) {
+              return [
+                ...finalized,
+                {
+                  seq: nextSeq(),
+                  turn: liveTurnIdx,
+                  kind: "tool_result",
+                  output: e.result_preview,
+                  success: e.success,
+                },
+              ];
+            }
+            return finalized;
+          });
+          break;
+        }
+
+        case "turn_metrics": {
+          // Turn boundary — flush streaming flags; keep items so the
+          // just-completed turn stays visible until turnsQuery refetches.
+          currentTextSeq = null;
+          currentThinkSeq = null;
+          setLiveItems((prev) =>
+            prev.map((it) => ({ ...it, streaming: false })),
+          );
+          break;
+        }
+
+        case "done":
+          setIsStreaming(false);
+          setLiveItems([]);
+          break;
+
+        default:
+          // Unknown / unhandled event types (PlanCreated, UsageUpdate, etc.)
+          // are ignored. Add cases here as UI coverage expands.
+          break;
+      }
+    };
+
+    ws.onclose = () => setIsStreaming(false);
+    ws.onerror = () => setIsStreaming(false);
+
+    return () => {
+      ws.close();
+      setIsStreaming(false);
+      setLiveItems([]);
+    };
+  }, [sessionKey, sessionState]);
+
+  const items = useMemo(
+    () => [...historicalItems, ...liveItems],
+    [historicalItems, liveItems],
+  );
+
+  return {
+    items,
+    historicalItems,
+    liveItems,
+    isStreaming,
+    turns,
+    isLoading: turnsQuery.isLoading,
+    isError: turnsQuery.isError,
+    refetch: turnsQuery.refetch,
+  };
+}

--- a/web/src/pages/KernelTop.tsx
+++ b/web/src/pages/KernelTop.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { useState, useEffect, Fragment } from "react";
+import { useState, Fragment } from "react";
 import { useQuery } from "@tanstack/react-query";
 import {
   Activity,
@@ -27,6 +27,7 @@ import {
   Zap,
 } from "lucide-react";
 import { api } from "@/api/client";
+import { useSessionTimeline } from "@/hooks/use-session-timeline";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
@@ -50,52 +51,6 @@ import {
 // ---------------------------------------------------------------------------
 // Types (matching Rust backend)
 // ---------------------------------------------------------------------------
-
-/** A single node streamed via WebSocket during live session observation. */
-interface StreamingNode {
-  type: "thought" | "action" | "observation";
-  key: string;
-  text?: string;
-  toolName?: string;
-  toolId?: string;
-  arguments?: Record<string, unknown>;
-  resultPreview?: string;
-  success?: boolean;
-  error?: string | null;
-  durationMs?: number;
-  streaming?: boolean;
-}
-
-interface ToolCallTrace {
-  name: string;
-  id: string;
-  duration_ms: number;
-  success: boolean;
-  arguments: Record<string, unknown>;
-  result_preview: string;
-  error: string | null;
-}
-
-interface IterationTrace {
-  index: number;
-  first_token_ms: number | null;
-  stream_ms: number;
-  text_preview: string;
-  reasoning_text: string | null;
-  tool_calls: ToolCallTrace[];
-}
-
-/** Trace data for a single agent turn (returned by the turns API). */
-interface TurnTrace {
-  duration_ms: number;
-  model: string;
-  input_text: string | null;
-  iterations: IterationTrace[];
-  final_text_len: number;
-  total_tool_calls: number;
-  success: boolean;
-  error: string | null;
-}
 
 interface SystemStats {
   active_sessions: number;
@@ -158,142 +113,28 @@ function formatRelativeTime(iso: string | null): string {
   return `${diffHr}h ago`;
 }
 
-function stateColor(state: string): "default" | "secondary" | "destructive" | "outline" {
+/**
+ * Map a kernel `SessionState` to a Badge variant.
+ *
+ * Kernel states are `Active`, `Ready`, `Suspended`, `Paused` — sessions
+ * are never terminal (see `crates/kernel/src/session/mod.rs:258`).
+ * Branches for `completed` / `failed` / `cancelled` are intentionally
+ * absent — kernel never produces them.
+ */
+function stateColor(
+  state: string,
+): "default" | "secondary" | "destructive" | "outline" {
   switch (state.toLowerCase()) {
-    case "running":
+    case "active":
       return "default";
-    case "idle":
-    case "paused":
+    case "ready":
       return "secondary";
-    case "waiting":
-      return "outline";
-    case "failed":
-    case "error":
-      return "destructive";
-    case "completed":
-    case "cancelled":
+    case "suspended":
+    case "paused":
       return "outline";
     default:
       return "outline";
   }
-}
-
-// ---------------------------------------------------------------------------
-// useSessionStream hook
-// ---------------------------------------------------------------------------
-
-function useSessionStream(agentId: string | null, sessionState: string | null) {
-  const [nodes, setNodes] = useState<StreamingNode[]>([]);
-  const [isStreaming, setIsStreaming] = useState(false);
-
-  useEffect(() => {
-    if (!agentId || !sessionState) return;
-    if (sessionState !== "Running" && sessionState !== "Idle") return;
-
-    const host = window.location.host;
-    const protocol = window.location.protocol === "https:" ? "wss:" : "ws:";
-    const token = localStorage.getItem("access_token") ?? "";
-    const ws = new WebSocket(
-      `${protocol}//${host}/api/v1/kernel/sessions/${agentId}/stream?token=${token}`
-    );
-
-    let currentThought = "";
-    let thoughtKey = `live-thought-${Date.now()}`;
-
-    ws.onopen = () => {
-      setIsStreaming(true);
-      setNodes([]);
-    };
-
-    ws.onmessage = (ev) => {
-      try {
-        const event = JSON.parse(ev.data);
-        switch (event.type) {
-          case "text_delta":
-            currentThought += event.text ?? "";
-            setNodes((prev) => {
-              const existing = prev.find((n) => n.key === thoughtKey);
-              if (existing) {
-                return prev.map((n) =>
-                  n.key === thoughtKey ? { ...n, text: currentThought } : n
-                );
-              }
-              return [
-                ...prev,
-                {
-                  type: "thought" as const,
-                  key: thoughtKey,
-                  text: currentThought,
-                  streaming: true,
-                },
-              ];
-            });
-            break;
-
-          case "tool_call_start":
-            if (currentThought) {
-              setNodes((prev) =>
-                prev.map((n) =>
-                  n.key === thoughtKey ? { ...n, streaming: false } : n
-                )
-              );
-            }
-            setNodes((prev) => [
-              ...prev,
-              {
-                type: "action" as const,
-                key: `live-action-${event.id}`,
-                toolName: event.name,
-                toolId: event.id,
-                arguments: event.arguments,
-                streaming: true,
-              },
-            ]);
-            break;
-
-          case "tool_call_end":
-            setNodes((prev) => [
-              ...prev.map((n) =>
-                n.key === `live-action-${event.id}`
-                  ? { ...n, streaming: false, success: event.success }
-                  : n
-              ),
-              {
-                type: "observation" as const,
-                key: `live-obs-${event.id}`,
-                resultPreview: event.result_preview,
-                success: event.success,
-                error: event.error,
-              },
-            ]);
-            break;
-
-          case "turn_metrics":
-            currentThought = "";
-            thoughtKey = `live-thought-${Date.now()}`;
-            break;
-
-          case "done":
-            setIsStreaming(false);
-            setNodes([]);
-            break;
-        }
-      } catch {
-        // ignore parse errors
-      }
-    };
-
-    ws.onclose = () => setIsStreaming(false);
-    ws.onerror = () => setIsStreaming(false);
-
-    return () => {
-      ws.close();
-      setIsStreaming(false);
-      setNodes([]);
-    };
-  }, [agentId, sessionState]);
-
-  return { streamingNodes: nodes, isStreaming };
 }
 
 // ---------------------------------------------------------------------------
@@ -318,32 +159,18 @@ export default function KernelTop() {
     refetchInterval: autoRefresh ? AUTO_REFRESH_INTERVAL : false,
   });
 
-  const turnsQuery = useQuery({
-    queryKey: ["session-turns", selectedSession],
-    queryFn: () =>
-      api.get<TurnTrace[]>(
-        `/api/v1/kernel/sessions/${selectedSession}/turns`,
-      ),
-    enabled: !!selectedSession,
-    refetchInterval: autoRefresh ? AUTO_REFRESH_INTERVAL : false,
-  });
-
   const stats = statsQuery.data;
   const sessions = sessionsQuery.data ?? [];
 
-  const selectedSessionState = sessions.find(
-    (p) => p.agent_id === selectedSession
-  )?.state ?? null;
+  const selectedSessionState =
+    sessions.find((p) => p.agent_id === selectedSession)?.state ?? null;
 
-  const { streamingNodes, isStreaming } = useSessionStream(
-    selectedSession,
-    selectedSessionState
-  );
+  const timeline = useSessionTimeline(selectedSession, selectedSessionState);
 
   const handleRefresh = () => {
     statsQuery.refetch();
     sessionsQuery.refetch();
-    if (selectedSession) turnsQuery.refetch();
+    if (selectedSession) timeline.refetch();
   };
 
   const handleRowClick = (agentId: string) => {
@@ -367,7 +194,10 @@ export default function KernelTop() {
               checked={autoRefresh}
               onCheckedChange={setAutoRefresh}
             />
-            <Label htmlFor="auto-refresh" className="text-sm text-muted-foreground">
+            <Label
+              htmlFor="auto-refresh"
+              className="text-sm text-muted-foreground"
+            >
               Auto-refresh
             </Label>
           </div>
@@ -440,9 +270,7 @@ export default function KernelTop() {
 
         <Card>
           <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-            <CardTitle className="text-sm font-medium">
-              Total Tokens
-            </CardTitle>
+            <CardTitle className="text-sm font-medium">Total Tokens</CardTitle>
             <Hash className="h-4 w-4 text-muted-foreground" />
           </CardHeader>
           <CardContent>
@@ -522,7 +350,9 @@ export default function KernelTop() {
                   <Fragment key={p.agent_id}>
                     <TableRow
                       className="cursor-pointer transition-colors hover:bg-muted/50"
-                      data-state={selectedSession === p.agent_id ? "selected" : undefined}
+                      data-state={
+                        selectedSession === p.agent_id ? "selected" : undefined
+                      }
                       onClick={() => handleRowClick(p.agent_id)}
                     >
                       <TableCell className="w-6 px-2">
@@ -534,9 +364,7 @@ export default function KernelTop() {
                       </TableCell>
                       <TableCell>
                         <div>
-                          <span className="font-medium">
-                            {p.manifest_name}
-                          </span>
+                          <span className="font-medium">{p.manifest_name}</span>
                           {p.parent_id && (
                             <span className="ml-1.5 text-xs text-muted-foreground">
                               (child)
@@ -584,44 +412,81 @@ export default function KernelTop() {
                               <Zap className="h-3.5 w-3.5" />
                               Cascade Viewer
                             </div>
-                            {turnsQuery.isLoading ? (
+                            {timeline.isLoading ? (
                               <div className="space-y-2">
                                 <Skeleton className="h-16 w-full" />
                                 <Skeleton className="h-16 w-full" />
                               </div>
-                            ) : turnsQuery.isError ? (
-                              <div className="text-sm text-muted-foreground italic">
+                            ) : timeline.isError ? (
+                              <div className="text-sm italic text-muted-foreground">
                                 Failed to load turn traces
                               </div>
                             ) : (
                               <div className="space-y-2">
-                                {isStreaming && streamingNodes.length > 0 && (
-                                  <div className="rounded border border-border bg-muted/30 p-3">
-                                    <div className="mb-1 text-xs font-medium text-muted-foreground">Live stream</div>
-                                    {streamingNodes.map((n) => (
-                                      <div key={n.key} className="text-xs font-mono truncate">
-                                        <Badge variant="outline" className="mr-1.5 text-[10px]">{n.type}</Badge>
-                                        {n.text ?? n.toolName ?? n.resultPreview ?? "..."}
+                                {timeline.isStreaming &&
+                                  timeline.liveItems.length > 0 && (
+                                    <div className="rounded border border-border bg-muted/30 p-3">
+                                      <div className="mb-1 text-xs font-medium text-muted-foreground">
+                                        Live stream
                                       </div>
-                                    ))}
-                                  </div>
-                                )}
-                                {(turnsQuery.data ?? []).map((t, i) => (
-                                  <div key={i} className="rounded border border-border p-3 text-xs">
+                                      {timeline.liveItems.map((item) => (
+                                        <div
+                                          key={`l-${item.seq}`}
+                                          className="truncate font-mono text-xs"
+                                        >
+                                          <Badge
+                                            variant="outline"
+                                            className="mr-1.5 text-[10px]"
+                                          >
+                                            {item.kind}
+                                          </Badge>
+                                          {item.content ??
+                                            item.tool ??
+                                            item.output ??
+                                            "..."}
+                                        </div>
+                                      ))}
+                                    </div>
+                                  )}
+                                {timeline.turns.map((t, i) => (
+                                  <div
+                                    key={i}
+                                    className="rounded border border-border p-3 text-xs"
+                                  >
                                     <div className="flex items-center gap-2">
-                                      <Badge variant={t.success ? "secondary" : "destructive"} className="text-[10px]">
+                                      <Badge
+                                        variant={
+                                          t.success
+                                            ? "secondary"
+                                            : "destructive"
+                                        }
+                                        className="text-[10px]"
+                                      >
                                         {t.success ? "OK" : "ERR"}
                                       </Badge>
-                                      <span className="font-mono text-muted-foreground">{t.model}</span>
-                                      <span className="text-muted-foreground">{t.duration_ms}ms</span>
-                                      <span className="text-muted-foreground">{t.total_tool_calls} tool calls</span>
+                                      <span className="font-mono text-muted-foreground">
+                                        {t.model}
+                                      </span>
+                                      <span className="text-muted-foreground">
+                                        {t.duration_ms}ms
+                                      </span>
+                                      <span className="text-muted-foreground">
+                                        {t.total_tool_calls} tool calls
+                                      </span>
                                     </div>
-                                    {t.error && <div className="mt-1 text-destructive">{t.error}</div>}
+                                    {t.error && (
+                                      <div className="mt-1 text-destructive">
+                                        {t.error}
+                                      </div>
+                                    )}
                                   </div>
                                 ))}
-                                {(turnsQuery.data ?? []).length === 0 && !isStreaming && (
-                                  <div className="text-sm text-muted-foreground italic">No turns recorded</div>
-                                )}
+                                {timeline.turns.length === 0 &&
+                                  !timeline.isStreaming && (
+                                    <div className="text-sm italic text-muted-foreground">
+                                      No turns recorded
+                                    </div>
+                                  )}
                               </div>
                             )}
                           </div>


### PR DESCRIPTION
## Summary

Part of #1468. Data-layer refactor — **no visual changes** beyond dead-branch cleanup.

Merges historical \`TurnTrace\` from \`GET /kernel/sessions/{key}/turns\` with live WebSocket \`StreamEvent\` into a single \`TimelineItem[]\` model. All downstream UI rendering flows through one \`useSessionTimeline(sessionKey, sessionState)\` hook.

**Key design choices**:
- \`seq\` is source-local (historical: 0..N; live: 0..M); React keys prefix with \`h-\`/\`l-\` to avoid cross-source collision
- WS \`useEffect\` depends only on \`[sessionKey, sessionState]\` — captures \`turns.length\` via a ref so the 5s turns refetch does not trigger WS reconnect
- \`turn_metrics\` event flushes \`streaming\` flags but keeps items visible until the next turns refetch promotes them to historical
- Unknown \`StreamEvent\` variants (\`PlanCreated\`, \`UsageUpdate\`, \`BackgroundTaskStarted\`, …) are silently ignored; event coverage can expand in follow-up PRs

**Dead code removed**:
- \`stateColor()\` branches for \`completed\` / \`failed\` / \`cancelled\` / \`error\` / \`running\` / \`idle\` — kernel \`SessionState\` never produces these (enum is \`{Active, Ready, Suspended, Paused}\`; \`is_terminal()\` returns \`false\` by design, see \`crates/kernel/src/session/mod.rs:258\`)
- Legacy \`useSessionStream\` hook in \`KernelTop.tsx\` (gated WS on \`state === "Running" || "Idle"\` which the backend also never produces — the new \`isLiveState()\` correctly matches \`active\`/\`ready\`)

## Type of change

| Type | Label |
|------|-------|
| Refactor | \`refactor\` |

## Component

\`ui\`

## Closes

Closes #1470

## Test plan

- [x] \`npm run build\` (tsc + vite) passes
- [x] \`npm run lint\` — no new warnings/errors from changed files
- [x] Cascade Viewer still renders turn summaries and live stream panel identically
- [ ] Manual smoke test: open KernelTop, select a running session, verify live events appear under "Live stream"
- [ ] Manual smoke test: let session transition Active → Ready, verify no UI jitter

## Non-goals (deferred)

- No \`TimelineBar\` / \`TimelineRow\` components (next PR in stack)
- No three-column layout (later in stack)
- No new stream event coverage (\`PlanProgress\`, \`UsageUpdate\`, etc.)