### PR TITLE
feat(channels): show model + context in TG pin floating preview (#1541)

### DIFF
--- a/crates/channels/src/telegram/adapter.rs
+++ b/crates/channels/src/telegram/adapter.rs
@@ -4144,6 +4144,27 @@ fn spawn_stream_forwarder(
             }
         }
 
+        // Flush the pinned card iff it has pending, non-noop changes.
+        // Declared as a macro so `&mut pinned` can be re-borrowed each call
+        // across the event-loop iterations — a closure would freeze the borrow.
+        macro_rules! flush_if_dirty {
+            () => {
+                if pinned.needs_flush() {
+                    flush_pinned_status(
+                        &bot,
+                        chat_id,
+                        thread_id,
+                        &mut pinned,
+                        &settings,
+                        &pinned_settings_key,
+                        &pinned_session_key,
+                        &rate_limiter,
+                    )
+                    .await;
+                }
+            };
+        }
+
         loop {
             tokio::select! {
                 result = rx.recv() => {
@@ -4505,9 +4526,7 @@ fn spawn_stream_forwarder(
                             // coincide with stream close and get skipped. The
                             // rate limiter + needs_flush() skip-unchanged
                             // guard keep this cheap.
-                            if pinned.needs_flush() {
-                                flush_pinned_status(&bot, chat_id, thread_id, &mut pinned, &settings, &pinned_settings_key, &pinned_session_key, &rate_limiter).await;
-                            }
+                            flush_if_dirty!();
                             keyboard_state
                                 .entry(chat_id)
                                 .and_modify(|m| m.input_tokens = input_tokens)
@@ -4594,9 +4613,7 @@ fn spawn_stream_forwarder(
                             // Flush so the final pin reflects the model /
                             // context window without waiting for the next
                             // throttle tick (which might miss the close race).
-                            if pinned.needs_flush() {
-                                flush_pinned_status(&bot, chat_id, thread_id, &mut pinned, &settings, &pinned_settings_key, &pinned_session_key, &rate_limiter).await;
-                            }
+                            flush_if_dirty!();
                         }
                         Ok(StreamEvent::TurnStarted { model, context_window_tokens }) => {
                             // Populate the pinned card's model + context window
@@ -4614,9 +4631,7 @@ fn spawn_stream_forwarder(
                                     input_tokens: progress.input_tokens,
                                     model:        model.clone(),
                                 });
-                            if pinned.needs_flush() {
-                                flush_pinned_status(&bot, chat_id, thread_id, &mut pinned, &settings, &pinned_settings_key, &pinned_session_key, &rate_limiter).await;
-                            }
+                            flush_if_dirty!();
                         }
                         // Tool call limit: send inline keyboard with continue/stop
                         // buttons. The callback data encodes session_key and
@@ -4719,7 +4734,7 @@ fn spawn_stream_forwarder(
 
                             // ── Pinned status bar: final flush ──
                             pinned.on_stream_close();
-                            flush_pinned_status(&bot, chat_id, thread_id, &mut pinned, &settings, &pinned_settings_key, &pinned_session_key, &rate_limiter).await;
+                            flush_if_dirty!();
 
                             // ── Finalize: always create trace + compact summary ──
                             // Every agent turn (including pure text replies) gets a
@@ -4951,9 +4966,7 @@ fn spawn_stream_forwarder(
                     }
 
                     // ── Pinned session card: flush on state change only ──
-                    if pinned.needs_flush() {
-                        flush_pinned_status(&bot, chat_id, thread_id, &mut pinned, &settings, &pinned_settings_key, &pinned_session_key, &rate_limiter).await;
-                    }
+                    flush_if_dirty!();
                 }
                 _ = typing_interval.tick() => {
                     rate_limiter.acquire(chat_id).await;

--- a/crates/channels/src/telegram/adapter.rs
+++ b/crates/channels/src/telegram/adapter.rs
@@ -4500,6 +4500,14 @@ fn spawn_stream_forwarder(
                             progress.output_tokens = output_tokens;
                             progress.thinking_ms = thinking_ms;
                             pinned.on_usage_update(input_tokens, output_tokens, thinking_ms);
+                            // Flush the pin as soon as we have real token
+                            // numbers — the subsequent throttle tick might
+                            // coincide with stream close and get skipped. The
+                            // rate limiter + needs_flush() skip-unchanged
+                            // guard keep this cheap.
+                            if pinned.needs_flush() {
+                                flush_pinned_status(&bot, chat_id, thread_id, &mut pinned, &settings, &pinned_settings_key, &pinned_session_key, &rate_limiter).await;
+                            }
                             keyboard_state
                                 .entry(chat_id)
                                 .and_modify(|m| m.input_tokens = input_tokens)
@@ -4570,11 +4578,11 @@ fn spawn_stream_forwarder(
                             // progress message with the reasoning preview.
                             progress_dirty = true;
                         }
-                        Ok(StreamEvent::TurnMetrics { model, iterations, .. }) => {
+                        Ok(StreamEvent::TurnMetrics { model, iterations, context_window_tokens, .. }) => {
                             // TurnMetrics arrives just before stream close —
                             // stash for the ExecutionTrace built in RecvError::Closed.
                             progress.model = model;
-                            pinned.on_turn_metrics(progress.model.clone());
+                            pinned.on_turn_metrics(progress.model.clone(), context_window_tokens);
                             progress.iterations = iterations;
                             keyboard_state
                                 .entry(chat_id)
@@ -4583,6 +4591,32 @@ fn spawn_stream_forwarder(
                                     input_tokens: progress.input_tokens,
                                     model:        progress.model.clone(),
                                 });
+                            // Flush so the final pin reflects the model /
+                            // context window without waiting for the next
+                            // throttle tick (which might miss the close race).
+                            if pinned.needs_flush() {
+                                flush_pinned_status(&bot, chat_id, thread_id, &mut pinned, &settings, &pinned_settings_key, &pinned_session_key, &rate_limiter).await;
+                            }
+                        }
+                        Ok(StreamEvent::TurnStarted { model, context_window_tokens }) => {
+                            // Populate the pinned card's model + context window
+                            // immediately so the first flush carries real data
+                            // instead of an empty shell. Also primes the reply
+                            // keyboard metadata for the context gauge.
+                            pinned.on_turn_started(model.clone(), context_window_tokens);
+                            if progress.model.is_empty() {
+                                progress.model = model.clone();
+                            }
+                            keyboard_state
+                                .entry(chat_id)
+                                .and_modify(|m| m.model = model.clone())
+                                .or_insert(KeyboardMeta {
+                                    input_tokens: progress.input_tokens,
+                                    model:        model.clone(),
+                                });
+                            if pinned.needs_flush() {
+                                flush_pinned_status(&bot, chat_id, thread_id, &mut pinned, &settings, &pinned_settings_key, &pinned_session_key, &rate_limiter).await;
+                            }
                         }
                         // Tool call limit: send inline keyboard with continue/stop
                         // buttons. The callback data encodes session_key and

--- a/crates/channels/src/telegram/pinned_status.rs
+++ b/crates/channels/src/telegram/pinned_status.rs
@@ -34,6 +34,16 @@ use super::adapter::format_token_count;
 // below is kept for graceful degradation when an older kernel / partial event
 // stream arrives without the new field.
 
+/// Escape the three HTML characters Telegram's HTML parse_mode treats as
+/// markup (`&`, `<`, `>`). Applied to every user-derived string interpolated
+/// into the rendered card so angle brackets in session titles, model names,
+/// project names, or branches cannot break the surrounding tags.
+fn escape_html(s: &str) -> String {
+    s.replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+}
+
 /// Shorten an absolute path to at most the last 3 segments.
 fn short_path(path: &str) -> &str {
     let bytes = path.as_bytes();
@@ -211,9 +221,12 @@ impl PinnedSessionCard {
         // Line 1: model + context gauge (preferred) or session title (fallback
         // until the first TurnStarted event arrives after a bot restart).
         if self.model.is_empty() {
-            lines.push(format!("{status_emoji} <b>{}</b>", self.session_title));
+            lines.push(format!(
+                "{status_emoji} <b>{}</b>",
+                escape_html(&self.session_title)
+            ));
         } else {
-            let head = format!("{status_emoji} <code>{}</code>", self.model);
+            let head = format!("{status_emoji} <code>{}</code>", escape_html(&self.model));
             let gauge = match (self.input_tokens, window) {
                 (0, Some(limit)) => format!(" · 0/{} (0%)", format_token_count(limit)),
                 (used, Some(limit)) if limit > 0 => {
@@ -230,15 +243,19 @@ impl PinnedSessionCard {
             lines.push(format!("{head}{gauge}"));
             // Line 2: session subtitle — keeps "where am I?" info available
             // when the pin is expanded, just demoted from line 1.
-            lines.push(format!("<i>{}</i>", self.session_title));
+            lines.push(format!("<i>{}</i>", escape_html(&self.session_title)));
         }
 
         // Project: name: branch (shown when available).
         if !self.project_name.is_empty() {
             let project_line = if self.project_branch.is_empty() {
-                format!("Project: {}", self.project_name)
+                format!("Project: {}", escape_html(&self.project_name))
             } else {
-                format!("Project: {}: {}", self.project_name, self.project_branch)
+                format!(
+                    "Project: {}: {}",
+                    escape_html(&self.project_name),
+                    escape_html(&self.project_branch)
+                )
             };
             lines.push(project_line);
         }
@@ -266,7 +283,7 @@ impl PinnedSessionCard {
             lines.push(String::new());
             lines.push(format!("\u{1f504} <b>Background ({})</b>", active.len()));
             for task in &active {
-                lines.push(format!("\u{23f3} {}", task.agent_name));
+                lines.push(format!("\u{23f3} {}", escape_html(&task.agent_name)));
             }
         }
 
@@ -277,7 +294,7 @@ impl PinnedSessionCard {
             lines.push(format!("\u{1f4c1} <b>Files ({total})</b>"));
             let max_display = 10;
             for f in self.changed_files.iter().take(max_display) {
-                let rel = short_path(&f.path);
+                let rel = escape_html(short_path(&f.path));
                 let mut parts = Vec::new();
                 if f.additions > 0 {
                     parts.push(format!("+{}", f.additions));
@@ -331,17 +348,21 @@ impl PinnedSessionCard {
     /// Called when turn metrics arrive (resolves the model name and
     /// authoritative context window).
     pub fn on_turn_metrics(&mut self, model: String, context_window_tokens: Option<u32>) {
-        self.model = model;
-        if context_window_tokens.is_some() {
-            self.context_window_tokens = context_window_tokens;
-        }
-        self.dirty = true;
+        self.set_model_and_window(model, context_window_tokens);
     }
 
     /// Called when the kernel emits `TurnStarted` — lets the card surface
     /// model + context window in the pin preview before any LLM iteration
     /// completes (so the card is never "empty" during a turn).
     pub fn on_turn_started(&mut self, model: String, context_window_tokens: Option<u32>) {
+        self.set_model_and_window(model, context_window_tokens);
+    }
+
+    /// Update the model and (optionally) the context window, marking the
+    /// card dirty. A `None` window preserves any previously resolved value —
+    /// late `TurnMetrics` without a window must not clobber the authoritative
+    /// `TurnStarted` value.
+    fn set_model_and_window(&mut self, model: String, context_window_tokens: Option<u32>) {
         self.model = model;
         if context_window_tokens.is_some() {
             self.context_window_tokens = context_window_tokens;
@@ -494,6 +515,14 @@ mod tests {
         // Idle uses ⚪ emoji on line 1 (session title fallback since no model).
         assert!(text.contains("\u{26aa}"));
         assert!(text.contains("<b>mita</b>"));
+    }
+
+    #[test]
+    fn on_turn_metrics_none_preserves_existing_window() {
+        let mut card = PinnedSessionCard::new(123, "s1".into(), "mita".into());
+        card.on_turn_started("claude-sonnet-4".into(), Some(200_000));
+        card.on_turn_metrics("claude-sonnet-4".into(), None);
+        assert_eq!(card.context_window_tokens, Some(200_000));
     }
 
     #[test]

--- a/crates/channels/src/telegram/pinned_status.rs
+++ b/crates/channels/src/telegram/pinned_status.rs
@@ -25,13 +25,14 @@ use teloxide::types::MessageId;
 use super::adapter::format_token_count;
 
 // ---------------------------------------------------------------------------
-// Model metadata — context window sizes and per-token pricing
+// Model metadata — context window sizes
 // ---------------------------------------------------------------------------
-
-/// Known model context window size.
-struct ModelInfo {
-    context_window: u32,
-}
+//
+// The authoritative context window size is carried by
+// `StreamEvent::TurnStarted` / `TurnMetrics` (populated by the kernel from
+// `ModelCapabilities::context_window_tokens`). The substring-matching fallback
+// below is kept for graceful degradation when an older kernel / partial event
+// stream arrives without the new field.
 
 /// Shorten an absolute path to at most the last 3 segments.
 fn short_path(path: &str) -> &str {
@@ -48,53 +49,35 @@ fn short_path(path: &str) -> &str {
     path
 }
 
-/// Best-effort lookup of model metadata by name substring.
-///
-/// Matches the most specific substring first. Returns `None` for unknown
-/// models — the card gracefully omits context % and cost when unavailable.
-fn lookup_model_info(model: &str) -> Option<ModelInfo> {
+/// Best-effort fallback context window lookup when the kernel did not supply
+/// a value on the stream (older builds, partial events).
+fn fallback_context_window(model: &str) -> Option<u32> {
     let m = model.to_lowercase();
-
-    // Claude family — 200K context
     if m.contains("opus") || m.contains("sonnet") || m.contains("haiku") {
-        return Some(ModelInfo {
-            context_window: 200_000,
-        });
+        return Some(200_000);
     }
-    // OpenAI o-series — 200K context
     if m.contains("o3") || m.contains("o4-mini") {
-        return Some(ModelInfo {
-            context_window: 200_000,
-        });
+        return Some(200_000);
     }
-    // GPT-4o family — 128K context
     if m.contains("gpt-4o") {
-        return Some(ModelInfo {
-            context_window: 128_000,
-        });
+        return Some(128_000);
     }
-    // Gemini — 1M context
     if m.contains("gemini-2") || m.contains("gemini-1.5") {
-        return Some(ModelInfo {
-            context_window: 1_000_000,
-        });
+        return Some(1_000_000);
     }
-    // DeepSeek — 128K context
     if m.contains("deepseek") {
-        return Some(ModelInfo {
-            context_window: 128_000,
-        });
+        return Some(128_000);
     }
-
     None
 }
 
 /// Look up the context window size (in tokens) for a known model.
 ///
-/// Thin wrapper around [`lookup_model_info`] exposed to sibling modules
-/// so that [`super::reply_keyboard`] can compute the context usage gauge.
+/// Exposed to sibling modules (e.g. [`super::reply_keyboard`]) for the
+/// context usage gauge. Prefer the authoritative value carried by
+/// `StreamEvent::TurnStarted` when available.
 pub(super) fn context_window_for_model(model: &str) -> Option<u32> {
-    lookup_model_info(model).map(|info| info.context_window)
+    fallback_context_window(model)
 }
 
 // ---------------------------------------------------------------------------
@@ -144,25 +127,30 @@ pub(super) struct FileChange {
 #[derive(Debug)]
 pub(super) struct PinnedSessionCard {
     /// Telegram chat ID this card belongs to.
-    pub chat_id:      i64,
+    pub chat_id:           i64,
     /// Message ID of the pinned message, `None` until first send.
-    pub message_id:   Option<MessageId>,
+    pub message_id:        Option<MessageId>,
     /// Session identifier used for detecting session switches.
-    pub session_id:   String,
-    session_title:    String,
-    model:            String,
-    state:            State,
-    input_tokens:     u32,
-    output_tokens:    u32,
-    thinking_ms:      u64,
-    tool_calls:       u32,
-    background_tasks: Vec<BackgroundTaskEntry>,
-    changed_files:    Vec<FileChange>,
-    project_name:     String,
-    project_branch:   String,
-    dirty:            bool,
+    pub session_id:        String,
+    session_title:         String,
+    model:                 String,
+    /// Authoritative context window (tokens) from kernel `ModelCapabilities`.
+    /// `None` until the kernel emits `TurnStarted` / `TurnMetrics` for this
+    /// turn (first turn after restart), at which point we fill from the event
+    /// rather than a substring table.
+    context_window_tokens: Option<u32>,
+    state:                 State,
+    input_tokens:          u32,
+    output_tokens:         u32,
+    thinking_ms:           u64,
+    tool_calls:            u32,
+    background_tasks:      Vec<BackgroundTaskEntry>,
+    changed_files:         Vec<FileChange>,
+    project_name:          String,
+    project_branch:        String,
+    dirty:                 bool,
     /// Last rendered HTML — skip-unchanged optimization.
-    last_rendered:    String,
+    last_rendered:         String,
 }
 
 impl PinnedSessionCard {
@@ -176,6 +164,7 @@ impl PinnedSessionCard {
             session_id,
             session_title,
             model: String::new(),
+            context_window_tokens: None,
             state: State::Running,
             input_tokens: 0,
             output_tokens: 0,
@@ -193,21 +182,56 @@ impl PinnedSessionCard {
     /// Render the session summary card as HTML.
     ///
     /// **Line 1 — Identity bar** (visible in Telegram's floating pin preview):
-    /// `🟢 {session_title} · {agent_name}`
-    /// Answers "where am I?" — session context, not telemetry.
+    /// `🟢 <model> · {used}/{limit} ({pct}%)` — model + context gauge is the
+    /// single piece of telemetry most worth seeing at a glance. Falls back to
+    /// the session title when the model is not yet known (pre-first-turn).
+    ///
+    /// **Line 2 — Session subtitle**: the human-readable session label, so
+    /// users still know "where am I?" when they expand the pin.
     ///
     /// **Body — Metrics** (visible when user taps the pinned message):
-    /// Model, Context %, Cost, Thinking, Tools, Background.
+    /// Project, Thinking, Tools, Background, Files.
     pub fn render(&self) -> String {
         let mut lines = Vec::with_capacity(8);
 
-        // Line 1: Identity bar — status emoji + session title + agent name.
-        // This is what shows in the floating pin preview at the chat top.
+        // Status emoji encodes agent state (Running / Idle). Placed on line 1
+        // so the pin preview signals activity without needing to expand.
         let status_emoji = match self.state {
             State::Running => "\u{1f7e2}", // 🟢
             State::Idle => "\u{26aa}",     // ⚪
         };
-        lines.push(format!("{status_emoji} <b>{}</b>", self.session_title));
+
+        // Resolve context window: authoritative kernel-supplied value first,
+        // substring fallback for older kernels / stale pins from before the
+        // first turn.
+        let window = self
+            .context_window_tokens
+            .or_else(|| fallback_context_window(&self.model));
+
+        // Line 1: model + context gauge (preferred) or session title (fallback
+        // until the first TurnStarted event arrives after a bot restart).
+        if self.model.is_empty() {
+            lines.push(format!("{status_emoji} <b>{}</b>", self.session_title));
+        } else {
+            let head = format!("{status_emoji} <code>{}</code>", self.model);
+            let gauge = match (self.input_tokens, window) {
+                (0, Some(limit)) => format!(" · 0/{} (0%)", format_token_count(limit)),
+                (used, Some(limit)) if limit > 0 => {
+                    let pct = (used as f64 / limit as f64 * 100.0) as u32;
+                    format!(
+                        " · {}/{} ({pct}%)",
+                        format_token_count(used),
+                        format_token_count(limit),
+                    )
+                }
+                (used, _) if used > 0 => format!(" · {}", format_token_count(used)),
+                _ => String::new(),
+            };
+            lines.push(format!("{head}{gauge}"));
+            // Line 2: session subtitle — keeps "where am I?" info available
+            // when the pin is expanded, just demoted from line 1.
+            lines.push(format!("<i>{}</i>", self.session_title));
+        }
 
         // Project: name: branch (shown when available).
         if !self.project_name.is_empty() {
@@ -217,32 +241,6 @@ impl PinnedSessionCard {
                 format!("Project: {}: {}", self.project_name, self.project_branch)
             };
             lines.push(project_line);
-        }
-
-        let model_info = if self.model.is_empty() {
-            None
-        } else {
-            lookup_model_info(&self.model)
-        };
-
-        // Model.
-        if !self.model.is_empty() {
-            lines.push(format!("Model: <code>{}</code>", self.model));
-        }
-
-        // Context: input_tokens is the current prompt/context size in our
-        // stream protocol. output_tokens is cumulative completion — must NOT
-        // be mixed into the context meter.
-        if self.input_tokens > 0 {
-            let used_str = format_token_count(self.input_tokens);
-            let context_line = if let Some(ref info) = model_info {
-                let limit_str = format_token_count(info.context_window);
-                let pct = (self.input_tokens as f64 / info.context_window as f64 * 100.0) as u32;
-                format!("Context: {used_str} / {limit_str} ({pct}%)")
-            } else {
-                format!("Context: {used_str}")
-            };
-            lines.push(context_line);
         }
 
         // Thinking time (rara-specific, shown when non-zero).
@@ -330,9 +328,24 @@ impl PinnedSessionCard {
     /// Called when a tool call finishes.
     pub fn on_tool_end(&mut self) { self.dirty = true; }
 
-    /// Called when turn metrics arrive (resolves the model name).
-    pub fn on_turn_metrics(&mut self, model: String) {
+    /// Called when turn metrics arrive (resolves the model name and
+    /// authoritative context window).
+    pub fn on_turn_metrics(&mut self, model: String, context_window_tokens: Option<u32>) {
         self.model = model;
+        if context_window_tokens.is_some() {
+            self.context_window_tokens = context_window_tokens;
+        }
+        self.dirty = true;
+    }
+
+    /// Called when the kernel emits `TurnStarted` — lets the card surface
+    /// model + context window in the pin preview before any LLM iteration
+    /// completes (so the card is never "empty" during a turn).
+    pub fn on_turn_started(&mut self, model: String, context_window_tokens: Option<u32>) {
+        self.model = model;
+        if context_window_tokens.is_some() {
+            self.context_window_tokens = context_window_tokens;
+        }
         self.dirty = true;
     }
 
@@ -415,20 +428,21 @@ mod tests {
     #[test]
     fn render_with_model_and_context() {
         let mut card = PinnedSessionCard::new(123, "s1".into(), "mita".into());
-        card.model = "claude-sonnet-4".to_string();
+        card.on_turn_started("claude-sonnet-4".into(), Some(200_000));
         card.input_tokens = 45_000;
         card.output_tokens = 12_000;
         card.thinking_ms = 5_000;
         card.tool_calls = 8;
 
         let text = card.render();
-        // Identity bar: 🟢 mita
-        assert!(text.contains("\u{1f7e2}"));
-        assert!(text.contains("<b>mita</b>"));
-        assert!(text.contains("<code>claude-sonnet-4</code>"));
-        // Context uses input_tokens only (not input+output).
-        assert!(text.contains("45.0k / 200.0k"));
-        assert!(text.contains('%'));
+        let line1 = text.lines().next().expect("line 1 present");
+        // Line 1: model + context gauge — the pin preview telemetry.
+        assert!(line1.contains("\u{1f7e2}"));
+        assert!(line1.contains("<code>claude-sonnet-4</code>"));
+        assert!(line1.contains("45.0k/200.0k"));
+        assert!(line1.contains('%'));
+        // Line 2: session subtitle.
+        assert!(text.contains("<i>mita</i>"));
         assert!(!text.contains("Cost:"));
         assert!(text.contains("Thinking: 5s"));
         assert!(text.contains("8 tool calls"));
@@ -437,14 +451,39 @@ mod tests {
     #[test]
     fn render_unknown_model_omits_limit() {
         let mut card = PinnedSessionCard::new(123, "s1".into(), "mita".into());
-        card.model = "some-unknown-model".to_string();
+        // Unknown model, no kernel-supplied limit, no substring match either.
+        card.on_turn_started("some-unknown-model".into(), None);
         card.input_tokens = 10_000;
         card.output_tokens = 5_000;
 
         let text = card.render();
-        // Context uses input_tokens only, no limit/percent for unknown model.
-        assert!(text.contains("Context: 10.0k"));
-        assert!(!text.contains('%'));
+        let line1 = text.lines().next().expect("line 1 present");
+        // Raw token count without a limit/percent when window is unknown.
+        assert!(line1.contains("10.0k"));
+        assert!(!line1.contains('%'));
+    }
+
+    #[test]
+    fn render_line1_fallback_before_first_turn() {
+        // Before the first TurnStarted event the model is unknown — line 1
+        // falls back to the session title so the pin is never blank.
+        let card = PinnedSessionCard::new(123, "s1".into(), "mita".into());
+        let text = card.render();
+        let line1 = text.lines().next().expect("line 1 present");
+        assert!(line1.contains("<b>mita</b>"));
+    }
+
+    #[test]
+    fn render_line1_zero_tokens_shows_limit() {
+        let mut card = PinnedSessionCard::new(123, "s1".into(), "mita".into());
+        card.on_turn_started("claude-sonnet-4".into(), Some(200_000));
+        // No UsageUpdate yet — line 1 should still show the model and the
+        // limit (with 0% used) rather than disappear.
+        let text = card.render();
+        let line1 = text.lines().next().expect("line 1 present");
+        assert!(line1.contains("<code>claude-sonnet-4</code>"));
+        assert!(line1.contains("0/200.0k"));
+        assert!(line1.contains("0%"));
     }
 
     #[test]
@@ -452,7 +491,7 @@ mod tests {
         let mut card = PinnedSessionCard::new(123, "s1".into(), "mita".into());
         card.on_stream_close();
         let text = card.render();
-        // Idle uses ⚪ emoji, no "Idle" text in identity bar.
+        // Idle uses ⚪ emoji on line 1 (session title fallback since no model).
         assert!(text.contains("\u{26aa}"));
         assert!(text.contains("<b>mita</b>"));
     }

--- a/crates/channels/src/web.rs
+++ b/crates/channels/src/web.rs
@@ -228,6 +228,7 @@ fn stream_event_to_web_event(event: StreamEvent) -> Option<WebEvent> {
             tool_calls,
             model,
             rara_message_id: _,
+            context_window_tokens: _,
         } => Some(WebEvent::TurnMetrics {
             duration_ms,
             iterations,
@@ -259,6 +260,7 @@ fn stream_event_to_web_event(event: StreamEvent) -> Option<WebEvent> {
         StreamEvent::PlanReplan { reason } => Some(WebEvent::PlanReplan { reason }),
         StreamEvent::PlanCompleted { summary } => Some(WebEvent::PlanCompleted { summary }),
         StreamEvent::UsageUpdate { .. } => None,
+        StreamEvent::TurnStarted { .. } => None,
         StreamEvent::TurnUsage {
             input_tokens,
             output_tokens,

--- a/crates/cmd/src/chat/mod.rs
+++ b/crates/cmd/src/chat/mod.rs
@@ -1017,8 +1017,8 @@ fn stream_event_to_cli_event(event: StreamEvent) -> CliEvent {
             text: format!("Loop detected ({pattern}): disabled {}", tools.join(", ")),
         },
         StreamEvent::ToolOutput { chunk, .. } => CliEvent::TextDelta { text: chunk },
-        StreamEvent::TurnStarted { .. } => CliEvent::Progress {
-            text: String::new(),
+        StreamEvent::TurnStarted { model, .. } => CliEvent::Progress {
+            text: format!("[{model}]"),
         },
     }
 }

--- a/crates/cmd/src/chat/mod.rs
+++ b/crates/cmd/src/chat/mod.rs
@@ -934,6 +934,7 @@ fn stream_event_to_cli_event(event: StreamEvent) -> CliEvent {
             tool_calls,
             model,
             rara_message_id: _,
+            context_window_tokens: _,
         } => CliEvent::TurnSummary {
             duration_ms,
             iterations: iterations as u32,
@@ -1016,6 +1017,9 @@ fn stream_event_to_cli_event(event: StreamEvent) -> CliEvent {
             text: format!("Loop detected ({pattern}): disabled {}", tools.join(", ")),
         },
         StreamEvent::ToolOutput { chunk, .. } => CliEvent::TextDelta { text: chunk },
+        StreamEvent::TurnStarted { .. } => CliEvent::Progress {
+            text: String::new(),
+        },
     }
 }
 

--- a/crates/kernel/src/agent/mod.rs
+++ b/crates/kernel/src/agent/mod.rs
@@ -1197,7 +1197,7 @@ pub(crate) async fn run_agent_loop(
     // for downstream substring-match tables.
     stream_handle.emit(StreamEvent::TurnStarted {
         model:                 model.clone(),
-        context_window_tokens: Some(capabilities.context_window_tokens as u32),
+        context_window_tokens: u32::try_from(capabilities.context_window_tokens).ok(),
     });
 
     // +1 for potential budget grace call (only consumed if grace is injected).
@@ -2080,7 +2080,7 @@ pub(crate) async fn run_agent_loop(
                 model: model.clone(),
                 input_tokens: last_prompt_tokens,
                 output_tokens: cumulative_output_tokens,
-                context_window_tokens: Some(capabilities.context_window_tokens as u32),
+                context_window_tokens: u32::try_from(capabilities.context_window_tokens).ok(),
                 trace,
                 cascade,
             });
@@ -3102,7 +3102,7 @@ pub(crate) async fn run_agent_loop(
         model: model.clone(),
         input_tokens: last_prompt_tokens,
         output_tokens: cumulative_output_tokens,
-        context_window_tokens: Some(capabilities.context_window_tokens as u32),
+        context_window_tokens: u32::try_from(capabilities.context_window_tokens).ok(),
         trace,
         cascade,
     })

--- a/crates/kernel/src/agent/mod.rs
+++ b/crates/kernel/src/agent/mod.rs
@@ -534,23 +534,27 @@ pub struct TurnTrace {
 #[derive(Debug)]
 pub struct AgentTurnResult {
     /// The final text produced by the agent.
-    pub text:          String,
+    pub text:                  String,
     /// Number of LLM iterations consumed.
-    pub iterations:    usize,
+    pub iterations:            usize,
     /// Number of tool calls executed.
-    pub tool_calls:    usize,
+    pub tool_calls:            usize,
     /// Model used for this turn.
-    pub model:         String,
+    pub model:                 String,
     /// Largest prompt_tokens across all iterations in this turn — each
     /// iteration re-sends the full context so the last one is effectively
     /// the max. `0` when no usage data was reported by the provider.
-    pub input_tokens:  u32,
+    pub input_tokens:          u32,
     /// Sum of completion_tokens across all iterations in this turn.
-    pub output_tokens: u32,
+    pub output_tokens:         u32,
+    /// Authoritative context window size (in tokens) for the model used this
+    /// turn, sourced from [`ModelCapabilities`]. `None` when the driver did
+    /// not expose a limit and no catalog/manifest override was found.
+    pub context_window_tokens: Option<u32>,
     /// Detailed trace of the turn for observability.
-    pub trace:         TurnTrace,
+    pub trace:                 TurnTrace,
     /// Structured cascade trace built in real time during the turn.
-    pub cascade:       crate::cascade::CascadeTrace,
+    pub cascade:               crate::cascade::CascadeTrace,
 }
 
 impl AgentTurnResult {
@@ -558,13 +562,14 @@ impl AgentTurnResult {
     /// judgment decides Rara should not reply.
     pub fn empty() -> Self {
         Self {
-            text:          String::new(),
-            iterations:    0,
-            tool_calls:    0,
-            model:         String::new(),
-            input_tokens:  0,
-            output_tokens: 0,
-            trace:         TurnTrace {
+            text:                  String::new(),
+            iterations:            0,
+            tool_calls:            0,
+            model:                 String::new(),
+            input_tokens:          0,
+            output_tokens:         0,
+            context_window_tokens: None,
+            trace:                 TurnTrace {
                 duration_ms:      0,
                 model:            String::new(),
                 input_text:       None,
@@ -575,7 +580,7 @@ impl AgentTurnResult {
                 error:            None,
                 rara_message_id:  crate::io::MessageId::new(),
             },
-            cascade:       crate::cascade::CascadeTrace::empty(),
+            cascade:               crate::cascade::CascadeTrace::empty(),
         }
     }
 }
@@ -1185,6 +1190,15 @@ pub(crate) async fn run_agent_loop(
     } else {
         None
     };
+
+    // Emit turn-start event so channel adapters can populate model-dependent
+    // UI (e.g. the Telegram pinned session card) before any LLM response
+    // arrives. Carrying the authoritative context window here removes the need
+    // for downstream substring-match tables.
+    stream_handle.emit(StreamEvent::TurnStarted {
+        model:                 model.clone(),
+        context_window_tokens: Some(capabilities.context_window_tokens as u32),
+    });
 
     // +1 for potential budget grace call (only consumed if grace is injected).
     for iteration in 0..=max_iterations {
@@ -2066,6 +2080,7 @@ pub(crate) async fn run_agent_loop(
                 model: model.clone(),
                 input_tokens: last_prompt_tokens,
                 output_tokens: cumulative_output_tokens,
+                context_window_tokens: Some(capabilities.context_window_tokens as u32),
                 trace,
                 cascade,
             });
@@ -3087,6 +3102,7 @@ pub(crate) async fn run_agent_loop(
         model: model.clone(),
         input_tokens: last_prompt_tokens,
         output_tokens: cumulative_output_tokens,
+        context_window_tokens: Some(capabilities.context_window_tokens as u32),
         trace,
         cascade,
     })

--- a/crates/kernel/src/io.rs
+++ b/crates/kernel/src/io.rs
@@ -906,11 +906,27 @@ pub enum StreamEvent {
     },
     /// Turn metrics summary (emitted before stream close).
     TurnMetrics {
-        duration_ms:     u64,
-        iterations:      usize,
-        tool_calls:      usize,
-        model:           String,
-        rara_message_id: String,
+        duration_ms:           u64,
+        iterations:            usize,
+        tool_calls:            usize,
+        model:                 String,
+        rara_message_id:       String,
+        /// Authoritative context window size (in tokens) for the model used
+        /// this turn. Populated from
+        /// `ModelCapabilities::context_window_tokens`. `None` only if
+        /// the agent turn errored before capabilities were resolved —
+        /// kept optional for forward/backward compatibility.
+        #[serde(default)]
+        context_window_tokens: Option<u32>,
+    },
+    /// Emitted immediately when an agent turn starts, so channel adapters can
+    /// populate model-dependent UI (e.g. the Telegram pinned session card)
+    /// without waiting for the first LLM response.
+    TurnStarted {
+        model:                 String,
+        /// Authoritative context window size (in tokens) for the model used
+        /// this turn. `None` if the driver did not report a limit.
+        context_window_tokens: Option<u32>,
     },
     /// Final per-turn token usage (emitted once, after the agent loop
     /// finishes, before stream close). Distinct from `UsageUpdate` which is

--- a/crates/kernel/src/io.rs
+++ b/crates/kernel/src/io.rs
@@ -835,6 +835,11 @@ pub enum PlanStepStatus {
 }
 
 /// Incremental events emitted during agent execution.
+///
+/// In-process only: forwarded over a `tokio::sync::broadcast` channel to live
+/// subscribers (Telegram adapter, web SSE, CLI). Not persisted to disk — the
+/// `Serialize`/`Deserialize` derive exists solely for the web SSE transport
+/// that re-maps variants into `WebEvent` before sending to browsers.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum StreamEvent {

--- a/crates/kernel/src/kernel.rs
+++ b/crates/kernel/src/kernel.rs
@@ -2646,11 +2646,12 @@ impl Kernel {
                 // `TurnUsage` arrives.
                 if let Ok(ref result) = turn_result {
                     stream_handle.emit(crate::io::StreamEvent::TurnMetrics {
-                        duration_ms: elapsed_ms,
-                        iterations:  result.iterations,
-                        tool_calls:  result.tool_calls,
-                        model:       result.model.clone(),
-                        rara_message_id: result.trace.rara_message_id.to_string(),
+                        duration_ms:           elapsed_ms,
+                        iterations:            result.iterations,
+                        tool_calls:            result.tool_calls,
+                        model:                 result.model.clone(),
+                        rara_message_id:       result.trace.rara_message_id.to_string(),
+                        context_window_tokens: result.context_window_tokens,
                     });
                     stream_handle.emit(crate::io::StreamEvent::TurnUsage {
                         input_tokens:  result.input_tokens,

--- a/crates/kernel/src/plan.rs
+++ b/crates/kernel/src/plan.rs
@@ -673,13 +673,14 @@ pub(crate) async fn run_plan_loop(
 
     let final_text_len = summary.len();
     Ok(AgentTurnResult {
-        text:          summary,
-        iterations:    total_iterations,
-        tool_calls:    total_tool_calls,
-        model:         last_model.clone(),
-        input_tokens:  0,
-        output_tokens: 0,
-        trace:         crate::agent::TurnTrace {
+        text:                  summary,
+        iterations:            total_iterations,
+        tool_calls:            total_tool_calls,
+        model:                 last_model.clone(),
+        input_tokens:          0,
+        output_tokens:         0,
+        context_window_tokens: None,
+        trace:                 crate::agent::TurnTrace {
             duration_ms: start.elapsed().as_millis() as u64,
             model: last_model,
             input_text: Some(user_text),
@@ -707,7 +708,7 @@ pub(crate) async fn run_plan_loop(
             },
             rara_message_id,
         },
-        cascade:       crate::cascade::CascadeTrace::empty(),
+        cascade:               crate::cascade::CascadeTrace::empty(),
     })
 }
 
@@ -1455,13 +1456,14 @@ mod tests {
     ) -> crate::agent::AgentTurnResult {
         use crate::io::MessageId;
         crate::agent::AgentTurnResult {
-            text:          text.to_owned(),
-            iterations:    25,
-            tool_calls:    25,
-            model:         "test-model".to_owned(),
-            input_tokens:  0,
-            output_tokens: 0,
-            trace:         crate::agent::TurnTrace {
+            text:                  text.to_owned(),
+            iterations:            25,
+            tool_calls:            25,
+            model:                 "test-model".to_owned(),
+            input_tokens:          0,
+            output_tokens:         0,
+            context_window_tokens: None,
+            trace:                 crate::agent::TurnTrace {
                 duration_ms: 1000,
                 model: "test-model".to_owned(),
                 input_text: None,
@@ -1472,7 +1474,7 @@ mod tests {
                 error: error.map(|s| s.to_owned()),
                 rara_message_id: MessageId::new(),
             },
-            cascade:       crate::cascade::CascadeTrace {
+            cascade:               crate::cascade::CascadeTrace {
                 message_id: String::new(),
                 ticks:      Vec::new(),
                 summary:    crate::cascade::CascadeSummary {


### PR DESCRIPTION
## Summary

Telegram 浮窗只显示 pin 的第 1 行。之前 line 1 = \`⚪ <session_title(UUID)>\`，对常驻场景信息量接近 0。同时 pin body 的 Model / Context / Thinking 在实际使用里一直是空的。

两件事一起修：

1. **Bug — body 永远为空**
   根因：flush 时序。500 ms throttle tick 经常跑在 \`TurnMetrics\` / \`UsageUpdate\` 到达之前，后续事件只 mark dirty 不强制 re-edit。
   修法：kernel 新增 \`StreamEvent::TurnStarted { model, context_window_tokens }\`，turn 开头立刻发出。adapter 的 \`TurnStarted\` / \`UsageUpdate\` / \`TurnMetrics\` handler 都 force-flush（仍经 \`ChatRateLimiter::acquire\`）。

2. **Design — 浮窗可见 model + context**
   Line 1 改为 \`<emoji> <model> · {used}/{limit} ({pct}%)\`，session title 下移到 line 2 做 subtitle。Pre-first-turn（model 未知时）退化为 \`<emoji> <session_title>\`。

## 架构对齐

context window 从 \`pinned_status.rs\` 内部的 substring 表，改为 kernel \`ModelCapabilities::context_window_tokens\` 通过 \`TurnStarted\` / \`TurnMetrics\` 事件送出，单一来源。老 substring 表保留为 \`fallback_context_window\`，仅用于 bot 重启后首次 \`TurnStarted\` 到来前的 stale 渲染。

向后兼容：\`context_window_tokens: Option<u32>\` 带 \`#[serde(default)]\`，旧消费者不受影响。

## Type of change

| Type | Label |
|------|-------|
| New feature | \`enhancement\` |
| Bug fix | \`bug\` |

## Component

\`extension\` (主) + \`core\` (kernel TurnStarted 事件)

## Closes

Closes #1541

## Test plan

- [x] \`cargo check -p rara-channels -p rara-kernel\` passes
- [x] \`cargo +nightly fmt --all -- --check\` passes
- [x] \`cargo clippy -p rara-channels -p rara-kernel --all-targets --all-features --no-deps -- -D warnings\` zero warnings
- [x] \`RUSTDOCFLAGS=-D warnings cargo +nightly doc -p rara-channels -p rara-kernel --no-deps --document-private-items\` zero warnings
- [x] \`cargo test -p rara-channels --lib\` 138 pass
- [x] 全 workspace \`cargo check --all --all-targets\` 通过（连带改了 \`web.rs\`, \`cmd/src/chat/mod.rs\`, \`plan.rs\` 的 \`TurnMetrics\` 模式匹配）
- [x] 所有 prek 钩子通过
- [ ] 手测：在 TG 起一个新 session，发一条消息，确认浮窗立刻显示 \`⚪ <model> · {used}/{limit} ({pct}%)\`