### PR TITLE
fix(kernel): raise StreamHub broadcast capacity to avoid dropped text deltas (#1473)

### DIFF
--- a/crates/kernel/src/io.rs
+++ b/crates/kernel/src/io.rs
@@ -1017,6 +1017,18 @@ impl StreamHandle {
 // StreamHub
 // ---------------------------------------------------------------------------
 
+/// Per-stream [`broadcast`] channel capacity used by the production
+/// [`IOSubsystem`].
+///
+/// Sized to absorb bursty LLM token streams while a single subscriber
+/// (e.g. the Telegram forwarder) is blocked in a synchronous HTTP flush.
+/// `gpt-5.x` can emit 200–500 text deltas per second; a 4096-event buffer
+/// tolerates a ~10 s stall without dropping events via `RecvError::Lagged`.
+/// Production logs showed 565 deltas dropped in a single turn at the old
+/// `256` value (see #1473). Tests intentionally use smaller values to
+/// exercise lag behaviour and should not reference this constant.
+pub const STREAM_HUB_BROADCAST_CAPACITY: usize = 4096;
+
 /// Central registry for active ephemeral streams.
 ///
 /// Manages the lifecycle of per-execution streams and provides
@@ -1496,7 +1508,7 @@ impl IOSubsystem {
         Self {
             identity_resolver,
             session_index,
-            stream_hub: Arc::new(StreamHub::new(256)),
+            stream_hub: Arc::new(StreamHub::new(STREAM_HUB_BROADCAST_CAPACITY)),
             adapters: HashMap::new(),
             endpoint_registry: Arc::new(EndpointRegistry::new()),
             notification_channel_id,


### PR DESCRIPTION
## Summary

- Introduce named constant `STREAM_HUB_BROADCAST_CAPACITY = 4096` in `io.rs`
- Replace hardcoded `StreamHub::new(256)` with the new constant
- Doc comment explains sizing rationale (GPT-5.x at 200-500 tokens/sec, ~10s stall tolerance)

**Root cause**: production logs showed 565 stream events dropped in a single turn — the old 256-event broadcast buffer overflowed while the Telegram forwarder was blocked on HTTP calls.

## Type of change

| Type | Label |
|------|-------|
| Bug fix | `bug` |

## Component

`core`

## Closes

Closes #1473

## Test plan

- [x] `cargo check -p rara-kernel` passes
- [x] `cargo clippy -p rara-kernel --all-targets -- -D warnings` passes
- [x] `cargo +nightly fmt --all -- --check` passes
- [x] Pre-commit hooks pass
- [x] Test call sites (`StreamHub::new(16)`) intentionally left unchanged