### PR TITLE
feat(kernel): context pressure warnings in AgentMachine (#1545)

### DIFF
--- a/crates/kernel/src/agent/effect.rs
+++ b/crates/kernel/src/agent/effect.rs
@@ -119,6 +119,21 @@ pub enum Effect {
         /// Maximum continuations allowed.
         max:  usize,
     },
+    /// Inject a context-pressure warning as a user-visible message into the
+    /// conversation before the next LLM call. Emitted at most once per
+    /// threshold crossing (`Warning` at `>= 0.70`, `Critical` at `>= 0.85`)
+    /// so the LLM is nudged exactly when pressure rises, not on every
+    /// iteration thereafter. Preserves the semantics of the legacy
+    /// `classify_context_pressure` helper in `agent::mod`.
+    ContextPressureWarning {
+        /// Severity bucket the observed usage crossed.
+        level:                 PressureLevel,
+        /// Runner-estimated tokens currently in the tape context.
+        estimated_tokens:      usize,
+        /// Model context window in tokens (informational; typically from
+        /// the active `ModelCapabilities`).
+        context_window_tokens: usize,
+    },
     /// Signal that the loop breaker tripped and one or more tools were
     /// disabled for the remainder of the turn. Emitted immediately before
     /// the [`Effect::CallLlm`] of the next iteration so the runner can
@@ -166,6 +181,19 @@ pub enum TapeAppendKind {
     ToolCalls,
     /// One or more tool results returned to the LLM.
     ToolResults,
+}
+
+/// Severity bucket classifying observed context-window usage.
+///
+/// Mirrors the legacy `ContextPressure` enum in `agent::mod` but surfaces only
+/// the actionable (non-`Normal`) levels, because `Normal` never produces an
+/// effect.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PressureLevel {
+    /// Usage ratio crossed `CONTEXT_WARN_THRESHOLD` (0.70) — a SHOULD hint.
+    Warning,
+    /// Usage ratio crossed `CONTEXT_CRITICAL_THRESHOLD` (0.85) — a MUST hint.
+    Critical,
 }
 
 /// User decision when the tool-call-limit circuit breaker pauses the turn.

--- a/crates/kernel/src/agent/machine.rs
+++ b/crates/kernel/src/agent/machine.rs
@@ -41,11 +41,24 @@
 
 use crate::{
     agent::{
-        effect::{Effect, FinishReason, LimitDecision, TapeAppendKind, ToolCall, ToolResult},
+        effect::{
+            Effect, FinishReason, LimitDecision, PressureLevel, TapeAppendKind, ToolCall,
+            ToolResult,
+        },
         loop_breaker::{LoopBreakerConfig, LoopIntervention, ToolCallLoopBreaker},
     },
     tool::ToolName,
 };
+
+/// Usage fraction at which the machine emits a `Warning`-level
+/// `ContextPressureWarning` effect. Mirrors the legacy
+/// `CONTEXT_WARN_THRESHOLD` constant in `agent::mod`.
+pub const CONTEXT_WARN_THRESHOLD: f64 = 0.70;
+
+/// Usage fraction at which the machine emits a `Critical`-level
+/// `ContextPressureWarning` effect. Mirrors the legacy
+/// `CONTEXT_CRITICAL_THRESHOLD` constant in `agent::mod`.
+pub const CONTEXT_CRITICAL_THRESHOLD: f64 = 0.85;
 
 /// High-level phases of one agent turn.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -104,6 +117,14 @@ pub struct AgentMachine {
     /// Monotonic counter for limit-pause ids, handed to the runner so it
     /// can key its oneshot channel and reject stale decisions.
     limit_id_counter:     u64,
+    /// Whether a `PressureLevel::Warning` has already been emitted this
+    /// turn.  The legacy loop nudged the LLM once at each threshold
+    /// crossing to avoid spamming a repeating reminder every iteration.
+    warned_at_warning:    bool,
+    /// Whether a `PressureLevel::Critical` has already been emitted this
+    /// turn.  Critical can fire even after Warning has fired (they are
+    /// distinct thresholds), but each is still one-shot.
+    warned_at_critical:   bool,
 }
 
 impl AgentMachine {
@@ -125,6 +146,8 @@ impl AgentMachine {
             limit_interval: 0,
             next_limit_at: usize::MAX,
             limit_id_counter: 0,
+            warned_at_warning: false,
+            warned_at_critical: false,
         }
     }
 
