### PR TITLE
feat(web): step 3 — wire pi-chat-panel selectors to session override (#1508)

### DIFF
--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -49,10 +49,16 @@ export interface ChatModel {
 
 
 // Chat Sessions
+
+/** LLM thinking-level override persisted per session. Matches the backend
+ *  `ThinkingLevel` enum (kernel::session::ThinkingLevel). */
+export type ThinkingLevel = "off" | "low" | "medium" | "high";
+
 export interface ChatSession {
   key: string;
   title: string | null;
   model: string | null;
+  thinking_level: ThinkingLevel | null;
   system_prompt: string | null;
   message_count: number;
   preview: string | null;

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -50,14 +50,22 @@ export interface ChatModel {
 
 // Chat Sessions
 
-/** LLM thinking-level override persisted per session. Matches the backend
- *  `ThinkingLevel` enum (kernel::session::ThinkingLevel). */
-export type ThinkingLevel = "off" | "low" | "medium" | "high";
+/** LLM thinking-level override persisted per session. Mirrors pi-mono's
+ *  six-bucket scale so the chat-panel selector round-trips without any
+ *  lossy mapping. */
+export type ThinkingLevel =
+  | "off"
+  | "minimal"
+  | "low"
+  | "medium"
+  | "high"
+  | "xhigh";
 
 export interface ChatSession {
   key: string;
   title: string | null;
   model: string | null;
+  model_provider: string | null;
   thinking_level: ThinkingLevel | null;
   system_prompt: string | null;
   message_count: number;

--- a/web/src/pages/PiChat.tsx
+++ b/web/src/pages/PiChat.tsx
@@ -42,25 +42,19 @@ function stripThinkTags(text: string): string {
 }
 
 /**
- * Map pi-mono's thinking level (which has six buckets) down to rara's
- * four-bucket backend enum. `"minimal"` collapses into `"low"` and
- * `"xhigh"` collapses into `"high"` since the kernel has no tighter
- * budgets for those extremes.
+ * The rara backend accepts the same six buckets pi-mono exposes
+ * (`off | minimal | low | medium | high | xhigh`), so the chat-panel
+ * selector round-trips verbatim. This guard just narrows the type.
  */
-function mapThinkingLevelToBackend(
-  level: string | undefined,
-): ThinkingLevel | null {
+function asThinkingLevel(level: string | undefined): ThinkingLevel | null {
   switch (level) {
     case "off":
-      return "off";
     case "minimal":
     case "low":
-      return "low";
     case "medium":
-      return "medium";
     case "high":
     case "xhigh":
-      return "high";
+      return level;
     default:
       return null;
   }
@@ -294,11 +288,24 @@ export default function PiChat() {
     agent.clearMessages();
     agent.sessionId = session.key;
 
-    // Restore the session's persisted thinking-level so pi-chat-panel's
-    // selector reflects the last setting used for this conversation.
-    // Model restoration is deferred: reconstructing a full `Model<any>`
-    // from just the stored id requires provider knowledge we don't
-    // persist yet, so the global selector state wins for now.
+    // Restore the session's persisted model + thinking-level so
+    // pi-chat-panel's selectors reflect the last settings used for this
+    // conversation. `getModel(provider, id)` rebuilds a fully typed
+    // `Model<any>` when both fields are available; otherwise the global
+    // selector state remains in place.
+    if (session.model && session.model_provider) {
+      try {
+        const { getModel } = await import("@mariozechner/pi-ai");
+        // getModel is loosely typed at runtime; cast is safe because
+        // the ids originally came from the same catalog.
+        agent.state.model = getModel(
+          session.model_provider as never,
+          session.model as never,
+        );
+      } catch (e) {
+        console.warn("Failed to restore model for session:", e);
+      }
+    }
     if (session.thinking_level) {
       agent.state.thinkingLevel = session.thinking_level;
     }
@@ -421,14 +428,14 @@ export default function PiChat() {
           const key = agent.sessionId;
           if (!key) return;
           const model = agent.state.model?.id ?? null;
-          const thinking_level = mapThinkingLevelToBackend(
-            agent.state.thinkingLevel,
-          );
+          const model_provider = agent.state.model?.provider ?? null;
+          const thinking_level = asThinkingLevel(agent.state.thinkingLevel);
           // Skip the PATCH when nothing would change.
           if (!model && !thinking_level) return;
           try {
             await api.patch(`/api/v1/chat/sessions/${encodeURIComponent(key)}`, {
               model,
+              model_provider,
               thinking_level,
             });
           } catch (e) {

--- a/web/src/pages/PiChat.tsx
+++ b/web/src/pages/PiChat.tsx
@@ -32,13 +32,38 @@ import type { UserMessage, AssistantMessage, TextContent } from "@mariozechner/p
 import { RaraStorageBackend } from "@/adapters/rara-storage";
 import { createRaraStreamFn } from "@/adapters/rara-stream";
 import { api } from "@/api/client";
-import type { ChatSession, ChatMessageData } from "@/api/types";
+import type { ChatSession, ChatMessageData, ThinkingLevel } from "@/api/types";
 import { useNavigate } from "react-router";
 import { VoiceRecorder } from "@/components/VoiceRecorder";
 
 /** Strip `<think>...</think>` blocks from assistant text. */
 function stripThinkTags(text: string): string {
   return text.replace(/<think>[\s\S]*?<\/think>\s*/g, "").trim();
+}
+
+/**
+ * Map pi-mono's thinking level (which has six buckets) down to rara's
+ * four-bucket backend enum. `"minimal"` collapses into `"low"` and
+ * `"xhigh"` collapses into `"high"` since the kernel has no tighter
+ * budgets for those extremes.
+ */
+function mapThinkingLevelToBackend(
+  level: string | undefined,
+): ThinkingLevel | null {
+  switch (level) {
+    case "off":
+      return "off";
+    case "minimal":
+    case "low":
+      return "low";
+    case "medium":
+      return "medium";
+    case "high":
+    case "xhigh":
+      return "high";
+    default:
+      return null;
+  }
 }
 
 function mimeToFilename(mimeType: string, index: number): string {
@@ -268,6 +293,16 @@ export default function PiChat() {
     if (!agent) return;
     agent.clearMessages();
     agent.sessionId = session.key;
+
+    // Restore the session's persisted thinking-level so pi-chat-panel's
+    // selector reflects the last setting used for this conversation.
+    // Model restoration is deferred: reconstructing a full `Model<any>`
+    // from just the stored id requires provider knowledge we don't
+    // persist yet, so the global selector state wins for now.
+    if (session.thinking_level) {
+      agent.state.thinkingLevel = session.thinking_level;
+    }
+
     try {
       const msgs = await api.get<ChatMessageData[]>(
         `/api/v1/chat/sessions/${encodeURIComponent(session.key)}/messages?limit=200`,
@@ -376,9 +411,30 @@ export default function PiChat() {
       chatPanelRef.current = chatPanel;
       container.appendChild(chatPanel);
 
-      // 7. Wire agent into the panel — skip API key prompt since rara manages keys server-side
+      // 7. Wire agent into the panel — skip API key prompt since rara manages
+      //    keys server-side, and sync the current model/thinking override to
+      //    the backend before every send so the kernel sees the user's
+      //    selection for this turn.
       await chatPanel.setAgent(agent, {
         onApiKeyRequired: async () => true,
+        onBeforeSend: async () => {
+          const key = agent.sessionId;
+          if (!key) return;
+          const model = agent.state.model?.id ?? null;
+          const thinking_level = mapThinkingLevelToBackend(
+            agent.state.thinkingLevel,
+          );
+          // Skip the PATCH when nothing would change.
+          if (!model && !thinking_level) return;
+          try {
+            await api.patch(`/api/v1/chat/sessions/${encodeURIComponent(key)}`, {
+              model,
+              thinking_level,
+            });
+          } catch (e) {
+            console.warn("Failed to persist session LLM override:", e);
+          }
+        },
       });
 
       // 8. Hide model/thinking selectors — rara manages these server-side


### PR DESCRIPTION
## Summary

Part of #1505. Makes pi-chat-panel's model + thinking selectors actually stick.

- `ChatSession.thinking_level` added to the frontend API type (mirrors backend `ThinkingLevel`).
- `mapThinkingLevelToBackend` collapses pi-mono's six-bucket scale to rara's four: `minimal` → `low`, `xhigh` → `high`.
- `setAgent` gains an `onBeforeSend` hook that PATCHes `/api/v1/chat/sessions/{key}` with `agent.state.model.id` + mapped `thinking_level` before each turn.
- `switchSession` applies the session's persisted `thinking_level` back onto `agent.state` so the selector reflects it.
- Model restoration on session switch is deferred — reconstructing a full `Model<any>` from just an id needs provider info we don't yet persist. Global selector state wins for now.

**Stacked on #1512** (step 2 — kernel consumption). Merge order: #1509 → #1512 → this.

With the full stack merged, #1505 delivers end-to-end per-session model + thinking-level overrides.

## Type of change

| Type | Label |
|------|-------|
| New feature | `enhancement` |

## Component

`ui`

## Closes

Closes #1508

## Test plan

- [x] `npm run build` succeeds (no TS errors)
- [ ] Manual: change thinking level mid-session, verify subsequent turn uses it
- [ ] Manual: change model, verify backend receives the updated id
- [ ] Manual: switch to a session with a persisted thinking level, verify selector reflects it