### PR TITLE
feat(kernel): per-iteration tape rebuild in AgentMachine (#1551)

### DIFF
--- a/crates/kernel/src/agent/effect.rs
+++ b/crates/kernel/src/agent/effect.rs
@@ -183,6 +183,35 @@ pub enum Effect {
     /// empty-stream recovery branch when a zero-content response suggests
     /// the context window is full.
     ForceFoldNextIteration,
+    /// Rebuild the LLM message list from the persisted tape and sanitise
+    /// any malformed tool-call arguments. Emitted once per iteration
+    /// immediately before every [`Effect::CallLlm`] (and before the
+    /// matching resume-from-limit / continuation / recovery call). The
+    /// tape is the single source of truth for conversation history in the
+    /// legacy `run_agent_loop`; this effect preserves that invariant in
+    /// the sans-IO split.
+    ///
+    /// Ordering contract, matching legacy `run_agent_loop`:
+    ///
+    /// 1. [`Effect::ForceFoldNextIteration`] (when present) — runs first so the
+    ///    new anchor is materialised before the rebuild snapshots the tape.
+    /// 2. [`Effect::InjectUserMessage`] / [`Effect::InjectContinuationWake`] /
+    ///    [`Effect::ContextPressureWarning`] — runner writes these to the tape
+    ///    so the rebuild picks them up.
+    /// 3. [`Effect::RebuildTape`] — runner rebuilds the message list from the
+    ///    tape, sanitises tool-call arguments, stores the messages in its
+    ///    per-turn buffer for the upcoming LLM request.
+    /// 4. [`Effect::CallLlm`] — consumes the rebuilt buffer.
+    ///
+    /// Fire-and-continue: the runner does not feed an event back; a
+    /// rebuild failure is logged and bubbles out of the turn through the
+    /// next LLM call's error path.
+    RebuildTape {
+        /// Zero-based iteration counter of the upcoming LLM call. Purely
+        /// informational — mirrors [`Effect::CallLlm::iteration`] for
+        /// tracing / metrics parity.
+        iteration: usize,
+    },
     /// Refresh the set of LLM-visible tool definitions after the LLM
     /// invoked `discover-tools` in the just-completed wave. The runner
     /// already owns the raw tool-output JSON, so the machine only carries

--- a/crates/kernel/src/agent/machine.rs
+++ b/crates/kernel/src/agent/machine.rs
@@ -272,6 +272,25 @@ impl AgentMachine {
         Vec::new()
     }
 
+    /// Emit the standard pre-LLM effect pair: a [`Effect::RebuildTape`]
+    /// immediately followed by a [`Effect::CallLlm`]. Every site that
+    /// reaches [`Phase::AwaitingLlm`] uses this so the runner always
+    /// regenerates messages from the tape before the call fires —
+    /// preserving the legacy `run_agent_loop`'s "tape is the single source
+    /// of truth" invariant.
+    fn rebuild_then_call(&self) -> [Effect; 2] {
+        [
+            Effect::RebuildTape {
+                iteration: self.iteration,
+            },
+            Effect::CallLlm {
+                iteration:      self.iteration,
+                tools_enabled:  self.tools_enabled,
+                disabled_tools: self.disabled_tools.clone(),
+            },
+        ]
+    }
+
     /// Translate an LLM-failure event into recovery effects.
     ///
     /// Preserves the legacy `run_agent_loop` branching verbatim:
@@ -299,6 +318,7 @@ impl AgentMachine {
             // The legacy code path does NOT increment the recovery counter.
             LlmFailureKind::RateLimited if self.tool_calls_made > 0 => {
                 self.tools_enabled = false;
+                let [rebuild, call] = self.rebuild_then_call();
                 vec![
                     Effect::InjectUserMessage {
                         text: "[System] You hit a rate limit. Do NOT call any more tools. \
@@ -307,11 +327,8 @@ impl AgentMachine {
                             .to_owned(),
                     },
                     Effect::ForceFoldNextIteration,
-                    Effect::CallLlm {
-                        iteration:      self.iteration,
-                        tools_enabled:  self.tools_enabled,
-                        disabled_tools: self.disabled_tools.clone(),
-                    },
+                    rebuild,
+                    call,
                 ]
             }
 
@@ -342,6 +359,7 @@ impl AgentMachine {
                 }
                 self.llm_recoveries += 1;
                 self.tools_enabled = false;
+                let [rebuild, call] = self.rebuild_then_call();
                 vec![
                     Effect::InjectUserMessage {
                         text: "[System] The previous request produced an empty response (possible \
@@ -350,11 +368,8 @@ impl AgentMachine {
                             .to_owned(),
                     },
                     Effect::ForceFoldNextIteration,
-                    Effect::CallLlm {
-                        iteration:      self.iteration,
-                        tools_enabled:  self.tools_enabled,
-                        disabled_tools: self.disabled_tools.clone(),
-                    },
+                    rebuild,
+                    call,
                 ]
             }
 
@@ -377,14 +392,8 @@ impl AgentMachine {
         }
         self.llm_recoveries += 1;
         self.tools_enabled = false;
-        vec![
-            Effect::InjectUserMessage { text: nudge },
-            Effect::CallLlm {
-                iteration:      self.iteration,
-                tools_enabled:  self.tools_enabled,
-                disabled_tools: self.disabled_tools.clone(),
-            },
-        ]
+        let [rebuild, call] = self.rebuild_then_call();
+        vec![Effect::InjectUserMessage { text: nudge }, rebuild, call]
     }
 
     /// Drive the machine with one event.  Returns the side effects the runner
@@ -397,11 +406,7 @@ impl AgentMachine {
             // ── Turn boot ────────────────────────────────────────────────
             (Phase::Idle, Event::TurnStarted) => {
                 self.phase = Phase::AwaitingLlm;
-                vec![Effect::CallLlm {
-                    iteration:      self.iteration,
-                    tools_enabled:  self.tools_enabled,
-                    disabled_tools: self.disabled_tools.clone(),
-                }]
+                self.rebuild_then_call().to_vec()
             }
 
             // ── LLM produced a terminal response ─────────────────────────
@@ -422,6 +427,7 @@ impl AgentMachine {
                     self.continuation_pending = false;
                     self.continuation_count += 1;
                     self.phase = Phase::AwaitingLlm;
+                    let [rebuild, call] = self.rebuild_then_call();
                     return vec![
                         Effect::AppendTape {
                             kind: TapeAppendKind::AssistantIntermediate,
@@ -430,11 +436,8 @@ impl AgentMachine {
                             turn: self.continuation_count,
                             max:  self.max_continuations,
                         },
-                        Effect::CallLlm {
-                            iteration:      self.iteration,
-                            tools_enabled:  self.tools_enabled,
-                            disabled_tools: self.disabled_tools.clone(),
-                        },
+                        rebuild,
+                        call,
                     ];
                 }
 
@@ -556,11 +559,9 @@ impl AgentMachine {
                         });
                     } else {
                         self.phase = Phase::AwaitingLlm;
-                        effects.push(Effect::CallLlm {
-                            iteration:      self.iteration,
-                            tools_enabled:  self.tools_enabled,
-                            disabled_tools: self.disabled_tools.clone(),
-                        });
+                        let [rebuild, call] = self.rebuild_then_call();
+                        effects.push(rebuild);
+                        effects.push(call);
                     }
                 }
                 effects
