### PR TITLE
feat: stream usage events for cost display (#1523)

### DIFF
--- a/crates/channels/src/web.rs
+++ b/crates/channels/src/web.rs
@@ -120,6 +120,20 @@ pub enum WebEvent {
         tool_calls:  usize,
         model:       String,
     },
+    /// Final per-turn token usage (sent before Done). Clients use this to
+    /// populate the cost pill + token display in the chat UI. `cache_read`
+    /// / `cache_write` are `0` until the kernel tracks them; `cost` is
+    /// reported as `0.0` and recomputed client-side against the session's
+    /// model pricing table.
+    Usage {
+        input:        u32,
+        output:       u32,
+        cache_read:   u32,
+        cache_write:  u32,
+        total_tokens: u32,
+        cost:         f64,
+        model:        String,
+    },
     /// A plan has been created with a goal and steps.
     PlanCreated {
         goal:                    String,
@@ -245,6 +259,20 @@ fn stream_event_to_web_event(event: StreamEvent) -> Option<WebEvent> {
         StreamEvent::PlanReplan { reason } => Some(WebEvent::PlanReplan { reason }),
         StreamEvent::PlanCompleted { summary } => Some(WebEvent::PlanCompleted { summary }),
         StreamEvent::UsageUpdate { .. } => None,
+        StreamEvent::TurnUsage {
+            input_tokens,
+            output_tokens,
+            total_tokens,
+            model,
+        } => Some(WebEvent::Usage {
+            input: input_tokens,
+            output: output_tokens,
+            cache_read: 0,
+            cache_write: 0,
+            total_tokens,
+            cost: 0.0,
+            model,
+        }),
         StreamEvent::BackgroundTaskStarted {
             task_id,
             agent_name,
@@ -1225,6 +1253,38 @@ mod tests {
                         && data == "AAAA"
                 )
         ));
+    }
+
+    #[test]
+    fn turn_usage_is_mapped_to_web_usage_event() {
+        let event = StreamEvent::TurnUsage {
+            input_tokens:  1_234,
+            output_tokens: 56,
+            total_tokens:  1_290,
+            model:         "gpt-5".to_owned(),
+        };
+
+        let mapped = stream_event_to_web_event(event).expect("usage event");
+        match mapped {
+            WebEvent::Usage {
+                input,
+                output,
+                cache_read,
+                cache_write,
+                total_tokens,
+                cost,
+                model,
+            } => {
+                assert_eq!(input, 1_234);
+                assert_eq!(output, 56);
+                assert_eq!(cache_read, 0);
+                assert_eq!(cache_write, 0);
+                assert_eq!(total_tokens, 1_290);
+                assert!((cost - 0.0).abs() < f64::EPSILON);
+                assert_eq!(model, "gpt-5");
+            }
+            other => panic!("unexpected event: {other:?}"),
+        }
     }
 
     #[test]

--- a/crates/cmd/src/chat/mod.rs
+++ b/crates/cmd/src/chat/mod.rs
@@ -972,6 +972,16 @@ fn stream_event_to_cli_event(event: StreamEvent) -> CliEvent {
             output_tokens,
             thinking_ms,
         },
+        StreamEvent::TurnUsage {
+            input_tokens,
+            output_tokens,
+            total_tokens: _,
+            model: _,
+        } => CliEvent::UsageUpdate {
+            input_tokens,
+            output_tokens,
+            thinking_ms: 0,
+        },
         StreamEvent::BackgroundTaskStarted {
             agent_name,
             description,

--- a/crates/kernel/src/agent/mod.rs
+++ b/crates/kernel/src/agent/mod.rs
@@ -534,17 +534,23 @@ pub struct TurnTrace {
 #[derive(Debug)]
 pub struct AgentTurnResult {
     /// The final text produced by the agent.
-    pub text:       String,
+    pub text:          String,
     /// Number of LLM iterations consumed.
-    pub iterations: usize,
+    pub iterations:    usize,
     /// Number of tool calls executed.
-    pub tool_calls: usize,
+    pub tool_calls:    usize,
     /// Model used for this turn.
-    pub model:      String,
+    pub model:         String,
+    /// Largest prompt_tokens across all iterations in this turn — each
+    /// iteration re-sends the full context so the last one is effectively
+    /// the max. `0` when no usage data was reported by the provider.
+    pub input_tokens:  u32,
+    /// Sum of completion_tokens across all iterations in this turn.
+    pub output_tokens: u32,
     /// Detailed trace of the turn for observability.
-    pub trace:      TurnTrace,
+    pub trace:         TurnTrace,
     /// Structured cascade trace built in real time during the turn.
-    pub cascade:    crate::cascade::CascadeTrace,
+    pub cascade:       crate::cascade::CascadeTrace,
 }
 
 impl AgentTurnResult {
@@ -552,11 +558,13 @@ impl AgentTurnResult {
     /// judgment decides Rara should not reply.
     pub fn empty() -> Self {
         Self {
-            text:       String::new(),
-            iterations: 0,
-            tool_calls: 0,
-            model:      String::new(),
-            trace:      TurnTrace {
+            text:          String::new(),
+            iterations:    0,
+            tool_calls:    0,
+            model:         String::new(),
+            input_tokens:  0,
+            output_tokens: 0,
+            trace:         TurnTrace {
                 duration_ms:      0,
                 model:            String::new(),
                 input_text:       None,
@@ -567,7 +575,7 @@ impl AgentTurnResult {
                 error:            None,
                 rara_message_id:  crate::io::MessageId::new(),
             },
-            cascade:    crate::cascade::CascadeTrace::empty(),
+            cascade:       crate::cascade::CascadeTrace::empty(),
         }
     }
 }
@@ -1139,6 +1147,10 @@ pub(crate) async fn run_agent_loop(
     // each iteration re-sends the full context.
     let mut cumulative_output_tokens: u32 = 0;
     let mut cumulative_thinking_ms: u64 = 0;
+    // Last iteration's prompt_tokens — each iteration re-sends the full
+    // context, so this represents the max context size for the turn.
+    // Surfaced in `AgentTurnResult.input_tokens` for the final usage event.
+    let mut last_prompt_tokens: u32 = 0;
     let user_id = Some(tool_context.user_id.as_str());
 
     // ── Context folding state ────────────────────────────────────────
@@ -1569,6 +1581,7 @@ pub(crate) async fn run_agent_loop(
                     if let Some(ref u) = last_usage {
                         cumulative_output_tokens =
                             cumulative_output_tokens.saturating_add(u.completion_tokens);
+                        last_prompt_tokens = u.prompt_tokens;
                         stream_handle.emit(StreamEvent::UsageUpdate {
                             input_tokens:  u.prompt_tokens,
                             output_tokens: cumulative_output_tokens,
@@ -2037,6 +2050,8 @@ pub(crate) async fn run_agent_loop(
                 iterations: iteration + 1,
                 tool_calls: tool_calls_made,
                 model: model.clone(),
+                input_tokens: last_prompt_tokens,
+                output_tokens: cumulative_output_tokens,
                 trace,
                 cascade,
             });
@@ -3056,6 +3071,8 @@ pub(crate) async fn run_agent_loop(
         iterations: actual_iterations,
         tool_calls: tool_calls_made,
         model: model.clone(),
+        input_tokens: last_prompt_tokens,
+        output_tokens: cumulative_output_tokens,
         trace,
         cascade,
     })

--- a/crates/kernel/src/io.rs
+++ b/crates/kernel/src/io.rs
@@ -905,6 +905,25 @@ pub enum StreamEvent {
         model:           String,
         rara_message_id: String,
     },
+    /// Final per-turn token usage (emitted once, after the agent loop
+    /// finishes, before stream close). Distinct from `UsageUpdate` which is
+    /// emitted per-iteration for progress UX — this one carries the settled
+    /// totals clients need for cost display.
+    ///
+    /// - `input_tokens`: the latest iteration's prompt_tokens (= the largest
+    ///   context the turn sent; each iteration re-sends the full context so
+    ///   this is effectively the max).
+    /// - `output_tokens`: cumulative completion_tokens across all iterations in
+    ///   this turn.
+    /// - `total_tokens`: `input_tokens + output_tokens`.
+    /// - `model`: the model id actually used for the turn (respects per-session
+    ///   overrides when set).
+    TurnUsage {
+        input_tokens:  u32,
+        output_tokens: u32,
+        total_tokens:  u32,
+        model:         String,
+    },
     /// A plan has been created with a goal and ordered steps.
     PlanCreated {
         goal:                    String,

--- a/crates/kernel/src/kernel.rs
+++ b/crates/kernel/src/kernel.rs
@@ -2592,7 +2592,10 @@ impl Kernel {
                     turn_span.record("tool_calls", result.tool_calls);
                 }
 
-                // Emit turn metrics before closing stream.
+                // Emit turn metrics and final per-turn usage before closing
+                // the stream. `TurnUsage` carries the settled totals needed
+                // for cost display; clients must ignore `UsageUpdate` once
+                // `TurnUsage` arrives.
                 if let Ok(ref result) = turn_result {
                     stream_handle.emit(crate::io::StreamEvent::TurnMetrics {
                         duration_ms: elapsed_ms,
@@ -2600,6 +2603,14 @@ impl Kernel {
                         tool_calls:  result.tool_calls,
                         model:       result.model.clone(),
                         rara_message_id: result.trace.rara_message_id.to_string(),
+                    });
+                    stream_handle.emit(crate::io::StreamEvent::TurnUsage {
+                        input_tokens:  result.input_tokens,
+                        output_tokens: result.output_tokens,
+                        total_tokens:  result
+                            .input_tokens
+                            .saturating_add(result.output_tokens),
+                        model:         result.model.clone(),
                     });
                 }
 

--- a/crates/kernel/src/plan.rs
+++ b/crates/kernel/src/plan.rs
@@ -673,11 +673,13 @@ pub(crate) async fn run_plan_loop(
 
     let final_text_len = summary.len();
     Ok(AgentTurnResult {
-        text:       summary,
-        iterations: total_iterations,
-        tool_calls: total_tool_calls,
-        model:      last_model.clone(),
-        trace:      crate::agent::TurnTrace {
+        text:          summary,
+        iterations:    total_iterations,
+        tool_calls:    total_tool_calls,
+        model:         last_model.clone(),
+        input_tokens:  0,
+        output_tokens: 0,
+        trace:         crate::agent::TurnTrace {
             duration_ms: start.elapsed().as_millis() as u64,
             model: last_model,
             input_text: Some(user_text),
@@ -705,7 +707,7 @@ pub(crate) async fn run_plan_loop(
             },
             rara_message_id,
         },
-        cascade:    crate::cascade::CascadeTrace::empty(),
+        cascade:       crate::cascade::CascadeTrace::empty(),
     })
 }
 
@@ -1453,11 +1455,13 @@ mod tests {
     ) -> crate::agent::AgentTurnResult {
         use crate::io::MessageId;
         crate::agent::AgentTurnResult {
-            text:       text.to_owned(),
-            iterations: 25,
-            tool_calls: 25,
-            model:      "test-model".to_owned(),
-            trace:      crate::agent::TurnTrace {
+            text:          text.to_owned(),
+            iterations:    25,
+            tool_calls:    25,
+            model:         "test-model".to_owned(),
+            input_tokens:  0,
+            output_tokens: 0,
+            trace:         crate::agent::TurnTrace {
                 duration_ms: 1000,
                 model: "test-model".to_owned(),
                 input_text: None,
@@ -1468,7 +1472,7 @@ mod tests {
                 error: error.map(|s| s.to_owned()),
                 rara_message_id: MessageId::new(),
             },
-            cascade:    crate::cascade::CascadeTrace {
+            cascade:       crate::cascade::CascadeTrace {
                 message_id: String::new(),
                 ticks:      Vec::new(),
                 summary:    crate::cascade::CascadeSummary {

--- a/web/src/adapters/rara-stream.ts
+++ b/web/src/adapters/rara-stream.ts
@@ -27,7 +27,7 @@ import type {
   ToolCall,
   Usage,
 } from "@mariozechner/pi-ai";
-import { createAssistantMessageEventStream } from "@mariozechner/pi-ai";
+import { calculateCost, createAssistantMessageEventStream } from "@mariozechner/pi-ai";
 import type { AssistantMessageEventStream } from "@mariozechner/pi-ai";
 
 import { BASE_URL } from "@/api/client";
@@ -66,6 +66,16 @@ type WebEvent =
       tool_calls: number;
       model: string;
     }
+  | {
+      type: "usage";
+      input: number;
+      output: number;
+      cache_read: number;
+      cache_write: number;
+      total_tokens: number;
+      cost: number;
+      model: string;
+    }
   | { type: "phase"; phase: string };
 
 // ---------------------------------------------------------------------------
@@ -79,7 +89,12 @@ export type SessionKeyFn = () => string | undefined;
 // Helpers
 // ---------------------------------------------------------------------------
 
-/** Build a zeroed Usage object — rara tracks usage server-side. */
+/**
+ * Build a zeroed Usage object — used as the initial value before the
+ * backend streams its final `usage` event. Cost is filled in from the
+ * session's model pricing table via {@link calculateCost} once real
+ * token counts arrive.
+ */
 function emptyUsage(): Usage {
   return {
     input: 0,
@@ -95,6 +110,7 @@ function emptyUsage(): Usage {
 function buildPartial(
   model: Model<any>,
   content: (TextContent | ThinkingContent | ToolCall)[],
+  usage: Usage,
 ): AssistantMessage {
   return {
     role: "assistant",
@@ -102,7 +118,7 @@ function buildPartial(
     api: model.api,
     provider: model.provider,
     model: model.id,
-    usage: emptyUsage(),
+    usage,
     stopReason: "stop",
     timestamp: Date.now(),
   };
@@ -196,9 +212,11 @@ export function createRaraStreamFn(getSessionKey: SessionKeyFn): StreamFn {
 
     const sessionKey = getSessionKey();
     if (!sessionKey) {
-      const errorMsg = buildPartial(model, [
-        { type: "text", text: "No active session key set." },
-      ]);
+      const errorMsg = buildPartial(
+        model,
+        [{ type: "text", text: "No active session key set." }],
+        emptyUsage(),
+      );
       errorMsg.stopReason = "error";
       errorMsg.errorMessage = "No active session key set.";
       stream.push({ type: "error", reason: "error", error: errorMsg });
@@ -211,6 +229,10 @@ export function createRaraStreamFn(getSessionKey: SessionKeyFn): StreamFn {
 
     // Accumulated content blocks for building partial messages
     const content: (TextContent | ThinkingContent | ToolCall)[] = [];
+    // Running usage — starts empty, replaced when the backend emits its
+    // final `usage` event. Cost is computed against the session model's
+    // pricing table so per-session model overrides are honoured.
+    let currentUsage: Usage = emptyUsage();
     let streamEnded = false;
 
     /** Push an event to the stream, guarding against double-end. */
@@ -249,7 +271,7 @@ export function createRaraStreamFn(getSessionKey: SessionKeyFn): StreamFn {
 
       ws.onopen = () => {
         // Emit start event
-        safePush({ type: "start", partial: buildPartial(model, content) });
+        safePush({ type: "start", partial: buildPartial(model, content, currentUsage) });
         // Send user message
         ws.send(userPayload);
       };
@@ -272,7 +294,7 @@ export function createRaraStreamFn(getSessionKey: SessionKeyFn): StreamFn {
               safePush({
                 type: "text_start",
                 contentIndex: idx,
-                partial: buildPartial(model, content),
+                partial: buildPartial(model, content, currentUsage),
               });
             } else {
               block.text += event.text;
@@ -281,7 +303,7 @@ export function createRaraStreamFn(getSessionKey: SessionKeyFn): StreamFn {
               type: "text_delta",
               contentIndex: idx,
               delta: event.text,
-              partial: buildPartial(model, content),
+              partial: buildPartial(model, content, currentUsage),
             });
             break;
           }
@@ -294,7 +316,7 @@ export function createRaraStreamFn(getSessionKey: SessionKeyFn): StreamFn {
               safePush({
                 type: "thinking_start",
                 contentIndex: idx,
-                partial: buildPartial(model, content),
+                partial: buildPartial(model, content, currentUsage),
               });
             } else {
               block.thinking += event.text;
@@ -303,7 +325,7 @@ export function createRaraStreamFn(getSessionKey: SessionKeyFn): StreamFn {
               type: "thinking_delta",
               contentIndex: idx,
               delta: event.text,
-              partial: buildPartial(model, content),
+              partial: buildPartial(model, content, currentUsage),
             });
             break;
           }
@@ -320,7 +342,7 @@ export function createRaraStreamFn(getSessionKey: SessionKeyFn): StreamFn {
             safePush({
               type: "toolcall_start",
               contentIndex: idx,
-              partial: buildPartial(model, content),
+              partial: buildPartial(model, content, currentUsage),
             });
             break;
           }
@@ -335,7 +357,7 @@ export function createRaraStreamFn(getSessionKey: SessionKeyFn): StreamFn {
                 type: "toolcall_end",
                 contentIndex: idx,
                 toolCall,
-                partial: buildPartial(model, content),
+                partial: buildPartial(model, content, currentUsage),
               });
             }
             break;
@@ -343,9 +365,9 @@ export function createRaraStreamFn(getSessionKey: SessionKeyFn): StreamFn {
 
           case "done": {
             // Close any open text/thinking blocks
-            emitEndBlocks(model, content, safePush);
+            emitEndBlocks(model, content, currentUsage, safePush);
 
-            const finalMsg = buildPartial(model, content);
+            const finalMsg = buildPartial(model, content, currentUsage);
             finalMsg.stopReason = "stop";
             safePush({ type: "done", reason: "stop", message: finalMsg });
             safeEnd(finalMsg);
@@ -357,9 +379,9 @@ export function createRaraStreamFn(getSessionKey: SessionKeyFn): StreamFn {
             // Complete message in a single frame — treat like text + done
             const block = ensureTextBlock();
             block.text += event.content;
-            emitEndBlocks(model, content, safePush);
+            emitEndBlocks(model, content, currentUsage, safePush);
 
-            const finalMsg = buildPartial(model, content);
+            const finalMsg = buildPartial(model, content, currentUsage);
             finalMsg.stopReason = "stop";
             safePush({ type: "done", reason: "stop", message: finalMsg });
             safeEnd(finalMsg);
@@ -368,12 +390,29 @@ export function createRaraStreamFn(getSessionKey: SessionKeyFn): StreamFn {
           }
 
           case "error": {
-            const errorMsg = buildPartial(model, content);
+            const errorMsg = buildPartial(model, content, currentUsage);
             errorMsg.stopReason = "error";
             errorMsg.errorMessage = event.message;
             safePush({ type: "error", reason: "error", error: errorMsg });
             safeEnd(errorMsg);
             ws.close();
+            break;
+          }
+
+          case "usage": {
+            // Backend reports raw token counts; cost comes from pi-ai's
+            // pricing table for the session's model so per-session
+            // overrides are honoured without duplicating pricing in Rust.
+            const next: Usage = {
+              input: event.input,
+              output: event.output,
+              cacheRead: event.cache_read,
+              cacheWrite: event.cache_write,
+              totalTokens: event.total_tokens,
+              cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+            };
+            next.cost = calculateCost(model, next);
+            currentUsage = next;
             break;
           }
 
@@ -388,7 +427,7 @@ export function createRaraStreamFn(getSessionKey: SessionKeyFn): StreamFn {
       };
 
       ws.onerror = () => {
-        const errorMsg = buildPartial(model, content);
+        const errorMsg = buildPartial(model, content, currentUsage);
         errorMsg.stopReason = "error";
         errorMsg.errorMessage = "WebSocket connection error";
         safePush({ type: "error", reason: "error", error: errorMsg });
@@ -398,7 +437,7 @@ export function createRaraStreamFn(getSessionKey: SessionKeyFn): StreamFn {
       ws.onclose = () => {
         // Ensure stream is ended if WS closes unexpectedly
         if (!streamEnded) {
-          const finalMsg = buildPartial(model, content);
+          const finalMsg = buildPartial(model, content, currentUsage);
           finalMsg.stopReason = content.length > 0 ? "stop" : "error";
           if (content.length > 0) {
             safePush({ type: "done", reason: "stop", message: finalMsg });
@@ -410,7 +449,7 @@ export function createRaraStreamFn(getSessionKey: SessionKeyFn): StreamFn {
         }
       };
     } catch (err) {
-      const errorMsg = buildPartial(model, content);
+      const errorMsg = buildPartial(model, content, currentUsage);
       errorMsg.stopReason = "error";
       errorMsg.errorMessage =
         err instanceof Error ? err.message : "Failed to connect";
@@ -429,6 +468,7 @@ export function createRaraStreamFn(getSessionKey: SessionKeyFn): StreamFn {
 function emitEndBlocks(
   model: Model<any>,
   content: (TextContent | ThinkingContent | ToolCall)[],
+  usage: Usage,
   safePush: (event: AssistantMessageEvent) => void,
 ): void {
   for (let i = 0; i < content.length; i++) {
@@ -438,14 +478,14 @@ function emitEndBlocks(
         type: "text_end",
         contentIndex: i,
         content: block.text,
-        partial: buildPartial(model, content),
+        partial: buildPartial(model, content, usage),
       });
     } else if (block.type === "thinking" && block.thinking) {
       safePush({
         type: "thinking_end",
         contentIndex: i,
         content: block.thinking,
-        partial: buildPartial(model, content),
+        partial: buildPartial(model, content, usage),
       });
     }
   }

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -103,6 +103,16 @@ export type ChatStreamEvent =
   | { type: "iteration"; index: number }
   | { type: "tool_call_start"; id: string; name: string }
   | { type: "tool_call_end"; id: string; name: string; success: boolean; error?: string }
+  | {
+      type: "usage";
+      input: number;
+      output: number;
+      cache_read: number;
+      cache_write: number;
+      total_tokens: number;
+      cost: number;
+      model: string;
+    }
   | { type: "done"; text: string }
   | { type: "error"; message: string };
 


### PR DESCRIPTION
## Summary

Phase D of the pi-mono web UI alignment epic (#1518). Streams live
per-turn token usage so pi-chat-panel's cost pill + token display stop
showing zeros.

- Kernel emits a new `TurnUsage` stream event at the `done` boundary,
  alongside `TurnMetrics`, carrying the settled `{input, output,
  total_tokens, model}`.
- Web channel maps it to a new `WebEvent::Usage` variant with placeholder
  `cache_read` / `cache_write` / `cost` (kernel doesn't track cache yet).
- `rara-stream.ts` consumes the event, fills the running `Usage` on the
  partial + final `AssistantMessage`, and computes cost client-side via
  pi-ai's `calculateCost` against the session's model pricing table so
  per-session model overrides are honoured.
- `ChatStreamEvent` gains the `usage` variant for parity.

Closes #1523. Part of #1518.

## Type of change

| Type | Label |
|------|-------|
| New feature | `enhancement` |

## Component

`backend`

## Closes

Closes #1523

## Test plan

- [x] `prek run --all-files` passes
- [x] `cargo test -p rara-channels --lib` passes (new mapping test added)
- [x] `cd web && npm run build` succeeds