### PR TITLE
feat(web): plan timeline with step hierarchy (#1595)

### DIFF
--- a/web/src/api/kernel-types.ts
+++ b/web/src/api/kernel-types.ts
@@ -66,11 +66,24 @@ export interface TurnTrace {
 }
 
 /**
+ * Structured per-step status carried by `plan_progress` events.
+ *
+ * Mirrors `rara_kernel::io::PlanStepStatus` (snake_case serde tag).
+ * `failed` / `needs_replan` carry a human-readable reason that the UI
+ * surfaces on the corresponding step row.
+ */
+export type PlanStepStatusEvent =
+  | "running"
+  | "done"
+  | { failed: { reason: string } }
+  | { needs_replan: { reason: string } };
+
+/**
  * Narrow subset of kernel `StreamEvent` the UI consumes today.
  *
- * The kernel emits more variants (PlanCreated, UsageUpdate,
- * BackgroundTaskStarted, etc.); we parse defensively — unknown variants
- * are ignored by the hook.
+ * The kernel emits more variants (UsageUpdate, BackgroundTaskStarted,
+ * etc.); we parse defensively — unknown variants are ignored by the
+ * hook.
  */
 export type StreamEvent =
   | { type: "text_delta"; text: string }
@@ -96,6 +109,22 @@ export type StreamEvent =
       model: string;
       rara_message_id: string;
     }
+  | {
+      type: "plan_created";
+      goal: string;
+      total_steps: number;
+      compact_summary: string;
+      estimated_duration_secs: number | null;
+    }
+  | {
+      type: "plan_progress";
+      current_step: number;
+      total_steps: number;
+      step_status: PlanStepStatusEvent;
+      status_text: string;
+    }
+  | { type: "plan_replan"; reason: string }
+  | { type: "plan_completed"; summary: string }
   | { type: "done" }
   | { type: string; [k: string]: unknown };
 
@@ -117,7 +146,48 @@ export type EventKind =
    * the first real delta / tool call arrives, or when the turn ends.
    * Never appears in historical turn projections.
    */
-  | "in_progress";
+  | "in_progress"
+  /**
+   * Live-only multi-step plan progress widget. Created on the first
+   * `plan_created` event and mutated in place by `plan_progress` /
+   * `plan_replan` / `plan_completed`. Self-contained — renders its own
+   * step list rather than going through the standard row layout.
+   */
+  | "plan_card";
+
+/** Per-step status for the live `plan_card` row. */
+export type PlanStepUiStatus =
+  | "pending"
+  | "running"
+  | "done"
+  | "failed"
+  | "needs_replan";
+
+/** Single step within a plan card row. */
+export interface PlanStep {
+  /** 1-based step number for display (matches kernel's `current_step + 1`). */
+  index: number;
+  /** Free-form task description, parsed from the event's `status_text`. */
+  task: string;
+  status: PlanStepUiStatus;
+  /** Failure / replan reason (only set when status is failed/needs_replan). */
+  reason?: string;
+}
+
+/** State for an in-flight `plan_card` timeline row. */
+export interface PlanState {
+  goal: string;
+  totalSteps: number;
+  steps: PlanStep[];
+  /** 0-based index of the most recent step that received an update. */
+  currentStepIdx: number | null;
+  /** Optional reason from the most recent `plan_replan`. */
+  replanReason?: string;
+  /** Final summary set by `plan_completed`. */
+  summary?: string;
+  /** True once `plan_completed` fires. */
+  completed: boolean;
+}
 
 /**
  * One renderable row in the session timeline.
@@ -145,6 +215,8 @@ export interface TimelineItem {
   success?: boolean;
   /** Still receiving WS deltas — callers may show a cursor/pulse. */
   streaming?: boolean;
