### PR TITLE
feat(kernel): cascade and mood in machine (#1560)

### DIFF
--- a/crates/kernel/src/agent/effect.rs
+++ b/crates/kernel/src/agent/effect.rs
@@ -23,7 +23,24 @@
 //! state machine free of `.await` so it can be unit-tested synchronously
 //! against any combination of events without spinning up real subsystems.
 
-use crate::tool::ToolName;
+use crate::{cascade::CascadeTrace, tool::ToolName};
+
+/// Lightweight, serialisable inference of the conversation's emotional tone,
+/// carried on [`Effect::EmitCascadeTrace`] so the runner can update the
+/// soul-state persistence layer without pulling `rara_soul` into the pure
+/// state machine.
+///
+/// Mirrors the legacy `crate::mood::MoodInference` struct exactly — the
+/// `label` string uses the `MoodLabel` snake_case serde representation
+/// (`"calm" | "cheerful" | "focused" | "playful" | "tired"`) so the runner
+/// can `serde_json::from_value` it back into the real enum at the boundary.
+#[derive(Debug, Clone, PartialEq)]
+pub struct MoodInference {
+    /// Snake-case mood label, matching `rara_soul::MoodLabel` serde form.
+    pub label:      &'static str,
+    /// Confidence score in `[0.3, 0.9]`, scaling with keyword-hit density.
+    pub confidence: f32,
+}
 
 /// Identifier for a single tool invocation issued by the LLM.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -229,6 +246,29 @@ pub enum Effect {
         /// in the wave that just completed. Preserves the order from the
         /// original [`Effect::RunTools::calls`] slice.
         trigger_call_ids: Vec<ToolCallId>,
+    },
+    /// Emit the structured cascade trace assembled during the turn and the
+    /// inferred mood just before the terminal [`Effect::Finish`] /
+    /// [`Effect::Fail`].
+    ///
+    /// Emitted at end-of-turn only — cascade assembly is real-time (the
+    /// machine accumulates entries as events arrive) but publication is
+    /// one-shot so the runner can write a single `cascade.trace` event to
+    /// the tape and update soul mood in a single boundary.
+    ///
+    /// Ordering contract: when a turn terminates, this effect is the first
+    /// in the terminal-effect tail, followed by either [`Effect::Finish`]
+    /// or [`Effect::Fail`]. The runner is responsible for persisting both
+    /// the trace (via `Subsystems::emit_cascade_trace`) and the mood label
+    /// (same hook) before returning to the caller.
+    EmitCascadeTrace {
+        /// Final assembled cascade trace for this turn.
+        trace: CascadeTrace,
+        /// Inferred mood over the turn's assistant text, or `None` when
+        /// there is no clear signal (apology / empty / no assistant
+        /// output). `None` means "keep the existing mood" in the legacy
+        /// semantics.
+        mood:  Option<MoodInference>,
     },
     /// Terminate the loop with a failure.
     Fail {

--- a/crates/kernel/src/agent/machine.rs
+++ b/crates/kernel/src/agent/machine.rs
@@ -46,8 +46,10 @@ use crate::{
             ToolResult,
         },
         loop_breaker::{LoopBreakerConfig, LoopIntervention, ToolCallLoopBreaker},
+        mood,
         repetition::RepetitionGuard,
     },
+    cascade::CascadeAssembler,
     tool::ToolName,
 };
 
@@ -194,6 +196,22 @@ pub struct AgentMachine {
     /// flag — they still emit [`Effect::ForceFoldNextIteration`] and rely
     /// on the subsystem to no-op when its own fold path has been disabled.
     fold_disabled:        bool,
+    /// Real-time cascade trace assembler. Entries are appended via
+    /// [`AgentMachine::observe_user_input`] (turn start) and implicitly on
+    /// every `LlmCompleted` / `ToolsCompleted` transition. The finished
+    /// trace is consumed once, via [`AgentMachine::finalize_cascade_trace`],
+    /// when the machine first produces a terminal [`Effect::Finish`] /
+    /// [`Effect::Fail`].
+    cascade_asm:          CascadeAssembler,
+    /// Latched once [`Effect::EmitCascadeTrace`] has been prepended to a
+    /// terminal effect vector so a double-terminal step (e.g. the fallback
+    /// `invalid transition` arm firing after `Done`) does not emit a
+    /// duplicate trace.
+    cascade_emitted:      bool,
+    /// Every non-empty assistant text seen this turn, appended in order
+    /// (intermediate + final). Fed into [`mood::infer_mood`] at
+    /// end-of-turn; the inference itself only inspects the tail window.
+    assistant_texts:      Vec<String>,
 }
 
 impl AgentMachine {
@@ -221,6 +239,9 @@ impl AgentMachine {
             auto_fold_config: None,
             force_fold_pending: false,
             fold_disabled: false,
+            cascade_asm: CascadeAssembler::new(String::new()),
+            cascade_emitted: false,
+            assistant_texts: Vec::new(),
         }
     }
 
