### PR TITLE
fix(web): surface agent errors via WebEvent (#1573)

### DIFF
--- a/crates/channels/src/telegram/adapter.rs
+++ b/crates/channels/src/telegram/adapter.rs
@@ -1386,6 +1386,17 @@ impl ChannelAdapter for TelegramAdapter {
             }
         };
 
+        // Telegram has no typed error frame — collapse Error into a
+        // plain Reply so users still see the failure as a text bubble.
+        let msg = match msg {
+            PlatformOutbound::Error { code, message } => PlatformOutbound::Reply {
+                content:       format!("Error [{code}]: {message}"),
+                attachments:   vec![],
+                reply_context: None,
+            },
+            other => other,
+        };
+
         match msg {
             PlatformOutbound::Reply {
                 content,
@@ -1612,6 +1623,9 @@ impl ChannelAdapter for TelegramAdapter {
                 );
                 let _ = req.await;
             }
+            // Already rewritten to Reply above — kept exhaustive so the
+            // compiler catches any new PlatformOutbound variant.
+            PlatformOutbound::Error { .. } => unreachable!("Error collapsed to Reply above"),
         }
 
         Ok(())

--- a/crates/channels/src/telegram/adapter.rs
+++ b/crates/channels/src/telegram/adapter.rs
@@ -1342,6 +1342,38 @@ impl TelegramAdapter {
         }
     }
 
+    /// Send plain text as one or more HTML-formatted Telegram messages.
+    ///
+    /// Used for `PlatformOutbound::Error` (Telegram has no typed error frame)
+    /// — applies markdown-to-HTML conversion and 4096-byte chunking without
+    /// any of `Reply`'s stream-coalescing, reply-context, or reply-keyboard
+    /// logic, which don't apply to error frames.
+    async fn send_plain_text_reply(
+        &self,
+        chat_id: i64,
+        thread_id: Option<i64>,
+        content: &str,
+    ) -> Result<(), EgressError> {
+        if content.is_empty() {
+            return Ok(());
+        }
+        let html = crate::telegram::markdown::markdown_to_telegram_html(content);
+        let chunks = crate::telegram::markdown::chunk_message(&html, 4096);
+        for chunk in &chunks {
+            self.rate_limiter.acquire(chat_id).await;
+            let req = with_thread_id!(
+                self.bot
+                    .send_message(ChatId(chat_id), chunk)
+                    .parse_mode(ParseMode::Html),
+                thread_id
+            );
+            req.await.map_err(|e| EgressError::DeliveryFailed {
+                message: format!("failed to send telegram message: {e}"),
+            })?;
+        }
+        Ok(())
+    }
+
     /// Synthesize speech from `text` and send it as a Telegram voice note.
     ///
     /// Returns `true` if the voice note was sent successfully. On any failure
@@ -1386,18 +1418,14 @@ impl ChannelAdapter for TelegramAdapter {
             }
         };
 
-        // Telegram has no typed error frame — collapse Error into a
-        // plain Reply so users still see the failure as a text bubble.
-        let msg = match msg {
-            PlatformOutbound::Error { code, message } => PlatformOutbound::Reply {
-                content:       format!("Error [{code}]: {message}"),
-                attachments:   vec![],
-                reply_context: None,
-            },
-            other => other,
-        };
-
         match msg {
+            // Telegram has no typed error frame — render as plain text via
+            // the dedicated helper (bypasses stream-coalescing / keyboard
+            // logic that only makes sense for `Reply`).
+            PlatformOutbound::Error { code, message } => {
+                let text = format!("Error [{code}]: {message}");
+                return self.send_plain_text_reply(chat_id, thread_id, &text).await;
+            }
             PlatformOutbound::Reply {
                 content,
                 reply_context,
@@ -1623,9 +1651,6 @@ impl ChannelAdapter for TelegramAdapter {
                 );
                 let _ = req.await;
             }
-            // Already rewritten to Reply above — kept exhaustive so the
-            // compiler catches any new PlatformOutbound variant.
-            PlatformOutbound::Error { .. } => unreachable!("Error collapsed to Reply above"),
         }
 
         Ok(())

