### PR TITLE
feat(web): cascade execution trace modal (#1598)

### DIFF
--- a/web/src/api/kernel-types.ts
+++ b/web/src/api/kernel-types.ts
@@ -262,3 +262,50 @@ export function isLiveState(state: string | null): boolean {
   const s = state.toLowerCase();
   return s === "active" || s === "ready";
 }
+
+// ---------------------------------------------------------------------------
+// Cascade execution trace
+// ---------------------------------------------------------------------------
+// Mirrors `rara_kernel::cascade::CascadeTrace` (crates/kernel/src/cascade.rs).
+// Returned by `GET /api/v1/chat/sessions/{key}/trace?seq={seq}` and rendered
+// by `<CascadeModal>` when the user expands an assistant turn's "📊 详情"
+// button. Empty traces (no recorded ticks/entries) are surfaced explicitly so
+// the modal can show an empty state rather than a broken view.
+
+/** Classification of a single entry within a cascade tick. */
+export type CascadeEntryKind = "user_input" | "thought" | "action" | "observation";
+
+/** A single entry: user input, assistant thought, tool action, or observation. */
+export interface CascadeEntry {
+  /** Stable, human-readable identifier (`"{prefix}.{tick}-{short_id}-{seq}"`). */
+  id:        string;
+  kind:      CascadeEntryKind;
+  /** Display content — text, JSON-encoded tool args, or tool output. */
+  content:   string;
+  /** RFC3339 timestamp of the underlying tape entry. */
+  timestamp: string;
+  /** Optional structured metadata copied from the tape entry. */
+  metadata?: unknown;
+}
+
+/** One reasoning-action cycle (an LLM call + its emitted entries). */
+export interface CascadeTick {
+  /** Zero-based tick index within the trace. */
+  index:   number;
+  entries: CascadeEntry[];
+}
+
+/** High-level summary statistics for a cascade trace. */
+export interface CascadeSummary {
+  tick_count:      number;
+  tool_call_count: number;
+  total_entries:   number;
+}
+
+/** Top-level cascade trace for a single agent turn. */
+export interface CascadeTrace {
+  /** Opaque identifier — typically `"{session_key}-{seq}"`. */
+  message_id: string;
+  ticks:      CascadeTick[];
+  summary:    CascadeSummary;
+}

--- a/web/src/components/chat/CascadeModal.tsx
+++ b/web/src/components/chat/CascadeModal.tsx
@@ -1,0 +1,166 @@
+/*
+ * Copyright 2025 Rararulab
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useState } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import type {
+  CascadeEntry,
+  CascadeEntryKind,
+  CascadeTrace,
+} from "@/api/kernel-types";
+
+/**
+ * Cascade execution-trace viewer — opened from the "📊 详情" button on a
+ * completed assistant turn. Mirrors the Telegram renderer in
+ * `crates/channels/src/telegram/adapter.rs::render_cascade_html` so the two
+ * surfaces stay visually consistent.
+ *
+ * The trace is fetched lazily by the parent (PiChat) once the user opens
+ * the modal — the kernel does not stream cascade data, it only assembles it
+ * after a turn finishes (see `service.get_cascade_trace`).
+ */
+
+const ENTRY_LABELS: Record<CascadeEntryKind, { emoji: string; label: string }> = {
+  user_input:  { emoji: "💬", label: "User Input" },
+  thought:     { emoji: "🧠", label: "Thought" },
+  action:      { emoji: "⚡", label: "Action" },
+  observation: { emoji: "👁", label: "Observation" },
+};
+
+/**
+ * Inline collapse threshold (chars) — entries longer than this start
+ * collapsed and reveal the full body when "展开" is clicked. The TG
+ * adapter caps at 4000 chars *total*; web has no such hard limit, so we
+ * just hide individual long bodies behind a toggle to keep the modal
+ * scannable while still allowing inspection of any single entry.
+ */
+const COLLAPSE_THRESHOLD = 600;
+
+interface Props {
+  open:    boolean;
+  trace:   CascadeTrace | null;
+  loading: boolean;
+  error:   string | null;
+  onClose: () => void;
+}
+
+/** Modal wrapper + status switching (loading / error / empty / trace). */
+export function CascadeModal({ open, trace, loading, error, onClose }: Props) {
+  return (
+    <Dialog open={open} onOpenChange={(v) => { if (!v) onClose(); }}>
+      <DialogContent className="flex max-h-[85vh] w-[95vw] max-w-3xl flex-col gap-3 overflow-hidden">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <span aria-hidden>🔍</span>
+            <span>Cascade Trace</span>
+          </DialogTitle>
+          {trace && (
+            <DialogDescription>
+              {trace.summary.tick_count} ticks · {trace.summary.tool_call_count} tool calls · {trace.summary.total_entries} entries
+            </DialogDescription>
+          )}
+        </DialogHeader>
+        <div className="min-h-0 flex-1 overflow-y-auto pr-1">
+          {loading && (
+            <div className="flex items-center justify-center py-10 text-sm text-muted-foreground">
+              <div className="mr-2 h-4 w-4 animate-spin rounded-full border-2 border-muted-foreground/30 border-t-muted-foreground" />
+              加载中…
+            </div>
+          )}
+          {!loading && error && (
+            <div className="rounded-md border border-destructive/30 bg-destructive/10 p-3 text-sm text-destructive">
+              加载失败：{error}
+            </div>
+          )}
+          {!loading && !error && trace && trace.ticks.length === 0 && (
+            <div className="py-10 text-center text-sm text-muted-foreground">
+              该轮未记录任何 cascade 条目。
+            </div>
+          )}
+          {!loading && !error && trace && trace.ticks.length > 0 && (
+            <TraceBody trace={trace} />
+          )}
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function TraceBody({ trace }: { trace: CascadeTrace }) {
+  return (
+    <div className="flex flex-col gap-4">
+      {trace.ticks.map((tick) => (
+        <section key={tick.index} className="flex flex-col gap-2">
+          <header className="sticky top-0 z-[1] flex items-center gap-2 bg-background/95 py-1 text-sm font-semibold backdrop-blur">
+            <span aria-hidden>▶</span>
+            <span>TICK {tick.index + 1}</span>
+            <span className="text-xs font-normal text-muted-foreground">
+              · {tick.entries.length} entries
+            </span>
+          </header>
+          <div className="flex flex-col gap-2">
+            {tick.entries.map((entry) => (
+              <EntryCard key={entry.id} entry={entry} />
+            ))}
+          </div>
+        </section>
+      ))}
+    </div>
+  );
+}
+
+function EntryCard({ entry }: { entry: CascadeEntry }) {
+  const [expanded, setExpanded] = useState(false);
+  const meta = ENTRY_LABELS[entry.kind];
+  const collapsible = entry.content.length > COLLAPSE_THRESHOLD;
+  const body = !collapsible || expanded
+    ? entry.content
+    : entry.content.slice(0, COLLAPSE_THRESHOLD) + "…";
+
+  return (
+    <article className="rounded-md border border-border/60 bg-muted/20 p-3">
+      <header className="mb-2 flex flex-wrap items-center gap-x-2 gap-y-1 text-xs">
+        <span className="text-base leading-none" aria-hidden>{meta.emoji}</span>
+        <span className="font-semibold text-foreground/90">{meta.label}</span>
+        <code className="rounded bg-muted/60 px-1.5 py-0.5 font-mono text-[10px] text-muted-foreground">
+          {entry.id}
+        </code>
+      </header>
+      {body.length === 0 ? (
+        <p className="text-xs italic text-muted-foreground">(empty)</p>
+      ) : (
+        <pre className="whitespace-pre-wrap break-words font-mono text-xs leading-relaxed text-foreground/85">
+          {body}
+        </pre>
+      )}
+      {collapsible && (
+        <button
+          type="button"
+          onClick={() => setExpanded((v) => !v)}
+          className="mt-2 text-xs text-primary hover:underline"
+        >
+          {expanded ? "收起" : `展开（共 ${entry.content.length} 字符）`}
+        </button>
+      )}
+    </article>
+  );
+}

--- a/web/src/pages/PiChat.tsx
+++ b/web/src/pages/PiChat.tsx
@@ -212,21 +212,28 @@ function parseAssistantContent(
 }
 
 /**
+ * WeakMap from assistant `AgentMessage` object references to their
+ * persisted `seq`. Populated by {@link toAgentMessages} and read by the
+ * Lit assistant-message renderer when the user clicks the "📊 详情"
+ * button — the seq is then embedded on the dispatched CustomEvent so
+ * the React layer can call the trace endpoint directly without any
+ * timestamp-based lookup (which collided at second resolution).
+ *
+ * Keyed by object identity: the same references flow from
+ * `toAgentMessages` → `agent.replaceMessages(...)` → pi-web-ui's
+ * renderer, so the renderer sees the exact keys set here.
+ */
+const assistantSeqByRef = new WeakMap<AgentMessage, number>();
+
+/**
  * Convert rara ChatMessageData to pi-agent-core AgentMessage for display.
  *
- * Also returns a map from each assistant message's `timestamp` (ms epoch)
- * back to its persisted `seq`, so the cascade-trace button rendered by the
- * custom Lit renderer can look up the seq required by the trace endpoint
- * (`GET /chat/sessions/{key}/trace?seq=...`). Timestamps come from the
- * backend's `created_at`, which is unique per-row at second resolution and
- * unique per-row in practice for assistant turns within a session.
+ * Assistant messages are registered in {@link assistantSeqByRef} keyed by
+ * object identity so the Lit renderer can resolve each rendered message
+ * back to its persisted `seq` without a lossy timestamp lookup.
  */
-function toAgentMessages(msgs: ChatMessageData[]): {
-  agentMessages:    AgentMessage[];
-  seqByTimestamp:   Map<number, number>;
-} {
+function toAgentMessages(msgs: ChatMessageData[]): AgentMessage[] {
   const result: AgentMessage[] = [];
-  const seqByTimestamp = new Map<number, number>();
   // Track the last assistant message so "tool" role messages can attach ToolCall items.
   let lastAssistant: AssistantMessage | null = null;
 
@@ -303,7 +310,7 @@ function toAgentMessages(msgs: ChatMessageData[]): {
         timestamp: ts,
       };
       lastAssistant = assistant;
-      seqByTimestamp.set(ts, m.seq);
+      assistantSeqByRef.set(assistant, m.seq);
       result.push(assistant);
     } else if (m.role === "tool") {
       // Tool call from the assistant — attach as ToolCall to the last AssistantMessage.
@@ -347,28 +354,27 @@ function toAgentMessages(msgs: ChatMessageData[]): {
       }
     }
   }
-  return { agentMessages: result, seqByTimestamp };
+  return result;
 }
 
 /**
  * DOM event dispatched by the Lit assistant-message renderer when the
- * user clicks the "📊 详情" button. The React layer listens for this on
- * `document` and resolves the timestamp back to a persisted `seq` via
- * the active session's `seqByTimestamp` map.
+ * user clicks the "📊 详情" button. The React layer listens on
+ * `document` and calls the trace endpoint with the carried `seq`
+ * directly — no timestamp indirection (see {@link assistantSeqByRef}).
  */
 const CASCADE_TRACE_EVENT = "rara:cascade-trace";
 
 interface CascadeTraceEventDetail {
-  timestamp: number;
+  seq: number;
 }
 
 /**
  * Register a Lit message renderer that wraps pi-web-ui's built-in
  * `<assistant-message>` element and appends a "📊 详情" button. The
  * button dispatches a bubbling {@link CASCADE_TRACE_EVENT} carrying the
- * assistant turn's timestamp; the React layer listens on `document` and
- * looks up the matching `seq` via the active session's
- * `seqByTimestampRef` map.
+ * persisted `seq` directly — resolved via {@link assistantSeqByRef}
+ * keyed by the rendered message's object identity.
  *
  * The renderer must rebuild the same `toolResultsById` lookup that
  * `MessageList` normally hands `<assistant-message>` — otherwise paired
@@ -376,9 +382,9 @@ interface CascadeTraceEventDetail {
  * closure gives us that map at click time without re-registering on
  * every message-list change.
  *
- * Skips placeholder turns whose timestamp is 0 (e.g. mid-stream
- * assistant frames) — there's no persisted seq to ask the trace
- * endpoint for, and showing a button that 404s would be misleading.
+ * Skips placeholder turns with no mapped seq (e.g. mid-stream assistant
+ * frames not yet persisted) — there's no row to ask the trace endpoint
+ * for, and showing a button that 404s would be misleading.
  *
  * Idempotent: calling this multiple times leaves only the latest
  * registration in pi-web-ui's renderer map (a Map.set overwrite), which
@@ -389,8 +395,8 @@ function registerCascadeAssistantRenderer(
 ): void {
   registerMessageRenderer("assistant", {
     render(message) {
-      const ts = message.timestamp;
-      const showButton = ts > 0;
+      const seq = assistantSeqByRef.get(message);
+      const showButton = seq !== undefined;
       // Rebuild the toolResult lookup from current agent state. Cheap
       // (a single linear scan) and avoids stale-closure bugs because the
       // resolver always hits the live agent ref.
@@ -422,7 +428,8 @@ function registerCascadeAssistantRenderer(
                     title="查看本轮 cascade 执行详情"
                     @click=${(e: Event) => {
                       e.stopPropagation();
-                      const detail: CascadeTraceEventDetail = { timestamp: ts };
+                      if (seq === undefined) return;
+                      const detail: CascadeTraceEventDetail = { seq };
                       document.dispatchEvent(
                         new CustomEvent<CascadeTraceEventDetail>(
                           CASCADE_TRACE_EVENT,
@@ -494,11 +501,6 @@ export default function PiChat() {
   const [cascadeTrace, setCascadeTrace] = useState<CascadeTrace | null>(null);
   const [cascadeLoading, setCascadeLoading] = useState(false);
   const [cascadeError, setCascadeError] = useState<string | null>(null);
-  // timestamp (ms) → assistant message seq for the active session. Rebuilt
-  // on every history load (switchSession / reloadMessages). The Lit
-  // renderer dispatches a CustomEvent carrying just the timestamp; this
-  // map turns it back into the `seq` the trace endpoint requires.
-  const seqByTimestampRef = useRef<Map<number, number>>(new Map());
 
   // Clear any stale reset-error banner whenever the model dialog is
   // closed — regardless of close path (backdrop click, successful
@@ -510,20 +512,15 @@ export default function PiChat() {
 
   // Bridge between the Lit assistant-message renderer and React: when
   // the user clicks a "📊 详情" button, the renderer dispatches a
-  // bubbling CustomEvent on `document` carrying the assistant turn's
-  // timestamp. Resolve it back to a `seq` and call the trace endpoint.
-  // A failed/empty fetch shows an inline state in the modal rather
-  // than swallowing the click silently — the button is always offered
-  // for completed assistant turns regardless of whether a trace ends
-  // up being present.
+  // bubbling CustomEvent on `document` carrying the persisted `seq`
+  // (resolved via `assistantSeqByRef`). A failed/empty fetch shows an
+  // inline state in the modal rather than swallowing the click silently.
   useEffect(() => {
     const handler = (ev: Event) => {
       const ce = ev as CustomEvent<CascadeTraceEventDetail>;
-      const ts = ce.detail?.timestamp;
+      const seq = ce.detail?.seq;
       const sessionKey = agentRef.current?.sessionId;
-      if (!ts || !sessionKey) return;
-      const seq = seqByTimestampRef.current.get(ts);
-      if (seq === undefined) return;
+      if (seq === undefined || !sessionKey) return;
       setCascadeOpen(true);
       setCascadeTrace(null);
       setCascadeError(null);
@@ -605,8 +602,7 @@ export default function PiChat() {
       const msgs = await api.get<ChatMessageData[]>(
         `/api/v1/chat/sessions/${encodeURIComponent(session.key)}/messages?limit=200`,
       );
-      const { agentMessages: agentMsgs, seqByTimestamp } = toAgentMessages(msgs);
-      seqByTimestampRef.current = seqByTimestamp;
+      const agentMsgs = toAgentMessages(msgs);
       if (agentMsgs.length > 0) {
         agent.replaceMessages(agentMsgs);
       } else if (agentRef.current?.sessionId === session.key) {
@@ -643,8 +639,7 @@ export default function PiChat() {
       const msgs = await api.get<ChatMessageData[]>(
         `/api/v1/chat/sessions/${encodeURIComponent(agent.sessionId)}/messages?limit=200`,
       );
-      const { agentMessages: agentMsgs, seqByTimestamp } = toAgentMessages(msgs);
-      seqByTimestampRef.current = seqByTimestamp;
+      const agentMsgs = toAgentMessages(msgs);
       agent.replaceMessages(agentMsgs);
       await chatPanelRef.current?.artifactsPanel?.reconstructFromMessages(
         agentMsgs,
@@ -763,9 +758,9 @@ export default function PiChat() {
       // assistant turn gets a "📊 详情" trigger that opens the cascade
       // execution-trace modal. The renderer fires a CustomEvent on the
       // host element (which bubbles up through the light DOM since
-      // pi-web-ui's components opt out of shadow DOM), and the React
-      // layer below resolves the timestamp back to a `seq` via
-      // `seqByTimestampRef` to call `GET /chat/sessions/{key}/trace`.
+      // pi-web-ui's components opt out of shadow DOM) carrying the
+      // persisted `seq` (resolved via `assistantSeqByRef`) so the React
+      // layer below can call `GET /chat/sessions/{key}/trace` directly.
       registerCascadeAssistantRenderer(() => agentRef.current);
 
       // 1. Create and initialize the rara storage backend

--- a/web/src/pages/PiChat.tsx
+++ b/web/src/pages/PiChat.tsx
@@ -25,9 +25,11 @@ import {
   ProviderKeysStore,
   CustomProvidersStore,
   defaultConvertToLlm,
+  registerMessageRenderer,
   type Attachment,
   type UserMessageWithAttachments,
 } from "@mariozechner/pi-web-ui";
+import { html } from "lit";
 import { Agent } from "@mariozechner/pi-agent-core";
 import type { AgentMessage } from "@mariozechner/pi-agent-core";
 // Importing the extract-document tool from pi-web-ui triggers the
@@ -57,8 +59,10 @@ import { VoiceRecorder } from "@/components/VoiceRecorder";
 import { RaraModelDialog } from "@/components/RaraModelDialog";
 import { AlmaCaret } from "@/components/AlmaCaret";
 import { ChatSidebar } from "@/components/ChatSidebar";
+import { CascadeModal } from "@/components/chat/CascadeModal";
 import { useSettingsModal } from "@/components/settings/SettingsModalProvider";
 import type { ProviderInfo } from "@/api/types";
+import type { CascadeTrace } from "@/api/kernel-types";
 import { UNKNOWN_MODEL_SENTINEL, isUnknownModel, syntheticModel } from "@/lib/synthetic-model";
 
 const ACTIVE_SESSION_KEY = "rara.activeSessionKey";
@@ -207,9 +211,22 @@ function parseAssistantContent(
   return blocks;
 }
 
-/** Convert rara ChatMessageData to pi-agent-core AgentMessage for display. */
-function toAgentMessages(msgs: ChatMessageData[]): AgentMessage[] {
+/**
+ * Convert rara ChatMessageData to pi-agent-core AgentMessage for display.
+ *
+ * Also returns a map from each assistant message's `timestamp` (ms epoch)
+ * back to its persisted `seq`, so the cascade-trace button rendered by the
+ * custom Lit renderer can look up the seq required by the trace endpoint
+ * (`GET /chat/sessions/{key}/trace?seq=...`). Timestamps come from the
+ * backend's `created_at`, which is unique per-row at second resolution and
+ * unique per-row in practice for assistant turns within a session.
+ */
+function toAgentMessages(msgs: ChatMessageData[]): {
+  agentMessages:    AgentMessage[];
+  seqByTimestamp:   Map<number, number>;
+} {
   const result: AgentMessage[] = [];
+  const seqByTimestamp = new Map<number, number>();
   // Track the last assistant message so "tool" role messages can attach ToolCall items.
   let lastAssistant: AssistantMessage | null = null;
 
@@ -286,6 +303,7 @@ function toAgentMessages(msgs: ChatMessageData[]): AgentMessage[] {
         timestamp: ts,
       };
       lastAssistant = assistant;
+      seqByTimestamp.set(ts, m.seq);
       result.push(assistant);
     } else if (m.role === "tool") {
       // Tool call from the assistant — attach as ToolCall to the last AssistantMessage.
@@ -329,7 +347,100 @@ function toAgentMessages(msgs: ChatMessageData[]): AgentMessage[] {
       }
     }
   }
-  return result;
+  return { agentMessages: result, seqByTimestamp };
+}
+
+/**
+ * DOM event dispatched by the Lit assistant-message renderer when the
+ * user clicks the "📊 详情" button. The React layer listens for this on
+ * `document` and resolves the timestamp back to a persisted `seq` via
+ * the active session's `seqByTimestamp` map.
+ */
+const CASCADE_TRACE_EVENT = "rara:cascade-trace";
+
+interface CascadeTraceEventDetail {
+  timestamp: number;
+}
+
+/**
+ * Register a Lit message renderer that wraps pi-web-ui's built-in
+ * `<assistant-message>` element and appends a "📊 详情" button. The
+ * button dispatches a bubbling {@link CASCADE_TRACE_EVENT} carrying the
+ * assistant turn's timestamp; the React layer listens on `document` and
+ * looks up the matching `seq` via the active session's
+ * `seqByTimestampRef` map.
+ *
+ * The renderer must rebuild the same `toolResultsById` lookup that
+ * `MessageList` normally hands `<assistant-message>` — otherwise paired
+ * tool results would not render under the call. The `agentResolver`
+ * closure gives us that map at click time without re-registering on
+ * every message-list change.
+ *
+ * Skips placeholder turns whose timestamp is 0 (e.g. mid-stream
+ * assistant frames) — there's no persisted seq to ask the trace
+ * endpoint for, and showing a button that 404s would be misleading.
+ *
+ * Idempotent: calling this multiple times leaves only the latest
+ * registration in pi-web-ui's renderer map (a Map.set overwrite), which
+ * is what we want during HMR.
+ */
+function registerCascadeAssistantRenderer(
+  agentResolver: () => Agent | null,
+): void {
+  registerMessageRenderer("assistant", {
+    render(message) {
+      const ts = message.timestamp;
+      const showButton = ts > 0;
+      // Rebuild the toolResult lookup from current agent state. Cheap
+      // (a single linear scan) and avoids stale-closure bugs because the
+      // resolver always hits the live agent ref.
+      const agent = agentResolver();
+      const resultByCallId = new Map<string, import("@mariozechner/pi-ai").ToolResultMessage>();
+      if (agent) {
+        for (const m of agent.state.messages) {
+          if (m.role === "toolResult") {
+            const tr = m as import("@mariozechner/pi-ai").ToolResultMessage;
+            resultByCallId.set(tr.toolCallId, tr);
+          }
+        }
+      }
+      return html`
+        <div class="rara-assistant-with-trace">
+          <assistant-message
+            .message=${message}
+            .tools=${agent?.state.tools ?? []}
+            .isStreaming=${false}
+            .toolResultsById=${resultByCallId}
+            .hideToolCalls=${false}
+          ></assistant-message>
+          ${showButton
+            ? html`
+                <div class="mt-1 flex justify-start pl-1">
+                  <button
+                    type="button"
+                    class="rara-cascade-trigger inline-flex items-center gap-1 rounded-md px-2 py-0.5 text-xs text-muted-foreground transition hover:bg-accent hover:text-foreground"
+                    title="查看本轮 cascade 执行详情"
+                    @click=${(e: Event) => {
+                      e.stopPropagation();
+                      const detail: CascadeTraceEventDetail = { timestamp: ts };
+                      document.dispatchEvent(
+                        new CustomEvent<CascadeTraceEventDetail>(
+                          CASCADE_TRACE_EVENT,
+                          { detail, bubbles: true },
+                        ),
+                      );
+                    }}
+                  >
+                    <span aria-hidden>📊</span>
+                    <span>详情</span>
+                  </button>
+                </div>
+              `
+            : null}
+        </div>
+      `;
+    },
+  });
 }
 
 // Session list now lives in `ChatSidebar`; legacy slide-over deleted
@@ -374,6 +485,20 @@ export default function PiChat() {
   // that land on a populated session.
   const [showWelcome, setShowWelcome] = useState(true);
   const { openSettings } = useSettingsModal();
+  // Cascade trace viewer state — opened when the user clicks the "📊 详情"
+  // button injected into each assistant message by the custom Lit renderer
+  // registered below. The seq → trace fetch is lazy: the kernel does not
+  // stream cascade data, the UI only assembles it via REST after a turn
+  // finishes (see `service.get_cascade_trace`).
+  const [cascadeOpen, setCascadeOpen] = useState(false);
+  const [cascadeTrace, setCascadeTrace] = useState<CascadeTrace | null>(null);
+  const [cascadeLoading, setCascadeLoading] = useState(false);
+  const [cascadeError, setCascadeError] = useState<string | null>(null);
+  // timestamp (ms) → assistant message seq for the active session. Rebuilt
+  // on every history load (switchSession / reloadMessages). The Lit
+  // renderer dispatches a CustomEvent carrying just the timestamp; this
+  // map turns it back into the `seq` the trace endpoint requires.
+  const seqByTimestampRef = useRef<Map<number, number>>(new Map());
 
   // Clear any stale reset-error banner whenever the model dialog is
   // closed — regardless of close path (backdrop click, successful
@@ -382,6 +507,45 @@ export default function PiChat() {
   useEffect(() => {
     if (!modelDialogOpen) setResetError(null);
   }, [modelDialogOpen]);
+
+  // Bridge between the Lit assistant-message renderer and React: when
+  // the user clicks a "📊 详情" button, the renderer dispatches a
+  // bubbling CustomEvent on `document` carrying the assistant turn's
+  // timestamp. Resolve it back to a `seq` and call the trace endpoint.
+  // A failed/empty fetch shows an inline state in the modal rather
+  // than swallowing the click silently — the button is always offered
+  // for completed assistant turns regardless of whether a trace ends
+  // up being present.
+  useEffect(() => {
+    const handler = (ev: Event) => {
+      const ce = ev as CustomEvent<CascadeTraceEventDetail>;
+      const ts = ce.detail?.timestamp;
+      const sessionKey = agentRef.current?.sessionId;
+      if (!ts || !sessionKey) return;
+      const seq = seqByTimestampRef.current.get(ts);
+      if (seq === undefined) return;
+      setCascadeOpen(true);
+      setCascadeTrace(null);
+      setCascadeError(null);
+      setCascadeLoading(true);
+      api
+        .get<CascadeTrace>(
+          `/api/v1/chat/sessions/${encodeURIComponent(sessionKey)}/trace?seq=${seq}`,
+        )
+        .then((trace) => {
+          setCascadeTrace(trace);
+        })
+        .catch((e: unknown) => {
+          const msg = e instanceof Error ? e.message : String(e);
+          setCascadeError(msg);
+        })
+        .finally(() => {
+          setCascadeLoading(false);
+        });
+    };
+    document.addEventListener(CASCADE_TRACE_EVENT, handler);
+    return () => document.removeEventListener(CASCADE_TRACE_EVENT, handler);
+  }, []);
 
   /** Switch the agent to a different session, loading its history. */
   const switchSession = useCallback(async (session: ChatSession) => {
@@ -441,7 +605,8 @@ export default function PiChat() {
       const msgs = await api.get<ChatMessageData[]>(
         `/api/v1/chat/sessions/${encodeURIComponent(session.key)}/messages?limit=200`,
       );
-      const agentMsgs = toAgentMessages(msgs);
+      const { agentMessages: agentMsgs, seqByTimestamp } = toAgentMessages(msgs);
+      seqByTimestampRef.current = seqByTimestamp;
       if (agentMsgs.length > 0) {
         agent.replaceMessages(agentMsgs);
       } else if (agentRef.current?.sessionId === session.key) {
@@ -478,7 +643,8 @@ export default function PiChat() {
       const msgs = await api.get<ChatMessageData[]>(
         `/api/v1/chat/sessions/${encodeURIComponent(agent.sessionId)}/messages?limit=200`,
       );
-      const agentMsgs = toAgentMessages(msgs);
+      const { agentMessages: agentMsgs, seqByTimestamp } = toAgentMessages(msgs);
+      seqByTimestampRef.current = seqByTimestamp;
       agent.replaceMessages(agentMsgs);
       await chatPanelRef.current?.artifactsPanel?.reconstructFromMessages(
         agentMsgs,
@@ -593,6 +759,14 @@ export default function PiChat() {
       //    ChatPanel.setAgent() mounts any messages — the registry is
       //    consulted at render time with no retro-active update.
       registerRaraToolRenderers();
+      // Wrap pi-web-ui's built-in `<assistant-message>` so each completed
+      // assistant turn gets a "📊 详情" trigger that opens the cascade
+      // execution-trace modal. The renderer fires a CustomEvent on the
+      // host element (which bubbles up through the light DOM since
+      // pi-web-ui's components opt out of shadow DOM), and the React
+      // layer below resolves the timestamp back to a `seq` via
+      // `seqByTimestampRef` to call `GET /chat/sessions/{key}/trace`.
+      registerCascadeAssistantRenderer(() => agentRef.current);
 
       // 1. Create and initialize the rara storage backend
       const backend = new RaraStorageBackend();
@@ -912,6 +1086,13 @@ export default function PiChat() {
         }}
         resetError={resetError}
         onUseDefault={handleUseDefault}
+      />
+      <CascadeModal
+        open={cascadeOpen}
+        trace={cascadeTrace}
+        loading={cascadeLoading}
+        error={cascadeError}
+        onClose={() => setCascadeOpen(false)}
       />
     </div>
   );


### PR DESCRIPTION
## Summary

- Add a "📊 详情" button under every completed assistant turn that lazy-fetches `GET /chat/sessions/{key}/trace?seq=...` and opens a new `CascadeModal` rendering the kernel's `CascadeTrace` (ticks → entries with emoji + label + content) — feature parity with the Telegram inline trace command.
- Wire the click through a Lit `assistant`-role message renderer registered against pi-web-ui; the renderer emits a bubbling `rara:cascade-trace` CustomEvent and React looks the timestamp back up in a per-session `timestamp → seq` map populated alongside `toAgentMessages`.
- Long entries (> 600 chars) collapse with an inline "展开/收起" toggle so a chatty observation does not blow out the modal scroll.

## Type of change

| Type | Label |
|------|-------|
| New feature | `enhancement` |

## Component

`ui`

## Closes

Closes #1598

## Test plan

- [x] `npm run build` passes
- [x] No new `npm run lint` errors in touched files
- [ ] Manually open a session with a completed assistant turn → "📊 详情" appears, click loads trace and renders ticks + entries
- [ ] Empty trace shows the empty-state message, network error shows inline error