### PR TITLE
fix: address codex review findings on epic (#1535)

### DIFF
--- a/crates/app/src/tools/artifacts.rs
+++ b/crates/app/src/tools/artifacts.rs
@@ -31,7 +31,10 @@
 //! cheap because artifact sessions are bounded by session length and the tape
 //! is already in memory.
 
-use std::collections::HashMap;
+use std::{
+    collections::{BTreeSet, HashMap},
+    sync::Arc,
+};
 
 use async_trait::async_trait;
 use rara_kernel::{
@@ -42,6 +45,7 @@ use rara_tool_macro::ToolDef;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
+use tokio::sync::Mutex as AsyncMutex;
 
 /// LLM-facing parameters — matches `artifactsParamsSchema` in
 /// `vendor/pi-mono/packages/web-ui/src/tools/artifacts/artifacts.ts`.
@@ -84,6 +88,35 @@ const ARTIFACTS_DESCRIPTION: &str =
      placeholder).\n\nPrefer HTML for interactive UIs, SVG for diagrams, and markdown for prose. \
      Create one file per artifact and iterate with `update` or `rewrite`.";
 
+/// Per-session in-flight overlay for artifact operations within a single
+/// tool-call batch. The kernel persists one `ToolCall` tape entry covering
+/// an entire wave before dispatching its tools, and only appends the
+/// matching `ToolResult` after every tool in the wave has returned. Between
+/// those two points an artifact call cannot see the effects of earlier
+/// artifact calls in the same wave by replaying the tape alone — it would
+/// miss every in-flight operation. The overlay bridges that gap by
+/// recording the effect of each successful artifact call so the next one in
+/// the same batch validates against the merged state.
+#[derive(Default)]
+struct InflightOverlay {
+    /// Set of tool-call IDs that make up the current in-flight batch.
+    /// Reset whenever a new batch is detected.
+    batch_ids: BTreeSet<String>,
+    /// Artifact writes accumulated within the current batch, merged on top
+    /// of the committed tape state.
+    writes:    HashMap<String, ArtifactWrite>,
+}
+
+/// Recorded effect of a successful in-flight artifact call — either a write
+/// (with content) or a delete (no content).
+#[derive(Clone)]
+enum ArtifactWrite {
+    /// Set or replace the file content.
+    Set(String),
+    /// Remove the file.
+    Delete,
+}
+
 /// Artifacts tool — deferred tier, discovered on demand.
 #[derive(ToolDef)]
 #[tool(
@@ -94,10 +127,19 @@ const ARTIFACTS_DESCRIPTION: &str =
 )]
 pub struct ArtifactsTool {
     tape_service: TapeService,
+    /// Per-session overlay keyed by tape name. Holds successful writes for
+    /// the current in-flight tool-call batch so sibling artifact calls can
+    /// validate against merged state.
+    inflight:     Arc<AsyncMutex<HashMap<String, InflightOverlay>>>,
 }
 
 impl ArtifactsTool {
-    pub fn new(tape_service: TapeService) -> Self { Self { tape_service } }
+    pub fn new(tape_service: TapeService) -> Self {
+        Self {
+            tape_service,
+            inflight: Arc::new(AsyncMutex::new(HashMap::new())),
+        }
+    }
 
     /// Fold the session tape forward, applying every prior successful
     /// `artifacts` tool operation to yield the current artifact set.
@@ -111,7 +153,7 @@ impl ArtifactsTool {
         // Walk entries in order, pairing `ToolCall` (per-id) with its
         // `ToolResult`.  We apply an operation only if its matching result
         // was successful and marked the tool by name.
-        let mut pending: Vec<(String, ArtifactsParams)> = Vec::new();
+        let mut pending: Vec<ArtifactCall> = Vec::new();
         let mut state: HashMap<String, String> = HashMap::new();
 
         for entry in &entries {
@@ -129,10 +171,96 @@ impl ArtifactsTool {
 
         Ok(state)
     }
+
+    /// Extract the set of tool-call IDs for the most recent ToolCall entry
+    /// that has not yet been paired with a ToolResult. That entry, when
+    /// present, is the current in-flight batch dispatched by the kernel.
+    async fn current_batch_call_ids(&self, tape_name: &str) -> anyhow::Result<BTreeSet<String>> {
+        let entries = self
+            .tape_service
+            .entries(tape_name)
+            .await
+            .map_err(|e| anyhow::anyhow!("failed to read tape: {e}"))?;
+
+        let mut last_batch: Option<BTreeSet<String>> = None;
+        for entry in &entries {
+            match entry.kind {
+                TapEntryKind::ToolCall => {
+                    last_batch = Some(extract_all_call_ids(&entry.payload));
+                }
+                TapEntryKind::ToolResult => {
+                    last_batch = None;
+                }
+                _ => {}
+            }
+        }
+        Ok(last_batch.unwrap_or_default())
+    }
+
+    /// Return artifact state with the current in-flight batch overlaid on
+    /// top of persisted state. Mutates the per-session overlay to clear
+    /// stale entries when a new batch is detected.
+    async fn effective_state(
+        &self,
+        tape_name: &str,
+        current_call_id: Option<&str>,
+    ) -> anyhow::Result<HashMap<String, String>> {
+        let mut state = self.current_state(tape_name).await?;
+
+        let batch_ids = self.current_batch_call_ids(tape_name).await?;
+        let mut inflight = self.inflight.lock().await;
+        let overlay = inflight.entry(tape_name.to_owned()).or_default();
+
+        // Detect batch rollover: if the stored batch's IDs differ from the
+        // tape's current unpaired batch (or the current call is not part of
+        // the stored batch), the overlay is stale and must be dropped.
+        let current_in_batch = current_call_id
+            .map(|id| overlay.batch_ids.contains(id))
+            .unwrap_or(false);
+        if overlay.batch_ids != batch_ids || !current_in_batch {
+            overlay.batch_ids = batch_ids;
+            overlay.writes.clear();
+        }
+
+        for (filename, write) in &overlay.writes {
+            match write {
+                ArtifactWrite::Set(content) => {
+                    state.insert(filename.clone(), content.clone());
+                }
+                ArtifactWrite::Delete => {
+                    state.remove(filename);
+                }
+            }
+        }
+
+        Ok(state)
+    }
+
+    /// Record a successful artifact write into the in-flight overlay so
+    /// sibling calls within the same batch observe it.
+    async fn record_overlay(&self, tape_name: &str, write: (String, ArtifactWrite)) {
+        let mut inflight = self.inflight.lock().await;
+        if let Some(overlay) = inflight.get_mut(tape_name) {
+            overlay.writes.insert(write.0, write.1);
+        }
+    }
 }
 
-/// Extract `(call_id, params)` tuples for artifact calls in a ToolCall entry.
-fn extract_artifact_calls(payload: &Value) -> Vec<(String, ArtifactsParams)> {
+/// Position in the parent ToolCall entry's `calls` array, paired with the
+/// parsed artifact params. Preserving the original index lets `apply_results`
+/// look up the matching entry in the `results` array even when the batch
+/// mixes artifact calls with other tools.
+struct ArtifactCall {
+    idx:    usize,
+    #[allow(dead_code)]
+    id:     String,
+    params: ArtifactsParams,
+}
+
+/// Extract artifact calls from a ToolCall entry, preserving each call's
+/// index in the full `calls` array so results can be matched positionally
+/// against the matching ToolResult entry.
+fn extract_artifact_calls(payload: &Value) -> Vec<ArtifactCall> {
     let calls = payload.get("calls").and_then(Value::as_array);
     let Some(calls) = calls else {
         return Vec::new();
@@ -140,7 +268,8 @@ fn extract_artifact_calls(payload: &Value) -> Vec<(String, ArtifactsParams)> {
 
     calls
         .iter()
-        .filter_map(|call| {
+        .enumerate()
+        .filter_map(|(idx, call)| {
             let function = call.get("function")?;
             let name = function.get("name")?.as_str()?;
             if name != ARTIFACTS_TOOL_NAME {
@@ -149,34 +278,57 @@ fn extract_artifact_calls(payload: &Value) -> Vec<(String, ArtifactsParams)> {
             let id = call.get("id")?.as_str()?.to_owned();
             let args_str = function.get("arguments")?.as_str().unwrap_or("{}");
             let params: ArtifactsParams = serde_json::from_str(args_str).ok()?;
-            Some((id, params))
+            Some(ArtifactCall { idx, id, params })
         })
         .collect()
 }
 
-/// Apply results (by position) against pending calls; mutate artifact state.
-fn apply_results(
-    payload: &Value,
-    pending: &[(String, ArtifactsParams)],
-    state: &mut HashMap<String, String>,
-) {
+/// Extract every call's id from a ToolCall payload, regardless of tool name.
+/// Used to identify the membership of the current in-flight batch.
+fn extract_all_call_ids(payload: &Value) -> BTreeSet<String> {
+    payload
+        .get("calls")
+        .and_then(Value::as_array)
+        .map(|calls| {
+            calls
+                .iter()
+                .filter_map(|c| c.get("id").and_then(Value::as_str).map(ToOwned::to_owned))
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+/// Apply each artifact call's result from a ToolResult entry against the
+/// state map, indexing the results array by the call's original position in
+/// the parent ToolCall entry (not by position within `pending`). A failed
+/// result is skipped; both pi-mono-style `Error:` string prefixes and rara's
+/// `{"error": "..."}` JSON shape are recognised as failures.
+fn apply_results(payload: &Value, pending: &[ArtifactCall], state: &mut HashMap<String, String>) {
     let results = payload.get("results").and_then(Value::as_array);
     let Some(results) = results else { return };
 
-    for (idx, result) in results.iter().enumerate() {
-        let Some((_id, params)) = pending.get(idx) else {
+    for call in pending {
+        let Some(result) = results.get(call.idx) else {
             continue;
         };
-        // Treat anything starting with "Error:" as a failure — matches the
-        // pi-mono TS tool's result strings.
-        let text = match result {
-            Value::String(s) => s.clone(),
-            other => serde_json::to_string(other).unwrap_or_default(),
-        };
-        if text.starts_with("Error:") {
+        if is_failure_result(result) {
             continue;
         }
-        apply_op(params, state);
+        apply_op(&call.params, state);
+    }
+}
+
+/// Recognise the two failure shapes the agent loop emits for tool results:
+///
+/// * a bare string starting with `Error:` (pi-mono convention carried over from
+///   the TS tool), and
+/// * a JSON object with an `error` key (produced by the kernel when the tool's
+///   `anyhow::Error` is captured into `ToolOutput`).
+fn is_failure_result(result: &Value) -> bool {
+    match result {
+        Value::String(s) => s.starts_with("Error:"),
+        Value::Object(map) => map.contains_key("error"),
+        _ => false,
     }
 }
 
@@ -214,9 +366,17 @@ impl ToolExecute for ArtifactsTool {
         context: &ToolContext,
     ) -> anyhow::Result<ArtifactsResult> {
         let tape_name = context.session_key.to_string();
-        // Compute current state BEFORE the current call is appended to the
-        // tape.  (The kernel appends the tool call after the tool returns.)
-        let state = self.current_state(&tape_name).await?;
+        // Compute state from the committed tape, overlaid with any in-flight
+        // writes from earlier artifact calls in the current tool-call batch.
+        // The kernel persists the wave's ToolCall entry before dispatching
+        // its tools and appends the matching ToolResult only after the whole
+        // wave returns, so replaying the tape alone cannot see sibling
+        // writes from the same batch — the overlay bridges that gap.
+        let state = self
+            .effective_state(&tape_name, context.tool_call_id.as_deref())
+            .await?;
+
+        let mut overlay_update: Option<(String, ArtifactWrite)> = None;
 
         let message = match params.command.as_str() {
             "create" => {
@@ -227,14 +387,22 @@ impl ToolExecute for ArtifactsTool {
                 if state.contains_key(&params.filename) {
                     anyhow::bail!("Error: File {} already exists", params.filename);
                 }
-                let _ = content; // content is captured in the tape via the call args
+                overlay_update = Some((
+                    params.filename.clone(),
+                    ArtifactWrite::Set(content.to_owned()),
+                ));
                 format!("Created file {}", params.filename)
             }
             "rewrite" => {
-                if params.content.is_none() {
-                    anyhow::bail!("Error: rewrite command requires content");
-                }
+                let content = params
+                    .content
+                    .as_deref()
+                    .ok_or_else(|| anyhow::anyhow!("Error: rewrite command requires content"))?;
                 ensure_exists(&state, &params.filename)?;
+                overlay_update = Some((
+                    params.filename.clone(),
+                    ArtifactWrite::Set(content.to_owned()),
+                ));
                 format!("Rewrote file {}", params.filename)
             }
             "update" => {
@@ -242,9 +410,10 @@ impl ToolExecute for ArtifactsTool {
                     .old_str
                     .as_deref()
                     .ok_or_else(|| anyhow::anyhow!("Error: update command requires old_str"))?;
-                if params.new_str.is_none() {
-                    anyhow::bail!("Error: update command requires new_str");
-                }
+                let new = params
+                    .new_str
+                    .as_deref()
+                    .ok_or_else(|| anyhow::anyhow!("Error: update command requires new_str"))?;
                 let existing = state
                     .get(&params.filename)
                     .ok_or_else(|| anyhow::anyhow!(not_found_message(&state, &params.filename)))?;
@@ -253,6 +422,8 @@ impl ToolExecute for ArtifactsTool {
                         "Error: String not found in file. Here is the full content:\n\n{existing}"
                     );
                 }
+                let updated = existing.replacen(old, new, 1);
+                overlay_update = Some((params.filename.clone(), ArtifactWrite::Set(updated)));
                 format!("Updated file {}", params.filename)
             }
             "get" => state
@@ -261,6 +432,7 @@ impl ToolExecute for ArtifactsTool {
                 .ok_or_else(|| anyhow::anyhow!(not_found_message(&state, &params.filename)))?,
             "delete" => {
                 ensure_exists(&state, &params.filename)?;
+                overlay_update = Some((params.filename.clone(), ArtifactWrite::Delete));
                 format!("Deleted file {}", params.filename)
             }
             "logs" => {
@@ -276,6 +448,10 @@ impl ToolExecute for ArtifactsTool {
             }
             other => anyhow::bail!("Error: Unknown command '{other}'"),
         };
+
+        if let Some(update) = overlay_update {
+            self.record_overlay(&tape_name, update).await;
+        }
 
         Ok(ArtifactsResult { message })
     }

--- a/crates/kernel/src/agent/mod.rs
+++ b/crates/kernel/src/agent/mod.rs
@@ -832,13 +832,27 @@ call `discover-tools` to load it first.{tool_list}
 ///
 /// Budgets mirror Anthropic's extended-thinking guidance: larger levels give
 /// the model more scratch tokens for silent reasoning before answering.
-/// `Off` returns `None` so the driver sees no thinking field.
+///
+/// The output distinguishes three states:
+///
+/// * `None` — no session override. Drivers fall back to their own default (e.g.
+///   OpenAI Responses uses "medium" effort for reasoning models).
+/// * `Some(ThinkingConfig { enabled: false, .. })` — the user explicitly
+///   selected `Off`. Drivers must disable extended thinking even when the model
+///   family defaults to reasoning.
+/// * `Some(ThinkingConfig { enabled: true, budget_tokens: Some(_) })` — an
+///   explicit non-zero budget.
 fn thinking_level_to_config(
     level: Option<crate::session::ThinkingLevel>,
 ) -> Option<llm::ThinkingConfig> {
     use crate::session::ThinkingLevel;
     let budget = match level? {
-        ThinkingLevel::Off => return None,
+        ThinkingLevel::Off => {
+            return Some(llm::ThinkingConfig {
+                enabled:       false,
+                budget_tokens: None,
+            });
+        }
         ThinkingLevel::Minimal => 512,
         ThinkingLevel::Low => 1024,
         ThinkingLevel::Medium => 4096,

--- a/crates/kernel/src/llm/openai.rs
+++ b/crates/kernel/src/llm/openai.rs
@@ -761,12 +761,21 @@ pub(crate) fn build_responses_request(request: &CompletionRequest, _format: ApiF
         body["tools"] = json!(tools);
     }
 
-    // Reasoning config — map thinking budget to effort level.
-    let reasoning_effort = request
-        .thinking
-        .as_ref()
-        .and_then(|t| {
-            t.budget_tokens.map(|b| {
+    // Reasoning config.
+    //
+    // Three cases:
+    //   * `None` — no session override; fall back to the model family's default
+    //     (medium) so reasoning-family models still reason.
+    //   * `Some(enabled: false)` — the user explicitly turned reasoning off. Ask
+    //     the API for the minimal effort the Responses contract allows; omitting
+    //     the block entirely would be read as "default" by the server.
+    //   * `Some(enabled: true)` — map the budget to an effort bucket.
+    let reasoning_effort = match request.thinking.as_ref() {
+        None => "medium",
+        Some(t) if !t.enabled => "minimal",
+        Some(t) => t
+            .budget_tokens
+            .map(|b| {
                 if b >= 10_000 {
                     "high"
                 } else if b >= 3_000 {
@@ -775,8 +784,8 @@ pub(crate) fn build_responses_request(request: &CompletionRequest, _format: ApiF
                     "low"
                 }
             })
-        })
-        .unwrap_or("medium");
+            .unwrap_or("medium"),
+    };
 
     body["reasoning"] = json!({
         "effort": reasoning_effort,

--- a/web/src/pages/PiChat.tsx
+++ b/web/src/pages/PiChat.tsx
@@ -81,6 +81,28 @@ function asThinkingLevel(level: string | undefined): ThinkingLevel | null {
   }
 }
 
+/**
+ * Detect whether a tool-result payload represents a failure. Mirrors the
+ * backend's `is_failure_result` in `crates/app/src/tools/artifacts.rs`: a
+ * bare string starting with `Error:` (pi-mono convention) or a JSON object
+ * with an `error` key (kernel-serialized anyhow error).
+ */
+function isToolFailure(text: string): boolean {
+  const trimmed = text.trimStart();
+  if (trimmed.startsWith("Error:")) return true;
+  try {
+    const parsed = JSON.parse(trimmed);
+    return (
+      typeof parsed === "object"
+      && parsed !== null
+      && !Array.isArray(parsed)
+      && "error" in parsed
+    );
+  } catch {
+    return false;
+  }
+}
+
 function mimeToFilename(mimeType: string, index: number): string {
   const ext = mimeType.split("/")[1] || "bin";
   return `session-image-${index + 1}.${ext}`;
@@ -218,7 +240,12 @@ function toAgentMessages(msgs: ChatMessageData[]): AgentMessage[] {
         (lastAssistant.content as (TextContent | ThinkingContent | ToolCall)[]).push(toolCall);
       }
     } else if (m.role === "tool_result") {
-      // Tool result — emit as a separate ToolResultMessage.
+      // Tool result — emit as a separate ToolResultMessage. Preserve the
+      // backend's failure markers so ArtifactsPanel.reconstructFromMessages
+      // (which only replays successful ops) skips failed calls on reload.
+      // The kernel serializes failures in two shapes: a bare string starting
+      // with "Error:" (pi-mono convention) and JSON objects with an `error`
+      // key (produced by the anyhow -> ToolOutput path).
       if (m.tool_call_id && m.tool_name) {
         const text = typeof m.content === "string"
           ? m.content
@@ -231,7 +258,7 @@ function toAgentMessages(msgs: ChatMessageData[]): AgentMessage[] {
           toolCallId: m.tool_call_id,
           toolName: m.tool_name,
           content: text ? [{ type: "text", text }] : [],
-          isError: false,
+          isError: isToolFailure(text),
           timestamp: ts,
         };
         result.push(toolResult as AgentMessage);


### PR DESCRIPTION
## Summary

Addresses all 5 P2 findings from the Codex review of `feat/pi-mono-alignment`.

### Changes

1. **artifacts.rs — result index alignment.** `extract_artifact_calls` now carries each artifact call's original position in the parent `calls` array. `apply_results` looks up results by that index so a mixed batch like `[bash, artifacts.create]` pairs the artifact params with the right result.
2. **artifacts.rs — failure detection.** New `is_failure_result` handles both shapes the kernel emits: bare strings starting with `Error:` and JSON objects with an `error` key. Previously only the string form was detected, so failed artifact ops replayed as successes when folding the tape.
3. **artifacts.rs — in-flight batch overlay.** Added `InflightOverlay` keyed by tape name. Each successful artifact call records its write (Set/Delete); the next call in the same batch merges overlay on top of committed state before validating. The overlay resets when the unpaired ToolCall entry's call-id set changes, so it never leaks across batches.
4. **PiChat.tsx — preserve failure flag.** `toAgentMessages` now calls a new `isToolFailure` helper (mirrors the backend's `is_failure_result`) so `ArtifactsPanel.reconstructFromMessages` skips failed artifact ops on reload. Previously every restored tool result had `isError: false`.
5. **agent/mod.rs + openai.rs — Off vs unset.** `thinking_level_to_config` now returns `Some(ThinkingConfig { enabled: false, .. })` for `ThinkingLevel::Off` instead of `None`. `build_responses_request` reads `enabled: false` as `"minimal"` effort (the lowest the Responses contract allows) so the UI's Off selection no longer silently maps to medium reasoning on Codex/OpenAI Responses models.

## Type of change

| Type | Label |
|------|-------|
| Bug fix | `bug` |

## Component

`core`

## Closes

Closes #1535

## Test plan

- [x] `prek run --all-files` green (cargo check/fmt/clippy/doc)
- [x] `cd web && npm run build` green
- [x] `cargo test -p rara-kernel --lib openai::` — 16 passed
- [ ] Manual: emit `[bash, artifacts.create]` batch, verify artifact applies with the correct result
- [ ] Manual: emit failing `artifacts.create` (duplicate filename), reload session — panel should not show the fake create
- [ ] Manual: emit `create(a.html), update(a.html)` in the same batch — both succeed
- [ ] Manual: select Off on a Codex model session, verify request body uses minimal effort