@@ -637,9 +658,162 @@ impl AgentMachine {
     /// Drive the machine with one event.  Returns the side effects the runner
     /// must perform before feeding the next event back in.
     ///
+    /// Push an assistant text sample into the cascade assembler (and the
+    /// mood inference corpus). No-op on empty strings to match the legacy
+    /// `build_cascade` skip-empty-thought rule and to avoid polluting the
+    /// mood window with zero-content responses.
+    fn push_cascade_assistant(&mut self, text: &str) {
+        if text.is_empty() {
+            return;
+        }
+        self.assistant_texts.push(text.to_owned());
+        self.cascade_asm
+            .push_assistant(text, None, jiff::Timestamp::now(), None);
+    }
+
+    /// Record the tool-call wave the LLM just emitted in the cascade trace.
+    fn push_cascade_tool_calls(&mut self, calls: &[ToolCall]) {
+        if calls.is_empty() {
+            return;
+        }
+        let pairs: Vec<(&str, &str)> = calls
+            .iter()
+            .map(|c| (c.name.as_str(), c.arguments.as_str()))
+            .collect();
+        self.cascade_asm
+            .push_tool_calls(&pairs, jiff::Timestamp::now(), None);
+    }
+
+    /// Record a tool-result wave in the cascade trace. Uses the per-call
+    /// `error` string when the tool failed, and a synthesised
+    /// "ok ({duration}ms)" marker on success — the machine does not see the
+    /// real tool output, only [`ToolResult`] metadata.
+    fn push_cascade_tool_results(&mut self, results: &[ToolResult]) {
+        if results.is_empty() {
+            return;
+        }
+        let rendered: Vec<String> = results
+            .iter()
+            .map(|r| match (&r.error, r.success) {
+                (Some(msg), _) => msg.clone(),
+                (None, true) => format!("ok ({}ms)", r.duration_ms),
+                (None, false) => "error".to_owned(),
+            })
+            .collect();
+        let refs: Vec<&str> = rendered.iter().map(String::as_str).collect();
+        self.cascade_asm
+            .push_tool_results(&refs, jiff::Timestamp::now(), None);
+    }
+
+    /// Consume the assembled trace + compute mood inference, latching
+    /// `cascade_emitted` so a duplicate terminal step does not re-emit the
+    /// effect. Returns `None` on the second and subsequent calls — the
+    /// caller should only invoke this when prepending
+    /// [`Effect::EmitCascadeTrace`] to a terminal effect vector.
+    fn finalize_cascade_trace(&mut self) -> Option<Effect> {
+        if self.cascade_emitted {
+            return None;
+        }
+        self.cascade_emitted = true;
+        // Replace with a throwaway empty assembler; the original holds the
+        // accumulated entries and can be consumed by `finish`.
+        let asm = std::mem::replace(&mut self.cascade_asm, CascadeAssembler::new(String::new()));
+        let trace = asm.finish();
+        let mood = mood::infer_mood(&self.assistant_texts);
+        Some(Effect::EmitCascadeTrace { trace, mood })
+    }
+
+    /// If `effects` contains a terminal [`Effect::Finish`] or
+    /// [`Effect::Fail`], prepend a single [`Effect::EmitCascadeTrace`]
+    /// immediately before the first terminal effect. Idempotent: further
+    /// calls are no-ops once `cascade_emitted` latches.
+    ///
+    /// Keeping the injection central here — rather than modifying every
+    /// `Effect::Finish` / `Effect::Fail` construction site — keeps the
+    /// terminal paths syntactically unchanged and guarantees every exit
+    /// carries the same trace+mood payload in the same relative position.
+    fn inject_cascade_trace(&mut self, mut effects: Vec<Effect>) -> Vec<Effect> {
+        if self.cascade_emitted {
+            return effects;
+        }
+        let terminal_idx = effects
+            .iter()
+            .position(|e| matches!(e, Effect::Finish { .. } | Effect::Fail { .. }));
+        if let Some(idx) = terminal_idx
+            && let Some(cascade_effect) = self.finalize_cascade_trace()
+        {
+            effects.insert(idx, cascade_effect);
+        }
+        effects
+    }
+
+    /// Seed the cascade trace with the user input that started this turn.
+    ///
+    /// Must be called once, before driving the machine with
+    /// [`Event::TurnStarted`], so the assembled trace's first tick contains a
+    /// [`CascadeEntryKind::UserInput`] entry. The runner typically calls this
+    /// together with [`AgentMachine::set_cascade_message_id`] immediately
+    /// after constructing the machine.
+    ///
+    /// [`CascadeEntryKind::UserInput`]: crate::cascade::CascadeEntryKind::UserInput
+    pub fn observe_user_input(&mut self, text: &str) {
+        self.cascade_asm
+            .push_user(text, jiff::Timestamp::now(), None);
+    }
+
+    /// Set the cascade trace's message id (typically a Rara-side message
+    /// handle). Call this exactly once, before [`Event::TurnStarted`].
+    ///
+    /// Left as a setter rather than a constructor argument because adding a
+    /// mandatory field to every existing constructor would ripple through
+    /// every call site and every test; the assembler tolerates an empty id
+    /// and the runner only reads the id when it serialises the trace for
+    /// downstream persistence.
+    pub fn set_cascade_message_id(&mut self, id: String) {
+        let previous = std::mem::replace(&mut self.cascade_asm, CascadeAssembler::new(id));
+        let drained = previous.finish();
+        // Late calls (after entries were pushed) silently drop the prior
+        // partial trace — a loud warning surfaces the misuse without
+        // corrupting the new turn's trace.
+        if !drained.ticks.is_empty() {
+            tracing::warn!(
+                "set_cascade_message_id called after cascade entries were already pushed; \
+                 dropping prior entries"
+            );
+        }
+    }
+
     /// Calling `step` after the machine has reached [`Phase::Done`] or
     /// [`Phase::Failed`] is a logic error and produces no effects.
     pub fn step(&mut self, event: Event) -> Vec<Effect> {
+        // Real-time cascade assembly: record the entries implied by the
+        // incoming event before dispatching the transition so the trace
+        // mirrors what the legacy `run_agent_loop` publishes. The push
+        // helpers are no-ops on empty payloads; we inspect the event by
+        // reference first so the borrow checker accepts the later `match`
+        // that consumes it.
+        match &event {
+            Event::LlmCompleted {
+                text, tool_calls, ..
+            } => {
+                self.push_cascade_assistant(text);
+                self.push_cascade_tool_calls(tool_calls);
+            }
+            Event::ToolsCompleted { results } => {
+                self.push_cascade_tool_results(results);
+            }
+            _ => {}
+        }
+
+        let effects = self.step_inner(event);
+        self.inject_cascade_trace(effects)
+    }
+
+    /// Pure transition function: consumes the event and returns the raw
+    /// effect list without cascade-trace injection. Split out so the outer
+    /// [`AgentMachine::step`] can centralise `EmitCascadeTrace` emission
+    /// without the transition arms needing to know about it.
+    fn step_inner(&mut self, event: Event) -> Vec<Effect> {
         match (self.phase, event) {
             // ── Turn boot ────────────────────────────────────────────────
             (Phase::Idle, Event::TurnStarted) => {
@@ -1020,6 +1194,7 @@ mod tests {
                 Effect::AppendTape {
                     kind: TapeAppendKind::AssistantFinal,
                 },
+                Effect::EmitCascadeTrace { .. },
                 Effect::Finish {
                     reason: FinishReason::Stopped,
                     ..
@@ -1115,7 +1290,10 @@ mod tests {
             },
         });
         assert_eq!(m.phase(), Phase::Failed);
-        assert!(matches!(effects.as_slice(), [Effect::Fail { .. }]));
+        assert!(matches!(
+            effects.as_slice(),
+            [Effect::EmitCascadeTrace { .. }, Effect::Fail { .. }]
+        ));
     }
 
     #[test]
@@ -1136,7 +1314,10 @@ mod tests {
             },
         });
         assert_eq!(m.phase(), Phase::Failed);
-        assert!(matches!(effects.as_slice(), [Effect::Fail { .. }]));
+        assert!(matches!(
+            effects.as_slice(),
+            [Effect::EmitCascadeTrace { .. }, Effect::Fail { .. }]
+        ));
     }
 
     #[test]
