### PR TITLE
feat: drag-drop, paste, document attachments (#1524)

### DIFF
--- a/crates/channels/src/web.rs
+++ b/crates/channels/src/web.rs
@@ -1228,6 +1228,39 @@ mod tests {
     }
 
     #[test]
+    fn parses_document_attachment_frame() {
+        let raw = serde_json::json!({
+            "content": [
+                { "type": "text", "text": "summarize this" },
+                {
+                    "type": "file_base64",
+                    "media_type": "application/pdf",
+                    "data": "JVBERi0x",
+                    "filename": "spec.pdf"
+                }
+            ]
+        })
+        .to_string();
+
+        let payload = parse_inbound_text_frame(&raw);
+
+        assert!(matches!(
+            payload.content,
+            MessageContent::Multimodal(blocks)
+                if matches!(
+                    blocks.as_slice(),
+                    [
+                        ContentBlock::Text { text },
+                        ContentBlock::FileBase64 { media_type, data, filename }
+                    ] if text == "summarize this"
+                        && media_type == "application/pdf"
+                        && data == "JVBERi0x"
+                        && filename.as_deref() == Some("spec.pdf")
+                )
+        ));
+    }
+
+    #[test]
     fn turn_rationale_is_forwarded_to_web_clients() {
         let event = StreamEvent::TurnRationale {
             text: "checking logs".to_owned(),

--- a/crates/kernel/src/channel/types.rs
+++ b/crates/kernel/src/channel/types.rs
@@ -141,6 +141,23 @@ pub enum ContentBlock {
         media_type: String,
         data:       String,
     },
+    /// Inline base64-encoded non-image document attachment (PDF/DOCX/XLSX/PPTX
+    /// and friends).
+    ///
+    /// Document extraction currently happens client-side (pi-mono's
+    /// `extract-document` tool and `attachment-utils.loadAttachment`), so
+    /// text extracted from the file still reaches the LLM as a
+    /// [`Text`](Self::Text) block for compatibility with text-only models.
+    /// This variant preserves the raw bytes end-to-end for future paths
+    /// that hand the file to a native multimodal model or invoke
+    /// `extract-document` server-side. The current LLM serializer renders
+    /// it as a text placeholder (`[document: …]`).
+    FileBase64 {
+        media_type: String,
+        data:       String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        filename:   Option<String>,
+    },
 }
 
 /// Message content — either plain text or multimodal blocks.
@@ -171,7 +188,8 @@ impl MessageContent {
                     ContentBlock::Text { text } => Some(text.as_str()),
                     ContentBlock::ImageUrl { .. }
                     | ContentBlock::ImageBase64 { .. }
-                    | ContentBlock::AudioBase64 { .. } => None,
+                    | ContentBlock::AudioBase64 { .. }
+                    | ContentBlock::FileBase64 { .. } => None,
                 })
                 .collect::<Vec<_>>()
                 .join("\n"),

--- a/crates/kernel/src/llm/openai.rs
+++ b/crates/kernel/src/llm/openai.rs
@@ -2040,6 +2040,14 @@ impl<'a> WireMessage<'a> {
                         ContentBlock::AudioBase64 { .. } => WireContentPart::Text {
                             text: "[audio: not transcribed]",
                         },
+                        // Documents are extracted client-side and delivered as
+                        // a sibling Text block; leak the raw-bytes variant
+                        // through as a placeholder so the prompt structure is
+                        // preserved.
+                        ContentBlock::FileBase64 { .. } => WireContentPart::Text {
+                            text: "[document: raw bytes omitted — extracted text provided \
+                                   separately]",
+                        },
                     })
                     .collect();
                 WireContent::Multimodal(parts)

--- a/crates/kernel/src/llm/types.rs
+++ b/crates/kernel/src/llm/types.rs
@@ -62,6 +62,20 @@ pub enum ContentBlock {
         media_type: String,
         data:       String,
     },
