### PR TITLE
fix(channels): per-chat rate limiter + delta gating for TG edits (#1510)

### DIFF
--- a/crates/channels/AGENT.md
+++ b/crates/channels/AGENT.md
@@ -38,6 +38,7 @@ Concrete channel adapter implementations for the rara platform — bridges the k
 - Telegram bot token comes from the settings store (not config file) — the adapter is skipped if the token is unset.
 - The `reqwest` version for telegram proxy is pinned to 0.12 (`reqwest012`) because teloxide 0.17 requires it — do not upgrade to workspace reqwest 0.13 until teloxide supports it.
 - Group message handling is controlled by `GroupPolicy` — respect the policy to avoid responding in unauthorized groups.
+- **Rate limiting**: All outbound Telegram API calls (`send_message`, `edit_message_text`, `send_photo`, `send_voice`, `send_chat_action`) MUST pass through `ChatRateLimiter::acquire(chat_id)` first (see `src/telegram/rate_limit.rs`). Telegram's group quota is 20 msg/min per group (editMessage shares sendMessage quota — tdlib/td#3034), and bypassing the limiter will cause 429 FloodWait errors that silently drop plan-summary inline buttons in forum topics.
 
 ## What NOT To Do
 
@@ -45,6 +46,7 @@ Concrete channel adapter implementations for the rara platform — bridges the k
 - Do NOT bypass `IOSubsystem` for sending messages — adapters should only be accessed through the kernel's I/O layer.
 - Do NOT upgrade the telegram `reqwest` dependency to 0.13 — teloxide 0.17 is pinned to 0.12.
 - Do NOT hardcode chat IDs or bot tokens — they come from runtime settings.
+- Do NOT use `bot.send_message()` / `bot.edit_message_text()` directly — **why:** bypasses `ChatRateLimiter`; Telegram will 429 and inline buttons will silently vanish in forum topics. Always call `rate_limiter.acquire(chat_id).await` first.
 
 ## Dependencies
 

--- a/crates/channels/Cargo.toml
+++ b/crates/channels/Cargo.toml
@@ -12,6 +12,7 @@ base64 = { workspace = true }
 chrono = { workspace = true }
 dashmap = "6"
 futures = { workspace = true }
+governor = "0.7"
 image = { workspace = true }
 jiff = { workspace = true }
 rand = { workspace = true }

--- a/crates/channels/src/telegram/adapter.rs
+++ b/crates/channels/src/telegram/adapter.rs
@@ -1690,6 +1690,7 @@ impl ChannelAdapter for TelegramAdapter {
             let approval_bot = self.bot.clone();
             let approval_config = Arc::clone(&self.config);
             let approval_session_index = Arc::clone(handle.session_index());
+            let approval_rate_limiter = Arc::clone(&self.rate_limiter);
             let mut approval_shutdown = self.shutdown_rx.clone();
             tokio::spawn(async move {
                 approval_listener(
@@ -1697,6 +1698,7 @@ impl ChannelAdapter for TelegramAdapter {
                     approval_rx,
                     approval_config,
                     approval_session_index,
+                    approval_rate_limiter,
                     &mut approval_shutdown,
                 )
                 .await;
@@ -1711,6 +1713,7 @@ impl ChannelAdapter for TelegramAdapter {
             let question_bot = self.bot.clone();
             let question_config = Arc::clone(&self.config);
             let question_mgr = Arc::clone(mgr);
+            let question_rate_limiter = Arc::clone(&self.rate_limiter);
             let mut question_shutdown = self.shutdown_rx.clone();
             tokio::spawn(async move {
                 question_listener(
@@ -1718,6 +1721,7 @@ impl ChannelAdapter for TelegramAdapter {
                     question_rx,
                     question_config,
                     question_mgr,
+                    question_rate_limiter,
                     &mut question_shutdown,
                 )
                 .await;
@@ -2574,6 +2578,7 @@ async fn approval_listener(
     mut rx: tokio::sync::broadcast::Receiver<ApprovalRequest>,
     config: Arc<StdRwLock<TelegramConfig>>,
     session_index: SessionIndexRef,
+    rate_limiter: Arc<super::rate_limit::ChatRateLimiter>,
     shutdown_rx: &mut watch::Receiver<bool>,
 ) {
     loop {
@@ -2684,6 +2689,7 @@ async fn approval_listener(
                     InlineKeyboardButton::callback("❌ Deny", format!("guard:deny:{}", req.id)),
                 ]]);
 
+                rate_limiter.acquire(chat_id).await;
                 let send_req = with_thread_id!(
                     bot.send_message(ChatId(chat_id), &display_text)
                         .parse_mode(ParseMode::Html)
@@ -2720,6 +2726,7 @@ async fn approval_listener(
                         let expiry_msg_id = sent_msg.id;
                         let timeout_secs = req.timeout_secs;
                         let request_id = req.id;
+                        let expiry_rate_limiter = Arc::clone(&rate_limiter);
                         let handle = tokio::spawn(async move {
                             tokio::time::sleep(std::time::Duration::from_secs(timeout_secs)).await;
 
@@ -2732,6 +2739,7 @@ async fn approval_listener(
 
                             // Collapse to compact one-liner on expiry.
                             let expired_text = "🛡 <b>Guard</b> ⏰ timed out".to_string();
+                            expiry_rate_limiter.acquire(chat_id).await;
                             let _ = expiry_bot
                                 .edit_message_text(expiry_chat_id, expiry_msg_id, expired_text)
                                 .parse_mode(ParseMode::Html)
@@ -2760,6 +2768,7 @@ async fn question_listener(
     mut rx: tokio::sync::broadcast::Receiver<UserQuestion>,
     config: Arc<StdRwLock<TelegramConfig>>,
     mgr: UserQuestionManagerRef,
+    rate_limiter: Arc<super::rate_limit::ChatRateLimiter>,
     shutdown_rx: &mut watch::Receiver<bool>,
 ) {
     loop {
@@ -2778,7 +2787,7 @@ async fn question_listener(
                     }
                 };
 
-                if let Err(e) = dispatch_user_question(&bot, &config, &mgr, question).await {
+                if let Err(e) = dispatch_user_question(&bot, &config, &mgr, &rate_limiter, question).await {
                     warn!(error = %e, "telegram question listener: dispatch failed");
                 }
             }
@@ -2798,6 +2807,7 @@ async fn dispatch_user_question(
     bot: &teloxide::Bot,
     config: &Arc<StdRwLock<TelegramConfig>>,
     mgr: &UserQuestionManagerRef,
+    rate_limiter: &Arc<super::rate_limit::ChatRateLimiter>,
     question: UserQuestion,
 ) -> anyhow::Result<()> {
     let primary_chat_id = {
@@ -2833,6 +2843,7 @@ async fn dispatch_user_question(
             if origin_chat != pm {
                 let notice =
                     "🔒 I sent a private question to your DM. Please check there to answer.";
+                rate_limiter.acquire(origin_chat).await;
                 let breadcrumb =
                     with_thread_id!(bot.send_message(ChatId(origin_chat), notice), origin_thread);
                 if let Err(e) = breadcrumb.await {
@@ -2887,6 +2898,7 @@ async fn dispatch_user_question(
             })
             .collect();
         let markup = InlineKeyboardMarkup::new(keyboard);
+        rate_limiter.acquire(route_chat_id).await;
         let req = with_thread_id!(
             bot.send_message(ChatId(route_chat_id), &text)
                 .parse_mode(ParseMode::Html)
@@ -2895,6 +2907,7 @@ async fn dispatch_user_question(
         );
         req.await
     } else {
+        rate_limiter.acquire(route_chat_id).await;
         let req = with_thread_id!(
             bot.send_message(ChatId(route_chat_id), &text)
                 .parse_mode(ParseMode::Html),
@@ -3496,6 +3509,7 @@ async fn handle_update(
                                     error = %e,
                                     "telegram adapter: command handler failed"
                                 );
+                                rate_limiter.acquire(chat_id).await;
                                 let req = with_thread_id!(
                                     bot.send_message(
                                         ChatId(chat_id),
@@ -3586,6 +3600,7 @@ async fn handle_update(
                                     error = %e,
                                     "telegram adapter: New Session button handler failed"
                                 );
+                                rate_limiter.acquire(chat_id).await;
                                 let req = with_thread_id!(
                                     bot.send_message(
                                         ChatId(chat_id),
@@ -3601,6 +3616,7 @@ async fn handle_update(
                         // Fallback for stripped/test configurations where no
                         // `"new"` command handler is registered: preserve the
                         // original acknowledgment so the button is not silent.
+                        rate_limiter.acquire(chat_id).await;
                         let req = with_thread_id!(
                             bot.send_message(
                                 ChatId(chat_id),

--- a/crates/channels/src/telegram/adapter.rs
+++ b/crates/channels/src/telegram/adapter.rs
@@ -272,9 +272,26 @@ const INITIAL_RETRY_DELAY: std::time::Duration = std::time::Duration::from_secs(
 /// Maximum retry delay for exponential backoff.
 const MAX_RETRY_DELAY: std::time::Duration = std::time::Duration::from_secs(60);
 
-/// Minimum interval between Telegram `edit_message_text` calls (1.5 seconds)
-/// to avoid hitting Telegram API rate limits.
-const MIN_EDIT_INTERVAL: std::time::Duration = std::time::Duration::from_millis(1500);
+/// Edit interval for private (1:1) chats. Telegram allows ~60 msg/min per
+/// private chat.
+const MIN_EDIT_INTERVAL_PRIVATE: std::time::Duration = std::time::Duration::from_millis(1500);
+
+/// Edit interval for group / supergroup / forum-topic chats. Telegram caps
+/// edits at 20 msg/min per group (edit shares sendMessage quota —
+/// tdlib/td#3034), so we must stay above 3000 ms per chat to avoid 429
+/// FloodWait. Use 3500 ms for safety buffer.
+const MIN_EDIT_INTERVAL_GROUP: std::time::Duration = std::time::Duration::from_millis(3500);
+
+/// Resolve the edit interval for a given chat_id. Telegram negative chat_ids
+/// are groups/supergroups/channels; positive ids are private 1:1 chats.
+#[inline]
+fn min_edit_interval(chat_id: i64) -> std::time::Duration {
+    if chat_id < 0 {
+        MIN_EDIT_INTERVAL_GROUP
+    } else {
+        MIN_EDIT_INTERVAL_PRIVATE
+    }
+}
 
 /// Maximum characters per Telegram message before splitting to a new message.
 /// Set below 4096 to leave buffer for HTML tag expansion from markdown→html.
@@ -407,8 +424,9 @@ impl ProgressMessage {
         Self {
             message_id: None,
             tools: Vec::new(),
+            // TODO(#1510): thread chat_id through so we can use the group interval here.
             last_edit: Instant::now()
-                .checked_sub(MIN_EDIT_INTERVAL)
+                .checked_sub(MIN_EDIT_INTERVAL_PRIVATE)
                 .unwrap_or_else(Instant::now),
             turn_started: Instant::now(),
             input_tokens: 0,
@@ -3961,7 +3979,7 @@ fn spawn_stream_forwarder(
             None => return,
         };
 
-        let mut throttle = tokio::time::interval(MIN_EDIT_INTERVAL);
+        let mut throttle = tokio::time::interval(min_edit_interval(chat_id));
         throttle.tick().await; // skip immediate first tick
 
         let mut typing_interval = tokio::time::interval(std::time::Duration::from_secs(4));
@@ -4108,7 +4126,7 @@ fn spawn_stream_forwarder(
                             }
 
                             let text = progress.render_text();
-                            if progress.last_edit.elapsed() >= MIN_EDIT_INTERVAL {
+                            if progress.last_edit.elapsed() >= min_edit_interval(chat_id) {
                                 match progress.message_id {
                                     Some(mid) => {
                                         let _ = bot
@@ -4154,7 +4172,7 @@ fn spawn_stream_forwarder(
                             }
 
                             let text = progress.render_text();
-                            if progress.last_edit.elapsed() >= MIN_EDIT_INTERVAL {
+                            if progress.last_edit.elapsed() >= min_edit_interval(chat_id) {
                                 match progress.message_id {
                                     Some(mid) => {
                                         let _ = bot
@@ -4280,7 +4298,7 @@ fn spawn_stream_forwarder(
 
                                 // Render and edit with throttle + dirty flag.
                                 let text = progress.render_text();
-                                if progress.last_edit.elapsed() >= MIN_EDIT_INTERVAL {
+                                if progress.last_edit.elapsed() >= min_edit_interval(chat_id) {
                                     if let Some(mid) = progress.message_id {
                                         let _ = bot.edit_message_text(ChatId(chat_id), mid, &text).await;
                                     }
@@ -4369,7 +4387,7 @@ fn spawn_stream_forwarder(
                             // Trigger a progress re-render if we have a message
                             if progress.message_id.is_some() || !progress.tools.is_empty() {
                                 let text = progress.render_text();
-                                if progress.last_edit.elapsed() >= MIN_EDIT_INTERVAL {
+                                if progress.last_edit.elapsed() >= min_edit_interval(chat_id) {
                                     if let Some(mid) = progress.message_id {
                                         let _ = bot
                                             .edit_message_text(ChatId(chat_id), mid, &text)
@@ -4641,13 +4659,34 @@ fn spawn_stream_forwarder(
                                                 if let Err(ref re) = bot
                                                     .edit_message_text(ChatId(chat_id), mid, &compact)
                                                     .parse_mode(ParseMode::Html)
-                                                    .reply_markup(keyboard)
+                                                    .reply_markup(keyboard.clone())
                                                     .await
                                                 {
-                                                    warn!(chat_id, error = %re, "compact summary edit retry failed — buttons lost");
+                                                    warn!(chat_id, error = %re, "compact summary edit retry failed — falling back to fresh send");
+                                                    // Rate-limit window still closed for edits. A fresh send uses
+                                                    // 1 msg from the 20/min group quota and is often available when
+                                                    // edits are blocked — better than silently dropping the buttons.
+                                                    let fresh = with_thread_id!(
+                                                        bot.send_message(ChatId(chat_id), &compact)
+                                                            .parse_mode(ParseMode::Html)
+                                                            .reply_markup(keyboard.clone()),
+                                                        thread_id
+                                                    );
+                                                    if let Err(ref send_err) = fresh.await {
+                                                        warn!(chat_id, error = %send_err, "compact summary fallback send also failed — buttons truly lost");
+                                                    }
                                                 }
                                             } else if !e.to_string().contains("message is not modified") {
-                                                warn!(chat_id, error = %e, "compact summary edit failed — buttons lost");
+                                                warn!(chat_id, error = %e, "compact summary edit failed — falling back to fresh send");
+                                                let fresh = with_thread_id!(
+                                                    bot.send_message(ChatId(chat_id), &compact)
+                                                        .parse_mode(ParseMode::Html)
+                                                        .reply_markup(keyboard.clone()),
+                                                    thread_id
+                                                );
+                                                if let Err(ref send_err) = fresh.await {
+                                                    warn!(chat_id, error = %send_err, "compact summary fallback send also failed — buttons truly lost");
+                                                }
                                             }
                                         }
                                     }

--- a/crates/channels/src/telegram/adapter.rs
+++ b/crates/channels/src/telegram/adapter.rs
@@ -272,26 +272,19 @@ const INITIAL_RETRY_DELAY: std::time::Duration = std::time::Duration::from_secs(
 /// Maximum retry delay for exponential backoff.
 const MAX_RETRY_DELAY: std::time::Duration = std::time::Duration::from_secs(60);
 
-/// Edit interval for private (1:1) chats. Telegram allows ~60 msg/min per
-/// private chat.
-const MIN_EDIT_INTERVAL_PRIVATE: std::time::Duration = std::time::Duration::from_millis(1500);
+/// Minimum time between successive streaming edits, regardless of delta
+/// size. Acts as a coalescing floor so pathological sub-ms bursts (from
+/// extremely fast token streams) don't translate into thrashing edit calls.
+/// Telegram's per-chat quota is enforced separately by
+/// [`super::rate_limit::ChatRateLimiter`];
+/// this floor is purely for local batching efficiency.
+const MIN_EDIT_FLOOR: std::time::Duration = std::time::Duration::from_millis(500);
 
-/// Edit interval for group / supergroup / forum-topic chats. Telegram caps
-/// edits at 20 msg/min per group (edit shares sendMessage quota —
-/// tdlib/td#3034), so we must stay above 3000 ms per chat to avoid 429
-/// FloodWait. Use 3500 ms for safety buffer.
-const MIN_EDIT_INTERVAL_GROUP: std::time::Duration = std::time::Duration::from_millis(3500);
-
-/// Resolve the edit interval for a given chat_id. Telegram negative chat_ids
-/// are groups/supergroups/channels; positive ids are private 1:1 chats.
-#[inline]
-fn min_edit_interval(chat_id: i64) -> std::time::Duration {
-    if chat_id < 0 {
-        MIN_EDIT_INTERVAL_GROUP
-    } else {
-        MIN_EDIT_INTERVAL_PRIVATE
-    }
-}
+/// Minimum character delta since the last streaming edit before we flush
+/// another one. Emits ~1 edit per ~100 chars of generated text — coarse
+/// enough to fit within Telegram's per-chat quota after the rate limiter
+/// gates it, fine enough to feel "live".
+const EDIT_DELTA_THRESHOLD: usize = 100;
 
 /// Maximum characters per Telegram message before splitting to a new message.
 /// Set below 4096 to leave buffer for HTML tag expansion from markdown→html.
@@ -424,9 +417,9 @@ impl ProgressMessage {
         Self {
             message_id: None,
             tools: Vec::new(),
-            // TODO(#1510): thread chat_id through so we can use the group interval here.
+            // Prime `last_edit` so the first event triggers an immediate flush.
             last_edit: Instant::now()
-                .checked_sub(MIN_EDIT_INTERVAL_PRIVATE)
+                .checked_sub(MIN_EDIT_FLOOR)
                 .unwrap_or_else(Instant::now),
             turn_started: Instant::now(),
             input_tokens: 0,
@@ -986,29 +979,35 @@ struct StreamingMessage {
     /// Monotonic tag identifying which turn owns this entry. Used by the
     /// delayed cleanup task to distinguish its own state from a successor
     /// turn's fresh state.
-    epoch:                 u64,
+    epoch:                    u64,
     /// All message IDs sent for this stream (multiple when splitting long
     /// content).
-    message_ids:           Vec<MessageId>,
+    message_ids:              Vec<MessageId>,
     /// Accumulated raw text for the current (latest) message.
-    accumulated:           String,
+    accumulated:              String,
     /// Number of raw characters already finalized into earlier split messages.
-    streamed_prefix_chars: usize,
+    streamed_prefix_chars:    usize,
     /// Last successful `editMessageText` timestamp for throttling.
-    last_edit:             Instant,
+    last_edit:                Instant,
     /// Whether new text has been appended since the last edit.
-    dirty:                 bool,
+    dirty:                    bool,
+    /// Bytes of text appended to `accumulated` since the last flushed edit.
+    /// Used by the throttle tick to gate flushes on delta size rather than
+    /// wall time alone.
+    pending_bytes_since_edit: usize,
 }
 
 impl StreamingMessage {
     fn new() -> Self {
         Self {
-            epoch:                 STREAM_EPOCH.fetch_add(1, std::sync::atomic::Ordering::Relaxed),
-            message_ids:           Vec::new(),
-            accumulated:           String::new(),
-            streamed_prefix_chars: 0,
-            last_edit:             Instant::now(),
-            dirty:                 false,
+            epoch:                    STREAM_EPOCH
+                .fetch_add(1, std::sync::atomic::Ordering::Relaxed),
+            message_ids:              Vec::new(),
+            accumulated:              String::new(),
+            streamed_prefix_chars:    0,
+            last_edit:                Instant::now(),
+            dirty:                    false,
+            pending_bytes_since_edit: 0,
         }
     }
 }
@@ -1107,6 +1106,11 @@ pub struct TelegramAdapter {
     /// keyboard attached to outbound messages. Populated by the streaming
     /// forwarder and read by [`Self::send`].
     keyboard_state:        Arc<DashMap<i64, KeyboardMeta>>,
+    /// Per-chat + global rate limiter for outbound Telegram API calls. All
+    /// `sendMessage`, `editMessageText`, `sendPhoto`, `sendVoice`, and
+    /// `sendChatAction` call sites must `.acquire(chat_id)` first (see
+    /// `AGENT.md` invariants).
+    rate_limiter:          Arc<super::rate_limit::ChatRateLimiter>,
 }
 
 impl TelegramAdapter {
@@ -1141,6 +1145,7 @@ impl TelegramAdapter {
             voice_chat_ids: Arc::new(DashSet::new()),
             settings,
             keyboard_state: Arc::new(DashMap::new()),
+            rate_limiter: Arc::new(super::rate_limit::ChatRateLimiter::new()),
         }
     }
 
@@ -1317,6 +1322,7 @@ impl TelegramAdapter {
                 input_file
             };
 
+            self.rate_limiter.acquire(chat_id).await;
             if attachment.mime_type.starts_with("image/") {
                 let req =
                     with_thread_id!(self.bot.send_photo(ChatId(chat_id), input_file), thread_id);
@@ -1350,6 +1356,7 @@ impl TelegramAdapter {
         };
 
         let input_file = teloxide::types::InputFile::memory(audio.data).file_name("reply.ogg");
+        self.rate_limiter.acquire(chat_id).await;
         let req = with_thread_id!(self.bot.send_voice(ChatId(chat_id), input_file), thread_id);
         if let Err(e) = req.await {
             warn!(error = %e, "failed to send voice note, falling back to text");
@@ -1466,6 +1473,7 @@ impl ChannelAdapter for TelegramAdapter {
                                     crate::telegram::markdown::markdown_to_telegram_html(&content);
                                 let chunks = crate::telegram::markdown::chunk_message(&html, 4096);
                                 let first_chunk = chunks.first().map(|s| s.as_str()).unwrap_or("");
+                                self.rate_limiter.acquire(chat_id).await;
                                 let edit_result = self
                                     .bot
                                     .edit_message_text(ChatId(chat_id), last_msg_id, first_chunk)
@@ -1485,6 +1493,7 @@ impl ChannelAdapter for TelegramAdapter {
 
                                 if edit_ok {
                                     for chunk in chunks.iter().skip(1) {
+                                        self.rate_limiter.acquire(chat_id).await;
                                         let req = with_thread_id!(
                                             self.bot
                                                 .send_message(ChatId(chat_id), chunk)
@@ -1527,6 +1536,7 @@ impl ChannelAdapter for TelegramAdapter {
                     let chunks = crate::telegram::markdown::chunk_message(&html, 4096);
                     let last_idx = chunks.len().saturating_sub(1);
                     for (i, chunk) in chunks.iter().enumerate() {
+                        self.rate_limiter.acquire(chat_id).await;
                         let mut req = with_thread_id!(
                             self.bot
                                 .send_message(ChatId(chat_id), chunk)
@@ -1574,6 +1584,7 @@ impl ChannelAdapter for TelegramAdapter {
                 if let Some(ref target_id) = edit_target {
                     if let Ok(msg_id) = parse_message_id(target_id) {
                         let html = crate::telegram::markdown::markdown_to_telegram_html(&delta);
+                        self.rate_limiter.acquire(chat_id).await;
                         let _ = self
                             .bot
                             .edit_message_text(ChatId(chat_id), msg_id, &html)
@@ -1581,12 +1592,14 @@ impl ChannelAdapter for TelegramAdapter {
                             .await;
                     }
                 } else {
+                    self.rate_limiter.acquire(chat_id).await;
                     let req =
                         with_thread_id!(self.bot.send_message(ChatId(chat_id), &delta), thread_id);
                     let _ = req.await;
                 }
             }
             PlatformOutbound::Progress { .. } => {
+                self.rate_limiter.acquire(chat_id).await;
                 let req = with_thread_id!(
                     self.bot
                         .send_chat_action(ChatId(chat_id), ChatAction::Typing),
@@ -1649,6 +1662,7 @@ impl ChannelAdapter for TelegramAdapter {
         let stt_service = self.stt_service.clone();
         let voice_chat_ids = Arc::clone(&self.voice_chat_ids);
         let settings = Arc::clone(&self.settings);
+        let rate_limiter = Arc::clone(&self.rate_limiter);
 
         // Register slash-menu with Telegram so '/' shows available commands.
         {
@@ -1727,6 +1741,7 @@ impl ChannelAdapter for TelegramAdapter {
                 stt_service,
                 voice_chat_ids,
                 settings,
+                rate_limiter,
             )
             .await;
         });
@@ -1743,6 +1758,7 @@ impl ChannelAdapter for TelegramAdapter {
 
     async fn typing_indicator(&self, session_key: &str) -> Result<(), KernelError> {
         let chat_id = parse_chat_id(session_key)?;
+        self.rate_limiter.acquire(chat_id).await;
         self.bot
             .send_chat_action(ChatId(chat_id), ChatAction::Typing)
             .await
@@ -1814,6 +1830,7 @@ async fn polling_loop(
     stt_service: Option<rara_stt::SttService>,
     voice_chat_ids: Arc<DashSet<i64>>,
     settings: Arc<dyn SettingsProvider>,
+    rate_limiter: Arc<super::rate_limit::ChatRateLimiter>,
 ) {
     let mut offset: Option<i32> = None;
     let mut retry_delay = INITIAL_RETRY_DELAY;
@@ -1874,6 +1891,7 @@ async fn polling_loop(
                     let stt = stt_service.clone();
                     let voice_ids = Arc::clone(&voice_chat_ids);
                     let stg = Arc::clone(&settings);
+                    let rl = Arc::clone(&rate_limiter);
                     tokio::spawn(async move {
                         handle_update(
                             update,
@@ -1890,6 +1908,7 @@ async fn polling_loop(
                             &stt,
                             &voice_ids,
                             &stg,
+                            &rl,
                         )
                         .await;
                     });
@@ -3057,6 +3076,7 @@ async fn handle_update(
     stt_service: &Option<rara_stt::SttService>,
     voice_chat_ids: &Arc<DashSet<i64>>,
     settings: &Arc<dyn SettingsProvider>,
+    rate_limiter: &Arc<super::rate_limit::ChatRateLimiter>,
 ) {
     // Read a snapshot of the runtime config for this update.
     let cfg = match config.read() {
@@ -3461,7 +3481,14 @@ async fn handle_update(
 
                         match handler.handle(&info, &ctx).await {
                             Ok(result) => {
-                                dispatch_command_result(bot, chat_id, tg_thread_id, result).await;
+                                dispatch_command_result(
+                                    bot,
+                                    chat_id,
+                                    tg_thread_id,
+                                    result,
+                                    rate_limiter,
+                                )
+                                .await;
                             }
                             Err(e) => {
                                 error!(
@@ -3544,7 +3571,14 @@ async fn handle_update(
 
                         match handler.handle(&info, &ctx).await {
                             Ok(result) => {
-                                dispatch_command_result(bot, chat_id, tg_thread_id, result).await;
+                                dispatch_command_result(
+                                    bot,
+                                    chat_id,
+                                    tg_thread_id,
+                                    result,
+                                    rate_limiter,
+                                )
+                                .await;
                             }
                             Err(e) => {
                                 error!(
@@ -3727,6 +3761,7 @@ async fn handle_update(
                     "\u{1f4ac} New topic: <a href=\"{link}\">{name}</a>",
                     name = guard_html_escape(&topic_name),
                 );
+                rate_limiter.acquire(chat_id).await;
                 let _ = bot
                     .send_message(ChatId(chat_id), notice)
                     .parse_mode(ParseMode::Html)
@@ -3737,6 +3772,7 @@ async fn handle_update(
                 // activity there (the original message stays in General —
                 // Telegram does not allow moving messages between topics).
                 let intro = format!("\u{1f4ac} {topic_name}");
+                rate_limiter.acquire(chat_id).await;
                 let _ =
                     with_thread_id!(bot.send_message(ChatId(chat_id), &intro), tg_thread_id).await;
 
@@ -3761,6 +3797,7 @@ async fn handle_update(
     let msg = match handle.resolve(raw).await {
         Ok(msg) => msg,
         Err(IOError::SystemBusy) => {
+            rate_limiter.acquire(chat_id).await;
             let req = with_thread_id!(
                 bot.send_message(
                     ChatId(chat_id),
@@ -3772,6 +3809,7 @@ async fn handle_update(
             return;
         }
         Err(IOError::RateLimited { message }) => {
+            rate_limiter.acquire(chat_id).await;
             let req = with_thread_id!(
                 bot.send_message(ChatId(chat_id), format!("\u{26a0}\u{fe0f} {message}")),
                 tg_thread_id
@@ -3821,10 +3859,12 @@ async fn handle_update(
                     handle.trace_service().clone(),
                     rara_message_id.clone(),
                     Arc::clone(settings),
+                    Arc::clone(rate_limiter),
                 );
             }
         }
         Err(_) => {
+            rate_limiter.acquire(chat_id).await;
             let req = with_thread_id!(
                 bot.send_message(ChatId(chat_id), "⚠️ 系统繁忙，请稍后再试。"),
                 tg_thread_id
@@ -3844,13 +3884,16 @@ async fn dispatch_command_result(
     chat_id: i64,
     thread_id: Option<i64>,
     result: CommandResult,
+    rate_limiter: &super::rate_limit::ChatRateLimiter,
 ) {
     match result {
         CommandResult::Text(text) => {
+            rate_limiter.acquire(chat_id).await;
             let req = with_thread_id!(bot.send_message(ChatId(chat_id), text), thread_id);
             let _ = req.await;
         }
         CommandResult::Html(html) => {
+            rate_limiter.acquire(chat_id).await;
             let req = with_thread_id!(
                 bot.send_message(ChatId(chat_id), html)
                     .parse_mode(ParseMode::Html),
@@ -3877,6 +3920,7 @@ async fn dispatch_command_result(
                 })
                 .collect();
             let markup = InlineKeyboardMarkup::new(rows);
+            rate_limiter.acquire(chat_id).await;
             let req = with_thread_id!(
                 bot.send_message(ChatId(chat_id), html)
                     .parse_mode(ParseMode::Html)
@@ -3888,6 +3932,7 @@ async fn dispatch_command_result(
         CommandResult::Photo { data, caption } => {
             use teloxide::types::InputFile;
 
+            rate_limiter.acquire(chat_id).await;
             let mut request = bot.send_photo(ChatId(chat_id), InputFile::memory(data));
             if let Some(caption) = caption {
                 request = request.caption(caption);
@@ -3933,6 +3978,7 @@ fn spawn_stream_forwarder(
     trace_service: rara_kernel::trace::TraceService,
     rara_message_id: String,
     settings: Arc<dyn SettingsProvider>,
+    rate_limiter: Arc<super::rate_limit::ChatRateLimiter>,
 ) {
     use rara_kernel::io::{PlanStepStatus, StreamEvent};
 
@@ -3979,7 +4025,7 @@ fn spawn_stream_forwarder(
             None => return,
         };
 
-        let mut throttle = tokio::time::interval(min_edit_interval(chat_id));
+        let mut throttle = tokio::time::interval(MIN_EDIT_FLOOR);
         throttle.tick().await; // skip immediate first tick
 
         let mut typing_interval = tokio::time::interval(std::time::Duration::from_secs(4));
@@ -4043,6 +4089,8 @@ fn spawn_stream_forwarder(
                             let flush_req = {
                                 if let Some(mut state) = active_streams.get_mut(&chat_id) {
                                     state.accumulated.push_str(&text);
+                                    state.pending_bytes_since_edit =
+                                        state.pending_bytes_since_edit.saturating_add(text.len());
                                     state.dirty = true;
 
                                     if state.accumulated.len() > STREAM_SPLIT_THRESHOLD {
@@ -4065,7 +4113,7 @@ fn spawn_stream_forwarder(
                             };
 
                             if let Some(req) = flush_req {
-                                let result = flush_edit(&bot, chat_id, thread_id, &req).await;
+                                let result = flush_edit(&bot, chat_id, thread_id, &req, &rate_limiter).await;
                                 let split_applied =
                                     matches!(result, FlushResult::Sent(_) | FlushResult::Edited);
                                 apply_flush_result(&active_streams, chat_id, result);
@@ -4077,6 +4125,7 @@ fn spawn_stream_forwarder(
                                         state.accumulated.clear();
                                         state.message_ids.push(MessageId(0)); // sentinel
                                         state.dirty = false;
+                                        state.pending_bytes_since_edit = 0;
                                     }
                                 }
                             }
@@ -4120,20 +4169,23 @@ fn spawn_stream_forwarder(
 
                             // Send typing indicator before the first progress message.
                             if progress.message_id.is_none() {
+                                rate_limiter.acquire(chat_id).await;
                                 let req = with_thread_id!(bot
                                     .send_chat_action(ChatId(chat_id), ChatAction::Typing), thread_id);
                                 let _ = req.await;
                             }
 
                             let text = progress.render_text();
-                            if progress.last_edit.elapsed() >= min_edit_interval(chat_id) {
+                            if progress.last_edit.elapsed() >= MIN_EDIT_FLOOR {
                                 match progress.message_id {
                                     Some(mid) => {
+                                        rate_limiter.acquire(chat_id).await;
                                         let _ = bot
                                             .edit_message_text(ChatId(chat_id), mid, &text)
                                             .await;
                                     }
                                     None => {
+                                        rate_limiter.acquire(chat_id).await;
                                         let req = with_thread_id!(bot
                                             .send_message(ChatId(chat_id), &text), thread_id);
                                         if let Ok(msg) = req.await
@@ -4172,14 +4224,16 @@ fn spawn_stream_forwarder(
                             }
 
                             let text = progress.render_text();
-                            if progress.last_edit.elapsed() >= min_edit_interval(chat_id) {
+                            if progress.last_edit.elapsed() >= MIN_EDIT_FLOOR {
                                 match progress.message_id {
                                     Some(mid) => {
+                                        rate_limiter.acquire(chat_id).await;
                                         let _ = bot
                                             .edit_message_text(ChatId(chat_id), mid, &text)
                                             .await;
                                     }
                                     None => {
+                                        rate_limiter.acquire(chat_id).await;
                                         let req = with_thread_id!(bot
                                             .send_message(ChatId(chat_id), &text), thread_id);
                                         if let Ok(msg) = req.await
@@ -4209,6 +4263,7 @@ fn spawn_stream_forwarder(
                                     state.accumulated.clear();
                                     state.streamed_prefix_chars = 0;
                                     state.dirty = false;
+                                    state.pending_bytes_since_edit = 0;
                                     ids
                                 } else {
                                     Vec::new()
@@ -4241,6 +4296,7 @@ fn spawn_stream_forwarder(
                             // Send initial plan message immediately.
                             let text = progress.render_text();
                             if !text.is_empty() {
+                                rate_limiter.acquire(chat_id).await;
                                 let req = with_thread_id!(bot.send_message(ChatId(chat_id), &text), thread_id);
                                 match req.await {
                                     Ok(msg) => { progress.message_id = Some(msg.id); }
@@ -4298,8 +4354,9 @@ fn spawn_stream_forwarder(
 
                                 // Render and edit with throttle + dirty flag.
                                 let text = progress.render_text();
-                                if progress.last_edit.elapsed() >= min_edit_interval(chat_id) {
+                                if progress.last_edit.elapsed() >= MIN_EDIT_FLOOR {
                                     if let Some(mid) = progress.message_id {
+                                        rate_limiter.acquire(chat_id).await;
                                         let _ = bot.edit_message_text(ChatId(chat_id), mid, &text).await;
                                     }
                                     progress.last_edit = Instant::now();
@@ -4330,6 +4387,7 @@ fn spawn_stream_forwarder(
 
                                 let text = progress.render_text();
                                 if let Some(mid) = progress.message_id {
+                                    rate_limiter.acquire(chat_id).await;
                                     let _ = bot.edit_message_text(ChatId(chat_id), mid, &text).await;
                                 }
                                 progress.last_edit = Instant::now();
@@ -4368,6 +4426,7 @@ fn spawn_stream_forwarder(
                                 // Final render.
                                 let text = progress.render_text();
                                 if let Some(mid) = progress.message_id {
+                                    rate_limiter.acquire(chat_id).await;
                                     let _ = bot.edit_message_text(ChatId(chat_id), mid, &text).await;
                                 }
                             }
@@ -4387,8 +4446,9 @@ fn spawn_stream_forwarder(
                             // Trigger a progress re-render if we have a message
                             if progress.message_id.is_some() || !progress.tools.is_empty() {
                                 let text = progress.render_text();
-                                if progress.last_edit.elapsed() >= min_edit_interval(chat_id) {
+                                if progress.last_edit.elapsed() >= MIN_EDIT_FLOOR {
                                     if let Some(mid) = progress.message_id {
+                                        rate_limiter.acquire(chat_id).await;
                                         let _ = bot
                                             .edit_message_text(ChatId(chat_id), mid, &text)
                                             .await;
@@ -4406,11 +4466,13 @@ fn spawn_stream_forwarder(
                                 // Send initial thinking message immediately so
                                 // the user sees feedback instead of silence.
                                 if progress.message_id.is_none() {
+                                    rate_limiter.acquire(chat_id).await;
                                     let req = with_thread_id!(bot
                                         .send_chat_action(ChatId(chat_id), ChatAction::Typing), thread_id);
                                     let _ = req.await;
                                     let text = progress.render_text();
                                     if !text.is_empty() {
+                                        rate_limiter.acquire(chat_id).await;
                                         let req = with_thread_id!(bot
                                             .send_message(ChatId(chat_id), &text), thread_id);
                                         if let Ok(msg) = req.await
@@ -4478,6 +4540,7 @@ fn spawn_stream_forwarder(
                                     format!("limit:stop:{session_key}:{limit_id}"),
                                 ),
                             ]]);
+                            rate_limiter.acquire(chat_id).await;
                             let req = with_thread_id!(bot
                                 .send_message(ChatId(chat_id), &text)
                                 .parse_mode(ParseMode::Html)
@@ -4552,13 +4615,13 @@ fn spawn_stream_forwarder(
                                 // Guard dropped here.
                             };
                             if let Some(req) = flush_req {
-                                let result = flush_edit(&bot, chat_id, thread_id, &req).await;
+                                let result = flush_edit(&bot, chat_id, thread_id, &req, &rate_limiter).await;
                                 apply_flush_result(&active_streams, chat_id, result);
                             }
 
                             // ── Pinned status bar: final flush ──
                             pinned.on_stream_close();
-                            flush_pinned_status(&bot, chat_id, thread_id, &mut pinned, &settings, &pinned_settings_key, &pinned_session_key).await;
+                            flush_pinned_status(&bot, chat_id, thread_id, &mut pinned, &settings, &pinned_settings_key, &pinned_session_key, &rate_limiter).await;
 
                             // ── Finalize: always create trace + compact summary ──
                             // Every agent turn (including pure text replies) gets a
@@ -4593,6 +4656,7 @@ fn spawn_stream_forwarder(
                                 let mid = if let Some(mid) = progress.message_id {
                                     mid
                                 } else {
+                                    rate_limiter.acquire(chat_id).await;
                                     let req = with_thread_id!(bot
                                         .send_message(ChatId(chat_id), &compact)
                                         .parse_mode(ParseMode::Html), thread_id);
@@ -4647,6 +4711,7 @@ fn spawn_stream_forwarder(
                                         // exhaust the edit quota with progress
                                         // updates, so the final edit often hits
                                         // a rate-limit window.
+                                        rate_limiter.acquire(chat_id).await;
                                         let edit_res = bot
                                             .edit_message_text(ChatId(chat_id), mid, &compact)
                                             .parse_mode(ParseMode::Html)
@@ -4656,6 +4721,7 @@ fn spawn_stream_forwarder(
                                             if let Some(secs) = parse_retry_after(&e.to_string()) {
                                                 info!(chat_id, retry_after = secs, "compact summary edit rate-limited, retrying");
                                                 tokio::time::sleep(std::time::Duration::from_secs(secs)).await;
+                                                rate_limiter.acquire(chat_id).await;
                                                 if let Err(ref re) = bot
                                                     .edit_message_text(ChatId(chat_id), mid, &compact)
                                                     .parse_mode(ParseMode::Html)
@@ -4666,6 +4732,7 @@ fn spawn_stream_forwarder(
                                                     // Rate-limit window still closed for edits. A fresh send uses
                                                     // 1 msg from the 20/min group quota and is often available when
                                                     // edits are blocked — better than silently dropping the buttons.
+                                                    rate_limiter.acquire(chat_id).await;
                                                     let fresh = with_thread_id!(
                                                         bot.send_message(ChatId(chat_id), &compact)
                                                             .parse_mode(ParseMode::Html)
@@ -4678,6 +4745,7 @@ fn spawn_stream_forwarder(
                                                 }
                                             } else if !e.to_string().contains("message is not modified") {
                                                 warn!(chat_id, error = %e, "compact summary edit failed — falling back to fresh send");
+                                                rate_limiter.acquire(chat_id).await;
                                                 let fresh = with_thread_id!(
                                                     bot.send_message(ChatId(chat_id), &compact)
                                                         .parse_mode(ParseMode::Html)
@@ -4696,6 +4764,7 @@ fn spawn_stream_forwarder(
                                         // without buttons. For newly sent messages the
                                         // compact text is already visible.
                                         if progress.message_id.is_some() {
+                                            rate_limiter.acquire(chat_id).await;
                                             let edit_res = bot
                                                 .edit_message_text(ChatId(chat_id), mid, &compact)
                                                 .parse_mode(ParseMode::Html)
@@ -4703,6 +4772,7 @@ fn spawn_stream_forwarder(
                                             if let Err(ref e) = edit_res {
                                                 if let Some(secs) = parse_retry_after(&e.to_string()) {
                                                     tokio::time::sleep(std::time::Duration::from_secs(secs)).await;
+                                                    rate_limiter.acquire(chat_id).await;
                                                     let _ = bot
                                                         .edit_message_text(ChatId(chat_id), mid, &compact)
                                                         .parse_mode(ParseMode::Html)
@@ -4721,7 +4791,15 @@ fn spawn_stream_forwarder(
                 _ = throttle.tick() => {
                     let flush_req = {
                         if let Some(state) = active_streams.get(&chat_id) {
-                            if state.dirty && !state.accumulated.is_empty() {
+                            // Delta-gated flush: only emit an edit when enough new
+                            // content has accumulated. `pending_bytes_since_edit`
+                            // is used as a cheap proxy for char delta — UTF-8
+                            // bytes >= chars, so this slightly over-estimates
+                            // growth for multi-byte scripts, which is safe
+                            // (errs on the side of fewer edits).
+                            let enough_delta =
+                                state.pending_bytes_since_edit >= EDIT_DELTA_THRESHOLD;
+                            if state.dirty && !state.accumulated.is_empty() && enough_delta {
                                 let html = crate::telegram::markdown::markdown_to_telegram_html(&state.accumulated);
                                 Some(FlushRequest {
                                     message_ids: state.message_ids.clone(),
@@ -4737,7 +4815,7 @@ fn spawn_stream_forwarder(
                         // Guard dropped here.
                     };
                     if let Some(req) = flush_req {
-                        let result = flush_edit(&bot, chat_id, thread_id, &req).await;
+                        let result = flush_edit(&bot, chat_id, thread_id, &req, &rate_limiter).await;
                         apply_flush_result(&active_streams, chat_id, result);
                     }
 
@@ -4755,11 +4833,13 @@ fn spawn_stream_forwarder(
                         let text = progress.render_text();
                         match progress.message_id {
                             Some(mid) => {
+                                rate_limiter.acquire(chat_id).await;
                                 let _ = bot
                                     .edit_message_text(ChatId(chat_id), mid, &text)
                                     .await;
                             }
                             None => {
+                                rate_limiter.acquire(chat_id).await;
                                 let req = with_thread_id!(bot
                                     .send_message(ChatId(chat_id), &text), thread_id);
                                 if let Ok(msg) = req.await
@@ -4774,10 +4854,11 @@ fn spawn_stream_forwarder(
 
                     // ── Pinned session card: flush on state change only ──
                     if pinned.needs_flush() {
-                        flush_pinned_status(&bot, chat_id, thread_id, &mut pinned, &settings, &pinned_settings_key, &pinned_session_key).await;
+                        flush_pinned_status(&bot, chat_id, thread_id, &mut pinned, &settings, &pinned_settings_key, &pinned_session_key, &rate_limiter).await;
                     }
                 }
                 _ = typing_interval.tick() => {
+                    rate_limiter.acquire(chat_id).await;
                     let req = with_thread_id!(bot
                         .send_chat_action(ChatId(chat_id), ChatAction::Typing), thread_id);
                     let _ = req.await;
@@ -4940,19 +5021,23 @@ async fn flush_pinned_status(
     settings: &Arc<dyn SettingsProvider>,
     settings_key: &str,
     session_settings_key: &str,
+    rate_limiter: &super::rate_limit::ChatRateLimiter,
 ) {
     use teloxide::payloads::PinChatMessageSetters;
 
     let html = pinned.render();
     let need_new_msg = match pinned.message_id {
-        Some(mid) => bot
-            .edit_message_text(ChatId(chat_id), mid, &html)
-            .parse_mode(ParseMode::Html)
-            .await
-            .is_err(),
+        Some(mid) => {
+            rate_limiter.acquire(chat_id).await;
+            bot.edit_message_text(ChatId(chat_id), mid, &html)
+                .parse_mode(ParseMode::Html)
+                .await
+                .is_err()
+        }
         None => true,
     };
     if need_new_msg {
+        rate_limiter.acquire(chat_id).await;
         let req = with_thread_id!(
             bot.send_message(ChatId(chat_id), &html)
                 .parse_mode(ParseMode::Html),
@@ -4960,6 +5045,7 @@ async fn flush_pinned_status(
         );
         if let Ok(msg) = req.await {
             pinned.message_id = Some(msg.id);
+            rate_limiter.acquire(chat_id).await;
             let _ = bot
                 .pin_chat_message(ChatId(chat_id), msg.id)
                 .disable_notification(true)
@@ -4991,9 +5077,11 @@ async fn flush_edit(
     chat_id: i64,
     thread_id: Option<i64>,
     req: &FlushRequest,
+    rate_limiter: &super::rate_limit::ChatRateLimiter,
 ) -> FlushResult {
     if req.message_ids.is_empty() || req.message_ids.last().copied() == Some(MessageId(0)) {
         // First message or new split — send a new message.
+        rate_limiter.acquire(chat_id).await;
         let req2 = with_thread_id!(
             bot.send_message(ChatId(chat_id), &req.text_html)
                 .parse_mode(ParseMode::Html),
@@ -5008,6 +5096,7 @@ async fn flush_edit(
         }
     } else {
         let msg_id = *req.message_ids.last().unwrap();
+        rate_limiter.acquire(chat_id).await;
         match bot
             .edit_message_text(ChatId(chat_id), msg_id, &req.text_html)
             .parse_mode(ParseMode::Html)
@@ -5053,16 +5142,19 @@ fn apply_flush_result(
                 }
                 state.last_edit = Instant::now();
                 state.dirty = false;
+                state.pending_bytes_since_edit = 0;
             }
             FlushResult::Edited | FlushResult::Failed => {
                 state.last_edit = Instant::now();
                 state.dirty = false;
+                state.pending_bytes_since_edit = 0;
             }
             FlushResult::RateLimited => {
                 // Leave dirty=true so the next tick retries.
             }
             FlushResult::SendFailed => {
                 state.dirty = false;
+                state.pending_bytes_since_edit = 0;
             }
         }
     }

--- a/crates/channels/src/telegram/mod.rs
+++ b/crates/channels/src/telegram/mod.rs
@@ -21,6 +21,7 @@ pub mod latex;
 pub mod loading_hints;
 pub mod markdown;
 pub mod pinned_status;
+pub mod rate_limit;
 pub mod reply_keyboard;
 pub mod spinner_verbs;
 

--- a/crates/channels/src/telegram/rate_limit.rs
+++ b/crates/channels/src/telegram/rate_limit.rs
@@ -21,8 +21,15 @@
 //!
 //! `editMessage` counts against the same quota as `sendMessage`. We treat all
 //! outbound requests (edit + send) as one stream per chat.
+//!
+//! All quotas use `Quota::with_period(...)` which yields **burst capacity 1**
+//! and paces strictly at the declared period. The alternative
+//! `Quota::per_minute(20)` would seed a fresh limiter with 20 cells of burst,
+//! allowing an idle chat to drain all 20 edits instantly — which is exactly
+//! the bursty plan-streaming case where Telegram will 429 us on the 21st
+//! request within the rolling minute.
 
-use std::{num::NonZeroU32, sync::Arc};
+use std::{sync::Arc, time::Duration};
 
 use dashmap::DashMap;
 use governor::{
@@ -44,14 +51,17 @@ pub struct ChatRateLimiter {
     /// One limiter per chat_id. Quota depends on chat kind (group vs private),
     /// derived from the sign of `chat_id` at first lookup.
     per_chat: Arc<DashMap<i64, Arc<DirectLimiter>>>,
-    /// Global 30 req/sec cap across all chats.
+    /// Global ~30 req/sec cap across all chats (paced, burst 1).
     global:   Arc<DirectLimiter>,
 }
 
 impl ChatRateLimiter {
-    /// Build a new limiter with the Telegram global cap (30 req/sec).
+    /// Build a new limiter with the Telegram global cap (~30 req/sec, paced).
     pub fn new() -> Self {
-        let global = Quota::per_second(NonZeroU32::new(30).expect("30 > 0"));
+        // 34ms period ≈ 29.4 req/sec — stays safely below the 30/sec global
+        // cap while keeping burst 1.
+        let global =
+            Quota::with_period(Duration::from_millis(34)).expect("34ms period is non-zero");
         Self {
             per_chat: Arc::new(DashMap::new()),
             global:   Arc::new(RateLimiter::direct(global)),
@@ -69,12 +79,13 @@ impl ChatRateLimiter {
             .entry(chat_id)
             .or_insert_with(|| {
                 let quota = if chat_id < 0 {
-                    // 20/min for groups, supergroups, and forum-topic
-                    // supergroups (editMessage shares sendMessage quota).
-                    Quota::per_minute(NonZeroU32::new(20).expect("20 > 0"))
+                    // Groups, supergroups, forum-topic supergroups:
+                    // 1 msg per 3s ≈ 20/min, burst 1. editMessage shares
+                    // the sendMessage quota.
+                    Quota::with_period(Duration::from_secs(3)).expect("3s period is non-zero")
                 } else {
-                    // ~60/min for private chats (1/sec).
-                    Quota::per_second(NonZeroU32::new(1).expect("1 > 0"))
+                    // Private chats: 1 msg/sec, burst 1.
+                    Quota::with_period(Duration::from_secs(1)).expect("1s period is non-zero")
                 };
                 Arc::new(RateLimiter::direct(quota))
             })

--- a/crates/channels/src/telegram/rate_limit.rs
+++ b/crates/channels/src/telegram/rate_limit.rs
@@ -1,0 +1,89 @@
+// Copyright 2025 Rararulab
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Per-chat Telegram API rate limiter.
+//!
+//! Telegram rate limits for bots (tdlib/td#3034):
+//! - Private chats: 1 message/sec (edit + send share this quota)
+//! - Groups / supergroups / forum-topic supergroups: 20 messages/min
+//! - Global: 30 messages/sec across all chats
+//!
+//! `editMessage` counts against the same quota as `sendMessage`. We treat all
+//! outbound requests (edit + send) as one stream per chat.
+
+use std::{num::NonZeroU32, sync::Arc};
+
+use dashmap::DashMap;
+use governor::{
+    Quota, RateLimiter,
+    clock::DefaultClock,
+    state::{InMemoryState, NotKeyed},
+};
+
+type DirectLimiter = RateLimiter<NotKeyed, InMemoryState, DefaultClock>;
+
+/// Per-chat + global rate limiter for Telegram outbound calls.
+///
+/// All outbound Telegram calls (`sendMessage`, `editMessageText`, `sendPhoto`,
+/// `sendVoice`, `sendChatAction`) MUST pass through [`Self::acquire`] before
+/// being sent. Bypassing the limiter causes 429 `FloodWait` errors which (in
+/// forum topics) silently drop inline reply keyboards.
+#[derive(Clone)]
+pub struct ChatRateLimiter {
+    /// One limiter per chat_id. Quota depends on chat kind (group vs private),
+    /// derived from the sign of `chat_id` at first lookup.
+    per_chat: Arc<DashMap<i64, Arc<DirectLimiter>>>,
+    /// Global 30 req/sec cap across all chats.
+    global:   Arc<DirectLimiter>,
+}
+
+impl ChatRateLimiter {
+    /// Build a new limiter with the Telegram global cap (30 req/sec).
+    pub fn new() -> Self {
+        let global = Quota::per_second(NonZeroU32::new(30).expect("30 > 0"));
+        Self {
+            per_chat: Arc::new(DashMap::new()),
+            global:   Arc::new(RateLimiter::direct(global)),
+        }
+    }
+
+    /// Block until a send/edit against `chat_id` is allowed by both the
+    /// per-chat quota and the global quota.
+    ///
+    /// Order matters: per-chat first so global quota isn't consumed while a
+    /// chat-specific wait is still pending.
+    pub async fn acquire(&self, chat_id: i64) {
+        let per = self
+            .per_chat
+            .entry(chat_id)
+            .or_insert_with(|| {
+                let quota = if chat_id < 0 {
+                    // 20/min for groups, supergroups, and forum-topic
+                    // supergroups (editMessage shares sendMessage quota).
+                    Quota::per_minute(NonZeroU32::new(20).expect("20 > 0"))
+                } else {
+                    // ~60/min for private chats (1/sec).
+                    Quota::per_second(NonZeroU32::new(1).expect("1 > 0"))
+                };
+                Arc::new(RateLimiter::direct(quota))
+            })
+            .clone();
+        per.until_ready().await;
+        self.global.until_ready().await;
+    }
+}
+
+impl Default for ChatRateLimiter {
+    fn default() -> Self { Self::new() }
+}


### PR DESCRIPTION
## Summary

在 Telegram supergroup / forum topic 下跑 plan 长链路时，用户看不到最终的 plan 折叠摘要和 "🔍 Cascade" 按钮。

根因：`MIN_EDIT_INTERVAL = 1500ms` 意味着每分钟最多 40 次编辑，**超过 Telegram 群聊 20 msg/min 的硬上限**（`editMessage` 与 `sendMessage` 共享配额，见 [tdlib/td#3034](https://github.com/tdlib/td/issues/3034)）。私聊限制是 60/min，所以只在群聊暴露。最终挂 buttons 的 edit 撞进已关闭的限流窗口，原代码只重试一次就丢弃按钮。

## 架构对齐 karfly/chatgpt_telegram_bot

不做止血，做正确的架构：

1. **Per-chat + global token bucket**（新模块 `telegram/rate_limit.rs`，基于 `governor`）
   - 按 `chat_id` 正负自动选择配额：群聊 20/min（tdlib/td#3034），私聊 1/sec
   - 全局 30/sec 上限兜底
   - 所有 `send_message` / `edit_message_text` / `send_photo` / `send_voice` / `send_chat_action` / `delete_message` 调用必须先 `rate_limiter.acquire(chat_id).await`
2. **字符增量门控取代时间节流**
   - 流式文本 flush 条件：`pending_bytes_since_edit >= EDIT_DELTA_THRESHOLD(100)` 或 stream end
   - 保留 `MIN_EDIT_FLOOR = 500ms` 只用于合并病态突发；限流是真正的硬保护
3. **Buttons fallback 保留**：最终 edit 失败时 fallback 成 `send_message` 新发带 keyboard 的消息，覆盖 Telegram server 状态与本地 token bucket 漂移的极端情况
4. **AGENT.md 落档不变式**：所有出站 Telegram API 必须过限流器；`answer_callback_query` 是记录在案的唯一例外

## Coverage audit

```
$ grep bot\.(send_message|edit_message_text|send_photo|send_voice|send_chat_action|delete_message) crates/channels/src/telegram/adapter.rs
```

29 个命中，每个前 10 行内都有 `rate_limiter.acquire(chat_id).await`。无静默漏洞。

## Type of change

| Type | Label |
|------|-------|
| Bug fix | \`bug\` |

## Component

\`extension\`

## Closes

Closes #1510

## Test plan

- [x] \`cargo check -p rara-channels\` passes
- [x] \`cargo +nightly fmt --all -- --check\` passes
- [x] \`cargo clippy -p rara-channels --all-targets --all-features --no-deps -- -D warnings\` passes (zero warnings)
- [x] \`RUSTDOCFLAGS="-D warnings" cargo +nightly doc -p rara-channels --no-deps --document-private-items\` passes
- [x] 所有 prek 钩子（check/fmt/clippy/doc/AGENT.md）通过
- [ ] 手测：在 forum topic 下跑 plan 长链路，确认最终消息带 "📊 详情 / 🔍 Cascade" 按钮