@@ -184,6 +207,63 @@ impl AgentMachine {
 
     /// Whether the machine has reached a terminal state.
     pub fn is_terminal(&self) -> bool { matches!(self.phase, Phase::Done | Phase::Failed) }
+
+    /// Synchronous observation: report the current context-window usage and
+    /// return any resulting `ContextPressureWarning` effects.
+    ///
+    /// The runner is expected to call this once per LLM round — after
+    /// rebuilding the tape context for the next iteration but before
+    /// interpreting `Effect::CallLlm` — so the injected warning message lands
+    /// in the conversation immediately ahead of the model's next turn.
+    ///
+    /// Unlike `step`, this method does **not** consume an [`Event`] and does
+    /// **not** change [`Phase`]. It is a pure observation:
+    ///
+    /// - Returns `[Effect::ContextPressureWarning { level: Critical, .. }]` the
+    ///   first time usage crosses `CONTEXT_CRITICAL_THRESHOLD`.
+    /// - Returns `[Effect::ContextPressureWarning { level: Warning, .. }]` the
+    ///   first time usage crosses `CONTEXT_WARN_THRESHOLD` (and Critical has
+    ///   not yet fired).
+    /// - Returns `[]` otherwise (already warned at the bucket, or below
+    ///   threshold, or window is zero).
+    ///
+    /// Warning and Critical each fire at most once per turn — the legacy
+    /// loop nudged the LLM once per crossing to avoid spam that would anchor
+    /// the conversation on the reminder itself.
+    pub fn observe_context_usage(
+        &mut self,
+        estimated_tokens: usize,
+        context_window_tokens: usize,
+    ) -> Vec<Effect> {
+        if context_window_tokens == 0 {
+            return Vec::new();
+        }
+        let usage_ratio = estimated_tokens as f64 / context_window_tokens as f64;
+
+        if usage_ratio >= CONTEXT_CRITICAL_THRESHOLD && !self.warned_at_critical {
+            self.warned_at_critical = true;
+            // Ensure Warning is also marked as delivered once we jumped
+            // straight past it — avoids emitting a stale Warning after a
+            // Critical has already been surfaced.
+            self.warned_at_warning = true;
+            return vec![Effect::ContextPressureWarning {
+                level: PressureLevel::Critical,
+                estimated_tokens,
+                context_window_tokens,
+            }];
+        }
+
+        if usage_ratio >= CONTEXT_WARN_THRESHOLD && !self.warned_at_warning {
+            self.warned_at_warning = true;
+            return vec![Effect::ContextPressureWarning {
+                level: PressureLevel::Warning,
+                estimated_tokens,
+                context_window_tokens,
+            }];
+        }
+
+        Vec::new()
+    }
 
     /// Drive the machine with one event.  Returns the side effects the runner
     /// must perform before feeding the next event back in.
@@ -1151,6 +1231,92 @@ mod tests {
             })
             .expect("expected second PauseForLimit");
         assert_eq!(id, 2, "limit id monotonically increases");
