### PR TITLE
feat(web): chat UI overhaul — sidebar, welcome, glass (#1585)

### DIFF
--- a/web/src/components/ChatSidebar.tsx
+++ b/web/src/components/ChatSidebar.tsx
@@ -1,0 +1,246 @@
+/*
+ * Copyright 2025 Rararulab
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useEffect, useState } from "react";
+import {
+  PanelLeftClose,
+  PanelLeft,
+  Plus,
+  Settings,
+  Trash2,
+  MessageSquare,
+} from "lucide-react";
+import { cn } from "@/lib/utils";
+import { api } from "@/api/client";
+import type { ChatSession } from "@/api/types";
+
+const COLLAPSED_STORAGE_KEY = "rara.sidebar.collapsed";
+
+interface ChatSidebarProps {
+  activeSessionKey: string | undefined;
+  onSelect: (session: ChatSession) => void;
+  onNewSession: () => void;
+  onOpenSettings: () => void;
+  onDeleteSession: (key: string) => void;
+  /** Bump this from the parent to force a session-list refetch (e.g. after
+   * creating a new session or receiving the first message of a fresh one). */
+  refreshKey: number;
+}
+
+function stripForPreview(text: string): string {
+  return text.replace(/<think>[\s\S]*?<\/think>\s*/g, "").trim();
+}
+
+function formatRelativeDate(iso: string): string {
+  const diff = Date.now() - new Date(iso).getTime();
+  const days = Math.floor(diff / 86_400_000);
+  if (days === 0) return "今天";
+  if (days === 1) return "昨天";
+  if (days < 7) return `${days} 天前`;
+  return new Date(iso).toLocaleDateString();
+}
+
+/**
+ * Persistent left-hand sidebar for the chat page: new-session button,
+ * settings entry, and a scrollable history list. Collapsible to an
+ * icon-only rail; the collapsed state is persisted to `localStorage`
+ * so the choice survives reloads.
+ */
+export function ChatSidebar({
+  activeSessionKey,
+  onSelect,
+  onNewSession,
+  onOpenSettings,
+  onDeleteSession,
+  refreshKey,
+}: ChatSidebarProps) {
+  const [collapsed, setCollapsed] = useState<boolean>(() => {
+    try {
+      return localStorage.getItem(COLLAPSED_STORAGE_KEY) === "1";
+    } catch {
+      return false;
+    }
+  });
+  const [sessions, setSessions] = useState<ChatSession[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let alive = true;
+    setLoading(true);
+    api
+      .get<ChatSession[]>("/api/v1/chat/sessions?limit=100&offset=0")
+      .then((list) => {
+        if (alive) setSessions(list);
+      })
+      .catch(() => {
+        if (alive) setSessions([]);
+      })
+      .finally(() => {
+        if (alive) setLoading(false);
+      });
+    return () => {
+      alive = false;
+    };
+  }, [refreshKey]);
+
+  const toggleCollapsed = () => {
+    setCollapsed((prev) => {
+      const next = !prev;
+      try {
+        localStorage.setItem(COLLAPSED_STORAGE_KEY, next ? "1" : "0");
+      } catch {
+        /* ignore */
+      }
+      return next;
+    });
+  };
+
+  const handleDelete = async (key: string, e: React.MouseEvent) => {
+    e.stopPropagation();
+    if (!confirm("删除这个会话？")) return;
+    try {
+      await api.del(`/api/v1/chat/sessions/${encodeURIComponent(key)}`);
+      setSessions((prev) => prev.filter((s) => s.key !== key));
+      onDeleteSession(key);
+    } catch {
+      /* ignore */
+    }
+  };
+
+  return (
+    <aside
+      className={cn(
+        "flex h-screen shrink-0 flex-col border-r border-border/50 bg-background/40 backdrop-blur-md transition-[width] duration-200 ease-out",
+        collapsed ? "w-14" : "w-64",
+      )}
+    >
+      {/* Top: logo + collapse toggle */}
+      <div
+        className={cn(
+          "flex h-12 shrink-0 items-center border-b border-border/40",
+          collapsed ? "justify-center" : "justify-between px-3",
+        )}
+      >
+        {!collapsed && (
+          <span className="text-sm font-semibold tracking-[0.15em] text-foreground/90">
+            RARA
+          </span>
+        )}
+        <button
+          type="button"
+          onClick={toggleCollapsed}
+          className="flex h-8 w-8 items-center justify-center rounded-md text-muted-foreground hover:bg-secondary/60 hover:text-foreground transition-colors cursor-pointer"
+          title={collapsed ? "展开边栏" : "折叠边栏"}
+        >
+          {collapsed ? (
+            <PanelLeft className="h-4 w-4" />
+          ) : (
+            <PanelLeftClose className="h-4 w-4" />
+          )}
+        </button>
+      </div>
+
+      {/* Actions: new session + settings */}
+      <div className={cn("flex shrink-0 flex-col gap-1", collapsed ? "items-center py-2" : "px-2 py-2")}>
+        <button
+          type="button"
+          onClick={onNewSession}
+          className={cn(
+            "flex h-9 items-center rounded-md text-sm font-medium transition-colors cursor-pointer",
+            collapsed
+              ? "w-9 justify-center text-muted-foreground hover:bg-secondary/60 hover:text-foreground"
+              : "w-full gap-2 px-3 text-foreground bg-secondary/40 hover:bg-secondary/70",
+          )}
+          title="新建会话"
+        >
+          <Plus className="h-4 w-4 shrink-0" />
+          {!collapsed && <span className="truncate">新建会话</span>}
+        </button>
+        <button
+          type="button"
+          onClick={onOpenSettings}
+          className={cn(
+            "flex h-9 items-center rounded-md text-sm text-muted-foreground transition-colors cursor-pointer hover:bg-secondary/60 hover:text-foreground",
+            collapsed ? "w-9 justify-center" : "w-full gap-2 px-3",
+          )}
+          title="设置"
+        >
+          <Settings className="h-4 w-4 shrink-0" />
+          {!collapsed && <span className="truncate">设置</span>}
+        </button>
+      </div>
+
+      {/* History list */}
+      {!collapsed && (
+        <>
+          <div className="mt-2 flex shrink-0 items-center gap-2 px-4 py-2 text-[11px] font-medium uppercase tracking-wider text-muted-foreground/80">
+            <MessageSquare className="h-3 w-3" />
+            历史会话
+          </div>
+          <div className="min-h-0 flex-1 overflow-y-auto">
+            {loading ? (
+              <div className="py-6 text-center text-xs text-muted-foreground">
+                加载中…
+              </div>
+            ) : sessions.length === 0 ? (
+              <div className="py-6 text-center text-xs text-muted-foreground">
+                暂无会话
+              </div>
+            ) : (
+              sessions.map((s) => (
+                <div
+                  key={s.key}
+                  role="button"
+                  tabIndex={0}
+                  onClick={() => onSelect(s)}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter" || e.key === " ") {
+                      e.preventDefault();
+                      onSelect(s);
+                    }
+                  }}
+                  className={cn(
+                    "group mx-2 flex cursor-pointer items-start gap-2 rounded-md px-2 py-1.5 text-sm transition-colors",
+                    s.key === activeSessionKey
+                      ? "bg-secondary/70 text-foreground"
+                      : "text-foreground/80 hover:bg-secondary/50 hover:text-foreground",
+                  )}
+                >
+                  <div className="min-w-0 flex-1">
+                    <div className="truncate text-[13px] leading-tight">
+                      {stripForPreview(s.title || s.preview || "新对话")}
+                    </div>
+                    <div className="mt-0.5 truncate text-[11px] text-muted-foreground/80">
+                      {formatRelativeDate(s.updated_at)}
+                    </div>
+                  </div>
+                  <button
+                    type="button"
+                    onClick={(e) => handleDelete(s.key, e)}
+                    className="shrink-0 rounded p-1 text-muted-foreground/0 transition-[color,opacity] hover:bg-destructive/10 hover:text-destructive group-hover:text-muted-foreground group-hover:opacity-100"
+                    title="删除"
+                  >
+                    <Trash2 className="h-3 w-3" />
+                  </button>
+                </div>
+              ))
+            )}
+          </div>
+        </>
+      )}
+    </aside>
+  );
+}

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -252,6 +252,33 @@
  * in `@layer components {}` (as the first attempt did) made it invisible.
  */
 /*
+ * Avatar for Rara's assistant messages. Pi-web-ui renders each reply as
+ * a bare `<assistant-message>` custom element with no visual marker for
+ * who is speaking; a small round portrait on the left gives the reply
+ * an identity. Served from `web/public/rara.png` (see issue #1585) so
+ * the URL stays stable across deploys. A thin info-blue ring echoes
+ * the user-bubble glass palette so the two participants read as one
+ * coherent design.
+ */
+.rara-chat assistant-message {
+  display: block;
+  position: relative;
+  padding-left: 2.75rem;
+  min-height: 2rem;
+}
+.rara-chat assistant-message::before {
+  content: "";
+  position: absolute;
+  left: 0.75rem;
+  top: 0;
+  width: 1.75rem;
+  height: 1.75rem;
+  border-radius: 9999px;
+  background: url("/rara.png") center / cover;
+  box-shadow: 0 0 0 2px color-mix(in oklab, oklch(0.62 0.18 250) 30%, transparent);
+}
+
+/*
  * Pi-web-ui left-aligns user messages (`class="flex justify-start"`
  * on the bubble's parent). Flip to the right side — the standard
  * chat convention of "my messages on the right". `:has()` gives us a

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -315,9 +315,7 @@
  * first message flips us out of welcome mode.
  */
 .rara-chat[data-welcome="true"] agent-interface .flex-col.bg-background > *:last-child,