+  /** Plan widget state for `kind === "plan_card"`. */
+  plan?: PlanState;
 }
 
 /**

--- a/web/src/components/kernel/TimelineRow.tsx
+++ b/web/src/components/kernel/TimelineRow.tsx
@@ -17,7 +17,11 @@
 import { forwardRef, useState } from "react";
 import { AlertCircle, Brain, ChevronRight, Loader2 } from "lucide-react";
 import { cn } from "@/lib/utils";
-import type { TimelineItem } from "@/api/kernel-types";
+import type {
+  PlanState,
+  PlanStepUiStatus,
+  TimelineItem,
+} from "@/api/kernel-types";
 import { KIND_PALETTE, eventLabel, eventSummary } from "./timeline-colors";
 
 const DETAIL_MAX_CHARS = 4000;
@@ -40,6 +44,23 @@ export interface TimelineRowProps {
 export const TimelineRow = forwardRef<HTMLDivElement, TimelineRowProps>(
   function TimelineRow({ item, isSelected, onClick }, ref) {
     const [expanded, setExpanded] = useState(false);
+
+    // Plan cards render a self-contained widget (goal header, step list,
+    // footer) rather than the standard badge+summary row layout.
+    if (item.kind === "plan_card" && item.plan) {
+      return (
+        <div
+          ref={ref}
+          className={cn(
+            "group transition-colors",
+            isSelected && "bg-accent/50",
+          )}
+          onClick={onClick}
+        >
+          <PlanCardBody item={item} plan={item.plan} />
+        </div>
+      );
+    }
 
     const palette = KIND_PALETTE[item.kind];
     const label = eventLabel(item.kind, item.tool);
@@ -150,6 +171,9 @@ function rowHasDetail(item: TimelineItem): boolean {
     case "in_progress":
       // Placeholder is purely decorative — never expandable.
       return false;
+    case "plan_card":
+      // Self-contained widget — early-returned before this helper runs.
+      return false;
   }
 }
 
@@ -183,7 +207,115 @@ function RowDetail({ item }: { item: TimelineItem }) {
     case "in_progress":
       // Never rendered — `rowHasDetail` returns false for this kind.
       return null;
+    case "plan_card":
+      // Self-contained widget — never renders via the shared detail pane.
+      return null;
   }
+}
+
+const STEP_STATUS_ICON: Record<PlanStepUiStatus, string> = {
+  pending: "\u{26AA}",
+  running: "\u{1F504}",
+  done: "\u{2705}",
+  failed: "\u{274C}",
+  needs_replan: "\u{1F501}",
+};
+
+/**
+ * Self-contained plan widget: goal header, step list with status icons,
+ * nested active tool calls, optional replan/summary footer.
+ */
+function PlanCardBody({
+  item,
+  plan,
+}: {
+  item: TimelineItem;
+  plan: PlanState;
+}) {
+  const palette = KIND_PALETTE.plan_card;
+  const completed = plan.steps.filter((s) => s.status === "done").length;
+
+  return (
+    <div className="px-4 py-2">
+      <div className="flex items-start gap-2">
+        <span
+          className={cn(
+            "mt-0.5 inline-flex min-w-[60px] shrink-0 items-center justify-center rounded px-1.5 py-0.5 text-[11px] font-medium",
+            palette.label,
+          )}
+        >
+          <span className="truncate">📋 {palette.text}</span>
+        </span>
+
+        <div className="min-w-0 flex-1">
+          <div className="flex items-baseline gap-2">
+            <span className="truncate text-xs font-medium text-foreground">
+              {plan.goal}
+            </span>
+            <span className="shrink-0 text-[10px] tabular-nums text-muted-foreground/70">
+              {completed}/{plan.totalSteps}
+            </span>
+            {item.streaming && !plan.completed && (
+              <span className="inline-block h-3 w-0.5 translate-y-0.5 animate-pulse bg-current align-middle" />
+            )}
+          </div>
+
+          <ul className="mt-1.5 space-y-0.5">
+            {plan.steps.map((step) => (
+              <li
+                key={step.index}
+                className="flex items-start gap-1.5 text-[11px] leading-relaxed"
+              >
+                <span className="shrink-0" aria-hidden>
+                  {STEP_STATUS_ICON[step.status]}
+                </span>
+                <span
+                  className={cn(
+                    "min-w-0 flex-1",
+                    step.status === "done" &&
+                      "text-muted-foreground line-through decoration-muted-foreground/40",
+                    step.status === "pending" && "text-muted-foreground/70",
+                    (step.status === "failed" ||
+                      step.status === "needs_replan") &&
+                      "text-destructive",
+                  )}
+                >
+                  <span className="mr-1 tabular-nums text-muted-foreground/60">
+                    {step.index}.
+                  </span>
+                  {step.task || (
+                    <span className="italic opacity-60">(pending)</span>
+                  )}
+                  {step.reason && (
+                    <span className="ml-1 text-muted-foreground">
+                      — {step.reason}
+                    </span>
+                  )}
+                </span>
+              </li>
+            ))}
+          </ul>
+
+          {plan.replanReason && !plan.completed && (
+            <div className="mt-1.5 text-[11px] text-muted-foreground">
+              <span aria-hidden>🔁 </span>
+              Replan: {plan.replanReason}
+            </div>
+          )}
+          {plan.completed && plan.summary && (
+            <div className="mt-1.5 text-[11px] text-muted-foreground">
+              <span aria-hidden>✅ </span>
+              {plan.summary}
+            </div>
+          )}
+        </div>
+
+        <span className="mt-1 shrink-0 text-[10px] tabular-nums text-muted-foreground/50">
+          #{item.seq}
+        </span>
+      </div>
+    </div>
+  );
 }
 
 function truncate(s: string): string {

--- a/web/src/components/kernel/timeline-colors.ts
+++ b/web/src/components/kernel/timeline-colors.ts
@@ -80,6 +80,15 @@ export const KIND_PALETTE: Record<EventKind, KindPalette> = {
       "bg-violet-500/15 text-violet-700 dark:bg-violet-500/10 dark:text-violet-300",
     text: "…",
   },
+  plan_card: {
+    // Amber distinguishes "directive / structured plan" from the other
+    // kinds while staying within the existing tonal range.
+    bar: "bg-amber-400/60",
+    barActive: "bg-amber-500",
+    label:
+      "bg-amber-500/20 text-amber-700 dark:bg-amber-500/15 dark:text-amber-300",
+    text: "Plan",
+  },
 };
 
 /** Short label to show inside a row's type badge. */
