### PR TITLE
fix(web): persist session + disable mobile caret (#1592)

### DIFF
--- a/web/src/components/AlmaCaret.tsx
+++ b/web/src/components/AlmaCaret.tsx
@@ -131,7 +131,18 @@ export function AlmaCaret({ measureKey }: AlmaCaretProps = {}) {
   const [pos, setPos] = useState<CaretPos | null>(null);
   const [visible, setVisible] = useState(false);
   const textareaRef = useRef<HTMLTextAreaElement | null>(null);
-  const [enabled] = useState(() => !isCoarsePointer());
+  // Track coarse-pointer state reactively so plugging in/out a mouse
+  // on a hybrid device (tablet with keyboard cover, touch-screen
+  // laptop) flips the Alma caret on/off mid-session rather than
+  // latching whatever pointer type happened to be active at mount.
+  const [enabled, setEnabled] = useState(() => !isCoarsePointer());
+  useEffect(() => {
+    if (typeof window === "undefined" || !window.matchMedia) return;
+    const mq = window.matchMedia("(pointer: coarse)");
+    const onChange = (e: MediaQueryListEvent) => setEnabled(!e.matches);
+    mq.addEventListener("change", onChange);
+    return () => mq.removeEventListener("change", onChange);
+  }, []);
 
   // When ancestors animate (e.g. the composer slides out of welcome
   // position), `getBoundingClientRect()` reports the mid-animation

--- a/web/src/components/AlmaCaret.tsx
+++ b/web/src/components/AlmaCaret.tsx
@@ -113,10 +113,25 @@ function measureCaret(textarea: HTMLTextAreaElement): CaretPos | null {
  * whose textarea lands in the DOM asynchronously, so we can't ref it
  * through React.
  */
+/**
+ * `true` when the user's primary pointer is coarse (touch) — i.e. a
+ * phone or tablet. The fake-caret approach relies on
+ * `getBoundingClientRect` lining up with a `position: fixed` element,
+ * which iOS Safari breaks once the virtual keyboard opens because
+ * fixed elements pin to the layout viewport while the rect reports
+ * visual-viewport coordinates. Native caret is already fine on mobile,
+ * so the cleanest fix is to opt out entirely there.
+ */
+function isCoarsePointer(): boolean {
+  if (typeof window === "undefined") return false;
+  return window.matchMedia?.("(pointer: coarse)").matches ?? false;
+}
+
 export function AlmaCaret({ measureKey }: AlmaCaretProps = {}) {
   const [pos, setPos] = useState<CaretPos | null>(null);
   const [visible, setVisible] = useState(false);
   const textareaRef = useRef<HTMLTextAreaElement | null>(null);
+  const [enabled] = useState(() => !isCoarsePointer());
 
   // When ancestors animate (e.g. the composer slides out of welcome
   // position), `getBoundingClientRect()` reports the mid-animation
@@ -124,6 +139,7 @@ export function AlmaCaret({ measureKey }: AlmaCaretProps = {}) {
   // transition so the caret tracks the textarea's position in sync
   // with the layout tween rather than jumping after it finishes.
   useEffect(() => {
+    if (!enabled) return;
     if (measureKey === undefined) return;
     const ta = textareaRef.current;
     if (!ta) return;
@@ -141,9 +157,10 @@ export function AlmaCaret({ measureKey }: AlmaCaretProps = {}) {
     return () => {
       cancelled = true;
     };
-  }, [measureKey]);
+  }, [measureKey, enabled]);
 
   useEffect(() => {
+    if (!enabled) return;
     let raf = 0;
     let canceled = false;
 
@@ -202,9 +219,9 @@ export function AlmaCaret({ measureKey }: AlmaCaretProps = {}) {
       if (raf) clearTimeout(raf);
       if (typeof cleanup === "function") cleanup();
     };
-  }, []);
+  }, [enabled]);
 
-  if (!pos || !visible) return null;
+  if (!enabled || !pos || !visible) return null;
 
   // Head: sharp bar; smooth translate so moves across characters glide
   // rather than jumping. Blink animation still fires because it runs on

--- a/web/src/pages/PiChat.tsx
+++ b/web/src/pages/PiChat.tsx
@@ -61,6 +61,25 @@ import { useSettingsModal } from "@/components/settings/SettingsModalProvider";
 import type { ProviderInfo } from "@/api/types";
 import { UNKNOWN_MODEL_SENTINEL, isUnknownModel, syntheticModel } from "@/lib/synthetic-model";
 
+const ACTIVE_SESSION_KEY = "rara.activeSessionKey";
+
+function readStoredSessionKey(): string | null {
+  try {
+    return localStorage.getItem(ACTIVE_SESSION_KEY);
+  } catch {
+    return null;
+  }
+}
+
+function writeStoredSessionKey(key: string | null): void {
+  try {
+    if (key) localStorage.setItem(ACTIVE_SESSION_KEY, key);
+    else localStorage.removeItem(ACTIVE_SESSION_KEY);
+  } catch {
+    /* ignore */
+  }
+}
+
 /**
  * True when the given provider id is still present in rara's routable
  * catalog (from `/api/v1/chat/providers`). Fails open when the catalog
@@ -371,6 +390,7 @@ export default function PiChat() {
     agent.clearMessages();
     agent.sessionId = session.key;
     setActiveSession(session);
+    writeStoredSessionKey(session.key);
     // Optimistically hide the welcome overlay during the switch: the
     // backend's `message_count` is unreliable (always 0 in the listing
     // for older sessions, see #1585 round-2 notes), so trusting it
@@ -615,21 +635,37 @@ export default function PiChat() {
         });
 
       // 4b. Resolve the active session key before creating the agent.
-      //     Use the most recent existing session or create a new one.
-      const existingSessions = await api.get<ChatSession[]>(
-        "/api/v1/chat/sessions?limit=1&offset=0",
-      );
+      //     Prefer the last-active session from localStorage so a
+      //     reload lands the user back on whatever they were reading,
+      //     falling back to the most recent session, finally creating
+      //     a fresh one when nothing exists.
+      const storedKey = readStoredSessionKey();
+      let initialSession: ChatSession | null = null;
+      if (storedKey) {
+        try {
+          initialSession = await api.get<ChatSession>(
+            `/api/v1/chat/sessions/${encodeURIComponent(storedKey)}`,
+          );
+        } catch {
+          // Session was deleted or the key is stale — fall through.
+          writeStoredSessionKey(null);
+        }
+      }
+      if (!initialSession) {
+        const existingSessions = await api.get<ChatSession[]>(
+          "/api/v1/chat/sessions?limit=1&offset=0",
+        );
+        initialSession = existingSessions[0] ?? null;
+      }
       // Block on provider catalog here so the pre-mount restore step has
       // an authoritative allowlist. It's one cheap request; running it
       // serially after the sessions fetch keeps the code simple.
       await providersPromise;
-      let initialSession: ChatSession;
-      if (existingSessions.length > 0) {
-        initialSession = existingSessions[0];
-      } else {
+      if (!initialSession) {
         initialSession = await api.post<ChatSession>("/api/v1/chat/sessions", {});
       }
       setActiveSession(initialSession);
+      writeStoredSessionKey(initialSession.key);
       setShowWelcome((initialSession.message_count ?? 0) === 0);
       // 5. Create the Agent with rara's WebSocket-backed stream function.
       //    The streamFn reads agent.sessionId at call time to get the active session key.


### PR DESCRIPTION
## Summary

- Store \`activeSession.key\` in localStorage on every switch; on initial mount, prefer the stored key via a direct session GET. Reloading mid-chat restores the conversation instead of jumping to the RARA welcome.
- Skip AlmaCaret on coarse-pointer devices. The fake caret's \`position: fixed\` conflicts with mobile Safari's visual-viewport shift when the virtual keyboard opens; native caret is already fine on touch so opting out is the cleanest fix.

## Type of change

| Type | Label |
|------|-------|
| Bug fix | \`bug\` |

## Component

\`ui\`

## Closes

Closes #1592