### PR TITLE
fix(kernel): deliver outbound envelopes for web-originated messages (#1499)

### DIFF
--- a/crates/kernel/src/event.rs
+++ b/crates/kernel/src/event.rs
@@ -322,6 +322,9 @@ pub enum KernelEvent {
         user:            UserId,
         /// Origin endpoint from the inbound message for session-scoped routing.
         origin_endpoint: Option<crate::io::Endpoint>,
+        /// Channel type of the inbound message that triggered this turn.
+        /// `None` for abnormal exits where source info is unavailable.
+        source_channel:  Option<crate::channel::types::ChannelType>,
         /// Whether this turn was interrupted by a user /stop command.
         interrupted:     bool,
     },
@@ -522,6 +525,7 @@ impl KernelEventEnvelope {
         in_reply_to: MessageId,
         user: UserId,
         origin_endpoint: Option<crate::io::Endpoint>,
+        source_channel: Option<crate::channel::types::ChannelType>,
         interrupted: bool,
     ) -> Self {
         Self {
@@ -531,6 +535,7 @@ impl KernelEventEnvelope {
                 in_reply_to,
                 user,
                 origin_endpoint,
+                source_channel,
                 interrupted,
             },
         }

--- a/crates/kernel/src/io.rs
+++ b/crates/kernel/src/io.rs
@@ -428,6 +428,13 @@ impl OutboundEnvelope {
         self
     }
 
+    /// Override the default routing strategy.
+    #[must_use]
+    pub fn with_routing(mut self, routing: OutboundRouting) -> Self {
+        self.routing = routing;
+        self
+    }
+
     /// Format this envelope as a [`PlatformOutbound`] for delivery.
     pub fn to_platform_outbound(&self) -> PlatformOutbound {
         match &self.payload {

--- a/crates/kernel/src/io.rs
+++ b/crates/kernel/src/io.rs
@@ -1806,12 +1806,37 @@ impl IOSubsystem {
         )
     )]
     async fn deliver_to_endpoints(&self, envelope: OutboundEnvelope) {
-        // Build candidates from origin_endpoint (if set) or user registry,
-        // then apply routing filters.
+        // Build candidates from origin_endpoint (if set) or session-scoped
+        // channel bindings, then apply routing filters.
+        //
+        // Why session bindings, not the per-user endpoint registry:
+        // the registry holds every endpoint the user has ever touched,
+        // including TG/WeChat chats from unrelated sessions. Broadcasting to
+        // that set leaks one session's output into another. Session bindings
+        // only contain endpoints explicitly tied to *this* session (via
+        // `bind_channel_for_message` or `/sessions`), so cross-channel
+        // mirroring stays within the session's own chats.
         let candidates: Vec<Endpoint> = if let Some(ref origin) = envelope.origin_endpoint {
             vec![origin.clone()]
         } else {
-            self.endpoint_registry.get_endpoints(&envelope.user)
+            match self
+                .session_index
+                .list_channel_bindings_by_session(&envelope.session_key)
+                .await
+            {
+                Ok(bindings) => bindings
+                    .into_iter()
+                    .filter_map(binding_to_endpoint)
+                    .collect(),
+                Err(e) => {
+                    tracing::warn!(
+                        %e,
+                        session_key = %envelope.session_key,
+                        "deliver_to_endpoints: binding lookup failed; skipping fanout"
+                    );
+                    Vec::new()
+                }
+            }
         };
         let targets = resolve_delivery_targets(candidates, &envelope.routing);
 
@@ -1867,6 +1892,40 @@ impl IOSubsystem {
             }
         });
         futures::future::join_all(futs).await;
+    }
+}
+
+/// Convert a [`ChannelBinding`](crate::session::ChannelBinding) into a
+/// deliverable [`Endpoint`].
+///
+/// Only channels that accept platform-level delivery via
+/// [`ChannelAdapter`](crate::channel::adapter::ChannelAdapter) are mapped.
+/// Web and CLI bindings are self-referential (`chat_id == session_key`) —
+/// their adapters fan out through [`StreamHub`] rather than
+/// `deliver_to_endpoints`, so routing them here would double-deliver.
+/// Returning `None` for those variants keeps the fanout list
+/// adapter-compatible without relying on downstream routing filters.
+fn binding_to_endpoint(binding: crate::session::ChannelBinding) -> Option<Endpoint> {
+    match binding.channel_type {
+        ChannelType::Telegram => {
+            let chat_id = binding.chat_id.parse::<i64>().ok()?;
+            let thread_id = binding.thread_id.and_then(|t| t.parse::<i64>().ok());
+            Some(Endpoint {
+                channel_type: ChannelType::Telegram,
+                address:      EndpointAddress::Telegram { chat_id, thread_id },
+            })
+        }
+        ChannelType::Wechat => Some(Endpoint {
+            channel_type: ChannelType::Wechat,
+            address:      EndpointAddress::Wechat {
+                user_id: binding.chat_id,
+            },
+        }),
+        ChannelType::Web
+        | ChannelType::Cli
+        | ChannelType::Api
+        | ChannelType::Internal
+        | ChannelType::Proactive => None,
     }
 }
 