--- a/crates/channels/src/terminal.rs
+++ b/crates/channels/src/terminal.rs
@@ -164,6 +164,9 @@ impl ChannelAdapter for TerminalAdapter {
             PlatformOutbound::Reply { content, .. } => CliEvent::Reply { content },
             PlatformOutbound::StreamChunk { delta, .. } => CliEvent::TextDelta { text: delta },
             PlatformOutbound::Progress { text } => CliEvent::Progress { text },
+            PlatformOutbound::Error { code, message } => CliEvent::Error {
+                message: format!("Error [{code}]: {message}"),
+            },
         };
 
         self.send_event(event);

--- a/crates/channels/src/web.rs
+++ b/crates/channels/src/web.rs
@@ -196,6 +196,18 @@ pub struct SessionQuery {
 
 fn default_user_id() -> String { "anonymous".to_owned() }
 
+/// Map an egress [`PlatformOutbound`] into the [`WebEvent`] frame the
+/// browser consumes. Kept pure so adapter behaviour is unit-testable
+/// without spinning up the broadcast channel.
+fn platform_outbound_to_web_event(msg: PlatformOutbound) -> WebEvent {
+    match msg {
+        PlatformOutbound::Reply { content, .. } => WebEvent::Message { content },
+        PlatformOutbound::StreamChunk { delta, .. } => WebEvent::TextDelta { text: delta },
+        PlatformOutbound::Progress { text } => WebEvent::Progress { stage: text },
+        PlatformOutbound::Error { message, .. } => WebEvent::Error { message },
+    }
+}
+
 fn stream_event_to_web_event(event: StreamEvent) -> Option<WebEvent> {
     match event {
         StreamEvent::TextDelta { text } => Some(WebEvent::TextDelta { text }),
@@ -1179,12 +1191,7 @@ impl ChannelAdapter for WebAdapter {
             _ => return Ok(()),
         };
 
-        let event = match msg {
-            PlatformOutbound::Reply { content, .. } => WebEvent::Message { content },
-            PlatformOutbound::StreamChunk { delta, .. } => WebEvent::TextDelta { text: delta },
-            PlatformOutbound::Progress { text } => WebEvent::Progress { stage: text },
-        };
-
+        let event = platform_outbound_to_web_event(msg);
         WebAdapter::broadcast_event(&self.sessions, broadcast_key, &event);
         Ok(())
     }
@@ -1228,11 +1235,12 @@ impl ChannelAdapter for WebAdapter {
 mod tests {
     use rara_kernel::{
         channel::types::{ContentBlock, MessageContent},
-        io::StreamEvent,
+        io::{PlatformOutbound, StreamEvent},
     };
 
     use super::{
-        SendMessageRequest, WebEvent, parse_inbound_text_frame, stream_event_to_web_event,
+        SendMessageRequest, WebEvent, parse_inbound_text_frame, platform_outbound_to_web_event,
+        stream_event_to_web_event,
     };
 
     #[test]
@@ -1357,6 +1365,27 @@ mod tests {
                         && filename.as_deref() == Some("spec.pdf")
                 )
         ));
+    }
+
+    #[test]
+    fn platform_error_maps_to_web_error_frame() {
+        let event = platform_outbound_to_web_event(PlatformOutbound::Error {
+            code:    "agent_error".to_owned(),
+            message: "model rejected reasoning=minimal".to_owned(),
+        });
+
+        match &event {
+            WebEvent::Error { message } => {
+                assert_eq!(message, "model rejected reasoning=minimal");
+            }
+            other => panic!("expected WebEvent::Error, got {other:?}"),
+        }
+
+        // The wire format is what the frontend actually parses — lock it
+        // down so a future serde rename can't silently break rara-stream.ts.
+        let json = serde_json::to_value(&event).expect("serialize");
+        assert_eq!(json["type"], "error");
+        assert_eq!(json["message"], "model rejected reasoning=minimal");
     }
 
     #[test]

--- a/crates/channels/src/wechat/adapter.rs
+++ b/crates/channels/src/wechat/adapter.rs
@@ -285,6 +285,22 @@ impl ChannelAdapter for WechatAdapter {
             }
             // WeChat does not support streaming edits.
             PlatformOutbound::StreamChunk { .. } => {}
+            PlatformOutbound::Error { code, message } => {
+                let token = context_token.ok_or_else(|| EgressError::DeliveryFailed {
+                    message: format!(
+                        "no context_token cached for wechat user {user_id} — cannot send error \
+                         without a prior inbound message"
+                    ),
+                })?;
+                let plain = format!("Error [{code}]: {message}");
+                let result = self
+                    .send_client
+                    .send_text_message(&self.bot_user_id, &user_id, &token, &plain)
+                    .await;
+                result.map_err(|e| EgressError::DeliveryFailed {
+                    message: format!("wechat send_text_message failed: {e}"),
+                })?;
+            }
         }
 
         Ok(())

