### PR TITLE
feat(web): filter model selector to rara-routable providers (#1542)

### DIFF
--- a/web/src/pages/PiChat.tsx
+++ b/web/src/pages/PiChat.tsx
@@ -52,8 +52,8 @@ import type {
 import { RaraStorageBackend } from "@/adapters/rara-storage";
 import { createRaraStreamFn } from "@/adapters/rara-stream";
 import { registerRaraToolRenderers } from "@/tools/rara-tool-renderers";
-import { api } from "@/api/client";
-import type { ChatSession, ChatMessageData, ChatModel, ThinkingLevel } from "@/api/types";
+import { api, settingsApi } from "@/api/client";
+import type { ChatSession, ChatMessageData, ThinkingLevel } from "@/api/types";
 import { useNavigate } from "react-router";
 import { VoiceRecorder } from "@/components/VoiceRecorder";
 
@@ -102,6 +102,24 @@ function isToolFailure(text: string): boolean {
     return false;
   }
 }
+
+/**
+ * Map rara's LLM provider ids (as they appear in `/api/v1/settings`
+ * under `llm.providers.<id>.enabled`) to the provider ids pi-mono's
+ * `ModelSelector` filters by (`model.provider` on each pi-ai `Model`).
+ *
+ * Entries with an empty array (e.g. `ollama`) are known but not yet
+ * exposed through pi-mono's built-in catalog — they need a
+ * `CustomProvidersStore` injection to appear in the selector. Leaving
+ * them empty keeps them out of the allowlist so the UI does not imply
+ * support that is not wired up.
+ */
+const RARA_TO_PIMONO_PROVIDERS: Record<string, readonly string[]> = {
+  openrouter: ["openrouter"],
+  codex: ["openai-codex"],
+  "kimi-code": ["kimi-coding"],
+  ollama: [],
+};
 
 function mimeToFilename(mimeType: string, index: number): string {
   const ext = mimeType.split("/")[1] || "bin";
@@ -593,24 +611,35 @@ export default function PiChat() {
       container.appendChild(chatPanel);
 
       // 7. Derive the provider allowlist for pi-mono's ModelSelector from
-      //    rara's curated model catalog. `/api/v1/chat/models` already
-      //    reflects which providers the backend can route through (OpenRouter
-      //    gateway, Ollama, Kimi-Code, etc.), encoded as OpenRouter-style
-      //    `"<provider>/<model>"` ids. Splitting on "/" gives pi-mono's
-      //    provider name for each selectable family. Best-effort: if the
-      //    fetch fails, leave the allowlist undefined so pi-mono falls back
-      //    to its default (show everything).
+      //    the set of rara LLM providers currently enabled in settings.
+      //    Rara's provider ids (`openrouter`, `codex`, `kimi-code`, ...) do
+      //    not match pi-mono's provider ids 1:1, so the mapping is explicit.
+      //    `/api/v1/chat/models` cannot be used here: its ids are
+      //    OpenRouter-style `"<family>/<model>"`, and the family prefix is
+      //    NOT pi-mono's provider name — pi-mono's `ModelSelector` filters
+      //    by `model.provider`, which for OpenRouter models is the literal
+      //    string `"openrouter"`, not `openai`/`anthropic`/etc. (verified
+      //    against `vendor/pi-mono/packages/ai/src/models.generated.ts`).
+      //
+      //    Best-effort: if the fetch fails or yields no enabled providers,
+      //    leave the allowlist undefined so pi-mono falls back to showing
+      //    everything rather than locking the user out.
       let allowedProviders: string[] | undefined;
       try {
-        const models = await api.get<ChatModel[]>("/api/v1/chat/models");
-        const providers = new Set(
-          models
-            .map((m) => m.id.split("/")[0])
-            .filter((p): p is string => Boolean(p)),
-        );
+        const rawSettings = await settingsApi.list();
+        const providers = new Set<string>();
+        for (const [key, value] of Object.entries(rawSettings)) {
+          // rara stores booleans as the literal string "true".
+          if (value !== "true") continue;
+          const match = /^llm\.providers\.([^.]+)\.enabled$/.exec(key);
+          if (!match) continue;
+          for (const piProvider of RARA_TO_PIMONO_PROVIDERS[match[1]] ?? []) {
+            providers.add(piProvider);
+          }
+        }
         if (providers.size > 0) allowedProviders = [...providers];
       } catch (e) {
-        console.warn("Failed to load model catalog for selector filter:", e);
+        console.warn("Failed to load settings for selector filter:", e);
       }
 
       // 8. Wire agent into the panel — skip API key prompt since rara manages

--- a/web/src/pages/PiChat.tsx
+++ b/web/src/pages/PiChat.tsx
@@ -35,7 +35,7 @@ import type { AgentMessage } from "@mariozechner/pi-agent-core";
 // module-level `registerToolRenderer("extract_document", ...)` side
 // effect so pi-mono can render server-triggered document-extraction tool
 // calls in chat.
-import { extractDocumentTool } from "@mariozechner/pi-web-ui";
+import { extractDocumentTool, ModelSelector } from "@mariozechner/pi-web-ui";
 
 // Reference the tool so Vite's tree-shaker keeps the module (and its
 // `registerToolRenderer` side effect) in the bundle. The actual tool
@@ -53,7 +53,7 @@ import { RaraStorageBackend } from "@/adapters/rara-storage";
 import { createRaraStreamFn } from "@/adapters/rara-stream";
 import { registerRaraToolRenderers } from "@/tools/rara-tool-renderers";
 import { api } from "@/api/client";
-import type { ChatSession, ChatMessageData, ThinkingLevel } from "@/api/types";
+import type { ChatSession, ChatMessageData, ChatModel, ThinkingLevel } from "@/api/types";
 import { useNavigate } from "react-router";
 import { VoiceRecorder } from "@/components/VoiceRecorder";
 
@@ -592,12 +592,42 @@ export default function PiChat() {
       chatPanelRef.current = chatPanel;
       container.appendChild(chatPanel);
 
-      // 7. Wire agent into the panel — skip API key prompt since rara manages
+      // 7. Derive the provider allowlist for pi-mono's ModelSelector from
+      //    rara's curated model catalog. `/api/v1/chat/models` already
+      //    reflects which providers the backend can route through (OpenRouter
+      //    gateway, Ollama, Kimi-Code, etc.), encoded as OpenRouter-style
+      //    `"<provider>/<model>"` ids. Splitting on "/" gives pi-mono's
+      //    provider name for each selectable family. Best-effort: if the
+      //    fetch fails, leave the allowlist undefined so pi-mono falls back
+      //    to its default (show everything).
+      let allowedProviders: string[] | undefined;
+      try {
+        const models = await api.get<ChatModel[]>("/api/v1/chat/models");
+        const providers = new Set(
+          models
+            .map((m) => m.id.split("/")[0])
+            .filter((p): p is string => Boolean(p)),
+        );
+        if (providers.size > 0) allowedProviders = [...providers];
+      } catch (e) {
+        console.warn("Failed to load model catalog for selector filter:", e);
+      }
+
+      // 8. Wire agent into the panel — skip API key prompt since rara manages
       //    keys server-side, and sync the current model/thinking override to
       //    the backend before every send so the kernel sees the user's
       //    selection for this turn.
       await chatPanel.setAgent(agent, {
         onApiKeyRequired: async () => true,
+        onModelSelect: () => {
+          // Open pi-mono's native ModelSelector but restrict to providers
+          // rara's backend can actually route to.
+          ModelSelector.open(
+            agent.state.model,
+            (model) => { agent.state.model = model; },
+            allowedProviders,
+          );
+        },
         onBeforeSend: async () => {
           const key = agent.sessionId;
           if (!key) return;


### PR DESCRIPTION
## Summary

pi-mono's `ModelSelector` showed every provider baked into pi-ai's MODELS catalog (Anthropic/OpenAI/Google/xAI/DeepSeek/…), regardless of what rara's backend can actually route to. This PR filters it to the providers implied by `/api/v1/chat/models` so users only see models the configured backend can handle.

- Fetch \`/api/v1/chat/models\` once during chat init.
- Derive \`allowedProviders\` = unique \`model.id.split("/")[0]\` (OpenRouter-style ids already carry the provider family).
- Override \`onModelSelect\` on \`ChatPanel.setAgent()\` to call \`ModelSelector.open(currentModel, onSelect, allowedProviders)\`.
- If the fetch fails or returns empty, leave the allowlist undefined — pi-mono falls back to its default behaviour.

No new backend endpoint: \`/api/v1/chat/models\` already aggregates the routable catalog across OpenRouter / Ollama / Kimi-Code / etc., so the provider set falls out of the curated list for free. When a user only enables e.g. \`ollama\`, the selector naturally narrows to the families that appear in that catalog.

## Type of change

| Type | Label |
|------|-------|
| New feature | \`enhancement\` |

## Component

\`ui\`

## Closes

Closes #1542

## Test plan

- [x] \`cd web && npm run build\` passes
- [ ] Manual: enable only \`openrouter\`, confirm selector lists only models with \`<provider>/...\` ids present in \`/api/v1/chat/models\`
- [ ] Manual: disable catalog fetch (e.g. offline) and confirm selector falls back to showing everything