### PR TITLE
fix(llm): gpt-5.4 reasoning effort clamp (#1567)

### DIFF
--- a/crates/kernel/src/agent/mod.rs
+++ b/crates/kernel/src/agent/mod.rs
@@ -830,8 +830,15 @@ call `discover-tools` to load it first.{tool_list}
 /// Map a [`crate::session::ThinkingLevel`] to a provider
 /// [`llm::ThinkingConfig`].
 ///
-/// Budgets mirror Anthropic's extended-thinking guidance: larger levels give
-/// the model more scratch tokens for silent reasoning before answering.
+/// Two hints are stamped on the output so each driver family can pick what
+/// it understands:
+///
+/// * `budget_tokens` mirrors Anthropic's extended-thinking guidance — larger
+///   levels give the model more scratch tokens for silent reasoning.
+/// * `effort` carries the explicit level name (`"off" | "minimal" | "low" |
+///   "medium" | "high" | "xhigh"`) for the OpenAI Responses API, which rejects
+///   the intermediate budget→bucket lossy mapping (notably gpt-5.4, which needs
+///   `"none"`/`"xhigh"`).
 ///
 /// The output distinguishes three states:
 ///
@@ -840,28 +847,35 @@ call `discover-tools` to load it first.{tool_list}
 /// * `Some(ThinkingConfig { enabled: false, .. })` — the user explicitly
 ///   selected `Off`. Drivers must disable extended thinking even when the model
 ///   family defaults to reasoning.
-/// * `Some(ThinkingConfig { enabled: true, budget_tokens: Some(_) })` — an
-///   explicit non-zero budget.
+/// * `Some(ThinkingConfig { enabled: true, budget_tokens: Some(_), effort:
+///   Some(_) })` — an explicit level.
 fn thinking_level_to_config(
     level: Option<crate::session::ThinkingLevel>,
 ) -> Option<llm::ThinkingConfig> {
+    use llm::ReasoningEffort;
+
     use crate::session::ThinkingLevel;
-    let budget = match level? {
+    let (budget, effort) = match level? {
         ThinkingLevel::Off => {
             return Some(llm::ThinkingConfig {
                 enabled:       false,
                 budget_tokens: None,
+                // Preserve the explicit "off" intent for reasoning-family
+                // drivers; the OpenAI driver clamps it to the lowest bucket
+                // the concrete model accepts (`none` or `minimal`).
+                effort:        Some(ReasoningEffort::Off),
             });
         }
-        ThinkingLevel::Minimal => 512,
-        ThinkingLevel::Low => 1024,
-        ThinkingLevel::Medium => 4096,
-        ThinkingLevel::High => 16384,
-        ThinkingLevel::Xhigh => 32768,
+        ThinkingLevel::Minimal => (512, ReasoningEffort::Minimal),
+        ThinkingLevel::Low => (1024, ReasoningEffort::Low),
+        ThinkingLevel::Medium => (4096, ReasoningEffort::Medium),
+        ThinkingLevel::High => (16384, ReasoningEffort::High),
+        ThinkingLevel::Xhigh => (32768, ReasoningEffort::Xhigh),
     };
     Some(llm::ThinkingConfig {
         enabled:       true,
         budget_tokens: Some(budget),
+        effort:        Some(effort),
     })
 }
 

--- a/crates/kernel/src/llm/codex.rs
+++ b/crates/kernel/src/llm/codex.rs
@@ -206,6 +206,7 @@ mod tests {
             thinking:            Some(ThinkingConfig {
                 enabled:       true,
                 budget_tokens: Some(20_000),
+                effort:        None,
             }),
             tool_choice:         Default::default(),
             parallel_tool_calls: false,

--- a/crates/kernel/src/llm/openai.rs
+++ b/crates/kernel/src/llm/openai.rs
@@ -31,8 +31,8 @@ use super::{
     stream::StreamDelta,
     types::{
         CompletionRequest, CompletionResponse, ContentBlock, EmbeddingRequest, EmbeddingResponse,
-        LlmProviderFamily, Message, MessageContent, ModelInfo, Role, StopReason, ToolCallRequest,
-        ToolChoice, Usage, detect_provider_family,
+        LlmProviderFamily, Message, MessageContent, ModelInfo, ReasoningEffort, Role, StopReason,
+        ThinkingConfig, ToolCallRequest, ToolChoice, Usage, detect_provider_family,
     },
 };
 use crate::error::{KernelError, Result};
@@ -761,40 +761,51 @@ pub(crate) fn build_responses_request(request: &CompletionRequest, _format: ApiF
         body["tools"] = json!(tools);
     }
 
-    // Reasoning config.
-    //
-    // Three cases:
-    //   * `None` — no session override; fall back to the model family's default
-    //     (medium) so reasoning-family models still reason.
-    //   * `Some(enabled: false)` — the user explicitly turned reasoning off. Ask
-    //     the API for the minimal effort the Responses contract allows; omitting
-    //     the block entirely would be read as "default" by the server.
-    //   * `Some(enabled: true)` — map the budget to an effort bucket.
-    let reasoning_effort = match request.thinking.as_ref() {
-        None => "medium",
-        Some(t) if !t.enabled => "minimal",
-        Some(t) => t
-            .budget_tokens
-            .map(|b| {
-                if b >= 10_000 {
-                    "high"
-                } else if b >= 3_000 {
-                    "medium"
-                } else {
-                    "low"
-                }
-            })
-            .unwrap_or("medium"),
-    };
+    let reasoning_effort = resolve_reasoning_effort(&request.model, request.thinking.as_ref());
 
     body["reasoning"] = json!({
-        "effort": reasoning_effort,
+        "effort": reasoning_effort.as_wire(),
         "summary": "auto",
     });
 
     body
 }
 
+/// Resolve the [`ReasoningEffort`] for an OpenAI Responses API call.
+///
+/// Preference order:
+///
+/// 1. `ThinkingConfig { enabled: false, .. }` → [`ReasoningEffort::Off`].
+///    Dominates any `effort` hint the caller happens to carry alongside, so we
+///    cannot ask the API for reasoning on a disabled turn.
+/// 2. Typed [`ThinkingConfig::effort`] — used verbatim, clamped to the concrete
+///    model's accepted set.
+/// 3. Legacy [`ThinkingConfig::budget_tokens`] fallback — the pre-`effort` code
+///    path, kept so callers that still set only a budget keep working.
+/// 4. No config → [`ReasoningEffort::Medium`], so reasoning-family models still
+///    reason by default.
+fn resolve_reasoning_effort(model: &str, thinking: Option<&ThinkingConfig>) -> ReasoningEffort {
+    let effort = match thinking {
+        None => return ReasoningEffort::Medium,
+        Some(t) if !t.enabled => ReasoningEffort::Off,
+        Some(t) => t
+            .effort
+            .unwrap_or_else(|| effort_from_budget(t.budget_tokens)),
+    };
+    effort.clamp_for_model(model)
+}
+
+/// Map a legacy Anthropic-style token budget to the closest
+/// [`ReasoningEffort`] bucket. Kept so pre-`effort` callers still route to
+/// sensible values.
+fn effort_from_budget(budget: Option<u32>) -> ReasoningEffort {
+    match budget {
+        Some(b) if b >= 10_000 => ReasoningEffort::High,
+        Some(b) if b >= 3_000 => ReasoningEffort::Medium,
+        Some(_) => ReasoningEffort::Low,
+        None => ReasoningEffort::Medium,
+    }
+}
 // ---------------------------------------------------------------------------
 // Non-streaming response parsing
 // ---------------------------------------------------------------------------
@@ -2408,6 +2419,7 @@ mod tests {
             thinking:            Some(ThinkingConfig {
                 enabled:       true,
                 budget_tokens: Some(20_000),
+                effort:        None,
             }),
             tool_choice:         Default::default(),
             parallel_tool_calls: false,
@@ -2418,6 +2430,147 @@ mod tests {
 
         let body = build_responses_request(&request, ApiFormat::Responses);
         assert_eq!(body["reasoning"]["effort"], "high");
+    }
+
+    #[test]
+    fn reasoning_effort_clamp_handles_gpt_5_4_quirks() {
+        // gpt-5.4 accepts none | low | medium | high | xhigh. Off → None_
+        // (wire "none"); Minimal isn't accepted so it bumps to Low.
+        assert_eq!(
+            ReasoningEffort::Off.clamp_for_model("gpt-5.4"),
+            ReasoningEffort::None_
+        );
+        assert_eq!(
+            ReasoningEffort::Minimal.clamp_for_model("gpt-5.4"),
+            ReasoningEffort::Low
+        );
+        assert_eq!(
+            ReasoningEffort::Xhigh.clamp_for_model("gpt-5.4-mini"),
+            ReasoningEffort::Xhigh
+        );
+    }
+
+    #[test]
+    fn reasoning_effort_clamp_preserves_minimal_for_other_models() {
+        // Non-gpt-5.4 reasoning models accept Minimal. Legacy reasoning
+        // families (`o*`, `codex-*`) cap Xhigh at High.
+        assert_eq!(
+            ReasoningEffort::Off.clamp_for_model("gpt-5"),
+            ReasoningEffort::Minimal
+        );
+        assert_eq!(
+            ReasoningEffort::Minimal.clamp_for_model("gpt-5"),
+            ReasoningEffort::Minimal
+        );
+        assert_eq!(
+            ReasoningEffort::Xhigh.clamp_for_model("codex-mini"),
+            ReasoningEffort::High
+        );
+        assert_eq!(
+            ReasoningEffort::Xhigh.clamp_for_model("o3"),
+            ReasoningEffort::High
+        );
+    }
+
+    #[test]
+    fn reasoning_effort_clamp_keeps_xhigh_on_gpt_5_family() {
+        // gpt-5 (not just gpt-5.4) accepts Xhigh; the old budget→bucket
+        // ladder silently downgraded it to High.
+        assert_eq!(
+            ReasoningEffort::Xhigh.clamp_for_model("gpt-5"),
+            ReasoningEffort::Xhigh
+        );
+        assert_eq!(
+            ReasoningEffort::Xhigh.clamp_for_model("gpt-5-mini"),
+            ReasoningEffort::Xhigh
+        );
+    }
+
+    #[test]
+    fn reasoning_effort_clamp_strips_vendor_prefix() {
+        // A router that prepends `<vendor>/` must not defeat family
+        // detection — gpt-5.4 quirks still apply to `openai/gpt-5.4`.
+        assert_eq!(
+            ReasoningEffort::Minimal.clamp_for_model("openai/gpt-5.4"),
+            ReasoningEffort::Low
+        );
+        assert_eq!(
+            ReasoningEffort::Off.clamp_for_model("openai/gpt-5.4"),
+            ReasoningEffort::None_
+        );
+        assert_eq!(
+            ReasoningEffort::Xhigh.clamp_for_model("openai/gpt-5"),
+            ReasoningEffort::Xhigh
+        );
+    }
+
+    #[test]
+    fn resolve_reasoning_effort_disabled_ignores_effort_hint() {
+        // `enabled: false` is authoritative — a stray `effort: High` must
+        // not leak through and ask the API for reasoning on a disabled turn.
+        let thinking = ThinkingConfig {
+            enabled:       false,
+            budget_tokens: None,
+            effort:        Some(ReasoningEffort::High),
+        };
+        assert_eq!(
+            resolve_reasoning_effort("gpt-5.4", Some(&thinking)),
+            ReasoningEffort::None_
+        );
+        assert_eq!(
+            resolve_reasoning_effort("gpt-5", Some(&thinking)),
+            ReasoningEffort::Minimal
+        );
+    }
+
+    #[test]
+    fn build_responses_request_uses_explicit_effort_hint() {
+        // Xhigh round-trips end-to-end; the pre-typed-enum ladder capped
+        // at "high" and silently lost the user's selection.
+        let request = CompletionRequest {
+            model:               "gpt-5.4".into(),
+            messages:            vec![],
+            tools:               vec![],
+            temperature:         None,
+            max_tokens:          None,
+            thinking:            Some(ThinkingConfig {
+                enabled:       true,
+                budget_tokens: Some(32_768),
+                effort:        Some(ReasoningEffort::Xhigh),
+            }),
+            tool_choice:         Default::default(),
+            parallel_tool_calls: false,
+            frequency_penalty:   None,
+            top_p:               None,
+            emit_reasoning:      false,
+        };
+        let body = build_responses_request(&request, ApiFormat::Responses);
+        assert_eq!(body["reasoning"]["effort"], "xhigh");
+    }
+
+    #[test]
+    fn build_responses_request_gpt_5_4_off_maps_to_none() {
+        // Regression: pre-fix, Off was sent as `"minimal"` which gpt-5.4
+        // rejects with HTTP 400. Must now emit `"none"`.
+        let request = CompletionRequest {
+            model:               "gpt-5.4".into(),
+            messages:            vec![],
+            tools:               vec![],
+            temperature:         None,
+            max_tokens:          None,
+            thinking:            Some(ThinkingConfig {
+                enabled:       false,
+                budget_tokens: None,
+                effort:        Some(ReasoningEffort::Off),
+            }),
+            tool_choice:         Default::default(),
+            parallel_tool_calls: false,
+            frequency_penalty:   None,
+            top_p:               None,
+            emit_reasoning:      false,
+        };
+        let body = build_responses_request(&request, ApiFormat::Responses);
+        assert_eq!(body["reasoning"]["effort"], "none");
     }
 
     #[test]

--- a/crates/kernel/src/llm/types.rs
+++ b/crates/kernel/src/llm/types.rs
@@ -319,11 +319,124 @@ pub struct ToolDefinition {
 // ---------------------------------------------------------------------------
 
 /// Thinking/reasoning budget configuration.
+///
+/// Two hints travel together so each driver family can pick what it
+/// understands: `budget_tokens` for Anthropic-style extended thinking, and
+/// `effort` — a typed [`ReasoningEffort`] — for the OpenAI Responses API.
+/// Drivers that do not understand a hint MUST ignore it.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ThinkingConfig {
     pub enabled:       bool,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub budget_tokens: Option<u32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub effort:        Option<ReasoningEffort>,
+}
+
+// ---------------------------------------------------------------------------
+// ReasoningEffort
+// ---------------------------------------------------------------------------
+
+/// User-facing reasoning effort bucket for OpenAI Responses-style drivers.
+///
+/// Not every variant is accepted by every model — `gpt-5.4` rejects
+/// [`Minimal`](Self::Minimal), legacy reasoning families (`o*`, `codex-*`)
+/// reject [`Xhigh`](Self::Xhigh). Call
+/// [`clamp_for_model`](Self::clamp_for_model) before serialising to the wire so
+/// the API never sees an unsupported value.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum ReasoningEffort {
+    /// User intent: reasoning off. Clamps to [`None_`](Self::None_) on
+    /// gpt-5.4 and [`Minimal`](Self::Minimal) elsewhere.
+    Off,
+    /// Wire `"none"` — the gpt-5.4-only opt-out bucket.
+    #[serde(rename = "none")]
+    None_,
+    /// Wire `"minimal"` — rejected by gpt-5.4.
+    Minimal,
+    Low,
+    Medium,
+    High,
+    /// Wire `"xhigh"` — accepted by the full `gpt-5*` family; legacy
+    /// reasoning families clamp to [`High`](Self::High).
+    Xhigh,
+}
+
+impl ReasoningEffort {
+    /// Serialise to the string the OpenAI Responses API expects.
+    ///
+    /// [`Off`](Self::Off) is a pre-clamp intent; if it ever reaches this
+    /// function it means someone skipped
+    /// [`clamp_for_model`](Self::clamp_for_model). Return the safest wire
+    /// bucket the API universally accepts so the request still succeeds
+    /// even if the clamp invariant slips.
+    pub fn as_wire(self) -> &'static str {
+        match self {
+            Self::Off | Self::Minimal => "minimal",
+            Self::None_ => "none",
+            Self::Low => "low",
+            Self::Medium => "medium",
+            Self::High => "high",
+            Self::Xhigh => "xhigh",
+        }
+    }
+
+    /// Clamp the effort to the set the concrete OpenAI model accepts.
+    ///
+    /// The `model` argument tolerates a `<vendor>/` routing prefix so this
+    /// keeps working when a router rewrites `gpt-5.4` to `openai/gpt-5.4`.
+    #[must_use]
+    pub fn clamp_for_model(self, model: &str) -> Self {
+        match (self, ModelFamily::detect(model)) {
+            (Self::Off, ModelFamily::Gpt5_4) => Self::None_,
+            (Self::Off, _) => Self::Minimal,
+            (Self::Minimal, ModelFamily::Gpt5_4) => Self::Low,
+            (Self::Xhigh, ModelFamily::LegacyReasoning) => Self::High,
+            (e, _) => e,
+        }
+    }
+}
+
+/// OpenAI reasoning-model families with distinct effort acceptance sets.
+///
+/// The acceptance matrix (April 2026, Responses API):
+///
+/// | family            | none | minimal | low | medium | high | xhigh |
+/// |-------------------|:----:|:-------:|:---:|:------:|:----:|:-----:|
+/// | `gpt-5.4*`        |  ✓   |    ✗    |  ✓  |   ✓    |  ✓   |   ✓   |
+/// | other `gpt-5*`    |  ✗   |    ✓    |  ✓  |   ✓    |  ✓   |   ✓   |
+/// | legacy (`o*`/`codex-*`) | ✗ |   ✓    |  ✓  |   ✓    |  ✓   |   ✗   |
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[allow(non_camel_case_types)]
+enum ModelFamily {
+    /// The `gpt-5.4` family — `gpt-5.4`, `gpt-5.4-mini`, etc.
+    Gpt5_4,
+    /// Other `gpt-5*` models that accept `xhigh` but also `minimal`.
+    Gpt5,
+    /// Legacy reasoning models: `o3`, `o4`, `codex-mini`, etc. — no `xhigh`.
+    LegacyReasoning,
+    /// Non-reasoning model. Effort clamp is a no-op (drivers shouldn't
+    /// reach this path, but we fail open rather than rejecting the request).
+    Other,
+}
+
+impl ModelFamily {
+    fn detect(model: &str) -> Self {
+        let lower = model.to_lowercase();
+        // Strip a leading `<vendor>/` prefix so routers that rewrite model
+        // ids don't defeat family detection (e.g. `openai/gpt-5.4`).
+        let bare = lower.rsplit('/').next().unwrap_or(&lower);
+        if bare.starts_with("gpt-5.4") {
+            Self::Gpt5_4
+        } else if bare.starts_with("gpt-5") {
+            Self::Gpt5
+        } else if bare.starts_with('o') || bare.starts_with("codex-") {
+            Self::LegacyReasoning
+        } else {
+            Self::Other
+        }
+    }
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Thread the explicit `ThinkingLevel` name through `ThinkingConfig::effort` so the OpenAI Responses driver no longer loses information through the budget→bucket ladder.
- Clamp `reasoning.effort` per model family: `gpt-5.4` accepts `none | low | medium | high | xhigh` (no `minimal`); other reasoning models keep the prior `off → minimal`, `xhigh → high` behavior.
- Regression fix for HTTP 400 `Unsupported value: 'minimal' is not supported with the 'gpt-5.4' model` reported by the user, plus the silent `Xhigh → high` downgrade.

## Type of change

| Type | Label |
|------|-------|
| Bug fix | `bug` |

## Component

`core`

## Closes

Closes #1567

## Test plan

- [x] `cargo test -p rara-kernel --lib llm::openai::tests` passes (added 4 new tests covering gpt-5.4 clamp, xhigh round-trip, and off→none mapping)
- [x] `cargo check --all --all-targets` passes
- [x] pre-commit hooks (fmt + clippy + doc) pass