### PR TITLE
feat(kernel): deferred tool activation in machine (#1547)

### DIFF
--- a/crates/kernel/src/agent/effect.rs
+++ b/crates/kernel/src/agent/effect.rs
@@ -163,6 +163,24 @@ pub enum Effect {
         /// Cumulative tool calls executed before the pause.
         tool_calls_made: usize,
     },
+    /// Refresh the set of LLM-visible tool definitions after the LLM
+    /// invoked `discover-tools` in the just-completed wave. The runner
+    /// already owns the raw tool-output JSON, so the machine only carries
+    /// the call ids of the triggering `discover-tools` invocations; the
+    /// runner extracts activated tool names from the corresponding outputs,
+    /// merges them into the session's `activated_deferred` set, regenerates
+    /// the LLM tool definitions, and persists the set to the process
+    /// table.
+    ///
+    /// Emitted between [`Effect::AppendTape`] (`ToolResults`) and the next
+    /// [`Effect::CallLlm`] so the upcoming LLM call sees the newly
+    /// activated catalog. Fire-and-continue: no follow-up event.
+    RefreshDeferredTools {
+        /// Tool call ids of every successful `discover-tools` invocation
+        /// in the wave that just completed. Preserves the order from the
+        /// original [`Effect::RunTools::calls`] slice.
+        trigger_call_ids: Vec<ToolCallId>,
+    },
     /// Terminate the loop with a failure.
     Fail {
         /// Free-form failure description.

--- a/crates/kernel/src/agent/machine.rs
+++ b/crates/kernel/src/agent/machine.rs
@@ -85,6 +85,13 @@ pub const MAX_LLM_RECOVERIES: u32 = 3;
 /// Default maximum self-elected continuations per turn.
 pub const DEFAULT_MAX_CONTINUATIONS: usize = 10;
 
+/// Name of the meta-tool the LLM calls to activate deferred tools.
+///
+/// Appearing (successfully) in a completed tool wave triggers an
+/// [`Effect::RefreshDeferredTools`] so the next [`Effect::CallLlm`] sees
+/// the newly activated catalog.
+pub const DISCOVER_TOOLS_TOOL_NAME: &str = "discover-tools";
+
 /// Mutable state carried across machine transitions for one turn.
 #[derive(Debug)]
 pub struct AgentMachine {
@@ -401,6 +408,15 @@ impl AgentMachine {
                     }
                 };
 
+                // Collect call ids of successful discover-tools invocations so
+                // the runner can resolve their outputs and refresh the LLM
+                // tool catalog before the next `CallLlm`.
+                let discover_trigger_ids: Vec<_> = results
+                    .iter()
+                    .filter(|r| r.name == DISCOVER_TOOLS_TOOL_NAME && r.success)
+                    .map(|r| r.id.clone())
+                    .collect();
+
                 self.iteration += 1;
                 let mut effects = vec![Effect::AppendTape {
                     kind: TapeAppendKind::ToolResults,
@@ -412,26 +428,39 @@ impl AgentMachine {
                 if self.iteration >= self.max_iterations {
                     self.phase = Phase::Done;
                     let text = std::mem::take(&mut self.last_assistant_text);
+                    // Terminal wave — no upcoming CallLlm, so the activation
+                    // set would never be consulted. Skip the refresh.
                     effects.push(Effect::Finish {
                         text,
                         iterations: self.iteration,
                         tool_calls: self.tool_calls_made,
                         reason: FinishReason::MaxIterations,
                     });
-                } else if self.limit_interval > 0 && self.tool_calls_made >= self.next_limit_at {
-                    self.limit_id_counter += 1;
-                    self.phase = Phase::PausedForLimit;
-                    effects.push(Effect::PauseForLimit {
-                        limit_id:        self.limit_id_counter,
-                        tool_calls_made: self.tool_calls_made,
-                    });
                 } else {
-                    self.phase = Phase::AwaitingLlm;
-                    effects.push(Effect::CallLlm {
-                        iteration:      self.iteration,
-                        tools_enabled:  self.tools_enabled,
-                        disabled_tools: self.disabled_tools.clone(),
-                    });
+                    // Refresh once *before* either the pause or the next LLM
+                    // call. When a limit pause follows, the user-resume path
+                    // (LimitResolved::Continue) will re-enter `CallLlm` with
+                    // the activation set already in place.
+                    if !discover_trigger_ids.is_empty() {
+                        effects.push(Effect::RefreshDeferredTools {
+                            trigger_call_ids: discover_trigger_ids,
+                        });
+                    }
+                    if self.limit_interval > 0 && self.tool_calls_made >= self.next_limit_at {
+                        self.limit_id_counter += 1;
+                        self.phase = Phase::PausedForLimit;
+                        effects.push(Effect::PauseForLimit {
+                            limit_id:        self.limit_id_counter,
+                            tool_calls_made: self.tool_calls_made,
+                        });
+                    } else {
+                        self.phase = Phase::AwaitingLlm;
+                        effects.push(Effect::CallLlm {
+                            iteration:      self.iteration,
+                            tools_enabled:  self.tools_enabled,
+                            disabled_tools: self.disabled_tools.clone(),
+                        });
+                    }
                 }
                 effects
             }
@@ -1357,5 +1386,166 @@ mod tests {
                 "exempt tool should not flood at wave {i}",
             );
         }
+    }
+
+    /// A successful `discover-tools` call in a mid-turn wave must queue a
+    /// [`Effect::RefreshDeferredTools`] right before the next
+    /// [`Effect::CallLlm`] so the upcoming LLM call sees the freshly
+    /// activated catalog.
+    #[test]
+    fn discover_tools_emits_refresh_before_next_llm_call() {
+        let mut m = AgentMachine::new(8);
+        let _ = m.step(Event::TurnStarted);
+        let _ = m.step(Event::LlmCompleted {
+            text:           String::new(),
+            tool_calls:     vec![tool_call("c1", DISCOVER_TOOLS_TOOL_NAME)],
+            has_tool_calls: true,
+        });
+
+        let effects = m.step(Event::ToolsCompleted {
+            results: vec![tool_result(
+                "c1",
+                DISCOVER_TOOLS_TOOL_NAME,
+                r#"{"query":"fs"}"#,
+                true,
+            )],
+        });
+
+        assert_eq!(m.phase(), Phase::AwaitingLlm);
+        let refresh_idx = effects
+            .iter()
+            .position(|e| matches!(e, Effect::RefreshDeferredTools { .. }))
+            .expect("expected RefreshDeferredTools");
+        let call_idx = effects
+            .iter()
+            .position(|e| matches!(e, Effect::CallLlm { .. }))
+            .expect("expected follow-up CallLlm");
+        assert!(
+            refresh_idx < call_idx,
+            "refresh must precede next CallLlm: {effects:?}"
+        );
+        match &effects[refresh_idx] {
+            Effect::RefreshDeferredTools { trigger_call_ids } => {
+                assert_eq!(
+                    trigger_call_ids,
+                    &vec![crate::agent::effect::ToolCallId::new("c1")]
+                );
+            }
+            other => panic!("unexpected effect variant: {other:?}"),
+        }
+    }
+
+    /// Collect every successful `discover-tools` call in a mixed wave while
+    /// ignoring failed and unrelated calls.
+    #[test]
+    fn discover_tools_mixed_wave_only_forwards_successful_ids() {
+        let mut m = AgentMachine::new(8);
+        let _ = m.step(Event::TurnStarted);
+        let _ = m.step(Event::LlmCompleted {
+            text:           String::new(),
+            tool_calls:     vec![
+                tool_call("a", DISCOVER_TOOLS_TOOL_NAME),
+                tool_call("b", "search"),
+                tool_call("c", DISCOVER_TOOLS_TOOL_NAME),
+            ],
+            has_tool_calls: true,
+        });
+
+        let effects = m.step(Event::ToolsCompleted {
+            results: vec![
+                tool_result("a", DISCOVER_TOOLS_TOOL_NAME, "{}", true),
+                tool_result("b", "search", "{}", true),
+                // A failed discover-tools must not trigger activation.
+                tool_result("c", DISCOVER_TOOLS_TOOL_NAME, "{}", false),
+            ],
+        });
+
+        let refresh = effects
+            .iter()
+            .find_map(|e| match e {
+                Effect::RefreshDeferredTools { trigger_call_ids } => Some(trigger_call_ids),
+                _ => None,
+            })
+            .expect("expected RefreshDeferredTools");
+        assert_eq!(
+            refresh,
+            &vec![crate::agent::effect::ToolCallId::new("a")],
+            "only successful discover-tools ids should propagate"
+        );
+    }
+
+    /// Waves that don't include a successful `discover-tools` call must NOT
+    /// emit a refresh effect — the runner would otherwise redo work for
+    /// every iteration.
+    #[test]
+    fn no_refresh_when_discover_tools_absent() {
+        let mut m = AgentMachine::new(8);
+        let _ = m.step(Event::TurnStarted);
+        let _ = m.step(Event::LlmCompleted {
+            text:           String::new(),
+            tool_calls:     vec![tool_call("c1", "search")],
+            has_tool_calls: true,
+        });
+        let effects = m.step(Event::ToolsCompleted {
+            results: vec![tool_result("c1", "search", "{}", true)],
+        });
+        assert!(
+            !effects
+                .iter()
+                .any(|e| matches!(e, Effect::RefreshDeferredTools { .. })),
+            "no refresh expected: {effects:?}"
+        );
+    }
+
+    /// A terminal wave that hits `max_iterations` must NOT emit a refresh —
+    /// there's no upcoming LLM call to consume the activation set.
+    #[test]
+    fn terminal_max_iterations_wave_skips_refresh() {
+        let mut m = AgentMachine::new(1);
+        let _ = m.step(Event::TurnStarted);
+        let _ = m.step(Event::LlmCompleted {
+            text:           "final".into(),
+            tool_calls:     vec![tool_call("c1", DISCOVER_TOOLS_TOOL_NAME)],
+            has_tool_calls: true,
+        });
+        let effects = m.step(Event::ToolsCompleted {
+            results: vec![tool_result("c1", DISCOVER_TOOLS_TOOL_NAME, "{}", true)],
+        });
+        assert_eq!(m.phase(), Phase::Done);
+        assert!(
+            !effects
+                .iter()
+                .any(|e| matches!(e, Effect::RefreshDeferredTools { .. })),
+            "refresh should be suppressed on terminal wave: {effects:?}"
+        );
+    }
+
+    /// When a discover-tools wave also trips the tool-call limit, the refresh
+    /// must precede the pause so that on resume the stored activation set is
+    /// already in place for the next `CallLlm`.
+    #[test]
+    fn refresh_precedes_pause_for_limit() {
+        let mut m = AgentMachine::with_tool_call_limit(8, 1);
+        let _ = m.step(Event::TurnStarted);
+        let _ = m.step(Event::LlmCompleted {
+            text:           String::new(),
+            tool_calls:     vec![tool_call("c1", DISCOVER_TOOLS_TOOL_NAME)],
+            has_tool_calls: true,
+        });
+        let effects = m.step(Event::ToolsCompleted {
+            results: vec![tool_result("c1", DISCOVER_TOOLS_TOOL_NAME, "{}", true)],
+        });
+        let refresh_idx = effects
+            .iter()
+            .position(|e| matches!(e, Effect::RefreshDeferredTools { .. }))
+            .expect("expected RefreshDeferredTools");
+        let pause_idx = effects
+            .iter()
+            .position(|e| matches!(e, Effect::PauseForLimit { .. }))
+            .expect("expected PauseForLimit");
+        assert!(
+            refresh_idx < pause_idx,
+            "refresh must precede pause: {effects:?}"
+        );
     }
 }

--- a/crates/kernel/src/agent/runner.rs
+++ b/crates/kernel/src/agent/runner.rs
@@ -48,7 +48,8 @@
 //! - Tool-call-limit circuit breaker with oneshot resume — ✓ machine-side
 //!   implemented; legacy removal pending
 //! - Repetition guard truncation
-//! - Deferred tool activation (`discover-tools`) feedback
+//! - Deferred tool activation (`discover-tools`) feedback — ✓ machine-side
+//!   implemented; legacy removal pending
 //! - Per-iteration tape rebuild + sanitisation
 //! - Empty-stream / rate-limit recovery branches
 //! - Cascade trace assembly + mood inference
@@ -168,6 +169,25 @@ pub trait Subsystems: Send + Sync {
     ///
     /// Treat a cancel-token firing as [`Event::Interrupted`] instead.
     async fn pause_for_limit(&mut self, limit_id: u64, tool_calls_made: usize) -> Event;
+
+    /// Refresh the LLM-visible tool catalog after one or more successful
+    /// `discover-tools` calls in the most recent wave.
+    ///
+    /// `trigger_call_ids` lists the originating tool-call ids so the runner
+    /// can resolve each call's output JSON (which it already owns), extract
+    /// the activated tool names, merge them into the session's
+    /// `activated_deferred` set, regenerate the tool definitions passed to
+    /// the next [`Effect::CallLlm`], and persist the updated set to the
+    /// process table so activations survive across turns.
+    ///
+    /// Fire-and-forget from the machine's perspective: the runner does not
+    /// produce a follow-up event. Failures (e.g. unparseable output) must be
+    /// logged but never abort the turn — the LLM can always call
+    /// `discover-tools` again.
+    async fn refresh_deferred_tools(
+        &mut self,
+        trigger_call_ids: Vec<crate::agent::effect::ToolCallId>,
+    );
 }
 
 /// Drive the [`AgentMachine`] to completion against `subsys`.
@@ -234,6 +254,9 @@ pub async fn drive<S: Subsystems>(machine: &mut AgentMachine, subsys: &mut S) ->
                     tool_calls_made,
                 } => {
                     follow_up = Some(subsys.pause_for_limit(limit_id, tool_calls_made).await);
+                }
+                Effect::RefreshDeferredTools { trigger_call_ids } => {
+                    subsys.refresh_deferred_tools(trigger_call_ids).await;
                 }
                 Effect::RunTools { calls } => {
                     follow_up = Some(subsys.run_tools(calls).await);
@@ -357,6 +380,9 @@ mod tests {
         /// A test can leave this empty to keep sampling off (zero window).
         context_samples: Vec<(usize, usize)>,
         next_sample:     usize,
+        /// Records each `refresh_deferred_tools` invocation's trigger id list
+        /// so tests can assert on activation ordering and payload.
+        refresh_log:     Vec<Vec<ToolCallId>>,
     }
 
     #[async_trait]
@@ -399,6 +425,10 @@ mod tests {
                 (0, 0)
             }
         }
