### PR TITLE
feat(chat): allow clearing session model override (#1569)

### DIFF
--- a/crates/extensions/backend-admin/src/chat/router.rs
+++ b/crates/extensions/backend-admin/src/chat/router.rs
@@ -42,7 +42,7 @@ use rara_kernel::{
     channel::types::{ChannelType, ChatMessage},
 };
 use rara_sessions::types::{ChannelBinding, SessionEntry, SessionKey, ThinkingLevel};
-use serde::Deserialize;
+use serde::{Deserialize, Deserializer};
 use tracing::instrument;
 use utoipa_axum::{router::OpenApiRouter, routes};
 
@@ -52,8 +52,11 @@ use crate::chat::{
     service::{ProviderInfo, SessionService},
 };
 
-/// Parse an optional thinking-level string from a request body, converting
-/// invalid values into a 400 response with a list of accepted variants.
+/// Parse an optional thinking-level string from a create-session body.
+///
+/// Returns `None` for a missing or explicit-null value and validates any
+/// non-null string against the accepted variants, producing a 400 on a
+/// typo.
 fn parse_thinking_level(raw: Option<String>) -> Result<Option<ThinkingLevel>, ChatError> {
     use strum::VariantNames;
     raw.map(|s| {
@@ -66,6 +69,47 @@ fn parse_thinking_level(raw: Option<String>) -> Result<Option<ThinkingLevel>, Ch
             })
     })
     .transpose()
+}
+
+/// Parse a PATCH-shaped thinking-level field while preserving the
+/// absent-vs-null distinction the caller needs to drive
+/// [`SessionService::update_session_fields`] semantics.
+///
+/// - `None`              → field absent, leave untouched.
+/// - `Some(None)`        → explicit `null`, clear the field.
+/// - `Some(Some(value))` → validated and normalised to the enum.
+fn parse_patch_thinking_level(
+    raw: Option<Option<String>>,
+) -> Result<Option<Option<ThinkingLevel>>, ChatError> {
+    use strum::VariantNames;
+    match raw {
+        None => Ok(None),
+        Some(None) => Ok(Some(None)),
+        Some(Some(s)) => s
+            .parse::<ThinkingLevel>()
+            .map(|v| Some(Some(v)))
+            .map_err(|_| ChatError::InvalidRequest {
+                message: format!(
+                    "invalid thinking level: {s} (expected one of: {})",
+                    ThinkingLevel::VARIANTS.join(", "),
+                ),
+            }),
+    }
+}
+
+/// Custom deserializer that distinguishes a missing field (`None`) from a
+/// present `null` (`Some(None)`) and a present value (`Some(Some(v))`).
+///
+/// Serde's default `Option<T>` collapses the first two cases together,
+/// but a session PATCH must treat "leave alone" and "reset to default"
+/// as different operations — this helper keeps the semantic visible on
+/// the wire without pulling in `serde_with`.
+fn deserialize_double_option<'de, T, D>(de: D) -> Result<Option<Option<T>>, D::Error>
+where
+    T: Deserialize<'de>,
+    D: Deserializer<'de>,
+{
+    Option::<T>::deserialize(de).map(Some)
 }
 
 /// Parse a session key from a URL path parameter, returning 400 on invalid
@@ -114,19 +158,36 @@ pub struct ListSessionsQuery {
 }
 
 /// Request body for `PATCH /sessions/{key}`.
+///
+/// Each field is a double-option so the caller can distinguish three
+/// intents: **absent** (leave the stored value alone), **`null`** (clear
+/// the per-session override so the admin default applies), and **set**
+/// (persist the new value). Collapsing absent and `null` would strand
+/// sessions with a stale pinned model even after the admin changes the
+/// default provider.
 #[derive(Debug, Deserialize, utoipa::ToSchema)]
 pub struct UpdateSessionRequest {
     /// New human-readable title.
-    pub title:          Option<String>,
+    #[serde(default, deserialize_with = "deserialize_double_option")]
+    #[schema(value_type = Option<String>, nullable)]
+    pub title:          Option<Option<String>>,
     /// New LLM model identifier (e.g. `"openai/gpt-4o"`).
-    pub model:          Option<String>,
+    #[serde(default, deserialize_with = "deserialize_double_option")]
+    #[schema(value_type = Option<String>, nullable)]
+    pub model:          Option<Option<String>>,
     /// New provider identifier paired with `model`.
-    pub model_provider: Option<String>,
+    #[serde(default, deserialize_with = "deserialize_double_option")]
+    #[schema(value_type = Option<String>, nullable)]
+    pub model_provider: Option<Option<String>>,
     /// New thinking-level override — one of `"off"`, `"minimal"`, `"low"`,
     /// `"medium"`, `"high"`, `"xhigh"`.
-    pub thinking_level: Option<String>,
+    #[serde(default, deserialize_with = "deserialize_double_option")]
+    #[schema(value_type = Option<String>, nullable)]
+    pub thinking_level: Option<Option<String>>,
     /// New system prompt override.
-    pub system_prompt:  Option<String>,
+    #[serde(default, deserialize_with = "deserialize_double_option")]
+    #[schema(value_type = Option<String>, nullable)]
+    pub system_prompt:  Option<Option<String>>,
 }
 
 /// Request body for `PUT /models/favorites`.
