### PR TITLE
refactor(agents): expand rara anti-slop prompt (#1587)

### DIFF
--- a/crates/agents/src/lib.rs
+++ b/crates/agents/src/lib.rs
@@ -282,17 +282,26 @@ Do NOT use continue-work when:
 
 Fallback: end your response with CONTINUE_WORK (exact text) if tool calling fails."#;
 
-/// Anti-narration — prevent common LLM chattiness patterns.
+/// Anti-slop — prevent common LLM chattiness and padding patterns.
 const RARA_ANTI_NARRATION_FRAGMENT: &str = r#"## Anti-patterns
 
-Do NOT:
+Narration slop — do NOT:
 - Narrate tool calls ("Let me search for..." → just search)
 - Summarize what you just did unless the user asks
-- Repeat the user's question back to them
-- Add disclaimers or hedging ("I think...", "It seems like...")
-- Over-explain simple actions
+- Repeat the user's question back
+- Open with filler ("Great question!", "Certainly!", "当然可以", "好的")
+- Hedge when stating facts ("I think...", "Perhaps...", "It seems like...")
 - Ask for confirmation on routine operations
-- Stop mid-task to ask "should I continue?" when the next step is obvious"#;
+- Stop mid-task to ask "should I continue?" when the next step is obvious
+
+Content slop — do NOT:
+- Pad responses with disclaimers, caveats, or unsolicited "next steps you might consider"
+- Use bullet lists when one sentence works
+- Use emoji for tone unless the user does
+- Restate constraints the user already gave
+- Over-explain simple actions
+
+One thousand no's for every yes — every sentence must earn its place."#;
 
 /// Rara prompt fragment: skill maintenance and draft handling.
 const RARA_SKILL_MAINTENANCE_FRAGMENT: &str = r#"## Skill Maintenance

--- a/crates/agents/src/lib.rs
+++ b/crates/agents/src/lib.rs
@@ -283,13 +283,13 @@ Do NOT use continue-work when:
 Fallback: end your response with CONTINUE_WORK (exact text) if tool calling fails."#;
 
 /// Anti-slop — prevent common LLM chattiness and padding patterns.
-const RARA_ANTI_NARRATION_FRAGMENT: &str = r#"## Anti-patterns
+const RARA_ANTI_SLOP_FRAGMENT: &str = r#"## Anti-patterns
 
 Narration slop — do NOT:
 - Narrate tool calls ("Let me search for..." → just search)
 - Summarize what you just did unless the user asks
 - Repeat the user's question back
-- Open with filler ("Great question!", "Certainly!", "当然可以", "好的")
+- Open with filler ("Great question!", "Certainly!", "当然可以", "好的", "没问题", "明白了", "好嘞")
 - Hedge when stating facts ("I think...", "Perhaps...", "It seems like...")
 - Ask for confirmation on routine operations
 - Stop mid-task to ask "should I continue?" when the next step is obvious
@@ -301,7 +301,8 @@ Content slop — do NOT:
 - Restate constraints the user already gave
 - Over-explain simple actions
 
-One thousand no's for every yes — every sentence must earn its place."#;
+One thousand no's for every yes — every sentence must earn its place.
+每句话都要挣来自己的位置。"#;
 
 /// Rara prompt fragment: skill maintenance and draft handling.
 const RARA_SKILL_MAINTENANCE_FRAGMENT: &str = r#"## Skill Maintenance
@@ -327,7 +328,7 @@ fn rara_system_prompt() -> String {
         RARA_SAFETY_FRAGMENT,
         RARA_CONTINUATION_FRAGMENT,
         RARA_SKILL_MAINTENANCE_FRAGMENT,
-        RARA_ANTI_NARRATION_FRAGMENT,
+        RARA_ANTI_SLOP_FRAGMENT,
     ]
     .join("\n\n")
 }


### PR DESCRIPTION
## Summary

Learned from the Claude Design system prompt (CL4R1T4S) — its "AI slop" checklist is mechanically enforceable. Expanded `RARA_ANTI_NARRATION_FRAGMENT`:

- Split anti-patterns into **narration slop** and **content slop** groups
- Added filler-opener patterns including CN ("当然可以", "好的")
- Forbade bullet-list padding when one sentence works, and tone-emoji mimicry
- Closed with the "one thousand no's for every yes" anchor line

No changes to Mita / Nana / Worker prompts.

## Type of change

| Type | Label |
|------|-------|
| Refactor | `refactor` |

## Component

`core`

## Closes

Closes #1587

## Test plan

- [x] `cargo check -p rara-agents` passes
- [x] pre-commit hooks passed (check / fmt / clippy / doc)
- [ ] Verify via simple inputs ("hello" / "你好") post-merge that no abnormal output is produced — per `docs/guides/anti-patterns.md` agent-system-prompt rule