@@ -99,6 +108,7 @@ export function eventSummary(item: {
   content?: string;
   input?: Record<string, unknown>;
   output?: string;
+  plan?: { goal: string };
 }): string {
   switch (item.kind) {
     case "agent":
@@ -110,6 +120,8 @@ export function eventSummary(item: {
       return toolInputSummary(item.input);
     case "tool_result":
       return item.output?.trim().slice(0, 200) ?? "";
+    case "plan_card":
+      return item.plan?.goal ?? "";
   }
 }
 

--- a/web/src/hooks/use-session-timeline.ts
+++ b/web/src/hooks/use-session-timeline.ts
@@ -20,6 +20,10 @@ import { api } from "@/api/client";
 import {
   isLiveState,
   turnsToTimeline,
+  type PlanState,
+  type PlanStep,
+  type PlanStepStatusEvent,
+  type PlanStepUiStatus,
   type StreamEvent,
   type TimelineItem,
   type TurnTrace,
@@ -110,6 +114,11 @@ export function useSessionTimeline(
     let currentTextSeq: number | null = null;
     let currentThinkSeq: number | null = null;
     const toolSeqById = new Map<string, number>();
+
+    // The active plan widget for this turn. A single `plan_card` row per
+    // plan; subsequent `plan_progress` / `plan_replan` / `plan_completed`
+    // events mutate the same row in place.
+    let planSeq: number | null = null;
 
     // Placeholder "thinking…" row inserted as soon as the WS opens so the
     // user gets immediate feedback while the kernel is bootstrapping the
@@ -324,6 +333,86 @@ export function useSessionTimeline(
           break;
         }
 
+        case "plan_created": {
+          clearPlaceholder();
+          const e = event as Extract<StreamEvent, { type: "plan_created" }>;
+          const steps: PlanStep[] = Array.from(
+            { length: e.total_steps },
+            (_, i) => ({ index: i + 1, task: "", status: "pending" }),
+          );
+          const plan: PlanState = {
+            goal: e.goal,
+            totalSteps: e.total_steps,
+            steps,
+            currentStepIdx: null,
+            completed: false,
+          };
+          const seq = nextSeq();
+          planSeq = seq;
+          setLiveItems((prev) => [
+            ...prev,
+            {
+              seq,
+              turn: liveTurnIdx,
+              kind: "plan_card",
+              plan,
+              streaming: true,
+            },
+          ]);
+          break;
+        }
+
+        case "plan_progress": {
+          clearPlaceholder();
+          if (planSeq === null) break;
+          const e = event as Extract<StreamEvent, { type: "plan_progress" }>;
+          const target = planSeq;
+          setLiveItems((prev) =>
+            prev.map((it) => {
+              if (it.seq !== target || it.kind !== "plan_card" || !it.plan) {
+                return it;
+              }
+              return { ...it, plan: applyPlanProgress(it.plan, e) };
+            }),
+          );
+          break;
+        }
+
+        case "plan_replan": {
+          if (planSeq === null) break;
+          const e = event as Extract<StreamEvent, { type: "plan_replan" }>;
+          const target = planSeq;
+          setLiveItems((prev) =>
+            prev.map((it) => {
+              if (it.seq !== target || it.kind !== "plan_card" || !it.plan) {
+                return it;
+              }
+              return { ...it, plan: applyPlanReplan(it.plan, e.reason) };
+            }),
+          );
+          break;
+        }
+
+        case "plan_completed": {
+          if (planSeq === null) break;
+          const e = event as Extract<StreamEvent, { type: "plan_completed" }>;
+          const target = planSeq;
+          planSeq = null;
+          setLiveItems((prev) =>
+            prev.map((it) => {
+              if (it.seq !== target || it.kind !== "plan_card" || !it.plan) {
+                return it;
+              }
+              return {
+                ...it,
+                streaming: false,
+                plan: { ...it.plan, summary: e.summary, completed: true },
+              };
+            }),
+          );
+          break;
+        }
+
         case "done":
           setIsStreaming(false);
           // Drop the placeholder unconditionally — turns that produced
@@ -338,8 +427,9 @@ export function useSessionTimeline(
           break;
 
         default:
-          // Unknown / unhandled event types (PlanCreated, UsageUpdate, etc.)
-          // are ignored. Add cases here as UI coverage expands.
+          // Unknown / unhandled event types (UsageUpdate,
+          // BackgroundTaskStarted, etc.) are ignored. Add cases here as
+          // UI coverage expands.
           break;
       }
     };
@@ -375,4 +465,89 @@ export function useSessionTimeline(
     isError: turnsQuery.isError,
     refetch: turnsQuery.refetch,
   };
+}
+
+/** Map kernel `PlanStepStatus` JSON onto the UI-facing status enum. */
+function mapStepStatus(status: PlanStepStatusEvent): {
+  ui: PlanStepUiStatus;
+  reason?: string;
+} {
+  if (status === "running") return { ui: "running" };
+  if (status === "done") return { ui: "done" };
+  if ("failed" in status) {
+    return { ui: "failed", reason: status.failed.reason };
+  }
+  return { ui: "needs_replan", reason: status.needs_replan.reason };
+}
+
+/**
+ * Extract the task description from kernel `status_text`.
+ *
+ * Kernel formats status_text as `第N步：{task}…`; the TG adapter splits
+ * on the full-width colon (U+FF1A) and trims the trailing ellipsis. We
+ * mirror that logic so step rows render the same task text across
+ * channels.
+ */
+function extractTask(statusText: string): string {
+  const colon = statusText.indexOf("\uFF1A");
+  const tail = colon >= 0 ? statusText.slice(colon + 1) : statusText;
+  return tail.replace(/\u2026$/, "").trim();
+}
+
+/** Apply a `plan_progress` event to the current plan state. */
+function applyPlanProgress(
+  plan: PlanState,
+  event: Extract<StreamEvent, { type: "plan_progress" }>,
+): PlanState {
+  const { current_step: idx, total_steps: total, step_status, status_text } =
+    event;
+  const { ui, reason } = mapStepStatus(step_status);
+
+  const steps = plan.steps.slice();
+  // Replan can dynamically extend the plan beyond the original length.
+  while (steps.length <= idx) {
+    steps.push({ index: steps.length + 1, task: "", status: "pending" });
+  }
+  // When the active step advances, finalize any prior `running` step that
+  // never received an explicit `done` (kernel emits Done for the prior
+  // step before Running for the next, but be defensive against drops).
+  if (plan.currentStepIdx !== null && plan.currentStepIdx !== idx) {
+    const prev = steps[plan.currentStepIdx];
+    if (prev && prev.status === "running") {
+      steps[plan.currentStepIdx] = { ...prev, status: "done" };
+    }
+  }
+
+  const existing = steps[idx]!;
+  const task = existing.task || extractTask(status_text);
+  steps[idx] = { ...existing, task, status: ui, reason };
+
+  return {
+    ...plan,
+    totalSteps: Math.max(plan.totalSteps, total, steps.length),
+    steps,
+    currentStepIdx: idx,
+  };
+}
+
+/**
+ * Apply a `plan_replan` event: mark the current step failed and drop
+ * trailing pending steps. Replacement steps arrive via subsequent
+ * `plan_progress` events at higher indices and dynamically extend the
+ * plan in {@link applyPlanProgress}.
+ */
+function applyPlanReplan(plan: PlanState, reason: string): PlanState {
+  const steps = plan.steps.slice();
+  if (plan.currentStepIdx !== null) {
+    const cur = steps[plan.currentStepIdx];
+    if (cur) {
+      steps[plan.currentStepIdx] = {
+        ...cur,
+        status: "needs_replan",
+        reason,
+      };
+    }
+  }
+  const trimmed = steps.filter((s) => s.status !== "pending");
+  return { ...plan, steps: trimmed, replanReason: reason };
 }


### PR DESCRIPTION
## Summary

Render multi-step plan progress in the web chat timeline. The kernel already broadcasts `WebEvent::Plan*` events (see `crates/channels/src/web.rs:250-273`), but the web frontend previously ignored them — plan execution looked indistinguishable from a long tool-using turn.

This PR adds a dedicated `plan_card` timeline row that mirrors the Telegram `render_plan_progress` widget (`crates/channels/src/telegram/adapter.rs:651`): a goal header with `(completed/total)` counter, per-step status icons (⚪ pending / 🔄 running / ✅ done / ❌ failed / 🔁 needs_replan), the extracted task text, plus optional replan reason and completion summary footers. The card mutates in place as `plan_progress` / `plan_replan` / `plan_completed` events stream in.

## Type of change

| Type | Label |
|------|-------|
| New feature | `enhancement` |

## Component

`ui`

## Closes

Closes #1595

## Test plan

- [x] `npm run build` passes (tsc + vite)
- [x] `eslint` clean on the four touched files (pre-existing unrelated errors remain)
- [ ] Manual verification on a live kernel session that emits plan events