@@ -335,7 +396,7 @@ async fn update_session(
     Path(key): Path<String>,
     Json(req): Json<UpdateSessionRequest>,
 ) -> Result<Json<SessionEntry>, ChatError> {
-    let thinking_level = parse_thinking_level(req.thinking_level)?;
+    let thinking_level = parse_patch_thinking_level(req.thinking_level)?;
     let session = service
         .update_session_fields(
             &parse_session_key(&key)?,

--- a/crates/extensions/backend-admin/src/chat/router.rs
+++ b/crates/extensions/backend-admin/src/chat/router.rs
@@ -49,7 +49,7 @@ use utoipa_axum::{router::OpenApiRouter, routes};
 use crate::chat::{
     error::ChatError,
     model_catalog::ChatModel,
-    service::{ProviderInfo, SessionService},
+    service::{ProviderInfo, SessionPatch, SessionService},
 };
 
 /// Parse an optional thinking-level string from a create-session body.
@@ -104,6 +104,9 @@ fn parse_patch_thinking_level(
 /// but a session PATCH must treat "leave alone" and "reset to default"
 /// as different operations — this helper keeps the semantic visible on
 /// the wire without pulling in `serde_with`.
+///
+/// **MUST be paired with `#[serde(default)]` on the target field;
+/// otherwise an absent field becomes a hard deserialization error.**
 fn deserialize_double_option<'de, T, D>(de: D) -> Result<Option<Option<T>>, D::Error>
 where
     T: Deserialize<'de>,
@@ -168,23 +171,38 @@ pub struct ListSessionsQuery {
 #[derive(Debug, Deserialize, utoipa::ToSchema)]
 pub struct UpdateSessionRequest {
     /// New human-readable title.
+    ///
+    /// Null clears the override so the admin default applies; absent leaves it
+    /// untouched.
     #[serde(default, deserialize_with = "deserialize_double_option")]
     #[schema(value_type = Option<String>, nullable)]
     pub title:          Option<Option<String>>,
     /// New LLM model identifier (e.g. `"openai/gpt-4o"`).
+    ///
+    /// Null clears the override so the admin default applies; absent leaves it
+    /// untouched.
     #[serde(default, deserialize_with = "deserialize_double_option")]
     #[schema(value_type = Option<String>, nullable)]
     pub model:          Option<Option<String>>,
     /// New provider identifier paired with `model`.
+    ///
+    /// Null clears the override so the admin default applies; absent leaves it
+    /// untouched.
     #[serde(default, deserialize_with = "deserialize_double_option")]
     #[schema(value_type = Option<String>, nullable)]
     pub model_provider: Option<Option<String>>,
     /// New thinking-level override — one of `"off"`, `"minimal"`, `"low"`,
     /// `"medium"`, `"high"`, `"xhigh"`.
+    ///
+    /// Null clears the override so the admin default applies; absent leaves it
+    /// untouched.
     #[serde(default, deserialize_with = "deserialize_double_option")]
     #[schema(value_type = Option<String>, nullable)]
     pub thinking_level: Option<Option<String>>,
     /// New system prompt override.
+    ///
+    /// Null clears the override so the admin default applies; absent leaves it
+    /// untouched.
     #[serde(default, deserialize_with = "deserialize_double_option")]
     #[schema(value_type = Option<String>, nullable)]
     pub system_prompt:  Option<Option<String>>,
@@ -396,16 +414,15 @@ async fn update_session(
     Path(key): Path<String>,
     Json(req): Json<UpdateSessionRequest>,
 ) -> Result<Json<SessionEntry>, ChatError> {
-    let thinking_level = parse_patch_thinking_level(req.thinking_level)?;
+    let patch = SessionPatch {
+        title:          req.title,
+        model:          req.model,
+        model_provider: req.model_provider,
+        thinking_level: parse_patch_thinking_level(req.thinking_level)?,
+        system_prompt:  req.system_prompt,
+    };
     let session = service
-        .update_session_fields(
-            &parse_session_key(&key)?,
-            req.title,
-            req.model,
-            req.model_provider,
-            thinking_level,
-            req.system_prompt,
-        )
+        .update_session_fields(&parse_session_key(&key)?, patch)
         .await?;
     Ok(Json(session))
 }

--- a/crates/extensions/backend-admin/src/chat/service.rs
+++ b/crates/extensions/backend-admin/src/chat/service.rs
@@ -251,6 +251,37 @@ mod provider_tests {
     }
 }
 
+/// Apply a PATCH-shaped field diff to a [`SessionEntry`] in place.
+///
+/// Each argument follows the double-option convention documented on
+/// [`SessionService::update_session_fields`]. Extracting the mutation
+/// into a free function keeps the per-field branching trivially unit
+/// testable without spinning up tape storage or a settings provider.
+fn apply_session_patch(
+    session: &mut SessionEntry,
+    title: Option<Option<String>>,
+    model: Option<Option<String>>,
+    model_provider: Option<Option<String>>,
+    thinking_level: Option<Option<ThinkingLevel>>,
+    system_prompt: Option<Option<String>>,
+) {
+    if let Some(t) = title {
+        session.title = t;
+    }
+    if let Some(m) = model {
+        session.model = m;
+    }
+    if let Some(mp) = model_provider {
+        session.model_provider = mp;
+    }
+    if let Some(tl) = thinking_level {
+        session.thinking_level = tl;
+    }
+    if let Some(sp) = system_prompt {
+        session.system_prompt = sp;
+    }
+}
+
 /// Central orchestrator for session-based AI chat.
 ///
 /// `SessionService` ties together two concerns:
@@ -388,34 +419,29 @@ impl SessionService {
 
     /// Partially update mutable fields of a session.
     ///
-    /// Only the fields that are `Some` in the arguments are overwritten; the
-    /// rest are left untouched. Returns the updated [`SessionEntry`].
+    /// Each argument is a double-option so callers can separately express
+    /// **leave alone** (outer `None`), **clear** (`Some(None)`) and **set**
+    /// (`Some(Some(value))`). The clear variant is what lets a user drop a
+    /// per-session pin and fall back to the admin `llm.default_provider`.
     #[instrument(skip(self))]
     pub async fn update_session_fields(
         &self,
         key: &SessionKey,
-        title: Option<String>,
-        model: Option<String>,
-        model_provider: Option<String>,
-        thinking_level: Option<ThinkingLevel>,
-        system_prompt: Option<String>,
+        title: Option<Option<String>>,
+        model: Option<Option<String>>,
+        model_provider: Option<Option<String>>,
+        thinking_level: Option<Option<ThinkingLevel>>,
+        system_prompt: Option<Option<String>>,
     ) -> Result<SessionEntry, ChatError> {
         let mut session = self.get_session(key).await?;
-        if let Some(t) = title {
-            session.title = Some(t);
-        }
-        if let Some(m) = model {
-            session.model = Some(m);
-        }
-        if let Some(mp) = model_provider {
-            session.model_provider = Some(mp);
-        }
-        if let Some(tl) = thinking_level {
-            session.thinking_level = Some(tl);
-        }
-        if let Some(sp) = system_prompt {
-            session.system_prompt = Some(sp);
-        }
+        apply_session_patch(
+            &mut session,
+            title,
+            model,
+            model_provider,
+            thinking_level,
+            system_prompt,
+        );
         session.updated_at = Utc::now();
         let updated = self.session_index.update_session(&session).await?;
         info!(key = %key, "session fields updated");
@@ -746,4 +772,105 @@ fn tap_entries_to_chat_messages(entries: &[TapEntry]) -> Vec<ChatMessage> {
         }
     }
     messages
+}
+
+#[cfg(test)]
+mod session_patch_tests {
+    use chrono::Utc;
+    use rara_sessions::types::{SessionEntry, SessionKey, ThinkingLevel};
+
+    use super::apply_session_patch;
+
+    fn sample_session() -> SessionEntry {
+        let now = Utc::now();
+        SessionEntry {
+            key:            SessionKey::new(),
+            title:          Some("existing title".to_owned()),
+            model:          Some("kimi-k2.5".to_owned()),
+            model_provider: Some("kimi".to_owned()),
+            thinking_level: Some(ThinkingLevel::Medium),
+            system_prompt:  Some("hello".to_owned()),
+            message_count:  0,
+            preview:        None,
+            metadata:       None,
+            created_at:     now,
+            updated_at:     now,
+        }
+    }
+
+    #[test]
+    fn absent_fields_leave_session_untouched() {
+        let mut session = sample_session();
+        let before = session.clone();
+        apply_session_patch(&mut session, None, None, None, None, None);
+        assert_eq!(session.title, before.title);
+        assert_eq!(session.model, before.model);
+        assert_eq!(session.model_provider, before.model_provider);
+        assert_eq!(session.thinking_level, before.thinking_level);
+        assert_eq!(session.system_prompt, before.system_prompt);
+    }
+
+    #[test]
+    fn explicit_null_clears_model_override() {
+        // This is the #1569 case: a session pinned to `kimi` is reset so
+        // the admin's `llm.default_provider` can take effect on the next
+        // turn.
+        let mut session = sample_session();
+        apply_session_patch(&mut session, None, Some(None), Some(None), Some(None), None);
+        assert!(session.model.is_none());
+        assert!(session.model_provider.is_none());
+        assert!(session.thinking_level.is_none());
+        // Fields not in the patch are preserved.
+        assert_eq!(session.title.as_deref(), Some("existing title"));
+        assert_eq!(session.system_prompt.as_deref(), Some("hello"));
+    }
+
+    #[test]
+    fn some_value_overwrites_field() {
+        let mut session = sample_session();
+        apply_session_patch(
+            &mut session,
+            Some(Some("renamed".to_owned())),
+            Some(Some("gpt-4o".to_owned())),
+            Some(Some("openai".to_owned())),
+            Some(Some(ThinkingLevel::High)),
+            Some(Some("new prompt".to_owned())),
+        );
+        assert_eq!(session.title.as_deref(), Some("renamed"));
+        assert_eq!(session.model.as_deref(), Some("gpt-4o"));
+        assert_eq!(session.model_provider.as_deref(), Some("openai"));
+        assert_eq!(session.thinking_level, Some(ThinkingLevel::High));
+        assert_eq!(session.system_prompt.as_deref(), Some("new prompt"));
+    }
+}
+
+#[cfg(test)]
+mod update_request_deserialize_tests {
+    use crate::chat::UpdateSessionRequest;
+
+    #[test]
+    fn absent_model_field_deserializes_to_outer_none() {
+        let req: UpdateSessionRequest = serde_json::from_str("{}").expect("parse");
+        assert!(req.model.is_none());
+        assert!(req.model_provider.is_none());
+        assert!(req.thinking_level.is_none());
+    }
+
+    #[test]
+    fn explicit_null_model_deserializes_to_some_none() {
+        let req: UpdateSessionRequest =
+            serde_json::from_str(r#"{"model": null, "model_provider": null}"#).expect("parse");
+        assert_eq!(req.model, Some(None));
+        assert_eq!(req.model_provider, Some(None));
+        assert!(req.thinking_level.is_none());
+    }
+
+    #[test]
+    fn explicit_value_model_deserializes_to_some_some() {
+        let req: UpdateSessionRequest =
+            serde_json::from_str(r#"{"model": "gpt-4o", "thinking_level": "high"}"#)
+                .expect("parse");
+        assert_eq!(req.model, Some(Some("gpt-4o".to_owned())));
+        assert_eq!(req.thinking_level, Some(Some("high".to_owned())));
+    }
 }

--- a/crates/extensions/backend-admin/src/chat/service.rs
+++ b/crates/extensions/backend-admin/src/chat/service.rs
@@ -251,35 +251,63 @@ mod provider_tests {
     }
 }
 
-/// Apply a PATCH-shaped field diff to a [`SessionEntry`] in place.
+/// PATCH-shaped field diff for a [`SessionEntry`].
 ///
-/// Each argument follows the double-option convention documented on
-/// [`SessionService::update_session_fields`]. Extracting the mutation
-/// into a free function keeps the per-field branching trivially unit
-/// testable without spinning up tape storage or a settings provider.
-fn apply_session_patch(
-    session: &mut SessionEntry,
-    title: Option<Option<String>>,
-    model: Option<Option<String>>,
-    model_provider: Option<Option<String>>,
-    thinking_level: Option<Option<ThinkingLevel>>,
-    system_prompt: Option<Option<String>>,
-) {
-    if let Some(t) = title {
-        session.title = t;
+/// Every field follows the double-option convention documented on
+/// [`SessionService::update_session_fields`]: outer `None` means
+/// **leave alone**, `Some(None)` means **clear the override**, and
+/// `Some(Some(value))` means **persist this value**.
+///
+/// Grouped into a struct so the router's 5-field call site and future
+/// callers (Telegram `/model`, CLI, ...) are not exposed to a pile of
+/// positional `Option<Option<String>>` arguments — a swap-typo waiting
+/// to happen.
+#[derive(Debug, Clone, Default)]
+pub struct SessionPatch {
+    /// New human-readable title.
+    pub title:          Option<Option<String>>,
+    /// New LLM model identifier.
+    pub model:          Option<Option<String>>,
+    /// New provider identifier paired with `model`.
+    pub model_provider: Option<Option<String>>,
+    /// New thinking-level override.
+    pub thinking_level: Option<Option<ThinkingLevel>>,
+    /// New system prompt override.
+    pub system_prompt:  Option<Option<String>>,
+}
+
+/// Apply a [`SessionPatch`] to a [`SessionEntry`] in place, returning
+/// `true` when any field actually changed.
+///
+/// Extracting the mutation into a free function keeps the per-field
+/// branching trivially unit testable without spinning up tape storage
+/// or a settings provider. The caller uses the boolean result to skip
+/// the `updated_at` bump and the session-index write on a no-op PATCH
+/// (e.g. a double-click on the "Use default" row re-sending `null` for
+/// already-`None` fields).
+fn apply_session_patch(session: &mut SessionEntry, patch: &SessionPatch) -> bool {
+    /// Assign `new` to `slot` when the patch carries that field and the
+    /// stored value actually differs. Returns whether a write happened
+    /// so the caller can aggregate a single `changed` flag across all
+    /// five fields.
+    fn assign<T: Clone + PartialEq>(slot: &mut Option<T>, new: &Option<Option<T>>) -> bool {
+        match new {
+            Some(v) if slot != v => {
+                *slot = v.clone();
+                true
+            }
+            _ => false,
+        }
     }
-    if let Some(m) = model {
-        session.model = m;
-    }
-    if let Some(mp) = model_provider {
-        session.model_provider = mp;
-    }
-    if let Some(tl) = thinking_level {
-        session.thinking_level = tl;
-    }
-    if let Some(sp) = system_prompt {
-        session.system_prompt = sp;
-    }
+
+    // `|` (bitwise-or) instead of `||` is intentional: every field must
+    // be evaluated so its write lands even when an earlier field already
+    // flipped `changed` to true.
+    assign(&mut session.title, &patch.title)
+        | assign(&mut session.model, &patch.model)
+        | assign(&mut session.model_provider, &patch.model_provider)
+        | assign(&mut session.thinking_level, &patch.thinking_level)
+        | assign(&mut session.system_prompt, &patch.system_prompt)
 }
 
 /// Central orchestrator for session-based AI chat.
@@ -419,29 +447,25 @@ impl SessionService {
 
     /// Partially update mutable fields of a session.
     ///
-    /// Each argument is a double-option so callers can separately express
-    /// **leave alone** (outer `None`), **clear** (`Some(None)`) and **set**
-    /// (`Some(Some(value))`). The clear variant is what lets a user drop a
-    /// per-session pin and fall back to the admin `llm.default_provider`.
-    #[instrument(skip(self))]
+    /// The [`SessionPatch`] fields use the double-option convention so
+    /// callers can separately express **leave alone** (outer `None`),
+    /// **clear** (`Some(None)`) and **set** (`Some(Some(value))`). The
+    /// clear variant is what lets a user drop a per-session pin and
+    /// fall back to the admin `llm.default_provider`.
+    ///
+    /// Returns the session unchanged — without touching `updated_at` or
+    /// writing to the session index — when the patch is a no-op, so
+    /// repeat "Use default" clicks do not churn the list-order rank.
+    #[instrument(skip(self, patch))]
     pub async fn update_session_fields(
         &self,
         key: &SessionKey,
-        title: Option<Option<String>>,
-        model: Option<Option<String>>,
-        model_provider: Option<Option<String>>,
-        thinking_level: Option<Option<ThinkingLevel>>,
-        system_prompt: Option<Option<String>>,
+        patch: SessionPatch,
     ) -> Result<SessionEntry, ChatError> {
         let mut session = self.get_session(key).await?;
-        apply_session_patch(
-            &mut session,
-            title,
-            model,
-            model_provider,
-            thinking_level,
-            system_prompt,
-        );
+        if !apply_session_patch(&mut session, &patch) {
+            return Ok(session);
+        }
         session.updated_at = Utc::now();
         let updated = self.session_index.update_session(&session).await?;
         info!(key = %key, "session fields updated");
@@ -779,7 +803,7 @@ mod session_patch_tests {
     use chrono::Utc;
     use rara_sessions::types::{SessionEntry, SessionKey, ThinkingLevel};
 
-    use super::apply_session_patch;
+    use super::{SessionPatch, apply_session_patch};
 
     fn sample_session() -> SessionEntry {
         let now = Utc::now();
@@ -802,7 +826,8 @@ mod session_patch_tests {
     fn absent_fields_leave_session_untouched() {
         let mut session = sample_session();
         let before = session.clone();
-        apply_session_patch(&mut session, None, None, None, None, None);
+        let changed = apply_session_patch(&mut session, &SessionPatch::default());
+        assert!(!changed, "all-absent patch must report no-op");
         assert_eq!(session.title, before.title);
         assert_eq!(session.model, before.model);
         assert_eq!(session.model_provider, before.model_provider);
@@ -816,7 +841,14 @@ mod session_patch_tests {
         // the admin's `llm.default_provider` can take effect on the next
         // turn.
         let mut session = sample_session();
-        apply_session_patch(&mut session, None, Some(None), Some(None), Some(None), None);
+        let patch = SessionPatch {
+            model: Some(None),
+            model_provider: Some(None),
+            thinking_level: Some(None),
+            ..Default::default()
+        };
+        let changed = apply_session_patch(&mut session, &patch);
+        assert!(changed);
         assert!(session.model.is_none());
         assert!(session.model_provider.is_none());
         assert!(session.thinking_level.is_none());
@@ -826,21 +858,74 @@ mod session_patch_tests {
     }
 
     #[test]
+    fn partial_patch_clears_only_targeted_field() {
+        // Only `model` is cleared; `model_provider` and every other
+        // field must remain untouched.
+        let mut session = sample_session();
+        let patch = SessionPatch {
+            model: Some(None),
+            ..Default::default()
+        };
+        let changed = apply_session_patch(&mut session, &patch);
+        assert!(changed);
+        assert!(session.model.is_none());
+        assert_eq!(session.model_provider.as_deref(), Some("kimi"));
+        assert_eq!(session.thinking_level, Some(ThinkingLevel::Medium));
+        assert_eq!(session.title.as_deref(), Some("existing title"));
+        assert_eq!(session.system_prompt.as_deref(), Some("hello"));
+    }
+
+    #[test]
+    fn all_fields_cleared_in_one_call() {
+        let mut session = sample_session();
+        let patch = SessionPatch {
+            title:          Some(None),
+            model:          Some(None),
+            model_provider: Some(None),
+            thinking_level: Some(None),
+            system_prompt:  Some(None),
+        };
+        let changed = apply_session_patch(&mut session, &patch);
+        assert!(changed);
+        assert!(session.title.is_none());
+        assert!(session.model.is_none());
+        assert!(session.model_provider.is_none());
+        assert!(session.thinking_level.is_none());
+        assert!(session.system_prompt.is_none());
+    }
+
+    #[test]
     fn some_value_overwrites_field() {
         let mut session = sample_session();
-        apply_session_patch(
-            &mut session,
-            Some(Some("renamed".to_owned())),
-            Some(Some("gpt-4o".to_owned())),
-            Some(Some("openai".to_owned())),
-            Some(Some(ThinkingLevel::High)),
-            Some(Some("new prompt".to_owned())),
-        );
+        let patch = SessionPatch {
+            title:          Some(Some("renamed".to_owned())),
+            model:          Some(Some("gpt-4o".to_owned())),
+            model_provider: Some(Some("openai".to_owned())),
+            thinking_level: Some(Some(ThinkingLevel::High)),
+            system_prompt:  Some(Some("new prompt".to_owned())),
+        };
+        let changed = apply_session_patch(&mut session, &patch);
+        assert!(changed);
         assert_eq!(session.title.as_deref(), Some("renamed"));
         assert_eq!(session.model.as_deref(), Some("gpt-4o"));
         assert_eq!(session.model_provider.as_deref(), Some("openai"));
         assert_eq!(session.thinking_level, Some(ThinkingLevel::High));
         assert_eq!(session.system_prompt.as_deref(), Some("new prompt"));
+    }
+
+    #[test]
+    fn setting_same_value_is_a_noop() {
+        // Patching `model_provider` to the value it already holds must
+        // report `false` so the caller can skip the index write.
+        let mut session = sample_session();
+        let before = session.clone();
+        let patch = SessionPatch {
+            model_provider: Some(Some("kimi".to_owned())),
+            ..Default::default()
+        };
+        let changed = apply_session_patch(&mut session, &patch);
+        assert!(!changed);
+        assert_eq!(session.model_provider, before.model_provider);
     }
 }
 
@@ -849,11 +934,13 @@ mod update_request_deserialize_tests {
     use crate::chat::UpdateSessionRequest;
 
     #[test]
-    fn absent_model_field_deserializes_to_outer_none() {
+    fn absent_fields_deserialize_to_outer_none() {
         let req: UpdateSessionRequest = serde_json::from_str("{}").expect("parse");
+        assert!(req.title.is_none());
         assert!(req.model.is_none());
         assert!(req.model_provider.is_none());
         assert!(req.thinking_level.is_none());
+        assert!(req.system_prompt.is_none());
     }
 
     #[test]
@@ -872,5 +959,52 @@ mod update_request_deserialize_tests {
                 .expect("parse");
         assert_eq!(req.model, Some(Some("gpt-4o".to_owned())));
         assert_eq!(req.thinking_level, Some(Some("high".to_owned())));
+    }
+
+    #[test]
+    fn title_triple_absent_null_value() {
+        let absent: UpdateSessionRequest = serde_json::from_str("{}").expect("parse");
+        assert!(absent.title.is_none());
+        let null: UpdateSessionRequest = serde_json::from_str(r#"{"title": null}"#).expect("parse");
+        assert_eq!(null.title, Some(None));
+        let value: UpdateSessionRequest =
+            serde_json::from_str(r#"{"title": "hi"}"#).expect("parse");
+        assert_eq!(value.title, Some(Some("hi".to_owned())));
+    }
+
+    #[test]
+    fn model_provider_triple_absent_null_value() {
+        let absent: UpdateSessionRequest = serde_json::from_str("{}").expect("parse");
+        assert!(absent.model_provider.is_none());
+        let null: UpdateSessionRequest =
+            serde_json::from_str(r#"{"model_provider": null}"#).expect("parse");
+        assert_eq!(null.model_provider, Some(None));
+        let value: UpdateSessionRequest =
+            serde_json::from_str(r#"{"model_provider": "openai"}"#).expect("parse");
+        assert_eq!(value.model_provider, Some(Some("openai".to_owned())));
+    }
+
+    #[test]
+    fn thinking_level_triple_absent_null_value() {
+        let absent: UpdateSessionRequest = serde_json::from_str("{}").expect("parse");
+        assert!(absent.thinking_level.is_none());
+        let null: UpdateSessionRequest =
+            serde_json::from_str(r#"{"thinking_level": null}"#).expect("parse");
+        assert_eq!(null.thinking_level, Some(None));
+        let value: UpdateSessionRequest =
+            serde_json::from_str(r#"{"thinking_level": "medium"}"#).expect("parse");
+        assert_eq!(value.thinking_level, Some(Some("medium".to_owned())));
+    }
+
+    #[test]
+    fn system_prompt_triple_absent_null_value() {
+        let absent: UpdateSessionRequest = serde_json::from_str("{}").expect("parse");
+        assert!(absent.system_prompt.is_none());
+        let null: UpdateSessionRequest =
+            serde_json::from_str(r#"{"system_prompt": null}"#).expect("parse");
+        assert_eq!(null.system_prompt, Some(None));
+        let value: UpdateSessionRequest =
+            serde_json::from_str(r#"{"system_prompt": "you are..."}"#).expect("parse");
+        assert_eq!(value.system_prompt, Some(Some("you are...".to_owned())));
     }
 }

--- a/web/src/components/RaraModelDialog.tsx
+++ b/web/src/components/RaraModelDialog.tsx
@@ -15,6 +15,7 @@
  */
 
 import { useEffect, useMemo, useRef, useState } from "react";
+import { RotateCcw } from "lucide-react";
 import {
   Dialog,
   DialogContent,
@@ -38,6 +39,12 @@ interface Props {
   open:              boolean;
   onClose:           () => void;
   onSelect:          (entry: ProviderInfo) => void;
+  /**
+   * Clear the per-session model override so the admin-configured
+   * `llm.default_provider` takes effect on the next turn. Emitted by
+   * the "Use rara's default" row at the top of the picker.
+   */
+  onUseDefault:      () => void;
   currentProvider?:  string | null;
 }
 
@@ -56,6 +63,7 @@ export function RaraModelDialog({
   open,
   onClose,
   onSelect,
+  onUseDefault,
   currentProvider,
 }: Props) {
   const [entries, setEntries] = useState<ProviderInfo[]>([]);
@@ -154,6 +162,28 @@ export function RaraModelDialog({
         />
 
         <div className="max-h-[60vh] overflow-y-auto rounded border border-border">
+          {/*
+            Sits above the filter results so it stays accessible even
+            when the user is typing — the admin "default provider" is
+            the bailout path whenever a session has drifted into a pin
+            the user no longer wants.
+          */}
+          <button
+            className="flex w-full items-center gap-3 border-b border-border/60 bg-muted/30 px-4 py-3 text-left transition-colors hover:bg-secondary/40"
+            onClick={onUseDefault}
+          >
+            <span className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md border border-border/70 bg-background text-muted-foreground">
+              <RotateCcw className="h-3.5 w-3.5" />
+            </span>
+            <span className="flex flex-col">
+              <span className="text-sm font-medium text-foreground">
+                Use rara&apos;s default
+              </span>
+              <span className="text-xs text-muted-foreground">
+                Clear the per-session model and fall back to the admin default provider.
+              </span>
+            </span>
+          </button>
           {loading ? (
             <div className="py-8 text-center text-sm text-muted-foreground">
               Loading…

--- a/web/src/components/RaraModelDialog.tsx
+++ b/web/src/components/RaraModelDialog.tsx
@@ -46,6 +46,12 @@ interface Props {
    */
   onUseDefault:      () => void;
   currentProvider?:  string | null;
+  /**
+   * Optional error surfaced when the caller's `onUseDefault` PATCH
+   * failed. Rendered as a red banner directly above the "Use default"
+   * row so the user can retry without the dialog dismissing.
+   */
+  resetError?:       string | null;
 }
 
 /**
@@ -65,6 +71,7 @@ export function RaraModelDialog({
   onSelect,
   onUseDefault,
   currentProvider,
+  resetError,
 }: Props) {
   const [entries, setEntries] = useState<ProviderInfo[]>([]);
   const [loading, setLoading] = useState(false);
@@ -162,6 +169,14 @@ export function RaraModelDialog({
         />
 
         <div className="max-h-[60vh] overflow-y-auto rounded border border-border">
+          {resetError && (
+            <div
+              className="border-b border-destructive/30 bg-destructive/10 px-4 py-2 text-xs text-destructive"
+              role="alert"
+            >
+              {resetError}
+            </div>
+          )}
           {/*
             Sits above the filter results so it stays accessible even
             when the user is typing — the admin "default provider" is

--- a/web/src/pages/PiChat.tsx
+++ b/web/src/pages/PiChat.tsx
@@ -52,7 +52,7 @@ import type {
 import { RaraStorageBackend } from "@/adapters/rara-storage";
 import { createRaraStreamFn } from "@/adapters/rara-stream";
 import { registerRaraToolRenderers } from "@/tools/rara-tool-renderers";
-import { api } from "@/api/client";
+import { api, settingsApi } from "@/api/client";
 import type { ChatSession, ChatMessageData, ThinkingLevel } from "@/api/types";
 import { useNavigate } from "react-router";
 import { VoiceRecorder } from "@/components/VoiceRecorder";
@@ -452,6 +452,7 @@ export default function PiChat() {
   const [showSessionList, setShowSessionList] = useState(false);
   const [isInitializing, setIsInitializing] = useState(true);
   const [modelDialogOpen, setModelDialogOpen] = useState(false);
+  const [resetError, setResetError] = useState<string | null>(null);
   const navigate = useNavigate();
 
   /** Switch the agent to a different session, loading its history. */
@@ -809,7 +810,7 @@ export default function PiChat() {
       {/* Rara-native model picker — replaces pi-mono's ModelSelector. */}
       <RaraModelDialog
         open={modelDialogOpen}
-        onClose={() => setModelDialogOpen(false)}
+        onClose={() => { setModelDialogOpen(false); setResetError(null); }}
         currentProvider={agentRef.current?.state.model?.provider ?? null}
         onSelect={(entry: ProviderInfo) => {
           const agent = agentRef.current;
@@ -826,30 +827,69 @@ export default function PiChat() {
           }
           setModelDialogOpen(false);
         }}
+        resetError={resetError}
         onUseDefault={() => {
           const agent = agentRef.current;
           const key = agent?.sessionId;
-          setModelDialogOpen(false);
           if (!agent || !key) return;
+          setResetError(null);
           // PATCH with explicit nulls to clear the pinned provider/model
           // and let `llm.default_provider` take over on the next turn.
           // The double-option body is what makes the backend distinguish
           // this from a leave-alone call (see #1569).
+          //
+          // Close the dialog only after the PATCH succeeds — a network
+          // failure keeps the dialog open so the error row is visible
+          // and the user can retry without chasing a dismissed toast.
           api
             .patch(`/api/v1/chat/sessions/${encodeURIComponent(key)}`, {
               model:          null,
               model_provider: null,
               thinking_level: null,
             })
-            .then(() => {
-              // Drop the composer pill back to the "unknown" sentinel so
-              // the UI reads "default" instead of the stale selection.
-              agent.state.model = syntheticModel(UNKNOWN_MODEL_SENTINEL, UNKNOWN_MODEL_SENTINEL);
+            .then(async () => {
+              // Race guard: the user may have switched sessions while
+              // the PATCH was in-flight. If so, the composer now
+              // reflects a different session and must not be clobbered.
+              if (agentRef.current?.sessionId !== key) {
+                setModelDialogOpen(false);
+                return;
+              }
+              // Resolve the admin-configured default so the composer
+              // pill can read e.g. "codex: codex-mini" instead of the
+              // "unknown" sentinel. PiChat does not already consume
+              // react-query so we fire a one-shot request — failures
+              // here are non-fatal and fall back to the sentinel.
+              let resolvedModel = syntheticModel(
+                UNKNOWN_MODEL_SENTINEL,
+                UNKNOWN_MODEL_SENTINEL,
+              );
+              try {
+                const settings = await settingsApi.list();
+                const provider = settings["llm.default_provider"]?.trim();
+                const model = provider
+                  ? settings[`llm.providers.${provider}.default_model`]?.trim()
+                  : undefined;
+                if (provider && model) {
+                  resolvedModel = syntheticModel(provider, model);
+                }
+              } catch (e: unknown) {
+                console.warn("Failed to resolve admin default provider:", e);
+              }
+              // Re-check the race guard after the settings fetch.
+              if (agentRef.current?.sessionId !== key) {
+                setModelDialogOpen(false);
+                return;
+              }
+              agent.state.model = resolvedModel;
               lastPersistedRef.current = { model: null, provider: null, thinking: null };
               chatPanelRef.current?.agentInterface?.requestUpdate();
+              setModelDialogOpen(false);
             })
             .catch((e: unknown) => {
               console.warn("Failed to clear session model override:", e);
+              const msg = e instanceof Error ? e.message : String(e);
+              setResetError(`Failed to reset model: ${msg}`);
             });
         }}
       />

--- a/web/src/pages/PiChat.tsx
+++ b/web/src/pages/PiChat.tsx
@@ -58,7 +58,7 @@ import { useNavigate } from "react-router";
 import { VoiceRecorder } from "@/components/VoiceRecorder";
 import { RaraModelDialog } from "@/components/RaraModelDialog";
 import type { ProviderInfo } from "@/api/types";
-import { isUnknownModel, syntheticModel } from "@/lib/synthetic-model";
+import { UNKNOWN_MODEL_SENTINEL, isUnknownModel, syntheticModel } from "@/lib/synthetic-model";
 
 /**
  * True when the given provider id is still present in rara's routable
@@ -825,6 +825,32 @@ export default function PiChat() {
             chatPanelRef.current?.agentInterface?.requestUpdate();
           }
           setModelDialogOpen(false);
+        }}
+        onUseDefault={() => {
+          const agent = agentRef.current;
+          const key = agent?.sessionId;
+          setModelDialogOpen(false);
+          if (!agent || !key) return;
+          // PATCH with explicit nulls to clear the pinned provider/model
+          // and let `llm.default_provider` take over on the next turn.
+          // The double-option body is what makes the backend distinguish
+          // this from a leave-alone call (see #1569).
+          api
+            .patch(`/api/v1/chat/sessions/${encodeURIComponent(key)}`, {
+              model:          null,
+              model_provider: null,
+              thinking_level: null,
+            })
+            .then(() => {
+              // Drop the composer pill back to the "unknown" sentinel so
+              // the UI reads "default" instead of the stale selection.
+              agent.state.model = syntheticModel(UNKNOWN_MODEL_SENTINEL, UNKNOWN_MODEL_SENTINEL);
+              lastPersistedRef.current = { model: null, provider: null, thinking: null };
+              chatPanelRef.current?.agentInterface?.requestUpdate();
+            })
+            .catch((e: unknown) => {
+              console.warn("Failed to clear session model override:", e);
+            });
         }}
       />
     </div>

--- a/web/src/pages/PiChat.tsx
+++ b/web/src/pages/PiChat.tsx
@@ -449,11 +449,24 @@ export default function PiChat() {
   // from the pre-#1554 selector). `null` = not yet loaded; we fail-open
   // in that window so the restore isn't blocked on an unrelated fetch.
   const validProvidersRef = useRef<Set<string> | null>(null);
+  // Guards against double-invocations of `handleUseDefault` while a PATCH
+  // + settings fetch is still in flight. Backend no-ops the duplicate
+  // write (see #1569 round-1 fix) but the UI would still redundantly
+  // refetch settings and reset the composer state.
+  const resetInflight = useRef(false);
   const [showSessionList, setShowSessionList] = useState(false);
   const [isInitializing, setIsInitializing] = useState(true);
   const [modelDialogOpen, setModelDialogOpen] = useState(false);
   const [resetError, setResetError] = useState<string | null>(null);
   const navigate = useNavigate();
+
+  // Clear any stale reset-error banner whenever the model dialog is
+  // closed — regardless of close path (backdrop click, successful
+  // select, successful reset). Co-locating the clear here prevents the
+  // banner from leaking into the next dialog opening.
+  useEffect(() => {
+    if (!modelDialogOpen) setResetError(null);
+  }, [modelDialogOpen]);
 
   /** Switch the agent to a different session, loading its history. */
   const switchSession = useCallback(async (session: ChatSession) => {
@@ -548,6 +561,92 @@ export default function PiChat() {
     },
     [newSession],
   );
+
+  /**
+   * Reset the session's pinned (model, provider, thinking) triple so the
+   * backend falls back to `llm.default_provider` on the next turn, then
+   * mirror the admin-configured default into the composer pill. Guarded
+   * by `resetInflight` so a double-click cannot fire two PATCH + settings
+   * fetch round-trips. Deps are empty because the closure only reads
+   * mutable refs (`agentRef`, `chatPanelRef`, `lastPersistedRef`,
+   * `resetInflight`) and stable state setters.
+   */
+  const handleUseDefault = useCallback(async () => {
+    if (resetInflight.current) return;
+    resetInflight.current = true;
+    const agent = agentRef.current;
+    const key = agent?.sessionId;
+    if (!agent || !key) {
+      resetInflight.current = false;
+      return;
+    }
+    setResetError(null);
+    // PATCH with explicit nulls to clear the pinned provider/model
+    // and let `llm.default_provider` take over on the next turn.
+    // The double-option body is what makes the backend distinguish
+    // this from a leave-alone call (see #1569).
+    //
+    // Close the dialog only after the PATCH succeeds — a network
+    // failure keeps the dialog open so the error row is visible
+    // and the user can retry without chasing a dismissed toast.
+    try {
+      await api.patch(`/api/v1/chat/sessions/${encodeURIComponent(key)}`, {
+        model:          null,
+        model_provider: null,
+        thinking_level: null,
+      });
+      // Race guard: the user may have switched sessions while
+      // the PATCH was in-flight. If so, the composer now
+      // reflects a different session and must not be clobbered.
+      if (agentRef.current?.sessionId !== key) {
+        setModelDialogOpen(false);
+        return;
+      }
+      // Resolve the admin-configured default so the composer
+      // pill can read e.g. "codex: codex-mini" instead of the
+      // "unknown" sentinel. PiChat does not already consume
+      // react-query so we fire a one-shot request — failures
+      // here are non-fatal and fall back to the sentinel.
+      let resolvedModel = syntheticModel(
+        UNKNOWN_MODEL_SENTINEL,
+        UNKNOWN_MODEL_SENTINEL,
+      );
+      try {
+        const settings = await settingsApi.list();
+        const provider = settings["llm.default_provider"]?.trim();
+        const model = provider
+          ? settings[`llm.providers.${provider}.default_model`]?.trim()
+          : undefined;
+        if (provider && model) {
+          resolvedModel = syntheticModel(provider, model);
+        } else if (provider) {
+          // Admin set a default provider but forgot the paired
+          // `default_model` key — surface during development so the
+          // misconfig is caught before users see the unknown sentinel.
+          console.warn(
+            `Admin default provider \`${provider}\` has no default_model set — composer pill will show unknown.`,
+          );
+        }
+      } catch (e: unknown) {
+        console.warn("Failed to resolve admin default provider:", e);
+      }
+      // Re-check the race guard after the settings fetch.
+      if (agentRef.current?.sessionId !== key) {
+        setModelDialogOpen(false);
+        return;
+      }
+      agent.state.model = resolvedModel;
+      lastPersistedRef.current = { model: null, provider: null, thinking: null };
+      chatPanelRef.current?.agentInterface?.requestUpdate();
+      setModelDialogOpen(false);
+    } catch (e: unknown) {
+      console.warn("Failed to clear session model override:", e);
+      const msg = e instanceof Error ? e.message : String(e);
+      setResetError(`Failed to reset model: ${msg}`);
+    } finally {
+      resetInflight.current = false;
+    }
+  }, []);
 
   useEffect(() => {
     if (initRef.current || !containerRef.current) return;
@@ -810,7 +909,7 @@ export default function PiChat() {
       {/* Rara-native model picker — replaces pi-mono's ModelSelector. */}
       <RaraModelDialog
         open={modelDialogOpen}
-        onClose={() => { setModelDialogOpen(false); setResetError(null); }}
+        onClose={() => setModelDialogOpen(false)}
         currentProvider={agentRef.current?.state.model?.provider ?? null}
         onSelect={(entry: ProviderInfo) => {
           const agent = agentRef.current;
@@ -828,70 +927,7 @@ export default function PiChat() {
           setModelDialogOpen(false);
         }}
         resetError={resetError}
-        onUseDefault={() => {
-          const agent = agentRef.current;
-          const key = agent?.sessionId;
-          if (!agent || !key) return;
-          setResetError(null);
-          // PATCH with explicit nulls to clear the pinned provider/model
-          // and let `llm.default_provider` take over on the next turn.
-          // The double-option body is what makes the backend distinguish
-          // this from a leave-alone call (see #1569).
-          //
-          // Close the dialog only after the PATCH succeeds — a network
-          // failure keeps the dialog open so the error row is visible
-          // and the user can retry without chasing a dismissed toast.
-          api
-            .patch(`/api/v1/chat/sessions/${encodeURIComponent(key)}`, {
-              model:          null,
-              model_provider: null,
-              thinking_level: null,
-            })
-            .then(async () => {
-              // Race guard: the user may have switched sessions while
-              // the PATCH was in-flight. If so, the composer now
-              // reflects a different session and must not be clobbered.
-              if (agentRef.current?.sessionId !== key) {
-                setModelDialogOpen(false);
-                return;
-              }
-              // Resolve the admin-configured default so the composer
-              // pill can read e.g. "codex: codex-mini" instead of the
-              // "unknown" sentinel. PiChat does not already consume
-              // react-query so we fire a one-shot request — failures
-              // here are non-fatal and fall back to the sentinel.
-              let resolvedModel = syntheticModel(
-                UNKNOWN_MODEL_SENTINEL,
-                UNKNOWN_MODEL_SENTINEL,
-              );
-              try {
-                const settings = await settingsApi.list();
-                const provider = settings["llm.default_provider"]?.trim();
-                const model = provider
-                  ? settings[`llm.providers.${provider}.default_model`]?.trim()
-                  : undefined;
-                if (provider && model) {
-                  resolvedModel = syntheticModel(provider, model);
-                }
-              } catch (e: unknown) {
-                console.warn("Failed to resolve admin default provider:", e);
-              }
-              // Re-check the race guard after the settings fetch.
-              if (agentRef.current?.sessionId !== key) {
-                setModelDialogOpen(false);
-                return;
-              }
-              agent.state.model = resolvedModel;
-              lastPersistedRef.current = { model: null, provider: null, thinking: null };
-              chatPanelRef.current?.agentInterface?.requestUpdate();
-              setModelDialogOpen(false);
-            })
-            .catch((e: unknown) => {
-              console.warn("Failed to clear session model override:", e);
-              const msg = e instanceof Error ? e.message : String(e);
-              setResetError(`Failed to reset model: ${msg}`);
-            });
-        }}
+        onUseDefault={handleUseDefault}
       />
     </div>
   );

--- a/web/src/pages/Settings.tsx
+++ b/web/src/pages/Settings.tsx
@@ -843,6 +843,10 @@ export default function Settings() {
                       ))}
                     </SelectContent>
                   </Select>
+                  <p className="text-xs text-muted-foreground">
+                    Applies to new sessions and sessions with no explicit model override.
+                    Use the model picker&apos;s &quot;Use rara&apos;s default&quot; entry to clear a pinned session.
+                  </p>
                 </div>
 
                 <div className="flex items-center justify-between pt-2">


### PR DESCRIPTION
## Summary

Fixes the "admin page switch provider 不生效" bug reported in #1569: a chat session that had ever picked a specific model was permanently pinned to it, and there was no UI path to drop the pin so the admin `llm.default_provider` could take effect again.

- Switch `UpdateSessionRequest` to `Option<Option<String>>` so serde distinguishes **absent** (leave alone) from **explicit null** (clear) from **value** (set); the OpenAPI schema renders as `nullable: true` via `#[schema(value_type = Option<String>, nullable)]`.
- Thread the double-option through `SessionService::update_session_fields` and extract the per-field branching into a pure `apply_session_patch` helper so it is unit-testable without tape storage.
- Add a "Use rara's default" row to `RaraModelDialog` that PATCHes `{model: null, model_provider: null, thinking_level: null}` and resets the composer pill to the pi-agent-core unknown sentinel.
- Note under the admin Default Provider select that it applies to new sessions and sessions with no explicit override.
- Cover the patch helper and the three request-shape variants with unit tests.

## Type of change

| Type | Label |
|------|-------|
| New feature | `enhancement` |

## Component

`backend`, `ui`

## Closes

Closes #1569

## Test plan

- [x] `cargo check -p rara-backend-admin --all-targets`
- [x] `cargo test -p rara-backend-admin --lib` (12 passed)
- [x] `cargo +nightly fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings`
- [x] `RUSTDOCFLAGS="-D warnings" cargo +nightly doc --workspace --no-deps --document-private-items`
- [x] `cd web && npm run build`