-.rara-chat[data-welcome="true"] > button[title*="Record" i],
-.rara-chat[data-welcome="true"] > button[title*="recording" i],
-.rara-chat[data-welcome="true"] > button[title*="Sending" i] {
+.rara-chat[data-welcome="true"] .voice-float {
   /* Lifts the composer centre close to viewport centre. Natural bottom
      is ~8-10rem from the edge (padding + composer body), so ~40vh up
      lands the centre near 50vh with some headroom for the wordmark. */
@@ -325,9 +323,7 @@
   transition: transform 420ms cubic-bezier(0.22, 0.61, 0.36, 1);
 }
 .rara-chat agent-interface .flex-col.bg-background > *:last-child,
-.rara-chat > button[title*="Record" i],
-.rara-chat > button[title*="recording" i],
-.rara-chat > button[title*="Sending" i] {
+.rara-chat .voice-float {
   transition: transform 420ms cubic-bezier(0.22, 0.61, 0.36, 1);
 }
 

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -344,12 +344,13 @@
   margin-right: auto;
   width: 100%;
 }
-.rara-chat assistant-message,
-.rara-chat user-message {
-  max-width: 48rem;
-  margin-left: auto;
-  margin-right: auto;
-}
+/*
+ * No cap on `user-message` / `assistant-message` themselves — pi-web-ui
+ * already wraps the list in `.max-w-3xl mx-auto p-4 pb-0` (48rem
+ * centred), and re-applying `max-width + margin: auto` here collapses
+ * short user bubbles to content-width and recentres them, defeating
+ * the right-alignment we want for "my messages".
+ */
 
 /*
  * Voice button horizontal alignment. Paperclip sits at ~17px inside
@@ -364,6 +365,12 @@
 }
 
 .user-message-container {
+  /* Content-size the bubble so justify-end actually pushes it right.
+     In a flex container `display: block` resolves to "stretch" along
+     the main axis, which was making short user messages span the full
+     column width. */
+  width: fit-content;
+  max-width: 80%;
   background: color-mix(in oklab, oklch(0.55 0.18 250) 5%, transparent);
   border-color: color-mix(in oklab, oklch(0.55 0.18 250) 20%, transparent);
   /* `sm` in tailwind ≈ 4px; overrides pi-web-ui's heavier blur(10px). */

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -331,6 +331,26 @@
   transition: transform 420ms cubic-bezier(0.22, 0.61, 0.36, 1);
 }
 
