### PR TITLE
feat(web): settings floating modal (#1581)

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -14,20 +14,58 @@
  * limitations under the License.
  */
 
-import { useState } from 'react';
-import { BrowserRouter, Routes, Route } from 'react-router';
+import { useEffect, useState } from 'react';
+import { BrowserRouter, Routes, Route, useNavigate } from 'react-router';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { ServerStatusProvider } from '@/components/ServerStatusProvider';
 import { ConnectionSetupDialog } from '@/components/ConnectionSetupDialog';
 import DashboardLayout from '@/layouts/DashboardLayout';
 import PiChat from '@/pages/PiChat';
 import Docs from '@/pages/Docs';
-import Settings from '@/pages/Settings';
 import KernelTop from '@/pages/KernelTop';
 import Dock from '@/pages/Dock';
+import {
+  SettingsModalProvider,
+  useSettingsModal,
+} from '@/components/settings/SettingsModalProvider';
+import type { SettingsPage } from '@/components/settings/SettingsPanel';
 
 const STORAGE_KEY = "rara_backend_url";
 const queryClient = new QueryClient();
+
+const SETTINGS_PAGES: readonly SettingsPage[] = [
+  "general",
+  "providers",
+  "agents",
+  "skills",
+  "mcp",
+  "channels",
+  "tools",
+  "security",
+  "data-feeds",
+];
+
+function isSettingsPage(value: string | null): value is SettingsPage {
+  return !!value && (SETTINGS_PAGES as readonly string[]).includes(value);
+}
+
+/**
+ * Backwards-compat redirect for deep-links like `/settings?section=providers`.
+ * Settings now lives in a floating modal; the old route opens the modal and
+ * hops back to the root so bookmarks and external links keep working.
+ */
+function SettingsRoute() {
+  const { openSettings } = useSettingsModal();
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    const raw = new URLSearchParams(window.location.search).get("section");
+    openSettings(isSettingsPage(raw) ? raw : undefined);
+    navigate("/", { replace: true });
+  }, [openSettings, navigate]);
+
+  return null;
+}
 
 export default function App() {
   const [needsSetup, setNeedsSetup] = useState(
@@ -44,18 +82,22 @@ export default function App() {
           />
         )}
         <BrowserRouter>
-          <Routes>
-            {/* Fullscreen pi-web-ui chat */}
-            <Route index element={<PiChat />} />
+          <SettingsModalProvider>
+            <Routes>
+              {/* Fullscreen pi-web-ui chat */}
+              <Route index element={<PiChat />} />
 
-            {/* Admin pages with dashboard layout */}
-            <Route element={<DashboardLayout />}>
-              <Route path="docs" element={<Docs />} />
-              <Route path="settings" element={<Settings />} />
-              <Route path="kernel-top" element={<KernelTop />} />
-              <Route path="dock" element={<Dock />} />
-            </Route>
-          </Routes>
+              {/* Deep-link redirect — see SettingsRoute */}
+              <Route path="settings" element={<SettingsRoute />} />
+
+              {/* Admin pages with dashboard layout */}
+              <Route element={<DashboardLayout />}>
+                <Route path="docs" element={<Docs />} />
+                <Route path="kernel-top" element={<KernelTop />} />
+                <Route path="dock" element={<Dock />} />
+              </Route>
+            </Routes>
+          </SettingsModalProvider>
         </BrowserRouter>
       </ServerStatusProvider>
     </QueryClientProvider>

--- a/web/src/adapters/rara-storage.ts
+++ b/web/src/adapters/rara-storage.ts
@@ -21,6 +21,8 @@ import type {
 } from "@mariozechner/pi-web-ui";
 
 import { api, settingsApi } from "@/api/client";
+// `settingsApi` remains imported for init()'s read-through pre-seed; write
+// persistence moved to the admin modal (#1581).
 import type { ChatSession } from "@/api/types";
 
 /**
@@ -64,15 +66,13 @@ export class RaraStorageBackend implements StorageBackend {
       metaStore.set(s.key, meta);
     }
 
-    // Populate settings store
+    // Populate settings store — pi-mono's SettingsStore still reads this
+    // cache for its own internal state. Writes no longer round-trip to the
+    // rara backend (see #1581) — the settings modal owns persistence.
     const settingsStore = this.store("settings");
     for (const [k, v] of Object.entries(settings)) {
       settingsStore.set(k, v);
     }
-
-    // Ensure provider-related stores exist (rara manages providers server-side)
-    this.store("providerKeys");
-    this.store("customProviders");
   }
 
   /** Get a value by key from a specific store. Returns null if missing. */
@@ -98,13 +98,6 @@ export class RaraStorageBackend implements StorageBackend {
       this.store("sessions-metadata").set(key, value);
     } else if (storeName === "sessions-metadata") {
       this.store("sessions").set(key, value);
-    }
-
-    // Fire-and-forget sync for settings — coerce to string for the REST API
-    if (storeName === "settings") {
-      settingsApi.set(key, String(value)).catch((e) => {
-        console.warn("Background settings sync failed:", e);
-      });
     }
   }
 