@@ -1229,7 +1410,10 @@ mod tests {
             kind: LlmFailureKind::EmptyStream,
         });
         assert_eq!(m.phase(), Phase::Failed);
-        assert!(matches!(effects.as_slice(), [Effect::Fail { .. }]));
+        assert!(matches!(
+            effects.as_slice(),
+            [Effect::EmitCascadeTrace { .. }, Effect::Fail { .. }]
+        ));
     }
 
     #[test]
@@ -1264,7 +1448,10 @@ mod tests {
             reason: "denied path".into(),
         });
         assert_eq!(m.phase(), Phase::Failed);
-        assert!(matches!(effects.as_slice(), [Effect::Fail { .. }]));
+        assert!(matches!(
+            effects.as_slice(),
+            [Effect::EmitCascadeTrace { .. }, Effect::Fail { .. }]
+        ));
     }
 
     #[test]
@@ -1273,7 +1460,10 @@ mod tests {
         let _ = m.step(Event::TurnStarted);
         let effects = m.step(Event::Interrupted);
         assert_eq!(m.phase(), Phase::Failed);
-        assert!(matches!(effects.as_slice(), [Effect::Fail { .. }]));
+        assert!(matches!(
+            effects.as_slice(),
+            [Effect::EmitCascadeTrace { .. }, Effect::Fail { .. }]
+        ));
     }
 
     #[test]
@@ -1287,7 +1477,10 @@ mod tests {
         });
         let effects = m.step(Event::Interrupted);
         assert_eq!(m.phase(), Phase::Failed);
-        assert!(matches!(effects.as_slice(), [Effect::Fail { .. }]));
+        assert!(matches!(
+            effects.as_slice(),
+            [Effect::EmitCascadeTrace { .. }, Effect::Fail { .. }]
+        ));
     }
 
     #[test]
@@ -1448,7 +1641,10 @@ mod tests {
         // Feed ToolsCompleted before any LLM call — pure logic bug.
         let effects = m.step(Event::ToolsCompleted { results: vec![] });
         assert_eq!(m.phase(), Phase::Failed);
-        assert!(matches!(effects.as_slice(), [Effect::Fail { .. }]));
+        assert!(matches!(
+            effects.as_slice(),
+            [Effect::EmitCascadeTrace { .. }, Effect::Fail { .. }]
+        ));
     }
 
     // ─── Loop breaker integration ────────────────────────────────────────
@@ -1656,10 +1852,13 @@ mod tests {
         assert_eq!(m.phase(), Phase::Done);
         assert!(matches!(
             effects.as_slice(),
-            [Effect::Finish {
-                reason: FinishReason::StoppedByLimit,
-                ..
-            }]
+            [
+                Effect::EmitCascadeTrace { .. },
+                Effect::Finish {
+                    reason: FinishReason::StoppedByLimit,
+                    ..
+                },
+            ]
         ));
     }
 