+
+        async fn refresh_deferred_tools(&mut self, trigger_call_ids: Vec<ToolCallId>) {
+            self.refresh_log.push(trigger_call_ids);
+        }
     }
 
     /// Factory producing a fresh stub with empty scripts for every field.
@@ -415,6 +445,7 @@ mod tests {
             next_limit:      0,
             context_samples: vec![],
             next_sample:     0,
+            refresh_log:     vec![],
         }
     }
 
@@ -436,6 +467,7 @@ mod tests {
             injected:        vec![],
             context_samples: vec![],
             next_sample:     0,
+            refresh_log:     vec![],
         };
         let mut machine = AgentMachine::new(8);
         let outcome = drive(&mut machine, &mut subsys).await;
@@ -482,6 +514,7 @@ mod tests {
             injected:        vec![],
             context_samples: vec![],
             next_sample:     0,
+            refresh_log:     vec![],
         };
         let mut machine = AgentMachine::new(8);
         let outcome = drive(&mut machine, &mut subsys).await;
@@ -544,6 +577,7 @@ mod tests {
             injected:        vec![],
             context_samples: vec![],
             next_sample:     0,
+            refresh_log:     vec![],
         };
         let mut machine = AgentMachine::with_max_continuations(8, 3);
         let outcome = drive(&mut machine, &mut subsys).await;