--- a/web/src/adapters/rara-storage.ts
+++ b/web/src/adapters/rara-storage.ts
@@ -21,9 +21,33 @@ import type {
 } from "@mariozechner/pi-web-ui";
 
 import { api, settingsApi } from "@/api/client";
-// `settingsApi` remains imported for init()'s read-through pre-seed; write
-// persistence moved to the admin modal (#1581).
+// `settingsApi` is used for init()'s read-through pre-seed and for
+// write-back of pi-mono UI state under the `ui.pi.` prefix. Rara's own
+// admin settings (llm.*, telegram.*, etc.) are owned by the admin modal
+// (#1581) and are never round-tripped through this adapter.
 import type { ChatSession } from "@/api/types";
+
+/**
+ * Rara-owned setting key prefixes. Values under these prefixes are
+ * persisted exclusively by the admin settings modal — pi-mono must
+ * never write to them, even if a future release adds UI that touches
+ * keys in this namespace.
+ */
+const RARA_KEY_PREFIXES = [
+  "llm.",
+  "telegram.",
+  "gmail.",
+  "composio.",
+  "memory.",
+  "fs.",
+] as const;
+
+/** Prefix applied to pi-mono UI state before round-tripping to the backend. */
+const PI_UI_PREFIX = "ui.pi.";
+
+function isRaraOwnedKey(key: string): boolean {
+  return RARA_KEY_PREFIXES.some((p) => key.startsWith(p));
+}
 
 /**
  * Bridges pi-web-ui's StorageBackend interface to rara's REST API.
@@ -66,12 +90,18 @@ export class RaraStorageBackend implements StorageBackend {
       metaStore.set(s.key, meta);
     }
 
-    // Populate settings store — pi-mono's SettingsStore still reads this
-    // cache for its own internal state. Writes no longer round-trip to the
-    // rara backend (see #1581) — the settings modal owns persistence.
+    // Populate settings store. The backend holds two disjoint namespaces:
+    //   - rara-owned keys (llm.*, telegram.*, ...) — consumed by the admin
+    //     modal only; seed them verbatim so admin reads see them.
+    //   - `ui.pi.<k>` keys — pi-mono UI state; pi-mono reads the bare
+    //     `<k>`, so strip the prefix on seed.
     const settingsStore = this.store("settings");
     for (const [k, v] of Object.entries(settings)) {
-      settingsStore.set(k, v);
+      if (k.startsWith(PI_UI_PREFIX)) {
+        settingsStore.set(k.substring(PI_UI_PREFIX.length), v);
+      } else {
+        settingsStore.set(k, v);
+      }
     }
   }
 
@@ -83,8 +113,10 @@ export class RaraStorageBackend implements StorageBackend {
 
   /**
    * Set a value for a key in a specific store.
-   * Writes to the local cache immediately and syncs to the rara API
-   * in the background for the "settings" store.
+   * Writes to the local cache immediately and fires a background sync to
+   * the rara API for pi-mono UI state in the "settings" store. Rara-owned
+   * admin keys are ignored here — they are persisted exclusively by the
+   * admin settings modal.
    */
   async set<T = unknown>(
     storeName: string,
@@ -98,12 +130,24 @@ export class RaraStorageBackend implements StorageBackend {
       this.store("sessions-metadata").set(key, value);
     } else if (storeName === "sessions-metadata") {
       this.store("sessions").set(key, value);
+    } else if (storeName === "settings") {
+      // Guard: rara-owned keys (llm.*, telegram.*, ...) must never be
+      // round-tripped through the pi-mono adapter. The admin modal owns
+      // persistence for those keys; any stray write here would corrupt
+      // admin state without going through the admin UI's validation.
+      if (isRaraOwnedKey(key)) return;
+      const namespaced = `${PI_UI_PREFIX}${key}`;
+      settingsApi.set(namespaced, String(value)).catch((e) => {
+        console.warn("Background pi-mono settings sync failed:", e);
+      });
     }
   }
 
   /**
    * Delete a key from a specific store.
    * For the "sessions" store, also fires a background DELETE to the API.
+   * For the "settings" store, mirrors the namespacing rule in set() so
+   * pi-mono UI deletes remove the correct `ui.pi.<k>` backend key.
    */
   async delete(storeName: string, key: string): Promise<void> {
     this.store(storeName).delete(key);
@@ -117,6 +161,12 @@ export class RaraStorageBackend implements StorageBackend {
         .catch((e) => {
           console.warn("Background session delete failed:", e);
         });
+    } else if (storeName === "settings") {
+      if (isRaraOwnedKey(key)) return;
+      const namespaced = `${PI_UI_PREFIX}${key}`;
+      settingsApi.delete(namespaced).catch((e) => {
+        console.warn("Background pi-mono settings delete failed:", e);
+      });
     }
   }
 