@@ -1684,7 +1883,10 @@ mod tests {
             decision: LimitDecision::Continue,
         });
         assert_eq!(m.phase(), Phase::Failed);
-        assert!(matches!(effects.as_slice(), [Effect::Fail { .. }]));
+        assert!(matches!(
+            effects.as_slice(),
+            [Effect::EmitCascadeTrace { .. }, Effect::Fail { .. }]
+        ));
     }
 
     /// `limit_interval = 0` disables the circuit breaker entirely; the
@@ -2616,5 +2818,163 @@ mod tests {
             .filter(|e| matches!(e, Effect::ForceFoldNextIteration))
             .count();
         assert_eq!(fold_count, 1, "exactly one ForceFold per boundary");
+    }
+
+    // ---- Cascade trace + mood tests -----------------------------------
+
+    /// Full multi-round turn: user input + assistant thought + tool call +
+    /// tool result + final assistant text should all surface in the single
+    /// `EmitCascadeTrace` emitted just before `Finish`.
+    #[test]
+    fn cascade_trace_accumulates_full_turn() {
+        use crate::cascade::CascadeEntryKind;
+
+        let mut m = AgentMachine::new(8);
+        m.set_cascade_message_id("msg-xyz".to_owned());
+        m.observe_user_input("太好了 please search awesome!");
+
+        let _ = m.step(Event::TurnStarted);
+
+        // Round 1: thought + tool call.
+        let _ = m.step(Event::LlmCompleted {
+            text:           "thinking hard".into(),
+            tool_calls:     vec![tool_call("c1", "search")],
+            has_tool_calls: true,
+        });
+
+        // Tool results observed.
+        let _ = m.step(Event::ToolsCompleted {
+            results: vec![tool_result("c1", "search", "{\"q\":\"x\"}", true)],
+        });
+
+        // Final round: terminal assistant text.
+        let effects = m.step(Event::LlmCompleted {
+            text:           "太好了 awesome all done!".into(),
+            tool_calls:     vec![],
+            has_tool_calls: false,
+        });
+
+        // The terminal vector must contain exactly one EmitCascadeTrace,
+        // positioned immediately before Finish.
+        let mut emit_idx = None;
+        let mut finish_idx = None;
+        for (i, eff) in effects.iter().enumerate() {
+            match eff {
+                Effect::EmitCascadeTrace { .. } => emit_idx = Some(i),
+                Effect::Finish { .. } => finish_idx = Some(i),
+                _ => {}
+            }
+        }
+        let emit_idx = emit_idx.expect("EmitCascadeTrace missing");
+        let finish_idx = finish_idx.expect("Finish missing");
+        assert_eq!(
+            emit_idx + 1,
+            finish_idx,
+            "EmitCascadeTrace must precede Finish"
+        );
+
+        let Effect::EmitCascadeTrace { trace, mood } = &effects[emit_idx] else {
+            unreachable!()
+        };
+        assert_eq!(trace.message_id, "msg-xyz");
+        assert_eq!(trace.ticks.len(), 2, "expect two ticks: {trace:?}");
+
+        // Round 0 must contain user input + thought + action + observation.
+        let round0 = &trace.ticks[0];
+        assert!(round0.entries.iter().any(|e| {
+            e.kind == CascadeEntryKind::UserInput && e.content.contains("search awesome")
+        }));
+        assert!(
+            round0
+                .entries
+                .iter()
+                .any(|e| e.kind == CascadeEntryKind::Thought && e.content == "thinking hard")
+        );
+        assert!(
+            round0
+                .entries
+                .iter()
+                .any(|e| e.kind == CascadeEntryKind::Action && e.content.contains("search"))
+        );
+        assert!(
+            round0
+                .entries
+                .iter()
+                .any(|e| e.kind == CascadeEntryKind::Observation)
+        );
+
+        // Round 1 carries the final assistant text as a Thought entry.
+        let round1 = &trace.ticks[1];
+        assert!(
+            round1
+                .entries
+                .iter()
+                .any(|e| e.kind == CascadeEntryKind::Thought && e.content.contains("awesome"))
+        );
+
+        // Mood inference over assistant text tail should pick "cheerful".
+        let mood = mood.as_ref().expect("mood must be inferred");
+        assert_eq!(mood.label, "cheerful");
+        assert!(mood.confidence > 0.3);
+    }
+
+    /// The machine must latch `cascade_emitted` so a second terminal step
+    /// (e.g. late event arriving at `Phase::Done`) does not re-emit.
+    #[test]
+    fn cascade_trace_emitted_only_once() {
+        let mut m = AgentMachine::new(8);
+        m.observe_user_input("hi");
+        let _ = m.step(Event::TurnStarted);
+
+        let effects = m.step(Event::LlmCompleted {
+            text:           "bye".into(),
+            tool_calls:     vec![],
+            has_tool_calls: false,
+        });
+        let first_count = effects
+            .iter()
+            .filter(|e| matches!(e, Effect::EmitCascadeTrace { .. }))
+            .count();
+        assert_eq!(first_count, 1);
+
+        // A follow-up Interrupted event on an already-Done machine must
+        // not produce another EmitCascadeTrace.
+        let effects = m.step(Event::Interrupted);
+        let second_count = effects
+            .iter()
+            .filter(|e| matches!(e, Effect::EmitCascadeTrace { .. }))
+            .count();
+        assert_eq!(second_count, 0, "EmitCascadeTrace must latch once per turn");
+    }
+
+    /// A turn that fails without any assistant text still emits a cascade
+    /// trace (possibly empty body) but the mood is `None` because the
+    /// assistant-text tail is empty.
+    #[test]
+    fn cascade_trace_on_failure_carries_no_mood() {
+        let mut m = AgentMachine::new(8);
+        m.observe_user_input("hi");
+        let _ = m.step(Event::TurnStarted);
+
+        let effects = m.step(Event::LlmFailed {
+            kind: LlmFailureKind::Permanent {
+                message: "auth".into(),
+            },
+        });
+        let emit = effects
+            .iter()
+            .find_map(|e| match e {
+                Effect::EmitCascadeTrace { trace, mood } => Some((trace, mood)),
+                _ => None,
+            })
+            .expect("EmitCascadeTrace missing on failure");
+        assert!(
+            emit.1.is_none(),
+            "no assistant text → no mood: {:?}",
+            emit.1
+        );
+        // User-input entry must still be present so downstream tracing is
+        // not lying about what triggered the turn.
+        assert!(!emit.0.ticks.is_empty());
     }
 }

