### PR TITLE
feat(web): kernel timeline visual atoms — TimelineBar / TimelineRow / MetadataChip (#1474)

### DIFF
--- a/web/src/components/kernel/MetadataChip.tsx
+++ b/web/src/components/kernel/MetadataChip.tsx
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2025 Rararulab
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { ReactNode } from "react";
+
+export interface MetadataChipProps {
+  /** Optional leading icon (typically a lucide-react icon at h-3 w-3). */
+  icon?: ReactNode;
+  children: ReactNode;
+}
+
+/**
+ * Compact information chip used in session headers and stat bars.
+ *
+ * Visual contract: rounded-md, bordered, `bg-muted/50`, 11px text.
+ * Intentionally low-weight so rows of 5–8 chips stay visually quiet.
+ */
+export function MetadataChip({ icon, children }: MetadataChipProps) {
+  return (
+    <span className="inline-flex items-center gap-1 rounded-md border bg-muted/50 px-2 py-0.5 text-[11px] text-muted-foreground">
+      {icon}
+      {children}
+    </span>
+  );
+}

--- a/web/src/components/kernel/TimelineBar.tsx
+++ b/web/src/components/kernel/TimelineBar.tsx
@@ -1,0 +1,139 @@
+/*
+ * Copyright 2025 Rararulab
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useMemo } from "react";
+import { cn } from "@/lib/utils";
+import type { EventKind, TimelineItem } from "@/api/kernel-types";
+import { KIND_PALETTE, eventLabel } from "./timeline-colors";
+
+interface Segment {
+  startIdx: number;
+  endIdx: number;
+  kind: EventKind;
+  count: number;
+}
+
+/**
+ * Merge adjacent items of the same kind into display segments.
+ *
+ * Turn boundaries force a break even when the same color continues, so
+ * the rhythm of each turn stays visually separable.
+ */
+function buildSegments(items: TimelineItem[]): Segment[] {
+  const segments: Segment[] = [];
+  let start = 0;
+  for (let i = 0; i < items.length; i++) {
+    const prev = items[i - 1];
+    const curr = items[i]!;
+    const boundary =
+      !prev || prev.kind !== curr.kind || prev.turn !== curr.turn;
+    if (boundary && i !== 0) {
+      const head = items[start]!;
+      segments.push({
+        startIdx: start,
+        endIdx: i - 1,
+        kind: head.kind,
+        count: i - start,
+      });
+      start = i;
+    }
+  }
+  if (items.length > 0) {
+    const head = items[start]!;
+    segments.push({
+      startIdx: start,
+      endIdx: items.length - 1,
+      kind: head.kind,
+      count: items.length - start,
+    });
+  }
+  return segments;
+}
+
+export interface TimelineBarProps {
+  items: TimelineItem[];
+  /** Currently selected item index (highlights the containing segment). */
+  selectedIdx: number | null;
+  /** Click handler: receives the segment's first item index. */
+  onSegmentClick?: (idx: number) => void;
+}
+
+/**
+ * Horizontal color-coded rhythm bar.
+ *
+ * Each segment represents a run of adjacent items sharing the same
+ * {@link EventKind}; width is proportional to the count. Clicking a
+ * segment selects its first item.
+ */
+export function TimelineBar({
+  items,
+  selectedIdx,
+  onSegmentClick,
+}: TimelineBarProps) {
+  const segments = useMemo(() => buildSegments(items), [items]);
+
+  if (segments.length === 0) return null;
+
+  const total = items.length;
+
+  return (
+    <div
+      className="flex h-5 gap-0.5 overflow-hidden rounded"
+      role="navigation"
+      aria-label="Execution timeline"
+    >
+      {segments.map((seg, segIdx) => {
+        const isSelected =
+          selectedIdx !== null &&
+          selectedIdx >= seg.startIdx &&
+          selectedIdx <= seg.endIdx;
+        const palette = KIND_PALETTE[seg.kind];
+        const head = items[seg.startIdx]!;
+        const widthPct = Math.max((seg.count / total) * 100, 0.5);
+        const label = eventLabel(seg.kind, head.tool);
+
+        return (
+          <button
+            key={segIdx}
+            type="button"
+            onClick={() => onSegmentClick?.(seg.startIdx)}
+            className={cn(
+              "group relative h-full min-w-[4px] transition-all duration-150 hover:opacity-80",
+              isSelected ? palette.barActive : palette.bar,
+            )}
+            style={{ width: `${widthPct}%` }}
+            title={
+              seg.count > 1
+                ? `${label} (+${seg.count - 1} more)`
+                : label
+            }
+          >
+            <span className="pointer-events-none absolute bottom-full left-1/2 z-10 mb-1 hidden -translate-x-1/2 group-hover:block">
+              <span className="block whitespace-nowrap rounded border bg-popover px-2 py-1 text-[10px] text-popover-foreground shadow-md">
+                {label}
+                {seg.count > 1 && (
+                  <span className="ml-1 text-muted-foreground">
+                    +{seg.count - 1}
+                  </span>
+                )}
+              </span>
+            </span>
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/web/src/components/kernel/TimelineRow.tsx
+++ b/web/src/components/kernel/TimelineRow.tsx
@@ -1,0 +1,183 @@
+/*
+ * Copyright 2025 Rararulab
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { forwardRef, useState } from "react";
+import { AlertCircle, Brain, ChevronRight } from "lucide-react";
+import { cn } from "@/lib/utils";
+import type { TimelineItem } from "@/api/kernel-types";
+import { KIND_PALETTE, eventLabel, eventSummary } from "./timeline-colors";
+
+const DETAIL_MAX_CHARS = 4000;
+
+export interface TimelineRowProps {
+  item: TimelineItem;
+  /** When true, apply selected background (used by TimelineBar scroll-to). */
+  isSelected?: boolean;
+  onClick?: () => void;
+}
+
+/**
+ * One event row in the session timeline.
+ *
+ * Layout: `[ColoredBadge 60px]` `[summary truncate]` `[#seq mono 10px]`.
+ * When the item has expandable detail (tool JSON / long text / result
+ * preview), the summary becomes a button that toggles a muted detail
+ * panel underneath.
+ */
+export const TimelineRow = forwardRef<HTMLDivElement, TimelineRowProps>(
+  function TimelineRow({ item, isSelected, onClick }, ref) {
+    const [expanded, setExpanded] = useState(false);
+
+    const palette = KIND_PALETTE[item.kind];
+    const label = eventLabel(item.kind, item.tool);
+    const summary = eventSummary(item);
+    const hasDetail = rowHasDetail(item);
+
+    return (
+      <div
+        ref={ref}
+        className={cn(
+          "group transition-colors",
+          isSelected && "bg-accent/50",
+        )}
+        onClick={onClick}
+      >
+        <div className="flex items-start gap-2 px-4 py-2">
+          <span
+            className={cn(
+              "mt-0.5 inline-flex min-w-[60px] shrink-0 items-center justify-center rounded px-1.5 py-0.5 text-[11px] font-medium",
+              palette.label,
+            )}
+          >
+            {item.kind === "thinking" && (
+              <Brain className="mr-1 h-3 w-3 shrink-0" />
+            )}
+            {item.kind === "error" && (
+              <AlertCircle className="mr-1 h-3 w-3 shrink-0" />
+            )}
+            <span className="truncate">{label}</span>
+          </span>
+
+          <button
+            type="button"
+            onClick={(e) => {
+              e.stopPropagation();
+              if (hasDetail) setExpanded((v) => !v);
+            }}
+            disabled={!hasDetail}
+            className={cn(
+              "min-w-0 flex-1 py-0.5 text-left text-xs transition-colors",
+              hasDetail
+                ? "cursor-pointer hover:text-foreground"
+                : "cursor-default",
+              item.kind === "error"
+                ? "text-destructive"
+                : "text-muted-foreground",
+            )}
+          >
+            <div className="flex items-start gap-1.5">
+              {hasDetail && (
+                <ChevronRight
+                  className={cn(
+                    "mt-0.5 h-3 w-3 shrink-0 text-muted-foreground/50 transition-transform",
+                    expanded && "rotate-90",
+                  )}
+                />
+              )}
+              <span className="truncate">
+                {summary || <span className="italic opacity-60">(empty)</span>}
+                {item.streaming && (
+                  <span className="ml-1 inline-block h-3 w-0.5 translate-y-0.5 animate-pulse bg-current align-middle" />
+                )}
+              </span>
+            </div>
+          </button>
+
+          <span className="mt-1 shrink-0 text-[10px] tabular-nums text-muted-foreground/50">
+            #{item.seq}
+          </span>
+        </div>
+
+        {hasDetail && (
+          <div
+            className={cn(
+              "grid transition-[grid-template-rows] duration-200 ease-out",
+              expanded ? "grid-rows-[1fr]" : "grid-rows-[0fr]",
+            )}
+          >
+            <div className="overflow-hidden">
+              <div className="px-4 pb-3">
+                <div className="ml-[72px] rounded border bg-muted/40">
+                  <RowDetail item={item} />
+                </div>
+              </div>
+            </div>
+          </div>
+        )}
+      </div>
+    );
+  },
+);
+
+/** Whether the item carries content worth a collapsible detail panel. */
+function rowHasDetail(item: TimelineItem): boolean {
+  switch (item.kind) {
+    case "tool_use":
+      return !!item.input && Object.keys(item.input).length > 0;
+    case "tool_result":
+      return !!item.output && item.output.length > 0;
+    case "thinking":
+    case "error":
+      return !!item.content && item.content.length > 0;
+    case "agent":
+      return !!item.content && item.content.split("\n").length > 1;
+  }
+}
+
+function RowDetail({ item }: { item: TimelineItem }) {
+  switch (item.kind) {
+    case "tool_use":
+      return (
+        <pre className="max-h-60 overflow-auto whitespace-pre-wrap break-all p-3 text-[11px] text-muted-foreground">
+          {item.input ? JSON.stringify(item.input, null, 2) : ""}
+        </pre>
+      );
+    case "tool_result":
+      return (
+        <pre className="max-h-60 overflow-auto whitespace-pre-wrap break-all p-3 text-[11px] text-muted-foreground">
+          {truncate(item.output ?? "")}
+        </pre>
+      );
+    case "thinking":
+    case "agent":
+      return (
+        <pre className="max-h-60 overflow-auto whitespace-pre-wrap break-words p-3 text-[11px] text-muted-foreground">
+          {item.content ?? ""}
+        </pre>
+      );
+    case "error":
+      return (
+        <pre className="max-h-60 overflow-auto whitespace-pre-wrap break-words p-3 text-[11px] text-destructive">
+          {item.content ?? ""}
+        </pre>
+      );
+  }
+}
+
+function truncate(s: string): string {
+  if (s.length <= DETAIL_MAX_CHARS) return s;
+  return s.slice(0, DETAIL_MAX_CHARS) + "\n... (truncated)";
+}

--- a/web/src/components/kernel/timeline-colors.ts
+++ b/web/src/components/kernel/timeline-colors.ts
@@ -1,0 +1,143 @@
+/*
+ * Copyright 2025 Rararulab
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { EventKind } from "@/api/kernel-types";
+
+/** Visual classes for one timeline event-kind, across 3 use sites. */
+export interface KindPalette {
+  /** Muted bar segment (TimelineBar default). */
+  bar: string;
+  /** Saturated bar segment (TimelineBar selected). */
+  barActive: string;
+  /** Pill for the row's type-label badge. */
+  label: string;
+  /** Short textual label rendered inside the badge. */
+  text: string;
+}
+
+/**
+ * Color palette per {@link EventKind}.
+ *
+ * Mirrors multica's agent transcript colors: emerald / violet / blue /
+ * slate / red. Semantic tokens (`bg-info`, `bg-destructive`) are not used
+ * here because we deliberately want 5 distinct hues — semantic tokens
+ * collapse to 2-3 colors.
+ */
+export const KIND_PALETTE: Record<EventKind, KindPalette> = {
+  agent: {
+    bar: "bg-emerald-400/60",
+    barActive: "bg-emerald-500",
+    label:
+      "bg-emerald-500/20 text-emerald-700 dark:bg-emerald-500/15 dark:text-emerald-300",
+    text: "Agent",
+  },
+  thinking: {
+    bar: "bg-violet-400/60",
+    barActive: "bg-violet-500",
+    label:
+      "bg-violet-500/20 text-violet-700 dark:bg-violet-500/15 dark:text-violet-300",
+    text: "Think",
+  },
+  tool_use: {
+    bar: "bg-blue-400/60",
+    barActive: "bg-blue-500",
+    label:
+      "bg-blue-500/20 text-blue-700 dark:bg-blue-500/15 dark:text-blue-300",
+    text: "Tool",
+  },
+  tool_result: {
+    bar: "bg-slate-300/60 dark:bg-slate-600/60",
+    barActive: "bg-slate-400 dark:bg-slate-500",
+    label: "bg-muted text-muted-foreground",
+    text: "Result",
+  },
+  error: {
+    bar: "bg-red-400/60",
+    barActive: "bg-red-500",
+    label:
+      "bg-red-500/20 text-red-700 dark:bg-red-500/15 dark:text-red-300",
+    text: "Error",
+  },
+};
+
+/** Short label to show inside a row's type badge. */
+export function eventLabel(kind: EventKind, tool?: string): string {
+  if (kind === "tool_use" || kind === "tool_result") {
+    return tool ?? KIND_PALETTE[kind].text;
+  }
+  return KIND_PALETTE[kind].text;
+}
+
+/**
+ * One-line summary for a row — picked from the most informative field on
+ * the item. Truncated at the call site via CSS, not here.
+ */
+export function eventSummary(item: {
+  kind: EventKind;
+  content?: string;
+  input?: Record<string, unknown>;
+  output?: string;
+}): string {
+  switch (item.kind) {
+    case "agent":
+    case "thinking":
+    case "error":
+      return item.content?.trim() ?? "";
+    case "tool_use":
+      return toolInputSummary(item.input);
+    case "tool_result":
+      return item.output?.trim().slice(0, 200) ?? "";
+  }
+}
+
+/**
+ * Extract a short human-readable description from tool arguments.
+ *
+ * Picks the most-informative string field in priority order
+ * (query / file_path / pattern / command / prompt / skill). Returns
+ * empty string when nothing suitable is found.
+ */
+function toolInputSummary(input?: Record<string, unknown>): string {
+  if (!input) return "";
+  const keys = [
+    "query",
+    "file_path",
+    "path",
+    "pattern",
+    "description",
+    "command",
+    "prompt",
+    "skill",
+  ];
+  for (const k of keys) {
+    const v = input[k];
+    if (typeof v === "string" && v.length > 0) {
+      if (k === "file_path" || k === "path") return shortenPath(v);
+      if (v.length > 120) return v.slice(0, 120) + "...";
+      return v;
+    }
+  }
+  for (const v of Object.values(input)) {
+    if (typeof v === "string" && v.length > 0 && v.length < 120) return v;
+  }
+  return "";
+}
+
+function shortenPath(p: string): string {
+  const parts = p.split("/");
+  if (parts.length <= 3) return p;
+  return ".../" + parts.slice(-2).join("/");
+}

--- a/web/src/pages/KernelTop.tsx
+++ b/web/src/pages/KernelTop.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { useState, Fragment } from "react";
+import { Fragment, useCallback, useRef, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import {
   Activity,
@@ -28,6 +28,8 @@ import {
 } from "lucide-react";
 import { api } from "@/api/client";
 import { useSessionTimeline } from "@/hooks/use-session-timeline";
+import { TimelineBar } from "@/components/kernel/TimelineBar";
+import { TimelineRow } from "@/components/kernel/TimelineRow";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
@@ -146,6 +148,15 @@ const AUTO_REFRESH_INTERVAL = 5_000;
 export default function KernelTop() {
   const [autoRefresh, setAutoRefresh] = useState(true);
   const [selectedSession, setSelectedSession] = useState<string | null>(null);
+  const [selectedItemIdx, setSelectedItemIdx] = useState<number | null>(null);
+  const rowRefs = useRef<Map<number, HTMLDivElement>>(new Map());
+
+  const handleSegmentClick = useCallback((idx: number) => {
+    setSelectedItemIdx(idx);
+    rowRefs.current
+      .get(idx)
+      ?.scrollIntoView({ behavior: "smooth", block: "center" });
+  }, []);
 
   const statsQuery = useQuery({
     queryKey: ["kernel-stats"],
@@ -411,6 +422,14 @@ export default function KernelTop() {
                             <div className="flex items-center gap-2 text-sm font-medium">
                               <Zap className="h-3.5 w-3.5" />
                               Cascade Viewer
+                              {timeline.isStreaming && (
+                                <Badge
+                                  variant="secondary"
+                                  className="text-[10px]"
+                                >
+                                  streaming
+                                </Badge>
+                              )}
                             </div>
                             {timeline.isLoading ? (
                               <div className="space-y-2">
@@ -421,72 +440,49 @@ export default function KernelTop() {
                               <div className="text-sm italic text-muted-foreground">
                                 Failed to load turn traces
                               </div>
+                            ) : timeline.items.length === 0 ? (
+                              <div className="text-sm italic text-muted-foreground">
+                                No events recorded
+                              </div>
                             ) : (
-                              <div className="space-y-2">
-                                {timeline.isStreaming &&
-                                  timeline.liveItems.length > 0 && (
-                                    <div className="rounded border border-border bg-muted/30 p-3">
-                                      <div className="mb-1 text-xs font-medium text-muted-foreground">
-                                        Live stream
-                                      </div>
-                                      {timeline.liveItems.map((item) => (
-                                        <div
-                                          key={`l-${item.seq}`}
-                                          className="truncate font-mono text-xs"
-                                        >
-                                          <Badge
-                                            variant="outline"
-                                            className="mr-1.5 text-[10px]"
-                                          >
-                                            {item.kind}
-                                          </Badge>
-                                          {item.content ??
-                                            item.tool ??
-                                            item.output ??
-                                            "..."}
-                                        </div>
-                                      ))}
-                                    </div>
-                                  )}
-                                {timeline.turns.map((t, i) => (
-                                  <div
-                                    key={i}
-                                    className="rounded border border-border p-3 text-xs"
-                                  >
-                                    <div className="flex items-center gap-2">
-                                      <Badge
-                                        variant={
-                                          t.success
-                                            ? "secondary"
-                                            : "destructive"
-                                        }
-                                        className="text-[10px]"
-                                      >
-                                        {t.success ? "OK" : "ERR"}
-                                      </Badge>
-                                      <span className="font-mono text-muted-foreground">
-                                        {t.model}
-                                      </span>
-                                      <span className="text-muted-foreground">
-                                        {t.duration_ms}ms
-                                      </span>
-                                      <span className="text-muted-foreground">
-                                        {t.total_tool_calls} tool calls
-                                      </span>
-                                    </div>
-                                    {t.error && (
-                                      <div className="mt-1 text-destructive">
-                                        {t.error}
-                                      </div>
-                                    )}
-                                  </div>
-                                ))}
-                                {timeline.turns.length === 0 &&
-                                  !timeline.isStreaming && (
-                                    <div className="text-sm italic text-muted-foreground">
-                                      No turns recorded
-                                    </div>
-                                  )}
+                              <div className="space-y-3">
+                                <TimelineBar
+                                  items={timeline.items}
+                                  selectedIdx={selectedItemIdx}
+                                  onSegmentClick={handleSegmentClick}
+                                />
+                                <div className="divide-y rounded border bg-background">
+                                  {timeline.items.map((item, idx) => {
+                                    const prev = timeline.items[idx - 1];
+                                    const turnChanged =
+                                      idx > 0 &&
+                                      (!prev || prev.turn !== item.turn);
+                                    const isLive = idx >= timeline.historicalItems.length;
+                                    const rowKey = `${isLive ? "l" : "h"}-${item.turn}-${item.seq}-${idx}`;
+                                    return (
+                                      <Fragment key={rowKey}>
+                                        {turnChanged && (
+                                          <div className="bg-muted/40 px-4 py-1 text-[10px] uppercase tracking-wider text-muted-foreground">
+                                            Turn #{item.turn + 1}
+                                          </div>
+                                        )}
+                                        <TimelineRow
+                                          ref={(el) => {
+                                            if (el) rowRefs.current.set(idx, el);
+                                            else rowRefs.current.delete(idx);
+                                          }}
+                                          item={item}
+                                          isSelected={selectedItemIdx === idx}
+                                          onClick={() =>
+                                            setSelectedItemIdx((prev) =>
+                                              prev === idx ? null : idx,
+                                            )
+                                          }
+                                        />
+                                      </Fragment>
+                                    );
+                                  })}
+                                </div>
                               </div>
                             )}
                           </div>


### PR DESCRIPTION
## Summary

Part of #1468. Stacks on #1471.

Introduces the visual atoms that compose the session-centric kernel UI — borrowed from multica's \`agent-transcript-dialog\` visual language, adapted to rara's data model.

### What's new

- **\`web/src/components/kernel/timeline-colors.ts\`** — 5-color palette (emerald / violet / blue / slate / red) per \`EventKind\`, plus \`eventLabel\` and \`eventSummary\` helpers (input-field heuristic: \`query\` → \`file_path\` → \`pattern\` → \`command\` → \`prompt\` → \`skill\`).
- **\`TimelineBar.tsx\`** — horizontal rhythm bar. Adjacent same-kind items within one turn merge into a segment whose width scales with event count; turn boundaries force a visual break. Click selects and scrolls the corresponding row.
- **\`TimelineRow.tsx\`** — \`[60px colored badge] [flex-1 summary truncate] [10px tabular #seq]\` layout. Detail expansion uses the CSS \`grid-template-rows\` 0fr↔1fr trick for JS-free smooth collapse.
- **\`MetadataChip.tsx\`** — rounded-md bordered pill (\`bg-muted/50\`, 11px); ready for the SessionHeader in the next PR.

### Integration

\`KernelTop\` Cascade Viewer now renders \`TimelineBar\` + a \`divide-y\` list of \`TimelineRow\` driven by \`timeline.items\` (the unified feed from #1470). Turn separators (\`Turn #N\`) render between items of different turn indices.

- Removed: the old \`Live stream\` panel with mono badges + the per-turn summary card stack
- Kept unchanged: 4 StatCards, Session table — next PR replaces the IA wholesale

### Type of change

| Type | Label |
|------|-------|
| New feature | \`enhancement\` |

### Component

\`ui\`

### Closes

Closes #1474

### Test plan

- [x] \`npm run build\` (tsc + vite) passes
- [x] \`npm run lint\` — no new warnings/errors from changed files
- [ ] Manual smoke: running session shows rhythm bar with colored segments
- [ ] Manual smoke: clicking a bar segment scrolls the event list to the first event of that segment
- [ ] Manual smoke: expanding a \`tool_use\` row shows formatted JSON of arguments
- [ ] Manual smoke: expanding a \`thinking\` row shows full reasoning text

### Non-goals (deferred)

- Three-column layout (next PR)
- \`SessionList\` / \`SessionDetail\` components (next PR)
- Approvals drawer (next PR)
- \`KernelStatsBar\` (next PR)