### PR TITLE
chore(channels): log receiver_count in web broadcast_event (#1516)

### DIFF
--- a/crates/channels/src/web.rs
+++ b/crates/channels/src/web.rs
@@ -164,6 +164,31 @@ pub enum WebEvent {
     Done,
 }
 
+/// Static variant label for `WebEvent`, used in diagnostic logging.
+fn web_event_kind(event: &WebEvent) -> &'static str {
+    match event {
+        WebEvent::Message { .. } => "Message",
+        WebEvent::Typing => "Typing",
+        WebEvent::Phase { .. } => "Phase",
+        WebEvent::Error { .. } => "Error",
+        WebEvent::TextDelta { .. } => "TextDelta",
+        WebEvent::ReasoningDelta { .. } => "ReasoningDelta",
+        WebEvent::ToolCallStart { .. } => "ToolCallStart",
+        WebEvent::ToolCallEnd { .. } => "ToolCallEnd",
+        WebEvent::TurnRationale { .. } => "TurnRationale",
+        WebEvent::Progress { .. } => "Progress",
+        WebEvent::TurnMetrics { .. } => "TurnMetrics",
+        WebEvent::PlanCreated { .. } => "PlanCreated",
+        WebEvent::PlanProgress { .. } => "PlanProgress",
+        WebEvent::PlanReplan { .. } => "PlanReplan",
+        WebEvent::PlanCompleted { .. } => "PlanCompleted",
+        WebEvent::BackgroundTaskStarted { .. } => "BackgroundTaskStarted",
+        WebEvent::BackgroundTaskDone { .. } => "BackgroundTaskDone",
+        WebEvent::DockTurnComplete { .. } => "DockTurnComplete",
+        WebEvent::Done => "Done",
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Request / response types
 // ---------------------------------------------------------------------------
@@ -485,8 +510,34 @@ impl WebAdapter {
                     return;
                 }
             };
-            // Ignore send errors — they mean no active receivers.
-            let _ = tx.send(json);
+            let receiver_count = tx.receiver_count();
+            let event_kind = web_event_kind(event);
+            tracing::debug!(
+                session_key,
+                receiver_count,
+                event_kind,
+                "web broadcast_event"
+            );
+            match tx.send(json) {
+                Ok(delivered) => {
+                    if delivered != receiver_count {
+                        tracing::warn!(
+                            session_key,
+                            event_kind,
+                            delivered,
+                            receiver_count,
+                            "web broadcast: delivered count != receiver_count"
+                        );
+                    }
+                }
+                Err(_) => {
+                    tracing::warn!(
+                        session_key,
+                        event_kind,
+                        "web broadcast: no active receivers (tx.send returned Err)"
+                    );
+                }
+            }
         }
     }
 }
@@ -898,6 +949,17 @@ fn spawn_stream_forwarder(
             debug!(session_key, "no streams found after polling");
             return;
         }
+
+        let ws_receiver_count = sessions
+            .get(&session_key)
+            .map(|tx| tx.receiver_count())
+            .unwrap_or(0);
+        tracing::info!(
+            session_key,
+            stream_subs = subs.len(),
+            ws_receiver_count,
+            "stream_forwarder: subscribed"
+        );
 
         for (_stream_id, mut rx) in subs {
             let sessions = Arc::clone(&sessions);

--- a/crates/channels/src/web.rs
+++ b/crates/channels/src/web.rs
@@ -81,7 +81,7 @@ const BROADCAST_CAPACITY: usize = 256;
 // ---------------------------------------------------------------------------
 
 /// An event sent over SSE / WebSocket to the client.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, strum::IntoStaticStr)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum WebEvent {
     /// Agent response message (final reply).
@@ -162,31 +162,6 @@ pub enum WebEvent {
     },
     /// Stream completed (no more deltas).
     Done,
-}
-
-/// Static variant label for `WebEvent`, used in diagnostic logging.
-fn web_event_kind(event: &WebEvent) -> &'static str {
-    match event {
-        WebEvent::Message { .. } => "Message",
-        WebEvent::Typing => "Typing",
-        WebEvent::Phase { .. } => "Phase",
-        WebEvent::Error { .. } => "Error",
-        WebEvent::TextDelta { .. } => "TextDelta",
-        WebEvent::ReasoningDelta { .. } => "ReasoningDelta",
-        WebEvent::ToolCallStart { .. } => "ToolCallStart",
-        WebEvent::ToolCallEnd { .. } => "ToolCallEnd",
-        WebEvent::TurnRationale { .. } => "TurnRationale",
-        WebEvent::Progress { .. } => "Progress",
-        WebEvent::TurnMetrics { .. } => "TurnMetrics",
-        WebEvent::PlanCreated { .. } => "PlanCreated",
-        WebEvent::PlanProgress { .. } => "PlanProgress",
-        WebEvent::PlanReplan { .. } => "PlanReplan",
-        WebEvent::PlanCompleted { .. } => "PlanCompleted",
-        WebEvent::BackgroundTaskStarted { .. } => "BackgroundTaskStarted",
-        WebEvent::BackgroundTaskDone { .. } => "BackgroundTaskDone",
-        WebEvent::DockTurnComplete { .. } => "DockTurnComplete",
-        WebEvent::Done => "Done",
-    }
 }
 
 // ---------------------------------------------------------------------------
@@ -511,7 +486,7 @@ impl WebAdapter {
                 }
             };
             let receiver_count = tx.receiver_count();
-            let event_kind = web_event_kind(event);
+            let event_kind: &'static str = event.into();
             tracing::debug!(
                 session_key,
                 receiver_count,


### PR DESCRIPTION
## Summary

Diagnostic logging for the multi-device web stream bug (phone + desktop on same session, only one receives the LLM stream). Static analysis says both should receive — logging `receiver_count` in `broadcast_event` + the sub/receiver counts in `spawn_stream_forwarder` will pin down which layer actually drops the other client.

## Type of change

| Type | Label |
|------|-------|
| Chore | `chore` |

## Component

`backend`

## Closes

Closes #1516

## Test plan

- [x] `cargo check -p rara-channels`
- [x] `cargo clippy -p rara-channels` clean
- [x] `cargo +nightly fmt --all` clean
- [ ] Reproduce with phone + desktop connected to same session; grep log for `web broadcast_event` and `stream_forwarder: subscribed`