+/*
+ * Cap the composer width and centre it so a wide viewport doesn't
+ * stretch the input into an uncomfortably long strip. `max-width` +
+ * auto margins on the composer row; message list gets the same cap
+ * so replies line up with the composer below rather than drifting
+ * past its right edge.
+ */
+.rara-chat agent-interface .flex-col.bg-background > *:last-child {
+  max-width: 48rem;
+  margin-left: auto;
+  margin-right: auto;
+  width: 100%;
+}
+.rara-chat assistant-message,
+.rara-chat user-message {
+  max-width: 48rem;
+  margin-left: auto;
+  margin-right: auto;
+}
+
 .user-message-container {
   background: color-mix(in oklab, oklch(0.55 0.18 250) 5%, transparent);
   border-color: color-mix(in oklab, oklch(0.55 0.18 250) 20%, transparent);

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -351,6 +351,18 @@
   margin-right: auto;
 }
 
+/*
+ * Voice button horizontal alignment. Paperclip sits at ~17px inside
+ * the composer's left edge; when the composer is capped at 48rem and
+ * centred, that edge is at `50% - 24rem`. `max()` clamps the voice
+ * button to 17px on narrow viewports where the composer fills the
+ * full width and the calc would go negative.
+ */
+.rara-chat .voice-float {
+  /* 17px inside-composer padding + 32px paperclip width + 8px gap. */
+  left: max(57px, calc(50% - 24rem + 57px));
+}
+
 .user-message-container {
   background: color-mix(in oklab, oklch(0.55 0.18 250) 5%, transparent);
   border-color: color-mix(in oklab, oklch(0.55 0.18 250) 20%, transparent);

--- a/web/src/pages/PiChat.tsx
+++ b/web/src/pages/PiChat.tsx
@@ -76,6 +76,36 @@ function isRoutableProvider(
   return catalog.has(provider);
 }
 
+/**
+ * Look up the admin-configured default `(provider, model)` pair in the
+ * rara settings store. Returns `null` if the admin has not paired a
+ * default model with their default provider — the caller falls back to
+ * the unknown sentinel and pi-web-ui's composer pill goes blank instead
+ * of inventing a model from its own hard-coded catalog (which would
+ * surface a ghost "gemini-2.5-flash-lite" on a minimax-default install).
+ */
+async function resolveAdminDefaultModel(): Promise<{
+  provider: string;
+  model: string;
+} | null> {
+  try {
+    const settings = await settingsApi.list();
+    const provider = settings["llm.default_provider"]?.trim();
+    if (!provider) return null;
+    const model = settings[`llm.providers.${provider}.default_model`]?.trim();
+    if (!model) {
+      console.warn(
+        `Admin default provider \`${provider}\` has no default_model set — composer pill will show unknown.`,
+      );
+      return null;
+    }
+    return { provider, model };
+  } catch (e: unknown) {
+    console.warn("Failed to resolve admin default provider:", e);
+    return null;
+  }
+}
+
 /** Strip `<think>...</think>` blocks — used only for UI preview/title text. */
 function stripForPreview(text: string): string {
   return text.replace(/<think>[\s\S]*?<\/think>\s*/g, "").trim();
@@ -496,6 +526,14 @@ export default function PiChat() {
       isRoutableProvider(validProvidersRef.current, session.model_provider)
     ) {
       agent.state.model = syntheticModel(session.model_provider, session.model);
+    } else {
+      // Unpinned session — seed the composer pill with rara's admin
+      // default so it reads "minimax: MiniMax-M2.7" rather than
+      // pi-web-ui's hard-coded catalog fallback (`gemini-2.5-*`).
+      const resolved = await resolveAdminDefaultModel();
+      if (resolved && agentRef.current?.sessionId === session.key) {
+        agent.state.model = syntheticModel(resolved.provider, resolved.model);
+      }
     }
     if (session.thinking_level) {
       agent.state.thinkingLevel = session.thinking_level;
@@ -607,34 +645,14 @@ export default function PiChat() {
         setModelDialogOpen(false);
         return;
       }
-      // Resolve the admin-configured default so the composer
-      // pill can read e.g. "codex: codex-mini" instead of the
-      // "unknown" sentinel. PiChat does not already consume
-      // react-query so we fire a one-shot request — failures
-      // here are non-fatal and fall back to the sentinel.
-      let resolvedModel = syntheticModel(
-        UNKNOWN_MODEL_SENTINEL,
-        UNKNOWN_MODEL_SENTINEL,
-      );
-      try {
-        const settings = await settingsApi.list();
-        const provider = settings["llm.default_provider"]?.trim();
-        const model = provider
-          ? settings[`llm.providers.${provider}.default_model`]?.trim()
-          : undefined;
-        if (provider && model) {
-          resolvedModel = syntheticModel(provider, model);
-        } else if (provider) {
-          // Admin set a default provider but forgot the paired
-          // `default_model` key — surface during development so the
-          // misconfig is caught before users see the unknown sentinel.
-          console.warn(
-            `Admin default provider \`${provider}\` has no default_model set — composer pill will show unknown.`,
-          );
-        }
-      } catch (e: unknown) {
-        console.warn("Failed to resolve admin default provider:", e);
-      }
+      // Resolve the admin-configured default so the composer pill can
+      // read e.g. "minimax: MiniMax-M2.7" instead of pi-web-ui's own
+      // hard-coded catalog default (which would otherwise surface a
+      // ghost "gemini-2.5-flash-lite" unrelated to rara's config).
+      const resolved = await resolveAdminDefaultModel();
+      const resolvedModel = resolved
+        ? syntheticModel(resolved.provider, resolved.model)
+        : syntheticModel(UNKNOWN_MODEL_SENTINEL, UNKNOWN_MODEL_SENTINEL);
       // Re-check the race guard after the settings fetch.
       if (agentRef.current?.sessionId !== key) {
         setModelDialogOpen(false);
@@ -765,6 +783,14 @@ export default function PiChat() {
           provider: initialSession.model_provider,
           thinking: initialSession.thinking_level ?? null,
         };
+      } else {
+        // Unpinned session — seed the composer pill with rara's admin
+        // default so it reads "minimax: MiniMax-M2.7" rather than
+        // pi-web-ui's hard-coded catalog fallback (`gemini-2.5-*`).
+        const resolved = await resolveAdminDefaultModel();
+        if (resolved) {
+          agent.state.model = syntheticModel(resolved.provider, resolved.model);
+        }
       }
       if (initialSession.thinking_level) {
         agent.state.thinkingLevel = initialSession.thinking_level;

--- a/web/src/pages/PiChat.tsx
+++ b/web/src/pages/PiChat.tsx
@@ -440,6 +440,14 @@ export default function PiChat() {
     // Always trigger re-render after switching — even for empty sessions
     // so cleared messages are reflected in the UI.
     chatPanelRef.current?.agentInterface?.requestUpdate();
+    // Drop focus into the composer so the user can start typing
+    // immediately without a mouse click. Pi-web-ui's textarea mounts
+    // lazily so we defer to the next frame and, for added belt, again
+    // after the lit element completes its update pass.
+    requestAnimationFrame(() => {
+      const ta = document.querySelector<HTMLTextAreaElement>("textarea");
+      ta?.focus();
+    });
   }, []);
 
   /** Reload current session messages (e.g. after voice message completes). */
@@ -757,6 +765,12 @@ export default function PiChat() {
         // Clear the loading overlay even if init fails (network/CORS/etc.)
         // so the user sees the empty chat panel rather than a spinner forever.
         setIsInitializing(false);
+        // Focus the composer on first mount so the caret is live
+        // immediately; subsequent session switches do the same via
+        // the `switchSession` callback.
+        requestAnimationFrame(() => {
+          document.querySelector<HTMLTextAreaElement>("textarea")?.focus();
+        });
       }
     })();
 

--- a/web/src/pages/PiChat.tsx
+++ b/web/src/pages/PiChat.tsx
@@ -340,6 +340,11 @@ export default function PiChat() {
   const resetInflight = useRef(false);
   const [isInitializing, setIsInitializing] = useState(true);
   const [sidebarRefreshKey, setSidebarRefreshKey] = useState(0);
+  // Active session metadata — surfaced in the main-area header so the
+  // current chat's title sits above its messages (kimi-style). Updated
+  // from switchSession / newSession / initial mount; a refetch fires
+  // after the first send so backend-assigned titles appear promptly.
+  const [activeSession, setActiveSession] = useState<ChatSession | null>(null);
   // Bump to force ChatSidebar to refetch the session list (e.g. after
   // creating a new session or sending the first message of a fresh one).
   const [modelDialogOpen, setModelDialogOpen] = useState(false);
@@ -365,6 +370,7 @@ export default function PiChat() {
     if (!agent) return;
     agent.clearMessages();
     agent.sessionId = session.key;
+    setActiveSession(session);
     setShowWelcome((session.message_count ?? 0) === 0);
 
     // Restore the session's persisted model + thinking-level so the
@@ -602,6 +608,7 @@ export default function PiChat() {
       } else {
         initialSession = await api.post<ChatSession>("/api/v1/chat/sessions", {});
       }
+      setActiveSession(initialSession);
       setShowWelcome((initialSession.message_count ?? 0) === 0);
       // 5. Create the Agent with rara's WebSocket-backed stream function.
       //    The streamFn reads agent.sessionId at call time to get the active session key.
@@ -684,6 +691,16 @@ export default function PiChat() {
           // Nudge the sidebar to refetch so the fresh session's new
           // title and preview surface in the history list.
           setSidebarRefreshKey((k) => k + 1);
+          // Refetch the active session so the backend-assigned title
+          // lands in the header above the messages. Fire-and-forget;
+          // a retry happens on the next send if the backend hadn't
+          // finished assigning a title yet.
+          api
+            .get<ChatSession>(`/api/v1/chat/sessions/${encodeURIComponent(key)}`)
+            .then((fresh) => {
+              if (agentRef.current?.sessionId === key) setActiveSession(fresh);
+            })
+            .catch(() => { /* non-fatal */ });
 
           // Skip the PATCH when `agent.state.model` is pi-agent-core's
           // placeholder default (id/provider = "unknown"). Persisting it
@@ -758,6 +775,17 @@ export default function PiChat() {
         refreshKey={sidebarRefreshKey}
       />
       <main className="relative flex min-h-0 min-w-0 flex-1 flex-col">
+        {/* Session title header — shows the current conversation's
+            title above its messages (kimi-style). Hidden during the
+            welcome state since the RARA wordmark already serves as
+            the brand marker there. */}
+        {activeSession && !showWelcome && !isInitializing && (
+          <div className="flex h-11 shrink-0 items-center border-b border-border/30 bg-background/30 px-5 backdrop-blur-sm">
+            <span className="truncate text-sm font-medium text-foreground/85">
+              {activeSession.title || activeSession.preview || "新对话"}
+            </span>
+          </div>
+        )}
         {/* Chat panel container — takes remaining vertical space. */}
         <div ref={containerRef} className="min-h-0 flex-1 w-full" />
         {/*

--- a/web/src/pages/PiChat.tsx
+++ b/web/src/pages/PiChat.tsx
@@ -555,6 +555,11 @@ export default function PiChat() {
       const agentMsgs = toAgentMessages(msgs);
       if (agentMsgs.length > 0) {
         agent.replaceMessages(agentMsgs);
+        // Belt-and-suspenders: the listing's `message_count` is sometimes
+        // stale (e.g. older sessions whose counter never caught up), so
+        // reconcile against the actual loaded messages before showing a
+        // welcome overlay over a populated thread.
+        setShowWelcome(false);
       }
       // Rebuild the artifacts panel from the same message list so switching
       // back to a session restores every previously-created artifact.

--- a/web/src/pages/PiChat.tsx
+++ b/web/src/pages/PiChat.tsx
@@ -371,7 +371,13 @@ export default function PiChat() {
     agent.clearMessages();
     agent.sessionId = session.key;
     setActiveSession(session);
-    setShowWelcome((session.message_count ?? 0) === 0);
+    // Optimistically hide the welcome overlay during the switch: the
+    // backend's `message_count` is unreliable (always 0 in the listing
+    // for older sessions, see #1585 round-2 notes), so trusting it
+    // here would flash the RARA overlay on every click before the
+    // messages arrive. We flip it back on after `list_messages` if
+    // the session really is empty.
+    setShowWelcome(false);
 
     // Restore the session's persisted model + thinking-level so the
     // model pill in the composer reflects the last settings used for
@@ -418,11 +424,10 @@ export default function PiChat() {
       const agentMsgs = toAgentMessages(msgs);
       if (agentMsgs.length > 0) {
         agent.replaceMessages(agentMsgs);
-        // Belt-and-suspenders: the listing's `message_count` is sometimes
-        // stale (e.g. older sessions whose counter never caught up), so
-        // reconcile against the actual loaded messages before showing a
-        // welcome overlay over a populated thread.
-        setShowWelcome(false);
+      } else if (agentRef.current?.sessionId === session.key) {
+        // Really an empty session (not just a stale backend count) —
+        // reveal the welcome overlay now that we know for sure.
+        setShowWelcome(true);
       }
       // Rebuild the artifacts panel from the same message list so switching
       // back to a session restores every previously-created artifact.

--- a/web/src/pages/PiChat.tsx
+++ b/web/src/pages/PiChat.tsx
@@ -56,6 +56,7 @@ import type { ChatSession, ChatMessageData, ThinkingLevel } from "@/api/types";
 import { VoiceRecorder } from "@/components/VoiceRecorder";
 import { RaraModelDialog } from "@/components/RaraModelDialog";
 import { AlmaCaret } from "@/components/AlmaCaret";
+import { ChatSidebar } from "@/components/ChatSidebar";
 import { useSettingsModal } from "@/components/settings/SettingsModalProvider";
 import type { ProviderInfo } from "@/api/types";
 import { UNKNOWN_MODEL_SENTINEL, isUnknownModel, syntheticModel } from "@/lib/synthetic-model";
@@ -104,11 +105,6 @@ async function resolveAdminDefaultModel(): Promise<{
     console.warn("Failed to resolve admin default provider:", e);
     return null;
   }
-}
-
-/** Strip `<think>...</think>` blocks — used only for UI preview/title text. */
-function stripForPreview(text: string): string {
-  return text.replace(/<think>[\s\S]*?<\/think>\s*/g, "").trim();
 }
 
 /**
@@ -317,149 +313,8 @@ function toAgentMessages(msgs: ChatMessageData[]): AgentMessage[] {
   return result;
 }
 
-function formatRelativeDate(iso: string): string {
-  const diff = Date.now() - new Date(iso).getTime();
-  const days = Math.floor(diff / 86_400_000);
-  if (days === 0) return "Today";
-  if (days === 1) return "Yesterday";
-  if (days < 7) return `${days}d ago`;
-  return new Date(iso).toLocaleDateString();
-}
-
-function SessionListPanel({
-  activeKey,
-  onSelect,
-  onClose,
-  onDelete,
-  onNew,
-  onOpenAdmin,
-}: {
-  activeKey: string | undefined;
-  onSelect: (s: ChatSession) => void;
-  onClose: () => void;
-  onDelete: (key: string) => void;
-  onNew: () => void;
-  onOpenAdmin: () => void;
-}) {
-  const [sessions, setSessions] = useState<ChatSession[]>([]);
-  const [loading, setLoading] = useState(true);
-
-  useEffect(() => {
-    api
-      .get<ChatSession[]>("/api/v1/chat/sessions?limit=100&offset=0")
-      .then(setSessions)
-      .catch(() => setSessions([]))
-      .finally(() => setLoading(false));
-
-    const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key === "Escape") onClose();
-    };
-    window.addEventListener("keydown", handleKeyDown);
-    return () => window.removeEventListener("keydown", handleKeyDown);
-  }, [onClose]);
-
-  const handleDelete = async (key: string, e: React.MouseEvent) => {
-    e.stopPropagation();
-    if (!confirm("Delete this session?")) return;
-    try {
-      await api.del(`/api/v1/chat/sessions/${encodeURIComponent(key)}`);
-      setSessions((prev) => prev.filter((s) => s.key !== key));
-      onDelete(key);
-    } catch {
-      /* ignore */
-    }
-  };
-
-  return (
-    <>
-      {/* Backdrop */}
-      <div
-        className="fixed inset-0 z-[60] bg-black/40 backdrop-blur-sm"
-        onClick={onClose}
-      />
-      {/* Panel */}
-      <div className="fixed inset-0 right-auto z-[61] flex w-full max-w-80 flex-col border-r border-border bg-background shadow-xl">
-        <div className="flex items-center justify-between border-b border-border px-4 py-3">
-          <span className="text-sm font-semibold text-foreground">Sessions</span>
-          <div className="flex items-center gap-1">
-            <button
-              onClick={() => { onNew(); onClose(); }}
-              className="rounded p-1 text-muted-foreground hover:bg-secondary hover:text-foreground transition-colors cursor-pointer"
-              title="New session"
-            >
-              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
-                <path d="M12 5v14M5 12h14" />
-              </svg>
-            </button>
-            <button
-              onClick={onClose}
-              className="rounded p-1 text-muted-foreground hover:bg-secondary hover:text-foreground transition-colors cursor-pointer"
-            >
-              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
-                <path d="M18 6 6 18M6 6l12 12" />
-              </svg>
-            </button>
-          </div>
-        </div>
-        <div className="flex-1 overflow-y-auto">
-          {loading ? (
-            <div className="py-8 text-center text-sm text-muted-foreground">Loading...</div>
-          ) : sessions.length === 0 ? (
-            <div className="py-8 text-center text-sm text-muted-foreground">No sessions yet</div>
-          ) : (
-            sessions.map((s) => (
-              <div
-                key={s.key}
-                className={`group flex cursor-pointer items-start gap-3 border-b border-border/50 px-4 py-3 transition-colors hover:bg-secondary/50 ${s.key === activeKey ? "bg-secondary/70" : ""}`}
-                onClick={() => { onSelect(s); onClose(); }}
-              >
-                <div className="min-w-0 flex-1">
-                  <div className="truncate text-sm font-medium text-foreground">
-                    {stripForPreview(s.title || s.preview || "New conversation")}
-                  </div>
-                  {s.title && s.preview && (
-                    <div className="mt-0.5 truncate text-xs text-muted-foreground">
-                      {stripForPreview(s.preview)}
-                    </div>
-                  )}
-                  <div className="mt-1 text-[11px] text-muted-foreground/70">
-                    {formatRelativeDate(s.updated_at)}
-                  </div>
-                </div>
-                <button
-                  className="mt-0.5 shrink-0 rounded p-1 text-destructive opacity-0 transition-opacity hover:bg-destructive/10 group-hover:opacity-100 cursor-pointer"
-                  onClick={(e) => handleDelete(s.key, e)}
-                  title="Delete"
-                >
-                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
-                    <path d="M3 6h18M19 6v14c0 1-1 2-2 2H7c-1 0-2-1-2-2V6M8 6V4c0-1 1-2 2-2h4c1 0 2 1 2 2v2" />
-                  </svg>
-                </button>
-              </div>
-            ))
-          )}
-        </div>
-        {/*
-          Server-wide admin settings (MCP servers, agent manifests, skills,
-          kernel config, provider keys). Opens the floating settings modal
-          in place — no navigation away from the chat.
-        */}
-        <div className="border-t border-border px-4 py-3">
-          <button
-            onClick={() => { onOpenAdmin(); onClose(); }}
-            className="flex w-full items-center gap-2 rounded px-2 py-1.5 text-sm text-muted-foreground hover:bg-secondary hover:text-foreground transition-colors cursor-pointer"
-          >
-            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
-              <path d="M3 3h7v7H3zM14 3h7v7h-7zM14 14h7v7h-7zM3 14h7v7H3z" />
-            </svg>
-            Admin
-          </button>
-        </div>
-      </div>
-    </>
-  );
-}
-
+// Session list now lives in `ChatSidebar`; legacy slide-over deleted
+// during the persistent-sidebar refactor — see #1585.
 /**
  * Fullscreen wrapper that mounts pi-web-ui's <pi-chat-panel> Web Component,
  * wiring it up to rara's storage backend and WebSocket stream function.
@@ -483,8 +338,10 @@ export default function PiChat() {
   // write (see #1569 round-1 fix) but the UI would still redundantly
   // refetch settings and reset the composer state.
   const resetInflight = useRef(false);
-  const [showSessionList, setShowSessionList] = useState(false);
   const [isInitializing, setIsInitializing] = useState(true);
+  const [sidebarRefreshKey, setSidebarRefreshKey] = useState(0);
+  // Bump to force ChatSidebar to refetch the session list (e.g. after
+  // creating a new session or sending the first message of a fresh one).
   const [modelDialogOpen, setModelDialogOpen] = useState(false);
   const [resetError, setResetError] = useState<string | null>(null);
   // `true` when the active session has no messages — we render a welcome
@@ -597,6 +454,7 @@ export default function PiChat() {
   const newSession = useCallback(async () => {
     const created = await api.post<ChatSession>("/api/v1/chat/sessions", {});
     switchSession(created);
+    setSidebarRefreshKey((k) => k + 1);
   }, [switchSession]);
 
   /** Handle session deletion from the panel. */
@@ -823,6 +681,9 @@ export default function PiChat() {
           if (!key) return;
           // The user just committed their first message — no more welcome.
           setShowWelcome(false);
+          // Nudge the sidebar to refetch so the fresh session's new
+          // title and preview surface in the history list.
+          setSidebarRefreshKey((k) => k + 1);
 
           // Skip the PATCH when `agent.state.model` is pi-agent-core's
           // placeholder default (id/provider = "unknown"). Persisting it
@@ -885,91 +746,59 @@ export default function PiChat() {
 
   return (
     <div
-      className="rara-chat relative flex h-screen w-screen flex-col"
+      className="rara-chat flex h-screen w-screen"
       data-welcome={showWelcome && !isInitializing ? "true" : undefined}
     >
-      {/*
-        Top utility bar — reserves its own row (not `absolute`) so the
-        chat panel's message list can never render underneath the
-        Sessions / Settings icons. Transparent + backdrop-blur so the
-        chat-page canvas + radial glow read through as frosted glass.
-      */}
-      <div className="flex h-12 shrink-0 items-center gap-1 border-b border-border/40 bg-background/40 px-2 backdrop-blur-md">
-        <button
-          onClick={() => setShowSessionList(true)}
-          className="flex h-9 w-9 items-center justify-center rounded-md text-muted-foreground hover:bg-secondary/60 hover:text-foreground transition-colors cursor-pointer"
-          title="Sessions"
-        >
-          <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
-            <path d="M3 12h18M3 6h18M3 18h18" />
-          </svg>
-        </button>
-        {/*
-          Opens the rara floating settings modal (provider keys, MCP
-          servers, agent manifests, kernel config). Single source of
-          truth since #1581 retired pi-mono's separate SettingsDialog.
-        */}
-        <button
-          onClick={() => openSettings()}
-          className="flex h-9 w-9 items-center justify-center rounded-md text-muted-foreground hover:bg-secondary/60 hover:text-foreground transition-colors cursor-pointer"
-          title="Settings"
-        >
-          <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
-            <circle cx="12" cy="12" r="3" />
-            <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z" />
-          </svg>
-        </button>
-      </div>
-      {/* Chat panel container — takes remaining vertical space. */}
-      <div ref={containerRef} className="min-h-0 flex-1 w-full" />
-      {/*
-        Welcome overlay — rendered above pi-web-ui's empty message list
-        when the active session has no messages. Pointer-events-none so
-        clicks pass through to the composer below; flipped off the
-        moment the user commits their first message (onBeforeSend).
-      */}
-      {showWelcome && !isInitializing && (
-        <div className="pointer-events-none absolute inset-x-0 bottom-[calc(40vh+9rem)] z-10 flex justify-center px-6">
-          <h1 className="bg-gradient-to-br from-foreground via-foreground/80 to-foreground/40 bg-clip-text text-6xl font-semibold tracking-[0.2em] text-transparent sm:text-7xl">
-            RARA
-          </h1>
-        </div>
-      )}
-      {/*
-        Voice button floats over pi-web-ui's composer, anchored to the
-        viewport bottom-right so it sits on the same line as the send
-        button without needing to patch pi-web-ui's input internals.
-      */}
-      <VoiceRecorder
-        className="voice-float absolute bottom-[29px] z-20 !h-8 !w-8 !rounded-md !bg-transparent !shadow-none hover:!bg-accent"
-        getSessionKey={() => agentRef.current?.sessionId}
-        onComplete={reloadMessages}
+      <ChatSidebar
+        activeSessionKey={agentRef.current?.sessionId}
+        onSelect={switchSession}
+        onNewSession={newSession}
+        onOpenSettings={() => openSettings()}
+        onDeleteSession={handleSessionDeleted}
+        refreshKey={sidebarRefreshKey}
       />
-      {/*
-        Custom textarea caret (Alma-style): smooth moves + a cool-blue
-        comet tail. Mounts after pi-web-ui's composer is in the DOM via
-        an internal DOM query since the textarea is owned by a Lit
-        custom element we don't ref directly.
-      */}
-      {!isInitializing && <AlmaCaret measureKey={showWelcome ? "welcome" : "chat"} />}
-      {/* Initial load overlay — covers the empty container while sessions + agent initialize */}
-      {isInitializing && (
-        <div className="pointer-events-none absolute inset-0 z-40 flex flex-col items-center justify-center gap-3 bg-background">
-          <div className="h-8 w-8 animate-spin rounded-full border-2 border-muted-foreground/30 border-t-muted-foreground" />
-          <div className="text-sm text-muted-foreground">Loading sessions…</div>
-        </div>
-      )}
-      {/* Session list slide-over */}
-      {showSessionList && (
-        <SessionListPanel
-          activeKey={agentRef.current?.sessionId}
-          onSelect={switchSession}
-          onClose={() => setShowSessionList(false)}
-          onDelete={handleSessionDeleted}
-          onNew={newSession}
-          onOpenAdmin={() => openSettings()}
+      <main className="relative flex min-h-0 min-w-0 flex-1 flex-col">
+        {/* Chat panel container — takes remaining vertical space. */}
+        <div ref={containerRef} className="min-h-0 flex-1 w-full" />
+        {/*
+          Welcome overlay — rendered above pi-web-ui's empty message list
+          when the active session has no messages. Pointer-events-none so
+          clicks pass through to the composer below; flipped off the
+          moment the user commits their first message (onBeforeSend).
+        */}
+        {showWelcome && !isInitializing && (
+          <div className="pointer-events-none absolute inset-x-0 bottom-[calc(40vh+9rem)] z-10 flex justify-center px-6">
+            <h1 className="bg-gradient-to-br from-foreground via-foreground/80 to-foreground/40 bg-clip-text text-6xl font-semibold tracking-[0.2em] text-transparent sm:text-7xl">
+              RARA
+            </h1>
+          </div>
+        )}
+        {/*
+          Voice button floats over pi-web-ui's composer, aligned with
+          the paperclip via a calc that tracks the centred composer.
+          Lives inside `<main>` so the calc uses main's width (not the
+          viewport) — correct when the sidebar takes leftmost space.
+        */}
+        <VoiceRecorder
+          className="voice-float absolute bottom-[29px] z-20 !h-8 !w-8 !rounded-md !bg-transparent !shadow-none hover:!bg-accent"
+          getSessionKey={() => agentRef.current?.sessionId}
+          onComplete={reloadMessages}
         />
-      )}
+        {/*
+          Custom textarea caret (Alma-style): smooth moves + a cool-blue
+          comet tail. Mounts after pi-web-ui's composer is in the DOM via
+          an internal DOM query since the textarea is owned by a Lit
+          custom element we don't ref directly.
+        */}
+        {!isInitializing && <AlmaCaret measureKey={showWelcome ? "welcome" : "chat"} />}
+        {/* Initial load overlay — covers the empty container while sessions + agent initialize */}
+        {isInitializing && (
+          <div className="pointer-events-none absolute inset-0 z-40 flex flex-col items-center justify-center gap-3 bg-background">
+            <div className="h-8 w-8 animate-spin rounded-full border-2 border-muted-foreground/30 border-t-muted-foreground" />
+            <div className="text-sm text-muted-foreground">Loading sessions…</div>
+          </div>
+        )}
+      </main>
       {/* Rara-native model picker — replaces pi-mono's ModelSelector. */}
       <RaraModelDialog
         open={modelDialogOpen}

--- a/web/src/pages/PiChat.tsx
+++ b/web/src/pages/PiChat.tsx
@@ -936,7 +936,7 @@ export default function PiChat() {
         button without needing to patch pi-web-ui's input internals.
       */}
       <VoiceRecorder
-        className="absolute bottom-[29px] left-14 z-20 !h-8 !w-8 !rounded-md !bg-transparent !shadow-none hover:!bg-accent"
+        className="voice-float absolute bottom-[29px] z-20 !h-8 !w-8 !rounded-md !bg-transparent !shadow-none hover:!bg-accent"
         getSessionKey={() => agentRef.current?.sessionId}
         onComplete={reloadMessages}
       />


### PR DESCRIPTION
## Summary

Large follow-up to PR #1586 (which shipped the user-bubble glass fix). Collects all the chat-UI polish that accumulated on the branch after that merge. 16 commits, single branch, single diff.

### Highlights

- **Persistent collapsible sidebar** (kimi-style): new-session button, settings, full scrollable history list; icon-rail mode at 56px with localStorage-persisted state.
- **Session title header** in the main area.
- **Welcome state**: single gradient \`RARA\` wordmark centred above the composer; composer lifts to viewport centre in welcome, slides back on first send.
- **Glass palette**: user bubbles get info-blue frosted glass (multica tool-call aesthetic), canvas + dual radial glows (blue top-left, rose bottom-right), transparent top header.
- **Rara avatar** on assistant messages (served from \`web/public/rara.png\`).
- **Alma-style caret**: fake caret with smooth translate + blinking head + cool-blue comet trail, fades to zero between keystrokes.
- **Composer polish**: capped at 48rem centred column, voice button tracks paperclip via \`max(57px, calc(50% - 24rem + 57px))\`, user messages right-aligned, assistant messages left-aligned.
- **Bug fixes**: admin-default composer pill (no more ghost gemini-2.5), welcome flash on session switch (uses loaded messages not stale \`message_count\`), auto-focus textarea on mount + switch.

### Verified via Playwright

Live against \`http://10.0.0.183:25555\` backend — every commit has a screenshot diff attached to the session log. Session title, bubble alignment, RARA welcome, sidebar collapse, composer lift, caret trail, avatar, focus-on-switch all tested.

## Type of change

| Type | Label |
|------|-------|
| Enhancement | \`enhancement\` |

## Component

\`ui\`

## Test plan

- [x] \`npm run build\` passes in \`web/\`
- [x] \`cargo check --all --all-targets\` passes (web-only diff, Rust unchanged)
- [x] Manual Playwright QA against staging backend