### PR TITLE
feat(web): in-progress thinking placeholder (#1596)

### DIFF
--- a/web/src/api/kernel-types.ts
+++ b/web/src/api/kernel-types.ts
@@ -109,7 +109,15 @@ export type EventKind =
   | "thinking"
   | "tool_use"
   | "tool_result"
-  | "error";
+  | "error"
+  /**
+   * Live-only placeholder inserted right after the user submits a
+   * message so the UI gives immediate feedback while the kernel is
+   * setting up the turn / dispatching the LLM call. Cleared as soon as
+   * the first real delta / tool call arrives, or when the turn ends.
+   * Never appears in historical turn projections.
+   */
+  | "in_progress";
 
 /**
  * One renderable row in the session timeline.

--- a/web/src/components/kernel/TimelineRow.tsx
+++ b/web/src/components/kernel/TimelineRow.tsx
@@ -15,7 +15,7 @@
  */
 
 import { forwardRef, useState } from "react";
-import { AlertCircle, Brain, ChevronRight } from "lucide-react";
+import { AlertCircle, Brain, ChevronRight, Loader2 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import type { TimelineItem } from "@/api/kernel-types";
 import { KIND_PALETTE, eventLabel, eventSummary } from "./timeline-colors";
@@ -64,6 +64,9 @@ export const TimelineRow = forwardRef<HTMLDivElement, TimelineRowProps>(
           >
             {item.kind === "thinking" && (
               <Brain className="mr-1 h-3 w-3 shrink-0" />
+            )}
+            {item.kind === "in_progress" && (
+              <Loader2 className="mr-1 h-3 w-3 shrink-0 animate-spin" />
             )}
             {item.kind === "error" && (
               <AlertCircle className="mr-1 h-3 w-3 shrink-0" />
@@ -144,6 +147,9 @@ function rowHasDetail(item: TimelineItem): boolean {
       return !!item.content && item.content.length > 0;
     case "agent":
       return !!item.content && item.content.split("\n").length > 1;
+    case "in_progress":
+      // Placeholder is purely decorative — never expandable.
+      return false;
   }
 }
 
@@ -174,6 +180,9 @@ function RowDetail({ item }: { item: TimelineItem }) {
           {item.content ?? ""}
         </pre>
       );
+    case "in_progress":
+      // Never rendered — `rowHasDetail` returns false for this kind.
+      return null;
   }
 }
 

--- a/web/src/components/kernel/timeline-colors.ts
+++ b/web/src/components/kernel/timeline-colors.ts
@@ -71,6 +71,15 @@ export const KIND_PALETTE: Record<EventKind, KindPalette> = {
       "bg-red-500/20 text-red-700 dark:bg-red-500/15 dark:text-red-300",
     text: "Error",
   },
+  in_progress: {
+    // Reuse the thinking violet hue so the placeholder visually belongs
+    // to the "pre-output" phase of the turn.
+    bar: "bg-violet-300/50",
+    barActive: "bg-violet-400",
+    label:
+      "bg-violet-500/15 text-violet-700 dark:bg-violet-500/10 dark:text-violet-300",
+    text: "…",
+  },
 };
 
 /** Short label to show inside a row's type badge. */
@@ -95,6 +104,7 @@ export function eventSummary(item: {
     case "agent":
     case "thinking":
     case "error":
+    case "in_progress":
       return item.content?.trim() ?? "";
     case "tool_use":
       return toolInputSummary(item.input);

--- a/web/src/hooks/loading-hints.ts
+++ b/web/src/hooks/loading-hints.ts
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2025 Rararulab
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Poetic "thinking" hints shown while the web chat timeline waits for
+ * the first LLM delta. Mirrors the Telegram adapter's
+ * `crates/channels/src/telegram/loading_hints.rs` so the two channels
+ * feel cohesive, but lives in TS to avoid pulling a Rust string table
+ * across the WASM boundary just to render eight bytes of placeholder.
+ */
+export const LOADING_HINTS: readonly string[] = [
+  "稍候片刻，日出文自明。",
+  "风过空庭，字句正徐来。",
+  "纸白微明，未成篇章。",
+  "夜退星沉，此页初醒。",
+  "墨痕未定，片语已生香。",
+  "云开一隙，文章将至。",
+  "万籁俱寂，万字将成。",
+  "且听风定，再看句成。",
+];
+
+/** Return a random hint from {@link LOADING_HINTS}. */
+export function randomLoadingHint(): string {
+  const idx = Math.floor(Math.random() * LOADING_HINTS.length);
+  return LOADING_HINTS[idx] ?? LOADING_HINTS[0]!;
+}

--- a/web/src/hooks/use-session-timeline.ts
+++ b/web/src/hooks/use-session-timeline.ts
@@ -24,6 +24,7 @@ import {
   type TimelineItem,
   type TurnTrace,
 } from "@/api/kernel-types";
+import { randomLoadingHint } from "./loading-hints";
 
 const TURNS_REFETCH_MS = 5_000;
 
@@ -110,6 +111,20 @@ export function useSessionTimeline(
     let currentThinkSeq: number | null = null;
     const toolSeqById = new Map<string, number>();
 
+    // Placeholder "thinking…" row inserted as soon as the WS opens so the
+    // user gets immediate feedback while the kernel is bootstrapping the
+    // turn (LLM dispatch can take 2-30s for cold runs). Cleared on the
+    // first real delta/tool call, on `done`, or when the WS closes.
+    let placeholderSeq: number | null = null;
+    const clearPlaceholder = () => {
+      if (placeholderSeq === null) return;
+      const target = placeholderSeq;
+      placeholderSeq = null;
+      setLiveItems((prev) =>
+        prev.filter((it) => !(it.seq === target && it.kind === "in_progress")),
+      );
+    };
+
     // Live events belong to the turn after the last one already recorded.
     // Captured at WS-open time; not refreshed mid-stream. `done` clears
     // live state, so drift between this value and turnsQuery is bounded.
@@ -117,7 +132,17 @@ export function useSessionTimeline(
 
     ws.onopen = () => {
       setIsStreaming(true);
-      setLiveItems([]);
+      const seq = nextSeq();
+      placeholderSeq = seq;
+      setLiveItems([
+        {
+          seq,
+          turn: liveTurnIdx,
+          kind: "in_progress",
+          content: randomLoadingHint(),
+          streaming: true,
+        },
+      ]);
     };
 
     ws.onmessage = (ev) => {
@@ -132,6 +157,7 @@ export function useSessionTimeline(
         case "text_delta": {
           const delta = (event as { text?: string }).text ?? "";
           if (!delta) break;
+          clearPlaceholder();
           setLiveItems((prev) => {
             if (currentTextSeq !== null) {
               const target = currentTextSeq;
@@ -160,6 +186,7 @@ export function useSessionTimeline(
         case "reasoning_delta": {
           const delta = (event as { text?: string }).text ?? "";
           if (!delta) break;
+          clearPlaceholder();
           setLiveItems((prev) => {
             if (currentThinkSeq !== null) {
               const target = currentThinkSeq;
@@ -199,6 +226,7 @@ export function useSessionTimeline(
         }
 
         case "tool_call_start": {
+          clearPlaceholder();
           const e = event as {
             name: string;
             id: string;
@@ -298,6 +326,11 @@ export function useSessionTimeline(
 
         case "done":
           setIsStreaming(false);
+          // Drop the placeholder unconditionally — turns that produced
+          // zero deltas (e.g. a tool-only turn that errored before any
+          // streaming) would otherwise leave the spinner row hanging
+          // until the historical refetch overwrote `liveItems`.
+          clearPlaceholder();
           // Trigger an immediate refetch so the just-completed turn
           // appears as historical items before we clear live rows.
           // This avoids a 5s blank/stale window after every turn.
@@ -311,8 +344,14 @@ export function useSessionTimeline(
       }
     };
 
-    ws.onclose = () => setIsStreaming(false);
-    ws.onerror = () => setIsStreaming(false);
+    ws.onclose = () => {
+      setIsStreaming(false);
+      clearPlaceholder();
+    };
+    ws.onerror = () => {
+      setIsStreaming(false);
+      clearPlaceholder();
+    };
 
     return () => {
       ws.close();


### PR DESCRIPTION
## Summary

Adds an immediate "thinking…" placeholder row to the kernel session timeline so users see live feedback the moment a turn begins, instead of staring at an unchanged transcript for 2-30s while the LLM dispatches.

- New `in_progress` `EventKind` (live-only — never produced by `turnsToTimeline`).
- `useSessionTimeline` inserts the placeholder on `ws.onopen` with a randomly-picked Chinese loading hint (mirroring the Telegram adapter's poetic copy in TS).
- Placeholder is cleared on the first `text_delta` / `reasoning_delta` / `tool_call_start`, and unconditionally on `done`, `ws.onclose`, `ws.onerror`.
- `TimelineRow` renders the new kind with a spinning `Loader2` icon and a matching violet palette entry; rows are not expandable.

## Type of change

| Type | Label |
|------|-------|
| New feature | `enhancement` |

## Component

`ui`

## Closes

Closes #1596

## Test plan

- [x] `npm run build` passes in `web/`
- [x] `npx eslint` clean on the touched files
- [ ] Manual: send a message, confirm placeholder appears, gets replaced by streaming text, and disappears on completion / errors