### PR TITLE
fix(kernel): separate session reap from list() (#1491)

### DIFF
--- a/crates/kernel/src/kernel.rs
+++ b/crates/kernel/src/kernel.rs
@@ -514,6 +514,12 @@ impl Kernel {
         let mita_interval = self.config.mita_heartbeat_interval;
         let mut next_mita = mita_interval.map(|d| tokio::time::Instant::now() + d);
 
+        // Periodic session-table reap. Decoupled from `list_processes()` so
+        // readers never mutate the table; runs at a steady cadence regardless
+        // of whether anyone is polling.
+        let reap_interval = std::time::Duration::from_secs(30);
+        let mut next_reap = tokio::time::Instant::now() + reap_interval;
+
         loop {
             // Compute next wake time for the unified scheduler (processor 0 only).
             let scheduler_sleep = if id == 0 {
@@ -528,8 +534,9 @@ impl Kernel {
                     tokio::time::Instant::now() + clamped
                 });
 
-                // Find the earliest deadline among: mita heartbeat, next scheduled job.
-                let earliest = [next_mita, next_job_instant]
+                // Find the earliest deadline among: mita heartbeat, reap tick, next scheduled
+                // job.
+                let earliest = [next_mita, Some(next_reap), next_job_instant]
                     .into_iter()
                     .flatten()
                     .min()
@@ -577,6 +584,14 @@ impl Kernel {
                             }
                             next_mita = mita_interval.map(|d| now + d);
                         }
+                    }
+
+                    // Check if periodic session-table reap is due.
+                    if now >= next_reap {
+                        if let Err(e) = self.event_queue.try_push(KernelEventEnvelope::idle_check()) {
+                            error!(%e, "failed to push IdleCheck");
+                        }
+                        next_reap = now + reap_interval;
                     }
 
                     // Evict expired rate-limiter entries.
@@ -775,9 +790,7 @@ impl Kernel {
                 self.handle_mita_heartbeat().await;
             }
             KernelEvent::IdleCheck => {
-                // Periodic idle check — handled by session table reaping.
-                self.process_table
-                    .reap_terminal(std::time::Duration::from_secs(300));
+                self.process_table.reap_terminal(SessionTable::TERMINAL_TTL);
             }
             KernelEvent::Shutdown => {
                 info!("shutdown event received");

--- a/crates/kernel/src/session/mod.rs
+++ b/crates/kernel/src/session/mod.rs
@@ -627,8 +627,11 @@ pub struct SessionTable {
 impl SessionTable {
     /// Maximum number of turn traces retained per process.
     const MAX_TURN_TRACES: usize = 50;
-    /// How long terminal processes remain visible before being reaped.
-    const TERMINAL_TTL: std::time::Duration = std::time::Duration::from_secs(60);
+    /// How long suspended sessions remain visible before the periodic
+    /// `IdleCheck` evicts them from the table. Chosen to give the kernel UI
+    /// enough time to surface recently-finished runs in the Dormant group
+    /// while still bounding memory growth for long-running processes.
+    pub const TERMINAL_TTL: std::time::Duration = std::time::Duration::from_secs(300);
 
     /// Create an empty process table.
     pub fn new() -> Self {
@@ -802,9 +805,10 @@ impl SessionTable {
 
     /// Build [`SessionStats`] for all sessions currently in the table.
     ///
-    /// Also performs lazy reaping of suspended sessions older than the TTL.
+    /// Pure read — does not evict anything. Reaping runs on its own schedule
+    /// via the `IdleCheck` event (see `kernel.rs`), so observers never see the
+    /// process table mutate just because they requested a snapshot.
     pub fn all_process_stats(&self) -> Vec<SessionStats> {
-        self.reap_terminal(Self::TERMINAL_TTL);
         let ids: Vec<SessionKey> = self.runtimes.iter().map(|p| p.session_key).collect();
         ids.iter().filter_map(|id| self.stats(*id)).collect()
     }


### PR DESCRIPTION
## Summary

Reaping of suspended sessions used to run as a side effect of `SessionTable::all_process_stats()` — every call to `list_processes` evicted sessions older than `TERMINAL_TTL = 60s`. The new kernel UI polls every 5s, so the Dormant group was effectively empty and history inspection was impossible.

- `all_process_stats()` is now a pure read.
- The scheduler on processor id=0 pushes `KernelEvent::IdleCheck` every 30s; the existing handler calls `reap_terminal(SessionTable::TERMINAL_TTL)`.
- `TERMINAL_TTL` raised from 60s to 300s and promoted to `pub const`, replacing the hard-coded literal that already lived in the handler.

## Type of change

| Type | Label |
|------|-------|
| Bug fix | `bug` |

## Component

`core`

## Closes

Closes #1491

## Test plan

- [x] `cargo check -p rara-kernel` passes
- [x] `cargo clippy -p rara-kernel --all-targets --all-features --no-deps` clean
- [x] `prek run --all-files` green (fmt, clippy, doc, AGENT.md)
- [ ] Manual: suspend a session, wait 2 minutes, verify it still shows in Dormant group (previously disappeared at 60s)