+    }
+
+    // ─── Context-pressure observation ───────────────────────────────────
+
+    /// Below the warning threshold the observer stays silent.
+    #[test]
+    fn context_pressure_silent_below_warning() {
+        let mut m = AgentMachine::new(8);
+        assert!(m.observe_context_usage(500, 1_000).is_empty());
+        assert!(m.observe_context_usage(699, 1_000).is_empty());
+    }
+
+    /// Crossing 0.70 (but not 0.85) emits a single Warning effect.
+    #[test]
+    fn context_pressure_fires_warning_at_threshold() {
+        let mut m = AgentMachine::new(8);
+        let effects = m.observe_context_usage(750, 1_000);
+        match effects.as_slice() {
+            [
+                Effect::ContextPressureWarning {
+                    level: PressureLevel::Warning,
+                    estimated_tokens,
+                    context_window_tokens,
+                },
+            ] => {
+                assert_eq!(*estimated_tokens, 750);
+                assert_eq!(*context_window_tokens, 1_000);
+            }
+            other => panic!("expected single Warning, got {other:?}"),
+        }
+    }
+
+    /// Warning is one-shot: repeated observations in the same bucket are
+    /// silent even when usage rises further within the Warning band.
+    #[test]
+    fn context_pressure_warning_is_one_shot() {
+        let mut m = AgentMachine::new(8);
+        assert_eq!(m.observe_context_usage(750, 1_000).len(), 1);
+        assert!(m.observe_context_usage(800, 1_000).is_empty());
+        assert!(m.observe_context_usage(849, 1_000).is_empty());
+    }
+
+    /// Crossing 0.85 emits Critical even if Warning has already fired; and
+    /// the subsequent Warning-band observation is swallowed.
+    #[test]
+    fn context_pressure_upgrades_to_critical() {
+        let mut m = AgentMachine::new(8);
+        assert_eq!(m.observe_context_usage(750, 1_000).len(), 1); // Warning
+        let effects = m.observe_context_usage(900, 1_000);
+        match effects.as_slice() {
+            [
+                Effect::ContextPressureWarning {
+                    level: PressureLevel::Critical,
+                    ..
+                },
+            ] => {}
+            other => panic!("expected Critical, got {other:?}"),
+        }
+        // No more warnings — critical is one-shot too.
+        assert!(m.observe_context_usage(950, 1_000).is_empty());
+    }
+
+    /// Jumping straight past Warning into Critical emits Critical only and
+    /// does not double up with a Warning.
+    #[test]
+    fn context_pressure_skips_warning_when_jumping_to_critical() {
+        let mut m = AgentMachine::new(8);
+        let effects = m.observe_context_usage(900, 1_000);
+        assert_eq!(effects.len(), 1);
+        assert!(matches!(
+            effects[0],
+            Effect::ContextPressureWarning {
+                level: PressureLevel::Critical,
+                ..
+            }
+        ));
+        // A subsequent Warning-band observation must NOT produce a stale
+        // Warning effect.
+        assert!(m.observe_context_usage(750, 1_000).is_empty());
+    }
+
+    /// Zero context window is treated as "unknown" and never emits.
+    #[test]
+    fn context_pressure_zero_window_is_noop() {
+        let mut m = AgentMachine::new(8);
+        assert!(m.observe_context_usage(10_000, 0).is_empty());
     }
 
     /// Mirrors the legacy `run_agent_loop` exemption for read-only tools:

--- a/crates/kernel/src/agent/runner.rs
+++ b/crates/kernel/src/agent/runner.rs
@@ -42,7 +42,9 @@
 //! - Loop breaker (`crate::agent::loop_breaker`) interventions — ✓ machine-side
 //!   implemented; legacy removal pending
 //! - Context pressure warnings + session-length reminders injected as user
-//!   messages
+//!   messages — ✓ machine-side implemented via
+//!   [`AgentMachine::observe_context_usage`] +
+//!   [`Effect::ContextPressureWarning`]; legacy removal pending
 //! - Tool-call-limit circuit breaker with oneshot resume — ✓ machine-side
 //!   implemented; legacy removal pending
 //! - Repetition guard truncation
