### PR TITLE
feat(kernel): stream recovery in machine (#1549)

### DIFF
--- a/crates/kernel/src/agent/effect.rs
+++ b/crates/kernel/src/agent/effect.rs
@@ -163,6 +163,26 @@ pub enum Effect {
         /// Cumulative tool calls executed before the pause.
         tool_calls_made: usize,
     },
+    /// Inject a free-form system/user message into the conversation so the
+    /// LLM sees it on the next [`Effect::CallLlm`]. Used by the stream
+    /// recovery branches (rate-limit, empty-stream, retryable provider
+    /// error) to deliver the legacy recovery nudge text verbatim.
+    ///
+    /// The runner appends this message to both the live `messages` buffer
+    /// feeding the LLM and to the tape (under whatever role conventions
+    /// apply) before the next LLM call fires.
+    InjectUserMessage {
+        /// Full message text, including any `[System]` prefix the legacy
+        /// loop emits. The machine is responsible for formatting; the
+        /// runner is responsible only for delivery.
+        text: String,
+    },
+    /// Request that the runner run an auto-fold (context compression) on
+    /// the next iteration, before the upcoming [`Effect::CallLlm`].
+    /// Mirrors the legacy `force_fold_next_iteration` flag — used by the
+    /// empty-stream recovery branch when a zero-content response suggests
+    /// the context window is full.
+    ForceFoldNextIteration,
     /// Refresh the set of LLM-visible tool definitions after the LLM
     /// invoked `discover-tools` in the just-completed wave. The runner
     /// already owns the raw tool-output JSON, so the machine only carries

--- a/crates/kernel/src/agent/machine.rs
+++ b/crates/kernel/src/agent/machine.rs
@@ -272,6 +272,121 @@ impl AgentMachine {
         Vec::new()
     }
 
+    /// Translate an LLM-failure event into recovery effects.
+    ///
+    /// Preserves the legacy `run_agent_loop` branching verbatim:
+    ///
+    /// - [`LlmFailureKind::RateLimited`] with `tool_calls_made > 0`: disable
+    ///   tools, inject the "summarize with what you have" nudge, force a fold,
+    ///   and retry. Does **not** consume a recovery slot — the legacy path uses
+    ///   `continue` without bumping the counter.
+    /// - [`LlmFailureKind::RateLimited`] with `tool_calls_made == 0`: falls
+    ///   through to the retryable branch (the legacy order tests the rate-limit
+    ///   special-case first, then the generic retryable predicate, and 429
+    ///   errors satisfy both).
+    /// - [`LlmFailureKind::Retryable`]: consumes a recovery slot, disables
+    ///   tools, injects the "server error, reply without tools" nudge, retries.
+    ///   Fails when the slot budget is exhausted.
+    /// - [`LlmFailureKind::EmptyStream`]: consumes a recovery slot, disables
+    ///   tools, injects the "empty response, context compressed" nudge, and
+    ///   emits [`Effect::ForceFoldNextIteration`] so the runner folds context
+    ///   before the next call.
+    /// - [`LlmFailureKind::Permanent`]: terminates the turn immediately.
+    fn handle_llm_failed(&mut self, kind: LlmFailureKind) -> Vec<Effect> {
+        match kind {
+            // Rate-limit after at least one tool call: legacy `continue` path
+            // — disable tools, inject a final-answer nudge, and force a fold.
+            // The legacy code path does NOT increment the recovery counter.
+            LlmFailureKind::RateLimited if self.tool_calls_made > 0 => {
+                self.tools_enabled = false;
+                vec![
+                    Effect::InjectUserMessage {
+                        text: "[System] You hit a rate limit. Do NOT call any more tools. \
+                               Summarize the information you already have and answer the user's \
+                               question now."
+                            .to_owned(),
+                    },
+                    Effect::ForceFoldNextIteration,
+                    Effect::CallLlm {
+                        iteration:      self.iteration,
+                        tools_enabled:  self.tools_enabled,
+                        disabled_tools: self.disabled_tools.clone(),
+                    },
+                ]
+            }
+
+            // Rate-limit with no tool calls made yet falls through to the
+            // retryable branch (legacy guard: `rate_limit && tool_calls_made > 0`,
+            // else `is_retryable_provider_error` — 429 is classified as both).
+            LlmFailureKind::RateLimited => self.retryable_recovery(
+                "[System] The previous request encountered a server error (rate limited). Please \
+                 reply to the user's question directly without using tools."
+                    .to_owned(),
+                "rate limited".to_owned(),
+            ),
+
+            LlmFailureKind::Retryable { message } => {
+                let nudge = format!(
+                    "[System] The previous request encountered a server error ({message}). Please \
+                     reply to the user's question directly without using tools."
+                );
+                self.retryable_recovery(nudge, message)
+            }
+
+            LlmFailureKind::EmptyStream => {
+                if self.llm_recoveries >= MAX_LLM_RECOVERIES {
+                    self.phase = Phase::Failed;
+                    return vec![Effect::Fail {
+                        message: "LLM stream returned empty after max recoveries".to_owned(),
+                    }];
+                }
+                self.llm_recoveries += 1;
+                self.tools_enabled = false;
+                vec![
+                    Effect::InjectUserMessage {
+                        text: "[System] The previous request produced an empty response (possible \
+                               context window limit). Context has been compressed. Please reply \
+                               to the user's question directly without using tools."
+                            .to_owned(),
+                    },
+                    Effect::ForceFoldNextIteration,
+                    Effect::CallLlm {
+                        iteration:      self.iteration,
+                        tools_enabled:  self.tools_enabled,
+                        disabled_tools: self.disabled_tools.clone(),
+                    },
+                ]
+            }
+
+            LlmFailureKind::Permanent { message } => {
+                self.phase = Phase::Failed;
+                vec![Effect::Fail { message }]
+            }
+        }
+    }
+
+    /// Shared body for retryable-provider and no-tools rate-limit branches.
+    /// Consumes a recovery slot and emits inject+CallLlm; falls back to
+    /// `Effect::Fail` when the slot budget is exhausted.
+    fn retryable_recovery(&mut self, nudge: String, fail_message: String) -> Vec<Effect> {
+        if self.llm_recoveries >= MAX_LLM_RECOVERIES {
+            self.phase = Phase::Failed;
+            return vec![Effect::Fail {
+                message: fail_message,
+            }];
+        }
+        self.llm_recoveries += 1;
+        self.tools_enabled = false;
+        vec![
+            Effect::InjectUserMessage { text: nudge },
+            Effect::CallLlm {
+                iteration:      self.iteration,
+                tools_enabled:  self.tools_enabled,
+                disabled_tools: self.disabled_tools.clone(),
+            },
+        ]
+    }
+
     /// Drive the machine with one event.  Returns the side effects the runner
     /// must perform before feeding the next event back in.
     ///
@@ -361,22 +476,8 @@ impl AgentMachine {
                 ]
             }
 
