### PR TITLE
style(web): user message bubble glass (#1583)

### DIFF
--- a/web/src/index.css
+++ b/web/src/index.css
@@ -180,6 +180,23 @@
 }
 
 @layer components {
+  /*
+   * Pi-web-ui ships `.user-message-container` with a warm orange gradient
+   * (`#d94f001f → #ff6b001f → #d4a5001f`) and matching orange border. On
+   * rara's rose/pink palette the orange reads as a clashing yellow. Swap
+   * to a neutral frosted-glass tint tied to the theme's foreground token
+   * so the bubble adapts with light/dark modes and any future re-palette.
+   * `backdrop-filter: blur(10px)` is already applied by pi-web-ui.
+   */
+  .user-message-container {
+    background: color-mix(in oklab, var(--color-foreground) 5%, transparent);
+    border-color: color-mix(in oklab, var(--color-foreground) 10%, transparent);
+  }
+  .dark .user-message-container {
+    background: color-mix(in oklab, var(--color-foreground) 7%, transparent);
+    border-color: color-mix(in oklab, var(--color-foreground) 14%, transparent);
+  }
+
   .app-surface {
     background: color-mix(in oklab, var(--color-card) 92%, transparent);
     backdrop-filter: blur(14px);


### PR DESCRIPTION
## Summary

- Override pi-web-ui's `.user-message-container` orange gradient with a neutral foreground-tinted frosted-glass background.
- Tune tint alpha per mode: 5%/10% in light, 7%/14% in dark.
- Glass pattern mirrors `vendor/multica`'s low-sat tint + same-color border + backdrop-blur.

## Type of change

| Type | Label |
|------|-------|
| Style | \`enhancement\` |

## Component

\`ui\`

## Closes

Closes #1583

## Test plan

- [x] \`npm run build\` passes in \`web/\`
- [x] Rose palette no longer reads yellow behind user bubbles