@@ -58,7 +60,7 @@ use async_trait::async_trait;
 
 use crate::{
     agent::{
-        effect::{Effect, ToolCall, ToolResult},
+        effect::{Effect, PressureLevel, ToolCall, ToolResult},
         machine::{AgentMachine, Event, Phase},
     },
     tool::ToolName,
@@ -125,10 +127,33 @@ pub trait Subsystems: Send + Sync {
     /// Forward a stream event to the user-facing transport.
     async fn emit_stream(&mut self, kind: String);
 
-    /// Inject a system/user message into the conversation context so the
-    /// LLM sees it on the next `call_llm`.  Used by continuation wake.
-    /// Default: no-op (test stubs that don't model message history).
-    async fn inject_user_message(&mut self, _text: String) {}
+    /// Inject a user-role message into the conversation context so the LLM
+    /// sees it on the next `call_llm`.
+    ///
+    /// Used by the continuation-wake path and by context-pressure warnings.
+    /// Implementations append the message to the tape (persisted history),
+    /// not just to an in-memory buffer — otherwise the nudge disappears on
+    /// the next tape rebuild. Failures should be logged but must not abort
+    /// the turn.
+    ///
+    /// No default impl: silent inject would hide broken integrations
+    /// (anti-pattern: "Do NOT use noop trait implementations"). Test stubs
+    /// keep a plain `Vec<String>` log; production wires the kernel
+    /// `TapeService`.
+    async fn inject_user_message(&mut self, text: String);
+
+    /// Observe context-window usage for the current turn and return the
+    /// estimated-tokens / window pair (in tokens).
+    ///
+    /// The runner calls this once per LLM round before interpreting
+    /// `Effect::CallLlm` so the machine's
+    /// [`AgentMachine::observe_context_usage`] can emit pressure warnings.
+    ///
+    /// Return `(0, 0)` — or any usage below `CONTEXT_WARN_THRESHOLD` —
+    /// when sampling is unavailable or disabled; the machine treats a zero
+    /// window as "unknown" and emits nothing. No default impl so test stubs
+    /// have to opt in explicitly.
+    async fn sample_context_usage(&mut self) -> (usize, usize);
 
     /// Pause the turn and await the user's continue/stop decision.
     ///
@@ -169,6 +194,26 @@ pub async fn drive<S: Subsystems>(machine: &mut AgentMachine, subsys: &mut S) ->
                     tools_enabled,
                     disabled_tools,
                 } => {
+                    // Sample context usage and let the machine emit any
+                    // pressure warnings before the LLM is invoked. The
+                    // generated `InjectUserMessage` is written straight to
+                    // the tape so it becomes part of the next rebuild.
+                    let (estimated_tokens, context_window_tokens) =
+                        subsys.sample_context_usage().await;
+                    for eff in
+                        machine.observe_context_usage(estimated_tokens, context_window_tokens)
+                    {
+                        if let Effect::ContextPressureWarning {
+                            level,
+                            estimated_tokens: used,
+                            context_window_tokens: window,
+                        } = eff
+                        {
+                            let text = render_pressure_message(level, used, window);
+                            subsys.inject_user_message(text.clone()).await;
+                            subsys.emit_stream(text).await;
+                        }
+                    }
                     follow_up = Some(
                         subsys
                             .call_llm(iteration, tools_enabled, disabled_tools)
@@ -205,6 +250,19 @@ pub async fn drive<S: Subsystems>(machine: &mut AgentMachine, subsys: &mut S) ->
                     subsys.emit_stream(wake_msg).await;
                 }
                 Effect::EmitStream { kind } => subsys.emit_stream(kind).await,
+                Effect::ContextPressureWarning {
+                    level,
+                    estimated_tokens,
+                    context_window_tokens,
+                } => {
+                    // Handled inline during the CallLlm branch today; this
+                    // arm keeps the match exhaustive in case `step` ever
+                    // surfaces the effect directly.
+                    let text =
+                        render_pressure_message(level, estimated_tokens, context_window_tokens);
+                    subsys.inject_user_message(text.clone()).await;
+                    subsys.emit_stream(text).await;
+                }
                 Effect::Finish {
                     text,
                     iterations,
@@ -239,6 +297,34 @@ pub async fn drive<S: Subsystems>(machine: &mut AgentMachine, subsys: &mut S) ->
     }
 }
 
+/// Render the user-facing pressure-warning text the runner injects into the
+/// tape. Kept in the runner (not the pure machine) so the wording stays an
+/// I/O concern and the machine only tracks threshold crossings.
+fn render_pressure_message(
+    level: PressureLevel,
+    estimated_tokens: usize,
+    context_window_tokens: usize,
+) -> String {
+    let ratio = if context_window_tokens == 0 {
+        0.0
+    } else {
+        estimated_tokens as f64 / context_window_tokens as f64
+    };
+    let pct = (ratio * 100.0).round() as u32;
+    match level {
+        PressureLevel::Warning => format!(
+            "[context-pressure:warning] Context usage is at ~{pct}% \
+             ({estimated_tokens}/{context_window_tokens} tokens). SHOULD begin summarising \
+             long-tail details and prepare to hand off."
+        ),
+        PressureLevel::Critical => format!(
+            "[context-pressure:critical] Context usage is at ~{pct}% \
+             ({estimated_tokens}/{context_window_tokens} tokens). MUST hand off or summarise \
+             before further tool calls."
+        ),
+    }
+}
+
 // Silence dead-code warnings until production wiring lands.
 const _: fn() = || {
     let _ = Phase::Idle;
@@ -262,10 +348,15 @@ mod tests {
         next_tool:       usize,
         tape_log:        Vec<TapeAppendKind>,
         stream_log:      Vec<String>,
+        injected:        Vec<String>,
         /// Scripted user decisions for each `pause_for_limit` invocation,
         /// consumed in order. Leave empty for tests that never pause.
         limit_decisions: Vec<crate::agent::effect::LimitDecision>,
         next_limit:      usize,
+        /// Scripted context-usage samples, consumed in order per CallLlm.
+        /// A test can leave this empty to keep sampling off (zero window).
+        context_samples: Vec<(usize, usize)>,
+        next_sample:     usize,
     }
 
     #[async_trait]
@@ -296,6 +387,35 @@ mod tests {
             self.next_limit += 1;
             Event::LimitResolved { limit_id, decision }
         }
+
+        async fn inject_user_message(&mut self, text: String) { self.injected.push(text); }
+
+        async fn sample_context_usage(&mut self) -> (usize, usize) {
+            if self.next_sample < self.context_samples.len() {
+                let s = self.context_samples[self.next_sample];
+                self.next_sample += 1;
+                s
+            } else {
+                (0, 0)
+            }
+        }
+    }
+
+    /// Factory producing a fresh stub with empty scripts for every field.
+    fn subsys() -> ScriptedSubsys {
+        ScriptedSubsys {
+            llm_script:      vec![],
+            next_llm:        0,
+            tool_responses:  vec![],
+            next_tool:       0,
+            tape_log:        vec![],
+            stream_log:      vec![],
+            injected:        vec![],
+            limit_decisions: vec![],
+            next_limit:      0,
+            context_samples: vec![],
+            next_sample:     0,
+        }
     }
 
     #[tokio::test]
@@ -313,6 +433,9 @@ mod tests {
             stream_log:      vec![],
             limit_decisions: vec![],
             next_limit:      0,
+            injected:        vec![],
+            context_samples: vec![],
+            next_sample:     0,
         };
         let mut machine = AgentMachine::new(8);
         let outcome = drive(&mut machine, &mut subsys).await;
@@ -356,6 +479,9 @@ mod tests {
             stream_log:      vec![],
             limit_decisions: vec![],
             next_limit:      0,
+            injected:        vec![],
+            context_samples: vec![],
+            next_sample:     0,
         };
         let mut machine = AgentMachine::new(8);
         let outcome = drive(&mut machine, &mut subsys).await;
@@ -415,6 +541,9 @@ mod tests {
             stream_log:      vec![],
             limit_decisions: vec![],
             next_limit:      0,
+            injected:        vec![],
+            context_samples: vec![],
+            next_sample:     0,
         };
         let mut machine = AgentMachine::with_max_continuations(8, 3);
         let outcome = drive(&mut machine, &mut subsys).await;
@@ -491,6 +620,9 @@ mod tests {
             stream_log:      vec![],
             limit_decisions: vec![LimitDecision::Continue, LimitDecision::Continue],
             next_limit:      0,
+            injected:        vec![],
+            context_samples: vec![],
+            next_sample:     0,
         };
         let mut machine = AgentMachine::with_tool_call_limit(8, 1);
         let outcome = drive(&mut machine, &mut subsys).await;
@@ -529,6 +661,9 @@ mod tests {
             stream_log:      vec![],
             limit_decisions: vec![LimitDecision::Stop],
             next_limit:      0,
+            injected:        vec![],
+            context_samples: vec![],
+            next_sample:     0,
         };
         let mut machine = AgentMachine::with_tool_call_limit(8, 1);
         let outcome = drive(&mut machine, &mut subsys).await;
@@ -551,10 +686,154 @@ mod tests {
             stream_log:      vec![],
             limit_decisions: vec![],
             next_limit:      0,
+            injected:        vec![],
+            context_samples: vec![],
+            next_sample:     0,
         };
         let mut machine = AgentMachine::new(8);
         let outcome = drive(&mut machine, &mut subsys).await;
         assert!(!outcome.success);
         assert!(outcome.failure_message.unwrap().contains("auth"));
+    }
+
+    // ─── Context pressure warnings (runner integration) ─────────────────
+
+    /// When the sampled context usage crosses the Warning threshold on the
+    /// first iteration, the runner must inject a pressure warning into the
+    /// tape AND emit it on the stream before the LLM call returns.
+    #[tokio::test]
+    async fn drive_emits_pressure_warning_on_first_iteration() {
+        let mut s = subsys();
+        s.llm_script = vec![Event::LlmCompleted {
+            text:           "ok".into(),
+            tool_calls:     vec![],
+            has_tool_calls: false,
+        }];
+        // 750 / 1000 = 0.75 → Warning.
+        s.context_samples = vec![(750, 1_000)];
+
+        let mut machine = AgentMachine::new(8);
+        let outcome = drive(&mut machine, &mut s).await;
+        assert!(outcome.success);
+        assert_eq!(s.injected.len(), 1, "exactly one injection");
+        assert!(
+            s.injected[0].contains("[context-pressure:warning]"),
+            "injection text missing marker: {:?}",
+            s.injected[0]
+        );
+        assert!(
+            s.stream_log
+                .iter()
+                .any(|line| line.contains("[context-pressure:warning]")),
+            "stream log missing pressure warning: {:?}",
+            s.stream_log
+        );
+    }
+
+    /// Warning fires exactly once even when multiple iterations each sample
+    /// pressure above the threshold — the one-shot latch lives in the
+    /// machine.
+    #[tokio::test]
+    async fn drive_warning_is_one_shot_across_iterations() {
+        let tc = Tc {
+            id:        ToolCallId::new("c1"),
+            name:      ToolName::new("search"),
+            arguments: "{}".into(),
+        };
+        let mut s = subsys();
+        s.llm_script = vec![
+            Event::LlmCompleted {
+                text:           "tool".into(),
+                tool_calls:     vec![tc.clone()],
+                has_tool_calls: true,
+            },
+            Event::LlmCompleted {
+                text:           "final".into(),
+                tool_calls:     vec![],
+                has_tool_calls: false,
+            },
+        ];
+        s.tool_responses = vec![vec![Tr {
+            id:          ToolCallId::new("c1"),
+            name:        ToolName::new("search"),
+            arguments:   "{}".into(),
+            success:     true,
+            duration_ms: 1,
+            error:       None,
+        }]];
+        // Both samples above 0.70 — should still only inject once.
+        s.context_samples = vec![(750, 1_000), (800, 1_000)];
+
+        let mut machine = AgentMachine::new(8);
+        let outcome = drive(&mut machine, &mut s).await;
+        assert!(outcome.success);
+        assert_eq!(
+            s.injected.len(),
+            1,
+            "Warning should fire exactly once across iterations, got: {:?}",
+            s.injected
+        );
+    }
+
+    /// Crossing from Warning into Critical across iterations produces two
+    /// distinct injections — one per bucket.
+    #[tokio::test]
+    async fn drive_warning_then_critical_emits_two_injections() {
+        let tc = Tc {
+            id:        ToolCallId::new("c1"),
+            name:      ToolName::new("search"),
+            arguments: "{}".into(),
+        };
+        let mut s = subsys();
+        s.llm_script = vec![
+            Event::LlmCompleted {
+                text:           "tool".into(),
+                tool_calls:     vec![tc.clone()],
+                has_tool_calls: true,
+            },
+            Event::LlmCompleted {
+                text:           "final".into(),
+                tool_calls:     vec![],
+                has_tool_calls: false,
+            },
+        ];
+        s.tool_responses = vec![vec![Tr {
+            id:          ToolCallId::new("c1"),
+            name:        ToolName::new("search"),
+            arguments:   "{}".into(),
+            success:     true,
+            duration_ms: 1,
+            error:       None,
+        }]];
+        // Iter 0: 0.75 → Warning. Iter 1: 0.90 → Critical.
+        s.context_samples = vec![(750, 1_000), (900, 1_000)];
+
+        let mut machine = AgentMachine::new(8);
+        let outcome = drive(&mut machine, &mut s).await;
+        assert!(outcome.success);
+        assert_eq!(s.injected.len(), 2);
+        assert!(s.injected[0].contains("[context-pressure:warning]"));
+        assert!(s.injected[1].contains("[context-pressure:critical]"));
+    }
+
+    /// Sampling `(0, 0)` (unavailable / disabled) never produces a
+    /// pressure injection.
+    #[tokio::test]
+    async fn drive_no_injection_when_sampling_disabled() {
+        let mut s = subsys();
+        s.llm_script = vec![Event::LlmCompleted {
+            text:           "ok".into(),
+            tool_calls:     vec![],
+            has_tool_calls: false,
+        }];
+        // Default: context_samples is empty → returns (0, 0) each call.
+        let mut machine = AgentMachine::new(8);
+        let outcome = drive(&mut machine, &mut s).await;
+        assert!(outcome.success);
+        assert!(
+            s.injected.is_empty(),
+            "expected no injections, got: {:?}",
+            s.injected
+        );
     }
 }


