### PR TITLE
feat(web): polish chat visual details (#1525)

### DIFF
--- a/web/src/index.css
+++ b/web/src/index.css
@@ -126,11 +126,6 @@
 
   /* ── pi-web-ui chat layout overrides (light DOM) ── */
 
-  /* User messages: right-aligned */
-  user-message > .flex.justify-start {
-    justify-content: flex-end !important;
-  }
-
   .dark pre code.hljs {
     background: transparent;
     color: var(--color-foreground);

--- a/web/src/pages/PiChat.tsx
+++ b/web/src/pages/PiChat.tsx
@@ -529,6 +529,13 @@ export default function PiChat() {
       // Model and thinking selectors are enabled by default in ChatPanel.setAgent().
       // Rara delegates model/thinking selection to the user via pi-chat-panel's
       // built-in UI — the chosen model is passed to the backend at stream time.
+      //
+      // Surface pi-mono's built-in theme toggle in the chat header. Rara's
+      // own <ThemeToggle /> is scoped to DashboardLayout (admin pages), so
+      // there's no duplicate on the chat page.
+      if (chatPanel.agentInterface) {
+        chatPanel.agentInterface.showThemeToggle = true;
+      }
       } finally {
         // Clear the loading overlay even if init fails (network/CORS/etc.)
         // so the user sees the empty chat panel rather than a spinner forever.


### PR DESCRIPTION
## Summary

Phase F of the pi-mono web UI alignment epic (#1518). Small visual flips that align rara's chat page with pi-mono's default look:

- Enable pi-mono's built-in theme toggle on the chat page (`agentInterface.showThemeToggle = true`). Rara's own `<ThemeToggle />` is already scoped to `DashboardLayout` (admin pages), so there's no duplicate.
- Remove the `user-message > .flex.justify-start` override from `web/src/index.css` so user messages use pi-mono's native left-aligned pill layout (with shimmer + cubic-bezier transitions intact).
- Verified the 800px overlay / side-by-side artifacts panel breakpoint fires via pi-mono's `windowWidth` listener — the `h-screen w-screen` wrapper in `PiChat.tsx` doesn't constrain it.
- Verified `@import "@mariozechner/pi-web-ui/app.css"` is active at the top of `web/src/index.css` and no later rule clobbers pi-mono's shimmer / cubic-bezier keyframes.

Admin pages (DashboardLayout, KernelTop, Settings, etc.) are visually unchanged.

Part of #1518.

## Type of change

| Type | Label |
|------|-------|
| Enhancement | `enhancement` |

## Component

`ui`

## Closes

Closes #1525

## Test plan

- [x] `cd web && npm install && npm run build` passes
- [x] Theme toggle surfaces in chat header; admin layout still has its own toggle
- [x] Resize browser across 800px — artifacts panel switches between overlay and side-by-side
- [x] Shimmer + streaming text animations visible