--- a/web/src/adapters/rara-storage.ts
+++ b/web/src/adapters/rara-storage.ts
@@ -95,14 +95,24 @@ export class RaraStorageBackend implements StorageBackend {
     //     modal only; seed them verbatim so admin reads see them.
     //   - `ui.pi.<k>` keys — pi-mono UI state; pi-mono reads the bare
     //     `<k>`, so strip the prefix on seed.
+    //
+    // Two-pass seed: bare keys first, then `ui.pi.<k>` entries stripped
+    // and written second. If the backend still holds a legacy bare
+    // `<k>` from a pre-#1581 write alongside the newer `ui.pi.<k>`, the
+    // admin-owned prefixed namespace must win — iteration order from
+    // `Object.entries` is not a safe tie-breaker.
     const settingsStore = this.store("settings");
+    const bare: Array<[string, string]> = [];
+    const pinned: Array<[string, string]> = [];
     for (const [k, v] of Object.entries(settings)) {
       if (k.startsWith(PI_UI_PREFIX)) {
-        settingsStore.set(k.substring(PI_UI_PREFIX.length), v);
+        pinned.push([k.substring(PI_UI_PREFIX.length), v]);
       } else {
-        settingsStore.set(k, v);
+        bare.push([k, v]);
       }
     }
+    for (const [k, v] of bare) settingsStore.set(k, v);
+    for (const [k, v] of pinned) settingsStore.set(k, v);
   }
 
   /** Get a value by key from a specific store. Returns null if missing. */

