### PR TITLE
feat(kernel): pause-for-limit in machine (#1537)

### DIFF
--- a/crates/kernel/src/agent/effect.rs
+++ b/crates/kernel/src/agent/effect.rs
@@ -134,6 +134,20 @@ pub enum Effect {
         /// Total tool calls the turn had accumulated when the trip fired.
         tool_calls_made: usize,
     },
+    /// Pause the turn and wait for the user to decide whether to keep
+    /// going. Emitted when the cumulative tool-call count crosses the
+    /// configured limit interval. The runner is responsible for surfacing
+    /// the pause to the user (inline buttons, CLI prompt, …), awaiting the
+    /// decision with a hard timeout, and feeding the outcome back as
+    /// [`crate::agent::machine::Event::LimitResolved`].
+    PauseForLimit {
+        /// Monotonically-increasing id identifying this specific pause.
+        /// The runner uses it as the oneshot key so a stale decision
+        /// delivered after timeout cannot resume a later pause.
+        limit_id:        u64,
+        /// Cumulative tool calls executed before the pause.
+        tool_calls_made: usize,
+    },
     /// Terminate the loop with a failure.
     Fail {
         /// Free-form failure description.
@@ -152,6 +166,16 @@ pub enum TapeAppendKind {
     ToolCalls,
     /// One or more tool results returned to the LLM.
     ToolResults,
+}
+
+/// User decision when the tool-call-limit circuit breaker pauses the turn.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LimitDecision {
+    /// User chose to continue; advance the next pause threshold.
+    Continue,
+    /// User chose to stop, decision timed out, or channel was dropped —
+    /// all three map to a graceful turn stop.
+    Stop,
 }
 
 /// Why the machine terminated.

--- a/crates/kernel/src/agent/machine.rs
+++ b/crates/kernel/src/agent/machine.rs
@@ -41,7 +41,7 @@
 
 use crate::{
     agent::{
-        effect::{Effect, FinishReason, TapeAppendKind, ToolCall, ToolResult},
+        effect::{Effect, FinishReason, LimitDecision, TapeAppendKind, ToolCall, ToolResult},
         loop_breaker::{LoopBreakerConfig, LoopIntervention, ToolCallLoopBreaker},
     },
     tool::ToolName,
@@ -56,6 +56,9 @@ pub enum Phase {
     AwaitingLlm,
     /// LLM responded with tool calls; runner is dispatching them.
     ExecutingTools,
+    /// Tool-call-limit tripped; runner is awaiting the user's continue/stop
+    /// decision before another LLM call is issued.
+    PausedForLimit,
     /// Terminal: turn finished successfully.
     Done,
     /// Terminal: turn failed.
@@ -92,6 +95,15 @@ pub struct AgentMachine {
     /// Tools the loop breaker has disabled, accumulated across the turn.
     /// Threaded into every subsequent [`Effect::CallLlm`].
     disabled_tools:       Vec<ToolName>,
+    /// Tool-call-limit circuit breaker: pause the turn every this many
+    /// cumulative tool calls and ask the user whether to continue. Zero
+    /// disables the circuit breaker entirely.
+    limit_interval:       usize,
+    /// Next `tool_calls_made` threshold at which to pause.
+    next_limit_at:        usize,
+    /// Monotonic counter for limit-pause ids, handed to the runner so it
+    /// can key its oneshot channel and reject stale decisions.
+    limit_id_counter:     u64,
 }
 
 impl AgentMachine {
@@ -110,6 +122,27 @@ impl AgentMachine {
             max_continuations: DEFAULT_MAX_CONTINUATIONS,
             loop_breaker: ToolCallLoopBreaker::new(LoopBreakerConfig::builder().build()),
             disabled_tools: Vec::new(),
+            limit_interval: 0,
+            next_limit_at: usize::MAX,
+            limit_id_counter: 0,
+        }
+    }
+
+    /// Construct a machine with a tool-call-limit circuit breaker.
+    ///
+    /// The turn will pause every `limit_interval` cumulative tool calls
+    /// and emit [`Effect::PauseForLimit`]; the runner awaits the user's
+    /// decision and feeds it back via [`Event::LimitResolved`]. A
+    /// `limit_interval` of zero disables the circuit breaker.
+    pub(crate) fn with_tool_call_limit(max_iterations: usize, limit_interval: usize) -> Self {
+        Self {
+            limit_interval,
+            next_limit_at: if limit_interval == 0 {
+                usize::MAX
+            } else {
+                limit_interval
+            },
+            ..Self::new(max_iterations)
         }
     }
 
@@ -289,36 +322,64 @@ impl AgentMachine {
                 };
 
                 self.iteration += 1;
+                let mut effects = vec![Effect::AppendTape {
+                    kind: TapeAppendKind::ToolResults,
+                }];
+                if let Some(e) = loop_breaker_effect {
+                    effects.push(e);
+                }
+
                 if self.iteration >= self.max_iterations {
                     self.phase = Phase::Done;
                     let text = std::mem::take(&mut self.last_assistant_text);
-                    let mut effects = vec![Effect::AppendTape {
-                        kind: TapeAppendKind::ToolResults,
-                    }];
-                    if let Some(e) = loop_breaker_effect {
-                        effects.push(e);
-                    }
                     effects.push(Effect::Finish {
                         text,
                         iterations: self.iteration,
                         tool_calls: self.tool_calls_made,
                         reason: FinishReason::MaxIterations,
                     });
-                    effects
+                } else if self.limit_interval > 0 && self.tool_calls_made >= self.next_limit_at {
+                    self.limit_id_counter += 1;
+                    self.phase = Phase::PausedForLimit;
+                    effects.push(Effect::PauseForLimit {
+                        limit_id:        self.limit_id_counter,
+                        tool_calls_made: self.tool_calls_made,
+                    });
                 } else {
                     self.phase = Phase::AwaitingLlm;
-                    let mut effects = vec![Effect::AppendTape {
-                        kind: TapeAppendKind::ToolResults,
-                    }];
-                    if let Some(e) = loop_breaker_effect {
-                        effects.push(e);
-                    }
                     effects.push(Effect::CallLlm {
                         iteration:      self.iteration,
                         tools_enabled:  self.tools_enabled,
                         disabled_tools: self.disabled_tools.clone(),
                     });
-                    effects
+                }
+                effects
+            }
+
+            // ── User decided whether to continue after a limit pause ─────
+            (Phase::PausedForLimit, Event::LimitResolved { limit_id, decision })
+                if limit_id == self.limit_id_counter =>
+            {
+                match decision {
+                    LimitDecision::Continue => {
+                        self.next_limit_at = self.tool_calls_made + self.limit_interval;
+                        self.phase = Phase::AwaitingLlm;
+                        vec![Effect::CallLlm {
+                            iteration:      self.iteration,
+                            tools_enabled:  self.tools_enabled,
+                            disabled_tools: self.disabled_tools.clone(),
+                        }]
+                    }
+                    LimitDecision::Stop => {
+                        self.phase = Phase::Done;
+                        let text = std::mem::take(&mut self.last_assistant_text);
+                        vec![Effect::Finish {
+                            text,
+                            iterations: self.iteration,
+                            tool_calls: self.tool_calls_made,
+                            reason: FinishReason::StoppedByLimit,
+                        }]
+                    }
                 }
             }
 
@@ -331,7 +392,10 @@ impl AgentMachine {
             }
 
             // ── Interruption from any non-terminal state ─────────────────
-            (Phase::AwaitingLlm | Phase::ExecutingTools, Event::Interrupted) => {
+            (
+                Phase::AwaitingLlm | Phase::ExecutingTools | Phase::PausedForLimit,
+                Event::Interrupted,
+            ) => {
                 self.phase = Phase::Failed;
                 vec![Effect::Fail {
                     message: "turn interrupted".to_owned(),
@@ -384,6 +448,16 @@ pub enum Event {
     },
     /// User cancelled the turn (Ctrl-C, /stop, kernel shutdown, …).
     Interrupted,
+    /// User (or the pause timeout) decided whether to continue after a
+    /// tool-call-limit pause.
+    LimitResolved {
+        /// Id of the pause the decision resolves. Stale ids are ignored
+        /// by the machine to prevent a late decision from resuming a
+        /// subsequent pause.
+        limit_id: u64,
+        /// Continue or stop.
+        decision: LimitDecision,
+    },
 }
 
 #[cfg(test)]
@@ -897,6 +971,186 @@ mod tests {
                 "disabled set should persist at iteration {i}",
             );
         }
+    }
+
+    // ─── Tool-call-limit circuit breaker ────────────────────────────────
+
+    /// With `limit_interval = 1`, the very first tool wave trips the
+    /// pause. The machine emits `PauseForLimit` and transitions to
+    /// `PausedForLimit`; feeding `Continue` back resumes the turn.
+    #[test]
+    fn pause_for_limit_fires_at_threshold_and_continue_resumes() {
+        let mut m = AgentMachine::with_tool_call_limit(8, 1);
+        let _ = m.step(Event::TurnStarted);
+        let _ = m.step(Event::LlmCompleted {
+            text:           "step".into(),
+            tool_calls:     vec![tool_call("c1", "search")],
+            has_tool_calls: true,
+        });
+        let effects = m.step(Event::ToolsCompleted {
+            results: vec![tool_result("c1", "search", "{}", true)],
+        });
+        assert_eq!(m.phase(), Phase::PausedForLimit);
+        let pause = effects
+            .iter()
+            .find_map(|e| match e {
+                Effect::PauseForLimit {
+                    limit_id,
+                    tool_calls_made,
+                } => Some((*limit_id, *tool_calls_made)),
+                _ => None,
+            })
+            .expect("expected PauseForLimit effect");
+        assert_eq!(pause, (1, 1));
+        assert!(
+            !effects.iter().any(|e| matches!(e, Effect::CallLlm { .. })),
+            "no CallLlm should be emitted while paused",
+        );
+
+        let effects = m.step(Event::LimitResolved {
+            limit_id: pause.0,
+            decision: LimitDecision::Continue,
+        });
+        assert_eq!(m.phase(), Phase::AwaitingLlm);
+        assert!(matches!(effects.as_slice(), [Effect::CallLlm { .. }]));
+    }
+
+    /// `Stop` is a graceful termination: `Finish` with `StoppedByLimit`.
+    #[test]
+    fn pause_for_limit_stop_terminates_gracefully() {
+        let mut m = AgentMachine::with_tool_call_limit(8, 1);
+        let _ = m.step(Event::TurnStarted);
+        let _ = m.step(Event::LlmCompleted {
+            text:           "step".into(),
+            tool_calls:     vec![tool_call("c1", "search")],
+            has_tool_calls: true,
+        });
+        let _ = m.step(Event::ToolsCompleted {
+            results: vec![tool_result("c1", "search", "{}", true)],
+        });
+        let effects = m.step(Event::LimitResolved {
+            limit_id: 1,
+            decision: LimitDecision::Stop,
+        });
+        assert_eq!(m.phase(), Phase::Done);
+        assert!(matches!(
+            effects.as_slice(),
+            [Effect::Finish {
+                reason: FinishReason::StoppedByLimit,
+                ..
+            }]
+        ));
+    }
+
+    /// Stale `LimitResolved` (mismatched id) must not advance the machine.
+    /// In legacy code this is prevented by the session-scoped oneshot key,
+    /// so the machine mirrors that guarantee with the id check.
+    #[test]
+    fn pause_for_limit_ignores_stale_resolution() {
+        let mut m = AgentMachine::with_tool_call_limit(8, 1);
+        let _ = m.step(Event::TurnStarted);
+        let _ = m.step(Event::LlmCompleted {
+            text:           "step".into(),
+            tool_calls:     vec![tool_call("c1", "search")],
+            has_tool_calls: true,
+        });
+        let _ = m.step(Event::ToolsCompleted {
+            results: vec![tool_result("c1", "search", "{}", true)],
+        });
+        // Feed a wrong id — falls into the invalid-transition arm.
+        let effects = m.step(Event::LimitResolved {
+            limit_id: 999,
+            decision: LimitDecision::Continue,
+        });
+        assert_eq!(m.phase(), Phase::Failed);
+        assert!(matches!(effects.as_slice(), [Effect::Fail { .. }]));
+    }
+
+    /// `limit_interval = 0` disables the circuit breaker entirely; the
+    /// machine keeps looping and never emits `PauseForLimit`.
+    #[test]
+    fn zero_interval_disables_limit() {
+        let mut m = AgentMachine::with_tool_call_limit(8, 0);
+        let _ = m.step(Event::TurnStarted);
+        for i in 0..3 {
+            let _ = m.step(Event::LlmCompleted {
+                text:           "t".into(),
+                tool_calls:     vec![tool_call(&format!("c{i}"), "t")],
+                has_tool_calls: true,
+            });
+            let effects = m.step(Event::ToolsCompleted {
+                results: vec![tool_result(&format!("c{i}"), "t", "{}", true)],
+            });
+            assert!(
+                !effects
+                    .iter()
+                    .any(|e| matches!(e, Effect::PauseForLimit { .. })),
+                "limit should stay disabled at wave {i}",
+            );
+            assert_eq!(m.phase(), Phase::AwaitingLlm);
+        }
+    }
+
+    /// Continue advances `next_limit_at` by `limit_interval`, so the next
+    /// pause only fires after another full interval of tool calls.
+    #[test]
+    fn continue_advances_next_threshold_by_interval() {
+        let mut m = AgentMachine::with_tool_call_limit(16, 2);
+        let _ = m.step(Event::TurnStarted);
+
+        // Two tool calls → crosses first threshold (2 ≥ 2) → pause.
+        let _ = m.step(Event::LlmCompleted {
+            text:           "x".into(),
+            tool_calls:     vec![tool_call("a", "t"), tool_call("b", "t")],
+            has_tool_calls: true,
+        });
+        let _ = m.step(Event::ToolsCompleted {
+            results: vec![
+                tool_result("a", "t", "{}", true),
+                tool_result("b", "t", r#"{"q":"2"}"#, true),
+            ],
+        });
+        assert_eq!(m.phase(), Phase::PausedForLimit);
+        let _ = m.step(Event::LimitResolved {
+            limit_id: 1,
+            decision: LimitDecision::Continue,
+        });
+
+        // One more tool call → at 3, below new threshold (2 + 2 = 4), no pause.
+        let _ = m.step(Event::LlmCompleted {
+            text:           "y".into(),
+            tool_calls:     vec![tool_call("c", "t")],
+            has_tool_calls: true,
+        });
+        let effects = m.step(Event::ToolsCompleted {
+            results: vec![tool_result("c", "t", r#"{"q":"3"}"#, true)],
+        });
+        assert_eq!(m.phase(), Phase::AwaitingLlm);
+        assert!(
+            !effects
+                .iter()
+                .any(|e| matches!(e, Effect::PauseForLimit { .. })),
+            "below advanced threshold should not pause",
+        );
+
+        // Another call → reaches 4 → pause again with next id.
+        let _ = m.step(Event::LlmCompleted {
+            text:           "z".into(),
+            tool_calls:     vec![tool_call("d", "t")],
+            has_tool_calls: true,
+        });
+        let effects = m.step(Event::ToolsCompleted {
+            results: vec![tool_result("d", "t", r#"{"q":"4"}"#, true)],
+        });
+        assert_eq!(m.phase(), Phase::PausedForLimit);
+        let id = effects
+            .iter()
+            .find_map(|e| match e {
+                Effect::PauseForLimit { limit_id, .. } => Some(*limit_id),
+                _ => None,
+            })
+            .expect("expected second PauseForLimit");
+        assert_eq!(id, 2, "limit id monotonically increases");
     }
 
     /// Mirrors the legacy `run_agent_loop` exemption for read-only tools:

--- a/crates/kernel/src/agent/runner.rs
+++ b/crates/kernel/src/agent/runner.rs
@@ -43,7 +43,8 @@
 //!   implemented; legacy removal pending
 //! - Context pressure warnings + session-length reminders injected as user
 //!   messages
-//! - Tool-call-limit circuit breaker with oneshot resume
+//! - Tool-call-limit circuit breaker with oneshot resume — ✓ machine-side
+//!   implemented; legacy removal pending
 //! - Repetition guard truncation
 //! - Deferred tool activation (`discover-tools`) feedback
 //! - Per-iteration tape rebuild + sanitisation
@@ -128,6 +129,20 @@ pub trait Subsystems: Send + Sync {
     /// LLM sees it on the next `call_llm`.  Used by continuation wake.
     /// Default: no-op (test stubs that don't model message history).
     async fn inject_user_message(&mut self, _text: String) {}
+
+    /// Pause the turn and await the user's continue/stop decision.
+    ///
+    /// Production implementations are expected to:
+    /// - emit the user-facing `ToolCallLimit` stream event keyed by `limit_id`;
+    /// - register a oneshot channel keyed by `(session, limit_id)`;
+    /// - `tokio::select!` over the oneshot, a hard timeout (legacy used 120s),
+    ///   and the turn cancel token;
+    /// - emit `ToolCallLimitResolved` before returning;
+    /// - map the outcome onto [`Event::LimitResolved`] (timeout / drop /
+    ///   explicit `Stop` all produce `LimitDecision::Stop`).
+    ///
+    /// Treat a cancel-token firing as [`Event::Interrupted`] instead.
+    async fn pause_for_limit(&mut self, limit_id: u64, tool_calls_made: usize) -> Event;
 }
 
 /// Drive the [`AgentMachine`] to completion against `subsys`.
@@ -168,6 +183,12 @@ pub async fn drive<S: Subsystems>(machine: &mut AgentMachine, subsys: &mut S) ->
                     subsys
                         .loop_breaker_triggered(disabled_tools, pattern, tool_calls_made)
                         .await;
+                }
+                Effect::PauseForLimit {
+                    limit_id,
+                    tool_calls_made,
+                } => {
+                    follow_up = Some(subsys.pause_for_limit(limit_id, tool_calls_made).await);
                 }
                 Effect::RunTools { calls } => {
                     follow_up = Some(subsys.run_tools(calls).await);
@@ -235,12 +256,16 @@ mod tests {
     /// Pure in-memory subsystem stub for end-to-end runner tests.
     /// Scripts the LLM responses up front so each turn is fully deterministic.
     struct ScriptedSubsys {
-        llm_script:     Vec<Event>,
-        next_llm:       usize,
-        tool_responses: Vec<Vec<Tr>>,
-        next_tool:      usize,
-        tape_log:       Vec<TapeAppendKind>,
-        stream_log:     Vec<String>,
+        llm_script:      Vec<Event>,
+        next_llm:        usize,
+        tool_responses:  Vec<Vec<Tr>>,
+        next_tool:       usize,
+        tape_log:        Vec<TapeAppendKind>,
+        stream_log:      Vec<String>,
+        /// Scripted user decisions for each `pause_for_limit` invocation,
+        /// consumed in order. Leave empty for tests that never pause.
+        limit_decisions: Vec<crate::agent::effect::LimitDecision>,
+        next_limit:      usize,
     }
 
     #[async_trait]
@@ -265,21 +290,29 @@ mod tests {
         async fn append_tape(&mut self, kind: TapeAppendKind) { self.tape_log.push(kind); }
 
         async fn emit_stream(&mut self, kind: String) { self.stream_log.push(kind); }
+
+        async fn pause_for_limit(&mut self, limit_id: u64, _tool_calls_made: usize) -> Event {
+            let decision = self.limit_decisions[self.next_limit];
+            self.next_limit += 1;
+            Event::LimitResolved { limit_id, decision }
+        }
     }
 
     #[tokio::test]
     async fn drive_terminates_on_text_only_response() {
         let mut subsys = ScriptedSubsys {
-            llm_script:     vec![Event::LlmCompleted {
+            llm_script:      vec![Event::LlmCompleted {
                 text:           "ok".into(),
                 tool_calls:     vec![],
                 has_tool_calls: false,
             }],
-            next_llm:       0,
-            tool_responses: vec![],
-            next_tool:      0,
-            tape_log:       vec![],
-            stream_log:     vec![],
+            next_llm:        0,
+            tool_responses:  vec![],
+            next_tool:       0,
+            tape_log:        vec![],
+            stream_log:      vec![],
+            limit_decisions: vec![],
+            next_limit:      0,
         };
         let mut machine = AgentMachine::new(8);
         let outcome = drive(&mut machine, &mut subsys).await;
@@ -297,7 +330,7 @@ mod tests {
             arguments: "{}".into(),
         };
         let mut subsys = ScriptedSubsys {
-            llm_script:     vec![
+            llm_script:      vec![
                 Event::LlmCompleted {
                     text:           "thinking".into(),
                     tool_calls:     vec![tc.clone()],
@@ -309,8 +342,8 @@ mod tests {
                     has_tool_calls: false,
                 },
             ],
-            next_llm:       0,
-            tool_responses: vec![vec![Tr {
+            next_llm:        0,
+            tool_responses:  vec![vec![Tr {
                 id:          ToolCallId::new("c1"),
                 name:        ToolName::new("search"),
                 arguments:   "{}".into(),
@@ -318,9 +351,11 @@ mod tests {
                 duration_ms: 5,
                 error:       None,
             }]],
-            next_tool:      0,
-            tape_log:       vec![],
-            stream_log:     vec![],
+            next_tool:       0,
+            tape_log:        vec![],
+            stream_log:      vec![],
+            limit_decisions: vec![],
+            next_limit:      0,
         };
         let mut machine = AgentMachine::new(8);
         let outcome = drive(&mut machine, &mut subsys).await;
@@ -346,7 +381,7 @@ mod tests {
             arguments: r#"{"reason":"checking services"}"#.into(),
         };
         let mut subsys = ScriptedSubsys {
-            llm_script:     vec![
+            llm_script:      vec![
                 // Iteration 0: call continue-work
                 Event::LlmCompleted {
                     text:           "checking...".into(),
@@ -366,8 +401,8 @@ mod tests {
                     has_tool_calls: false,
                 },
             ],
-            next_llm:       0,
-            tool_responses: vec![vec![Tr {
+            next_llm:        0,
+            tool_responses:  vec![vec![Tr {
                 id:          ToolCallId::new("c1"),
                 name:        ToolName::new("continue-work"),
                 arguments:   r#"{"reason":"checking services"}"#.into(),
@@ -375,9 +410,11 @@ mod tests {
                 duration_ms: 1,
                 error:       None,
             }]],
-            next_tool:      0,
-            tape_log:       vec![],
-            stream_log:     vec![],
+            next_tool:       0,
+            tape_log:        vec![],
+            stream_log:      vec![],
+            limit_decisions: vec![],
+            next_limit:      0,
         };
         let mut machine = AgentMachine::with_max_continuations(8, 3);
         let outcome = drive(&mut machine, &mut subsys).await;
@@ -396,17 +433,124 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn drive_pauses_then_continues_on_limit() {
+        use crate::agent::effect::LimitDecision;
+
+        // Two tool waves with `limit_interval = 1` so the first wave trips
+        // the circuit breaker. The user continues, the second wave runs,
+        // and then the LLM wraps up.
+        let tc_a = Tc {
+            id:        ToolCallId::new("a"),
+            name:      ToolName::new("search"),
+            arguments: "{}".into(),
+        };
+        let tc_b = Tc {
+            id:        ToolCallId::new("b"),
+            name:      ToolName::new("search"),
+            arguments: r#"{"q":"2"}"#.into(),
+        };
+        let mut subsys = ScriptedSubsys {
+            llm_script:      vec![
+                Event::LlmCompleted {
+                    text:           "first".into(),
+                    tool_calls:     vec![tc_a.clone()],
+                    has_tool_calls: true,
+                },
+                Event::LlmCompleted {
+                    text:           "second".into(),
+                    tool_calls:     vec![tc_b.clone()],
+                    has_tool_calls: true,
+                },
+                Event::LlmCompleted {
+                    text:           "wrap".into(),
+                    tool_calls:     vec![],
+                    has_tool_calls: false,
+                },
+            ],
+            next_llm:        0,
+            tool_responses:  vec![
+                vec![Tr {
+                    id:          ToolCallId::new("a"),
+                    name:        ToolName::new("search"),
+                    arguments:   "{}".into(),
+                    success:     true,
+                    duration_ms: 1,
+                    error:       None,
+                }],
+                vec![Tr {
+                    id:          ToolCallId::new("b"),
+                    name:        ToolName::new("search"),
+                    arguments:   r#"{"q":"2"}"#.into(),
+                    success:     true,
+                    duration_ms: 1,
+                    error:       None,
+                }],
+            ],
+            next_tool:       0,
+            tape_log:        vec![],
+            stream_log:      vec![],
+            limit_decisions: vec![LimitDecision::Continue, LimitDecision::Continue],
+            next_limit:      0,
+        };
+        let mut machine = AgentMachine::with_tool_call_limit(8, 1);
+        let outcome = drive(&mut machine, &mut subsys).await;
+        assert!(outcome.success);
+        assert_eq!(outcome.text, "wrap");
+        assert_eq!(outcome.tool_calls_made, 2);
+        assert_eq!(subsys.next_limit, 2, "pause_for_limit fired once per wave");
+    }
+
+    #[tokio::test]
+    async fn drive_stops_gracefully_when_user_declines_limit() {
+        use crate::agent::effect::LimitDecision;
+
+        let tc = Tc {
+            id:        ToolCallId::new("a"),
+            name:      ToolName::new("search"),
+            arguments: "{}".into(),
+        };
+        let mut subsys = ScriptedSubsys {
+            llm_script:      vec![Event::LlmCompleted {
+                text:           "first".into(),
+                tool_calls:     vec![tc.clone()],
+                has_tool_calls: true,
+            }],
+            next_llm:        0,
+            tool_responses:  vec![vec![Tr {
+                id:          ToolCallId::new("a"),
+                name:        ToolName::new("search"),
+                arguments:   "{}".into(),
+                success:     true,
+                duration_ms: 1,
+                error:       None,
+            }]],
+            next_tool:       0,
+            tape_log:        vec![],
+            stream_log:      vec![],
+            limit_decisions: vec![LimitDecision::Stop],
+            next_limit:      0,
+        };
+        let mut machine = AgentMachine::with_tool_call_limit(8, 1);
+        let outcome = drive(&mut machine, &mut subsys).await;
+        assert!(outcome.success, "stop-by-limit is a graceful success");
+        assert_eq!(outcome.text, "first");
+        assert_eq!(outcome.tool_calls_made, 1);
+    }
+
+    #[tokio::test]
     async fn drive_propagates_llm_fatal_failure() {
         let mut subsys = ScriptedSubsys {
-            llm_script:     vec![Event::LlmFailed {
+            llm_script:      vec![Event::LlmFailed {
                 retryable: false,
                 message:   "auth".into(),
             }],
-            next_llm:       0,
-            tool_responses: vec![],
-            next_tool:      0,
-            tape_log:       vec![],
-            stream_log:     vec![],
+            next_llm:        0,
+            tool_responses:  vec![],
+            next_tool:       0,
+            tape_log:        vec![],
+            stream_log:      vec![],
+            limit_decisions: vec![],
+            next_limit:      0,
         };
         let mut machine = AgentMachine::new(8);
         let outcome = drive(&mut machine, &mut subsys).await;


### PR DESCRIPTION
## Summary

Part of #1534. Migrates the tool-call-limit circuit breaker (legacy: `crates/kernel/src/agent/mod.rs:2782-2842`) into the sans-IO `AgentMachine`.

- New `Phase::PausedForLimit`
- New `Effect::PauseForLimit { limit_id, tool_calls_made }`
- New `Event::LimitResolved { limit_id, decision: Continue | Stop }`
- `ToolsCompleted` now emits `PauseForLimit` (not the next `CallLlm`) when the cumulative threshold is crossed
- `Continue` advances `next_limit_at` by `limit_interval`; `Stop` terminates with `FinishReason::StoppedByLimit`
- Stale `limit_id`s fall into the invalid-transition arm (session-scoped oneshot equivalence)
- `Interrupted` now covers `PausedForLimit`
- New `Subsystems::pause_for_limit` trait method — no default, required hook
- 5 new pure-machine tests + 2 runner integration tests

Legacy `run_agent_loop` is unchanged and still owns the production path.

## Type of change

| Type | Label |
|------|-------|
| New feature | `enhancement` |

## Component

`core`

## Closes

Closes #1537

## Test plan

- [x] `cargo test -p rara-kernel` passes (115 agent tests)
- [x] `cargo clippy -p rara-kernel --all-targets --no-deps -- -D warnings` clean
- [x] `RUSTDOCFLAGS="-D warnings" cargo +nightly doc -p rara-kernel --no-deps --document-private-items` clean