### PR TITLE
fix(kernel): tool_call_id mismatch after interrupt causes Kimi 400 (#1487)

### DIFF
--- a/crates/kernel/src/memory/context.rs
+++ b/crates/kernel/src/memory/context.rs
@@ -145,16 +145,15 @@ fn append_tool_result_entry(
 
     for (index, result) in results.iter().enumerate() {
         let content = render_tool_result(result)?;
-        // Prefer the `tool_call_id` persisted inside each result payload
-        // (written by the agent loop at persist time). Fall back to
-        // positional indexing into `pending_calls` for legacy tape
-        // entries that lack the field. The positional approach breaks
-        // after an interrupt (partial results) or parallel execution
-        // (unordered results), producing empty IDs that Kimi rejects
-        // with HTTP 400 "toolcallid is not found".
+        // Successful tool results are persisted from raw tool output in
+        // agent/mod.rs, so a top-level `tool_call_id` may be user-visible tool
+        // payload rather than our correlation id. Trust it only when it matches
+        // one of the assistant's pending calls; otherwise keep the legacy
+        // positional fallback.
         let call_id = result
             .get("tool_call_id")
             .and_then(Value::as_str)
+            .filter(|id| pending_calls.iter().any(|call| call.id == *id))
             .or_else(|| pending_calls.get(index).map(|c| c.id.as_str()))
             .unwrap_or("");
         messages.push(Message::tool_result(call_id, content));
@@ -565,6 +564,86 @@ mod tests {
         assert_eq!(messages.len(), 2);
         assert_eq!(messages[0].role, Role::User);
         assert_eq!(messages[1].role, Role::Assistant);
+    }
+
+    #[test]
+    fn default_tape_context_uses_matching_tool_call_id_from_result_payload() {
+        let entries = vec![
+            TapEntry {
+                id:        1,
+                kind:      TapEntryKind::ToolCall,
+                payload:   json!({
+                    "calls": [
+                        {
+                            "id": "call_first",
+                            "function": {"name": "first_tool", "arguments": "{}"}
+                        },
+                        {
+                            "id": "call_second",
+                            "function": {"name": "second_tool", "arguments": "{}"}
+                        }
+                    ]
+                }),
+                timestamp: Timestamp::now(),
+                metadata:  None,
+            },
+            TapEntry {
+                id:        2,
+                kind:      TapEntryKind::ToolResult,
+                payload:   json!({
+                    "results": [
+                        {
+                            "tool_call_id": "call_second",
+                            "ok": true
+                        }
+                    ]
+                }),
+                timestamp: Timestamp::now(),
+                metadata:  None,
+            },
+        ];
+
+        let messages = default_tape_context(&entries).unwrap();
+
+        assert_eq!(messages.len(), 2);
+        assert_eq!(messages[1].role, Role::Tool);
+        assert_eq!(messages[1].tool_call_id.as_deref(), Some("call_second"));
+    }
+
+    #[test]
+    fn default_tape_context_ignores_non_matching_tool_call_id_from_result_payload() {
+        let entries = vec![
+            TapEntry {
+                id:        1,
+                kind:      TapEntryKind::ToolCall,
+                payload:   json!({
+                    "calls": [{
+                        "id": "call_first",
+                        "function": {"name": "first_tool", "arguments": "{}"}
+                    }]
+                }),
+                timestamp: Timestamp::now(),
+                metadata:  None,
+            },
+            TapEntry {
+                id:        2,
+                kind:      TapEntryKind::ToolResult,
+                payload:   json!({
+                    "results": [{
+                        "tool_call_id": "payload_owned_by_tool",
+                        "ok": true
+                    }]
+                }),
+                timestamp: Timestamp::now(),
+                metadata:  None,
+            },
+        ];
+
+        let messages = default_tape_context(&entries).unwrap();
+
+        assert_eq!(messages.len(), 2);
+        assert_eq!(messages[1].role, Role::Tool);
+        assert_eq!(messages[1].tool_call_id.as_deref(), Some("call_first"));
     }
 
     // -----------------------------------------------------------------------

--- a/crates/kernel/src/memory/context.rs
+++ b/crates/kernel/src/memory/context.rs
@@ -145,9 +145,17 @@ fn append_tool_result_entry(
 
     for (index, result) in results.iter().enumerate() {
         let content = render_tool_result(result)?;
-        let call_id = pending_calls
-            .get(index)
-            .map(|c| c.id.as_str())
+        // Prefer the `tool_call_id` persisted inside each result payload
+        // (written by the agent loop at persist time). Fall back to
+        // positional indexing into `pending_calls` for legacy tape
+        // entries that lack the field. The positional approach breaks
+        // after an interrupt (partial results) or parallel execution
+        // (unordered results), producing empty IDs that Kimi rejects
+        // with HTTP 400 "toolcallid is not found".
+        let call_id = result
+            .get("tool_call_id")
+            .and_then(Value::as_str)
+            .or_else(|| pending_calls.get(index).map(|c| c.id.as_str()))
             .unwrap_or("");
         messages.push(Message::tool_result(call_id, content));
     }


### PR DESCRIPTION
## Summary

After an interrupt or parallel tool execution, tape context reconstruction paired tool results with `tool_call_id`s by **array position** (`context.rs:148`). When results were fewer than calls (partial execution after interrupt) or arrived out of order (parallel execution), the positional index fell through to an empty string fallback. Kimi strictly validates `tool_call_id` and returns HTTP 400 `"toolcallid is not found"`.

Each result payload already carries its own `tool_call_id` (written by the agent loop at `agent/mod.rs:2063`). Read it directly, falling back to positional indexing only for legacy tape entries that lack the field.

One-line fix in `crates/kernel/src/memory/context.rs`.

## Type of change

| Type | Label |
|------|-------|
| Bug fix | `bug` |

## Component

`core`

## Closes

Closes #1487

## Test plan

- [x] `cargo check -p rara-kernel` passes
- [x] `cargo test -p rara-kernel --lib` — 453 passed, 0 failed
- [x] Pre-commit hooks (check, fmt, clippy, doc) all pass
- [ ] Manual smoke test: interrupt a multi-tool Kimi session → next turn succeeds