--- a/crates/channels/src/wechat/adapter.rs
+++ b/crates/channels/src/wechat/adapter.rs
@@ -105,6 +105,43 @@ impl WechatAdapter {
             poll_handle: Mutex::new(None),
         })
     }
+
+    /// Send `text` to `user_id` via the iLink text-message API.
+    ///
+    /// Requires a cached `context_token` from a prior inbound message —
+    /// WeChat has no way to initiate a conversation from the bot side.
+    /// Returns `EgressError::DeliveryFailed` if the token is missing or
+    /// the API call fails. Shared last-mile send path for both `Reply`
+    /// and `Error` outbound frames.
+    async fn send_plain_text(
+        &self,
+        user_id: &str,
+        context_token: Option<&str>,
+        text: &str,
+    ) -> Result<(), EgressError> {
+        let token = context_token.ok_or_else(|| EgressError::DeliveryFailed {
+            message: format!(
+                "no context_token cached for wechat user {user_id} — cannot send without a prior \
+                 inbound message"
+            ),
+        })?;
+        // iLink protocol: from_user_id = bot, to_user_id = recipient.
+        // The context_token ties the reply to the conversation.
+        info!(
+            from = %self.bot_user_id,
+            to = %user_id,
+            text_len = text.len(),
+            "sending wechat text message"
+        );
+        let result = self
+            .send_client
+            .send_text_message(&self.bot_user_id, user_id, token, text)
+            .await;
+        info!(?result, "wechat send_text_message result");
+        result.map(|_| ()).map_err(|e| EgressError::DeliveryFailed {
+            message: format!("wechat send_text_message failed: {e}"),
+        })
+    }
 }
 
 #[async_trait]
