### PR TITLE
fix(web): replace pi-mono model selector with rara-native dialog (#1554)

### DIFF
--- a/crates/extensions/backend-admin/src/chat/router.rs
+++ b/crates/extensions/backend-admin/src/chat/router.rs
@@ -46,7 +46,11 @@ use serde::Deserialize;
 use tracing::instrument;
 use utoipa_axum::{router::OpenApiRouter, routes};
 
-use crate::chat::{error::ChatError, model_catalog::ChatModel, service::SessionService};
+use crate::chat::{
+    error::ChatError,
+    model_catalog::ChatModel,
+    service::{ProviderInfo, SessionService},
+};
 
 /// Parse an optional thinking-level string from a request body, converting
 /// invalid values into a 400 response with a list of accepted variants.
@@ -171,6 +175,7 @@ fn model_routes(service: SessionService) -> OpenApiRouter {
     OpenApiRouter::new()
         .routes(routes!(list_models))
         .routes(routes!(set_favorites))
+        .routes(routes!(list_providers))
         .with_state(service)
 }
 
@@ -205,6 +210,21 @@ fn session_routes(service: SessionService) -> OpenApiRouter {
 async fn list_models(State(service): State<SessionService>) -> Json<Vec<ChatModel>> {
     let models = service.list_models().await;
     Json(models)
+}
+
+/// `GET /api/v1/chat/providers` — return the LLM provider catalog derived
+/// from `llm.providers.*` settings, stripped of any sensitive fields
+/// (API keys never leave the backend via this endpoint).
+#[utoipa::path(
+    get,
+    path = "/api/v1/chat/providers",
+    tag = "chat",
+    responses(
+        (status = 200, description = "List of configured providers", body = Vec<ProviderInfo>),
+    )
+)]
+async fn list_providers(State(service): State<SessionService>) -> Json<Vec<ProviderInfo>> {
+    Json(service.list_llm_providers().await)
 }
 
 /// `PUT /api/v1/chat/models/favorites` — replace the user's favorite model

--- a/crates/extensions/backend-admin/src/chat/service.rs
+++ b/crates/extensions/backend-admin/src/chat/service.rs
@@ -46,6 +46,86 @@ use crate::chat::{
     model_catalog::{ChatModel, ModelCatalog},
 };
 
+/// Sanitised view of an `llm.providers.<id>.*` settings group.
+///
+/// Surfaces only the fields the chat UI needs to render a picker —
+/// raw API keys are intentionally replaced with the boolean
+/// `has_api_key` so secrets never leave the backend via this endpoint.
+#[derive(Debug, Clone, serde::Serialize, utoipa::ToSchema)]
+pub struct ProviderInfo {
+    /// Provider id, as used in `llm.providers.<id>.*` keys and in the
+    /// kernel `DriverRegistry` (e.g. `openrouter`, `kimi`, `minimax`).
+    pub id:            String,
+    /// Non-empty `default_model` value from settings. Providers without
+    /// one are omitted from the list.
+    pub default_model: String,
+    /// Base URL for OpenAI-compatible endpoints, if configured.
+    pub base_url:      Option<String>,
+    /// Whether `llm.providers.<id>.api_key` has a non-empty value.
+    pub has_api_key:   bool,
+    /// Whether `llm.providers.<id>.enabled` is the literal string `"true"`.
+    pub enabled:       bool,
+}
+
+/// Walk the flat settings map and assemble sanitised provider entries.
+/// Provider ids with no `default_model` are skipped; enabled providers
+/// sort first, then providers with an api key, then the rest by id.
+pub(crate) fn collect_providers(
+    settings: &std::collections::HashMap<String, String>,
+) -> Vec<ProviderInfo> {
+    use std::collections::HashMap;
+    let mut by_id: HashMap<&str, HashMap<&str, &str>> = HashMap::new();
+    for (key, value) in settings {
+        let rest = match key.strip_prefix("llm.providers.") {
+            Some(r) => r,
+            None => continue,
+        };
+        // `rest` looks like `<id>.<field>` — or `<id>.<sub>.<more>` for
+        // nested fields we do not care about. Split on the FIRST dot so
+        // `id` ends at the first segment.
+        let (id, field) = match rest.split_once('.') {
+            Some(pair) => pair,
+            None => continue,
+        };
+        by_id.entry(id).or_default().insert(field, value.as_str());
+    }
+
+    let mut entries: Vec<ProviderInfo> = by_id
+        .into_iter()
+        .filter_map(|(id, fields)| {
+            let default_model = fields.get("default_model").copied().unwrap_or("").trim();
+            if default_model.is_empty() {
+                return None;
+            }
+            let base_url = fields
+                .get("base_url")
+                .copied()
+                .map(str::trim)
+                .filter(|s| !s.is_empty())
+                .map(str::to_owned);
+            let has_api_key = fields
+                .get("api_key")
+                .copied()
+                .is_some_and(|v| !v.trim().is_empty());
+            let enabled = fields.get("enabled").copied() == Some("true");
+            Some(ProviderInfo {
+                id: id.to_owned(),
+                default_model: default_model.to_owned(),
+                base_url,
+                has_api_key,
+                enabled,
+            })
+        })
+        .collect();
+
+    entries.sort_by(|a, b| {
+        let score = |e: &ProviderInfo| (i32::from(e.enabled) * 2) + (i32::from(e.has_api_key));
+        let diff = score(b).cmp(&score(a));
+        if diff.is_eq() { a.id.cmp(&b.id) } else { diff }
+    });
+    entries
+}
+
 /// Central orchestrator for session-based AI chat.
 ///
 /// `SessionService` ties together two concerns:
@@ -111,6 +191,15 @@ impl SessionService {
                 message: format!("failed to update favorite models: {e}"),
             })?;
         Ok(())
+    }
+
+    /// List LLM providers derived from `llm.providers.<id>.*` settings,
+    /// stripped of any sensitive fields. Only `api_key` presence is
+    /// surfaced (as a boolean); actual key material never leaves the
+    /// backend via this endpoint.
+    pub async fn list_llm_providers(&self) -> Vec<ProviderInfo> {
+        let all = self.settings_provider.list().await;
+        collect_providers(&all)
     }
 
     // -- session CRUD -------------------------------------------------------

--- a/crates/extensions/backend-admin/src/chat/service.rs
+++ b/crates/extensions/backend-admin/src/chat/service.rs
@@ -68,8 +68,13 @@ pub struct ProviderInfo {
 }
 
 /// Walk the flat settings map and assemble sanitised provider entries.
-/// Provider ids with no `default_model` are skipped; enabled providers
+///
+/// Provider ids with no `default_model` are skipped. Enabled providers
 /// sort first, then providers with an api key, then the rest by id.