+    /// Inline base64-encoded non-image document attachment (PDF/DOCX/XLSX/PPTX
+    /// and friends). Text is extracted client-side (pi-mono's
+    /// `extract-document` / `attachment-utils.loadAttachment`) and delivered as
+    /// a [`Text`](Self::Text) block alongside this one, so the LLM already has
+    /// the readable content. This variant preserves the raw bytes for future
+    /// paths that hand the file directly to a multimodal model; the current
+    /// OpenAI-compatible serializer renders it as a `[document: …]`
+    /// placeholder.
+    FileBase64 {
+        media_type: String,
+        data:       String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        filename:   Option<String>,
+    },
 }
 
 /// Message content — either plain text or multimodal blocks.
@@ -231,6 +245,7 @@ impl Message {
                         ContentBlock::ImageUrl { .. }
                             | ContentBlock::ImageBase64 { .. }
                             | ContentBlock::AudioBase64 { .. }
+                            | ContentBlock::FileBase64 { .. }
                     )
                 });
                 if !has_non_text {
@@ -244,6 +259,7 @@ impl Message {
                             "[image: current model does not support vision]"
                         }
                         ContentBlock::AudioBase64 { .. } => "[audio]",
+                        ContentBlock::FileBase64 { .. } => "[document]",
                     })
                     .collect();
                 MessageContent::Text(text_parts.join("\n"))
@@ -271,6 +287,9 @@ impl Message {
                     // Audio blocks are transcribed before reaching the LLM;
                     // estimate a small placeholder size.
                     ContentBlock::AudioBase64 { .. } => 100,
+                    // Extracted text is delivered in a sibling Text block, so
+                    // the raw-bytes variant only contributes a placeholder.
+                    ContentBlock::FileBase64 { .. } => 100,
                 })
                 .sum(),
         };

--- a/web/src/adapters/rara-stream.ts
+++ b/web/src/adapters/rara-stream.ts
@@ -29,6 +29,7 @@ import type {
 } from "@mariozechner/pi-ai";
 import { createAssistantMessageEventStream } from "@mariozechner/pi-ai";
 import type { AssistantMessageEventStream } from "@mariozechner/pi-ai";
+import type { Attachment } from "@mariozechner/pi-web-ui";
 
 import { BASE_URL } from "@/api/client";
 
@@ -74,6 +75,15 @@ type WebEvent =
 
 /** Callback that returns the current session key for WebSocket connections. */
 export type SessionKeyFn = () => string | undefined;
+
+/**
+ * Callback that returns raw attachments associated with the pending user
+ * turn. Documents (PDF/DOCX/XLSX/PPTX) are serialized as `file_base64`
+ * blocks so the backend can forward the raw bytes to tools / multimodal
+ * models while still receiving the client-side extracted text via the
+ * pi-mono attachment pipeline.
+ */
+export type PendingAttachmentsFn = () => Attachment[] | undefined;
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -131,20 +141,56 @@ export function buildWsUrl(sessionKey: string): string {
 }
 
 /**
- * Extract the latest user message content from a pi-ai Context.
- * Returns a plain string for text-only messages, or a JSON string
- * matching the backend InboundPayload format when images are present.
+ * Wire-format block sent to the backend `InboundPayload.content` field.
+ * Mirrors rara's `ChatContentBlock` (crates/kernel/src/channel/types.rs).
  */
