### PR TITLE
feat(web): compact tool call renderer (#1564)

### DIFF
--- a/web/src/tools/CompactToolRenderer.ts
+++ b/web/src/tools/CompactToolRenderer.ts
@@ -1,0 +1,202 @@
+/*
+ * Copyright 2025 Rararulab
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+/**
+ * A compact tool renderer inspired by multica's `ToolCallRow`
+ * (vendor/multica/packages/views/chat/components/chat-message-list.tsx).
+ *
+ * Default pi-web-ui `DefaultRenderer` is visually heavy: two labeled
+ * JSON code blocks (Input/Output) plus a header, per tool call. That
+ * dominates the chat column when an assistant turn chains several
+ * tools. This renderer compresses each call into a single-line header
+ * with a short summary derived from the params, and hides the JSON
+ * payloads behind a collapsible section.
+ */
+
+import type { ToolResultMessage } from "@mariozechner/pi-ai";
+import { html } from "lit";
+import { createRef, ref } from "lit/directives/ref.js";
+import { Wrench } from "lucide";
+import {
+	renderCollapsibleHeader,
+	renderHeader,
+	type ToolRenderer,
+	type ToolRenderResult,
+} from "@mariozechner/pi-web-ui";
+
+const MAX_SUMMARY = 120;
+const MAX_RESULT_EXPANDED = 4000;
+
+function shortenPath(p: string): string {
+	const parts = p.split("/");
+	if (parts.length <= 3) return p;
+	return ".../" + parts.slice(-2).join("/");
+}
+
+function truncate(s: string, n: number): string {
+	return s.length > n ? s.slice(0, n) + "…" : s;
+}
+
+/**
+ * Pull a human-readable one-liner out of a tool's input JSON. Field
+ * priority matches multica's `getToolSummary` so call sites feel
+ * consistent for users who have seen both apps.
+ */
+function summarizeParams(params: unknown): string {
+	if (!params || typeof params !== "object") return "";
+	const inp = params as Record<string, unknown>;
+
+	const pick = (k: string): string | null => {
+		const v = inp[k];
+		return typeof v === "string" && v.length > 0 ? v : null;
+	};
+
+	const command = pick("command");
+	if (command) return truncate(command, MAX_SUMMARY);
+
+	const query = pick("query") ?? pick("pattern");
+	if (query) return truncate(query, MAX_SUMMARY);
+
+	const filePath = pick("file_path") ?? pick("path");
+	if (filePath) return shortenPath(filePath);
+
+	const description = pick("description");
+	if (description) return truncate(description, MAX_SUMMARY);
+
+	const prompt = pick("prompt");
+	if (prompt) return truncate(prompt, MAX_SUMMARY);
+
+	const skill = pick("skill");
+	if (skill) return skill;
+
+	for (const v of Object.values(inp)) {
+		if (typeof v === "string" && v.length > 0 && v.length < MAX_SUMMARY) {
+			return v;
+		}
+	}
+	return "";
+}
+
+function parseParams(raw: unknown): unknown {
+	if (raw == null) return undefined;
+	if (typeof raw === "string") {
+		try {
+			return JSON.parse(raw);
+		} catch {
+			return raw;
+		}
+	}
+	return raw;
+}
+
+function formatJson(value: unknown): string {
+	try {
+		return JSON.stringify(value, null, 2);
+	} catch {
+		return String(value);
+	}
+}
+
+function extractOutput(result: ToolResultMessage | undefined): string {
+	if (!result) return "";
+	const parts: string[] = [];
+	for (const c of result.content ?? []) {
+		if (c.type === "text") {
+			parts.push((c as { text?: string }).text ?? "");
+		}
+	}
+	return parts.join("\n");
+}
+
+export class CompactToolRenderer implements ToolRenderer {
+	private readonly toolName: string;
+
+	constructor(toolName: string) {
+		this.toolName = toolName;
+	}
+
+	render(
+		params: unknown,
+		result: ToolResultMessage | undefined,
+		isStreaming?: boolean,
+	): ToolRenderResult {
+		const state: "inprogress" | "complete" | "error" = result
+			? result.isError
+				? "error"
+				: "complete"
+			: isStreaming
+				? "inprogress"
+				: "complete";
+
+		const parsed = parseParams(params);
+		const summary = summarizeParams(parsed);
+		const output = extractOutput(result);
+
+		const headerLabel = html`
+			<span class="flex items-center gap-2 min-w-0">
+				<span class="font-medium text-foreground shrink-0">${this.toolName}</span>
+				${
+					summary
+						? html`<span class="truncate text-muted-foreground">${summary}</span>`
+						: ""
+				}
+			</span>
+		`;
+
+		// Nothing to expand — render plain header.
+		if (parsed === undefined && !output) {
+			return {
+				content: renderHeader(state, Wrench, headerLabel),
+				isCustom: false,
+			};
+		}
+
+		const contentRef = createRef<HTMLElement>();
+		const chevronRef = createRef<HTMLElement>();
+		const paramsJson = parsed !== undefined ? formatJson(parsed) : "";
+		const outputTrimmed =
+			output.length > MAX_RESULT_EXPANDED
+				? output.slice(0, MAX_RESULT_EXPANDED) + "\n… (truncated)"
+				: output;
+		return {
+			content: html`
+				<div>
+					${renderCollapsibleHeader(state, Wrench, headerLabel, contentRef, chevronRef, false)}
+					<div
+						${ref(contentRef)}
+						class="overflow-hidden transition-[max-height] duration-200 max-h-0"
+					>
+						${
+							paramsJson
+								? html`
+									<div class="mb-2">
+										<div class="text-[11px] font-medium mb-1 text-muted-foreground">Input</div>
+										<pre class="max-h-40 overflow-auto rounded bg-muted/50 p-2 text-[11px] text-muted-foreground whitespace-pre-wrap break-all">${paramsJson}</pre>
+									</div>
+								`
+								: ""
+						}
+						${
+							output
+								? html`
+									<div>
+										<div class="text-[11px] font-medium mb-1 text-muted-foreground">Output</div>
+										<pre class="max-h-60 overflow-auto rounded bg-muted/50 p-2 text-[11px] text-muted-foreground whitespace-pre-wrap break-all">${outputTrimmed}</pre>
+									</div>
+								`
+								: ""
+						}
+					</div>
+				</div>
+			`,
+			isCustom: false,
+		};
+	}
+}

--- a/web/src/tools/CompactToolRenderer.ts
+++ b/web/src/tools/CompactToolRenderer.ts
@@ -12,20 +12,26 @@
  * A compact tool renderer inspired by multica's `ToolCallRow`
  * (vendor/multica/packages/views/chat/components/chat-message-list.tsx).
  *
- * Default pi-web-ui `DefaultRenderer` is visually heavy: two labeled
- * JSON code blocks (Input/Output) plus a header, per tool call. That
- * dominates the chat column when an assistant turn chains several
- * tools. This renderer compresses each call into a single-line header
- * with a short summary derived from the params, and hides the JSON
- * payloads behind a collapsible section.
+ * pi-web-ui's `DefaultRenderer` is visually heavy: two labeled JSON code
+ * blocks (Input/Output) plus a header, per tool call. That dominates
+ * the chat column when an assistant turn chains several tools. This
+ * renderer compresses each call into a single-line summary and hides
+ * the JSON payloads inside a native `<details>` element.
+ *
+ * Why `<details>` instead of pi-web-ui's `renderCollapsibleHeader`:
+ * tool renderers are re-invoked on every stream tick (params stream in
+ * one JSON chunk, then the tool result arrives). `renderCollapsibleHeader`
+ * encodes open/closed state as a CSS class on a host div that Lit
+ * rewrites on every render — so a user's expansion would collapse on
+ * the next token. `<details>` keeps `open` as DOM state that survives
+ * Lit's incremental re-render, matching what pi-web-ui's own
+ * `<code-block>` relies on.
  */
 
-import type { ToolResultMessage } from "@mariozechner/pi-ai";
+import type { ImageContent, TextContent, ToolResultMessage } from "@mariozechner/pi-ai";
 import { html } from "lit";
-import { createRef, ref } from "lit/directives/ref.js";
 import { Wrench } from "lucide";
 import {
-	renderCollapsibleHeader,
 	renderHeader,
 	type ToolRenderer,
 	type ToolRenderResult,
@@ -34,20 +40,30 @@ import {
 const MAX_SUMMARY = 120;
 const MAX_RESULT_EXPANDED = 4000;
 
+/**
+ * Shorten a path to `.../parent/file` when it has more than two
+ * segments. Matches multica's `shortenPath` so summaries read the same
+ * across apps.
+ */
 function shortenPath(p: string): string {
 	const parts = p.split("/");
 	if (parts.length <= 3) return p;
 	return ".../" + parts.slice(-2).join("/");
 }
 
-function truncate(s: string, n: number): string {
-	return s.length > n ? s.slice(0, n) + "…" : s;
+/**
+ * Collapse whitespace to single spaces and truncate. Summaries live in
+ * a single-line `truncate` span, so unnormalised newlines (heredocs,
+ * multi-line commands) would either wrap awkwardly or break layout.
+ */
+function normalizeAndTruncate(s: string, n: number): string {
+	const flat = s.replace(/\s+/g, " ").trim();
+	return flat.length > n ? flat.slice(0, n) + "…" : flat;
 }
 
 /**
  * Pull a human-readable one-liner out of a tool's input JSON. Field
- * priority matches multica's `getToolSummary` so call sites feel
- * consistent for users who have seen both apps.
+ * priority mirrors multica's `getToolSummary`.
  */
 function summarizeParams(params: unknown): string {
 	if (!params || typeof params !== "object") return "";
@@ -59,26 +75,26 @@ function summarizeParams(params: unknown): string {
 	};
 
 	const command = pick("command");
-	if (command) return truncate(command, MAX_SUMMARY);
+	if (command) return normalizeAndTruncate(command, MAX_SUMMARY);
 
 	const query = pick("query") ?? pick("pattern");
-	if (query) return truncate(query, MAX_SUMMARY);
+	if (query) return normalizeAndTruncate(query, MAX_SUMMARY);
 
 	const filePath = pick("file_path") ?? pick("path");
 	if (filePath) return shortenPath(filePath);
 
 	const description = pick("description");
-	if (description) return truncate(description, MAX_SUMMARY);
+	if (description) return normalizeAndTruncate(description, MAX_SUMMARY);
 
 	const prompt = pick("prompt");
-	if (prompt) return truncate(prompt, MAX_SUMMARY);
+	if (prompt) return normalizeAndTruncate(prompt, MAX_SUMMARY);
 
 	const skill = pick("skill");
 	if (skill) return skill;
 
 	for (const v of Object.values(inp)) {
-		if (typeof v === "string" && v.length > 0 && v.length < MAX_SUMMARY) {
-			return v;
+		if (typeof v === "string" && v.length > 0) {
+			return normalizeAndTruncate(v, MAX_SUMMARY);
 		}
 	}
 	return "";
@@ -104,15 +120,26 @@ function formatJson(value: unknown): string {
 	}
 }
 
-function extractOutput(result: ToolResultMessage | undefined): string {
-	if (!result) return "";
-	const parts: string[] = [];
-	for (const c of result.content ?? []) {
-		if (c.type === "text") {
-			parts.push((c as { text?: string }).text ?? "");
+interface ExtractedOutput {
+	text: string;
+	nonTextCount: number;
+}
+
+function extractOutput(result: ToolResultMessage | undefined): ExtractedOutput {
+	if (!result) return { text: "", nonTextCount: 0 };
+	const textParts: string[] = [];
+	let nonTextCount = 0;
+	for (const block of result.content ?? []) {
+		if ("text" in block) {
+			textParts.push((block as TextContent).text ?? "");
+		} else {
+			// Currently only ImageContent falls here; treated uniformly so
+			// we degrade gracefully if pi-ai grows new block types.
+			void (block as ImageContent);
+			nonTextCount += 1;
 		}
 	}
-	return parts.join("\n");
+	return { text: textParts.join("\n"), nonTextCount };
 }
 
 export class CompactToolRenderer implements ToolRenderer {
@@ -137,10 +164,10 @@ export class CompactToolRenderer implements ToolRenderer {
 
 		const parsed = parseParams(params);
 		const summary = summarizeParams(parsed);
-		const output = extractOutput(result);
+		const { text: output, nonTextCount } = extractOutput(result);
 
 		const headerLabel = html`
-			<span class="flex items-center gap-2 min-w-0">
+			<span class="flex items-center gap-2 min-w-0 overflow-hidden">
 				<span class="font-medium text-foreground shrink-0">${this.toolName}</span>
 				${
 					summary
@@ -150,33 +177,39 @@ export class CompactToolRenderer implements ToolRenderer {
 			</span>
 		`;
 
-		// Nothing to expand — render plain header.
-		if (parsed === undefined && !output) {
+		const hasParams = parsed !== undefined;
+		const hasOutput = output.length > 0 || nonTextCount > 0;
+
+		// Nothing to expand — render plain header (streaming "thinking"
+		// state before the first param token arrives).
+		if (!hasParams && !hasOutput) {
 			return {
 				content: renderHeader(state, Wrench, headerLabel),
 				isCustom: false,
 			};
 		}
 
-		const contentRef = createRef<HTMLElement>();
-		const chevronRef = createRef<HTMLElement>();
-		const paramsJson = parsed !== undefined ? formatJson(parsed) : "";
-		const outputTrimmed =
+		const paramsJson = hasParams ? formatJson(parsed) : "";
+		const outputBody =
 			output.length > MAX_RESULT_EXPANDED
 				? output.slice(0, MAX_RESULT_EXPANDED) + "\n… (truncated)"
 				: output;
+		const outputPlaceholder =
+			!output && nonTextCount > 0
+				? `(no text output — ${nonTextCount} non-text block${nonTextCount === 1 ? "" : "s"})`
+				: "";
+
 		return {
 			content: html`
-				<div>
-					${renderCollapsibleHeader(state, Wrench, headerLabel, contentRef, chevronRef, false)}
-					<div
-						${ref(contentRef)}
-						class="overflow-hidden transition-[max-height] duration-200 max-h-0"
-					>
+				<details class="group">
+					<summary class="list-none cursor-pointer marker:hidden">
+						${renderHeader(state, Wrench, headerLabel)}
+					</summary>
+					<div class="mt-2 space-y-2">
 						${
 							paramsJson
 								? html`
-									<div class="mb-2">
+									<div>
 										<div class="text-[11px] font-medium mb-1 text-muted-foreground">Input</div>
 										<pre class="max-h-40 overflow-auto rounded bg-muted/50 p-2 text-[11px] text-muted-foreground whitespace-pre-wrap break-all">${paramsJson}</pre>
 									</div>
@@ -184,17 +217,17 @@ export class CompactToolRenderer implements ToolRenderer {
 								: ""
 						}
 						${
-							output
+							hasOutput
 								? html`
 									<div>
 										<div class="text-[11px] font-medium mb-1 text-muted-foreground">Output</div>
-										<pre class="max-h-60 overflow-auto rounded bg-muted/50 p-2 text-[11px] text-muted-foreground whitespace-pre-wrap break-all">${outputTrimmed}</pre>
+										<pre class="max-h-60 overflow-auto rounded bg-muted/50 p-2 text-[11px] text-muted-foreground whitespace-pre-wrap break-all">${outputBody || outputPlaceholder}</pre>
 									</div>
 								`
 								: ""
 						}
 					</div>
-				</div>
+				</details>
 			`,
 			isCustom: false,
 		};

--- a/web/src/tools/rara-tool-renderers.ts
+++ b/web/src/tools/rara-tool-renderers.ts
@@ -28,11 +28,22 @@ import { CompactToolRenderer } from "./CompactToolRenderer";
 
 /**
  * Tool names declared by the rara backend (see `crates/app/src/tools/`).
- * `bash`, `artifacts`, `javascript_repl`, and `extract_document` keep
- * their specialized pi-mono renderers; everything else gets a compact
- * single-line renderer that collapses the Input/Output JSON behind a
- * disclosure, so tool-heavy assistant turns do not dominate the chat
- * column.
+ * Everything in this list gets the compact single-line renderer.
+ *
+ * Four tools keep pi-mono's specialised renderers and are intentionally
+ * absent:
+ * - `bash`            — pi-mono's `BashRenderer` shows a live terminal
+ *                       block, which fits a single command better than
+ *                       a truncated one-liner.
+ * - `artifacts`       — `ArtifactsToolRenderer` renders the artifact
+ *                       card UX; JSON wouldn't help.
+ * - `javascript_repl` — pi-mono-registered; no rara-side equivalent.
+ * - `extract_document`— pi-mono-registered; handles PDF/DOCX preview.
+ *
+ * Drift risk: this list is hand-maintained from the Rust
+ * `#[tool(name = "…")]` declarations. A new backend tool added without
+ * updating this list silently falls back to pi-web-ui's verbose
+ * `DefaultRenderer`. Tracked in #1566.
  */
 const RARA_COMPACT_TOOLS = [
 	"acp-delegate",

--- a/web/src/tools/rara-tool-renderers.ts
+++ b/web/src/tools/rara-tool-renderers.ts
@@ -15,52 +15,78 @@
  */
 
 /**
- * Bridges rara backend tool names to pi-mono's built-in renderers.
- *
- * Rara's backend tools (declared in `crates/app/src/tools/`) emit names like
- * `bash`, `http-fetch`, `read-file`, etc. pi-mono ships tool-specific
- * renderers (`BashRenderer`, `javascript_repl`, `extract_document`,
- * `artifacts`) keyed by exact tool name. When a name does not match, the UI
- * falls back to `DefaultRenderer`, which prints raw JSON.
- *
- * This module registers aliases so any rara tool that conceptually matches a
- * pi-mono renderer gets the richer UX. Tools without a pi-mono equivalent
- * (`mita-*`, `skill-*`, `tape-*`, `marketplace-*`, ...) stay on the default
- * JSON renderer by design — writing custom renderers for them is out of
- * scope for this phase.
+ * Bridges rara backend tool names to pi-mono's renderers, plus a
+ * rara-specific compact renderer for tools without a specialized
+ * pi-mono equivalent.
  *
  * Must be called once, BEFORE `ChatPanel.setAgent()`. The registry is a
  * module-level `Map`, so late registration would miss the first render.
  */
 
-import {
-	BashRenderer,
-	registerToolRenderer,
-} from "@mariozechner/pi-web-ui";
+import { BashRenderer, registerToolRenderer } from "@mariozechner/pi-web-ui";
+import { CompactToolRenderer } from "./CompactToolRenderer";
 
 /**
- * Register rara → pi-mono renderer aliases.
- *
- * Current mappings:
- * - `bash` → `BashRenderer` (rara's bash tool is already named `bash`; we
- *   register explicitly so the wiring is visible and robust against any
- *   future change to pi-web-ui's auto-registration side effects).
- *
- * Left on `DefaultRenderer` intentionally:
- * - `http-fetch` — no pi-mono equivalent (extract_document is PDF/DOCX,
- *   not generic HTTP).
- * - `read-file` / `write-file` / `edit-file` / `multi-edit` / `grep` /
- *   `find-files` / `list-directory` / `walk-directory` / `file-stats` /
- *   `create-directory` / `delete-file` — pi-mono has no file-IO renderers.
- * - `mita-*`, `skill-*`, `tape-*`, `marketplace-*`, `mcp-*`, `acp-*`,
- *   `dispatch-rara`, `evolve-soul`, `ask-user`, etc. — rara-specific; JSON
- *   is acceptable until a custom renderer is justified.
- * - `javascript_repl`, `extract_document`, `artifacts` — pi-mono registers
- *   these itself; no rara-side equivalent exists to alias.
+ * Tool names declared by the rara backend (see `crates/app/src/tools/`).
+ * `bash`, `artifacts`, `javascript_repl`, and `extract_document` keep
+ * their specialized pi-mono renderers; everything else gets a compact
+ * single-line renderer that collapses the Input/Output JSON behind a
+ * disclosure, so tool-heavy assistant turns do not dominate the chat
+ * column.
  */
+const RARA_COMPACT_TOOLS = [
+	"acp-delegate",
+	"ask-user",
+	"create-directory",
+	"create-skill",
+	"debug_trace",
+	"delete-file",
+	"delete-skill",
+	"discover-tools",
+	"dispatch-rara",
+	"distill-user-notes",
+	"edit-file",
+	"evolve-soul",
+	"fff-find",
+	"fff-grep",
+	"file-stats",
+	"find-files",
+	"get-session-info",
+	"grep",
+	"http-fetch",
+	"install-acp-agent",
+	"install-mcp-server",
+	"list-acp-agents",
+	"list-directory",
+	"list-mcp-servers",
+	"list-sessions",
+	"list-skills",
+	"multi-edit",
+	"read-file",
+	"read-tape",
+	"remove-acp-agent",
+	"remove-mcp-server",
+	"send-email",
+	"send-file",
+	"set-avatar",
+	"settings",
+	"system-paths",
+	"type",
+	"update-session-title",
+	"update-soul-state",
+	"user-note",
+	"walk-directory",
+	"wechat-login-confirm",
+	"wechat-login-start",
+	"write-file",
+	"write-skill-draft",
+	"write-user-note",
+];
+
 export function registerRaraToolRenderers(): void {
-	// `bash` is the canonical name on both sides, but we call this explicitly
-	// so the binding is documented and not dependent on import-order side
-	// effects inside pi-web-ui.
 	registerToolRenderer("bash", new BashRenderer());
+
+	for (const name of RARA_COMPACT_TOOLS) {
+		registerToolRenderer(name, new CompactToolRenderer(name));
+	}
 }


### PR DESCRIPTION
## Summary

Each tool call used to render a header + `Tool Call` label + Input JSON block + Output JSON block via pi-web-ui's `DefaultRenderer` — 5+ vertical bands per call. This PR replaces it for rara's non-bash tools with a `CompactToolRenderer` inspired by multica's `ToolCallRow` (`vendor/multica/packages/views/chat/components/chat-message-list.tsx`).

- Default state: one-line header `<icon> tool_name <short summary>` where the summary is pulled from the most meaningful param (`command` / `query` / `pattern` / `file_path` / `description` / `prompt` / `skill` / first short string).
- Click to expand → Input + Output shown as soft `bg-muted/50` code blocks with `max-h` scroll.
- Long outputs truncated at 4k chars in the expanded view.
- `bash` / `artifacts` / `javascript_repl` / `extract_document` keep their specialised pi-mono renderers.

Per-call only — cross-message grouping (multica's `ToolGroupCollapsible`) is out of scope for this PR; it would require changes at the ChatPanel layer.

## Type of change

| Type | Label |
|------|-------|
| Enhancement | `enhancement` |

## Component

`ui`

## Closes

Closes #1564

## Test plan

- [x] `cd web && npm run build` passes
- [ ] Manual: open a chat with multiple tool calls, confirm each is a single line by default and expands on click