### PR TITLE
fix(channels): identity gate compares kernel UserId, not platform id (#1533)

### DIFF
--- a/crates/app/src/tools/ask_user.rs
+++ b/crates/app/src/tools/ask_user.rs
@@ -94,8 +94,11 @@ impl ToolExecute for AskUserTool {
         // pending question to the specific user who triggered the turn —
         // other members of a shared chat must not be able to answer on
         // their behalf. Adapters resolve the incoming reply/callback
-        // sender to a `UserId` via `IdentityResolver` and compare.
-        let expected_user_id = Some(rara_kernel::identity::UserId(context.user_id.clone()));
+        // sender to a `UserId` via `IdentityResolver` and compare. `None`
+        // for synthetic/background turns (scheduled jobs, Mita, spawn
+        // re-entry) so the prompt can be answered via chat-level auth
+        // when no real human originated the turn.
+        let expected_user_id = context.origin_user_id.clone();
         // Either the caller explicitly marked the prompt sensitive, or the
         // question text matches common secret-request patterns. Heuristic
         // detection is a defense-in-depth safety net, not a substitute for

--- a/crates/app/src/tools/ask_user.rs
+++ b/crates/app/src/tools/ask_user.rs
@@ -90,11 +90,12 @@ impl ToolExecute for AskUserTool {
         // question back to the same conversation surface (e.g. a Telegram
         // forum topic) instead of a default fallback like `primary_chat_id`.
         let endpoint = context.origin_endpoint.clone();
-        // Propagate the platform-native user identifier so channel adapters
-        // can bind the pending question to the specific user who triggered
-        // the turn — other members of a shared chat must not be able to
-        // answer on their behalf.
-        let expected_platform_user_id = context.origin_platform_user_id.clone();
+        // Propagate the kernel `UserId` so channel adapters can bind the
+        // pending question to the specific user who triggered the turn —
+        // other members of a shared chat must not be able to answer on
+        // their behalf. Adapters resolve the incoming reply/callback
+        // sender to a `UserId` via `IdentityResolver` and compare.
+        let expected_user_id = Some(rara_kernel::identity::UserId(context.user_id.clone()));
         // Either the caller explicitly marked the prompt sensitive, or the
         // question text matches common secret-request patterns. Heuristic
         // detection is a defense-in-depth safety net, not a substitute for
@@ -105,7 +106,7 @@ impl ToolExecute for AskUserTool {
             .ask(
                 params.question,
                 endpoint,
-                expected_platform_user_id,
+                expected_user_id,
                 sensitive,
                 params.options,
                 timeout,

--- a/crates/channels/src/telegram/adapter.rs
+++ b/crates/channels/src/telegram/adapter.rs
@@ -58,28 +58,32 @@ static GUARD_EXPIRY_HANDLES: LazyLock<DashMap<Uuid, AbortHandle>> = LazyLock::ne
 /// Inserted by [`approval_listener`] after the inline-keyboard prompt has
 /// been rendered, removed by [`handle_guard_callback`] (on resolve) or by
 /// the per-request expiry task spawned alongside the prompt. When
-/// `expected_platform_user_id` is set, [`handle_guard_callback`] rejects
-/// approve/deny presses from any other user — strictly narrower than the
+/// `expected_user_id` is set, [`handle_guard_callback`] resolves the
+/// incoming presser via `IdentityResolver` and rejects approve/deny presses
+/// from anyone whose kernel `UserId` differs — strictly narrower than the
 /// chat-level `allowed_user_ids` gate so the original asker (and only them)
-/// can resolve a guard prompt that was raised inside a shared chat.
+/// can resolve a guard prompt that was raised inside a shared chat. Using
+/// `UserId` here also allows cross-channel routing: a web-originated
+/// approval rendered in Telegram resolves correctly when the same kernel
+/// user presses the button.
 // `_id` postfix on `request_id`/`prompt_chat_id`/`prompt_msg_id` is the
 // established naming for kernel/Telegram identifiers across the adapter
 // (see `PendingUserQuestion`); renaming would obscure the meaning.
 #[allow(clippy::struct_field_names)]
 struct PendingGuardApproval {
-    request_id:                Uuid,
-    /// Telegram `from.id` (as a string) of the user who triggered the turn
-    /// that produced this approval request. `None` when the originating
-    /// turn carries no platform identity (synthetic re-entry, background
-    /// jobs, syscall path); in that case identity-gate enforcement is
-    /// skipped and only the chat-level gate applies.
-    expected_platform_user_id: Option<String>,
+    request_id:       Uuid,
+    /// Kernel `UserId` of the user who triggered the turn that produced
+    /// this approval request. `None` when the originating turn carries no
+    /// platform identity (synthetic re-entry, background jobs, syscall
+    /// path); in that case identity-gate enforcement is skipped and only
+    /// the chat-level gate applies.
+    expected_user_id: Option<rara_kernel::identity::UserId>,
     /// Chat where the approval prompt was rendered. Kept for the expiry
     /// task and for parity with [`PendingUserQuestion::prompt_location`].
-    prompt_chat_id:            i64,
+    prompt_chat_id:   i64,
     /// Telegram message id of the rendered prompt — combined with
     /// `prompt_chat_id` to form a stable address for the expiry task.
-    prompt_msg_id:             MessageId,
+    prompt_msg_id:    MessageId,
 }
 
 /// Pending guard-approval index keyed by the kernel-generated approval
@@ -90,20 +94,21 @@ static PENDING_GUARD_APPROVALS: LazyLock<DashMap<Uuid, PendingGuardApproval>> =
 
 /// Pending user-question entry stored in [`PENDING_USER_QUESTIONS`].
 struct PendingUserQuestion {
-    question_id:               Uuid,
-    question_text:             String,
-    manager:                   UserQuestionManagerRef,
-    /// Platform-native id of the user who asked — incoming answers are
-    /// rejected unless `msg.from.id`/`callback.from.id` matches this value.
-    /// `None` when the origin had no platform identity (web/cli).
-    expected_platform_user_id: Option<String>,
+    question_id:      Uuid,
+    question_text:    String,
+    manager:          UserQuestionManagerRef,
+    /// Kernel `UserId` of the user who asked — incoming answers are
+    /// rejected unless the resolved `UserId` of the reply/callback sender
+    /// matches this value. `None` when the origin had no platform
+    /// identity (web/cli).
+    expected_user_id: Option<rara_kernel::identity::UserId>,
     /// Pre-defined answer options. When `Some`, the prompt was rendered as
     /// an inline keyboard; callback resolution maps the pressed index into
     /// this list.
-    options:                   Option<Vec<String>>,
+    options:          Option<Vec<String>>,
     /// The `(chat_id, prompt_message_id)` where the prompt was rendered.
     /// Kept so the timeout cleanup task can remove both index entries.
-    prompt_location:           (i64, i32),
+    prompt_location:  (i64, i32),
 }
 
 /// Primary pending-question index keyed by the kernel-generated question
@@ -1965,21 +1970,31 @@ async fn handle_guard_callback(
     // pre-existing behavior for syscall-driven approvals and synthetic
     // re-entries that have no platform user identity).
     let caller_pid = callback.from.id.0.to_string();
-    if let Some(entry) = PENDING_GUARD_APPROVALS.get(&request_id) {
-        if let Some(expected) = entry.expected_platform_user_id.as_deref() {
-            if expected != caller_pid {
-                warn!(
-                    request_id = %request_id,
-                    caller_pid,
-                    "guard callback: identity gate rejected non-asker"
-                );
-                let _ = bot
-                    .answer_callback_query(callback.id.clone())
-                    .text("⚠️ Only the originator can approve this prompt")
-                    .show_alert(true)
-                    .await;
-                return;
-            }
+    let expected_user_id = PENDING_GUARD_APPROVALS
+        .get(&request_id)
+        .and_then(|entry| entry.expected_user_id.clone());
+    if let Some(expected) = expected_user_id.as_ref() {
+        let resolved = handle
+            .io()
+            .identity_resolver()
+            .resolve(ChannelType::Telegram, &caller_pid, None)
+            .await
+            .ok();
+        let matches = resolved.as_ref() == Some(expected);
+        if !matches {
+            warn!(
+                request_id = %request_id,
+                caller_pid,
+                expected = %expected.0,
+                resolved = ?resolved,
+                "guard callback: identity gate rejected non-asker"
+            );
+            let _ = bot
+                .answer_callback_query(callback.id.clone())
+                .text("⚠️ Only the originator can approve this prompt")
+                .show_alert(true)
+                .await;
+            return;
         }
     }
 
@@ -2665,12 +2680,10 @@ async fn approval_listener(
                         PENDING_GUARD_APPROVALS.insert(
                             req.id,
                             PendingGuardApproval {
-                                request_id:                req.id,
-                                expected_platform_user_id: req
-                                    .origin_platform_user_id
-                                    .clone(),
-                                prompt_chat_id:            chat_id,
-                                prompt_msg_id:             sent_msg.id,
+                                request_id:       req.id,
+                                expected_user_id: req.origin_user_id.clone(),
+                                prompt_chat_id:   chat_id,
+                                prompt_msg_id:    sent_msg.id,
                             },
                         );
 
@@ -2875,7 +2888,7 @@ async fn dispatch_user_question(
             question_id: question.id,
             question_text: question.question.clone(),
             manager: Arc::clone(mgr),
-            expected_platform_user_id: question.expected_platform_user_id.clone(),
+            expected_user_id: question.expected_user_id.clone(),
             options: question.options.clone(),
             prompt_location,
         },
@@ -2908,10 +2921,12 @@ async fn dispatch_user_question(
 /// Handle `au:<question_id>:<option_index>` inline-keyboard callbacks
 /// emitted by [`dispatch_user_question`] when a question has options.
 ///
-/// Validates `callback.from.id` against the pending question's expected
-/// platform user id and rejects mismatches, preventing other group members
-/// from pressing answer buttons on behalf of the original asker.
+/// Resolves the incoming presser's kernel `UserId` via `IdentityResolver`
+/// and compares it against the pending question's `expected_user_id`,
+/// rejecting mismatches so other group members cannot press answer buttons
+/// on behalf of the original asker.
 async fn handle_ask_user_callback(
+    handle: &KernelHandle,
     bot: &teloxide::Bot,
     callback: &teloxide::types::CallbackQuery,
     data: &str,
@@ -2946,9 +2961,11 @@ async fn handle_ask_user_callback(
     // Identity check against the asker recorded at dispatch time. We use
     // `callback.from.id` which Telegram guarantees to be the user who
     // pressed the button (platform-level attestation — cannot be spoofed
-    // by another group member).
+    // by another group member), then resolve it to a kernel `UserId` so
+    // cross-channel asks (e.g. originated from web) still resolve
+    // correctly when the same kernel user answers on Telegram.
     let caller_pid = callback.from.id.0.to_string();
-    {
+    let expected_user_id = {
         let Some(entry) = PENDING_USER_QUESTIONS.get(&qid) else {
             let _ = bot
                 .answer_callback_query(callback.id.clone())
@@ -2956,15 +2973,29 @@ async fn handle_ask_user_callback(
                 .await;
             return;
         };
-        if let Some(ref expected) = entry.expected_platform_user_id {
-            if expected != &caller_pid {
-                let _ = bot
-                    .answer_callback_query(callback.id.clone())
-                    .text("Only the original asker can answer this question.")
-                    .show_alert(true)
-                    .await;
-                return;
-            }
+        entry.expected_user_id.clone()
+    };
+    if let Some(expected) = expected_user_id.as_ref() {
+        let resolved = handle
+            .io()
+            .identity_resolver()
+            .resolve(ChannelType::Telegram, &caller_pid, None)
+            .await
+            .ok();
+        if resolved.as_ref() != Some(expected) {
+            warn!(
+                question_id = %qid,
+                caller_pid,
+                expected = %expected.0,
+                resolved = ?resolved,
+                "ask-user callback: identity gate rejected non-asker"
+            );
+            let _ = bot
+                .answer_callback_query(callback.id.clone())
+                .text("Only the original asker can answer this question.")
+                .show_alert(true)
+                .await;
+            return;
         }
     }
 
@@ -3067,12 +3098,12 @@ async fn handle_update(
                 return;
             }
             // au: (ask-user option press) enforces per-question identity
-            // (expected_platform_user_id) on its own, which is strictly
-            // narrower than the shared chat-level auth below. Route it
-            // before the chat gate so a legitimate asker in a shared but
-            // unlisted chat can still answer their own prompt.
+            // (expected_user_id) on its own, which is strictly narrower
+            // than the shared chat-level auth below. Route it before the
+            // chat gate so a legitimate asker in a shared but unlisted
+            // chat can still answer their own prompt.
             if data.starts_with("au:") {
-                handle_ask_user_callback(bot, callback, data).await;
+                handle_ask_user_callback(handle, bot, callback, data).await;
                 return;
             }
 
@@ -3253,14 +3284,31 @@ async fn handle_update(
                 return;
             };
 
-            // Identity gate: only the asker may answer. Other members of a
-            // shared group/topic see the prompt but must not be able to
-            // unblock the agent by replying with, say, a fabricated API
-            // key. Re-insert the pending state on rejection so the real
-            // asker can still answer later.
-            let actual_pid = msg.from.as_ref().map(|u| u.id.0.to_string());
-            if let Some(ref expected) = pending.expected_platform_user_id {
-                if actual_pid.as_deref() != Some(expected.as_str()) {
+            // Identity gate: only the asker may answer. Resolve the
+            // Telegram sender to a kernel `UserId` (so web-originated
+            // questions still match when the same kernel user replies on
+            // Telegram) and reject mismatches. Re-insert the pending
+            // state on rejection so the real asker can still answer
+            // later.
+            if let Some(ref expected) = pending.expected_user_id {
+                let actual_pid = msg.from.as_ref().map(|u| u.id.0.to_string());
+                let resolved = match actual_pid.as_deref() {
+                    Some(pid) => handle
+                        .io()
+                        .identity_resolver()
+                        .resolve(ChannelType::Telegram, pid, None)
+                        .await
+                        .ok(),
+                    None => None,
+                };
+                if resolved.as_ref() != Some(expected) {
+                    warn!(
+                        question_id = %qid,
+                        actual_pid = ?actual_pid,
+                        expected = %expected.0,
+                        resolved = ?resolved,
+                        "ask-user reply: identity gate rejected non-asker"
+                    );
                     PENDING_USER_QUESTIONS.insert(qid, pending);
                     PROMPT_MSG_TO_QID.insert(lookup_key, qid);
                     let _ = bot

--- a/crates/kernel/src/agent/mod.rs
+++ b/crates/kernel/src/agent/mod.rs
@@ -2305,7 +2305,9 @@ pub(crate) async fn run_agent_loop(
                             timeout_secs:            120,
                             context:                 None,
                             origin_endpoint:         tc.origin_endpoint.clone(),
-                            origin_platform_user_id: tc.origin_platform_user_id.clone(),
+                            origin_user_id:          Some(crate::identity::UserId(
+                                tc.user_id.clone(),
+                            )),
                         };
 
                         let decision = approval_manager.request_approval(approval_req).await;

--- a/crates/kernel/src/agent/mod.rs
+++ b/crates/kernel/src/agent/mod.rs
@@ -2305,9 +2305,7 @@ pub(crate) async fn run_agent_loop(
                             timeout_secs:            120,
                             context:                 None,
                             origin_endpoint:         tc.origin_endpoint.clone(),
-                            origin_user_id:          Some(crate::identity::UserId(
-                                tc.user_id.clone(),
-                            )),
+                            origin_user_id:          tc.origin_user_id.clone(),
                         };
 
                         let decision = approval_manager.request_approval(approval_req).await;

--- a/crates/kernel/src/io.rs
+++ b/crates/kernel/src/io.rs
@@ -1797,6 +1797,9 @@ impl IOSubsystem {
     /// Access the endpoint registry.
     pub fn endpoint_registry(&self) -> &EndpointRegistryRef { &self.endpoint_registry }
 
+    /// Access the identity resolver (platform id → kernel `UserId`).
+    pub fn identity_resolver(&self) -> &IdentityResolverRef { &self.identity_resolver }
+
     /// Deliver a single outbound envelope to all resolved targets.
     #[tracing::instrument(
         skip(self, envelope),

--- a/crates/kernel/src/kernel.rs
+++ b/crates/kernel/src/kernel.rs
@@ -2522,10 +2522,22 @@ impl Kernel {
                 // LLM calls interspersed with tool executions (bash, file I/O,
                 // etc.). The ToolContext carries the authenticated user_id so
                 // tools can access it without relying on LLM-supplied identity.
+                // Suppress `origin_user_id` for `ChannelType::Internal`
+                // synthetic re-entry (e.g. `handle_spawn_agent`, scheduled
+                // jobs, Mita bootstraps): those turns have no identifiable
+                // human originator, so forwarding a kernel `UserId` here
+                // would make the Telegram identity gate reject every
+                // Approve/Answer press (#1533 follow-up). Falling through
+                // to `None` lets chat-level auth resolve these prompts.
+                let origin_user_id = match msg.source.channel_type {
+                    crate::channel::types::ChannelType::Internal => None,
+                    _ => Some(user.clone()),
+                };
                 let tool_context = crate::tool::ToolContext {
                     user_id: user.0.clone(),
                     session_key: session_key.clone(),
                     origin_endpoint: origin_endpoint.clone(),
+                    origin_user_id,
                     event_queue: event_queue.clone(),
                     rara_message_id: msg_id.clone(),
                     context_window_tokens: 0,

--- a/crates/kernel/src/kernel.rs
+++ b/crates/kernel/src/kernel.rs
@@ -2526,23 +2526,6 @@ impl Kernel {
                     user_id: user.0.clone(),
                     session_key: session_key.clone(),
                     origin_endpoint: origin_endpoint.clone(),
-                    // Carry the platform-native user id (e.g. Telegram
-                    // `msg.from.id`) so interactive tools can bind pending
-                    // prompts to the actual responder in shared chats.
-                    //
-                    // Suppress for `ChannelType::Internal` synthetic
-                    // re-entry (e.g. `handle_spawn_agent` bootstrap
-                    // turns), where `platform_user_id` carries the
-                    // kernel `UserId.0` instead of a real platform id.
-                    // Surfacing that string would make the Telegram
-                    // identity gate compare `callback.from.id` against
-                    // a kernel username, locking out the real
-                    // originator on a session's first guarded turn
-                    // (Codex review of #1467).
-                    origin_platform_user_id: match msg.source.channel_type {
-                        crate::channel::types::ChannelType::Internal => None,
-                        _ => Some(msg.source.platform_user_id.clone()),
-                    },
                     event_queue: event_queue.clone(),
                     rara_message_id: msg_id.clone(),
                     context_window_tokens: 0,

--- a/crates/kernel/src/security.rs
+++ b/crates/kernel/src/security.rs
@@ -60,16 +60,16 @@ pub enum ApprovalDecision {
 /// An approval request submitted by an agent before executing a tool.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ApprovalRequest {
-    pub id: Uuid,
-    pub session_key: SessionKey,
-    pub tool_name: String,
-    pub tool_args: serde_json::Value,
-    pub summary: String,
-    pub risk_level: RiskLevel,
-    pub requested_at: Timestamp,
-    pub timeout_secs: u64,
+    pub id:              Uuid,
+    pub session_key:     SessionKey,
+    pub tool_name:       String,
+    pub tool_args:       serde_json::Value,
+    pub summary:         String,
+    pub risk_level:      RiskLevel,
+    pub requested_at:    Timestamp,
+    pub timeout_secs:    u64,
     /// Optional context explaining why the agent wants to call this tool.
-    pub context: Option<String>,
+    pub context:         Option<String>,
     /// Originating endpoint of the agent turn that raised this approval
     /// request.
     ///
@@ -82,16 +82,17 @@ pub struct ApprovalRequest {
     /// `primary_chat_id`.
     #[serde(default)]
     pub origin_endpoint: Option<crate::io::Endpoint>,
-    /// Platform-native user identifier of the user who triggered the turn
-    /// that raised this approval request (e.g. Telegram `msg.from.id` as a
-    /// string).
+    /// Kernel `UserId` of the originator of the turn that raised this
+    /// approval request.
     ///
-    /// Channel adapters MUST compare incoming approve/deny presses against
-    /// this value when set, so other members of a shared chat cannot
-    /// resolve a guard prompt meant for the original asker. `None` when the
-    /// origin has no platform-level identity (CLI, background jobs).
+    /// Adapters resolve incoming approve/deny presses to a `UserId` (via
+    /// `IdentityResolver`) and compare against this value, so cross-channel
+    /// routing still works: a web-originated turn whose approval is sent to
+    /// Telegram can only be resolved by the same kernel user pressing the
+    /// Telegram button. `None` when the origin has no platform-level
+    /// identity (CLI, background jobs).
     #[serde(default)]
-    pub origin_platform_user_id: Option<String>,
+    pub origin_user_id:  Option<UserId>,
 }
 
 /// Response after an approval request is resolved.

--- a/crates/kernel/src/syscall.rs
+++ b/crates/kernel/src/syscall.rs
@@ -289,11 +289,11 @@ impl SyscallDispatcher {
                     context: None,
                     origin_endpoint,
                     // Syscall-driven approval requests are not bound to a
-                    // single platform user — `KernelHandle::request_approval`
-                    // does not carry the inbound message identity. Setting
+                    // single user — `KernelHandle::request_approval` does
+                    // not carry the inbound message identity. Setting
                     // `None` falls back to chat-level authorization, which
                     // is the pre-existing behavior.
-                    origin_platform_user_id: None,
+                    origin_user_id: None,
                 };
 
                 // Spawn a task so the event loop is not blocked while waiting

--- a/crates/kernel/src/tool/mod.rs
+++ b/crates/kernel/src/tool/mod.rs
@@ -341,6 +341,18 @@ pub struct ToolContext {
     pub session_key:           crate::session::SessionKey,
     /// The originating endpoint (e.g. Telegram chat) for routing replies.
     pub origin_endpoint:       Option<crate::io::Endpoint>,
+    /// Kernel `UserId` of the user who triggered this turn, when the origin
+    /// is a real platform message. `None` for synthetic/background origins
+    /// (scheduled jobs, Mita/system bootstraps, `handle_spawn_agent`
+    /// re-entry), where no identifiable human triggered the turn.
+    ///
+    /// Tools that raise interactive prompts (`ask-user`, guard approval)
+    /// propagate this into `UserQuestion::expected_user_id` /
+    /// `ApprovalRequest::origin_user_id` so channel adapters can gate
+    /// responses to the originating user. `None` intentionally skips the
+    /// identity gate so fallback chat-level auth still lets the prompt be
+    /// answered (scheduled tasks etc. have no platform identity to bind).
+    pub origin_user_id:        Option<crate::identity::UserId>,
     /// Event queue for pushing outbound events.
     pub event_queue:           crate::queue::ShardedQueueRef,
     /// The inbound message ID that triggered the current turn.
@@ -364,6 +376,7 @@ impl std::fmt::Debug for ToolContext {
             .field("user_id", &self.user_id)
             .field("session_key", &self.session_key)
             .field("origin_endpoint", &self.origin_endpoint)
+            .field("origin_user_id", &self.origin_user_id)
             .field("event_queue", &"...")
             .field("rara_message_id", &self.rara_message_id)
             .field("context_window_tokens", &self.context_window_tokens)

--- a/crates/kernel/src/tool/mod.rs
+++ b/crates/kernel/src/tool/mod.rs
@@ -336,35 +336,26 @@ pub type ToolRegistryRef = Arc<ToolRegistry>;
 #[derive(Clone)]
 pub struct ToolContext {
     /// The authenticated user identifier for the current session.
-    pub user_id:                 String,
+    pub user_id:               String,
     /// The session key for the current conversation turn.
-    pub session_key:             crate::session::SessionKey,
+    pub session_key:           crate::session::SessionKey,
     /// The originating endpoint (e.g. Telegram chat) for routing replies.
-    pub origin_endpoint:         Option<crate::io::Endpoint>,
-    /// Platform-native user identifier of the user who triggered this turn
-    /// (e.g. the Telegram `msg.from.id` as a string).
-    ///
-    /// Tools that raise interactive prompts (`ask-user`) use this to bind
-    /// pending requests to the expected responder, so that other members of a
-    /// shared group chat cannot resolve a question meant for one specific
-    /// user. `None` for origins that have no platform-level identity (CLI,
-    /// background jobs, synthetic re-entry).
-    pub origin_platform_user_id: Option<String>,
+    pub origin_endpoint:       Option<crate::io::Endpoint>,
     /// Event queue for pushing outbound events.
-    pub event_queue:             crate::queue::ShardedQueueRef,
+    pub event_queue:           crate::queue::ShardedQueueRef,
     /// The inbound message ID that triggered the current turn.
-    pub rara_message_id:         crate::io::MessageId,
+    pub rara_message_id:       crate::io::MessageId,
     /// Context window size in tokens for the current model.
-    pub context_window_tokens:   usize,
+    pub context_window_tokens: usize,
     /// Live tool registry for the current session (includes dynamic MCP tools).
     /// Used by `discover-tools` to query the deferred catalog at runtime.
-    pub tool_registry:           Option<ToolRegistryRef>,
+    pub tool_registry:         Option<ToolRegistryRef>,
     /// Stream handle for emitting real-time output during execution.
     /// `None` when streaming is not available (e.g. background tasks).
-    pub stream_handle:           Option<crate::io::StreamHandle>,
+    pub stream_handle:         Option<crate::io::StreamHandle>,
     /// The tool call ID assigned by the LLM for this invocation.
     /// Used to correlate streaming output with the tool call.
-    pub tool_call_id:            Option<String>,
+    pub tool_call_id:          Option<String>,
 }
 
 impl std::fmt::Debug for ToolContext {
@@ -373,7 +364,6 @@ impl std::fmt::Debug for ToolContext {
             .field("user_id", &self.user_id)
             .field("session_key", &self.session_key)
             .field("origin_endpoint", &self.origin_endpoint)
-            .field("origin_platform_user_id", &self.origin_platform_user_id)
             .field("event_queue", &"...")
             .field("rara_message_id", &self.rara_message_id)
             .field("context_window_tokens", &self.context_window_tokens)

--- a/crates/kernel/src/tool/schedule.rs
+++ b/crates/kernel/src/tool/schedule.rs
@@ -366,16 +366,15 @@ mod tests {
 
     fn build_context() -> ToolContext {
         ToolContext {
-            user_id:                 "test-user".into(),
-            session_key:             SessionKey::new(),
-            origin_endpoint:         None,
-            origin_platform_user_id: None,
-            event_queue:             build_queue(),
-            rara_message_id:         MessageId::new(),
-            context_window_tokens:   0,
-            tool_registry:           None,
-            stream_handle:           None,
-            tool_call_id:            None,
+            user_id:               "test-user".into(),
+            session_key:           SessionKey::new(),
+            origin_endpoint:       None,
+            event_queue:           build_queue(),
+            rara_message_id:       MessageId::new(),
+            context_window_tokens: 0,
+            tool_registry:         None,
+            stream_handle:         None,
+            tool_call_id:          None,
         }
     }
 

--- a/crates/kernel/src/tool/schedule.rs
+++ b/crates/kernel/src/tool/schedule.rs
@@ -369,6 +369,7 @@ mod tests {
             user_id:               "test-user".into(),
             session_key:           SessionKey::new(),
             origin_endpoint:       None,
+            origin_user_id:        None,
             event_queue:           build_queue(),
             rara_message_id:       MessageId::new(),
             context_window_tokens: 0,

--- a/crates/kernel/src/user_question.rs
+++ b/crates/kernel/src/user_question.rs
@@ -28,29 +28,29 @@ use snafu::Snafu;
 use tracing::{info, warn};
 use uuid::Uuid;
 
-use crate::io::Endpoint;
+use crate::{identity::UserId, io::Endpoint};
 
 /// A question submitted by the agent to the user.
 #[derive(Debug, Clone, Serialize)]
 pub struct UserQuestion {
     /// Unique identifier for this question.
-    pub id: Uuid,
+    pub id:               Uuid,
     /// The question text to present to the user.
-    pub question: String,
+    pub question:         String,
     /// Whether the question is sensitive (e.g. asks for API keys, passwords,
     /// tokens).
     ///
     /// Channel adapters MUST route sensitive prompts to a private surface
     /// (e.g. Telegram DM via `primary_chat_id`) and avoid leaking the text
     /// into shared chats, even when the endpoint points at a group/topic.
-    pub sensitive: bool,
+    pub sensitive:        bool,
     /// Optional pre-defined answer choices.
     ///
     /// When `Some`, adapters SHOULD render structured controls (e.g. Telegram
     /// inline keyboard) so the user can pick without typing, and the answer
     /// returned to the agent is the exact selected option string. When
     /// `None`, adapters fall back to free-form reply-to-message input.
-    pub options: Option<Vec<String>>,
+    pub options:          Option<Vec<String>>,
     /// Originating endpoint of the agent turn that raised this question.
     ///
     /// Channel adapters route the rendered prompt back to this endpoint (e.g.
@@ -58,15 +58,15 @@ pub struct UserQuestion {
     /// `None` for origins that do not carry an endpoint (background tasks,
     /// legacy callers), in which case adapters fall back to a default
     /// destination such as Telegram's `primary_chat_id`.
-    pub endpoint: Option<Endpoint>,
-    /// Platform-native user identifier of the user who triggered this
-    /// question (e.g. Telegram `msg.from.id` as a string).
+    pub endpoint:         Option<Endpoint>,
+    /// Kernel `UserId` of the user who triggered this question.
     ///
-    /// Channel adapters MUST compare incoming answers (reply text or
-    /// callback press) against this value and reject mismatches, so that
-    /// other members of a shared chat cannot answer on behalf of the asker.
-    /// `None` when the origin has no platform-level identity.
-    pub expected_platform_user_id: Option<String>,
+    /// Channel adapters resolve the incoming reply/callback sender to a
+    /// `UserId` (via `IdentityResolver`) and compare against this value,
+    /// rejecting mismatches so other members of a shared chat cannot answer
+    /// on behalf of the asker. `None` when the origin has no platform-level
+    /// identity.
+    pub expected_user_id: Option<UserId>,
 }
 
 /// Error from user question operations.
@@ -135,10 +135,10 @@ impl UserQuestionManager {
     /// question back to the same conversation surface (e.g. a Telegram forum
     /// topic) rather than a default destination.
     ///
-    /// `expected_platform_user_id` identifies the user who triggered the
-    /// turn (typically `ToolContext::origin_platform_user_id`). Adapters
-    /// MUST validate incoming answers against it to prevent hijacking in
-    /// shared chats.
+    /// `expected_user_id` is the kernel `UserId` of the user who triggered
+    /// the turn (derived from `ToolContext::user_id`). Adapters resolve
+    /// incoming answers to a `UserId` and compare, preventing hijacking in
+    /// shared chats and allowing cross-channel approvals to match.
     ///
     /// When `sensitive` is `true`, adapters MUST route the prompt to a
     /// private surface (e.g. the user's DM) rather than to `endpoint` if it
@@ -155,7 +155,7 @@ impl UserQuestionManager {
         &self,
         question: String,
         endpoint: Option<Endpoint>,
-        expected_platform_user_id: Option<String>,
+        expected_user_id: Option<UserId>,
         sensitive: bool,
         options: Option<Vec<String>>,
         timeout: std::time::Duration,
@@ -168,7 +168,7 @@ impl UserQuestionManager {
             sensitive,
             options,
             endpoint,
-            expected_platform_user_id,
+            expected_user_id,
         };
 
         let (tx, rx) = tokio::sync::oneshot::channel();


### PR DESCRIPTION
## Summary

Guard approval and ask-user identity gate previously compared platform-native user id strings. For cross-channel routing — e.g. a web-originated session whose guard prompt falls back to Telegram \`primary_chat_id\` because origin endpoint isn't Telegram — the expected id was a web identifier (e.g. \`\"web_ryan\"\`) while the Telegram callback reports a numeric Telegram user id. The gate always false-rejected the originator with \"Only the originator can approve this prompt\".

Fix: compare kernel \`UserId\` instead.

- \`ApprovalRequest.origin_user_id: Option<UserId>\` (renamed from \`origin_platform_user_id\`), filled from \`ToolContext::user_id\`.
- \`UserQuestion.expected_user_id: Option<UserId>\` (renamed similarly).
- Telegram adapter resolves incoming approve/deny/answer presses through \`IdentityResolver\` to a \`UserId\`, compares to the pending entry.
- \`IOSubsystem::identity_resolver()\` accessor added so adapters can reach the resolver via \`KernelHandle\`.
- \`ToolContext::origin_platform_user_id\` removed — it existed only to feed the identity gate.

## Type of change

| Type | Label |
|------|-------|
| Bug fix | \`bug\` |

## Component

\`backend\`

## Closes

Closes #1533

## Test plan

- [x] \`cargo check --workspace --all-targets\` passes
- [x] \`prek run --all-files\` passes (fmt + clippy + doc)
- [ ] Manual: web-originated session triggers guard, approve button from Telegram works
- [ ] Manual: Telegram-originated session approve still works (same user id path)
- [ ] Manual: Telegram group member clicking someone else's approve still rejected