### PR TITLE
fix(web): delete active session falls through (#1590)

### DIFF
--- a/web/src/components/AlmaCaret.tsx
+++ b/web/src/components/AlmaCaret.tsx
@@ -120,20 +120,27 @@ export function AlmaCaret({ measureKey }: AlmaCaretProps = {}) {
 
   // When ancestors animate (e.g. the composer slides out of welcome
   // position), `getBoundingClientRect()` reports the mid-animation
-  // position at measure time — we re-measure once immediately and
-  // again after the layout transition to land the caret at the final
-  // resting place.
+  // position at measure time. Poll on every frame through the 420ms
+  // transition so the caret tracks the textarea's position in sync
+  // with the layout tween rather than jumping after it finishes.
   useEffect(() => {
     if (measureKey === undefined) return;
     const ta = textareaRef.current;
     if (!ta) return;
-    const now = measureCaret(ta);
-    if (now) setPos(now);
-    const timer = window.setTimeout(() => {
+    let cancelled = false;
+    const start = performance.now();
+    const tick = () => {
+      if (cancelled) return;
       const next = measureCaret(ta);
       if (next) setPos(next);
-    }, 460);
-    return () => window.clearTimeout(timer);
+      if (performance.now() - start < 480) {
+        requestAnimationFrame(tick);
+      }
+    };
+    requestAnimationFrame(tick);
+    return () => {
+      cancelled = true;
+    };
   }, [measureKey]);
 
   useEffect(() => {

--- a/web/src/components/ChatSidebar.tsx
+++ b/web/src/components/ChatSidebar.tsx
@@ -34,7 +34,10 @@ interface ChatSidebarProps {
   onSelect: (session: ChatSession) => void;
   onNewSession: () => void;
   onOpenSettings: () => void;
-  onDeleteSession: (key: string) => void;
+  /** Called after a session is deleted. `fallback` is the next
+   * session the caller should switch to when the deleted row was
+   * the active one, or `null` when no sessions are left. */
+  onDeleteSession: (key: string, fallback: ChatSession | null) => void;
   /** Bump this from the parent to force a session-list refetch (e.g. after
    * creating a new session or receiving the first message of a fresh one). */
   refreshKey: number;
@@ -113,8 +116,16 @@ export function ChatSidebar({
     if (!confirm("删除这个会话？")) return;
     try {
       await api.del(`/api/v1/chat/sessions/${encodeURIComponent(key)}`);
+      // Pick the neighbour *before* the list mutation so the
+      // parent can switch into a still-cached row rather than
+      // spinning up a fresh session.
+      const idx = sessions.findIndex((s) => s.key === key);
+      const fallback =
+        idx >= 0
+          ? sessions[idx + 1] ?? sessions[idx - 1] ?? null
+          : null;
       setSessions((prev) => prev.filter((s) => s.key !== key));
-      onDeleteSession(key);
+      onDeleteSession(key, fallback);
     } catch {
       /* ignore */
     }

--- a/web/src/pages/PiChat.tsx
+++ b/web/src/pages/PiChat.tsx
@@ -476,15 +476,23 @@ export default function PiChat() {
     setSidebarRefreshKey((k) => k + 1);
   }, [switchSession]);
 
-  /** Handle session deletion from the panel. */
+  /** Handle session deletion from the sidebar. */
   const handleSessionDeleted = useCallback(
-    (deletedKey: string) => {
-      const agent = agentRef.current;
-      if (agent && agent.sessionId === deletedKey) {
+    (deletedKey: string, fallback: ChatSession | null) => {
+      // Leave the user on whatever they were viewing when an
+      // unrelated row was deleted.
+      if (activeSession?.key !== deletedKey) return;
+      // Deleted the active session: switch into the sidebar's next
+      // neighbour. Only spin up a brand-new chat when the whole
+      // history is gone, otherwise we'd trap the user in an
+      // "auto-regenerated empty session" loop.
+      if (fallback) {
+        switchSession(fallback);
+      } else {
         newSession();
       }
     },
-    [newSession],
+    [activeSession, newSession, switchSession],
   );
 
   /**
@@ -786,7 +794,7 @@ export default function PiChat() {
       data-welcome={showWelcome && !isInitializing ? "true" : undefined}
     >
       <ChatSidebar
-        activeSessionKey={agentRef.current?.sessionId}
+        activeSessionKey={activeSession?.key}
         onSelect={switchSession}
         onNewSession={newSession}
         onOpenSettings={() => openSettings()}


### PR DESCRIPTION
## Summary

- ChatSidebar.handleDelete passes the neighbouring session as a fallback argument on \`onDeleteSession\`.
- PiChat switches into that fallback when the active session was the one deleted; only spins up a fresh chat when no sessions remain. Fixes the loop where deleting kept regenerating a new active session.
- Pass \`activeSessionKey\` from state rather than the \`agentRef\` so the sidebar highlight tracks re-renders.
- Drive AlmaCaret remeasurement via rAF through the 420 ms welcome lift so the fake caret follows the textarea frame by frame instead of snapping.

## Type of change

| Type | Label |
|------|-------|
| Bug fix | \`bug\` |

## Component

\`ui\`

## Closes

Closes #1590