### PR TITLE
fix(kernel): auto-register non-web endpoints on ingress (#1511)

### DIFF
--- a/crates/kernel/src/io.rs
+++ b/crates/kernel/src/io.rs
@@ -1263,6 +1263,43 @@ pub enum EndpointAddress {
     },
 }
 
+/// Derive an [`Endpoint`] from inbound routing data, when the channel's
+/// address is fully determined by `(chat_id, thread_id)`.
+///
+/// Used by [`IOSubsystem::resolve`] to auto-register the originating endpoint
+/// for channels that have no explicit connection lifecycle (Telegram, WeChat,
+/// CLI). Returns `None` for channels whose endpoint address cannot be
+/// recovered from a raw platform message — notably [`ChannelType::Web`],
+/// whose `connection_id` is only known to the adapter at WS/SSE open time.
+fn derive_endpoint(
+    channel_type: ChannelType,
+    platform_chat_id: Option<&str>,
+    thread_id: Option<&str>,
+) -> Option<Endpoint> {
+    let chat_id = platform_chat_id?;
+    let address = match channel_type {
+        ChannelType::Telegram => EndpointAddress::Telegram {
+            chat_id:   chat_id.parse().ok()?,
+            thread_id: thread_id.and_then(|t| t.parse().ok()),
+        },
+        ChannelType::Cli => EndpointAddress::Cli {
+            session_id: chat_id.to_owned(),
+        },
+        ChannelType::Wechat => EndpointAddress::Wechat {
+            user_id: chat_id.to_owned(),
+        },
+        // Web needs a `connection_id` the raw message doesn't carry; the
+        // adapter registers itself on WS/SSE connect.
+        ChannelType::Web | ChannelType::Api | ChannelType::Proactive | ChannelType::Internal => {
+            return None;
+        }
+    };
+    Some(Endpoint {
+        channel_type,
+        address,
+    })
+}
+
 // ---------------------------------------------------------------------------
 // EndpointRegistry
 // ---------------------------------------------------------------------------
@@ -1592,7 +1629,21 @@ impl IOSubsystem {
             None => None,
         };
 
-        // 4. Build InboundMessage with optional session_key
+        // 4. Auto-register the originating endpoint.
+        //
+        // Why: only the Web adapter has an explicit connection lifecycle
+        // (WS/SSE open/close) and registers itself there. Telegram, WeChat,
+        // and CLI have no equivalent signal — without this, outbound fan-out
+        // via `deliver_to_endpoints()` cannot find them and cross-channel
+        // delivery (e.g. web → tg) silently drops. `HashSet` insert is
+        // idempotent, so re-registering on every message is safe.
+        if let Some(endpoint) =
+            derive_endpoint(raw.channel_type, raw.platform_chat_id.as_deref(), thread_id)
+        {
+            self.endpoint_registry.register(&user_id, endpoint);
+        }
+
+        // 5. Build InboundMessage with optional session_key
         let msg = InboundMessage::unresolved(
             MessageId::new(),
             ChannelSource {


### PR DESCRIPTION
## Summary

Messages sent from the web UI were not mirrored to Telegram for the same user. The Telegram adapter never registered itself with `EndpointRegistry`, so `deliver_to_endpoints()` only found the web endpoint and dropped the tg side silently — even with `OutboundRouting::BroadcastAll`.

Register derivable endpoints (Telegram / WeChat / CLI) at the single ingress point `IOSubsystem::resolve()`, right after identity resolution. Web keeps its explicit WS/SSE register/unregister because its `connection_id` only exists at adapter connect time. `HashSet` insert is idempotent, so re-registering on every inbound message is safe.

## Type of change

| Type | Label |
|------|-------|
| Bug fix | `bug` |

## Component

`core`

## Closes

Closes #1511

## Test plan

- [x] `cargo check --all --all-targets` passes
- [x] `cargo clippy --workspace --all-targets --all-features --no-deps` passes
- [x] `cargo +nightly fmt --all -- --check` passes
- [ ] Manual: send from web, observe delivery on Telegram for the same user