### PR TITLE
feat(channels): /model 弹 inline keyboard 列表 (#1575)

### DIFF
--- a/crates/app/src/lib.rs
+++ b/crates/app/src/lib.rs
@@ -745,6 +745,7 @@ pub async fn start_with_options(
             rara.tape_service.clone(),
             kernel_handle.clone(),
             rara.mcp_manager.clone(),
+            rara.model_lister.clone(),
         ))
     };
 
@@ -802,9 +803,10 @@ pub async fn start_with_options(
         // Register callback handlers for inline keyboard interactions.
         {
             use rara_channels::telegram::commands::{
-                SessionDeleteCallbackHandler, SessionDeleteCancelHandler,
-                SessionDeleteConfirmHandler, SessionDetailCallbackHandler,
-                SessionSwitchCallbackHandler, StatusJobsCallbackHandler,
+                ModelSwitchCallbackHandler, SessionDeleteCallbackHandler,
+                SessionDeleteCancelHandler, SessionDeleteConfirmHandler,
+                SessionDetailCallbackHandler, SessionSwitchCallbackHandler,
+                StatusJobsCallbackHandler,
             };
             let callback_handlers: Vec<
                 std::sync::Arc<dyn rara_kernel::channel::command::CallbackHandler>,
@@ -814,6 +816,7 @@ pub async fn start_with_options(
                 std::sync::Arc::new(SessionDeleteCallbackHandler::new(bot_client.clone())),
                 std::sync::Arc::new(SessionDeleteConfirmHandler::new(bot_client.clone())),
                 std::sync::Arc::new(SessionDeleteCancelHandler::new()),
+                std::sync::Arc::new(ModelSwitchCallbackHandler::new(bot_client.clone())),
                 std::sync::Arc::new(StatusJobsCallbackHandler::new(kernel_handle.clone())),
             ];
             tg_adapter.set_callback_handlers(callback_handlers);

--- a/crates/channels/src/telegram/commands/callbacks.rs
+++ b/crates/channels/src/telegram/commands/callbacks.rs
@@ -90,6 +90,66 @@ impl CallbackHandler for SessionSwitchCallbackHandler {
 }
 
 // ---------------------------------------------------------------------------
+// ModelSwitchCallbackHandler
+// ---------------------------------------------------------------------------
+
+/// Handles `model:{model_id}` callback queries from the `/model` inline
+/// keyboard — switches the current session's model override.
+pub struct ModelSwitchCallbackHandler {
+    client: Arc<dyn BotServiceClient>,
+}
+
+impl ModelSwitchCallbackHandler {
+    /// Create a new handler backed by the given service client.
+    pub fn new(client: Arc<dyn BotServiceClient>) -> Self { Self { client } }
+}
+
+#[async_trait]
+impl CallbackHandler for ModelSwitchCallbackHandler {
+    fn prefix(&self) -> &str { "model:" }
+
+    async fn handle(&self, context: &CallbackContext) -> Result<CallbackResult, KernelError> {
+        let model_id = &context.data["model:".len()..];
+        let chat_id = super::extract_chat_id(&context.metadata)?;
+        let thread_id = super::extract_thread_id(&context.metadata);
+
+        let session_key = match self
+            .client
+            .get_channel_session("telegram", &chat_id, thread_id.as_deref())
+            .await
+        {
+            Ok(Some(binding)) => binding.session_key,
+            Ok(None) => {
+                return Ok(CallbackResult::SendMessage {
+                    text: "No active session. Send a message to create one.".to_owned(),
+                });
+            }
+            Err(e) => {
+                return Ok(CallbackResult::SendMessage {
+                    text: format!("Failed to resolve session: {e}"),
+                });
+            }
+        };
+
+        match self
+            .client
+            .update_session(&session_key, Some(model_id))
+            .await
+        {
+            Ok(detail) => {
+                let model = detail.model.as_deref().unwrap_or(model_id);
+                Ok(CallbackResult::EditMessage {
+                    text: format!("\u{2705} Model switched to <b>{}</b>", html_escape(model)),
+                })
+            }
+            Err(e) => Ok(CallbackResult::SendMessage {
+                text: format!("Failed to switch model: {e}"),
+            }),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
 // SessionDetailCallbackHandler
 // ---------------------------------------------------------------------------
 

--- a/crates/channels/src/telegram/commands/client.rs
+++ b/crates/channels/src/telegram/commands/client.rs
@@ -80,6 +80,17 @@ pub struct SessionDetail {
     pub updated_at:    String,
 }
 
+/// A chat model entry surfaced to users (e.g. by `/model`).
+#[derive(Debug, Clone)]
+pub struct ChatModelItem {
+    /// Provider model identifier (e.g. `"openai/gpt-4o"`).
+    pub id:             String,
+    /// Human-friendly display name.
+    pub name:           String,
+    /// Maximum context window in tokens, when known.
+    pub context_length: Option<u32>,
+}
+
 /// A job discovered through the search API.
 #[derive(Debug, Clone, Deserialize)]
 pub struct DiscoveryJob {
@@ -269,4 +280,9 @@ pub trait BotServiceClient: Send + Sync {
 
     /// Delete a session and all associated data (metadata, tape, bindings).
     async fn delete_session(&self, key: &str) -> Result<(), BotServiceError>;
+
+    // -- LLM models ---------------------------------------------------------
+
+    /// List chat models the user can switch to (e.g. for `/model`).
+    async fn list_chat_models(&self) -> Result<Vec<ChatModelItem>, BotServiceError>;
 }

--- a/crates/channels/src/telegram/commands/kernel_client.rs
+++ b/crates/channels/src/telegram/commands/kernel_client.rs
@@ -22,6 +22,7 @@ use chrono::Utc;
 use rara_kernel::{
     channel::types::ChannelType,
     handle::KernelHandle,
+    llm::LlmModelListerRef,
     memory::{TapeService, get_fork_metadata, set_fork_metadata},
     session::{self as ks, SessionIndex, SessionKey},
 };
@@ -29,18 +30,20 @@ use rara_mcp::manager::mgr::{ConnectionStatus, McpManager};
 use snafu::ResultExt;
 
 use super::client::{
-    BotServiceClient, BotServiceError, ChannelBinding, CheckoutResult, DiscoveryJob, McpServerInfo,
-    McpServerStatus, SessionDetail, SessionListItem, SessionSnafu, TapeSnafu,
+    BotServiceClient, BotServiceError, ChannelBinding, ChatModelItem, CheckoutResult, DiscoveryJob,
+    McpServerInfo, McpServerStatus, SessionDetail, SessionListItem, SessionSnafu, TapeSnafu,
 };
 
 /// A [`BotServiceClient`] that calls [`SessionIndex`] and [`TapeService`]
 /// directly, bypassing any HTTP layer.
 pub struct KernelBotServiceClient {
-    sessions: Arc<dyn SessionIndex>,
-    tape:     TapeService,
-    handle:   Option<KernelHandle>,
+    sessions:     Arc<dyn SessionIndex>,
+    tape:         TapeService,
+    handle:       Option<KernelHandle>,
     /// Optional MCP manager for managing MCP server connections.
-    mcp:      Option<McpManager>,
+    mcp:          Option<McpManager>,
+    /// Optional model lister for `/model` to enumerate available models.
+    model_lister: Option<LlmModelListerRef>,
 }
 
 impl KernelBotServiceClient {
@@ -50,12 +53,14 @@ impl KernelBotServiceClient {
         tape: TapeService,
         handle: impl Into<Option<KernelHandle>>,
         mcp: impl Into<Option<McpManager>>,
+        model_lister: impl Into<Option<LlmModelListerRef>>,
     ) -> Self {
         Self {
             sessions,
             tape,
             handle: handle.into(),
             mcp: mcp.into(),
+            model_lister: model_lister.into(),
         }
     }
 }
@@ -490,6 +495,29 @@ impl BotServiceClient for KernelBotServiceClient {
         Ok(())
     }
 
+    async fn list_chat_models(&self) -> Result<Vec<ChatModelItem>, BotServiceError> {
+        let lister = self
+            .model_lister
+            .as_ref()
+            .ok_or_else(|| BotServiceError::Service {
+                message: "model lister not configured".to_owned(),
+            })?;
+        let models = lister
+            .list_models()
+            .await
+            .map_err(|e| BotServiceError::Service {
+                message: format!("failed to list models: {e}"),
+            })?;
+        Ok(models
+            .into_iter()
+            .map(|m| ChatModelItem {
+                name:           m.id.clone(),
+                id:             m.id,
+                context_length: None,
+            })
+            .collect())
+    }
+
     async fn delete_session(&self, key: &str) -> Result<(), BotServiceError> {
         let sk = SessionKey::try_from_raw(key).map_err(|e| BotServiceError::Service {
             message: format!("invalid session key: {e}"),
@@ -699,6 +727,7 @@ mod tests {
             tape.clone(),
             None::<KernelHandle>,
             None::<McpManager>,
+            None::<LlmModelListerRef>,
         );
 
         let root_key = SessionKey::new();

--- a/crates/channels/src/telegram/commands/mod.rs
+++ b/crates/channels/src/telegram/commands/mod.rs
@@ -44,10 +44,10 @@ pub mod tape;
 
 pub use basic::BasicCommandHandler;
 pub use callbacks::{
-    SessionDeleteCallbackHandler, SessionDeleteCancelHandler, SessionDeleteConfirmHandler,
-    SessionDetailCallbackHandler, SessionSwitchCallbackHandler,
+    ModelSwitchCallbackHandler, SessionDeleteCallbackHandler, SessionDeleteCancelHandler,
+    SessionDeleteConfirmHandler, SessionDetailCallbackHandler, SessionSwitchCallbackHandler,
 };
-pub use client::BotServiceClient;
+pub use client::{BotServiceClient, ChatModelItem};
 pub use debug::DebugCommandHandler;
 pub use kernel_client::KernelBotServiceClient;
 pub use mcp::McpCommandHandler;

--- a/crates/channels/src/telegram/commands/session.rs
+++ b/crates/channels/src/telegram/commands/session.rs
@@ -348,20 +348,53 @@ impl SessionCommandHandler {
         let new_model = args.trim();
 
         if new_model.is_empty() {
-            // Show current model.
-            match self.client.get_session(&session_key).await {
-                Ok(detail) => {
-                    let model = detail.model.as_deref().unwrap_or("(default)");
+            // No args: render an inline keyboard listing available models so
+            // the user can switch by tapping. The currently selected model is
+            // highlighted with a check mark.
+            let current_model = match self.client.get_session(&session_key).await {
+                Ok(detail) => detail.model,
+                Err(e) => {
+                    return Ok(CommandResult::Text(format!(
+                        "Failed to get session details: {e}"
+                    )));
+                }
+            };
+
+            match self.client.list_chat_models().await {
+                Ok(models) if !models.is_empty() => {
+                    let mut keyboard_rows: Vec<Vec<InlineButton>> = Vec::new();
+                    for m in &models {
+                        let is_current = current_model.as_deref() == Some(m.id.as_str());
+                        let ctx_suffix = m
+                            .context_length
+                            .map(|c| format!(" \u{00b7} {}k", c / 1000))
+                            .unwrap_or_default();
+                        let label = if is_current {
+                            format!("\u{2705} {}{ctx_suffix}", m.name)
+                        } else {
+                            format!("{}{ctx_suffix}", m.name)
+                        };
+                        keyboard_rows.push(vec![InlineButton {
+                            text:          label,
+                            callback_data: Some(format!("model:{}", truncate_str(&m.id, 56))),
+                            url:           None,
+                        }]);
+                    }
+                    let header = format!("\u{1f916} Models ({} total)", models.len());
+                    Ok(CommandResult::HtmlWithKeyboard {
+                        html:     header,
+                        keyboard: keyboard_rows,
+                    })
+                }
+                // Empty list or error: fall back to showing the current model
+                // with a usage hint.
+                _ => {
+                    let model = current_model.as_deref().unwrap_or("(default)");
                     Ok(CommandResult::Html(format!(
-                        "Session <code>{}</code>\nModel: <b>{}</b>\n\nSwitch: <code>/model \
-                         model-name</code>",
-                        html_escape(&detail.key),
+                        "Model: <b>{}</b>\n\nSwitch: <code>/model model-name</code>",
                         html_escape(model),
                     )))
                 }
-                Err(e) => Ok(CommandResult::Text(format!(
-                    "Failed to get session details: {e}"
-                ))),
             }
         } else {
             // Update model.


### PR DESCRIPTION
## Summary

Telegram `/model` 无参数现在会弹出可用 model 的 inline keyboard 列表（当前选中带 ✅），点击即切换 session 的 model。`/model <name>` 直接切换的 fast path 保留。

## Type of change

| Type | Label |
|------|-------|
| New feature | `enhancement` |

## Component

`backend` (channels)

## Closes

Closes #1575

## Test plan

- [x] `cargo check -p rara-channels`
- [x] `cargo check -p rara-app`
- [x] `cargo +nightly fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings`
- [ ] 手动测试：在 TG 输入 `/model`，确认弹出列表 + 点击切换生效