@@ -246,29 +283,9 @@ impl ChannelAdapter for WechatAdapter {
 
         match msg {
             PlatformOutbound::Reply { content, .. } => {
-                let token = context_token.ok_or_else(|| EgressError::DeliveryFailed {
-                    message: format!(
-                        "no context_token cached for wechat user {user_id} — cannot send without \
-                         a prior inbound message"
-                    ),
-                })?;
                 let plain = markdown_to_plain_text(&content);
-                // iLink protocol: from_user_id = bot, to_user_id = recipient.
-                // The context_token ties the reply to the conversation.
-                info!(
-                    from = %self.bot_user_id,
-                    to = %user_id,
-                    text_len = plain.len(),
-                    "sending wechat reply"
-                );
-                let result = self
-                    .send_client
-                    .send_text_message(&self.bot_user_id, &user_id, &token, &plain)
-                    .await;
-                info!(?result, "wechat send_text_message result");
-                result.map_err(|e| EgressError::DeliveryFailed {
-                    message: format!("wechat send_text_message failed: {e}"),
-                })?;
+                self.send_plain_text(&user_id, context_token.as_deref(), &plain)
+                    .await?;
             }
             PlatformOutbound::Progress { .. } => {
                 // Kernel sends Progress as typing indicator. Trigger the
@@ -286,20 +303,9 @@ impl ChannelAdapter for WechatAdapter {
             // WeChat does not support streaming edits.
             PlatformOutbound::StreamChunk { .. } => {}
             PlatformOutbound::Error { code, message } => {
-                let token = context_token.ok_or_else(|| EgressError::DeliveryFailed {
-                    message: format!(
-                        "no context_token cached for wechat user {user_id} — cannot send error \
-                         without a prior inbound message"
-                    ),
-                })?;
                 let plain = format!("Error [{code}]: {message}");
-                let result = self
-                    .send_client
-                    .send_text_message(&self.bot_user_id, &user_id, &token, &plain)
-                    .await;
-                result.map_err(|e| EgressError::DeliveryFailed {
-                    message: format!("wechat send_text_message failed: {e}"),
-                })?;
+                self.send_plain_text(&user_id, context_token.as_deref(), &plain)
+                    .await?;
             }
         }
 

--- a/crates/kernel/src/io.rs
+++ b/crates/kernel/src/io.rs
@@ -449,10 +449,9 @@ impl OutboundEnvelope {
             OutboundPayload::Progress { stage, detail } => PlatformOutbound::Progress {
                 text: detail.as_deref().unwrap_or(stage).to_string(),
             },
-            OutboundPayload::Error { code, message } => PlatformOutbound::Reply {
-                content:       format!("Error [{}]: {}", code, message),
-                attachments:   vec![],
-                reply_context: None,
+            OutboundPayload::Error { code, message } => PlatformOutbound::Error {
+                code:    code.clone(),
+                message: message.clone(),
             },
         }
     }
@@ -1436,6 +1435,16 @@ pub enum PlatformOutbound {
         /// Progress text.
         text: String,
     },
+    /// A terminal error for the turn. Channels that support typed error
+    /// frames (web, ACP) render this as a failed-message indicator;
+    /// legacy channels (Telegram, WeChat, terminal) fall back to a plain
+    /// text reply formatted as `"Error [{code}]: {message}"`.
+    Error {
+        /// Short error code (e.g. `"agent_error"`, `"rate_limited"`).
+        code:    String,
+        /// Human-readable error message.
+        message: String,
+    },
 }
 
 // ---------------------------------------------------------------------------
@@ -2037,6 +2046,31 @@ fn resolve_delivery_targets(candidates: Vec<Endpoint>, routing: &OutboundRouting
             .into_iter()
             .filter(|e| channels.contains(&e.channel_type))
             .collect(),
+    }
+}
+
+#[cfg(test)]
+mod outbound_payload_tests {
+    use super::*;
+    use crate::identity::UserId;
+
+    #[test]
+    fn error_envelope_produces_typed_platform_error() {
+        let envelope = OutboundEnvelope::error(
+            MessageId::new(),
+            UserId("u".into()),
+            crate::session::SessionKey::new(),
+            "agent_error",
+            "model rejected reasoning=minimal",
+        );
+
+        match envelope.to_platform_outbound() {
+            PlatformOutbound::Error { code, message } => {
+                assert_eq!(code, "agent_error");
+                assert_eq!(message, "model rejected reasoning=minimal");
+            }
+            other => panic!("expected PlatformOutbound::Error, got {other:?}"),
+        }
     }
 }
 

--- a/crates/kernel/src/io.rs
+++ b/crates/kernel/src/io.rs
@@ -1436,8 +1436,8 @@ pub enum PlatformOutbound {
         text: String,
     },
     /// A terminal error for the turn. Channels that support typed error
-    /// frames (web, ACP) render this as a failed-message indicator;
-    /// legacy channels (Telegram, WeChat, terminal) fall back to a plain
+    /// frames (currently: web) render this as a failed-message indicator;
+    /// other channels (Telegram, WeChat, terminal) fall back to a plain
     /// text reply formatted as `"Error [{code}]: {message}"`.
     Error {
         /// Short error code (e.g. `"agent_error"`, `"rate_limited"`).
@@ -2070,6 +2070,48 @@ mod outbound_payload_tests {
                 assert_eq!(message, "model rejected reasoning=minimal");
             }
             other => panic!("expected PlatformOutbound::Error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn reply_envelope_produces_typed_platform_reply() {
+        let envelope = OutboundEnvelope::reply(
+            MessageId::new(),
+            UserId("u".into()),
+            crate::session::SessionKey::new(),
+            crate::channel::types::MessageContent::Text("hello world".into()),
+            vec![],
+        );
+
+        match envelope.to_platform_outbound() {
+            PlatformOutbound::Reply {
+                content,
+                attachments,
+                reply_context,
+            } => {
+                assert_eq!(content, "hello world");
+                assert!(attachments.is_empty());
+                assert!(reply_context.is_none());
+            }
+            other => panic!("expected PlatformOutbound::Reply, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn progress_envelope_produces_typed_platform_progress() {
+        let envelope = OutboundEnvelope::progress(
+            MessageId::new(),
+            UserId("u".into()),
+            crate::session::SessionKey::new(),
+            "thinking",
+            Some("running tool xyz".to_string()),
+        );
+
+        match envelope.to_platform_outbound() {
+            PlatformOutbound::Progress { text } => {
+                assert_eq!(text, "running tool xyz");
+            }
+            other => panic!("expected PlatformOutbound::Progress, got {other:?}"),
         }
     }
 }


### PR DESCRIPTION
## Summary

Preserve the agent-error shape end-to-end so web users see failed turns instead of a silent chat.

- Add `PlatformOutbound::Error { code, message }` — the kernel already built `OutboundEnvelope::error(...)`, but `to_platform_outbound` collapsed it into a stringified `Reply`, erasing the signal before any adapter saw it.
- Web adapter maps `PlatformOutbound::Error` → `WebEvent::Error { message }`. The `rara-stream.ts` front-end already consumes that frame (sets `stopReason: "error"` + `errorMessage`) — nothing else produced it until now.
- Telegram / WeChat / terminal adapters preserve today's UX by rendering the same `"Error [{code}]: {message}"` text that a stringified `Reply` used to carry.
- Factored `platform_outbound_to_web_event` out of the inline `match` so adapter mapping is unit-testable without the broadcast channel.

## Cleanup race (step 5 in the brief)

Investigated and did **not** patch. Rationale:

- `IoSubsystem::deliver` (`crates/kernel/src/io.rs:1733`) always `tokio::spawn`s the egress work — delivery is decoupled from the kernel event loop for every payload type, including the existing `Reply`.
- `cleanup_process` (`crates/kernel/src/kernel.rs:1235`) only runs for child agents with a `result_tx`. Regular web sessions hit the long-lived `Ready` path (`kernel.rs:3027-3030`) and never call `cleanup_process` on turn failure.
- For child agents the same race is latent in the existing `Reply` delivery — it is not a new regression introduced by this PR, and the typed `WebEvent::Error` alone resolves the symptom described in #1573.

Flagging but not fixing here to keep the PR focused on the visible bug.

## Type of change

| Type    | Label |
|---------|-------|
| Bug fix | `bug` |

## Component

`core`, `ui`

## Closes

Closes #1573

## Test plan

- [x] `cargo test -p rara-kernel --lib outbound_payload` — new test asserts `OutboundEnvelope::error().to_platform_outbound()` returns typed `PlatformOutbound::Error`.
- [x] `cargo test -p rara-channels --lib` — new test locks in the `{"type":"error","message":"..."}` wire format consumed by `rara-stream.ts`.
- [x] `cargo check --all --all-targets` passes.
- [x] `cargo +nightly fmt -- --check` passes.
- [x] `cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings` passes.
- [x] `RUSTDOCFLAGS="-D warnings" cargo +nightly doc --workspace --no-deps --document-private-items` passes.
- [x] `web/ npm run build` passes.