@@ -623,6 +657,7 @@ mod tests {
             injected:        vec![],
             context_samples: vec![],
             next_sample:     0,
+            refresh_log:     vec![],
         };
         let mut machine = AgentMachine::with_tool_call_limit(8, 1);
         let outcome = drive(&mut machine, &mut subsys).await;
@@ -664,12 +699,113 @@ mod tests {
             injected:        vec![],
             context_samples: vec![],
             next_sample:     0,
+            refresh_log:     vec![],
         };
         let mut machine = AgentMachine::with_tool_call_limit(8, 1);
         let outcome = drive(&mut machine, &mut subsys).await;
         assert!(outcome.success, "stop-by-limit is a graceful success");
         assert_eq!(outcome.text, "first");
         assert_eq!(outcome.tool_calls_made, 1);
+    }
+
+    #[tokio::test]
+    async fn drive_refreshes_deferred_tools_after_discover_wave() {
+        use crate::agent::machine::DISCOVER_TOOLS_TOOL_NAME;
+
+        let tc = Tc {
+            id:        ToolCallId::new("d1"),
+            name:      ToolName::new(DISCOVER_TOOLS_TOOL_NAME),
+            arguments: r#"{"query":"fs"}"#.into(),
+        };
+        let mut subsys = ScriptedSubsys {
+            llm_script:      vec![
+                Event::LlmCompleted {
+                    text:           "let me discover".into(),
+                    tool_calls:     vec![tc.clone()],
+                    has_tool_calls: true,
+                },
+                Event::LlmCompleted {
+                    text:           "done".into(),
+                    tool_calls:     vec![],
+                    has_tool_calls: false,
+                },
+            ],
+            next_llm:        0,
+            tool_responses:  vec![vec![Tr {
+                id:          ToolCallId::new("d1"),
+                name:        ToolName::new(DISCOVER_TOOLS_TOOL_NAME),
+                arguments:   r#"{"query":"fs"}"#.into(),
+                success:     true,
+                duration_ms: 1,
+                error:       None,
+            }]],
+            next_tool:       0,
+            tape_log:        vec![],
+            stream_log:      vec![],
+            limit_decisions: vec![],
+            next_limit:      0,
+            injected:        vec![],
+            context_samples: vec![],
+            next_sample:     0,
+            refresh_log:     vec![],
+        };
+        let mut machine = AgentMachine::new(8);
+        let outcome = drive(&mut machine, &mut subsys).await;
+        assert!(outcome.success);
+        assert_eq!(
+            subsys.refresh_log,
+            vec![vec![ToolCallId::new("d1")]],
+            "runner should receive exactly one refresh call with the discover-tools trigger id",
+        );
+    }
+
+    #[tokio::test]
+    async fn drive_skips_refresh_when_no_discover_tools() {
+        let tc = Tc {
+            id:        ToolCallId::new("s1"),
+            name:      ToolName::new("search"),
+            arguments: "{}".into(),
+        };
+        let mut subsys = ScriptedSubsys {
+            llm_script:      vec![
+                Event::LlmCompleted {
+                    text:           "thinking".into(),
+                    tool_calls:     vec![tc.clone()],
+                    has_tool_calls: true,
+                },
+                Event::LlmCompleted {
+                    text:           "done".into(),
+                    tool_calls:     vec![],
+                    has_tool_calls: false,
+                },
+            ],
+            next_llm:        0,
+            tool_responses:  vec![vec![Tr {
+                id:          ToolCallId::new("s1"),
+                name:        ToolName::new("search"),
+                arguments:   "{}".into(),
+                success:     true,
+                duration_ms: 1,
+                error:       None,
+            }]],
+            next_tool:       0,
+            tape_log:        vec![],
+            stream_log:      vec![],
+            limit_decisions: vec![],
+            next_limit:      0,
+            injected:        vec![],
+            context_samples: vec![],
+            next_sample:     0,
+            refresh_log:     vec![],
+        };
+        let mut machine = AgentMachine::new(8);
+        let outcome = drive(&mut machine, &mut subsys).await;
+        assert!(outcome.success);
+        assert!(
+            subsys.refresh_log.is_empty(),
+            "refresh should not fire on plain tool waves: {:?}",
+            subsys.refresh_log,
+        );
     }
 
     #[tokio::test]