### PR DESCRIPTION
## Summary

Part of epic #1534 (sans-IO `AgentMachine` migration). Migrate the legacy context-pressure warning mechanism into the state machine:

- Add `Effect::ContextPressureWarning { level, estimated_tokens, context_window_tokens }` and a new `PressureLevel::{Warning, Critical}` enum (mirroring `ContextPressure` in `agent::mod`).
- Add `AgentMachine::observe_context_usage(estimated, window) -> Vec<Effect>` — a pure synchronous observation method the runner calls once per LLM round. Threshold crossings emit exactly one effect per bucket (Warning at >=0.70, Critical at >=0.85; Warning is latched once Critical fires, so no stale Warning emits later).
- Promote `Subsystems::inject_user_message` to a required hook (no default impl, per the "Do NOT use noop trait implementations" anti-pattern). Add a new required `Subsystems::sample_context_usage` hook so the runner can feed token-usage estimates into the machine before each `CallLlm` effect is interpreted.
- Runner interprets `ContextPressureWarning` by rendering a user-visible string (`[context-pressure:warning] ...` / `[context-pressure:critical] ...`) and calling both `inject_user_message` (tape) and `emit_stream` (observability).

Pure unit tests in `machine.rs` cover: silent-below-threshold, Warning fires once, Warning is one-shot across repeated observations, upgrade to Critical, skip-Warning-when-jumping-to-Critical, zero-window no-op. Runner tests exercise first-iteration injection, one-shot across iterations, Warning→Critical transition, and disabled-sampling = no injection. No changes to the legacy `run_agent_loop`.

## Type of change

| Type | Label |
|------|-------|
| New feature | `enhancement` |

## Component

`core`

## Closes

Closes #1545

## Test plan

- [x] `cargo check -p rara-kernel`
- [x] `cargo test -p rara-kernel --lib agent::` — 125 passed
- [x] `cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings`
- [x] `RUSTDOCFLAGS=-D warnings cargo +nightly doc --workspace --no-deps --document-private-items`
- [x] `cargo +nightly fmt --all -- --check`