### PR TITLE
feat(kernel): jieba pre-segment tape fts (#1577)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -169,6 +169,7 @@ http = "^1"
 hyper = { version = "1", features = ["full"] }
 image = { version = "0.25", default-features = false, features = ["jpeg", "png", "webp", "gif"] }
 indexmap = "2"
+jieba-rs = "0.7"
 jiff = { version = "^0.2", features = ["serde"] }
 jsonwebtoken = "9"
 lazy_static = "^1.4"

--- a/crates/kernel/Cargo.toml
+++ b/crates/kernel/Cargo.toml
@@ -34,6 +34,7 @@ hex.workspace = true
 hmac.workspace = true
 image.workspace = true
 indexmap.workspace = true
+jieba-rs.workspace = true
 jiff.workspace = true
 md5.workspace = true
 opendal = { workspace = true }

--- a/crates/kernel/src/memory/fts/AGENT.md
+++ b/crates/kernel/src/memory/fts/AGENT.md
@@ -8,8 +8,9 @@ keyword search from O(n×m) brute-force to O(log n) indexed lookup.
 
 ```
 fts/
-├── mod.rs     # Business logic: TapeFts struct, entry filtering, query sanitization
-├── repo.rs    # Pure SQL: insert, search, get_hwm, upsert_hwm, delete_by_tape, delete_all
+├── mod.rs        # Business logic: TapeFts struct, entry filtering, query sanitization
+├── repo.rs       # Pure SQL: insert, search, get_hwm, upsert_hwm, delete_by_tape, delete_all
+├── tokenizer.rs  # Application-layer jieba pre-segmentation for CJK text
 └── AGENT.md
 ```
 
@@ -29,9 +30,11 @@ fts/
 ## Critical Invariants
 
 - **JSONL is source of truth** — FTS is a derived index. Deleting the FTS DB is always safe; it rebuilds on next search via lazy backfill.
-- **Text surface must match** — `extract_fts_content()` delegates to `service::extract_searchable_text()`. If you change what text the brute-force path searches, the FTS index must match. Do NOT create a separate extraction function.
+- **Symmetric segmentation** — indexed content and user queries MUST both pass through `tokenizer::segment`. `extract_fts_content` and `sanitize_fts_query` are the only two callers; any new write/query path must do the same or CJK results silently diverge.
+- **FTS text surface is narrower than brute-force** — `extract_fts_content` collects only JSON string leaves from payload + metadata (keys and structural punctuation are dropped so jieba doesn't tokenize JSON syntax). The brute-force path keeps the richer `service::extract_searchable_text` output. This asymmetry is intentional; do not "simplify" by merging them.
 - **Lifecycle cleanup is mandatory** — every code path that clears JSONL tape data MUST also call `TapeFts::remove_tape()`. Violation leaves stale FTS rows that return ghost results.
 - **All FTS operations are best-effort** — errors are logged and swallowed, never propagated. The system must work identically without FTS.
+- **Segmentation runs on the blocking pool** — `index_entries` wraps jieba in `spawn_blocking`. Do NOT call `tokenizer::segment` directly in async hot paths on long inputs.
 
 ## What NOT To Do
 
@@ -42,6 +45,6 @@ fts/
 
 ## Dependencies
 
-- **Upstream**: `sqlx::SqlitePool` from `rara-model` (shared pool), `service::extract_searchable_text`
+- **Upstream**: `sqlx::SqlitePool` from `rara-model` (shared pool), `jieba-rs` (dictionary ~7 MB, one-time load)
 - **Downstream**: consumed by `TapeService` in `service.rs`
-- **Schema**: `tape_fts` (FTS5 virtual table) + `tape_fts_meta` created by migration `20260415042041_tape_fts_init`
+- **Schema**: `tape_fts` (FTS5 virtual table) + `tape_fts_meta`, created by migration `20260415042041_tape_fts_init` and rebuilt by `20260418182710_tape_fts_rebuild_jieba` to re-index under the jieba-segmented surface

--- a/crates/kernel/src/memory/fts/mod.rs
+++ b/crates/kernel/src/memory/fts/mod.rs
@@ -10,6 +10,7 @@
 mod repo;
 mod tokenizer;
 
+use serde_json::Value;
 use sqlx::SqlitePool;
 pub(crate) use tokenizer::warmup as warmup_tokenizer;
 use tracing::{debug, warn};
@@ -66,27 +67,38 @@ impl TapeFts {
         // non-Message entries are not re-scanned on subsequent calls.
         let max_id = new_entries.iter().map(|e| e.id).max().unwrap_or(hwm);
 
-        let indexable: Vec<_> = new_entries
+        let indexable: Vec<TapEntry> = new_entries
             .iter()
             .filter(|e| e.kind == TapEntryKind::Message)
+            .map(|e| (*e).clone())
             .collect();
+
+        // Run jieba segmentation on the blocking pool — it's CPU-bound
+        // and can be slow on long messages (code blocks, transcripts).
+        // Keeping it off the runtime thread avoids stalling other async
+        // work while we index.
+        let segmented: Vec<(u64, String, String)> = tokio::task::spawn_blocking(move || {
+            indexable
+                .into_iter()
+                .filter_map(|entry| {
+                    let content = extract_fts_content(&entry);
+                    (!content.is_empty()).then(|| (entry.id, entry.kind.to_string(), content))
+                })
+                .collect()
+        })
+        .await
+        .map_err(|e| sqlx::Error::Protocol(format!("fts segment task: {e}")))?;
 
         let mut tx = self.pool.begin().await?;
         let mut count = 0usize;
 
-        for entry in &indexable {
-            let content = extract_fts_content(entry);
-            if content.is_empty() {
-                continue;
-            }
-            let kind_str = entry.kind.to_string();
-
+        for (entry_id, kind_str, content) in &segmented {
             repo::insert(
                 &mut tx,
-                &content,
+                content,
                 tape_name,
-                &kind_str,
-                entry.id as i64,
+                kind_str,
+                *entry_id as i64,
                 session_key,
             )
             .await?;
@@ -150,11 +162,28 @@ impl TapeFts {
 
 /// Extract searchable text from a tape entry for FTS indexing.
 ///
-/// Delegates to [`super::service::extract_searchable_text`] so the indexed
-/// text surface is identical to the brute-force search path.
+/// Returns only JSON string leaves (payload + metadata) joined by
+/// newlines — object keys, numbers, and JSON punctuation are dropped so
+/// the jieba segmenter doesn't chew on structural noise (e.g. `"role"`,
+/// `{`, `}`). The brute-force search path keeps its fuller text surface
+/// via [`super::service::extract_searchable_text`].
 fn extract_fts_content(entry: &TapEntry) -> String {
-    let raw = super::service::extract_searchable_text(&entry.payload, entry.metadata.as_ref());
-    tokenizer::segment(&raw)
+    let mut parts = Vec::new();
+    collect_json_strings(&entry.payload, &mut parts);
+    if let Some(meta) = entry.metadata.as_ref() {
+        collect_json_strings(meta, &mut parts);
+    }
+    tokenizer::segment(&parts.join("\n"))
+}
+
+/// Recursively push every string leaf in `value` into `out`.
+fn collect_json_strings(value: &Value, out: &mut Vec<String>) {
+    match value {
+        Value::String(s) if !s.is_empty() => out.push(s.clone()),
+        Value::Array(items) => items.iter().for_each(|v| collect_json_strings(v, out)),
+        Value::Object(map) => map.values().for_each(|v| collect_json_strings(v, out)),
+        _ => {}
+    }
 }
 
 /// Sanitize a user query for FTS5 MATCH syntax.

--- a/crates/kernel/src/memory/fts/mod.rs
+++ b/crates/kernel/src/memory/fts/mod.rs
@@ -257,6 +257,78 @@ mod tests {
         assert!(content.contains("test"));
     }
 
+    /// Guards the narrowing in `extract_fts_content`: JSON keys, numbers,
+    /// and structural punctuation must NOT reach the index — otherwise
+    /// jieba chews on `"role"`, `{`, `}` etc. and inflates BM25 noise.
+    #[test]
+    fn extract_fts_content_drops_json_structure() {
+        let entry = TapEntry {
+            id:        10,
+            kind:      TapEntryKind::Message,
+            payload:   serde_json::json!({
+                "role": "user",
+                "content": "actual message",
+                "token_count": 42,
+            }),
+            timestamp: jiff::Timestamp::now(),
+            metadata:  Some(serde_json::json!({"model_name": "claude", "latency_ms": 123})),
+        };
+        let content = extract_fts_content(&entry);
+
+        // String leaves survive.
+        assert!(content.contains("actual message"));
+        assert!(content.contains("user"));
+        assert!(content.contains("claude"));
+
+        // Keys and numbers must be absent.
+        for forbidden in [
+            "role",
+            "content",
+            "token_count",
+            "model_name",
+            "latency_ms",
+            "42",
+            "123",
+        ] {
+            assert!(
+                !content.contains(forbidden),
+                "content leaked {forbidden:?}: {content:?}"
+            );
+        }
+
+        // Structural JSON punctuation must not appear either.
+        for forbidden in ['{', '}', '[', ']', '"', ':'] {
+            assert!(
+                !content.contains(forbidden),
+                "content leaked {forbidden:?}: {content:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn extract_fts_content_walks_nested_json() {
+        let entry = TapEntry {
+            id:        11,
+            kind:      TapEntryKind::Message,
+            payload:   serde_json::json!({
+                "content": "outer",
+                "parts": [
+                    {"text": "inner-a"},
+                    {"text": "inner-b", "meta": {"label": "inner-c"}},
+                ],
+            }),
+            timestamp: jiff::Timestamp::now(),
+            metadata:  None,
+        };
+        let content = extract_fts_content(&entry);
+        for expected in ["outer", "inner-a", "inner-b", "inner-c"] {
+            assert!(
+                content.contains(expected),
+                "missing {expected:?}: {content:?}"
+            );
+        }
+    }
+
     #[test]
     fn extract_fts_content_empty_payload() {
         let entry = TapEntry {

--- a/crates/kernel/src/memory/fts/mod.rs
+++ b/crates/kernel/src/memory/fts/mod.rs
@@ -8,8 +8,10 @@
 //! business logic (entry filtering, text extraction, query sanitization).
 
 mod repo;
+mod tokenizer;
 
 use sqlx::SqlitePool;
+pub(crate) use tokenizer::warmup as warmup_tokenizer;
 use tracing::{debug, warn};
 
 use super::{TapEntry, TapEntryKind};
@@ -151,7 +153,8 @@ impl TapeFts {
 /// Delegates to [`super::service::extract_searchable_text`] so the indexed
 /// text surface is identical to the brute-force search path.
 fn extract_fts_content(entry: &TapEntry) -> String {
-    super::service::extract_searchable_text(&entry.payload, entry.metadata.as_ref())
+    let raw = super::service::extract_searchable_text(&entry.payload, entry.metadata.as_ref());
+    tokenizer::segment(&raw)
 }
 
 /// Sanitize a user query for FTS5 MATCH syntax.
@@ -160,7 +163,9 @@ fn extract_fts_content(entry: &TapEntry) -> String {
 /// We quote each term to treat them as literals, then join with spaces
 /// (implicit AND).
 fn sanitize_fts_query(query: &str) -> String {
-    query
+    // Pre-segment so CJK terms match the segmented index surface.
+    let segmented = tokenizer::segment(query);
+    segmented
         .split_whitespace()
         .filter(|t| !t.is_empty())
         .map(|term| {
@@ -326,5 +331,61 @@ mod tests {
             .await
             .expect("search after remove");
         assert!(hits.is_empty());
+    }
+
+    /// Verifies jieba pre-segmentation makes CJK BM25 work: a query for a
+    /// segmented word ("机器学习") must retrieve the right entry even when
+    /// the word appears inside a longer sentence.
+    #[tokio::test]
+    async fn chinese_segmentation_enables_bm25() {
+        let pool = test_pool().await;
+        let fts = TapeFts::new(pool);
+
+        let entries = vec![
+            TapEntry {
+                id:        1,
+                kind:      TapEntryKind::Message,
+                payload:   serde_json::json!({"content": "今天学习了机器学习的基础知识"}),
+                timestamp: jiff::Timestamp::now(),
+                metadata:  None,
+            },
+            TapEntry {
+                id:        2,
+                kind:      TapEntryKind::Message,
+                payload:   serde_json::json!({"content": "买了一台新的机器"}),
+                timestamp: jiff::Timestamp::now(),
+                metadata:  None,
+            },
+            TapEntry {
+                id:        3,
+                kind:      TapEntryKind::Message,
+                payload:   serde_json::json!({"content": "unrelated English content"}),
+                timestamp: jiff::Timestamp::now(),
+                metadata:  None,
+            },
+        ];
+
+        fts.index_entries("cn-tape", "session-cn", &entries)
+            .await
+            .expect("index");
+
+        // "机器学习" should hit entry 1 (where jieba keeps it as one word).
+        let hits = fts
+            .search("机器学习", Some("cn-tape"), 10)
+            .await
+            .expect("search ml");
+        assert!(
+            hits.iter().any(|h| h.entry_id == 1),
+            "expected entry 1 to match '机器学习', got {hits:?}"
+        );
+
+        // "机器" alone should retrieve both CJK entries.
+        let hits = fts
+            .search("机器", Some("cn-tape"), 10)
+            .await
+            .expect("search machine");
+        let ids: Vec<u64> = hits.iter().map(|h| h.entry_id).collect();
+        assert!(ids.contains(&1), "entry 1 should match '机器', got {ids:?}");
+        assert!(ids.contains(&2), "entry 2 should match '机器', got {ids:?}");
     }
 }

--- a/crates/kernel/src/memory/fts/tokenizer.rs
+++ b/crates/kernel/src/memory/fts/tokenizer.rs
@@ -16,43 +16,59 @@
 //! (`extract_fts_content`) and user queries (`sanitize_fts_query`),
 //! keeping the token vocabulary consistent on both sides.
 
-use std::sync::OnceLock;
+use std::sync::{Once, OnceLock};
 
 use jieba_rs::Jieba;
 
 static JIEBA: OnceLock<Jieba> = OnceLock::new();
+static WARMUP_ONCE: Once = Once::new();
 
 fn jieba() -> &'static Jieba { JIEBA.get_or_init(Jieba::new) }
 
-/// Eagerly initialize the shared Jieba instance.
+/// Eagerly initialize the shared Jieba instance on a background thread.
 ///
-/// Called once during kernel startup to absorb the ~200 ms dictionary
-/// load off the hot path. Safe to call multiple times.
-pub(crate) fn warmup() { let _ = jieba(); }
+/// Absorbs the ~200 ms dictionary load off the hot path. Subsequent
+/// calls are no-ops — the spawn itself is also guarded so repeated
+/// `TapeService::with_fts` invocations don't leak threads.
+pub(crate) fn warmup() {
+    WARMUP_ONCE.call_once(|| {
+        std::thread::spawn(|| {
+            let _ = jieba();
+        });
+    });
+}
 
 /// Segment `text` into whitespace-separated tokens suitable for
 /// `unicode61` indexing.
 ///
-/// Chinese runs are cut into semantic words; ASCII and whitespace are
-/// preserved so mixed-language input works naturally. Empty or
-/// whitespace-only input returns an empty string.
+/// Chinese runs are cut into semantic words; ASCII and whitespace pass
+/// through jieba untouched so mixed-language input works naturally.
+/// Input that contains no Chinese characters is returned verbatim
+/// (the `unicode61` tokenizer already splits such text correctly).
 pub(crate) fn segment(text: &str) -> String {
-    if text.chars().all(|c| !is_cjk(c)) {
-        // Pure non-CJK text needs no pre-segmentation — unicode61
-        // already splits it correctly.
+    if !text.chars().any(is_chinese_ideograph) {
+        // Nothing for jieba to do — skip the dictionary load for
+        // pure non-Chinese input (including empty/whitespace strings).
         return text.to_owned();
     }
 
     let tokens = jieba().cut(text, false);
     tokens
         .into_iter()
-        .map(|t| t.trim())
+        .map(str::trim)
         .filter(|t| !t.is_empty())
         .collect::<Vec<_>>()
         .join(" ")
 }
 
-fn is_cjk(c: char) -> bool {
+/// True when `c` is a Chinese ideograph.
+///
+/// Deliberately narrow: jieba's dictionary only covers Chinese, so we
+/// let Japanese/Korean fall through the `unicode61` path (suboptimal
+/// but non-regressive). CJK punctuation is also excluded — the
+/// surrounding ideographs will still trigger segmentation, and jieba
+/// handles punctuation internally.
+fn is_chinese_ideograph(c: char) -> bool {
     matches!(c as u32,
         0x3400..=0x4DBF       // CJK Unified Ideographs Extension A
         | 0x4E00..=0x9FFF     // CJK Unified Ideographs
@@ -71,25 +87,45 @@ mod tests {
     }
 
     #[test]
-    fn chinese_is_segmented() {
-        let out = segment("机器学习很强大");
-        // Jieba should split into at least two real words.
-        let tokens: Vec<_> = out.split_whitespace().collect();
-        assert!(tokens.len() >= 2, "expected multiple tokens, got {out:?}");
-        assert!(tokens.iter().any(|t| *t == "机器学习" || *t == "学习"));
+    fn whitespace_only_unchanged() {
+        // No Chinese → short-circuit returns input verbatim. Downstream
+        // `split_whitespace` in `sanitize_fts_query` drops it.
+        assert_eq!(segment(""), "");
+        assert_eq!(segment("   "), "   ");
+    }
+
+    #[test]
+    fn chinese_is_segmented_into_words() {
+        // Jieba's default dictionary splits "机器学习" into "机器" + "学习"
+        // — that's fine, BM25 now has real word tokens to work with
+        // instead of one sentence-sized glob. The point of this test is
+        // to assert *some* meaningful segmentation occurred, not to pin
+        // a specific dictionary's boundaries.
+        let tokens: Vec<String> = segment("今天学习了机器的原理")
+            .split_whitespace()
+            .map(str::to_owned)
+            .collect();
+        assert!(
+            tokens.contains(&"机器".to_owned()),
+            "expected '机器' token, got {tokens:?}"
+        );
+        assert!(
+            tokens.contains(&"学习".to_owned()),
+            "expected '学习' token, got {tokens:?}"
+        );
+        assert!(
+            tokens.len() >= 3,
+            "expected multi-token split, got {tokens:?}"
+        );
     }
 
     #[test]
     fn mixed_language() {
-        let out = segment("Rust 的 所有权 模型");
-        let tokens: Vec<_> = out.split_whitespace().collect();
-        assert!(tokens.contains(&"Rust"));
-        assert!(tokens.contains(&"所有权"));
-    }
-
-    #[test]
-    fn empty_input() {
-        assert_eq!(segment(""), "");
-        assert_eq!(segment("   "), "   ");
+        let tokens: Vec<String> = segment("Rust 的所有权模型")
+            .split_whitespace()
+            .map(str::to_owned)
+            .collect();
+        assert!(tokens.contains(&"Rust".to_owned()), "got {tokens:?}");
+        assert!(tokens.contains(&"所有权".to_owned()), "got {tokens:?}");
     }
 }

--- a/crates/kernel/src/memory/fts/tokenizer.rs
+++ b/crates/kernel/src/memory/fts/tokenizer.rs
@@ -1,0 +1,95 @@
+//! Application-layer segmentation for FTS5 indexing.
+//!
+//! SQLite FTS5's built-in `unicode61` tokenizer treats a run of CJK
+//! characters as a single token because CJK scripts lack whitespace
+//! boundaries. This collapses entire Chinese sentences into one FTS
+//! token, which defeats BM25 ranking and falls back on the brute-force
+//! fuzzy scorer.
+//!
+//! Instead of registering a custom FTS5 tokenizer (which requires
+//! per-connection unsafe FFI hooks across the SQLx pool), we segment in
+//! Rust with `jieba-rs` and emit space-separated tokens. The existing
+//! `unicode61` tokenizer then splits on those spaces, yielding real
+//! semantic tokens for both indexing and querying.
+//!
+//! The same function is applied symmetrically to indexed content
+//! (`extract_fts_content`) and user queries (`sanitize_fts_query`),
+//! keeping the token vocabulary consistent on both sides.
+
+use std::sync::OnceLock;
+
+use jieba_rs::Jieba;
+
+static JIEBA: OnceLock<Jieba> = OnceLock::new();
+
+fn jieba() -> &'static Jieba { JIEBA.get_or_init(Jieba::new) }
+
+/// Eagerly initialize the shared Jieba instance.
+///
+/// Called once during kernel startup to absorb the ~200 ms dictionary
+/// load off the hot path. Safe to call multiple times.
+pub(crate) fn warmup() { let _ = jieba(); }
+
+/// Segment `text` into whitespace-separated tokens suitable for
+/// `unicode61` indexing.
+///
+/// Chinese runs are cut into semantic words; ASCII and whitespace are
+/// preserved so mixed-language input works naturally. Empty or
+/// whitespace-only input returns an empty string.
+pub(crate) fn segment(text: &str) -> String {
+    if text.chars().all(|c| !is_cjk(c)) {
+        // Pure non-CJK text needs no pre-segmentation — unicode61
+        // already splits it correctly.
+        return text.to_owned();
+    }
+
+    let tokens = jieba().cut(text, false);
+    tokens
+        .into_iter()
+        .map(|t| t.trim())
+        .filter(|t| !t.is_empty())
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+fn is_cjk(c: char) -> bool {
+    matches!(c as u32,
+        0x3400..=0x4DBF       // CJK Unified Ideographs Extension A
+        | 0x4E00..=0x9FFF     // CJK Unified Ideographs
+        | 0xF900..=0xFAFF     // CJK Compatibility Ideographs
+        | 0x20000..=0x2FFFF   // CJK Extensions B–F
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn pure_ascii_unchanged() {
+        assert_eq!(segment("hello world"), "hello world");
+    }
+
+    #[test]
+    fn chinese_is_segmented() {
+        let out = segment("机器学习很强大");
+        // Jieba should split into at least two real words.
+        let tokens: Vec<_> = out.split_whitespace().collect();
+        assert!(tokens.len() >= 2, "expected multiple tokens, got {out:?}");
+        assert!(tokens.iter().any(|t| *t == "机器学习" || *t == "学习"));
+    }
+
+    #[test]
+    fn mixed_language() {
+        let out = segment("Rust 的 所有权 模型");
+        let tokens: Vec<_> = out.split_whitespace().collect();
+        assert!(tokens.contains(&"Rust"));
+        assert!(tokens.contains(&"所有权"));
+    }
+
+    #[test]
+    fn empty_input() {
+        assert_eq!(segment(""), "");
+        assert_eq!(segment("   "), "   ");
+    }
+}

--- a/crates/kernel/src/memory/service.rs
+++ b/crates/kernel/src/memory/service.rs
@@ -102,9 +102,9 @@ impl TapeService {
 
     /// Create a service with FTS5 full-text search support.
     pub fn with_fts(store: FileTapeStore, pool: sqlx::SqlitePool) -> Self {
-        // Preload the jieba dictionary so the first search doesn't pay
-        // the ~200 ms init cost inline.
-        std::thread::spawn(super::fts::warmup_tokenizer);
+        // Preload the jieba dictionary off the hot path. `warmup` is
+        // idempotent — repeated `with_fts` calls do not leak threads.
+        super::fts::warmup_tokenizer();
         Self {
             store,
             fts: Some(super::fts::TapeFts::new(pool)),

--- a/crates/kernel/src/memory/service.rs
+++ b/crates/kernel/src/memory/service.rs
@@ -102,6 +102,9 @@ impl TapeService {
 
     /// Create a service with FTS5 full-text search support.
     pub fn with_fts(store: FileTapeStore, pool: sqlx::SqlitePool) -> Self {
+        // Preload the jieba dictionary so the first search doesn't pay
+        // the ~200 ms init cost inline.
+        std::thread::spawn(super::fts::warmup_tokenizer);
         Self {
             store,
             fts: Some(super::fts::TapeFts::new(pool)),

--- a/crates/rara-model/migrations/20260418182710_tape_fts_rebuild_jieba.down.sql
+++ b/crates/rara-model/migrations/20260418182710_tape_fts_rebuild_jieba.down.sql
@@ -1,0 +1,3 @@
+-- No-op: tape_fts schema is unchanged; only the indexed content surface
+-- differs (jieba pre-segmentation). Reverting the data requires re-running
+-- backfill_fts() from JSONL, which happens automatically on next search.

--- a/crates/rara-model/migrations/20260418182710_tape_fts_rebuild_jieba.up.sql
+++ b/crates/rara-model/migrations/20260418182710_tape_fts_rebuild_jieba.up.sql
@@ -1,0 +1,14 @@
+-- Rebuild tape_fts to re-tokenize existing entries with jieba pre-segmented
+-- content. The FTS table is a derived index — source of truth is JSONL, and
+-- TapeService::backfill_fts() will repopulate on next search.
+DROP TABLE IF EXISTS tape_fts;
+DELETE FROM tape_fts_meta;
+
+CREATE VIRTUAL TABLE tape_fts USING fts5(
+    content,
+    tape_name UNINDEXED,
+    entry_kind UNINDEXED,
+    entry_id UNINDEXED,
+    session_key UNINDEXED,
+    tokenize = 'unicode61 remove_diacritics 2'
+);


### PR DESCRIPTION
## Summary

给 tape FTS 的索引和查询两端都加一层 jieba-rs 预分词——FTS5 `unicode61` 自身把整段中文当成单个 token，BM25 基本失效。应用层切好词用空格连接再塞进索引（查询端对称处理），不动 SQLx pool、不做 custom FTS5 tokenizer、也不影响 JSONL 这个 source of truth。

Rebuild migration 删掉 `tape_fts` 并清空 HWM，下次 search 通过 `TapeService::backfill_fts` 从 JSONL 自动回灌。

## Type of change

| Type | Label |
|------|-------|
| New feature | `enhancement` |

## Component

`core`

## Closes

Closes #1577

## Test plan

- [x] `cargo check --all --all-targets` 通过
- [x] `cargo clippy -p rara-kernel --all-targets` 通过
- [x] `cargo +nightly fmt --all -- --check` 通过
- [x] `cargo test -p rara-kernel --lib memory::fts` 通过（新增 `chinese_segmentation_enables_bm25` 用例）
- [ ] 部署后在真实 DB 上触发一次 search，验证 `backfill_fts` 回灌