+///
+/// The `enabled` flag is read strictly from the literal string `"true"`
+/// to match how the Settings UI writes the value — any other shape
+/// (including `"1"`, `"yes"`, `"True"`) is treated as disabled.
 pub(crate) fn collect_providers(
     settings: &std::collections::HashMap<String, String>,
 ) -> Vec<ProviderInfo> {
@@ -82,11 +87,16 @@ pub(crate) fn collect_providers(
         };
         // `rest` looks like `<id>.<field>` — or `<id>.<sub>.<more>` for
         // nested fields we do not care about. Split on the FIRST dot so
-        // `id` ends at the first segment.
+        // `id` ends at the first segment. Reject empty ids to shield
+        // against malformed keys like `llm.providers..default_model`
+        // producing a ghost entry.
         let (id, field) = match rest.split_once('.') {
             Some(pair) => pair,
             None => continue,
         };
+        if id.is_empty() {
+            continue;
+        }
         by_id.entry(id).or_default().insert(field, value.as_str());
     }
 
@@ -124,6 +134,121 @@ pub(crate) fn collect_providers(
         if diff.is_eq() { a.id.cmp(&b.id) } else { diff }
     });
     entries
+}
+
+#[cfg(test)]
+mod provider_tests {
+    use std::collections::HashMap;
+
+    use super::{ProviderInfo, collect_providers};
+
+    fn settings(pairs: &[(&str, &str)]) -> HashMap<String, String> {
+        pairs
+            .iter()
+            .map(|(k, v)| ((*k).to_owned(), (*v).to_owned()))
+            .collect()
+    }
+
+    #[test]
+    fn omits_api_key_values_from_serialized_output() {
+        // The whole point of the endpoint: raw key material must never
+        // appear in the response body, only its presence as a boolean.
+        let s = settings(&[
+            ("llm.providers.kimi.api_key", "sk-secret-value"),
+            ("llm.providers.kimi.default_model", "kimi-k2.5"),
+            ("llm.providers.kimi.enabled", "true"),
+        ]);
+        let out = collect_providers(&s);
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].id, "kimi");
+        assert!(out[0].has_api_key);
+
+        let json = serde_json::to_string(&out).expect("serialize");
+        assert!(
+            !json.contains("sk-secret-value"),
+            "serialized output leaked api_key: {json}"
+        );
+        // The boolean `has_api_key` field legitimately contains the
+        // substring — check the value side of the JSON by looking for
+        // the literal key name followed by a colon.
+        assert!(
+            !json.contains("\"api_key\":"),
+            "serialized output should not expose raw `api_key` field: {json}"
+        );
+    }
+
+    #[test]
+    fn skips_providers_without_default_model() {
+        let s = settings(&[
+            ("llm.providers.configured.api_key", "abc"),
+            ("llm.providers.configured.default_model", "m1"),
+            ("llm.providers.no_model.api_key", "abc"),
+        ]);
+        let out = collect_providers(&s);
+        let ids: Vec<&str> = out.iter().map(|p| p.id.as_str()).collect();
+        assert_eq!(ids, vec!["configured"]);
+    }
+
+    #[test]
+    fn ignores_malformed_empty_id_keys() {
+        // `llm.providers..default_model` should not materialise a row
+        // with id="" — protects against typos / partial writes.
+        let s = settings(&[
+            ("llm.providers..default_model", "m1"),
+            ("llm.providers.real.default_model", "m2"),
+        ]);
+        let out = collect_providers(&s);
+        let ids: Vec<&str> = out.iter().map(|p| p.id.as_str()).collect();
+        assert_eq!(ids, vec!["real"]);
+    }
+
+    #[test]
+    fn enabled_requires_literal_true_string() {
+        // Mirrors the guard on `enabled`: only lowercase "true" counts.
+        let s = settings(&[
+            ("llm.providers.a.default_model", "m"),
+            ("llm.providers.a.enabled", "True"),
+            ("llm.providers.b.default_model", "m"),
+            ("llm.providers.b.enabled", "true"),
+            ("llm.providers.c.default_model", "m"),
+            ("llm.providers.c.enabled", "1"),
+        ]);
+        let out = collect_providers(&s);
+        let flags: HashMap<_, _> = out.iter().map(|p| (p.id.as_str(), p.enabled)).collect();
+        assert_eq!(flags.get("a").copied(), Some(false));
+        assert_eq!(flags.get("b").copied(), Some(true));
+        assert_eq!(flags.get("c").copied(), Some(false));
+    }
+
+    #[test]
+    fn sorts_enabled_first_then_api_key_then_id() {
+        let s = settings(&[
+            ("llm.providers.zeta.default_model", "m"),
+            ("llm.providers.zeta.enabled", "true"),
+            ("llm.providers.alpha.default_model", "m"),
+            ("llm.providers.alpha.api_key", "k"),
+            ("llm.providers.mid.default_model", "m"),
+        ]);
+        let out = collect_providers(&s);
+        let ids: Vec<&str> = out.iter().map(|p| p.id.as_str()).collect();
+        assert_eq!(ids, vec!["zeta", "alpha", "mid"]);
+    }
+
+    #[test]
+    fn ignores_nested_subfields() {
+        // `llm.providers.X.fallback.models` is a known rara key shape
+        // that is NOT one of the fields we surface — it should be
+        // quietly ignored rather than crash or alter the output.
+        let s = settings(&[
+            ("llm.providers.x.default_model", "m"),
+            ("llm.providers.x.fallback.models", "a,b,c"),
+        ]);
+        let out: Vec<ProviderInfo> = collect_providers(&s);
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].id, "x");
+        assert!(!out[0].enabled);
+        assert!(!out[0].has_api_key);
+    }
 }
 
 /// Central orchestrator for session-based AI chat.

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -141,7 +141,8 @@ import type {
 } from './types';
 
 export const api = {
-  get: <T>(path: string) => request<T>(path),
+  get: <T>(path: string, options?: { signal?: AbortSignal }) =>
+    request<T>(path, options?.signal ? { signal: options.signal } : undefined),
   post: <T>(path: string, body?: unknown) =>
     request<T>(path, { method: 'POST', body: body ? JSON.stringify(body) : undefined }),
   put: <T>(path: string, body?: unknown) =>

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -140,16 +140,36 @@ import type {
   SettingsMap, SettingValue, SettingsPatch,
 } from './types';
 
+/** Callers can pass an `AbortSignal` to cancel in-flight requests
+ *  (e.g. a React effect cleanup or a user-triggered dialog close). */
+type ApiOptions = { signal?: AbortSignal };
+
 export const api = {
-  get: <T>(path: string, options?: { signal?: AbortSignal }) =>
+  get: <T>(path: string, options?: ApiOptions) =>
     request<T>(path, options?.signal ? { signal: options.signal } : undefined),
-  post: <T>(path: string, body?: unknown) =>
-    request<T>(path, { method: 'POST', body: body ? JSON.stringify(body) : undefined }),
-  put: <T>(path: string, body?: unknown) =>
-    request<T>(path, { method: 'PUT', body: body ? JSON.stringify(body) : undefined }),
-  patch: <T>(path: string, body?: unknown) =>
-    request<T>(path, { method: 'PATCH', body: body ? JSON.stringify(body) : undefined }),
-  del: <T>(path: string) => request<T>(path, { method: 'DELETE' }),
+  post: <T>(path: string, body?: unknown, options?: ApiOptions) =>
+    request<T>(path, {
+      method: 'POST',
+      body: body ? JSON.stringify(body) : undefined,
+      ...(options?.signal ? { signal: options.signal } : {}),
+    }),
+  put: <T>(path: string, body?: unknown, options?: ApiOptions) =>
+    request<T>(path, {
+      method: 'PUT',
+      body: body ? JSON.stringify(body) : undefined,
+      ...(options?.signal ? { signal: options.signal } : {}),
+    }),
+  patch: <T>(path: string, body?: unknown, options?: ApiOptions) =>
+    request<T>(path, {
+      method: 'PATCH',
+      body: body ? JSON.stringify(body) : undefined,
+      ...(options?.signal ? { signal: options.signal } : {}),
+    }),
+  del: <T>(path: string, options?: ApiOptions) =>
+    request<T>(path, {
+      method: 'DELETE',
+      ...(options?.signal ? { signal: options.signal } : {}),
+    }),
   blob: (path: string) => requestBlob(path),
 };
 

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -47,6 +47,16 @@ export interface ChatModel {
   is_favorite: boolean;
 }
 
+/** Sanitised LLM provider entry from `GET /api/v1/chat/providers`.
+ *  API keys never appear here — only their presence is surfaced. */
+export interface ProviderInfo {
+  id: string;
+  default_model: string;
+  base_url: string | null;
+  has_api_key: boolean;
+  enabled: boolean;
+}
+
 
 // Chat Sessions
 

--- a/web/src/components/RaraModelDialog.tsx
+++ b/web/src/components/RaraModelDialog.tsx
@@ -26,6 +26,14 @@ import { Input } from "@/components/ui/input";
 import { api } from "@/api/client";
 import type { ProviderInfo } from "@/api/types";
 
+/**
+ * How long the in-memory provider catalog is considered fresh. Settings
+ * edits are rare, and `/api/v1/chat/providers` walks the whole KV map,
+ * so caching for a short window trades negligible staleness for fewer
+ * round-trips on rapid open/close of the dialog.
+ */
+const CACHE_TTL_MS = 60_000;
+
 interface Props {
   open:              boolean;
   onClose:           () => void;
@@ -56,14 +64,17 @@ export function RaraModelDialog({
   const [selectedIdx, setSelectedIdx] = useState(0);
 
   // Cache the fetched list across open/close cycles — settings rarely
-  // change and the dialog is opened per-click.
-  const cacheRef = useRef<ProviderInfo[] | null>(null);
+  // change and the dialog is opened per-click. Cached entries expire
+  // after CACHE_TTL_MS so edits made in /settings while this page is
+  // open eventually show up without a full page reload.
+  const cacheRef = useRef<{ list: ProviderInfo[]; at: number } | null>(null);
 
   useEffect(() => {
     if (!open) return;
-    // Serve from cache on reopen; refetch only on first load.
-    if (cacheRef.current) {
-      setEntries(cacheRef.current);
+    // Serve from cache on reopen when still fresh; refetch otherwise.
+    const cached = cacheRef.current;
+    if (cached && Date.now() - cached.at < CACHE_TTL_MS) {
+      setEntries(cached.list);
       return;
     }
     const controller = new AbortController();
@@ -71,7 +82,7 @@ export function RaraModelDialog({
     api
       .get<ProviderInfo[]>("/api/v1/chat/providers", { signal: controller.signal })
       .then((list) => {
-        cacheRef.current = list;
+        cacheRef.current = { list, at: Date.now() };
         setEntries(list);
       })
       .catch((e: unknown) => {
@@ -95,7 +106,13 @@ export function RaraModelDialog({
     );
   }, [entries, query]);
 
-  // Clamp the selection cursor whenever the filtered list shrinks/grows.
+  // Reset the selection cursor whenever the query changes so the first
+  // match in the freshly-filtered list is always the highlighted row.
+  // Separate effect for `entries` clamps the cursor if the raw list
+  // grew/shrunk (e.g. after a refetch).
+  useEffect(() => {
+    setSelectedIdx(0);
+  }, [query]);
   useEffect(() => {
     setSelectedIdx((idx) =>
       filtered.length === 0 ? 0 : Math.min(idx, filtered.length - 1),

--- a/web/src/components/RaraModelDialog.tsx
+++ b/web/src/components/RaraModelDialog.tsx
@@ -1,0 +1,210 @@
+/*
+ * Copyright 2025 Rararulab
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useEffect, useMemo, useState } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { settingsApi } from "@/api/client";
+
+/**
+ * A rara-native LLM provider entry assembled from `/api/v1/settings`.
+ *
+ * Rara's provider catalog lives entirely in flat KV settings under
+ * `llm.providers.<id>.*`. Provider ids come straight from rara
+ * (`openrouter`, `kimi`, `minimax`, `glm`, `scnet`, `stepfun`, ...) so
+ * the backend's `DriverRegistry::resolve` can route directly when we
+ * PATCH this back onto the session.
+ */
+export interface RaraProviderEntry {
+  id:             string;
+  default_model:  string;
+  base_url?:      string;
+  has_api_key:    boolean;
+  enabled:        boolean;
+}
+
+interface Props {
+  open:              boolean;
+  onClose:           () => void;
+  onSelect:          (entry: RaraProviderEntry) => void;
+  currentProvider?:  string | null;
+}
+
+/**
+ * Model picker backed by rara's own settings. Replaces pi-mono's
+ * `ModelSelector`, whose catalog lives in pi-ai's hard-coded `MODELS`
+ * constant and cannot address rara's custom OpenAI-compatible
+ * endpoints (`scnet`, `stepfun`, `m3`, `local`, ...). Shows one entry
+ * per rara provider that has a `default_model` configured.
+ */
+export function RaraModelDialog({
+  open,
+  onClose,
+  onSelect,
+  currentProvider,
+}: Props) {
+  const [entries, setEntries] = useState<RaraProviderEntry[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [query, setQuery] = useState("");
+
+  useEffect(() => {
+    if (!open) return;
+    setLoading(true);
+    settingsApi
+      .list()
+      .then((settings) => setEntries(parseProviderEntries(settings)))
+      .catch((e) => {
+        console.warn("Failed to load provider catalog:", e);
+        setEntries([]);
+      })
+      .finally(() => setLoading(false));
+  }, [open]);
+
+  const filtered = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    if (!q) return entries;
+    return entries.filter(
+      (e) =>
+        e.id.toLowerCase().includes(q) ||
+        e.default_model.toLowerCase().includes(q),
+    );
+  }, [entries, query]);
+
+  return (
+    <Dialog open={open} onOpenChange={(next) => { if (!next) onClose(); }}>
+      <DialogContent className="max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Select model</DialogTitle>
+          <DialogDescription>
+            Rara providers configured via{" "}
+            <code className="text-[11px]">llm.providers.*</code> settings.
+          </DialogDescription>
+        </DialogHeader>
+
+        <Input
+          autoFocus
+          placeholder="Filter by provider or model…"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          className="mb-2"
+        />
+
+        <div className="max-h-[60vh] overflow-y-auto rounded border border-border">
+          {loading ? (
+            <div className="py-8 text-center text-sm text-muted-foreground">
+              Loading…
+            </div>
+          ) : filtered.length === 0 ? (
+            <div className="py-8 text-center text-sm text-muted-foreground">
+              {entries.length === 0
+                ? "No providers configured. Add one in /settings."
+                : "No matches."}
+            </div>
+          ) : (
+            filtered.map((entry) => {
+              const active = entry.id === currentProvider;
+              return (
+                <button
+                  key={entry.id}
+                  className={`flex w-full flex-col gap-0.5 border-b border-border/60 px-4 py-3 text-left transition-colors hover:bg-secondary/60 ${
+                    active ? "bg-secondary/80" : ""
+                  }`}
+                  onClick={() => onSelect(entry)}
+                >
+                  <div className="flex items-center justify-between">
+                    <span className="text-sm font-medium text-foreground">
+                      {entry.id}
+                    </span>
+                    <div className="flex items-center gap-1">
+                      {entry.enabled && (
+                        <span className="rounded bg-green-500/15 px-1.5 py-0.5 text-[10px] font-medium text-green-600">
+                          enabled
+                        </span>
+                      )}
+                      {!entry.has_api_key && !entry.enabled && (
+                        <span className="rounded bg-amber-500/15 px-1.5 py-0.5 text-[10px] font-medium text-amber-600">
+                          no key
+                        </span>
+                      )}
+                    </div>
+                  </div>
+                  <div className="font-mono text-xs text-muted-foreground">
+                    {entry.default_model}
+                  </div>
+                  {entry.base_url && (
+                    <div className="truncate text-[11px] text-muted-foreground/70">
+                      {entry.base_url}
+                    </div>
+                  )}
+                </button>
+              );
+            })
+          )}
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+/**
+ * Extract provider entries from the flat settings map. Keep any provider
+ * that has a non-empty `default_model`; surface enabled / api-key flags
+ * so the UI can warn but still let the user pick.
+ */
+function parseProviderEntries(settings: Record<string, string>): RaraProviderEntry[] {
+  // Group keys by provider id.
+  const byId = new Map<string, Record<string, string>>();
+  for (const [key, value] of Object.entries(settings)) {
+    const m = /^llm\.providers\.([^.]+)\.([^.]+)$/.exec(key);
+    if (!m) continue;
+    const [, id, field] = m;
+    let bucket = byId.get(id);
+    if (!bucket) {
+      bucket = {};
+      byId.set(id, bucket);
+    }
+    bucket[field] = value;
+  }
+
+  const entries: RaraProviderEntry[] = [];
+  for (const [id, fields] of byId.entries()) {
+    const defaultModel = (fields["default_model"] ?? "").trim();
+    if (!defaultModel) continue;
+    entries.push({
+      id,
+      default_model: defaultModel,
+      base_url:      (fields["base_url"] ?? "").trim() || undefined,
+      has_api_key:   (fields["api_key"] ?? "").trim().length > 0,
+      enabled:       fields["enabled"] === "true",
+    });
+  }
+
+  // Enabled first, then providers with api_key, then the rest.
+  entries.sort((a, b) => {
+    const score = (e: RaraProviderEntry) =>
+      (e.enabled ? 2 : 0) + (e.has_api_key ? 1 : 0);
+    const diff = score(b) - score(a);
+    return diff !== 0 ? diff : a.id.localeCompare(b.id);
+  });
+
+  return entries;
+}

--- a/web/src/components/RaraModelDialog.tsx
+++ b/web/src/components/RaraModelDialog.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import {
   Dialog,
   DialogContent,
@@ -23,38 +23,26 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
-import { settingsApi } from "@/api/client";
-
-/**
- * A rara-native LLM provider entry assembled from `/api/v1/settings`.
- *
- * Rara's provider catalog lives entirely in flat KV settings under
- * `llm.providers.<id>.*`. Provider ids come straight from rara
- * (`openrouter`, `kimi`, `minimax`, `glm`, `scnet`, `stepfun`, ...) so
- * the backend's `DriverRegistry::resolve` can route directly when we
- * PATCH this back onto the session.
- */
-export interface RaraProviderEntry {
-  id:             string;
-  default_model:  string;
-  base_url?:      string;
-  has_api_key:    boolean;
-  enabled:        boolean;
-}
+import { api } from "@/api/client";
+import type { ProviderInfo } from "@/api/types";
 
 interface Props {
   open:              boolean;
   onClose:           () => void;
-  onSelect:          (entry: RaraProviderEntry) => void;
+  onSelect:          (entry: ProviderInfo) => void;
   currentProvider?:  string | null;
 }
 
 /**
- * Model picker backed by rara's own settings. Replaces pi-mono's
- * `ModelSelector`, whose catalog lives in pi-ai's hard-coded `MODELS`
- * constant and cannot address rara's custom OpenAI-compatible
- * endpoints (`scnet`, `stepfun`, `m3`, `local`, ...). Shows one entry
- * per rara provider that has a `default_model` configured.
+ * Rara-native LLM provider picker. Replaces pi-mono's `ModelSelector`,
+ * whose catalog lives in pi-ai's hard-coded `MODELS` constant and
+ * cannot address rara's custom OpenAI-compatible endpoints (`scnet`,
+ * `stepfun`, `m3`, `local`, ...).
+ *
+ * Data source: `GET /api/v1/chat/providers` — a sanitised view of
+ * `llm.providers.*` settings. Shows one entry per rara provider that
+ * has a `default_model` configured. Sensitive `api_key` values never
+ * cross the wire; the backend surfaces only a `has_api_key` boolean.
  */
 export function RaraModelDialog({
   open,
@@ -62,21 +50,39 @@ export function RaraModelDialog({
   onSelect,
   currentProvider,
 }: Props) {
-  const [entries, setEntries] = useState<RaraProviderEntry[]>([]);
+  const [entries, setEntries] = useState<ProviderInfo[]>([]);
   const [loading, setLoading] = useState(false);
   const [query, setQuery] = useState("");
+  const [selectedIdx, setSelectedIdx] = useState(0);
+
+  // Cache the fetched list across open/close cycles — settings rarely
+  // change and the dialog is opened per-click.
+  const cacheRef = useRef<ProviderInfo[] | null>(null);
 
   useEffect(() => {
     if (!open) return;
+    // Serve from cache on reopen; refetch only on first load.
+    if (cacheRef.current) {
+      setEntries(cacheRef.current);
+      return;
+    }
+    const controller = new AbortController();
     setLoading(true);
-    settingsApi
-      .list()
-      .then((settings) => setEntries(parseProviderEntries(settings)))
-      .catch((e) => {
+    api
+      .get<ProviderInfo[]>("/api/v1/chat/providers", { signal: controller.signal })
+      .then((list) => {
+        cacheRef.current = list;
+        setEntries(list);
+      })
+      .catch((e: unknown) => {
+        if (controller.signal.aborted) return;
         console.warn("Failed to load provider catalog:", e);
         setEntries([]);
       })
-      .finally(() => setLoading(false));
+      .finally(() => {
+        if (!controller.signal.aborted) setLoading(false);
+      });
+    return () => controller.abort();
   }, [open]);
 
   const filtered = useMemo(() => {
@@ -89,9 +95,31 @@ export function RaraModelDialog({
     );
   }, [entries, query]);
 
+  // Clamp the selection cursor whenever the filtered list shrinks/grows.
+  useEffect(() => {
+    setSelectedIdx((idx) =>
+      filtered.length === 0 ? 0 : Math.min(idx, filtered.length - 1),
+    );
+  }, [filtered.length]);
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (filtered.length === 0) return;
+    if (e.key === "ArrowDown") {
+      e.preventDefault();
+      setSelectedIdx((i) => Math.min(i + 1, filtered.length - 1));
+    } else if (e.key === "ArrowUp") {
+      e.preventDefault();
+      setSelectedIdx((i) => Math.max(i - 1, 0));
+    } else if (e.key === "Enter") {
+      e.preventDefault();
+      const entry = filtered[selectedIdx];
+      if (entry) onSelect(entry);
+    }
+  };
+
   return (
     <Dialog open={open} onOpenChange={(next) => { if (!next) onClose(); }}>
-      <DialogContent className="max-w-lg">
+      <DialogContent className="max-w-lg" onKeyDown={handleKeyDown}>
         <DialogHeader>
           <DialogTitle>Select model</DialogTitle>
           <DialogDescription>
@@ -120,14 +148,16 @@ export function RaraModelDialog({
                 : "No matches."}
             </div>
           ) : (
-            filtered.map((entry) => {
+            filtered.map((entry, idx) => {
               const active = entry.id === currentProvider;
+              const highlighted = idx === selectedIdx;
               return (
                 <button
                   key={entry.id}
-                  className={`flex w-full flex-col gap-0.5 border-b border-border/60 px-4 py-3 text-left transition-colors hover:bg-secondary/60 ${
-                    active ? "bg-secondary/80" : ""
+                  className={`flex w-full flex-col gap-0.5 border-b border-border/60 px-4 py-3 text-left transition-colors ${
+                    highlighted ? "bg-secondary/80" : active ? "bg-secondary/50" : "hover:bg-secondary/40"
                   }`}
+                  onMouseEnter={() => setSelectedIdx(idx)}
                   onClick={() => onSelect(entry)}
                 >
                   <div className="flex items-center justify-between">
@@ -163,48 +193,4 @@ export function RaraModelDialog({
       </DialogContent>
     </Dialog>
   );
-}
-
-/**
- * Extract provider entries from the flat settings map. Keep any provider
- * that has a non-empty `default_model`; surface enabled / api-key flags
- * so the UI can warn but still let the user pick.
- */
-function parseProviderEntries(settings: Record<string, string>): RaraProviderEntry[] {
-  // Group keys by provider id.
-  const byId = new Map<string, Record<string, string>>();
-  for (const [key, value] of Object.entries(settings)) {
-    const m = /^llm\.providers\.([^.]+)\.([^.]+)$/.exec(key);
-    if (!m) continue;
-    const [, id, field] = m;
-    let bucket = byId.get(id);
-    if (!bucket) {
-      bucket = {};
-      byId.set(id, bucket);
-    }
-    bucket[field] = value;
-  }
-
-  const entries: RaraProviderEntry[] = [];
-  for (const [id, fields] of byId.entries()) {
-    const defaultModel = (fields["default_model"] ?? "").trim();
-    if (!defaultModel) continue;
-    entries.push({
-      id,
-      default_model: defaultModel,
-      base_url:      (fields["base_url"] ?? "").trim() || undefined,
-      has_api_key:   (fields["api_key"] ?? "").trim().length > 0,
-      enabled:       fields["enabled"] === "true",
-    });
-  }
-
-  // Enabled first, then providers with api_key, then the rest.
-  entries.sort((a, b) => {
-    const score = (e: RaraProviderEntry) =>
-      (e.enabled ? 2 : 0) + (e.has_api_key ? 1 : 0);
-    const diff = score(b) - score(a);
-    return diff !== 0 ? diff : a.id.localeCompare(b.id);
-  });
-
-  return entries;
 }

--- a/web/src/lib/synthetic-model.ts
+++ b/web/src/lib/synthetic-model.ts
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2025 Rararulab
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { Model } from "@mariozechner/pi-ai";
+
+/**
+ * Build a pi-ai [`Model`] shape from rara's own provider + model pair.
+ *
+ * pi-chat-panel consumes `agent.state.model` only for UI display (the
+ * model-name pill in the composer) and local bookkeeping — streaming
+ * bypasses pi-ai entirely and rides on rara's WebSocket. The
+ * synthesized fields (`api`, `baseUrl`, `cost`, `contextWindow`) need
+ * only be structurally valid; their values never hit the wire.
+ */
+export function syntheticModel(
+  providerId: string,
+  modelId: string,
+  options?: { baseUrl?: string; contextWindow?: number; name?: string },
+): Model<any> {
+  return {
+    id:            modelId,
+    name:          options?.name ?? `${providerId} / ${modelId}`,
+    api:           "openai-completions",
+    provider:      providerId,
+    baseUrl:       options?.baseUrl ?? "",
+    reasoning:     false,
+    input:         ["text", "image"],
+    cost:          { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    contextWindow: options?.contextWindow ?? 128_000,
+    maxTokens:     4096,
+  } as Model<any>;
+}
+
+/** Sentinel model-id/provider assigned by pi-agent-core before any pick. */
+export const UNKNOWN_MODEL_SENTINEL = "unknown";
+
+/**
+ * True when `agent.state.model` is pi-agent-core's placeholder default,
+ * i.e. the user has not selected a model and no session state has been
+ * restored. Callers use this to avoid persisting a bogus override.
+ */
+export function isUnknownModel(model: {
+  id?: string;
+  provider?: string;
+} | null | undefined): boolean {
+  if (!model) return true;
+  return (
+    model.id === UNKNOWN_MODEL_SENTINEL
+    || model.provider === UNKNOWN_MODEL_SENTINEL
+  );
+}

--- a/web/src/lib/synthetic-model.ts
+++ b/web/src/lib/synthetic-model.ts
@@ -30,7 +30,7 @@ export function syntheticModel(
   modelId: string,
   options?: { baseUrl?: string; contextWindow?: number; name?: string },
 ): Model<any> {
-  return {
+  const model: Model<any> = {
     id:            modelId,
     name:          options?.name ?? `${providerId} / ${modelId}`,
     api:           "openai-completions",
@@ -41,7 +41,8 @@ export function syntheticModel(
     cost:          { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
     contextWindow: options?.contextWindow ?? 128_000,
     maxTokens:     4096,
-  } as Model<any>;
+  };
+  return model;
 }
 
 /** Sentinel model-id/provider assigned by pi-agent-core before any pick. */

--- a/web/src/pages/PiChat.tsx
+++ b/web/src/pages/PiChat.tsx
@@ -35,7 +35,7 @@ import type { AgentMessage } from "@mariozechner/pi-agent-core";
 // module-level `registerToolRenderer("extract_document", ...)` side
 // effect so pi-mono can render server-triggered document-extraction tool
 // calls in chat.
-import { extractDocumentTool, ModelSelector } from "@mariozechner/pi-web-ui";
+import { extractDocumentTool } from "@mariozechner/pi-web-ui";
 
 // Reference the tool so Vite's tree-shaker keeps the module (and its
 // `registerToolRenderer` side effect) in the bundle. The actual tool
@@ -52,10 +52,14 @@ import type {
 import { RaraStorageBackend } from "@/adapters/rara-storage";
 import { createRaraStreamFn } from "@/adapters/rara-stream";
 import { registerRaraToolRenderers } from "@/tools/rara-tool-renderers";
-import { api, settingsApi } from "@/api/client";
+import { api } from "@/api/client";
 import type { ChatSession, ChatMessageData, ThinkingLevel } from "@/api/types";
 import { useNavigate } from "react-router";
 import { VoiceRecorder } from "@/components/VoiceRecorder";
+import {
+  RaraModelDialog,
+  type RaraProviderEntry,
+} from "@/components/RaraModelDialog";
 
 /** Strip `<think>...</think>` blocks — used only for UI preview/title text. */
 function stripForPreview(text: string): string {
@@ -104,22 +108,31 @@ function isToolFailure(text: string): boolean {
 }
 
 /**
- * Map rara's LLM provider ids (as they appear in `/api/v1/settings`
- * under `llm.providers.<id>.enabled`) to the provider ids pi-mono's
- * `ModelSelector` filters by (`model.provider` on each pi-ai `Model`).
- *
- * Entries with an empty array (e.g. `ollama`) are known but not yet
- * exposed through pi-mono's built-in catalog — they need a
- * `CustomProvidersStore` injection to appear in the selector. Leaving
- * them empty keeps them out of the allowlist so the UI does not imply
- * support that is not wired up.
+ * Build a pi-ai `Model<any>`-shaped object from rara's own provider
+ * data. pi-chat-panel uses `agent.state.model` only for UI display (the
+ * model-name pill above the composer); actual streaming bypasses pi-ai
+ * entirely and rides on rara's WebSocket, so the synthesized fields
+ * (`api`, `baseUrl`, `cost`, `contextWindow`) need only be structurally
+ * valid — their values never hit the wire.
  */
-const RARA_TO_PIMONO_PROVIDERS: Record<string, readonly string[]> = {
-  openrouter: ["openrouter"],
-  codex: ["openai-codex"],
-  "kimi-code": ["kimi-coding"],
-  ollama: [],
-};
+function syntheticModel(
+  providerId: string,
+  modelId: string,
+  options?: { baseUrl?: string; contextWindow?: number; name?: string },
+): unknown {
+  return {
+    id:            modelId,
+    name:          options?.name ?? `${providerId} / ${modelId}`,
+    api:           "openai-completions",
+    provider:      providerId,
+    baseUrl:       options?.baseUrl ?? "",
+    reasoning:     false,
+    input:         ["text", "image"],
+    cost:          { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    contextWindow: options?.contextWindow ?? 128_000,
+    maxTokens:     4096,
+  };
+}
 
 function mimeToFilename(mimeType: string, index: number): string {
   const ext = mimeType.split("/")[1] || "bin";
@@ -441,6 +454,7 @@ export default function PiChat() {
   const chatPanelRef = useRef<import("@mariozechner/pi-web-ui").ChatPanel | null>(null);
   const [showSessionList, setShowSessionList] = useState(false);
   const [isInitializing, setIsInitializing] = useState(true);
+  const [modelDialogOpen, setModelDialogOpen] = useState(false);
   const navigate = useNavigate();
 
   /** Switch the agent to a different session, loading its history. */
@@ -450,23 +464,14 @@ export default function PiChat() {
     agent.clearMessages();
     agent.sessionId = session.key;
 
-    // Restore the session's persisted model + thinking-level so
-    // pi-chat-panel's selectors reflect the last settings used for this
-    // conversation. `getModel(provider, id)` rebuilds a fully typed
-    // `Model<any>` when both fields are available; otherwise the global
-    // selector state remains in place.
+    // Restore the session's persisted model + thinking-level so the
+    // model pill in the composer reflects the last settings used for
+    // this conversation. We build a synthetic pi-ai Model rather than
+    // looking the pair up in pi-ai's catalog — rara's provider ids
+    // (`kimi`, `openrouter`, `scnet`, ...) do not exist there.
     if (session.model && session.model_provider) {
-      try {
-        const { getModel } = await import("@mariozechner/pi-ai");
-        // getModel is loosely typed at runtime; cast is safe because
-        // the ids originally came from the same catalog.
-        agent.state.model = getModel(
-          session.model_provider as never,
-          session.model as never,
-        );
-      } catch (e) {
-        console.warn("Failed to restore model for session:", e);
-      }
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      agent.state.model = syntheticModel(session.model_provider, session.model) as any;
     }
     if (session.thinking_level) {
       agent.state.thinkingLevel = session.thinking_level;
@@ -610,53 +615,18 @@ export default function PiChat() {
       chatPanelRef.current = chatPanel;
       container.appendChild(chatPanel);
 
-      // 7. Derive the provider allowlist for pi-mono's ModelSelector from
-      //    the set of rara LLM providers currently enabled in settings.
-      //    Rara's provider ids (`openrouter`, `codex`, `kimi-code`, ...) do
-      //    not match pi-mono's provider ids 1:1, so the mapping is explicit.
-      //    `/api/v1/chat/models` cannot be used here: its ids are
-      //    OpenRouter-style `"<family>/<model>"`, and the family prefix is
-      //    NOT pi-mono's provider name — pi-mono's `ModelSelector` filters
-      //    by `model.provider`, which for OpenRouter models is the literal
-      //    string `"openrouter"`, not `openai`/`anthropic`/etc. (verified
-      //    against `vendor/pi-mono/packages/ai/src/models.generated.ts`).
-      //
-      //    Best-effort: if the fetch fails or yields no enabled providers,
-      //    leave the allowlist undefined so pi-mono falls back to showing
-      //    everything rather than locking the user out.
-      let allowedProviders: string[] | undefined;
-      try {
-        const rawSettings = await settingsApi.list();
-        const providers = new Set<string>();
-        for (const [key, value] of Object.entries(rawSettings)) {
-          // rara stores booleans as the literal string "true".
-          if (value !== "true") continue;
-          const match = /^llm\.providers\.([^.]+)\.enabled$/.exec(key);
-          if (!match) continue;
-          for (const piProvider of RARA_TO_PIMONO_PROVIDERS[match[1]] ?? []) {
-            providers.add(piProvider);
-          }
-        }
-        if (providers.size > 0) allowedProviders = [...providers];
-      } catch (e) {
-        console.warn("Failed to load settings for selector filter:", e);
-      }
-
-      // 8. Wire agent into the panel — skip API key prompt since rara manages
+      // 7. Wire agent into the panel — skip API key prompt since rara manages
       //    keys server-side, and sync the current model/thinking override to
       //    the backend before every send so the kernel sees the user's
-      //    selection for this turn.
+      //    selection for this turn. Overriding `onModelSelect` replaces
+      //    pi-mono's `ModelSelector` (which only knows its own hard-coded
+      //    `MODELS` catalog) with rara's native dialog sourced from
+      //    `/api/v1/settings` — the only place provider ids (`openrouter`,
+      //    `kimi`, `minimax`, `glm`, `scnet`, ...) align with rara's kernel
+      //    `DriverRegistry`.
       await chatPanel.setAgent(agent, {
         onApiKeyRequired: async () => true,
-        onModelSelect: () => {
-          // Open pi-mono's native ModelSelector but restrict to providers
-          // rara's backend can actually route to.
-          ModelSelector.open(
-            agent.state.model,
-            (model) => { agent.state.model = model; },
-            allowedProviders,
-          );
-        },
+        onModelSelect: () => setModelDialogOpen(true),
         onBeforeSend: async () => {
           const key = agent.sessionId;
           if (!key) return;
@@ -757,6 +727,23 @@ export default function PiChat() {
           onNavigate={navigate}
         />
       )}
+      {/* Rara-native model picker — replaces pi-mono's ModelSelector. */}
+      <RaraModelDialog
+        open={modelDialogOpen}
+        onClose={() => setModelDialogOpen(false)}
+        currentProvider={agentRef.current?.state.model?.provider ?? null}
+        onSelect={(entry: RaraProviderEntry) => {
+          const agent = agentRef.current;
+          if (agent) {
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            agent.state.model = syntheticModel(entry.id, entry.default_model, {
+              baseUrl: entry.base_url,
+            }) as any;
+            chatPanelRef.current?.agentInterface?.requestUpdate();
+          }
+          setModelDialogOpen(false);
+        }}
+      />
     </div>
   );
 }

--- a/web/src/pages/PiChat.tsx
+++ b/web/src/pages/PiChat.tsx
@@ -638,10 +638,11 @@ export default function PiChat() {
           // would overwrite any previously saved rara provider with a
           // sentinel the kernel's DriverRegistry cannot route to, which
           // caused the original "LLM provider not configured" failure
-          // (see #1554).
+          // (see #1554). `isUnknownModel` returns true for null/undefined
+          // too, so the subsequent reads are safe without the `?.` guard.
           const picked = !isUnknownModel(agent.state.model);
-          const model = picked ? (agent.state.model?.id ?? null) : null;
-          const provider = picked ? (agent.state.model?.provider ?? null) : null;
+          const model = picked ? agent.state.model!.id : null;
+          const provider = picked ? agent.state.model!.provider : null;
           const thinking = asThinkingLevel(agent.state.thinkingLevel);
 
           // Nothing worth persisting.

--- a/web/src/pages/PiChat.tsx
+++ b/web/src/pages/PiChat.tsx
@@ -56,10 +56,9 @@ import { api } from "@/api/client";
 import type { ChatSession, ChatMessageData, ThinkingLevel } from "@/api/types";
 import { useNavigate } from "react-router";
 import { VoiceRecorder } from "@/components/VoiceRecorder";
-import {
-  RaraModelDialog,
-  type RaraProviderEntry,
-} from "@/components/RaraModelDialog";
+import { RaraModelDialog } from "@/components/RaraModelDialog";
+import type { ProviderInfo } from "@/api/types";
+import { isUnknownModel, syntheticModel } from "@/lib/synthetic-model";
 
 /** Strip `<think>...</think>` blocks — used only for UI preview/title text. */
 function stripForPreview(text: string): string {
@@ -105,33 +104,6 @@ function isToolFailure(text: string): boolean {
   } catch {
     return false;
   }
-}
-
-/**
- * Build a pi-ai `Model<any>`-shaped object from rara's own provider
- * data. pi-chat-panel uses `agent.state.model` only for UI display (the
- * model-name pill above the composer); actual streaming bypasses pi-ai
- * entirely and rides on rara's WebSocket, so the synthesized fields
- * (`api`, `baseUrl`, `cost`, `contextWindow`) need only be structurally
- * valid — their values never hit the wire.
- */
-function syntheticModel(
-  providerId: string,
-  modelId: string,
-  options?: { baseUrl?: string; contextWindow?: number; name?: string },
-): unknown {
-  return {
-    id:            modelId,
-    name:          options?.name ?? `${providerId} / ${modelId}`,
-    api:           "openai-completions",
-    provider:      providerId,
-    baseUrl:       options?.baseUrl ?? "",
-    reasoning:     false,
-    input:         ["text", "image"],
-    cost:          { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-    contextWindow: options?.contextWindow ?? 128_000,
-    maxTokens:     4096,
-  };
 }
 
 function mimeToFilename(mimeType: string, index: number): string {
@@ -452,6 +424,9 @@ export default function PiChat() {
   const initRef = useRef(false);
   const agentRef = useRef<Agent | null>(null);
   const chatPanelRef = useRef<import("@mariozechner/pi-web-ui").ChatPanel | null>(null);
+  // Tracks the last successfully-persisted (model, provider, thinking)
+  // triple so onBeforeSend can skip no-op PATCHes on every send.
+  const lastPersistedRef = useRef<{ model: string | null; provider: string | null; thinking: string | null } | null>(null);
   const [showSessionList, setShowSessionList] = useState(false);
   const [isInitializing, setIsInitializing] = useState(true);
   const [modelDialogOpen, setModelDialogOpen] = useState(false);
@@ -470,12 +445,20 @@ export default function PiChat() {
     // looking the pair up in pi-ai's catalog — rara's provider ids
     // (`kimi`, `openrouter`, `scnet`, ...) do not exist there.
     if (session.model && session.model_provider) {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      agent.state.model = syntheticModel(session.model_provider, session.model) as any;
+      agent.state.model = syntheticModel(session.model_provider, session.model);
     }
     if (session.thinking_level) {
       agent.state.thinkingLevel = session.thinking_level;
     }
+    // Reset the dedup ref to match the session that was just loaded so
+    // onBeforeSend correctly re-PATCHes if the user changes selection
+    // away from the restored values, and skips the identity write
+    // otherwise.
+    lastPersistedRef.current = {
+      model:    session.model ?? null,
+      provider: session.model_provider ?? null,
+      thinking: session.thinking_level ?? null,
+    };
 
     try {
       const msgs = await api.get<ChatMessageData[]>(
@@ -610,6 +593,25 @@ export default function PiChat() {
       });
       agentRef.current = agent;
 
+      // Restore the initial session's persisted model + thinking-level
+      // BEFORE mounting the chat panel, so the composer pill reflects
+      // the real selection and `onBeforeSend` does not see pi-agent-core's
+      // "unknown" default as the first thing to persist.
+      if (initialSession.model && initialSession.model_provider) {
+        agent.state.model = syntheticModel(
+          initialSession.model_provider,
+          initialSession.model,
+        );
+        lastPersistedRef.current = {
+          model:    initialSession.model,
+          provider: initialSession.model_provider,
+          thinking: initialSession.thinking_level ?? null,
+        };
+      }
+      if (initialSession.thinking_level) {
+        agent.state.thinkingLevel = initialSession.thinking_level;
+      }
+
       // 6. Mount the ChatPanel custom element
       const chatPanel = document.createElement("pi-chat-panel") as import("@mariozechner/pi-web-ui").ChatPanel;
       chatPanelRef.current = chatPanel;
@@ -630,17 +632,36 @@ export default function PiChat() {
         onBeforeSend: async () => {
           const key = agent.sessionId;
           if (!key) return;
-          const model = agent.state.model?.id ?? null;
-          const model_provider = agent.state.model?.provider ?? null;
-          const thinking_level = asThinkingLevel(agent.state.thinkingLevel);
-          // Skip the PATCH when nothing would change.
-          if (!model && !thinking_level) return;
+
+          // Skip the PATCH when `agent.state.model` is pi-agent-core's
+          // placeholder default (id/provider = "unknown"). Persisting it
+          // would overwrite any previously saved rara provider with a
+          // sentinel the kernel's DriverRegistry cannot route to, which
+          // caused the original "LLM provider not configured" failure
+          // (see #1554).
+          const picked = !isUnknownModel(agent.state.model);
+          const model = picked ? (agent.state.model?.id ?? null) : null;
+          const provider = picked ? (agent.state.model?.provider ?? null) : null;
+          const thinking = asThinkingLevel(agent.state.thinkingLevel);
+
+          // Nothing worth persisting.
+          if (!model && !thinking) return;
+
+          // Dedup consecutive identical writes — the chat UI round-trips
+          // every send through this hook even when the selection hasn't
+          // changed, and the PATCH wakes up the session index for nothing.
+          const last = lastPersistedRef.current;
+          if (last && last.model === model && last.provider === provider && last.thinking === thinking) {
+            return;
+          }
+
           try {
             await api.patch(`/api/v1/chat/sessions/${encodeURIComponent(key)}`, {
               model,
-              model_provider,
-              thinking_level,
+              model_provider: provider,
+              thinking_level: thinking,
             });
+            lastPersistedRef.current = { model, provider, thinking };
           } catch (e) {
             console.warn("Failed to persist session LLM override:", e);
           }
@@ -732,13 +753,12 @@ export default function PiChat() {
         open={modelDialogOpen}
         onClose={() => setModelDialogOpen(false)}
         currentProvider={agentRef.current?.state.model?.provider ?? null}
-        onSelect={(entry: RaraProviderEntry) => {
+        onSelect={(entry: ProviderInfo) => {
           const agent = agentRef.current;
           if (agent) {
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
             agent.state.model = syntheticModel(entry.id, entry.default_model, {
-              baseUrl: entry.base_url,
-            }) as any;
+              baseUrl: entry.base_url ?? undefined,
+            });
             chatPanelRef.current?.agentInterface?.requestUpdate();
           }
           setModelDialogOpen(false);


### PR DESCRIPTION
## Summary

pi-mono's built-in ModelSelector reads from pi-ai's hard-coded `MODELS` constant, whose provider names (`anthropic`, `openai`, `google`, ...) don't match rara's driver names (`openrouter`, `kimi`, `minimax`, `glm`, `scnet`, `stepfun`, ...). Picking anything from pi-mono's catalog persisted an unknown provider onto the session and the next turn failed with `LLM provider not configured`.

Replace the selector with a rara-native dialog sourced from `/api/v1/settings`.

### Changes

- **New** `web/src/components/RaraModelDialog.tsx` — shadcn/Dialog listing rara providers that have a `default_model` configured. Entries surface `enabled` / `no key` badges so the user sees state at a glance. Search filter by id or model name.
- **PiChat.tsx**:
  - Override `onModelSelect` to open RaraModelDialog instead of `ModelSelector.open`.
  - Synthesize a `Model<any>` from `{provider_id, default_model, base_url}` and assign to `agent.state.model`. pi-mono only reads this for the composer's model-name pill; streaming rides on rara's WebSocket regardless, so the synthetic cost/api fields never hit the wire.
  - On session switch, rebuild the synthetic model from the session's stored `model_provider` + `model`. (Previously used `getModel(provider, id)` which threw on non-pi-ai providers.)
  - Drop the pi-mono allowlist map and settings-enabled scan — no longer relevant once the selector is rara-native.

### Why not a smaller allowlist patch (#1543)

pi-mono's catalog has no entries for rara's custom OpenAI-compatible endpoints (`scnet`, `stepfun`, `m3`, `local`, ...). Even a complete name-mapping table can't surface those. The source of truth has to be rara's own settings.

## Type of change

| Type | Label |
|------|-------|
| Bug fix | `bug` |

## Component

`ui`

## Closes

Closes #1554

## Test plan

- [x] `cd web && npm run build` passes
- [ ] Manual: open chat, click model pill, verify only rara providers shown
- [ ] Manual: select a provider, send a turn, verify backend receives `model_provider` matching a rara driver and the turn succeeds
- [ ] Manual: reload a session, verify the selected provider pill is restored