--- a/web/src/components/OnboardingModal.tsx
+++ b/web/src/components/OnboardingModal.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { useNavigate } from "react-router";
+import { useSettingsModal } from "@/components/settings/SettingsModalProvider";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -44,7 +44,7 @@ interface OnboardingModalProps {
 }
 
 export default function OnboardingModal({ open, onDismiss, showLlmProviderPrompt = false }: OnboardingModalProps) {
-  const navigate = useNavigate();
+  const { openSettings } = useSettingsModal();
 
   const handleSkip = () => {
     dismissOnboarding();
@@ -54,7 +54,7 @@ export default function OnboardingModal({ open, onDismiss, showLlmProviderPrompt
   const handleOpenProviderSettings = () => {
     dismissOnboarding();
     onDismiss();
-    navigate("/settings?section=providers");
+    openSettings("providers");
   };
 
   return (

--- a/web/src/components/settings/SettingsModal.tsx
+++ b/web/src/components/settings/SettingsModal.tsx
@@ -33,6 +33,10 @@ interface SettingsModalProps {
  */
 export default function SettingsModal({ open, onClose, section }: SettingsModalProps) {
   const backdropRef = useRef<HTMLDivElement>(null);
+  // Tracks whether the current click began on the backdrop itself, so a drag
+  // that started inside an input (text selection) and released on the backdrop
+  // does not dismiss the modal mid-edit.
+  const mousedownOnBackdrop = useRef(false);
 
   // Escape-to-close + body scroll lock. Scoped to `open` so the listeners
   // and lock are installed exactly while the modal is visible.
@@ -59,10 +63,17 @@ export default function SettingsModal({ open, onClose, section }: SettingsModalP
     <div
       ref={backdropRef}
       className="rara-admin fixed inset-0 z-50 bg-black/40 backdrop-blur-sm"
+      onMouseDown={(e) => {
+        mousedownOnBackdrop.current = e.target === backdropRef.current;
+      }}
       onClick={(e) => {
-        // Close only when the mousedown originates on the backdrop itself,
-        // so drags ending inside an input (value selection) don't dismiss.
-        if (e.target === backdropRef.current) onClose();
+        // Only dismiss when both mousedown and click landed on the backdrop
+        // itself — protects drag-to-select gestures that originate in an
+        // input and release on the backdrop.
+        if (e.target === backdropRef.current && mousedownOnBackdrop.current) {
+          onClose();
+        }
+        mousedownOnBackdrop.current = false;
       }}
     >
       <div
@@ -77,7 +88,7 @@ export default function SettingsModal({ open, onClose, section }: SettingsModalP
           <X className="h-4 w-4" />
         </button>
         <div className="min-h-0 flex-1 overflow-hidden">
-          <SettingsPanel initialSection={section} />
+          <SettingsPanel key={section ?? "general"} initialSection={section} />
         </div>
       </div>
     </div>

--- a/web/src/components/settings/SettingsModal.tsx
+++ b/web/src/components/settings/SettingsModal.tsx
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2025 Rararulab
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useEffect, useRef } from "react";
+import { X } from "lucide-react";
+import SettingsPanel, { type SettingsPage } from "./SettingsPanel";
+
+interface SettingsModalProps {
+  open: boolean;
+  onClose: () => void;
+  section?: SettingsPage;
+}
+
+/**
+ * Floating admin-settings modal. Rendered from anywhere in the tree via
+ * {@link SettingsModalProvider}. Uses a custom shell rather than the shadcn
+ * `Dialog` primitive because the settings panel needs a large viewport with
+ * its own internal scroll regions that `Dialog`'s capped `max-w-lg`/`grid`
+ * content layout fights against.
+ */
+export default function SettingsModal({ open, onClose, section }: SettingsModalProps) {
+  const backdropRef = useRef<HTMLDivElement>(null);
+
+  // Escape-to-close + body scroll lock. Scoped to `open` so the listeners
+  // and lock are installed exactly while the modal is visible.
+  useEffect(() => {
+    if (!open) return;
+
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    window.addEventListener("keydown", onKeyDown);
+
+    const prevOverflow = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+
+    return () => {
+      window.removeEventListener("keydown", onKeyDown);
+      document.body.style.overflow = prevOverflow;
+    };
+  }, [open, onClose]);
+
+  if (!open) return null;
+
+  return (
+    <div
+      ref={backdropRef}
+      className="rara-admin fixed inset-0 z-50 bg-black/40 backdrop-blur-sm"
+      onClick={(e) => {
+        // Close only when the mousedown originates on the backdrop itself,
+        // so drags ending inside an input (value selection) don't dismiss.
+        if (e.target === backdropRef.current) onClose();
+      }}
+    >
+      <div
+        className="relative mx-auto my-[5vh] flex h-[90vh] w-[min(1200px,90vw)] flex-col overflow-hidden rounded-xl border border-border/60 bg-background shadow-2xl"
+      >
+        <button
+          type="button"
+          onClick={onClose}
+          aria-label="Close settings"
+          className="absolute right-3 top-3 z-10 flex h-8 w-8 items-center justify-center rounded-md text-muted-foreground hover:bg-secondary hover:text-foreground transition-colors cursor-pointer"
+        >
+          <X className="h-4 w-4" />
+        </button>
+        <div className="min-h-0 flex-1 overflow-hidden">
+          <SettingsPanel initialSection={section} />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/settings/SettingsModalProvider.tsx
+++ b/web/src/components/settings/SettingsModalProvider.tsx
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2025 Rararulab
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useMemo,
+  useState,
+  type ReactNode,
+} from "react";
+
+import SettingsModal from "./SettingsModal";
+import type { SettingsPage } from "./SettingsPanel";
+
+interface SettingsModalContextValue {
+  openSettings: (section?: SettingsPage) => void;
+  closeSettings: () => void;
+}
+
+const SettingsModalContext = createContext<SettingsModalContextValue | null>(null);
+
+/**
+ * Provides a single admin-settings modal instance to the whole tree and
+ * exposes imperative open/close helpers via {@link useSettingsModal}. The
+ * modal itself is rendered once here so every descendant shares state —
+ * mounting it per-caller would reset the active section on re-open.
+ */
+export function SettingsModalProvider({ children }: { children: ReactNode }) {
+  const [open, setOpen] = useState(false);
+  const [section, setSection] = useState<SettingsPage | undefined>(undefined);
+
+  const openSettings = useCallback((next?: SettingsPage) => {
+    setSection(next);
+    setOpen(true);
+  }, []);
+
+  const closeSettings = useCallback(() => {
+    setOpen(false);
+  }, []);
+
+  const value = useMemo<SettingsModalContextValue>(
+    () => ({ openSettings, closeSettings }),
+    [openSettings, closeSettings],
+  );
+
+  return (
+    <SettingsModalContext.Provider value={value}>
+      {children}
+      <SettingsModal open={open} onClose={closeSettings} section={section} />
+    </SettingsModalContext.Provider>
+  );
+}
+
+/**
+ * Read the settings-modal controls. Throws when called outside the
+ * provider so a misplaced caller fails loudly rather than silently no-op.
+ */
+export function useSettingsModal(): SettingsModalContextValue {
+  const ctx = useContext(SettingsModalContext);
+  if (!ctx) {
+    throw new Error(
+      "useSettingsModal must be used inside <SettingsModalProvider>",
+    );
+  }
+  return ctx;
+}

--- a/web/src/components/settings/SettingsPanel.tsx
+++ b/web/src/components/settings/SettingsPanel.tsx
@@ -16,7 +16,6 @@
 
 import type { ReactNode } from "react";
 import { useEffect, useState } from "react";
-import { useSearchParams } from "react-router";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { settingsApi } from "@/api/client";
 import type {
@@ -80,7 +79,18 @@ import Agents from "@/pages/Agents";
 import McpServers from "@/pages/McpServers";
 import DataFeedsPanel from "@/components/DataFeedsPanel";
 
-type SettingsPage = "general" | "providers" | "agents" | "skills" | "mcp" | "channels" | "tools" | "security" | "data-feeds";
+/** Admin settings section identifiers. Exported so the floating modal can deep-link into a specific tab. */
+export type SettingsPage =
+  | "general"
+  | "providers"
+  | "agents"
+  | "skills"
+  | "mcp"
+  | "channels"
+  | "tools"
+  | "security"
+  | "data-feeds";
+
 type ToastState = { kind: "success" | "error"; message: string } | null;
 
 // Well-known setting keys (must match backend keys module)
@@ -519,15 +529,29 @@ function AddProviderButton({ onAdd }: { onAdd: (name: string, baseUrl: string, a
   );
 }
 
-export default function Settings() {
-  const [searchParams, setSearchParams] = useSearchParams();
+const SETTINGS_PAGES: readonly SettingsPage[] = [
+  "general",
+  "providers",
+  "agents",
+  "skills",
+  "mcp",
+  "channels",
+  "tools",
+  "security",
+  "data-feeds",
+];
+
+/**
+ * Renders the rara admin settings UI (sidebar + content). Section state is
+ * owned locally so the panel can be embedded either in a floating modal or
+ * in a fullscreen route without coupling to the router.
+ */
+export default function SettingsPanel({ initialSection }: { initialSection?: SettingsPage }) {
   const { theme, setTheme } = useTheme();
   const queryClient = useQueryClient();
-  const [activeCategory, setActiveCategory] = useState<SettingsPage>(() => {
-    const section = searchParams.get("section");
-    const allowed: SettingsPage[] = ["general", "providers", "agents", "skills", "mcp", "channels", "tools", "security", "data-feeds"];
-    return allowed.includes(section as SettingsPage) ? (section as SettingsPage) : "general";
-  });
+  const [activeCategory, setActiveCategory] = useState<SettingsPage>(() =>
+    initialSection && SETTINGS_PAGES.includes(initialSection) ? initialSection : "general",
+  );
   const [toast, setToast] = useState<ToastState>(null);
 
   // Track which provider cards are expanded (collapsed by default)
@@ -613,7 +637,7 @@ export default function Settings() {
 
   if (settingsQuery.isLoading) {
     return (
-      <div className="space-y-6">
+      <div className="space-y-6 p-6">
         <Skeleton className="h-10 w-56" />
         <Skeleton className="h-72 w-full" />
       </div>
@@ -622,7 +646,7 @@ export default function Settings() {
 
   if (settingsQuery.isError) {
     return (
-      <div className="space-y-4">
+      <div className="space-y-4 p-6">
         <h1 className="text-2xl font-bold">Settings</h1>
         <p className="text-sm text-destructive">
           Failed to load settings. Please refresh and try again.
@@ -651,7 +675,7 @@ export default function Settings() {
   ];
 
   return (
-    <div className="flex h-full gap-4 overflow-hidden">
+    <div className="flex h-full gap-4 overflow-hidden p-4">
       {/* Sidebar */}
       <aside className="data-panel w-64 shrink-0 overflow-y-auto">
         <div className="border-b border-border/70 px-4 py-4">
@@ -666,10 +690,7 @@ export default function Settings() {
               <button
                 key={item.id}
                 type="button"
-                onClick={() => {
-                  setActiveCategory(item.id);
-                  setSearchParams({ section: item.id });
-                }}
+                onClick={() => setActiveCategory(item.id)}
                 className={cn(
                   "group flex w-full items-center gap-3 rounded-xl px-3 py-2.5 text-left text-sm transition-all",
                   activeCategory === item.id

--- a/web/src/layouts/DashboardLayout.tsx
+++ b/web/src/layouts/DashboardLayout.tsx
@@ -24,9 +24,10 @@ import { Button } from '@/components/ui/button';
 import OnboardingModal, { isOnboardingDismissed } from '@/components/OnboardingModal';
 import ThemeToggle from '@/components/ThemeToggle';
 import { useServerStatus } from '@/hooks/use-server-status';
+import { useSettingsModal } from '@/components/settings/SettingsModalProvider';
 
 /** Routes that need zero padding in the main content area. */
-const FULL_BLEED_ROUTES = new Set(['/agent', '/docs', '/dock', '/settings']);
+const FULL_BLEED_ROUTES = new Set(['/agent', '/docs', '/dock']);
 
 /** Routes that need full bleed when they match as a prefix. */
 const FULL_BLEED_PREFIXES: string[] = [];
@@ -90,6 +91,7 @@ function ConnectionStatus() {
 export default function DashboardLayout() {
   const location = useLocation();
   const navigate = useNavigate();
+  const { openSettings } = useSettingsModal();
   const isFullBleed = FULL_BLEED_ROUTES.has(location.pathname) || FULL_BLEED_PREFIXES.some(p => location.pathname.startsWith(p));
 
   const settingsQuery = useQuery({
@@ -143,7 +145,7 @@ export default function DashboardLayout() {
             variant="ghost"
             size="sm"
             className="h-7 gap-1.5 text-xs text-muted-foreground hover:text-foreground"
-            onClick={() => navigate('/settings')}
+            onClick={() => openSettings()}
           >
             <Settings className="h-3.5 w-3.5" />
             Settings

--- a/web/src/pages/PiChat.tsx
+++ b/web/src/pages/PiChat.tsx
@@ -20,12 +20,11 @@ import {
   setAppStorage,
   SessionsStore,
   SettingsStore,
+  // Stub stores only — rara's admin settings modal is the real source of
+  // truth for provider keys and custom providers (see #1581).
   ProviderKeysStore,
   CustomProvidersStore,
   defaultConvertToLlm,
-  ProvidersModelsTab,
-  ProxyTab,
-  SettingsDialog,
   type Attachment,
   type UserMessageWithAttachments,
 } from "@mariozechner/pi-web-ui";
@@ -54,9 +53,9 @@ import { createRaraStreamFn } from "@/adapters/rara-stream";
 import { registerRaraToolRenderers } from "@/tools/rara-tool-renderers";
 import { api, settingsApi } from "@/api/client";
 import type { ChatSession, ChatMessageData, ThinkingLevel } from "@/api/types";
-import { useNavigate } from "react-router";
 import { VoiceRecorder } from "@/components/VoiceRecorder";
 import { RaraModelDialog } from "@/components/RaraModelDialog";
+import { useSettingsModal } from "@/components/settings/SettingsModalProvider";
 import type { ProviderInfo } from "@/api/types";
 import { UNKNOWN_MODEL_SENTINEL, isUnknownModel, syntheticModel } from "@/lib/synthetic-model";
 
@@ -302,14 +301,14 @@ function SessionListPanel({
   onClose,
   onDelete,
   onNew,
-  onNavigate,
+  onOpenAdmin,
 }: {
   activeKey: string | undefined;
   onSelect: (s: ChatSession) => void;
   onClose: () => void;
   onDelete: (key: string) => void;
   onNew: () => void;
-  onNavigate: (path: string) => void;
+  onOpenAdmin: () => void;
 }) {
   const [sessions, setSessions] = useState<ChatSession[]>([]);
   const [loading, setLoading] = useState(true);
@@ -411,13 +410,12 @@ function SessionListPanel({
         </div>
         {/*
           Server-wide admin settings (MCP servers, agent manifests, skills,
-          kernel config). Chat-user preferences (provider API keys, proxy,
-          theme, thinking default) live in pi-mono's SettingsDialog opened
-          from the gear icon in the top bar.
+          kernel config, provider keys). Opens the floating settings modal
+          in place — no navigation away from the chat.
         */}
         <div className="border-t border-border px-4 py-3">
           <button
-            onClick={() => { onNavigate("/settings"); onClose(); }}
+            onClick={() => { onOpenAdmin(); onClose(); }}
             className="flex w-full items-center gap-2 rounded px-2 py-1.5 text-sm text-muted-foreground hover:bg-secondary hover:text-foreground transition-colors cursor-pointer"
           >
             <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
@@ -458,7 +456,7 @@ export default function PiChat() {
   const [isInitializing, setIsInitializing] = useState(true);
   const [modelDialogOpen, setModelDialogOpen] = useState(false);
   const [resetError, setResetError] = useState<string | null>(null);
-  const navigate = useNavigate();
+  const { openSettings } = useSettingsModal();
 
   // Clear any stale reset-error banner whenever the model dialog is
   // closed — regardless of close path (backdrop click, successful
@@ -863,15 +861,12 @@ export default function PiChat() {
             </svg>
           </button>
           {/*
-            Opens pi-mono's SettingsDialog (provider API keys, custom
-            providers, proxy). Rara's server-wide admin config (MCP
-            servers, agent manifests, kernel config) still lives at
-            `/settings` — reachable from the session-list footer.
+            Opens the rara floating settings modal (provider keys, MCP
+            servers, agent manifests, kernel config). Single source of
+            truth since #1581 retired pi-mono's separate SettingsDialog.
           */}
           <button
-            onClick={() =>
-              SettingsDialog.open([new ProvidersModelsTab(), new ProxyTab()])
-            }
+            onClick={() => openSettings()}
             className="flex h-9 w-9 items-center justify-center rounded-md text-muted-foreground hover:bg-secondary hover:text-foreground transition-colors cursor-pointer"
             title="Settings"
           >
@@ -903,7 +898,7 @@ export default function PiChat() {
           onClose={() => setShowSessionList(false)}
           onDelete={handleSessionDeleted}
           onNew={newSession}
-          onNavigate={navigate}
+          onOpenAdmin={() => openSettings()}
         />
       )}
       {/* Rara-native model picker — replaces pi-mono's ModelSelector. */}


### PR DESCRIPTION
## Summary

- Retire pi-mono's `SettingsDialog` (provider keys / proxy) — it wrote to an in-memory store that never persisted, so reloads lost config.
- Refactor the `/settings` admin page into a reusable `SettingsPanel`, wrap it in a floating `SettingsModal`, and expose `useSettingsModal()` via a root-level provider.
- Open the modal from the chat gear icon, the admin top-bar button, the sessions-panel Admin footer, and the onboarding CTA — all without route navigation.
- `/settings?section=...` now redirects to `/` after opening the modal so bookmarks still work.

## Type of change

| Type | Label |
|------|-------|
| New feature | `enhancement` |

## Component

`ui`

## Closes

Closes #1581

## Test plan

- [x] `cd web && npm run build` passes
- [x] `cargo check --all --all-targets` passes
- [ ] Manually verify gear icon on chat page opens modal
- [ ] Manually verify admin top-bar Settings button opens modal
- [ ] Manually verify `/settings?section=providers` deep link opens modal on Providers