@@ -1967,6 +2026,62 @@ mod delivery_routing_tests {
             },
         );
         assert_eq!(targets, vec![web]);
+    }
+
+    #[test]
+    fn binding_to_endpoint_maps_telegram_with_thread() {
+        let now = chrono::Utc::now();
+        let binding = crate::session::ChannelBinding {
+            channel_type: ChannelType::Telegram,
+            chat_id:      "-1001234567890".to_string(),
+            thread_id:    Some("42".to_string()),
+            session_key:  crate::session::SessionKey::new(),
+            created_at:   now,
+            updated_at:   now,
+        };
+        let ep = binding_to_endpoint(binding).expect("telegram binding maps");
+        assert_eq!(
+            ep,
+            Endpoint {
+                channel_type: ChannelType::Telegram,
+                address:      EndpointAddress::Telegram {
+                    chat_id:   -1001234567890,
+                    thread_id: Some(42),
+                },
+            }
+        );
+    }
+
+    #[test]
+    fn binding_to_endpoint_rejects_self_referential_web() {
+        // Web/CLI bindings are self-referential (chat_id == session_key) and
+        // their adapters deliver via StreamHub — mapping them here would
+        // double-deliver.
+        let now = chrono::Utc::now();
+        let key = crate::session::SessionKey::new();
+        let binding = crate::session::ChannelBinding {
+            channel_type: ChannelType::Web,
+            chat_id:      key.to_string(),
+            thread_id:    None,
+            session_key:  key,
+            created_at:   now,
+            updated_at:   now,
+        };
+        assert!(binding_to_endpoint(binding).is_none());
+    }
+
+    #[test]
+    fn binding_to_endpoint_rejects_malformed_telegram_chat_id() {
+        let now = chrono::Utc::now();
+        let binding = crate::session::ChannelBinding {
+            channel_type: ChannelType::Telegram,
+            chat_id:      "not-a-number".to_string(),
+            thread_id:    None,
+            session_key:  crate::session::SessionKey::new(),
+            created_at:   now,
+            updated_at:   now,
+        };
+        assert!(binding_to_endpoint(binding).is_none());
     }
 }
 

--- a/crates/kernel/src/kernel.rs
+++ b/crates/kernel/src/kernel.rs
@@ -716,6 +716,7 @@ impl Kernel {
                         None,
                         desired_session_key,
                         None,
+                        None, // source_channel: internal spawn
                         child_result_tx,
                     )
                     .await;