-function extractUserPayload(context: Context): string {
+type RaraBlock =
+  | { type: "text"; text: string }
+  | { type: "image_base64"; media_type: string; data: string }
+  | {
+      type: "file_base64";
+      media_type: string;
+      data: string;
+      filename?: string;
+    };
+
+/**
+ * Extract the latest user message content from a pi-ai Context and
+ * augment it with non-image document attachments as `file_base64` blocks.
+ *
+ * Returns a plain string for text-only messages with no attachments, or a
+ * JSON string matching the backend `InboundPayload` when images or raw
+ * document bytes need to be forwarded.
+ */
+function extractUserPayload(
+  context: Context,
+  attachments: Attachment[],
+): string {
   for (let i = context.messages.length - 1; i >= 0; i--) {
     const msg = context.messages[i];
     if (msg.role === "user") {
-      if (typeof msg.content === "string") return msg.content;
+      const hasImages =
+        typeof msg.content !== "string" &&
+        msg.content.some((c) => c.type === "image");
+      const documentAttachments = attachments.filter(
+        (a) => a.type === "document",
+      );
 
-      // Check if there are any image blocks
-      const hasImages = msg.content.some((c) => c.type === "image");
+      if (typeof msg.content === "string") {
+        if (documentAttachments.length === 0) return msg.content;
+        const blocks: RaraBlock[] = [{ type: "text", text: msg.content }];
+        for (const doc of documentAttachments) {
+          blocks.push({
+            type: "file_base64",
+            media_type: doc.mimeType,
+            data: doc.content,
+            filename: doc.fileName,
+          });
+        }
+        return JSON.stringify({ content: blocks });
+      }
 
-      if (!hasImages) {
+      if (!hasImages && documentAttachments.length === 0) {
         // Text-only — return plain string (backend parses as plain text)
         return msg.content
           .filter((c): c is TextContent => c.type === "text")
@@ -155,9 +201,6 @@ function extractUserPayload(context: Context): string {
       // Multimodal — build JSON payload matching backend InboundPayload.
       // Backend's parse_inbound_text_frame() tries JSON first, so this
       // will be deserialized as InboundPayload { content: MessageContent }.
-      type RaraBlock =
-        | { type: "text"; text: string }
-        | { type: "image_base64"; media_type: string; data: string };
       const blocks: RaraBlock[] = msg.content.flatMap((c): RaraBlock[] => {
         if (c.type === "text") {
           return [{ type: "text", text: c.text }];
@@ -171,6 +214,14 @@ function extractUserPayload(context: Context): string {
         }
         return [];
       });
+      for (const doc of documentAttachments) {
+        blocks.push({
+          type: "file_base64",
+          media_type: doc.mimeType,
+          data: doc.content,
+          filename: doc.fileName,
+        });
+      }
       return JSON.stringify({ content: blocks });
     }
   }
@@ -184,9 +235,16 @@ function extractUserPayload(context: Context): string {
 /**
  * Create a StreamFn that bridges rara's WebSocket chat API to pi-ai events.
  * The `getSessionKey` callback is invoked at stream time to obtain the
- * current session key for the WebSocket connection.
+ * current session key for the WebSocket connection. The optional
+ * `getPendingAttachments` callback surfaces raw attachments (in particular
+ * document base64 bytes) so they can be forwarded to the backend as
+ * `file_base64` blocks alongside the text-extracted content that pi-mono
+ * already inserts into the pi-ai Context.
  */
-export function createRaraStreamFn(getSessionKey: SessionKeyFn): StreamFn {
+export function createRaraStreamFn(
+  getSessionKey: SessionKeyFn,
+  getPendingAttachments?: PendingAttachmentsFn,
+): StreamFn {
   return (
     model: Model<any>,
     context: Context,
@@ -206,7 +264,10 @@ export function createRaraStreamFn(getSessionKey: SessionKeyFn): StreamFn {
       return stream;
     }
 
-    const userPayload = extractUserPayload(context);
+    const userPayload = extractUserPayload(
+      context,
+      getPendingAttachments?.() ?? [],
+    );
     const wsUrl = buildWsUrl(sessionKey);
 
     // Accumulated content blocks for building partial messages

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -88,7 +88,13 @@ export type ChatContentBlock =
   | { type: "text"; text: string }
   | { type: "image_url"; url: string }
   | { type: "image_base64"; media_type: string; data: string }
-  | { type: "audio_base64"; media_type: string; data: string };
+  | { type: "audio_base64"; media_type: string; data: string }
+  | {
+      type: "file_base64";
+      media_type: string;
+      data: string;
+      filename?: string;
+    };
 
 export interface SendMessageResponse {
   message: ChatMessageData;

--- a/web/src/pages/PiChat.tsx
+++ b/web/src/pages/PiChat.tsx
@@ -28,6 +28,16 @@ import {
 } from "@mariozechner/pi-web-ui";
 import { Agent } from "@mariozechner/pi-agent-core";
 import type { AgentMessage } from "@mariozechner/pi-agent-core";
+// Importing the extract-document tool from pi-web-ui triggers the
+// module-level `registerToolRenderer("extract_document", ...)` side
+// effect so pi-mono can render server-triggered document-extraction tool
+// calls in chat.
+import { extractDocumentTool } from "@mariozechner/pi-web-ui";
+
+// Reference the tool so Vite's tree-shaker keeps the module (and its
+// `registerToolRenderer` side effect) in the bundle. The actual tool
+// object is executed server-side; the renderer is what matters here.
+void extractDocumentTool;
 import type {
   UserMessage,
   AssistantMessage,
@@ -489,7 +499,23 @@ export default function PiChat() {
       // 5. Create the Agent with rara's WebSocket-backed stream function.
       //    The streamFn reads agent.sessionId at call time to get the active session key.
       const agent: Agent = new Agent({
-        streamFn: createRaraStreamFn(() => agent.sessionId),
+        streamFn: createRaraStreamFn(
+          () => agent.sessionId,
+          () => {
+            // Surface raw attachments from the latest user turn so the
+            // rara-stream adapter can forward document bytes as
+            // `file_base64` blocks in addition to pi-mono's client-side
+            // extracted text.
+            for (let i = agent.state.messages.length - 1; i >= 0; i--) {
+              const m = agent.state.messages[i];
+              if (m.role === "user-with-attachments") {
+                return (m as UserMessageWithAttachments).attachments;
+              }
+              if (m.role === "user") return [];
+            }
+            return [];
+          },
+        ),
         convertToLlm: defaultConvertToLlm,
         sessionId: initialSession.key,
       });


### PR DESCRIPTION
## Summary

Phase E of the pi-mono web UI alignment epic (#1518). pi-mono's
`MessageEditor` already wires drag-drop, clipboard paste, and
PDF/DOCX/XLSX/PPTX attachments natively — this change makes the rara
shell carry those inputs end-to-end.

- Extend `ChatContentBlock` (channel + llm) with a `FileBase64` variant
  carrying `media_type` + `data` + optional `filename`. The OpenAI wire
  serializer emits a `[document: …]` placeholder since the
  client-side-extracted text is already delivered in a sibling `Text`
  block; the raw-bytes variant is preserved for future multimodal paths.
- `parse_inbound_text_frame` accepts the new block via the existing
  serde pipeline; regression test covers the new shape.
- Mirror the block type in `web/src/api/types.ts`, and forward document
  attachments as `file_base64` from `extractUserPayload` via a new
  `PendingAttachmentsFn` callback on `createRaraStreamFn`. PiChat reads
  the latest `user-with-attachments` message on demand.
- Import `extractDocumentTool` in PiChat so pi-mono's `extract_document`
  renderer auto-registers on mount.
- Verified that PiChat's corner Sessions/Voice buttons do not overlap
  the editor's drop target and the loading overlay is
  `pointer-events-none`, so drag-drop / paste reach the MessageEditor
  unobstructed. Enforces pi-mono's 20MB per-attachment default.

Part of #1518. Closes #1524.

## Type of change

| Type | Label |
|------|-------|
| New feature | `enhancement` |

## Component

`ui`

## Closes

Closes #1524

## Test plan

- [x] `prek run --all-files` passes (cargo check / fmt / clippy / doc)
- [x] `cargo test -p rara-channels parses_document_attachment_frame` passes
- [x] `cd web && npm run build` succeeds
- [ ] Manual: drop a PDF on the chat panel and confirm the backend
  receives a `file_base64` block alongside the extracted text
- [ ] Manual: paste an image from the clipboard and confirm it still
  uploads as an `image_base64` block