### PR TITLE
feat(web): adopt Geist typography (#1495)

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -23,9 +23,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Nunito:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
-    <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
-    <link href="https://cdn.jsdelivr.net/npm/lxgw-wenkai-screen-webfont@1/style.css" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Geist:wght@400;500;600;700&family=Geist+Mono:wght@400;500&display=swap" rel="stylesheet">
     <title>rara</title>
   </head>
   <body>

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -51,6 +51,23 @@
   --motion-fast: 150ms;
   --motion-normal: 250ms;
   --motion-slow: 500ms;
+
+  /* Typography — Geist with CJK system fallback */
+  --font-sans: "Geist", ui-sans-serif, system-ui, -apple-system, "PingFang SC",
+    "Hiragino Sans GB", "Microsoft YaHei", "Noto Sans SC", sans-serif;
+  --font-mono: "Geist Mono", ui-monospace, SFMono-Regular, Menlo, Monaco,
+    Consolas, "Liberation Mono", "Courier New", monospace;
+}
+
+/*
+ * Override mini-lit's plain :root --font-sans / --font-mono (imported via
+ * pi-web-ui). Must be unlayered + after the import so it wins the cascade.
+ */
+:root {
+  --font-sans: "Geist", ui-sans-serif, system-ui, -apple-system, "PingFang SC",
+    "Hiragino Sans GB", "Microsoft YaHei", "Noto Sans SC", sans-serif;
+  --font-mono: "Geist Mono", ui-monospace, SFMono-Regular, Menlo, Monaco,
+    Consolas, "Liberation Mono", "Courier New", monospace;
 }
 
 /*
@@ -131,13 +148,16 @@
   * {
     @apply border-border;
   }
-  :root {
-    --font-sans: "LXGW WenKai Screen", ui-sans-serif, system-ui, -apple-system, sans-serif;
-  }
   body {
     @apply bg-background text-foreground antialiased;
     font-family: var(--font-sans);
     min-height: 100vh;
+  }
+  code,
+  kbd,
+  samp,
+  pre {
+    font-family: var(--font-mono);
   }
   /* Rara admin gradient background — only on admin pages */
   .rara-admin {


### PR DESCRIPTION
## Summary

- Replace Nunito/JetBrains Mono/LXGW stack with Geist + Geist Mono
- Keep CJK system fallback (PingFang SC, Hiragino Sans GB, Microsoft YaHei, Noto Sans SC)
- Override mini-lit's `:root` font tokens (imported via `pi-web-ui`) so our values win the cascade

## Why

- Matches Multica's typography direction and gives rara a cleaner, more modern look
- Addresses user feedback that the existing stack felt "ugly"

## Type of change

| Type | Label |
|------|-------|
| New feature | `enhancement` |

## Component

`ui`

## Closes

Closes #1495

## Test plan

- [x] `npm run build` passes in `web/`
- [x] Verified in browser via Playwright: `--font-sans` resolves to `Geist, ...`, `document.fonts.check('16px Geist')` returns `true`, Geist Mono loads for code/URL fields
- [x] Confirmed settings page renders Geist glyphs (distinctive "a"/"g") and URL input renders Geist Mono