### PR TITLE
feat(channels): enhance Telegram pinned session card (#1485)

### DIFF
--- a/crates/channels/src/telegram/adapter.rs
+++ b/crates/channels/src/telegram/adapter.rs
@@ -3846,6 +3846,8 @@ fn spawn_stream_forwarder(
             session_label.clone(),
             session_label,
         );
+        let (proj_name, proj_branch) = resolve_project_info().await;
+        pinned.set_project_info(proj_name, proj_branch);
         let pinned_settings_key = format!("telegram.pinned_message.{chat_id}");
         if let Some(raw) = settings.get(&pinned_settings_key).await {
             if let Ok(id) = raw.parse::<i32>() {
@@ -4616,6 +4618,27 @@ enum FlushResult {
 /// 2. **`message_id` is `Some` but edit fails** — the persisted message was
 ///    deleted by the user or expired. We fall through to scenario 3.
 ///
+/// Resolve project name (from CWD basename) and git branch (from `.git/HEAD`).
+///
+/// Best-effort: returns empty strings on failure.
+async fn resolve_project_info() -> (String, String) {
+    let project_name = std::env::current_dir()
+        .ok()
+        .and_then(|p| p.file_name().map(|n| n.to_string_lossy().into_owned()))
+        .unwrap_or_default();
+
+    let branch = match tokio::fs::read_to_string(".git/HEAD").await {
+        Ok(head) => head
+            .trim()
+            .strip_prefix("ref: refs/heads/")
+            .unwrap_or("")
+            .to_owned(),
+        Err(_) => String::new(),
+    };
+
+    (project_name, branch)
+}
+
 /// 3. **`message_id` is `None`** (first flush of this turn, or fallback from
 ///    scenario 2) — send a new message, pin it silently, and persist the new ID
 ///    so subsequent turns reuse it instead of accumulating orphan messages.

--- a/crates/channels/src/telegram/adapter.rs
+++ b/crates/channels/src/telegram/adapter.rs
@@ -3838,6 +3838,11 @@ fn spawn_stream_forwarder(
         let mut progress = ProgressMessage::new(rara_message_id);
         let mut progress_dirty = false;
 
+        // Map tool-call ID → file path for file-mutating tools, so we can
+        // pair file path with diff stats when the tool completes.
+        let mut file_tool_paths: std::collections::HashMap<String, String> =
+            std::collections::HashMap::new();
+
         // Pinned session card — a stable summary pinned to the chat top.
         // Restore persisted message ID so we can continue editing after restart.
         let session_label = session_id.to_string();
@@ -3911,6 +3916,18 @@ fn spawn_stream_forwarder(
                             progress.thinking = false;
                             pinned.on_tool_start();
 
+                            // Track file path for file-mutating tools before `id` and
+                            // `name` are moved into the ToolProgress entry below.
+                            if matches!(name.as_str(), "write-file" | "edit-file" | "multi-edit") {
+                                if let Some(path) = arguments
+                                    .get("file_path")
+                                    .or_else(|| arguments.get("path"))
+                                    .and_then(|v| v.as_str())
+                                {
+                                    file_tool_paths.insert(id.clone(), path.to_owned());
+                                }
+                            }
+
                             let (display, summary) = tool_display_info(&name, &arguments);
                             let activity = tool_activity_label(&name).to_owned();
                             progress.tools.push(ToolProgress {
@@ -3958,6 +3975,7 @@ fn spawn_stream_forwarder(
                             }
                         }
                         Ok(StreamEvent::ToolCallEnd { id, result_preview, success, error }) => {
+                            let mut raw_name_for_diff = String::new();
                             if let Some(tp) = progress.tools.iter_mut().find(|t| t.id == id) {
                                 tp.finished = true;
                                 tp.success = success;
@@ -3965,8 +3983,19 @@ fn spawn_stream_forwarder(
                                 tp.error = error;
                                 tp.result_hint =
                                     crate::tool_display::tool_result_hint(&tp.raw_name, &result_preview);
+                                raw_name_for_diff.clone_from(&tp.raw_name);
                             }
                             pinned.on_tool_end();
+
+                            // Feed successful file-mutating tools into the pinned
+                            // session card so the summary reflects per-file diff stats.
+                            if success {
+                                if let Some(file_path) = file_tool_paths.remove(&id) {
+                                    let (additions, deletions) =
+                                        parse_file_diff_stats(&raw_name_for_diff, &result_preview);
+                                    pinned.on_file_changed(file_path, additions, deletions);
+                                }
+                            }
 
                             let text = progress.render_text();
                             if progress.last_edit.elapsed() >= MIN_EDIT_INTERVAL {
@@ -4637,6 +4666,29 @@ async fn resolve_project_info() -> (String, String) {
     };
 
     (project_name, branch)
+}
+
+/// Extract line-level diff stats from a tool's `result_preview` JSON.
+///
+/// Returns `(additions, deletions)`. Falls back to `(0, 0)` for unparseable
+/// payloads or tools that do not produce line-change metadata.
+fn parse_file_diff_stats(tool_name: &str, result_preview: &str) -> (u64, u64) {
+    let v: serde_json::Value = match serde_json::from_str(result_preview) {
+        Ok(v) => v,
+        Err(_) => return (0, 0),
+    };
+    match tool_name {
+        "edit-file" | "multi-edit" => {
+            let added = v.get("lines_added").and_then(|n| n.as_u64()).unwrap_or(0);
+            let removed = v.get("lines_removed").and_then(|n| n.as_u64()).unwrap_or(0);
+            (added, removed)
+        }
+        "write-file" => {
+            let lines = v.get("lines_written").and_then(|n| n.as_u64()).unwrap_or(0);
+            (lines, 0)
+        }
+        _ => (0, 0),
+    }
 }
 
 /// 3. **`message_id` is `None`** (first flush of this turn, or fallback from

--- a/crates/channels/src/telegram/adapter.rs
+++ b/crates/channels/src/telegram/adapter.rs
@@ -3854,9 +3854,33 @@ fn spawn_stream_forwarder(
         let (proj_name, proj_branch) = resolve_project_info().await;
         pinned.set_project_info(proj_name, proj_branch);
         let pinned_settings_key = format!("telegram.pinned_message.{chat_id}");
+        let pinned_session_key = format!("telegram.pinned_session.{chat_id}");
         if let Some(raw) = settings.get(&pinned_settings_key).await {
             if let Ok(id) = raw.parse::<i32>() {
                 pinned.message_id = Some(MessageId(id));
+            }
+        }
+
+        // Detect session switch — if the persisted session differs from the
+        // current one, unpin the old message and start fresh so users never
+        // see stale data from a previous session.
+        {
+            use teloxide::payloads::UnpinChatMessageSetters;
+            let previous_session = settings.get(&pinned_session_key).await;
+            let current_session = session_id.to_string();
+            let is_session_switch = previous_session.is_some()
+                && previous_session.as_deref() != Some(current_session.as_str());
+            if is_session_switch {
+                if let Some(mid) = pinned.message_id {
+                    // Ignore errors — the old message may already be gone.
+                    let _ = bot
+                        .unpin_chat_message(ChatId(chat_id))
+                        .message_id(mid)
+                        .await;
+                }
+                pinned.message_id = None;
+                // Clear the persisted message ID so a stale one is not restored later.
+                let _ = settings.delete(&pinned_settings_key).await;
             }
         }
 
@@ -4370,7 +4394,7 @@ fn spawn_stream_forwarder(
 
                             // ── Pinned status bar: final flush ──
                             pinned.on_stream_close();
-                            flush_pinned_status(&bot, chat_id, thread_id, &mut pinned, &settings, &pinned_settings_key).await;
+                            flush_pinned_status(&bot, chat_id, thread_id, &mut pinned, &settings, &pinned_settings_key, &pinned_session_key).await;
 
                             // ── Finalize: always create trace + compact summary ──
                             // Every agent turn (including pure text replies) gets a
@@ -4536,7 +4560,7 @@ fn spawn_stream_forwarder(
 
                     // ── Pinned session card: flush on state change only ──
                     if pinned.needs_flush() {
-                        flush_pinned_status(&bot, chat_id, thread_id, &mut pinned, &settings, &pinned_settings_key).await;
+                        flush_pinned_status(&bot, chat_id, thread_id, &mut pinned, &settings, &pinned_settings_key, &pinned_session_key).await;
                     }
                 }
                 _ = typing_interval.tick() => {
@@ -4701,6 +4725,7 @@ async fn flush_pinned_status(
     pinned: &mut super::pinned_status::PinnedSessionCard,
     settings: &Arc<dyn SettingsProvider>,
     settings_key: &str,
+    session_settings_key: &str,
 ) {
     use teloxide::payloads::PinChatMessageSetters;
 
@@ -4726,6 +4751,7 @@ async fn flush_pinned_status(
                 .disable_notification(true)
                 .await;
             let _ = settings.set(settings_key, &msg.id.0.to_string()).await;
+            let _ = settings.set(session_settings_key, &pinned.session_id).await;
         }
     }
     pinned.mark_flushed();

--- a/crates/channels/src/telegram/pinned_status.rs
+++ b/crates/channels/src/telegram/pinned_status.rs
@@ -158,6 +158,8 @@ pub(super) struct PinnedSessionCard {
     tool_calls:       u32,
     background_tasks: Vec<BackgroundTaskEntry>,
     changed_files:    Vec<FileChange>,
+    project_name:     String,
+    project_branch:   String,
     dirty:            bool,
     /// Last rendered HTML — skip-unchanged optimization.
     last_rendered:    String,
@@ -181,6 +183,8 @@ impl PinnedSessionCard {
             tool_calls: 0,
             background_tasks: Vec::new(),
             changed_files: Vec::new(),
+            project_name: String::new(),
+            project_branch: String::new(),
             dirty: true,
             last_rendered: String::new(),
         }
@@ -204,6 +208,16 @@ impl PinnedSessionCard {
             State::Idle => "\u{26aa}",     // ⚪
         };
         lines.push(format!("{status_emoji} <b>{}</b>", self.session_title));
+
+        // Project: name: branch (shown when available).
+        if !self.project_name.is_empty() {
+            let project_line = if self.project_branch.is_empty() {
+                format!("Project: {}", self.project_name)
+            } else {
+                format!("Project: {}: {}", self.project_name, self.project_branch)
+            };
+            lines.push(project_line);
+        }
 
         let model_info = if self.model.is_empty() {
             None
@@ -286,6 +300,13 @@ impl PinnedSessionCard {
         }
 
         lines.join("\n")
+    }
+
+    /// Set project name and git branch for the card header.
+    pub fn set_project_info(&mut self, name: String, branch: String) {
+        self.project_name = name;
+        self.project_branch = branch;
+        self.dirty = true;
     }
 
     // ── Event callbacks ──
@@ -509,6 +530,23 @@ mod tests {
         assert!(text.contains("\u{2026} and 5 more"));
         assert!(text.contains("file_9.rs"));
         assert!(!text.contains("file_10.rs"));
+    }
+
+    #[test]
+    fn render_project_and_branch() {
+        let mut card = PinnedSessionCard::new(123, "s1".into(), "mita".into());
+        card.set_project_info("rara".into(), "main".into());
+        let text = card.render();
+        assert!(text.contains("Project: rara: main"));
+    }
+
+    #[test]
+    fn render_project_no_branch() {
+        let mut card = PinnedSessionCard::new(123, "s1".into(), "mita".into());
+        card.set_project_info("rara".into(), String::new());
+        let text = card.render();
+        assert!(text.contains("Project: rara"));
+        assert!(!text.contains("Project: rara:"));
     }
 
     #[test]

--- a/crates/channels/src/telegram/pinned_status.rs
+++ b/crates/channels/src/telegram/pinned_status.rs
@@ -33,6 +33,21 @@ struct ModelInfo {
     context_window: u32,
 }
 
+/// Shorten an absolute path to at most the last 3 segments.
+fn short_path(path: &str) -> &str {
+    let bytes = path.as_bytes();
+    let mut slash_count = 0;
+    for i in (0..bytes.len()).rev() {
+        if bytes[i] == b'/' {
+            slash_count += 1;
+            if slash_count == 3 {
+                return &path[i + 1..];
+            }
+        }
+    }
+    path
+}
+
 /// Best-effort lookup of model metadata by name substring.
 ///
 /// Matches the most specific substring first. Returns `None` for unknown
@@ -110,6 +125,14 @@ pub(super) struct BackgroundTaskEntry {
     pub finished:   bool,
 }
 
+/// A file modified during this session, tracked for pinned card display.
+#[derive(Debug, Clone)]
+pub(super) struct FileChange {
+    pub path:      String,
+    pub additions: u64,
+    pub deletions: u64,
+}
+
 /// Pinned session summary card.
 ///
 /// The first line is an **identity bar** — shown in Telegram's floating pin
@@ -134,6 +157,7 @@ pub(super) struct PinnedSessionCard {
     thinking_ms:      u64,
     tool_calls:       u32,
     background_tasks: Vec<BackgroundTaskEntry>,
+    changed_files:    Vec<FileChange>,
     dirty:            bool,
     /// Last rendered HTML — skip-unchanged optimization.
     last_rendered:    String,
@@ -156,6 +180,7 @@ impl PinnedSessionCard {
             thinking_ms: 0,
             tool_calls: 0,
             background_tasks: Vec::new(),
+            changed_files: Vec::new(),
             dirty: true,
             last_rendered: String::new(),
         }
@@ -233,6 +258,33 @@ impl PinnedSessionCard {
             }
         }
 
+        // Changed files (shown when any file-mutating tool completed).
+        if !self.changed_files.is_empty() {
+            let total = self.changed_files.len();
+            lines.push(String::new());
+            lines.push(format!("\u{1f4c1} <b>Files ({total})</b>"));
+            let max_display = 10;
+            for f in self.changed_files.iter().take(max_display) {
+                let rel = short_path(&f.path);
+                let mut parts = Vec::new();
+                if f.additions > 0 {
+                    parts.push(format!("+{}", f.additions));
+                }
+                if f.deletions > 0 {
+                    parts.push(format!("-{}", f.deletions));
+                }
+                let diff_str = if parts.is_empty() {
+                    String::new()
+                } else {
+                    format!(" ({})", parts.join(" "))
+                };
+                lines.push(format!("  {rel}{diff_str}"));
+            }
+            if total > max_display {
+                lines.push(format!("  \u{2026} and {} more", total - max_display));
+            }
+        }
+
         lines.join("\n")
     }
 
@@ -260,6 +312,23 @@ impl PinnedSessionCard {
     /// Called when turn metrics arrive (resolves the model name).
     pub fn on_turn_metrics(&mut self, model: String) {
         self.model = model;
+        self.dirty = true;
+    }
+
+    /// Record a file mutation (write/edit) with diff stats.
+    ///
+    /// If the file was already tracked, accumulates the +/- counts.
+    pub fn on_file_changed(&mut self, path: String, additions: u64, deletions: u64) {
+        if let Some(existing) = self.changed_files.iter_mut().find(|f| f.path == path) {
+            existing.additions += additions;
+            existing.deletions += deletions;
+        } else {
+            self.changed_files.push(FileChange {
+                path,
+                additions,
+                deletions,
+            });
+        }
         self.dirty = true;
     }
 
@@ -406,6 +475,49 @@ mod tests {
         card.on_background_task_done("task-1");
         let text = card.render();
         assert!(!text.contains("Background"));
+    }
+
+    #[test]
+    fn render_changed_files() {
+        let mut card = PinnedSessionCard::new(123, "s1".into(), "mita".into());
+        card.on_file_changed("src/main.rs".into(), 12, 5);
+        card.on_file_changed("tests/unit.rs".into(), 8, 0);
+        let text = card.render();
+        assert!(text.contains("<b>Files (2)</b>"));
+        assert!(text.contains("src/main.rs (+12 -5)"));
+        assert!(text.contains("tests/unit.rs (+8)"));
+    }
+
+    #[test]
+    fn file_change_accumulates() {
+        let mut card = PinnedSessionCard::new(123, "s1".into(), "mita".into());
+        card.on_file_changed("src/main.rs".into(), 5, 2);
+        card.on_file_changed("src/main.rs".into(), 3, 1);
+        assert_eq!(card.changed_files.len(), 1);
+        assert_eq!(card.changed_files[0].additions, 8);
+        assert_eq!(card.changed_files[0].deletions, 3);
+    }
+
+    #[test]
+    fn changed_files_truncated_at_10() {
+        let mut card = PinnedSessionCard::new(123, "s1".into(), "mita".into());
+        for i in 0..15 {
+            card.on_file_changed(format!("file_{i}.rs"), 1, 0);
+        }
+        let text = card.render();
+        assert!(text.contains("Files (15)"));
+        assert!(text.contains("\u{2026} and 5 more"));
+        assert!(text.contains("file_9.rs"));
+        assert!(!text.contains("file_10.rs"));
+    }
+
+    #[test]
+    fn short_path_trims_prefix() {
+        assert_eq!(
+            short_path("/Users/ryan/code/rara/src/main.rs"),
+            "rara/src/main.rs"
+        );
+        assert_eq!(short_path("src/main.rs"), "src/main.rs");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Bring the Telegram pinned session card to feature-parity with `vendor/opencode-telegram-bot`:

- **Changed files** — 📁 Files section shows modified paths with `+N -N` diff stats (capped at 10, overflow indicator)
- **Project + branch** — resolves CWD basename and `.git/HEAD` to show `Project: rara: main`
- **File change tracking** — captures `file_path` on `write-file` / `edit-file` / `multi-edit` ToolCallStart, feeds successful completions with parsed `lines_added` / `lines_removed` into the card
- **Session switch handling** — on session change, unpins the stale message and creates a fresh one; persists `telegram.pinned_session.{chat_id}` alongside the message ID

### Before

```
🟢 mita
Model: claude-sonnet-4
Context: 45.0k / 200.0k (22%)
🔧 8 tool calls
```

### After

```
🟢 mita
Project: rara: main
Model: claude-sonnet-4
Context: 45.0k / 200.0k (22%)
🔧 8 tool calls

📁 Files (3)
  channels/src/telegram/pinned_status.rs (+42 -5)
  channels/src/telegram/adapter.rs (+103 -2)
  channels/src/tool_display.rs (+6)
```

## Commits (stacked)

- 5307e2bd `feat(channels): pinned card — add changed files rendering`
- 8a30abd0 `feat(channels): pinned card — project and branch display`
- e3f44bd7 `feat(channels): pinned card — file change tracking from tool events`
- fc8bf987 `feat(channels): pinned card — unpin on session switch`

## Type of change

| Type | Label |
|------|-------|
| New feature | `enhancement` |

## Component

`backend`

## Closes

Closes #1485

## Test plan

- [x] 131 tests pass in `rara-channels` (14 in `pinned_status`)
- [x] `cargo clippy -p rara-channels --all-targets --no-deps -- -D warnings` clean
- [x] `cargo +nightly fmt --check` clean
- [x] All pre-commit hooks pass