### PR TITLE
fix(web): user bubble glass align w/ multica (#1585)

### DIFF
--- a/web/src/components/AlmaCaret.tsx
+++ b/web/src/components/AlmaCaret.tsx
@@ -1,0 +1,227 @@
+/*
+ * Copyright 2025 Rararulab
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useEffect, useRef, useState } from "react";
+
+/**
+ * Mirrored textarea trick: copy every layout-affecting computed style onto a
+ * hidden `<div>`, drop in the text up to the caret followed by a marker
+ * `<span>`, and read back the marker's bounding rect. That rect is where
+ * the real caret would sit — the textarea itself exposes no such API.
+ */
+const MIRROR_STYLE_KEYS = [
+  "boxSizing",
+  "width",
+  "height",
+  "paddingTop",
+  "paddingRight",
+  "paddingBottom",
+  "paddingLeft",
+  "borderTopWidth",
+  "borderRightWidth",
+  "borderBottomWidth",
+  "borderLeftWidth",
+  "fontFamily",
+  "fontSize",
+  "fontWeight",
+  "fontStyle",
+  "lineHeight",
+  "letterSpacing",
+  "wordSpacing",
+  "textTransform",
+  "textIndent",
+  "tabSize",
+] as const;
+
+interface CaretPos {
+  x: number;
+  y: number;
+  height: number;
+}
+
+function measureCaret(textarea: HTMLTextAreaElement): CaretPos | null {
+  if (!textarea.isConnected) return null;
+
+  const cs = getComputedStyle(textarea);
+  const mirror = document.createElement("div");
+  for (const key of MIRROR_STYLE_KEYS) {
+    mirror.style[key as never] = cs[key as never];
+  }
+  mirror.style.position = "absolute";
+  mirror.style.visibility = "hidden";
+  mirror.style.top = "0";
+  mirror.style.left = "0";
+  mirror.style.whiteSpace = "pre-wrap";
+  mirror.style.wordWrap = "break-word";
+  mirror.style.overflow = "hidden";
+
+  const end = textarea.selectionEnd ?? textarea.value.length;
+  mirror.textContent = textarea.value.substring(0, end);
+  const marker = document.createElement("span");
+  // U+200B (zero-width space) keeps the line alive without adding glyph width.
+  marker.textContent = "\u200b";
+  mirror.appendChild(marker);
+
+  document.body.appendChild(mirror);
+  const markerRect = marker.getBoundingClientRect();
+  const mirrorRect = mirror.getBoundingClientRect();
+  document.body.removeChild(mirror);
+
+  const taRect = textarea.getBoundingClientRect();
+  const lineHeight =
+    parseFloat(cs.lineHeight) ||
+    parseFloat(cs.fontSize) * 1.3 ||
+    18;
+
+  return {
+    x: taRect.left + (markerRect.left - mirrorRect.left) - textarea.scrollLeft,
+    y: taRect.top + (markerRect.top - mirrorRect.top) - textarea.scrollTop,
+    height: lineHeight,
+  };
+}
+
+/**
+ * Alma-style fake caret. Hides the textarea's native caret via CSS and
+ * paints a smoothly-animated replacement that trails the cursor with a
+ * comet tail.
+ *
+ * The component resolves the target `<textarea>` lazily by polling a
+ * short interval at mount: pi-web-ui's composer is a Lit custom element
+ * whose textarea lands in the DOM asynchronously, so we can't ref it
+ * through React.
+ */
+export function AlmaCaret() {
+  const [pos, setPos] = useState<CaretPos | null>(null);
+  const [visible, setVisible] = useState(false);
+  const textareaRef = useRef<HTMLTextAreaElement | null>(null);
+
+  useEffect(() => {
+    let raf = 0;
+    let canceled = false;
+
+    // Poll until pi-web-ui's textarea mounts, then bind listeners.
+    const findAndBind = () => {
+      if (canceled) return;
+      const ta = document.querySelector<HTMLTextAreaElement>("textarea");
+      if (!ta) {
+        raf = window.setTimeout(findAndBind, 80);
+        return;
+      }
+      textareaRef.current = ta;
+      ta.style.caretColor = "transparent";
+      // IME (composition) shows a browser-native caret under Chromium; accept it.
+
+      const update = () => {
+        const next = measureCaret(ta);
+        if (next) setPos(next);
+      };
+      const focus = () => {
+        setVisible(true);
+        update();
+      };
+      const blur = () => setVisible(false);
+
+      ta.addEventListener("input", update);
+      ta.addEventListener("keydown", update);
+      ta.addEventListener("keyup", update);
+      ta.addEventListener("click", update);
+      ta.addEventListener("scroll", update);
+      ta.addEventListener("focus", focus);
+      ta.addEventListener("blur", blur);
+      window.addEventListener("resize", update);
+      document.addEventListener("selectionchange", update);
+
+      if (document.activeElement === ta) focus();
+      update();
+
+      return () => {
+        ta.style.caretColor = "";
+        ta.removeEventListener("input", update);
+        ta.removeEventListener("keydown", update);
+        ta.removeEventListener("keyup", update);
+        ta.removeEventListener("click", update);
+        ta.removeEventListener("scroll", update);
+        ta.removeEventListener("focus", focus);
+        ta.removeEventListener("blur", blur);
+        window.removeEventListener("resize", update);
+        document.removeEventListener("selectionchange", update);
+      };
+    };
+
+    const cleanup = findAndBind();
+    return () => {
+      canceled = true;
+      if (raf) clearTimeout(raf);
+      if (typeof cleanup === "function") cleanup();
+    };
+  }, []);
+
+  if (!pos || !visible) return null;
+
+  // Head: sharp bar; smooth translate so moves across characters glide
+  // rather than jumping. Blink animation still fires because it runs on
+  // opacity, not transform.
+  const head: React.CSSProperties = {
+    position: "fixed",
+    left: 0,
+    top: 0,
+    width: 2,
+    height: pos.height,
+    transform: `translate(${pos.x}px, ${pos.y}px)`,
+    background: "var(--color-foreground)",
+    transition: "transform 90ms cubic-bezier(0.2, 0.9, 0.2, 1)",
+    animation: "alma-caret-blink 1.05s step-end infinite",
+    pointerEvents: "none",
+    zIndex: 30,
+    willChange: "transform",
+  };
+
+  // Trail: painted only during moves. Keyed on the caret position so the
+  // fade keyframe replays on every pixel change; between moves the element
+  // sits at opacity 0 and disappears — no idle halo.
+  const trail: React.CSSProperties = {
+    position: "fixed",
+    left: 0,
+    top: 0,
+    width: 24,
+    height: pos.height,
+    transform: `translate(${pos.x - 11}px, ${pos.y}px)`,
+    background:
+      "radial-gradient(ellipse at 55% 50%, color-mix(in oklab, oklch(0.62 0.18 250) 70%, transparent) 0%, transparent 70%)",
+    transition: "transform 260ms cubic-bezier(0.25, 0.85, 0.25, 1)",
+    filter: "blur(4px)",
+    opacity: 0,
+    animation: "alma-caret-trail 420ms ease-out",
+    pointerEvents: "none",
+    zIndex: 29,
+    willChange: "transform, opacity",
+  };
+
+  return (
+    <>
+      <style>{`
+        @keyframes alma-caret-blink { 0%, 55% { opacity: 1; } 56%, 100% { opacity: 0; } }
+        @keyframes alma-caret-trail { 0% { opacity: 0; } 30% { opacity: 0.9; } 100% { opacity: 0; } }
+      `}</style>
+      <div
+        aria-hidden
+        key={`${Math.round(pos.x)}-${Math.round(pos.y)}`}
+        style={trail}
+      />
+      <div aria-hidden style={head} />
+    </>
+  );
+}

--- a/web/src/components/AlmaCaret.tsx
+++ b/web/src/components/AlmaCaret.tsx
@@ -16,6 +16,16 @@
 
 import { useEffect, useRef, useState } from "react";
 
+interface AlmaCaretProps {
+  /**
+   * Bump this when an ancestor of the textarea animates position so
+   * the caret is re-measured both immediately and after the 420 ms
+   * layout transition finishes. Bumping the key is how PiChat tells
+   * the caret that welcome-mode was toggled.
+   */
+  measureKey?: string | number;
+}
+
 /**
  * Mirrored textarea trick: copy every layout-affecting computed style onto a
  * hidden `<div>`, drop in the text up to the caret followed by a marker
@@ -103,10 +113,28 @@ function measureCaret(textarea: HTMLTextAreaElement): CaretPos | null {
  * whose textarea lands in the DOM asynchronously, so we can't ref it
  * through React.
  */
-export function AlmaCaret() {
+export function AlmaCaret({ measureKey }: AlmaCaretProps = {}) {
   const [pos, setPos] = useState<CaretPos | null>(null);
   const [visible, setVisible] = useState(false);
   const textareaRef = useRef<HTMLTextAreaElement | null>(null);
+
+  // When ancestors animate (e.g. the composer slides out of welcome
+  // position), `getBoundingClientRect()` reports the mid-animation
+  // position at measure time — we re-measure once immediately and
+  // again after the layout transition to land the caret at the final
+  // resting place.
+  useEffect(() => {
+    if (measureKey === undefined) return;
+    const ta = textareaRef.current;
+    if (!ta) return;
+    const now = measureCaret(ta);
+    if (now) setPos(now);
+    const timer = window.setTimeout(() => {
+      const next = measureCaret(ta);
+      if (next) setPos(next);
+    }, 460);
+    return () => window.clearTimeout(timer);
+  }, [measureKey]);
 
   useEffect(() => {
     let raf = 0;

--- a/web/src/components/VoiceRecorder.tsx
+++ b/web/src/components/VoiceRecorder.tsx
@@ -16,6 +16,8 @@ type VoiceRecorderProps = {
   getSessionKey: () => string | undefined;
   /** Called when the backend finishes processing the voice message. */
   onComplete?: () => void;
+  /** Optional wrapper classes — used to position the floating button. */
+  className?: string;
 };
 
 /**
@@ -40,7 +42,7 @@ function blobToBase64(blob: Blob): Promise<string> {
  * Records audio via MediaRecorder, sends as an AudioBase64 content block
  * through the existing WebSocket chat API for server-side transcription.
  */
-export function VoiceRecorder({ getSessionKey, onComplete }: VoiceRecorderProps) {
+export function VoiceRecorder({ getSessionKey, onComplete, className }: VoiceRecorderProps) {
   const [recording, setRecording] = useState(false);
   const [sending, setSending] = useState(false);
   const recorderRef = useRef<MediaRecorder | null>(null);
@@ -167,7 +169,7 @@ export function VoiceRecorder({ getSessionKey, onComplete }: VoiceRecorderProps)
           : sending
             ? "bg-muted text-muted-foreground cursor-wait"
             : "bg-background/80 text-muted-foreground backdrop-blur hover:bg-secondary hover:text-foreground"
-      }`}
+      } ${className ?? ""}`}
       title={recording ? "Stop recording" : sending ? "Sending..." : "Record voice message"}
     >
       {sending ? (

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -38,6 +38,7 @@
   --color-border: var(--border);
   --color-input: var(--input);
   --color-ring: var(--ring);
+  --color-canvas: var(--canvas);
 
   /* Semantic status colors — rara admin */
   --color-ok: #7BC4A0;
@@ -68,6 +69,20 @@
     "Hiragino Sans GB", "Microsoft YaHei", "Noto Sans SC", sans-serif;
   --font-mono: "Geist Mono", ui-monospace, SFMono-Regular, Menlo, Monaco,
     Consolas, "Liberation Mono", "Courier New", monospace;
+
+  /*
+   * App-shell canvas color. Slightly cooler and a tick darker than
+   * pi-web-ui's pure-white `--background`, matching the pattern multica
+   * uses: a subtle off-white so cards, inputs, and message bubbles
+   * (which stay on `--background`) read as lifted surfaces rather than
+   * floating in a flat sheet. Hue 250 keeps it in the same cool family
+   * as the tool-call glass bubble so the page reads as one palette.
+   */
+  --canvas: oklch(0.96 0.005 250);
+}
+
+.dark {
+  --canvas: oklch(0.2 0.005 250);
 }
 
 /*
@@ -144,7 +159,14 @@
     @apply border-border;
   }
   body {
-    @apply bg-background text-foreground antialiased;
+    /*
+     * Body sits on the canvas, not on `--background`. Pi-web-ui inputs,
+     * bubbles, and cards keep `--background` (pure white) as their own
+     * surface color so they read as "lifted" against the canvas — the
+     * multica aesthetic. `.rara-admin` overrides this with its rose
+     * radial gradient on admin pages.
+     */
+    @apply bg-canvas text-foreground antialiased;
     font-family: var(--font-sans);
     min-height: 100vh;
   }
@@ -154,6 +176,39 @@
   pre {
     font-family: var(--font-mono);
   }
+  /*
+   * Chat-shell atmosphere: one very faint info-blue glow in the top-left
+   * corner, painted on top of the canvas. Ties the page to the same cool
+   * palette the user-message glass bubble uses, stops the chat from
+   * reading as "bare white sheet" without pulling focus from content.
+   */
+  .rara-chat {
+    background-image:
+      radial-gradient(
+        ellipse 70% 50% at 0% 0%,
+        color-mix(in oklab, oklch(0.62 0.18 250) 22%, transparent) 0%,
+        transparent 65%
+      ),
+      radial-gradient(
+        ellipse 60% 45% at 100% 100%,
+        color-mix(in oklab, oklch(0.72 0.14 340) 20%, transparent) 0%,
+        transparent 60%
+      );
+  }
+  .dark .rara-chat {
+    background-image:
+      radial-gradient(
+        ellipse 70% 50% at 0% 0%,
+        color-mix(in oklab, oklch(0.62 0.18 250) 22%, transparent) 0%,
+        transparent 65%
+      ),
+      radial-gradient(
+        ellipse 60% 45% at 100% 100%,
+        color-mix(in oklab, oklch(0.55 0.14 340) 20%, transparent) 0%,
+        transparent 60%
+      );
+  }
+
   /* Rara admin gradient background — only on admin pages */
   .rara-admin {
     background-image:
@@ -196,6 +251,22 @@
  * specificity or source order — loses to an unlayered one. Wrapping this
  * in `@layer components {}` (as the first attempt did) made it invisible.
  */
+/*
+ * Pi-web-ui's `<agent-interface>` paints a full-height
+ * `flex flex-col h-full bg-background` shell that covers any gradient
+ * behind it. Unpaint that single shell so the `.rara-chat` canvas and
+ * radial glow show through; individual bubbles, inputs, and cards keep
+ * their own `bg-background` and read as lifted surfaces.
+ *
+ * Unlayered for the same reason as `.user-message-container` below:
+ * Tailwind's `.bg-background` utility lives in the `utilities` layer,
+ * which trumps any `@layer base` / `components` override regardless of
+ * specificity — so this rule must sit outside the layer system.
+ */
+.rara-chat agent-interface .flex-col.bg-background {
+  background-color: transparent;
+}
+
 .user-message-container {
   background: color-mix(in oklab, oklch(0.55 0.18 250) 5%, transparent);
   border-color: color-mix(in oklab, oklch(0.55 0.18 250) 20%, transparent);

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -291,7 +291,10 @@
 .rara-chat[data-welcome="true"] > button[title*="Record" i],
 .rara-chat[data-welcome="true"] > button[title*="recording" i],
 .rara-chat[data-welcome="true"] > button[title*="Sending" i] {
-  transform: translateY(-28vh);
+  /* Lifts the composer centre close to viewport centre. Natural bottom
+     is ~8-10rem from the edge (padding + composer body), so ~40vh up
+     lands the centre near 50vh with some headroom for the wordmark. */
+  transform: translateY(-40vh);
   transition: transform 420ms cubic-bezier(0.22, 0.61, 0.36, 1);
 }
 .rara-chat agent-interface .flex-col.bg-background > *:last-child,

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -278,6 +278,29 @@
   background-color: transparent;
 }
 
+/*
+ * Welcome-state composer lift. When the session is empty we float the
+ * composer (pi-web-ui's last flex-col child) up to sit near the middle
+ * of the viewport, together with the RARA wordmark positioned just
+ * above it. The floating voice button piggybacks on the same translate
+ * so it keeps its alignment with the paperclip inside the composer.
+ * Transition is long enough to read as an intentional shift when the
+ * first message flips us out of welcome mode.
+ */
+.rara-chat[data-welcome="true"] agent-interface .flex-col.bg-background > *:last-child,
+.rara-chat[data-welcome="true"] > button[title*="Record" i],
+.rara-chat[data-welcome="true"] > button[title*="recording" i],
+.rara-chat[data-welcome="true"] > button[title*="Sending" i] {
+  transform: translateY(-28vh);
+  transition: transform 420ms cubic-bezier(0.22, 0.61, 0.36, 1);
+}
+.rara-chat agent-interface .flex-col.bg-background > *:last-child,
+.rara-chat > button[title*="Record" i],
+.rara-chat > button[title*="recording" i],
+.rara-chat > button[title*="Sending" i] {
+  transition: transform 420ms cubic-bezier(0.22, 0.61, 0.36, 1);
+}
+
 .user-message-container {
   background: color-mix(in oklab, oklch(0.55 0.18 250) 5%, transparent);
   border-color: color-mix(in oklab, oklch(0.55 0.18 250) 20%, transparent);

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -252,6 +252,17 @@
  * in `@layer components {}` (as the first attempt did) made it invisible.
  */
 /*
+ * Pi-web-ui left-aligns user messages (`class="flex justify-start"`
+ * on the bubble's parent). Flip to the right side — the standard
+ * chat convention of "my messages on the right". `:has()` gives us a
+ * parent selector without patching pi-web-ui's templates, and the
+ * rule is narrow enough that only the bubble's direct parent matches.
+ */
+.rara-chat div:has(> .user-message-container) {
+  justify-content: flex-end;
+}
+
+/*
  * Pi-web-ui's `<agent-interface>` paints a full-height
  * `flex flex-col h-full bg-background` shell that covers any gradient
  * behind it. Unpaint that single shell so the `.rara-chat` canvas and

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -179,24 +179,36 @@
   }
 }
 
-@layer components {
-  /*
-   * Pi-web-ui ships `.user-message-container` with a warm orange gradient
-   * (`#d94f001f → #ff6b001f → #d4a5001f`) and matching orange border. On
-   * rara's rose/pink palette the orange reads as a clashing yellow. Swap
-   * to a neutral frosted-glass tint tied to the theme's foreground token
-   * so the bubble adapts with light/dark modes and any future re-palette.
-   * `backdrop-filter: blur(10px)` is already applied by pi-web-ui.
-   */
-  .user-message-container {
-    background: color-mix(in oklab, var(--color-foreground) 5%, transparent);
-    border-color: color-mix(in oklab, var(--color-foreground) 10%, transparent);
-  }
-  .dark .user-message-container {
-    background: color-mix(in oklab, var(--color-foreground) 7%, transparent);
-    border-color: color-mix(in oklab, var(--color-foreground) 14%, transparent);
-  }
+/*
+ * Pi-web-ui ships `.user-message-container` with a warm orange gradient
+ * and a heavy `blur(10px)` backdrop — too opaque and clashes with rara's
+ * rose palette. Retint to match multica's tool-call glass pattern
+ * (`border-info/20 + bg-info/5 + backdrop-blur-sm`), the canonical
+ * "transparent frosted glass" treatment in that design language.
+ *
+ * `--info` values are taken verbatim from multica's `tokens.css`:
+ *   light: oklch(0.55 0.18 250), dark: oklch(0.65 0.18 250).
+ * Inlined because rara's chat page sits outside `.rara-admin` scope and
+ * therefore can't read rara's own semantic tokens.
+ *
+ * Kept UNLAYERED on purpose: pi-web-ui's rule is unlayered too, and per
+ * the CSS Cascade Layers spec any layered declaration — no matter its
+ * specificity or source order — loses to an unlayered one. Wrapping this
+ * in `@layer components {}` (as the first attempt did) made it invisible.
+ */
+.user-message-container {
+  background: color-mix(in oklab, oklch(0.55 0.18 250) 5%, transparent);
+  border-color: color-mix(in oklab, oklch(0.55 0.18 250) 20%, transparent);
+  /* `sm` in tailwind ≈ 4px; overrides pi-web-ui's heavier blur(10px). */
+  backdrop-filter: blur(4px);
+  -webkit-backdrop-filter: blur(4px);
+}
+.dark .user-message-container {
+  background: color-mix(in oklab, oklch(0.65 0.18 250) 6%, transparent);
+  border-color: color-mix(in oklab, oklch(0.65 0.18 250) 24%, transparent);
+}
 
+@layer components {
   .app-surface {
     background: color-mix(in oklab, var(--color-card) 92%, transparent);
     backdrop-filter: blur(14px);

--- a/web/src/pages/PiChat.tsx
+++ b/web/src/pages/PiChat.tsx
@@ -55,6 +55,7 @@ import { api, settingsApi } from "@/api/client";
 import type { ChatSession, ChatMessageData, ThinkingLevel } from "@/api/types";
 import { VoiceRecorder } from "@/components/VoiceRecorder";
 import { RaraModelDialog } from "@/components/RaraModelDialog";
+import { AlmaCaret } from "@/components/AlmaCaret";
 import { useSettingsModal } from "@/components/settings/SettingsModalProvider";
 import type { ProviderInfo } from "@/api/types";
 import { UNKNOWN_MODEL_SENTINEL, isUnknownModel, syntheticModel } from "@/lib/synthetic-model";
@@ -894,13 +895,10 @@ export default function PiChat() {
         moment the user commits their first message (onBeforeSend).
       */}
       {showWelcome && !isInitializing && (
-        <div className="pointer-events-none absolute inset-x-0 top-12 bottom-40 z-10 flex flex-col items-center justify-center gap-4 px-6 text-center">
-          <h1 className="bg-gradient-to-br from-foreground via-foreground/85 to-foreground/50 bg-clip-text text-4xl font-semibold tracking-tight text-transparent sm:text-5xl">
-            你好，我是 Rara
+        <div className="pointer-events-none absolute inset-x-0 top-12 bottom-40 z-10 flex items-center justify-center px-6">
+          <h1 className="bg-gradient-to-br from-foreground via-foreground/80 to-foreground/40 bg-clip-text text-6xl font-semibold tracking-[0.2em] text-transparent sm:text-7xl">
+            RARA
           </h1>
-          <p className="max-w-md text-sm text-muted-foreground sm:text-base">
-            有什么想聊的？写任务、问问题、让我帮你查点东西都行。
-          </p>
         </div>
       )}
       {/*
@@ -913,6 +911,13 @@ export default function PiChat() {
         getSessionKey={() => agentRef.current?.sessionId}
         onComplete={reloadMessages}
       />
+      {/*
+        Custom textarea caret (Alma-style): smooth moves + a cool-blue
+        comet tail. Mounts after pi-web-ui's composer is in the DOM via
+        an internal DOM query since the textarea is owned by a Lit
+        custom element we don't ref directly.
+      */}
+      {!isInitializing && <AlmaCaret />}
       {/* Initial load overlay — covers the empty container while sessions + agent initialize */}
       {isInitializing && (
         <div className="pointer-events-none absolute inset-0 z-40 flex flex-col items-center justify-center gap-3 bg-background">

--- a/web/src/pages/PiChat.tsx
+++ b/web/src/pages/PiChat.tsx
@@ -843,7 +843,7 @@ export default function PiChat() {
   }, []);
 
   return (
-    <div className="relative flex h-screen w-screen flex-col">
+    <div className="rara-chat relative flex h-screen w-screen flex-col">
       {/*
         Top utility bar — reserves its own row (not `absolute`) so the
         chat panel's message list can never render underneath the

--- a/web/src/pages/PiChat.tsx
+++ b/web/src/pages/PiChat.tsx
@@ -456,6 +456,11 @@ export default function PiChat() {
   const [isInitializing, setIsInitializing] = useState(true);
   const [modelDialogOpen, setModelDialogOpen] = useState(false);
   const [resetError, setResetError] = useState<string | null>(null);
+  // `true` when the active session has no messages — we render a welcome
+  // overlay in that window so the chat page isn't just an input box on
+  // empty canvas. Flipped off on the first send and on session switches
+  // that land on a populated session.
+  const [showWelcome, setShowWelcome] = useState(true);
   const { openSettings } = useSettingsModal();
 
   // Clear any stale reset-error banner whenever the model dialog is
@@ -472,6 +477,7 @@ export default function PiChat() {
     if (!agent) return;
     agent.clearMessages();
     agent.sessionId = session.key;
+    setShowWelcome((session.message_count ?? 0) === 0);
 
     // Restore the session's persisted model + thinking-level so the
     // model pill in the composer reflects the last settings used for
@@ -714,6 +720,7 @@ export default function PiChat() {
       } else {
         initialSession = await api.post<ChatSession>("/api/v1/chat/sessions", {});
       }
+      setShowWelcome((initialSession.message_count ?? 0) === 0);
       // 5. Create the Agent with rara's WebSocket-backed stream function.
       //    The streamFn reads agent.sessionId at call time to get the active session key.
       const agent: Agent = new Agent({
@@ -782,6 +789,8 @@ export default function PiChat() {
         onBeforeSend: async () => {
           const key = agent.sessionId;
           if (!key) return;
+          // The user just committed their first message — no more welcome.
+          setShowWelcome(false);
 
           // Skip the PATCH when `agent.state.model` is pi-agent-core's
           // placeholder default (id/provider = "unknown"). Persisting it
@@ -878,6 +887,22 @@ export default function PiChat() {
       </div>
       {/* Chat panel container — takes remaining vertical space. */}
       <div ref={containerRef} className="min-h-0 flex-1 w-full" />
+      {/*
+        Welcome overlay — rendered above pi-web-ui's empty message list
+        when the active session has no messages. Pointer-events-none so
+        clicks pass through to the composer below; flipped off the
+        moment the user commits their first message (onBeforeSend).
+      */}
+      {showWelcome && !isInitializing && (
+        <div className="pointer-events-none absolute inset-x-0 top-12 bottom-40 z-10 flex flex-col items-center justify-center gap-4 px-6 text-center">
+          <h1 className="bg-gradient-to-br from-foreground via-foreground/85 to-foreground/50 bg-clip-text text-4xl font-semibold tracking-tight text-transparent sm:text-5xl">
+            你好，我是 Rara
+          </h1>
+          <p className="max-w-md text-sm text-muted-foreground sm:text-base">
+            有什么想聊的？写任务、问问题、让我帮你查点东西都行。
+          </p>
+        </div>
+      )}
       {/*
         Voice button floats over pi-web-ui's composer, anchored to the
         viewport bottom-right so it sits on the same line as the send

--- a/web/src/pages/PiChat.tsx
+++ b/web/src/pages/PiChat.tsx
@@ -853,7 +853,10 @@ export default function PiChat() {
   }, []);
 
   return (
-    <div className="rara-chat relative flex h-screen w-screen flex-col">
+    <div
+      className="rara-chat relative flex h-screen w-screen flex-col"
+      data-welcome={showWelcome && !isInitializing ? "true" : undefined}
+    >
       {/*
         Top utility bar — reserves its own row (not `absolute`) so the
         chat panel's message list can never render underneath the
@@ -895,7 +898,7 @@ export default function PiChat() {
         moment the user commits their first message (onBeforeSend).
       */}
       {showWelcome && !isInitializing && (
-        <div className="pointer-events-none absolute inset-x-0 top-12 bottom-40 z-10 flex items-center justify-center px-6">
+        <div className="pointer-events-none absolute inset-x-0 bottom-[calc(28vh+10rem)] z-10 flex justify-center px-6">
           <h1 className="bg-gradient-to-br from-foreground via-foreground/80 to-foreground/40 bg-clip-text text-6xl font-semibold tracking-[0.2em] text-transparent sm:text-7xl">
             RARA
           </h1>
@@ -917,7 +920,7 @@ export default function PiChat() {
         an internal DOM query since the textarea is owned by a Lit
         custom element we don't ref directly.
       */}
-      {!isInitializing && <AlmaCaret />}
+      {!isInitializing && <AlmaCaret measureKey={showWelcome ? "welcome" : "chat"} />}
       {/* Initial load overlay — covers the empty container while sessions + agent initialize */}
       {isInitializing && (
         <div className="pointer-events-none absolute inset-0 z-40 flex flex-col items-center justify-center gap-3 bg-background">

--- a/web/src/pages/PiChat.tsx
+++ b/web/src/pages/PiChat.tsx
@@ -847,42 +847,47 @@ export default function PiChat() {
       {/*
         Top utility bar — reserves its own row (not `absolute`) so the
         chat panel's message list can never render underneath the
-        Sessions / Settings / Voice icon buttons.
+        Sessions / Settings icons. Transparent + backdrop-blur so the
+        chat-page canvas + radial glow read through as frosted glass.
       */}
-      <div className="flex h-12 shrink-0 items-center justify-between border-b border-border/60 bg-background px-2">
-        <div className="flex items-center gap-1">
-          <button
-            onClick={() => setShowSessionList(true)}
-            className="flex h-9 w-9 items-center justify-center rounded-md text-muted-foreground hover:bg-secondary hover:text-foreground transition-colors cursor-pointer"
-            title="Sessions"
-          >
-            <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
-              <path d="M3 12h18M3 6h18M3 18h18" />
-            </svg>
-          </button>
-          {/*
-            Opens the rara floating settings modal (provider keys, MCP
-            servers, agent manifests, kernel config). Single source of
-            truth since #1581 retired pi-mono's separate SettingsDialog.
-          */}
-          <button
-            onClick={() => openSettings()}
-            className="flex h-9 w-9 items-center justify-center rounded-md text-muted-foreground hover:bg-secondary hover:text-foreground transition-colors cursor-pointer"
-            title="Settings"
-          >
-            <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
-              <circle cx="12" cy="12" r="3" />
-              <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z" />
-            </svg>
-          </button>
-        </div>
-        <VoiceRecorder
-          getSessionKey={() => agentRef.current?.sessionId}
-          onComplete={reloadMessages}
-        />
+      <div className="flex h-12 shrink-0 items-center gap-1 border-b border-border/40 bg-background/40 px-2 backdrop-blur-md">
+        <button
+          onClick={() => setShowSessionList(true)}
+          className="flex h-9 w-9 items-center justify-center rounded-md text-muted-foreground hover:bg-secondary/60 hover:text-foreground transition-colors cursor-pointer"
+          title="Sessions"
+        >
+          <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+            <path d="M3 12h18M3 6h18M3 18h18" />
+          </svg>
+        </button>
+        {/*
+          Opens the rara floating settings modal (provider keys, MCP
+          servers, agent manifests, kernel config). Single source of
+          truth since #1581 retired pi-mono's separate SettingsDialog.
+        */}
+        <button
+          onClick={() => openSettings()}
+          className="flex h-9 w-9 items-center justify-center rounded-md text-muted-foreground hover:bg-secondary/60 hover:text-foreground transition-colors cursor-pointer"
+          title="Settings"
+        >
+          <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+            <circle cx="12" cy="12" r="3" />
+            <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z" />
+          </svg>
+        </button>
       </div>
       {/* Chat panel container — takes remaining vertical space. */}
       <div ref={containerRef} className="min-h-0 flex-1 w-full" />
+      {/*
+        Voice button floats over pi-web-ui's composer, anchored to the
+        viewport bottom-right so it sits on the same line as the send
+        button without needing to patch pi-web-ui's input internals.
+      */}
+      <VoiceRecorder
+        className="absolute bottom-[29px] left-14 z-20 !h-8 !w-8 !rounded-md !bg-transparent !shadow-none hover:!bg-accent"
+        getSessionKey={() => agentRef.current?.sessionId}
+        onComplete={reloadMessages}
+      />
       {/* Initial load overlay — covers the empty container while sessions + agent initialize */}
       {isInitializing && (
         <div className="pointer-events-none absolute inset-0 z-40 flex flex-col items-center justify-center gap-3 bg-background">

--- a/web/src/pages/PiChat.tsx
+++ b/web/src/pages/PiChat.tsx
@@ -898,7 +898,7 @@ export default function PiChat() {
         moment the user commits their first message (onBeforeSend).
       */}
       {showWelcome && !isInitializing && (
-        <div className="pointer-events-none absolute inset-x-0 bottom-[calc(28vh+10rem)] z-10 flex justify-center px-6">
+        <div className="pointer-events-none absolute inset-x-0 bottom-[calc(40vh+9rem)] z-10 flex justify-center px-6">
           <h1 className="bg-gradient-to-br from-foreground via-foreground/80 to-foreground/40 bg-clip-text text-6xl font-semibold tracking-[0.2em] text-transparent sm:text-7xl">
             RARA
           </h1>


### PR DESCRIPTION
## Summary

- Move the `.user-message-container` override out of `@layer components` — pi-web-ui's rule is unlayered, and the CSS Cascade Layers spec has any layered rule lose to an unlayered one regardless of specificity or source order. Wrapping the override in a layer (PR #1584) made it invisible.
- Retint to match multica's tool-call glass pattern (`bg-info/5 + border-info/20 + backdrop-blur-sm`). `--info` values taken verbatim from `vendor/multica/packages/ui/styles/tokens.css`.
- Override pi-web-ui's `backdrop-filter: blur(10px)` with `blur(4px)` for the transparent-glass feel multica uses.

## Verified

Ran \`vite dev\` locally against \`http://10.0.0.183:25555\` backend, sent a test message, and inspected computed style via Playwright:

\`\`\`
backgroundImage: none                                   ← pi-web-ui gradient overridden
backgroundColor: oklab(0.55 -0.06 -0.17 / 0.05)          ← info-blue 5%
borderColor:     oklab(0.55 -0.06 -0.17 / 0.20)          ← info-blue 20%
backdropFilter:  blur(4px)                               ← sm, not 10px
\`\`\`

## Type / Component

Bug fix · \`ui\`

## Closes

Closes #1585