-            // ── LLM error: retry by disabling tools, fail when exhausted ─
-            (Phase::AwaitingLlm, Event::LlmFailed { retryable, message }) => {
-                if retryable && self.llm_recoveries < MAX_LLM_RECOVERIES {
-                    self.llm_recoveries += 1;
-                    self.tools_enabled = false;
-                    // Stay in AwaitingLlm; runner re-issues CallLlm.
-                    vec![Effect::CallLlm {
-                        iteration:      self.iteration,
-                        tools_enabled:  self.tools_enabled,
-                        disabled_tools: self.disabled_tools.clone(),
-                    }]
-                } else {
-                    self.phase = Phase::Failed;
-                    vec![Effect::Fail { message }]
-                }
-            }
+            // ── LLM error: branch on failure kind ────────────────────────
+            (Phase::AwaitingLlm, Event::LlmFailed { kind }) => self.handle_llm_failed(kind),
 
             // ── Tool wave finished ───────────────────────────────────────
             (Phase::ExecutingTools, Event::ToolsCompleted { results }) => {
@@ -523,6 +624,42 @@ impl AgentMachine {
     }
 }
 
+/// Classification of an LLM streaming-call failure.
+///
+/// Each variant maps to a distinct recovery branch in the legacy
+/// `run_agent_loop` — preserved here so the sans-IO machine can express
+/// the full taxonomy without the runner having to replicate the branching
+/// logic.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum LlmFailureKind {
+    /// Provider rate limit (HTTP 429 or equivalent). Mirrors the legacy
+    /// `is_rate_limit_error` branch: when at least one tool call has
+    /// already been made this turn, stop retrying, disable tools, fold,
+    /// and inject a "summarize with what you have" nudge; when zero tool
+    /// calls have been made the machine falls back to the generic
+    /// retryable branch (legacy order: rate-limit check is gated on
+    /// `tool_calls_made > 0`, then `is_retryable_provider_error`).
+    RateLimited,
+    /// Generic retryable provider error (transient 5xx, connection reset,
+    /// parse timeouts, etc.). Disables tools and injects a
+    /// "reply without tools" nudge before retrying.
+    Retryable {
+        /// Underlying error message (surfaced to the recovery nudge).
+        message: String,
+    },
+    /// The stream completed without text, tool calls, or usage — the
+    /// provider silently dropped the request, usually because the context
+    /// window was exceeded on the free tier. Forces an auto-fold before
+    /// the retry so the follow-up request fits.
+    EmptyStream,
+    /// Non-retryable failure (authentication, model not found, …).
+    /// Terminates the turn immediately.
+    Permanent {
+        /// Underlying error message.
+        message: String,
+    },
+}
+
 /// Events fed to [`AgentMachine::step`] by the runner.
 #[derive(Debug, Clone, PartialEq)]
 pub enum Event {
@@ -537,12 +674,16 @@ pub enum Event {
         /// Whether the response indicates the LLM wants tools executed.
         has_tool_calls: bool,
     },
-    /// LLM streaming call errored.
+    /// LLM streaming call terminated without a usable response.
+    ///
+    /// The variants of [`LlmFailureKind`] encode the four distinct
+    /// recovery branches the legacy `run_agent_loop` distinguishes:
+    /// permanent error, retryable transport/server error, provider rate
+    /// limit, and silent empty stream (likely context-window overflow).
     LlmFailed {
-        /// True for transient/provider errors that warrant a retry.
-        retryable: bool,
-        /// Human-readable failure description.
-        message:   String,
+        /// Failure classification; drives which recovery effects the
+        /// machine emits (fold, message injection, retry limits).
+        kind: LlmFailureKind,
     },
     /// All tool calls in the current wave have results (success or error).
     ToolsCompleted {
@@ -680,13 +821,20 @@ mod tests {
         let _ = m.step(Event::TurnStarted);
 
         let effects = m.step(Event::LlmFailed {
-            retryable: true,
-            message:   "503".into(),
+            kind: LlmFailureKind::Retryable {
+                message: "503".into(),
+            },
         });
         // Recovery: machine stays in AwaitingLlm and re-issues CallLlm with tools off.
         assert_eq!(m.phase(), Phase::AwaitingLlm);
         match &effects[..] {
-            [Effect::CallLlm { tools_enabled, .. }] => assert!(!tools_enabled),
+            [
+                Effect::InjectUserMessage { text },
+                Effect::CallLlm { tools_enabled, .. },
+            ] => {
+                assert!(!tools_enabled);
+                assert!(text.contains("503"), "nudge should echo error: {text}");
+            }
             other => panic!("unexpected effects: {other:?}"),
         }
     }
@@ -697,8 +845,9 @@ mod tests {
         let _ = m.step(Event::TurnStarted);
 
         let effects = m.step(Event::LlmFailed {
-            retryable: false,
-            message:   "auth".into(),
+            kind: LlmFailureKind::Permanent {
+                message: "auth".into(),
+            },
         });
         assert_eq!(m.phase(), Phase::Failed);
         assert!(matches!(effects.as_slice(), [Effect::Fail { .. }]));
@@ -710,14 +859,103 @@ mod tests {
         let _ = m.step(Event::TurnStarted);
         for _ in 0..MAX_LLM_RECOVERIES {
             let _ = m.step(Event::LlmFailed {
-                retryable: true,
-                message:   "x".into(),
+                kind: LlmFailureKind::Retryable {
+                    message: "x".into(),
+                },
             });
             assert_eq!(m.phase(), Phase::AwaitingLlm);
         }
         let effects = m.step(Event::LlmFailed {
-            retryable: true,
-            message:   "x".into(),
+            kind: LlmFailureKind::Retryable {
+                message: "x".into(),
+            },
+        });
+        assert_eq!(m.phase(), Phase::Failed);
+        assert!(matches!(effects.as_slice(), [Effect::Fail { .. }]));
+    }
+
+    #[test]
+    fn rate_limit_with_tool_calls_folds_and_disables_tools() {
+        let mut m = AgentMachine::new(8);
+        let _ = m.step(Event::TurnStarted);
+        // Make one tool round-trip so `tool_calls_made > 0`.
+        let _ = m.step(Event::LlmCompleted {
+            text:           String::new(),
+            tool_calls:     vec![tool_call("c1", "search")],
+            has_tool_calls: true,
+        });
+        let _ = m.step(Event::ToolsCompleted {
+            results: vec![tool_result("c1", "search", "{}", true)],
+        });
+
+        // Now the follow-up LLM call hits a rate limit.
+        let effects = m.step(Event::LlmFailed {
+            kind: LlmFailureKind::RateLimited,
+        });
+        assert_eq!(m.phase(), Phase::AwaitingLlm);
+        match effects.as_slice() {
+            [
+                Effect::InjectUserMessage { text },
+                Effect::ForceFoldNextIteration,
+                Effect::CallLlm { tools_enabled, .. },
+            ] => {
+                assert!(!tools_enabled);
+                assert!(text.contains("rate limit"), "inject nudge: {text}");
+            }
+            other => panic!("unexpected effects: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn rate_limit_before_any_tool_falls_through_to_retryable() {
+        let mut m = AgentMachine::new(8);
+        let _ = m.step(Event::TurnStarted);
+        // First call errors with a rate limit, no tools made yet.
+        let effects = m.step(Event::LlmFailed {
+            kind: LlmFailureKind::RateLimited,
+        });
+        assert_eq!(m.phase(), Phase::AwaitingLlm);
+        // Retryable branch: inject + CallLlm, no ForceFold.
+        assert!(matches!(
+            effects.as_slice(),
+            [Effect::InjectUserMessage { .. }, Effect::CallLlm { .. }]
+        ));
+    }
+
+    #[test]
+    fn empty_stream_folds_and_retries() {
+        let mut m = AgentMachine::new(8);
+        let _ = m.step(Event::TurnStarted);
+
+        let effects = m.step(Event::LlmFailed {
+            kind: LlmFailureKind::EmptyStream,
+        });
+        assert_eq!(m.phase(), Phase::AwaitingLlm);
+        match effects.as_slice() {
+            [
+                Effect::InjectUserMessage { text },
+                Effect::ForceFoldNextIteration,
+                Effect::CallLlm { tools_enabled, .. },
+            ] => {
+                assert!(!tools_enabled);
+                assert!(text.contains("empty response"), "nudge: {text}");
+            }
+            other => panic!("unexpected effects: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn empty_stream_exhausts_recoveries() {
+        let mut m = AgentMachine::new(8);
+        let _ = m.step(Event::TurnStarted);
+        for _ in 0..MAX_LLM_RECOVERIES {
+            let _ = m.step(Event::LlmFailed {
+                kind: LlmFailureKind::EmptyStream,
+            });
+            assert_eq!(m.phase(), Phase::AwaitingLlm);
+        }
+        let effects = m.step(Event::LlmFailed {
+            kind: LlmFailureKind::EmptyStream,
         });
         assert_eq!(m.phase(), Phase::Failed);
         assert!(matches!(effects.as_slice(), [Effect::Fail { .. }]));

--- a/crates/kernel/src/agent/runner.rs
+++ b/crates/kernel/src/agent/runner.rs
@@ -51,7 +51,10 @@
 //! - Deferred tool activation (`discover-tools`) feedback — ✓ machine-side
 //!   implemented; legacy removal pending
 //! - Per-iteration tape rebuild + sanitisation
-//! - Empty-stream / rate-limit recovery branches
+//! - Empty-stream / rate-limit recovery branches — ✓ machine-side implemented
+//!   via [`crate::agent::machine::LlmFailureKind`] and
+//!   [`Effect::InjectUserMessage`] / [`Effect::ForceFoldNextIteration`]; legacy
+//!   removal pending
 //! - Cascade trace assembly + mood inference
 //!
 //! Each item maps to either an additional [`Effect`] variant or extra fields
@@ -188,6 +191,18 @@ pub trait Subsystems: Send + Sync {
         &mut self,
         trigger_call_ids: Vec<crate::agent::effect::ToolCallId>,
     );
+
+    /// Mark the upcoming iteration as a forced auto-fold.
+    ///
+    /// Production implementations set the `force_fold_next_iteration` flag
+    /// on the per-turn runtime state so the next tape rebuild runs context
+    /// compression before the follow-up [`Effect::CallLlm`] issues. Emitted
+    /// by the empty-stream and rate-limit (with tools-made) recovery
+    /// branches to shrink the context before retrying.
+    ///
+    /// No default impl: silent no-op would hide a broken integration where
+    /// the recovery retry still overflows the context window.
+    async fn force_fold_next_iteration(&mut self);
 }
 
 /// Drive the [`AgentMachine`] to completion against `subsys`.
@@ -273,6 +288,16 @@ pub async fn drive<S: Subsystems>(machine: &mut AgentMachine, subsys: &mut S) ->
                     subsys.emit_stream(wake_msg).await;
                 }
                 Effect::EmitStream { kind } => subsys.emit_stream(kind).await,
+                Effect::InjectUserMessage { text } => {
+                    // Stream-recovery nudges need to land in the tape *and*
+                    // be surfaced to the user so they can see why the agent
+                    // re-tried. Mirrors the continuation-wake handling.
+                    subsys.inject_user_message(text.clone()).await;
+                    subsys.emit_stream(text).await;
+                }
+                Effect::ForceFoldNextIteration => {
+                    subsys.force_fold_next_iteration().await;
+                }
                 Effect::ContextPressureWarning {
                     level,
                     estimated_tokens,
@@ -383,6 +408,9 @@ mod tests {
         /// Records each `refresh_deferred_tools` invocation's trigger id list
         /// so tests can assert on activation ordering and payload.
         refresh_log:     Vec<Vec<ToolCallId>>,
+        /// Count of `force_fold_next_iteration` calls; tests assert this
+        /// against expected fold requests from recovery branches.
+        force_fold_hits: u32,
     }
 
     #[async_trait]
@@ -429,6 +457,8 @@ mod tests {
         async fn refresh_deferred_tools(&mut self, trigger_call_ids: Vec<ToolCallId>) {
             self.refresh_log.push(trigger_call_ids);
         }
+
+        async fn force_fold_next_iteration(&mut self) { self.force_fold_hits += 1; }
     }
 
     /// Factory producing a fresh stub with empty scripts for every field.
@@ -446,6 +476,7 @@ mod tests {
             context_samples: vec![],
             next_sample:     0,
             refresh_log:     vec![],
+            force_fold_hits: 0,
         }
     }
 
@@ -468,6 +499,7 @@ mod tests {
             context_samples: vec![],
             next_sample:     0,
             refresh_log:     vec![],
+            force_fold_hits: 0,
         };
         let mut machine = AgentMachine::new(8);
         let outcome = drive(&mut machine, &mut subsys).await;
@@ -515,6 +547,7 @@ mod tests {
             context_samples: vec![],
             next_sample:     0,
             refresh_log:     vec![],
+            force_fold_hits: 0,
         };
         let mut machine = AgentMachine::new(8);
         let outcome = drive(&mut machine, &mut subsys).await;
@@ -578,6 +611,7 @@ mod tests {
             context_samples: vec![],
             next_sample:     0,
             refresh_log:     vec![],
+            force_fold_hits: 0,
         };
         let mut machine = AgentMachine::with_max_continuations(8, 3);
         let outcome = drive(&mut machine, &mut subsys).await;
@@ -658,6 +692,7 @@ mod tests {
             context_samples: vec![],
             next_sample:     0,
             refresh_log:     vec![],
+            force_fold_hits: 0,
         };
         let mut machine = AgentMachine::with_tool_call_limit(8, 1);
         let outcome = drive(&mut machine, &mut subsys).await;
@@ -700,6 +735,7 @@ mod tests {
             context_samples: vec![],
             next_sample:     0,
             refresh_log:     vec![],
+            force_fold_hits: 0,
         };
         let mut machine = AgentMachine::with_tool_call_limit(8, 1);
         let outcome = drive(&mut machine, &mut subsys).await;
@@ -748,6 +784,7 @@ mod tests {
             context_samples: vec![],
             next_sample:     0,
             refresh_log:     vec![],
+            force_fold_hits: 0,
         };
         let mut machine = AgentMachine::new(8);
         let outcome = drive(&mut machine, &mut subsys).await;
@@ -797,6 +834,7 @@ mod tests {
             context_samples: vec![],
             next_sample:     0,
             refresh_log:     vec![],
+            force_fold_hits: 0,
         };
         let mut machine = AgentMachine::new(8);
         let outcome = drive(&mut machine, &mut subsys).await;
@@ -812,8 +850,9 @@ mod tests {
     async fn drive_propagates_llm_fatal_failure() {
         let mut subsys = ScriptedSubsys {
             llm_script:      vec![Event::LlmFailed {
-                retryable: false,
-                message:   "auth".into(),
+                kind: crate::agent::machine::LlmFailureKind::Permanent {
+                    message: "auth".into(),
+                },
             }],
             next_llm:        0,
             tool_responses:  vec![],
@@ -826,6 +865,7 @@ mod tests {
             context_samples: vec![],
             next_sample:     0,
             refresh_log:     vec![],
+            force_fold_hits: 0,
         };
         let mut machine = AgentMachine::new(8);
         let outcome = drive(&mut machine, &mut subsys).await;
@@ -951,6 +991,117 @@ mod tests {
         assert_eq!(s.injected.len(), 2);
         assert!(s.injected[0].contains("[context-pressure:warning]"));
         assert!(s.injected[1].contains("[context-pressure:critical]"));
+    }
+
+    // ─── Stream recovery (empty stream / rate-limit) ────────────────────
+
+    /// Empty-stream recovery: inject nudge, force fold, retry with tools
+    /// disabled, then succeed on the follow-up call.
+    #[tokio::test]
+    async fn drive_recovers_from_empty_stream() {
+        use crate::agent::machine::LlmFailureKind;
+        let mut s = subsys();
+        s.llm_script = vec![
+            Event::LlmFailed {
+                kind: LlmFailureKind::EmptyStream,
+            },
+            Event::LlmCompleted {
+                text:           "recovered".into(),
+                tool_calls:     vec![],
+                has_tool_calls: false,
+            },
+        ];
+        let mut machine = AgentMachine::new(8);
+        let outcome = drive(&mut machine, &mut s).await;
+        assert!(outcome.success);
+        assert_eq!(outcome.text, "recovered");
+        assert_eq!(s.force_fold_hits, 1, "empty stream should force a fold");
+        assert_eq!(s.injected.len(), 1);
+        assert!(
+            s.injected[0].contains("empty response"),
+            "inject text: {:?}",
+            s.injected[0]
+        );
+        assert!(
+            s.stream_log.iter().any(|l| l.contains("empty response")),
+            "nudge should also hit stream: {:?}",
+            s.stream_log
+        );
+    }
+
+    /// Rate-limit recovery after at least one tool call: fold, disable
+    /// tools, inject the "summarize" nudge, then wrap up on the retry.
+    #[tokio::test]
+    async fn drive_recovers_from_rate_limit_after_tool_call() {
+        use crate::agent::machine::LlmFailureKind;
+        let tc = Tc {
+            id:        ToolCallId::new("c1"),
+            name:      ToolName::new("search"),
+            arguments: "{}".into(),
+        };
+        let mut s = subsys();
+        s.llm_script = vec![
+            Event::LlmCompleted {
+                text:           "thinking".into(),
+                tool_calls:     vec![tc.clone()],
+                has_tool_calls: true,
+            },
+            Event::LlmFailed {
+                kind: LlmFailureKind::RateLimited,
+            },
+            Event::LlmCompleted {
+                text:           "summarized".into(),
+                tool_calls:     vec![],
+                has_tool_calls: false,
+            },
+        ];
+        s.tool_responses = vec![vec![Tr {
+            id:          ToolCallId::new("c1"),
+            name:        ToolName::new("search"),
+            arguments:   "{}".into(),
+            success:     true,
+            duration_ms: 1,
+            error:       None,
+        }]];
+        let mut machine = AgentMachine::new(8);
+        let outcome = drive(&mut machine, &mut s).await;
+        assert!(outcome.success);
+        assert_eq!(outcome.text, "summarized");
+        assert_eq!(s.force_fold_hits, 1);
+        assert!(
+            s.injected.iter().any(|m| m.contains("rate limit")),
+            "expected rate-limit nudge in injected: {:?}",
+            s.injected
+        );
+    }
+
+    /// Retryable failure before any tool call: no fold, inject nudge, retry.
+    #[tokio::test]
+    async fn drive_recovers_from_retryable_error() {
+        use crate::agent::machine::LlmFailureKind;
+        let mut s = subsys();
+        s.llm_script = vec![
+            Event::LlmFailed {
+                kind: LlmFailureKind::Retryable {
+                    message: "503 upstream".into(),
+                },
+            },
+            Event::LlmCompleted {
+                text:           "fallback".into(),
+                tool_calls:     vec![],
+                has_tool_calls: false,
+            },
+        ];
+        let mut machine = AgentMachine::new(8);
+        let outcome = drive(&mut machine, &mut s).await;
+        assert!(outcome.success);
+        assert_eq!(outcome.text, "fallback");
+        assert_eq!(s.force_fold_hits, 0, "retryable does not force-fold");
+        assert!(
+            s.injected.iter().any(|m| m.contains("503 upstream")),
+            "inject should echo error: {:?}",
+            s.injected
+        );
     }
 
     /// Sampling `(0, 0)` (unavailable / disabled) never produces a


### PR DESCRIPTION
## Summary

Part of #1534. Extend the sans-IO `AgentMachine` with empty-stream and
rate-limit recovery branches so the machine now expresses the full
LLM-failure taxonomy the legacy `run_agent_loop` handles.

- Replace `Event::LlmFailed { retryable, message }` with
  `LlmFailed { kind: LlmFailureKind }` (`RateLimited` / `Retryable` /
  `EmptyStream` / `Permanent`).
- Add `Effect::InjectUserMessage` and `Effect::ForceFoldNextIteration`.
- Rate-limit after >=1 tool call: inject legacy summarize nudge, force-fold,
  retry with tools disabled (no recovery slot consumed — matches legacy
  `continue` path).
- Rate-limit before any tool call: fall through to retryable branch
  (legacy ordering: `is_rate_limit_error && tool_calls_made > 0` first,
  then `is_retryable_provider_error`, which covers 429 too).
- Empty-stream: force-fold + disable tools + inject "context compressed"
  nudge + retry, up to `MAX_LLM_RECOVERIES`.
- Permanent / exhausted retries → `Effect::Fail`.
- Add `Subsystems::force_fold_next_iteration` hook (no default).

Legacy `run_agent_loop` is untouched.

## Type of change

| Type | Label |
|------|-------|
| New feature | `enhancement` |

## Component

`core`

## Closes

Closes #1549

## Test plan

- [x] 5 new pure-machine tests (rate-limit w/ and w/o tool calls,
      empty-stream recovery, empty-stream exhaustion, updated retryable/
      permanent tests)
- [x] 3 new `ScriptedSubsys` runner tests covering end-to-end recovery
      for each `LlmFailureKind`
- [x] `cargo check -p rara-kernel`
- [x] `cargo test -p rara-kernel --lib agent::`
- [x] `cargo +nightly fmt --all`
- [x] `cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings`
- [x] `RUSTDOCFLAGS="-D warnings" cargo +nightly doc --workspace --no-deps --document-private-items`