@@ -689,6 +825,7 @@ mod tests {
             injected:        vec![],
             context_samples: vec![],
             next_sample:     0,
+            refresh_log:     vec![],
         };
         let mut machine = AgentMachine::new(8);
         let outcome = drive(&mut machine, &mut subsys).await;


### PR DESCRIPTION
## Summary

Part of #1534. Migrate the `discover-tools` deferred tool activation feedback into the sans-IO `AgentMachine`, so the runner can refresh the LLM-visible tool catalog mid-turn without living inside `run_agent_loop`.

- Add `Effect::RefreshDeferredTools { trigger_call_ids }`, queued between the tool-results tape append and the next `CallLlm`/`PauseForLimit` whenever the just-completed wave contains a successful `discover-tools` call.
- Add a required `Subsystems::refresh_deferred_tools` hook (no default) so the runner can parse the corresponding tool outputs, merge activated names into the session's `activated_deferred` set, regenerate tool definitions, and persist. Fire-and-forget — no follow-up event.
- Skip the refresh on terminal waves (max-iterations) since no next `CallLlm` would consume it.

Legacy `run_agent_loop` is untouched.

## Type of change

| Type | Label |
|------|-------|
| New feature | `enhancement` |

## Component

`core`

## Closes

Closes #1547

## Test plan

- [x] 5 pure-machine tests (ordering vs `CallLlm`, ordering vs `PauseForLimit`, mixed-wave filtering, no-refresh-on-miss, terminal-wave skip)
- [x] 2 runner integration tests via `ScriptedSubsys` (refresh fires, refresh skipped)
- [x] `cargo test -p rara-kernel --lib agent::` — 122 passed
- [x] `cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings`
- [x] `RUSTDOCFLAGS="-D warnings" cargo +nightly doc --workspace --no-deps --document-private-items`