@@ -574,11 +575,7 @@ impl AgentMachine {
                     LimitDecision::Continue => {
                         self.next_limit_at = self.tool_calls_made + self.limit_interval;
                         self.phase = Phase::AwaitingLlm;
-                        vec![Effect::CallLlm {
-                            iteration:      self.iteration,
-                            tools_enabled:  self.tools_enabled,
-                            disabled_tools: self.disabled_tools.clone(),
-                        }]
+                        self.rebuild_then_call().to_vec()
                     }
                     LimitDecision::Stop => {
                         self.phase = Phase::Done;
@@ -741,7 +738,10 @@ mod tests {
     fn happy_path_text_only() {
         let mut m = AgentMachine::new(8);
         let effects = m.step(Event::TurnStarted);
-        assert!(matches!(effects.as_slice(), [Effect::CallLlm { .. }]));
+        assert!(matches!(
+            effects.as_slice(),
+            [Effect::RebuildTape { .. }, Effect::CallLlm { .. }]
+        ));
         assert_eq!(m.phase(), Phase::AwaitingLlm);
 
         let effects = m.step(Event::LlmCompleted {
@@ -802,6 +802,7 @@ mod tests {
                 Effect::AppendTape {
                     kind: TapeAppendKind::ToolResults,
                 },
+                Effect::RebuildTape { iteration: 1 },
                 Effect::CallLlm { iteration: 1, .. },
             ]
         ));
@@ -830,6 +831,7 @@ mod tests {
         match &effects[..] {
             [
                 Effect::InjectUserMessage { text },
+                Effect::RebuildTape { .. },
                 Effect::CallLlm { tools_enabled, .. },
             ] => {
                 assert!(!tools_enabled);
@@ -897,6 +899,7 @@ mod tests {
             [
                 Effect::InjectUserMessage { text },
                 Effect::ForceFoldNextIteration,
+                Effect::RebuildTape { .. },
                 Effect::CallLlm { tools_enabled, .. },
             ] => {
                 assert!(!tools_enabled);
@@ -918,7 +921,11 @@ mod tests {
         // Retryable branch: inject + CallLlm, no ForceFold.
         assert!(matches!(
             effects.as_slice(),
-            [Effect::InjectUserMessage { .. }, Effect::CallLlm { .. }]
+            [
+                Effect::InjectUserMessage { .. },
+                Effect::RebuildTape { .. },
+                Effect::CallLlm { .. },
+            ]
         ));
     }
 
@@ -935,6 +942,7 @@ mod tests {
             [
                 Effect::InjectUserMessage { text },
                 Effect::ForceFoldNextIteration,
+                Effect::RebuildTape { .. },
                 Effect::CallLlm { tools_enabled, .. },
             ] => {
                 assert!(!tools_enabled);
@@ -1359,7 +1367,10 @@ mod tests {
             decision: LimitDecision::Continue,
         });
         assert_eq!(m.phase(), Phase::AwaitingLlm);
-        assert!(matches!(effects.as_slice(), [Effect::CallLlm { .. }]));
+        assert!(matches!(
+            effects.as_slice(),
+            [Effect::RebuildTape { .. }, Effect::CallLlm { .. }]
+        ));
     }
 
     /// `Stop` is a graceful termination: `Finish` with `StoppedByLimit`.
@@ -1756,6 +1767,234 @@ mod tests {
                 .any(|e| matches!(e, Effect::RefreshDeferredTools { .. })),
             "refresh should be suppressed on terminal wave: {effects:?}"
         );
+    }
+
+    // ─── Per-iteration tape rebuild + sanitisation ──────────────────────
+
+    /// Helper: count `Effect::RebuildTape` occurrences in a slice.
+    fn count_rebuilds(effects: &[Effect]) -> usize {
+        effects
+            .iter()
+            .filter(|e| matches!(e, Effect::RebuildTape { .. }))
+            .count()
+    }
+
+    /// Every `CallLlm` the machine emits must be immediately preceded by a
+    /// matching `RebuildTape`. The legacy `run_agent_loop` rebuilds the
+    /// message list from the tape at the top of every iteration; this
+    /// invariant is what makes the tape (not an in-memory buffer) the
+    /// single source of truth for conversation history.
+    #[test]
+    fn rebuild_tape_precedes_initial_call_llm() {
+        let mut m = AgentMachine::new(8);
+        let effects = m.step(Event::TurnStarted);
+        let call_idx = effects
+            .iter()
+            .position(|e| matches!(e, Effect::CallLlm { .. }))
+            .expect("expected CallLlm on turn boot");
+        let rebuild_idx = effects
+            .iter()
+            .position(|e| matches!(e, Effect::RebuildTape { .. }))
+            .expect("expected RebuildTape on turn boot");
+        assert!(
+            rebuild_idx + 1 == call_idx,
+            "rebuild must sit directly before CallLlm: {effects:?}"
+        );
+        match &effects[rebuild_idx] {
+            Effect::RebuildTape { iteration } => assert_eq!(*iteration, 0),
+            _ => unreachable!(),
+        }
+    }
+
+    /// After a tool wave, the next iteration's `CallLlm` carries the
+    /// bumped iteration number and the preceding `RebuildTape` shares it.
+    #[test]
+    fn rebuild_tape_precedes_post_tool_call_llm_with_matching_iteration() {
+        let mut m = AgentMachine::new(8);
+        let _ = m.step(Event::TurnStarted);
+        let _ = m.step(Event::LlmCompleted {
+            text:           "thinking".into(),
+            tool_calls:     vec![tool_call("c1", "search")],
+            has_tool_calls: true,
+        });
+        let effects = m.step(Event::ToolsCompleted {
+            results: vec![tool_result("c1", "search", "{}", true)],
+        });
+        let rebuild = effects
+            .iter()
+            .find_map(|e| match e {
+                Effect::RebuildTape { iteration } => Some(*iteration),
+                _ => None,
+            })
+            .expect("expected RebuildTape on next iteration");
+        assert_eq!(rebuild, 1);
+        // And it must still sit directly before the next CallLlm.
+        let rebuild_idx = effects
+            .iter()
+            .position(|e| matches!(e, Effect::RebuildTape { .. }))
+            .unwrap();
+        let call_idx = effects
+            .iter()
+            .position(|e| matches!(e, Effect::CallLlm { .. }))
+            .unwrap();
+        assert!(rebuild_idx + 1 == call_idx, "effects: {effects:?}");
+    }
+
+    /// The continuation-wake path issues an extra `CallLlm`; it MUST also
+    /// be preceded by a rebuild so the wake message (written to the tape)
+    /// is visible to the LLM.
+    #[test]
+    fn rebuild_tape_precedes_continuation_wake_call() {
+        let mut m = AgentMachine::new(8);
+        let _ = m.step(Event::TurnStarted);
+        let _ = m.step(Event::LlmCompleted {
+            text:           String::new(),
+            tool_calls:     vec![tool_call("c1", "continue-work")],
+            has_tool_calls: true,
+        });
+        let _ = m.step(Event::ToolsCompleted {
+            results: vec![tool_result("c1", "continue-work", "{}", true)],
+        });
+        let effects = m.step(Event::LlmCompleted {
+            text:           "still working".into(),
+            tool_calls:     vec![],
+            has_tool_calls: false,
+        });
+
+        // Ordering within this batch: AppendTape(Intermediate),
+        // InjectContinuationWake, RebuildTape, CallLlm.
+        let wake_idx = effects
+            .iter()
+            .position(|e| matches!(e, Effect::InjectContinuationWake { .. }))
+            .expect("expected wake");
+        let rebuild_idx = effects
+            .iter()
+            .position(|e| matches!(e, Effect::RebuildTape { .. }))
+            .expect("expected rebuild");
+        let call_idx = effects
+            .iter()
+            .position(|e| matches!(e, Effect::CallLlm { .. }))
+            .expect("expected call");
+        assert!(
+            wake_idx < rebuild_idx && rebuild_idx + 1 == call_idx,
+            "effects: {effects:?}"
+        );
+    }
+
+    /// The LimitResolved::Continue resume path re-enters `CallLlm`; the
+    /// rebuild must still prefix it so any nudges pushed during the pause
+    /// (pressure warnings, discover-tools refresh) land in the rebuilt
+    /// message list.
+    #[test]
+    fn rebuild_tape_precedes_resume_after_limit_pause() {
+        let mut m = AgentMachine::with_tool_call_limit(8, 1);
+        let _ = m.step(Event::TurnStarted);
+        let _ = m.step(Event::LlmCompleted {
+            text:           String::new(),
+            tool_calls:     vec![tool_call("c1", "search")],
+            has_tool_calls: true,
+        });
+        let _ = m.step(Event::ToolsCompleted {
+            results: vec![tool_result("c1", "search", "{}", true)],
+        });
+        let effects = m.step(Event::LimitResolved {
+            limit_id: 1,
+            decision: LimitDecision::Continue,
+        });
+        assert!(matches!(
+            effects.as_slice(),
+            [Effect::RebuildTape { .. }, Effect::CallLlm { .. }]
+        ));
+    }
+
+    /// Every LLM recovery path (retryable / rate-limit-with-tools / empty
+    /// stream) retries via `CallLlm` and MUST rebuild first so the
+    /// injected nudge is part of the rebuilt messages.
+    #[test]
+    fn rebuild_tape_precedes_each_recovery_call() {
+        use LlmFailureKind::*;
+        // Retryable: [Inject, Rebuild, Call]
+        {
+            let mut m = AgentMachine::new(8);
+            let _ = m.step(Event::TurnStarted);
+            let effects = m.step(Event::LlmFailed {
+                kind: Retryable {
+                    message: "503".into(),
+                },
+            });
+            assert_eq!(count_rebuilds(&effects), 1, "{effects:?}");
+        }
+        // Empty stream: [Inject, ForceFold, Rebuild, Call]
+        {
+            let mut m = AgentMachine::new(8);
+            let _ = m.step(Event::TurnStarted);
+            let effects = m.step(Event::LlmFailed { kind: EmptyStream });
+            assert_eq!(count_rebuilds(&effects), 1, "{effects:?}");
+        }
+        // Rate-limit with tools: [Inject, ForceFold, Rebuild, Call]
+        {
+            let mut m = AgentMachine::new(8);
+            let _ = m.step(Event::TurnStarted);
+            let _ = m.step(Event::LlmCompleted {
+                text:           String::new(),
+                tool_calls:     vec![tool_call("c1", "search")],
+                has_tool_calls: true,
+            });
+            let _ = m.step(Event::ToolsCompleted {
+                results: vec![tool_result("c1", "search", "{}", true)],
+            });
+            let effects = m.step(Event::LlmFailed { kind: RateLimited });
+            assert_eq!(count_rebuilds(&effects), 1, "{effects:?}");
+        }
+    }
+
+    /// Terminal waves (Finish on max iterations, PauseForLimit, Stopped)
+    /// must NOT emit a rebuild: there is no upcoming CallLlm to consume
+    /// it. Emitting one would cause the runner to do unnecessary work and
+    /// risk overwriting a buffer that will never be read.
+    #[test]
+    fn rebuild_tape_absent_on_terminal_waves() {
+        // Max iterations → Finish
+        {
+            let mut m = AgentMachine::new(1);
+            let _ = m.step(Event::TurnStarted);
+            let _ = m.step(Event::LlmCompleted {
+                text:           "x".into(),
+                tool_calls:     vec![tool_call("c1", "t")],
+                has_tool_calls: true,
+            });
+            let effects = m.step(Event::ToolsCompleted {
+                results: vec![tool_result("c1", "t", "{}", true)],
+            });
+            assert_eq!(m.phase(), Phase::Done);
+            assert_eq!(count_rebuilds(&effects), 0, "{effects:?}");
+        }
+        // Text-only Stopped → only AppendTape + Finish, no rebuild
+        {
+            let mut m = AgentMachine::new(8);
+            let _ = m.step(Event::TurnStarted);
+            let effects = m.step(Event::LlmCompleted {
+                text:           "done".into(),
+                tool_calls:     vec![],
+                has_tool_calls: false,
+            });
+            assert_eq!(count_rebuilds(&effects), 0, "{effects:?}");
+        }
+        // Tool-call-limit pause → no rebuild yet (the resume will emit one)
+        {
+            let mut m = AgentMachine::with_tool_call_limit(8, 1);
+            let _ = m.step(Event::TurnStarted);
+            let _ = m.step(Event::LlmCompleted {
+                text:           String::new(),
+                tool_calls:     vec![tool_call("c1", "t")],
+                has_tool_calls: true,
+            });
+            let effects = m.step(Event::ToolsCompleted {
+                results: vec![tool_result("c1", "t", "{}", true)],
+            });
+            assert_eq!(m.phase(), Phase::PausedForLimit);
+            assert_eq!(count_rebuilds(&effects), 0, "{effects:?}");
+        }
     }
 
     /// When a discover-tools wave also trips the tool-call limit, the refresh

--- a/crates/kernel/src/agent/runner.rs
+++ b/crates/kernel/src/agent/runner.rs
@@ -50,7 +50,9 @@
 //! - Repetition guard truncation
 //! - Deferred tool activation (`discover-tools`) feedback — ✓ machine-side
 //!   implemented; legacy removal pending
-//! - Per-iteration tape rebuild + sanitisation
+//! - Per-iteration tape rebuild + sanitisation — ✓ machine-side implemented via
+//!   [`Effect::RebuildTape`] and [`Subsystems::rebuild_tape`]; legacy removal
+//!   pending
 //! - Empty-stream / rate-limit recovery branches — ✓ machine-side implemented
 //!   via [`crate::agent::machine::LlmFailureKind`] and
 //!   [`Effect::InjectUserMessage`] / [`Effect::ForceFoldNextIteration`]; legacy
@@ -203,6 +205,29 @@ pub trait Subsystems: Send + Sync {
     /// No default impl: silent no-op would hide a broken integration where
     /// the recovery retry still overflows the context window.
     async fn force_fold_next_iteration(&mut self);
+
+    /// Rebuild the LLM message list from the persisted tape and sanitise
+    /// any malformed tool-call arguments, storing the result in the
+    /// runner's per-turn buffer so the subsequent
+    /// [`Subsystems::call_llm`] sends it to the provider.
+    ///
+    /// Production implementations call
+    /// `TapeService::rebuild_messages_for_llm(tape_name, user_id,
+    /// &effective_prompt)` followed by the
+    /// `sanitize_messages_for_llm` helper from `agent::mod` (strips
+    /// tool-call arguments that fail JSON parsing so the provider API
+    /// never sees malformed payloads). Every iteration goes through this
+    /// hook — the tape is the single source of truth for conversation
+    /// history, and in-memory message buffers drift after folds,
+    /// recovery nudges, and deferred-tool activations.
+    ///
+    /// Fire-and-continue: the machine does not wait for an event. A
+    /// rebuild failure should be logged; the bad state will surface on
+    /// the upcoming [`Subsystems::call_llm`] if messages are missing.
+    ///
+    /// No default impl: silent no-op would leave the runner's message
+    /// buffer permanently stale, so test stubs must opt in explicitly.
+    async fn rebuild_tape(&mut self, iteration: usize);
 }
 
 /// Drive the [`AgentMachine`] to completion against `subsys`.
@@ -297,6 +322,9 @@ pub async fn drive<S: Subsystems>(machine: &mut AgentMachine, subsys: &mut S) ->
                 }
                 Effect::ForceFoldNextIteration => {
                     subsys.force_fold_next_iteration().await;
+                }
+                Effect::RebuildTape { iteration } => {
+                    subsys.rebuild_tape(iteration).await;
                 }
                 Effect::ContextPressureWarning {
                     level,
@@ -411,6 +439,9 @@ mod tests {
         /// Count of `force_fold_next_iteration` calls; tests assert this
         /// against expected fold requests from recovery branches.
         force_fold_hits: u32,
+        /// Iterations observed via `rebuild_tape`, in order. Every
+        /// iteration must rebuild exactly once before its CallLlm.
+        rebuild_log:     Vec<usize>,
     }
 
     #[async_trait]
@@ -459,6 +490,8 @@ mod tests {
         }
 
         async fn force_fold_next_iteration(&mut self) { self.force_fold_hits += 1; }
+
+        async fn rebuild_tape(&mut self, iteration: usize) { self.rebuild_log.push(iteration); }
     }
 
     /// Factory producing a fresh stub with empty scripts for every field.
@@ -477,6 +510,7 @@ mod tests {
             next_sample:     0,
             refresh_log:     vec![],
             force_fold_hits: 0,
+            rebuild_log:     vec![],
         }
     }
 
@@ -500,6 +534,7 @@ mod tests {
             next_sample:     0,
             refresh_log:     vec![],
             force_fold_hits: 0,
+            rebuild_log:     vec![],
         };
         let mut machine = AgentMachine::new(8);
         let outcome = drive(&mut machine, &mut subsys).await;
@@ -548,6 +583,7 @@ mod tests {
             next_sample:     0,
             refresh_log:     vec![],
             force_fold_hits: 0,
+            rebuild_log:     vec![],
         };
         let mut machine = AgentMachine::new(8);
         let outcome = drive(&mut machine, &mut subsys).await;
@@ -612,6 +648,7 @@ mod tests {
             next_sample:     0,
             refresh_log:     vec![],
             force_fold_hits: 0,
+            rebuild_log:     vec![],
         };
         let mut machine = AgentMachine::with_max_continuations(8, 3);
         let outcome = drive(&mut machine, &mut subsys).await;
@@ -693,6 +730,7 @@ mod tests {
             next_sample:     0,
             refresh_log:     vec![],
             force_fold_hits: 0,
+            rebuild_log:     vec![],
         };
         let mut machine = AgentMachine::with_tool_call_limit(8, 1);
         let outcome = drive(&mut machine, &mut subsys).await;
@@ -736,6 +774,7 @@ mod tests {
             next_sample:     0,
             refresh_log:     vec![],
             force_fold_hits: 0,
+            rebuild_log:     vec![],
         };
         let mut machine = AgentMachine::with_tool_call_limit(8, 1);
         let outcome = drive(&mut machine, &mut subsys).await;
@@ -785,6 +824,7 @@ mod tests {
             next_sample:     0,
             refresh_log:     vec![],
             force_fold_hits: 0,
+            rebuild_log:     vec![],
         };
         let mut machine = AgentMachine::new(8);
         let outcome = drive(&mut machine, &mut subsys).await;
@@ -835,6 +875,7 @@ mod tests {
             next_sample:     0,
             refresh_log:     vec![],
             force_fold_hits: 0,
+            rebuild_log:     vec![],
         };
         let mut machine = AgentMachine::new(8);
         let outcome = drive(&mut machine, &mut subsys).await;
@@ -866,6 +907,7 @@ mod tests {
             next_sample:     0,
             refresh_log:     vec![],
             force_fold_hits: 0,
+            rebuild_log:     vec![],
         };
         let mut machine = AgentMachine::new(8);
         let outcome = drive(&mut machine, &mut subsys).await;
@@ -1102,6 +1144,94 @@ mod tests {
             "inject should echo error: {:?}",
             s.injected
         );
+    }
+
+    // ─── Per-iteration tape rebuild ─────────────────────────────────────
+
+    /// The runner must invoke `rebuild_tape` exactly once per LLM round,
+    /// with the iteration number matching the upcoming `CallLlm`, so the
+    /// production impl can refresh its message buffer from the tape.
+    #[tokio::test]
+    async fn drive_rebuilds_tape_once_per_iteration() {
+        let tc = Tc {
+            id:        ToolCallId::new("c1"),
+            name:      ToolName::new("search"),
+            arguments: "{}".into(),
+        };
+        let mut s = subsys();
+        s.llm_script = vec![
+            Event::LlmCompleted {
+                text:           "thinking".into(),
+                tool_calls:     vec![tc.clone()],
+                has_tool_calls: true,
+            },
+            Event::LlmCompleted {
+                text:           "final".into(),
+                tool_calls:     vec![],
+                has_tool_calls: false,
+            },
+        ];
+        s.tool_responses = vec![vec![Tr {
+            id:          ToolCallId::new("c1"),
+            name:        ToolName::new("search"),
+            arguments:   "{}".into(),
+            success:     true,
+            duration_ms: 1,
+            error:       None,
+        }]];
+        let mut machine = AgentMachine::new(8);
+        let outcome = drive(&mut machine, &mut s).await;
+        assert!(outcome.success);
+        assert_eq!(
+            s.rebuild_log,
+            vec![0, 1],
+            "expected one rebuild per iteration, in order: {:?}",
+            s.rebuild_log
+        );
+    }
+
+    /// Recovery branches (empty stream) still rebuild before the retry so
+    /// the injected nudge lands in the rebuilt message buffer.
+    #[tokio::test]
+    async fn drive_rebuilds_tape_before_recovery_retry() {
+        use crate::agent::machine::LlmFailureKind;
+        let mut s = subsys();
+        s.llm_script = vec![
+            Event::LlmFailed {
+                kind: LlmFailureKind::EmptyStream,
+            },
+            Event::LlmCompleted {
+                text:           "recovered".into(),
+                tool_calls:     vec![],
+                has_tool_calls: false,
+            },
+        ];
+        let mut machine = AgentMachine::new(8);
+        let outcome = drive(&mut machine, &mut s).await;
+        assert!(outcome.success);
+        // Two rebuilds total: the initial boot and the recovery retry.
+        assert_eq!(
+            s.rebuild_log.len(),
+            2,
+            "expected rebuild before initial + recovery: {:?}",
+            s.rebuild_log
+        );
+    }
+
+    /// A turn that terminates without a second LLM round (text-only
+    /// first response) rebuilds exactly once — for the initial boot.
+    #[tokio::test]
+    async fn drive_rebuilds_only_for_initial_boot_on_fast_stop() {
+        let mut s = subsys();
+        s.llm_script = vec![Event::LlmCompleted {
+            text:           "ok".into(),
+            tool_calls:     vec![],
+            has_tool_calls: false,
+        }];
+        let mut machine = AgentMachine::new(8);
+        let outcome = drive(&mut machine, &mut s).await;
+        assert!(outcome.success);
+        assert_eq!(s.rebuild_log, vec![0]);
     }
 
     /// Sampling `(0, 0)` (unavailable / disabled) never produces a


### PR DESCRIPTION
## Summary

Part of #1534. Extend the sans-IO `AgentMachine` so per-iteration tape
rebuild + sanitisation becomes an explicit effect emitted before every
LLM call, matching the legacy `run_agent_loop` behaviour.

- New `Effect::RebuildTape { iteration }`, always emitted directly
  before `Effect::CallLlm` on every code path (turn boot, post-tool
  next iteration, continuation wake, `LimitResolved::Continue` resume,
  and all three `LlmFailed` recovery branches).
- New required `Subsystems::rebuild_tape` hook (no default). Production
  impl will call `TapeService::rebuild_messages_for_llm` +
  `sanitize_messages_for_llm` (legacy helper) and store the result in
  the runner's per-turn buffer.
- Helper `AgentMachine::rebuild_then_call()` keeps the
  `[RebuildTape, CallLlm]` invariant syntactically local, so future
  effect sites can't forget the prefix.
- Terminal waves (max iterations, Stopped, PauseForLimit) deliberately
  skip the rebuild since no LLM call follows.
- Coordinates with `ForceFoldNextIteration` (#1550): fold is emitted
  first, then rebuild, so the new anchor is visible in the rebuilt
  messages.

Legacy `run_agent_loop` keeps the production path unchanged.

## Type of change

| Type | Label |
|------|-------|
| New feature | `enhancement` |

## Component

`core`

## Closes

Closes #1551

## Test plan

- [x] 5 new pure-machine tests (ordering + suppression on terminals)
- [x] 3 new `ScriptedSubsys` runner tests (rebuild count, recovery
      retry, fast-stop)
- [x] `cargo test -p rara-kernel --lib agent::` (148 passing)
- [x] `cargo +nightly fmt --all` clean
- [x] `cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings` clean
- [x] `RUSTDOCFLAGS="-D warnings" cargo +nightly doc --workspace --no-deps --document-private-items` clean