### PR TITLE
fix(kernel): persist error in rt.result on turn failure (#1501)

### DIFF
--- a/crates/kernel/src/kernel.rs
+++ b/crates/kernel/src/kernel.rs
@@ -2900,6 +2900,19 @@ impl Kernel {
                     info!(session_key = %session_key, "turn interrupted by user");
                 }
 
+                // Persist the error so `cleanup_process` can propagate it
+                // to the parent. Without this, `rt.result` stays `None`
+                // and the parent receives the uninformative fallback
+                // `"process ended"` instead of the actual error message.
+                self.process_table.with_mut(&session_key, |rt| {
+                    rt.result = Some(AgentRunLoopResult {
+                        output:     format!("error: {err_msg}"),
+                        iterations: 0,
+                        tool_calls: 0,
+                        success:    false,
+                    });
+                });
+
                 // Deliver error — use egress session for routing.
                 // Skip for user-initiated interrupts (the /stop handler
                 // already sent a confirmation message) and when


### PR DESCRIPTION
## Summary

When the agent loop returns `Err`, the error message was delivered to the user via `OutboundEnvelope::error` but **never written to `rt.result`**. The subsequent `cleanup_process` fell through to the hardcoded fallback `"process ended"` with `iterations=0`, losing the actual error message.

For child/background agents, this meant the parent received `"process ended"` instead of e.g. `"rate limited"` or `"model not found"` — making it impossible to diagnose failures without tailing logs.

Fix: write `AgentRunLoopResult { output: "error: {err_msg}", success: false }` to `rt.result` in the `Err` branch, so the parent receives the real failure reason.

## Type of change

| Type | Label |
|------|-------|
| Bug fix | `bug` |

## Component

`core`

## Closes

Closes #1501

## Test plan

- [x] `cargo check -p rara-kernel` passes
- [x] `cargo test -p rara-kernel --lib` — 455 passed
- [x] Pre-commit hooks all pass
- [ ] Manual: spawn background agent against rate-limited provider → parent message now shows "error: ..." instead of "process ended"