--- a/crates/kernel/src/agent/mod.rs
+++ b/crates/kernel/src/agent/mod.rs
@@ -17,6 +17,7 @@ pub mod effect;
 pub mod fold;
 pub(crate) mod loop_breaker;
 pub mod machine;
+pub(crate) mod mood;
 pub(crate) mod repetition;
 pub mod runner;
 pub mod scheduled;

--- a/crates/kernel/src/agent/mood.rs
+++ b/crates/kernel/src/agent/mood.rs
@@ -1,0 +1,215 @@
+// Copyright 2025 Rararulab
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Pure, sync mood inference over the assistant text accumulated during a
+//! turn.
+//!
+//! Mirrors the keyword-heuristic implementation in `crate::mood` but carries
+//! no dependency on `rara_soul` — the `MoodLabel` is surfaced as a
+//! snake-case `&'static str` (matching its `serde` representation) so the
+//! sans-IO state machine can compute and carry the inference without
+//! pulling soul-state IO into the pure layer.
+//!
+//! The runner re-hydrates the label into `rara_soul::MoodLabel` at the
+//! boundary when it persists the mood.
+
+use crate::agent::effect::MoodInference;
+
+/// How many trailing assistant messages to inspect when inferring mood.
+const TAIL_WINDOW: usize = 5;
+
+const CHEERFUL_KEYWORDS: &[&str] = &[
+    "哈哈",
+    "haha",
+    "😄",
+    "😊",
+    "太好了",
+    "great",
+    "awesome",
+    "wonderful",
+    "棒",
+    "nice",
+    "excited",
+    "开心",
+    "高兴",
+    "耶",
+    "🎉",
+    "excellent",
+];
+
+const PLAYFUL_KEYWORDS: &[&str] = &[
+    "哈", "lol", "😂", "🤣", "有趣", "funny", "joke", "玩笑", "好玩", "逗", "嘻嘻", "quirky",
+    "silly",
+];
+
+const FOCUSED_KEYWORDS: &[&str] = &[
+    "```",
+    "fn ",
+    "struct ",
+    "impl ",
+    "error[",
+    "warning[",
+    "SELECT ",
+    "CREATE ",
+    "ALTER ",
+    "INSERT ",
+    "def ",
+    "class ",
+    "import ",
+    "from ",
+    "module",
+    "migration",
+    "schema",
+    "query",
+    "debug",
+    "trace",
+];
+
+const APOLOGY_KEYWORDS: &[&str] = &[
+    "抱歉",
+    "sorry",
+    "my mistake",
+    "我的错",
+    "修正",
+    "correction",
+    "oops",
+    "不好意思",
+    "apologize",
+];
+
+/// Infer the mood over the tail of assistant-text samples collected during a
+/// turn. Input is newest-first or oldest-first; only `TAIL_WINDOW` entries
+/// closest to the end are consulted.
+///
+/// Returns `None` when there is no clear signal — apology-only or empty
+/// input — matching the legacy "keep current mood" semantics.
+pub fn infer_mood(assistant_texts: &[String]) -> Option<MoodInference> {
+    if assistant_texts.is_empty() {
+        return None;
+    }
+    let start = assistant_texts.len().saturating_sub(TAIL_WINDOW);
+    let tail = &assistant_texts[start..];
+    let combined: String = tail.join("\n");
+    let lower = combined.to_lowercase();
+
+    let cheerful_hits = count_hits(&lower, &combined, CHEERFUL_KEYWORDS);
+    let playful_hits = count_hits(&lower, &combined, PLAYFUL_KEYWORDS);
+    let focused_hits = count_hits(&lower, &combined, FOCUSED_KEYWORDS);
+    let apology_hits = count_hits(&lower, &combined, APOLOGY_KEYWORDS);
+
+    // Apology with no positive signal → keep current mood.
+    if apology_hits > 0 && cheerful_hits == 0 && playful_hits == 0 {
+        return None;
+    }
+
+    let max_hits = cheerful_hits.max(playful_hits).max(focused_hits);
+    if max_hits == 0 {
+        return Some(MoodInference {
+            label:      "calm",
+            confidence: 0.3,
+        });
+    }
+
+    // Confidence scales with hit count: 1 hit → 0.4, 2 → 0.55, 3 → 0.7,
+    // 4+ → 0.85, capped at 0.9. Matches legacy `crate::mood` exactly.
+    let confidence = (max_hits as f32).mul_add(0.15, 0.25).min(0.9);
+
+    let label = if cheerful_hits >= playful_hits && cheerful_hits >= focused_hits {
+        "cheerful"
+    } else if playful_hits >= focused_hits {
+        "playful"
+    } else {
+        "focused"
+    };
+
+    Some(MoodInference { label, confidence })
+}
+
+/// Case-sensitive keywords (uppercase letters or a leading backtick) are
+/// matched against the original text; everything else is lowercased first.
+fn count_hits(lower: &str, original: &str, keywords: &[&str]) -> usize {
+    keywords
+        .iter()
+        .filter(|kw| {
+            let case_sensitive = kw.chars().any(char::is_uppercase) || kw.starts_with('`');
+            if case_sensitive {
+                original.contains(*kw)
+            } else {
+                lower.contains(*kw)
+            }
+        })
+        .count()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_input_returns_none() {
+        assert!(infer_mood(&[]).is_none());
+    }
+
+    #[test]
+    fn apology_only_returns_none() {
+        let msgs = vec!["抱歉，我的错，让我修正一下".to_owned()];
+        assert!(infer_mood(&msgs).is_none());
+    }
+
+    #[test]
+    fn cheerful_keywords_detected() {
+        let msgs = vec!["太好了！这个功能终于完成了，haha awesome!".to_owned()];
+        let inf = infer_mood(&msgs).expect("should infer");
+        assert_eq!(inf.label, "cheerful");
+        assert!(inf.confidence >= 0.4);
+    }
+
+    #[test]
+    fn focused_on_code() {
+        let msgs = vec![
+            "我来看看这个 error:\n```rust\nfn main() {\n    let x = struct Foo;\n}\n```".to_owned(),
+        ];
+        let inf = infer_mood(&msgs).expect("should infer");
+        assert_eq!(inf.label, "focused");
+    }
+
+    #[test]
+    fn no_signals_defaults_to_calm() {
+        let msgs = vec!["现在是下午三点。".to_owned()];
+        let inf = infer_mood(&msgs).expect("should infer");
+        assert_eq!(inf.label, "calm");
+        assert!((inf.confidence - 0.3).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn only_inspects_tail_window() {
+        // Older messages are cheerful; recent TAIL_WINDOW messages are neutral.
+        let mut msgs: Vec<String> = Vec::new();
+        for _ in 0..10 {
+            msgs.push("太好了 haha awesome!".to_owned());
+        }
+        for _ in 0..TAIL_WINDOW {
+            msgs.push("好的。".to_owned());
+        }
+        let inf = infer_mood(&msgs).expect("should infer");
+        assert_eq!(inf.label, "calm");
+    }
+
+    #[test]
+    fn confidence_scales_with_hits() {
+        let r1 = infer_mood(&["太好了".to_owned()]).unwrap();
+        let r3 = infer_mood(&["太好了！awesome! haha 真棒".to_owned()]).unwrap();
+        assert!(r3.confidence > r1.confidence);
+    }
+}

--- a/crates/kernel/src/agent/runner.rs
+++ b/crates/kernel/src/agent/runner.rs
@@ -64,7 +64,9 @@
 //!   via [`crate::agent::machine::LlmFailureKind`] and
 //!   [`Effect::InjectUserMessage`] / [`Effect::ForceFoldNextIteration`]; legacy
 //!   removal pending
-//! - Cascade trace assembly + mood inference
+//! - Cascade trace assembly + mood inference — ✓ machine-side implemented via
+//!   [`Effect::EmitCascadeTrace`] and [`Subsystems::emit_cascade_trace`];
+//!   legacy removal pending
 //!
 //! Each item maps to either an additional [`Effect`] variant or extra fields
 //! on [`AgentMachine`].
@@ -73,7 +75,7 @@ use async_trait::async_trait;
 
 use crate::{
     agent::{
-        effect::{Effect, PressureLevel, ToolCall, ToolResult},
+        effect::{Effect, MoodInference, PressureLevel, ToolCall, ToolResult},
         machine::{AgentMachine, Event, Phase},
     },
     tool::ToolName,
@@ -235,6 +237,35 @@ pub trait Subsystems: Send + Sync {
     /// No default impl: silent no-op would leave the runner's message
     /// buffer permanently stale, so test stubs must opt in explicitly.
     async fn rebuild_tape(&mut self, iteration: usize);
+
+    /// Publish the finalised cascade trace and the inferred mood for the
+    /// just-completed turn.
+    ///
+    /// Emitted exactly once per turn, as the first effect preceding the
+    /// terminal [`Effect::Finish`] / [`Effect::Fail`] pair. Production
+    /// implementations:
+    ///
+    /// - Persist the trace as a `cascade.trace` event entry on the tape so the
+    ///   web UI can reconstruct the trace without re-scanning message history
+    ///   (mirrors the legacy `tape.append_event("cascade.trace", …)` call).
+    /// - Forward `mood` — when `Some` — to `rara_soul::loader::save_state` so
+    ///   the next turn renders the soul template with the updated mood
+    ///   + confidence. `None` means "keep current mood" (apology / no
+    ///   signal) and should be treated as a no-op.
+    ///
+    /// Failures must be logged but never abort the turn — mood persistence
+    /// and trace storage are both best-effort observability, not correctness
+    /// boundaries.
+    ///
+    /// No default impl: a silent no-op would suppress the trace in
+    /// production without any compile-time warning (anti-pattern: "Do NOT
+    /// use noop trait implementations"). Test stubs keep a `Vec` log; the
+    /// production impl wires the kernel handle's tape + soul loader.
+    async fn emit_cascade_trace(
+        &mut self,
+        trace: crate::cascade::CascadeTrace,
+        mood: Option<MoodInference>,
+    );
 }
 
 /// Drive the [`AgentMachine`] to completion against `subsys`.
@@ -346,6 +377,9 @@ pub async fn drive<S: Subsystems>(machine: &mut AgentMachine, subsys: &mut S) ->
                     subsys.inject_user_message(text.clone()).await;
                     subsys.emit_stream(text).await;
                 }
+                Effect::EmitCascadeTrace { trace, mood } => {
+                    subsys.emit_cascade_trace(trace, mood).await;
+                }
                 Effect::Finish {
                     text,
                     iterations,
@@ -449,6 +483,10 @@ mod tests {
         /// Iterations observed via `rebuild_tape`, in order. Every
         /// iteration must rebuild exactly once before its CallLlm.
         rebuild_log:     Vec<usize>,
+        /// Captured cascade traces + mood (one entry per
+        /// `emit_cascade_trace` invocation). Tests assert on this directly
+        /// rather than reconstructing the trace after the fact.
+        cascade_log:     Vec<(crate::cascade::CascadeTrace, Option<MoodInference>)>,
     }
 
     #[async_trait]
@@ -499,6 +537,14 @@ mod tests {
         async fn force_fold_next_iteration(&mut self) { self.force_fold_hits += 1; }
 
         async fn rebuild_tape(&mut self, iteration: usize) { self.rebuild_log.push(iteration); }
+
+        async fn emit_cascade_trace(
+            &mut self,
+            trace: crate::cascade::CascadeTrace,
+            mood: Option<MoodInference>,
+        ) {
+            self.cascade_log.push((trace, mood));
+        }
     }
 
     /// Factory producing a fresh stub with empty scripts for every field.
@@ -518,6 +564,7 @@ mod tests {
             refresh_log:     vec![],
             force_fold_hits: 0,
             rebuild_log:     vec![],
+            cascade_log:     vec![],
         }
     }
 
@@ -542,6 +589,7 @@ mod tests {
             refresh_log:     vec![],
             force_fold_hits: 0,
             rebuild_log:     vec![],
+            cascade_log:     vec![],
         };
         let mut machine = AgentMachine::new(8);
         let outcome = drive(&mut machine, &mut subsys).await;
@@ -591,6 +639,7 @@ mod tests {
             refresh_log:     vec![],
             force_fold_hits: 0,
             rebuild_log:     vec![],
+            cascade_log:     vec![],
         };
         let mut machine = AgentMachine::new(8);
         let outcome = drive(&mut machine, &mut subsys).await;
@@ -656,6 +705,7 @@ mod tests {
             refresh_log:     vec![],
             force_fold_hits: 0,
             rebuild_log:     vec![],
+            cascade_log:     vec![],
         };
         let mut machine = AgentMachine::with_max_continuations(8, 3);
         let outcome = drive(&mut machine, &mut subsys).await;
@@ -738,6 +788,7 @@ mod tests {
             refresh_log:     vec![],
             force_fold_hits: 0,
             rebuild_log:     vec![],
+            cascade_log:     vec![],
         };
         let mut machine = AgentMachine::with_tool_call_limit(8, 1);
         let outcome = drive(&mut machine, &mut subsys).await;
@@ -782,6 +833,7 @@ mod tests {
             refresh_log:     vec![],
             force_fold_hits: 0,
             rebuild_log:     vec![],
+            cascade_log:     vec![],
         };
         let mut machine = AgentMachine::with_tool_call_limit(8, 1);
         let outcome = drive(&mut machine, &mut subsys).await;
@@ -832,6 +884,7 @@ mod tests {
             refresh_log:     vec![],
             force_fold_hits: 0,
             rebuild_log:     vec![],
+            cascade_log:     vec![],
         };
         let mut machine = AgentMachine::new(8);
         let outcome = drive(&mut machine, &mut subsys).await;
@@ -883,6 +936,7 @@ mod tests {
             refresh_log:     vec![],
             force_fold_hits: 0,
             rebuild_log:     vec![],
+            cascade_log:     vec![],
         };
         let mut machine = AgentMachine::new(8);
         let outcome = drive(&mut machine, &mut subsys).await;
@@ -915,6 +969,7 @@ mod tests {
             refresh_log:     vec![],
             force_fold_hits: 0,
             rebuild_log:     vec![],
+            cascade_log:     vec![],
         };
         let mut machine = AgentMachine::new(8);
         let outcome = drive(&mut machine, &mut subsys).await;
@@ -1441,5 +1496,55 @@ mod tests {
         let outcome = drive(&mut machine, &mut s).await;
         assert!(outcome.success);
         assert_eq!(s.force_fold_hits, 0);
+    }
+
+    /// The machine must surface exactly one cascade trace to the subsystem
+    /// per turn, populated with the user input + all rounds, and the mood
+    /// inference driven off the assistant-text tail should be non-None for
+    /// any turn that emitted textual assistant content.
+    #[tokio::test]
+    async fn drive_emits_cascade_trace_on_terminal_stop() {
+        let mut s = subsys();
+        s.llm_script = vec![Event::LlmCompleted {
+            text:           "太好了 awesome!".into(),
+            tool_calls:     vec![],
+            has_tool_calls: false,
+        }];
+        let mut machine = AgentMachine::new(8);
+        machine.set_cascade_message_id("msg-42".to_owned());
+        machine.observe_user_input("please do the thing");
+
+        let outcome = drive(&mut machine, &mut s).await;
+        assert!(outcome.success);
+        assert_eq!(
+            s.cascade_log.len(),
+            1,
+            "exactly one cascade emission per turn"
+        );
+        let (trace, mood) = &s.cascade_log[0];
+        assert_eq!(trace.message_id, "msg-42");
+        assert!(!trace.ticks.is_empty());
+        let mood = mood.as_ref().expect("mood must be inferred");
+        assert_eq!(mood.label, "cheerful");
+    }
+
+    /// A fatal LLM failure must also emit exactly one cascade trace,
+    /// distinguishable because the turn recorded no assistant text (hence
+    /// mood is `None`).
+    #[tokio::test]
+    async fn drive_emits_cascade_trace_on_failure() {
+        let mut s = subsys();
+        s.llm_script = vec![Event::LlmFailed {
+            kind: crate::agent::machine::LlmFailureKind::Permanent {
+                message: "auth".into(),
+            },
+        }];
+        let mut machine = AgentMachine::new(8);
+        machine.observe_user_input("hi");
+
+        let outcome = drive(&mut machine, &mut s).await;
+        assert!(!outcome.success);
+        assert_eq!(s.cascade_log.len(), 1);
+        assert!(s.cascade_log[0].1.is_none());
     }
 }

--- a/crates/kernel/src/cascade.rs
+++ b/crates/kernel/src/cascade.rs
@@ -30,7 +30,7 @@ use crate::memory::{TapEntry, TapEntryKind};
 // ---------------------------------------------------------------------------
 
 /// Top-level cascade trace for a single agent turn.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct CascadeTrace {
     /// Opaque identifier for this trace (e.g. `"{session_key}-{seq}"`).
     pub message_id: String,
@@ -59,7 +59,7 @@ impl CascadeTrace {
 ///
 /// A new tick starts when a new assistant `Message` entry appears after
 /// tool results (i.e. the LLM was called again).
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct CascadeTick {
     /// Zero-based tick index within the trace.
     pub index:   usize,
@@ -68,7 +68,7 @@ pub struct CascadeTick {
 }
 
 /// A single entry in the cascade trace.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct CascadeEntry {
     /// Human-readable entry ID: `"{kind_prefix} . {tick}-{short_id}-{seq}"`.
     pub id:        String,
@@ -110,7 +110,7 @@ impl CascadeEntryKind {
 }
 
 /// Aggregate statistics for the cascade trace.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct CascadeSummary {
     /// Total number of ticks (LLM call rounds).
     pub tick_count:      usize,
@@ -133,6 +133,7 @@ pub struct CascadeSummary {
 /// Unlike a simple field-by-field builder, this struct tracks internal state
 /// (`seen_assistant`, `last_was_tool_result`) to detect tick boundaries
 /// dynamically as entries arrive.
+#[derive(Debug)]
 pub struct CascadeAssembler {
     message_id:           String,
     ticks:                Vec<CascadeTick>,


### PR DESCRIPTION
## Summary

Part of #1534. Migrates cascade trace assembly and mood inference into the sans-IO `AgentMachine`.

- `AgentMachine` accumulates trace entries (user input, assistant text, tool calls, tool results) throughout the turn via a `CascadeAssembler`
- Exactly one `Effect::EmitCascadeTrace { trace, mood }` is injected immediately before the first terminal `Finish`/`Fail`, latched so late events cannot re-emit
- `agent::mood` ports the legacy keyword heuristics as a pure sync fn; label is a snake_case `&'static str` re-hydrated at the runner IO boundary
- New `Subsystems::emit_cascade_trace` hook (no default impl — anti-pattern rule)
- `CascadeTrace` / tick / entry / summary gain `PartialEq` so `Effect` can derive it

Legacy `run_agent_loop` is untouched; this keeps `feat/agent-machine-migration` as the integration branch.

## Type of change

| Type | Label |
|------|-------|
| New feature | `enhancement` |

## Component

`core`

## Closes

Closes #1560

## Test plan

- [x] 5 new unit tests: machine-side cascade accumulation, idempotency, failure-path no-mood; runner-side terminal emission + failure emission
- [x] `cargo check -p rara-kernel` passes
- [x] `cargo test -p rara-kernel --lib agent::` passes (183 tests)
- [x] `cargo +nightly fmt --all` clean
- [x] `cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings` clean
- [x] `RUSTDOCFLAGS="-D warnings" cargo +nightly doc --workspace --no-deps --document-private-items` clean