@@ -812,6 +813,9 @@ impl Kernel {
         // The originating channel endpoint, stored in the session so that
         // reply routing works even for synthetic re-entry messages.
         origin_endpoint: Option<crate::io::Endpoint>,
+        // The channel type of the original user-facing message, stored so
+        // that the synthetic re-entry retains correct delivery routing.
+        source_channel: Option<ChannelType>,
         // Pre-created channel for streaming AgentEvents back to the spawner.
         // Set at creation time to avoid the race where a fast-completing child
         // turn checks result_tx before the spawner has a chance to set it.
@@ -887,6 +891,7 @@ impl Kernel {
             process_cancel,
             paused: false,
             origin_endpoint,
+            source_channel,
             pause_buffer: Vec::new(),
             interrupted: Arc::new(AtomicBool::new(false)),
             interrupt_notify: Arc::new(tokio::sync::Notify::new()),
@@ -1494,6 +1499,7 @@ impl Kernel {
                 resume_session_id,
                 Some(session_id.clone()),
                 origin_endpoint.clone(),
+                Some(msg.source.channel_type),
                 None, // no child_result_tx for user-initiated sessions
             )
             .await;
@@ -1554,6 +1560,7 @@ impl Kernel {
                 None, // no resume
                 None, // independent session, don't pollute the original tape
                 None, // no origin endpoint
+                None, // source_channel: scheduled task
                 None, // no child_result_tx for scheduled tasks
             )
             .await
@@ -1802,6 +1809,7 @@ impl Kernel {
                     None,
                     Some(session_key),
                     None,
+                    None, // source_channel: Mita bootstrap
                     None, // no child_result_tx for Mita
                 )
                 .await
@@ -2092,7 +2100,18 @@ impl Kernel {
                 .flatten()
         });
 
-        let source_channel = msg.source.channel_type;
+        // Synthetic re-entry messages (from handle_spawn_agent) carry
+        // Internal channel type. Fall back to the session's recorded
+        // source channel so the first turn inherits delivery routing
+        // from the original user-facing channel.
+        let source_channel = match msg.source.channel_type {
+            ChannelType::Internal => self
+                .process_table
+                .with(&session_key, |p| p.source_channel)
+                .flatten()
+                .unwrap_or(ChannelType::Internal),
+            other => other,
+        };
 
         // Web/CLI/API channels don't have an origin_endpoint (no platform
         // chat ID to route back to), but they are still user-facing and

--- a/crates/kernel/src/kernel.rs
+++ b/crates/kernel/src/kernel.rs
@@ -58,11 +58,14 @@ use crate::{
     agent::{
         AgentEnv, AgentManifest, AgentRegistryRef, AgentTurnResult, ExecutionMode, run_agent_loop,
     },
-    channel::types::MessageContent,
+    channel::types::{ChannelType, MessageContent},
     event::{KernelEvent, KernelEventEnvelope},
     hooks::{HookRunner, HookRunnerRef, HooksConfig},
     identity::Principal,
-    io::{IOSubsystem, InboundMessage, MessageId, OutboundEnvelope, PipeRegistry, StreamId},
+    io::{
+        IOSubsystem, InboundMessage, MessageId, OutboundEnvelope, OutboundRouting, PipeRegistry,
+        StreamId,
+    },
     kv::SharedKv,
     llm::DriverRegistryRef,
     memory::TapeService,
@@ -726,6 +729,7 @@ impl Kernel {
                 in_reply_to,
                 user,
                 origin_endpoint,
+                source_channel,
                 interrupted,
             } => {
                 self.handle_turn_completed(
@@ -734,6 +738,7 @@ impl Kernel {
                     in_reply_to,
                     user,
                     origin_endpoint,
+                    source_channel,
                     interrupted,
                 )
                 .await;
@@ -1943,6 +1948,7 @@ impl Kernel {
             msg_id:          MessageId,
             user:            crate::identity::UserId,
             origin_endpoint: Option<crate::io::Endpoint>,
+            source_channel:  Option<ChannelType>,
             completed:       bool,
         }
 
@@ -1964,6 +1970,7 @@ impl Kernel {
                         self.msg_id.clone(),
                         self.user.clone(),
                         self.origin_endpoint.clone(),
+                        self.source_channel,
                         false,
                     );
                     if let Err(e) = self.event_queue.try_push(event) {
@@ -2085,6 +2092,28 @@ impl Kernel {
                 .flatten()
         });
 
+        let source_channel = msg.source.channel_type;
+
+        // Web/CLI/API channels don't have an origin_endpoint (no platform
+        // chat ID to route back to), but they are still user-facing and
+        // should receive outbound delivery via the endpoint registry.
+        let should_deliver = origin_endpoint.is_some()
+            || !matches!(
+                source_channel,
+                ChannelType::Internal | ChannelType::Proactive
+            );
+
+        // When there is no origin_endpoint but we still need delivery
+        // (e.g. Web channel), route via BroadcastExcept to avoid
+        // double-delivery through the existing StreamHub path.
+        let cross_channel_routing = if origin_endpoint.is_none() && should_deliver {
+            Some(OutboundRouting::BroadcastExcept {
+                exclude: source_channel,
+            })
+        } else {
+            None
+        };
+
         // Update the session's stored origin endpoint when a real platform
         // message provides one, so that subsequent synthetic messages can
         // inherit the correct routing target.
@@ -2108,20 +2137,24 @@ impl Kernel {
         // received and the agent is working. On Telegram this shows the
         // "typing..." bubble.
         let egress_session_key = session_key;
-        // Only send typing indicator when there's an origin endpoint to
-        // deliver to. Headless agents (scheduled tasks, subagents) have no
-        // user-facing channel.
-        if origin_endpoint.is_some() {
-            let _ = &self.event_queue.try_push(KernelEventEnvelope::deliver(
-                OutboundEnvelope::progress(
-                    msg_id.clone(),
-                    user.clone(),
-                    egress_session_key.clone(),
-                    crate::io::stages::THINKING,
-                    None,
-                )
-                .with_origin(origin_endpoint.clone()),
-            ));
+        // Only send typing indicator to user-facing channels. Headless
+        // agents (scheduled tasks, subagents) have no user-facing channel.
+        if should_deliver {
+            let envelope = OutboundEnvelope::progress(
+                msg_id.clone(),
+                user.clone(),
+                egress_session_key.clone(),
+                crate::io::stages::THINKING,
+                None,
+            )
+            .with_origin(origin_endpoint.clone());
+            let envelope = match cross_channel_routing {
+                Some(ref routing) => envelope.with_routing(routing.clone()),
+                None => envelope,
+            };
+            let _ = &self
+                .event_queue
+                .try_push(KernelEventEnvelope::deliver(envelope));
         }
 
         if let Some(metrics) = self.process_table.get_metrics(&session_key) {
@@ -2430,6 +2463,7 @@ impl Kernel {
                 msg_id:          msg_id.clone(),
                 user:            user.clone(),
                 origin_endpoint: origin_endpoint.clone(),
+                source_channel:  Some(source_channel),
                 completed:       false,
             };
 
@@ -2605,6 +2639,7 @@ impl Kernel {
                     msg_id,
                     user,
                     origin_endpoint,
+                    Some(source_channel),
                     interrupted,
                 );
                 if let Err(e) = event_queue.try_push(event) {
@@ -2647,6 +2682,7 @@ impl Kernel {
                         turn_guard.msg_id.clone(),
                         turn_guard.user.clone(),
                         turn_guard.origin_endpoint.clone(),
+                        turn_guard.source_channel,
                         false,
                     );
                     if let Err(e) = turn_guard.event_queue.try_push(event) {
@@ -2673,6 +2709,7 @@ impl Kernel {
         in_reply_to: MessageId,
         user: crate::identity::UserId,
         origin_endpoint: Option<crate::io::Endpoint>,
+        source_channel: Option<ChannelType>,
         interrupted: bool,
     ) {
         let span = tracing::Span::current();
@@ -2689,6 +2726,21 @@ impl Kernel {
             self.cleanup_process(session_key).await;
             return;
         }
+
+        // Determine whether outbound delivery is needed. Messages from
+        // user-facing channels (Web, Telegram, CLI, etc.) should always
+        // be delivered, even when origin_endpoint is None (e.g. Web has
+        // no platform chat ID). Headless channels skip delivery.
+        let should_deliver = origin_endpoint.is_some()
+            || source_channel
+                .is_some_and(|ch| !matches!(ch, ChannelType::Internal | ChannelType::Proactive));
+
+        let cross_channel_routing = match (origin_endpoint.is_none(), should_deliver) {
+            (true, true) => {
+                source_channel.map(|ch| OutboundRouting::BroadcastExcept { exclude: ch })
+            }
+            _ => None,
+        };
 
         // Egress uses session_key directly. Subagents without external
         // delivery have their results flow back to the parent via
@@ -2808,11 +2860,10 @@ impl Kernel {
                     .push_turn_trace(session_key, turn.trace.clone());
 
                 // Push Deliver event for the reply — use egress session for routing.
-                // When origin_endpoint is None (e.g. scheduled tasks, subagents),
-                // skip delivery to avoid broadcasting to all user endpoints.
-                // These agents communicate results via other channels
-                // (PublishEvent/SendNotification or result_tx).
-                if origin_endpoint.is_some() {
+                // Headless agents (scheduled tasks, subagents) communicate
+                // results via other channels (PublishEvent/SendNotification
+                // or result_tx), so skip delivery for those.
+                if should_deliver {
                     let envelope = OutboundEnvelope::reply(
                         in_reply_to,
                         user.clone(),
@@ -2821,6 +2872,10 @@ impl Kernel {
                         vec![],
                     )
                     .with_origin(origin_endpoint.clone());
+                    let envelope = match cross_channel_routing {
+                        Some(ref routing) => envelope.with_routing(routing.clone()),
+                        None => envelope,
+                    };
 
                     if let Err(e) = &self
                         .event_queue
@@ -2860,7 +2915,7 @@ impl Kernel {
                 }
 
                 // Send fallback message so the user is not left without a reply.
-                if origin_endpoint.is_some() {
+                if should_deliver {
                     let fallback_text = "I wasn't able to generate a response. Please try again.";
                     let envelope = OutboundEnvelope::reply(
                         in_reply_to,
@@ -2870,6 +2925,10 @@ impl Kernel {
                         vec![],
                     )
                     .with_origin(origin_endpoint.clone());
+                    let envelope = match cross_channel_routing {
+                        Some(ref routing) => envelope.with_routing(routing.clone()),
+                        None => envelope,
+                    };
                     if let Err(e) = &self
                         .event_queue
                         .try_push(KernelEventEnvelope::deliver(envelope))
@@ -2889,10 +2948,9 @@ impl Kernel {
 
                 // Deliver error — use egress session for routing.
                 // Skip for user-initiated interrupts (the /stop handler
-                // already sent a confirmation message) and when
-                // origin_endpoint is None (same rationale as reply delivery
-                // above).
-                if _turn_failed && origin_endpoint.is_some() {
+                // already sent a confirmation message) and for headless
+                // agents that have no user-facing channel.
+                if _turn_failed && should_deliver {
                     let envelope = OutboundEnvelope::error(
                         in_reply_to,
                         user.clone(),
@@ -2901,6 +2959,10 @@ impl Kernel {
                         err_msg.clone(),
                     )
                     .with_origin(origin_endpoint.clone());
+                    let envelope = match cross_channel_routing {
+                        Some(ref routing) => envelope.with_routing(routing.clone()),
+                        None => envelope,
+                    };
                     if let Err(e) = &self
                         .event_queue
                         .try_push(KernelEventEnvelope::deliver(envelope))

--- a/crates/kernel/src/session/mod.rs
+++ b/crates/kernel/src/session/mod.rs
@@ -402,6 +402,10 @@ pub struct Session {
     /// Telegram chat). Used as a fallback for reply routing when the
     /// triggering message is synthetic (no platform origin).
     pub origin_endpoint: Option<Endpoint>,
+    /// The channel type that originally created this session (e.g. Web,
+    /// Telegram). Used as a fallback for delivery routing when the
+    /// triggering message is synthetic (`Internal`).
+    pub source_channel: Option<crate::channel::types::ChannelType>,
     /// Deferred tools activated via `discover-tools` during this session.
     /// Persists across turns so the LLM does not need to re-discover tools
     /// after each user message.
@@ -987,6 +991,7 @@ impl Session {
             background_tasks: Vec::new(),
             pending_tool_call_limit: None,
             origin_endpoint: None,
+            source_channel: None,
             activated_deferred: std::collections::HashSet::new(),
             child_semaphore: Arc::new(Semaphore::new(child_limit)),
             _parent_child_permit: None,
@@ -1066,6 +1071,7 @@ mod state_transition_tests {
             background_tasks: vec![],
             pending_tool_call_limit: None,
             origin_endpoint: None,
+            source_channel: None,
             activated_deferred: Default::default(),
             child_semaphore: Arc::new(Semaphore::new(1)),
             _parent_child_permit: None,


### PR DESCRIPTION
## Summary

Web-originated messages never reached Telegram because the kernel's delivery guard (`if origin_endpoint.is_some()`) skipped `OutboundEnvelope` creation for channels that don't provide an origin endpoint (Web, CLI, API). This conflated "no origin endpoint" with "headless/no user".

- Broadened the guard to allow delivery for all user-facing channels (everything except `Internal` and `Proactive`)
- Added `BroadcastExcept { exclude: source_channel }` routing for web-originated envelopes to avoid double-delivery through the existing StreamHub path
- Added `with_routing()` builder method to `OutboundEnvelope`
- Threaded `source_channel` through `TurnCompleted` event so `handle_turn_completed` has access to the originating channel type

## Type of change

| Type | Label |
|------|-------|
| Bug fix | `bug` |

## Component

`core`

## Closes

Closes #1499

## Test plan

- [x] `cargo check -p rara-kernel` passes
- [x] All pre-commit hooks pass (fmt, clippy, check, doc)
- [x] Verified via server logs: web session had 0 `deliver_to_endpoints` events (root cause confirmed)
- [ ] Manual test: send message from web UI, verify Telegram receives reply

🤖 Generated with [Claude Code](https://claude.com/claude-code)