### PR TITLE
feat(web): token footer + background tasks (#1597)

### DIFF
--- a/web/src/api/kernel-types.ts
+++ b/web/src/api/kernel-types.ts
@@ -125,6 +125,38 @@ export type StreamEvent =
     }
   | { type: "plan_replan"; reason: string }
   | { type: "plan_completed"; summary: string }
+  /**
+   * Settled per-turn token usage. Emitted once near turn end by the web
+   * channel adapter, which maps `StreamEvent::TurnUsage` → `WebEvent::Usage`
+   * (see `crates/channels/src/web.rs`). `input` is the largest iteration's
+   * prompt size; `output` is cumulative completion tokens across the turn.
+   */
+  | {
+      type: "usage";
+      input: number;
+      output: number;
+      cache_read: number;
+      cache_write: number;
+      total_tokens: number;
+      cost: number;
+      model: string;
+    }
+  /**
+   * A background agent has been spawned. The UI shows a chip with elapsed
+   * time until the matching `background_task_done` fires.
+   */
+  | {
+      type: "background_task_started";
+      task_id: string;
+      agent_name: string;
+      description: string;
+    }
+  /** Background agent has finished (completed, failed, or cancelled). */
+  | {
+      type: "background_task_done";
+      task_id: string;
+      status: "completed" | "failed" | "cancelled";
+    }
   | { type: "done" }
   | { type: string; [k: string]: unknown };
 
@@ -153,7 +185,20 @@ export type EventKind =
    * `plan_replan` / `plan_completed`. Self-contained — renders its own
    * step list rather than going through the standard row layout.
    */
-  | "plan_card";
+  | "plan_card"
+  /**
+   * Live-only per-turn token usage footer. Rendered as a small muted
+   * `↑12.5k ↓1.2k` line at the tail of the assistant turn. Populated
+   * from the web channel's `usage` event (mirrors
+   * `StreamEvent::TurnUsage`).
+   */
+  | "token_footer"
+  /**
+   * Live-only chip list of currently-running background tasks. Inserted
+   * on the first `background_task_started` for a turn, mutated in place
+   * as tasks start/finish, and removed when the active set goes empty.
+   */
+  | "background_tasks";
 
 /** Per-step status for the live `plan_card` row. */
 export type PlanStepUiStatus =
@@ -172,6 +217,23 @@ export interface PlanStep {
   status: PlanStepUiStatus;
   /** Failure / replan reason (only set when status is failed/needs_replan). */
   reason?: string;
+}
+
+/** Settled per-turn token totals for a `token_footer` row. */
+export interface TurnUsage {
+  /** Largest iteration's prompt size (kernel re-sends full context per iter). */
+  input: number;
+  /** Cumulative completion tokens across all iterations in the turn. */
+  output: number;
+}
+
+/** One active background task for a `background_tasks` row. */
+export interface BackgroundTaskInfo {
+  taskId: string;
+  name: string;
+  description: string;
+  /** `Date.now()` at insertion; used to compute the elapsed-time chip. */
+  startedAt: number;
 }
 
 /** State for an in-flight `plan_card` timeline row. */
@@ -217,6 +279,10 @@ export interface TimelineItem {
   streaming?: boolean;
   /** Plan widget state for `kind === "plan_card"`. */
   plan?: PlanState;
+  /** Settled token totals for `kind === "token_footer"`. */
+  usage?: TurnUsage;
+  /** Active background tasks for `kind === "background_tasks"`. */
+  bgTasks?: BackgroundTaskInfo[];
 }
 
 /**

--- a/web/src/components/kernel/TimelineRow.tsx
+++ b/web/src/components/kernel/TimelineRow.tsx
@@ -14,13 +14,15 @@
  * limitations under the License.
  */
 
-import { forwardRef, useState } from "react";
+import { forwardRef, useEffect, useState } from "react";
 import { AlertCircle, Brain, ChevronRight, Loader2 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import type {
+  BackgroundTaskInfo,
   PlanState,
   PlanStepUiStatus,
   TimelineItem,
+  TurnUsage,
 } from "@/api/kernel-types";
 import { KIND_PALETTE, eventLabel, eventSummary } from "./timeline-colors";
 
@@ -58,6 +60,26 @@ export const TimelineRow = forwardRef<HTMLDivElement, TimelineRowProps>(
           onClick={onClick}
         >
           <PlanCardBody item={item} plan={item.plan} />
+        </div>
+      );
+    }
+
+    // Token footer is a terminal, decoration-only row — no badge, no
+    // expand affordance, just the settled per-turn totals.
+    if (item.kind === "token_footer" && item.usage) {
+      return (
+        <div ref={ref} className="px-4 py-1.5">
+          <TokenFooterBody usage={item.usage} />
+        </div>
+      );
+    }
+
+    // Background-task chips render as a horizontal pill row with live
+    // elapsed timers; no badge / expand affordance.
+    if (item.kind === "background_tasks" && item.bgTasks) {
+      return (
+        <div ref={ref} className="px-4 py-2">
+          <BackgroundTasksBody tasks={item.bgTasks} />
         </div>
       );
     }
@@ -172,7 +194,9 @@ function rowHasDetail(item: TimelineItem): boolean {
       // Placeholder is purely decorative — never expandable.
       return false;
     case "plan_card":
-      // Self-contained widget — early-returned before this helper runs.
+    case "token_footer":
+    case "background_tasks":
+      // Self-contained widgets — early-returned before this helper runs.
       return false;
   }
 }
@@ -208,7 +232,9 @@ function RowDetail({ item }: { item: TimelineItem }) {
       // Never rendered — `rowHasDetail` returns false for this kind.
       return null;
     case "plan_card":
-      // Self-contained widget — never renders via the shared detail pane.
+    case "token_footer":
+    case "background_tasks":
+      // Self-contained widgets — never render via the shared detail pane.
       return null;
   }
 }
@@ -321,4 +347,78 @@ function PlanCardBody({
 function truncate(s: string): string {
   if (s.length <= DETAIL_MAX_CHARS) return s;
   return s.slice(0, DETAIL_MAX_CHARS) + "\n... (truncated)";
+}
+
+/**
+ * Compact a token count for the footer (`12500 → "12.5k"`,
+ * `1_200_000 → "1.2M"`). Numbers below 1k render raw.
+ */
+function compactTokens(n: number): string {
+  if (n < 1000) return String(n);
+  if (n < 1_000_000) {
+    const v = n / 1000;
+    return v >= 100 ? `${Math.round(v)}k` : `${v.toFixed(1)}k`;
+  }
+  const v = n / 1_000_000;
+  return v >= 100 ? `${Math.round(v)}M` : `${v.toFixed(1)}M`;
+}
+
+/** Per-turn token footer: `↑input ↓output` in small muted text. */
+function TokenFooterBody({ usage }: { usage: TurnUsage }) {
+  return (
+    <div className="ml-[72px] flex items-center gap-2 text-[10px] tabular-nums text-muted-foreground/70">
+      <span aria-label={`prompt ${usage.input} tokens`}>
+        ↑{compactTokens(usage.input)}
+      </span>
+      <span aria-label={`completion ${usage.output} tokens`}>
+        ↓{compactTokens(usage.output)}
+      </span>
+    </div>
+  );
+}
+
+/**
+ * Horizontal chip list of currently-running background tasks with live
+ * elapsed timers. A single 1Hz interval re-renders all chips while any
+ * task is active; it's cleared on unmount (i.e. when the row is removed
+ * after the active set goes empty).
+ */
+function BackgroundTasksBody({ tasks }: { tasks: BackgroundTaskInfo[] }) {
+  const [now, setNow] = useState(() => Date.now());
+  useEffect(() => {
+    if (tasks.length === 0) return;
+    const id = window.setInterval(() => setNow(Date.now()), 1000);
+    return () => window.clearInterval(id);
+  }, [tasks.length]);
+
+  const palette = KIND_PALETTE.background_tasks;
+  return (
+    <div className="flex flex-wrap items-center gap-1.5">
+      <span
+        className={cn(
+          "inline-flex min-w-[60px] shrink-0 items-center justify-center rounded px-1.5 py-0.5 text-[11px] font-medium",
+          palette.label,
+        )}
+      >
+        <Loader2 className="mr-1 h-3 w-3 shrink-0 animate-spin" />
+        <span className="truncate">{palette.text}</span>
+      </span>
+      {tasks.map((t) => {
+        const elapsed = Math.max(0, Math.floor((now - t.startedAt) / 1000));
+        return (
+          <span
+            key={t.taskId}
+            title={t.description || t.name}
+            className={cn(
+              "inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-[11px]",
+              palette.label,
+            )}
+          >
+            <span className="truncate max-w-[180px]">{t.name}</span>
+            <span className="tabular-nums opacity-70">{elapsed}s</span>
+          </span>
+        );
+      })}
+    </div>
+  );
 }

--- a/web/src/components/kernel/timeline-colors.ts
+++ b/web/src/components/kernel/timeline-colors.ts
@@ -89,6 +89,24 @@ export const KIND_PALETTE: Record<EventKind, KindPalette> = {
       "bg-amber-500/20 text-amber-700 dark:bg-amber-500/15 dark:text-amber-300",
     text: "Plan",
   },
+  token_footer: {
+    // Muted — the footer is metadata, not a distinct event-kind worth
+    // its own hue. Reuse the result palette so TimelineBar renders a
+    // slate segment when one appears.
+    bar: "bg-slate-300/40 dark:bg-slate-600/40",
+    barActive: "bg-slate-400 dark:bg-slate-500",
+    label: "bg-muted text-muted-foreground",
+    text: "Usage",
+  },
+  background_tasks: {
+    // Cyan reads as "ambient / side-effect" — distinct from tool_use
+    // blue so concurrent background work doesn't blend into tool calls.
+    bar: "bg-cyan-400/60",
+    barActive: "bg-cyan-500",
+    label:
+      "bg-cyan-500/20 text-cyan-700 dark:bg-cyan-500/15 dark:text-cyan-300",
+    text: "BG",
+  },
 };
 
 /** Short label to show inside a row's type badge. */
@@ -122,6 +140,11 @@ export function eventSummary(item: {
       return item.output?.trim().slice(0, 200) ?? "";
     case "plan_card":
       return item.plan?.goal ?? "";
+    case "token_footer":
+    case "background_tasks":
+      // Self-rendered rows — the badge+summary layout is bypassed in
+      // TimelineRow, so this branch is unreachable in practice.
+      return "";
   }
 }
 

--- a/web/src/hooks/use-session-timeline.ts
+++ b/web/src/hooks/use-session-timeline.ts
@@ -20,6 +20,7 @@ import { api } from "@/api/client";
 import {
   isLiveState,
   turnsToTimeline,
+  type BackgroundTaskInfo,
   type PlanState,
   type PlanStep,
   type PlanStepStatusEvent,
@@ -119,6 +120,12 @@ export function useSessionTimeline(
     // plan; subsequent `plan_progress` / `plan_replan` / `plan_completed`
     // events mutate the same row in place.
     let planSeq: number | null = null;
+
+    // Active background-task chip row. One `background_tasks` row is
+    // inserted on the first `background_task_started` and mutated in
+    // place as tasks start / finish. When the active set goes empty we
+    // drop the row so completed turns don't carry an empty footer.
+    let bgTasksSeq: number | null = null;
 
     // Placeholder "thinking…" row inserted as soon as the WS opens so the
     // user gets immediate feedback while the kernel is bootstrapping the
@@ -413,6 +420,103 @@ export function useSessionTimeline(
           break;
         }
 
+        case "usage": {
+          const e = event as Extract<StreamEvent, { type: "usage" }>;
+          // Append a footer row once per turn. If one already exists
+          // (defensive — kernel emits TurnUsage once), overwrite it in
+          // place rather than stacking duplicates.
+          setLiveItems((prev) => {
+            const existing = prev.findIndex(
+              (it) => it.kind === "token_footer" && it.turn === liveTurnIdx,
+            );
+            if (existing >= 0) {
+              const next = prev.slice();
+              next[existing] = {
+                ...next[existing]!,
+                usage: { input: e.input, output: e.output },
+              };
+              return next;
+            }
+            return [
+              ...prev,
+              {
+                seq: nextSeq(),
+                turn: liveTurnIdx,
+                kind: "token_footer",
+                usage: { input: e.input, output: e.output },
+              },
+            ];
+          });
+          break;
+        }
+
+        case "background_task_started": {
+          const e = event as Extract<
+            StreamEvent,
+            { type: "background_task_started" }
+          >;
+          const task: BackgroundTaskInfo = {
+            taskId: e.task_id,
+            name: e.agent_name,
+            description: e.description,
+            startedAt: Date.now(),
+          };
+          setLiveItems((prev) => {
+            if (bgTasksSeq !== null) {
+              const target = bgTasksSeq;
+              return prev.map((it) => {
+                if (it.seq !== target || it.kind !== "background_tasks") {
+                  return it;
+                }
+                const existing = it.bgTasks ?? [];
+                if (existing.some((t) => t.taskId === task.taskId)) return it;
+                return { ...it, bgTasks: [...existing, task] };
+              });
+            }
+            const seq = nextSeq();
+            bgTasksSeq = seq;
+            return [
+              ...prev,
+              {
+                seq,
+                turn: liveTurnIdx,
+                kind: "background_tasks",
+                bgTasks: [task],
+                streaming: true,
+              },
+            ];
+          });
+          break;
+        }
+
+        case "background_task_done": {
+          const e = event as Extract<
+            StreamEvent,
+            { type: "background_task_done" }
+          >;
+          if (bgTasksSeq === null) break;
+          const target = bgTasksSeq;
+          setLiveItems((prev) => {
+            let emptied = false;
+            const next = prev.flatMap((it) => {
+              if (it.seq !== target || it.kind !== "background_tasks") {
+                return [it];
+              }
+              const remaining = (it.bgTasks ?? []).filter(
+                (t) => t.taskId !== e.task_id,
+              );
+              if (remaining.length === 0) {
+                emptied = true;
+                return [];
+              }
+              return [{ ...it, bgTasks: remaining }];
+            });
+            if (emptied) bgTasksSeq = null;
+            return next;
+          });
+          break;
+        }
+
         case "done":
           setIsStreaming(false);
           // Drop the placeholder unconditionally — turns that produced
@@ -427,9 +531,8 @@ export function useSessionTimeline(
           break;
 
         default:
-          // Unknown / unhandled event types (UsageUpdate,
-          // BackgroundTaskStarted, etc.) are ignored. Add cases here as
-          // UI coverage expands.
+          // Forward-compat: silently drop any kernel event the UI does
+          // not yet render. Add a case above to adopt a new event type.
           break;
       }
     };


### PR DESCRIPTION
## Summary

Two final feedback channels completing the web-UI alignment sweep:

- **Token footer**: per-turn `↑12.5k ↓1.2k` compact token counts as a small muted row at the tail of each assistant turn. Driven by the web channel's `usage` event (maps from `StreamEvent::TurnUsage`).
- **Background task chips**: a horizontal chip row that appears when the agent spawns background work, one chip per active task with name + live elapsed timer; row self-removes when the active set goes empty. Driven by `background_task_started` / `background_task_done`.

Both integrate as new `TimelineItem` kinds (`token_footer`, `background_tasks`) so they compose cleanly with the existing flat timeline model — no refactor of the row schema, no backend changes.

## Type of change

| Type | Label |
|------|-------|
| New feature | `enhancement` |

## Component

`ui`

## Closes

Closes #1597

## Test plan

- [x] `npm run build` passes (TypeScript strict)
- [x] `npm run lint` regression-clean (baseline 19 errors, unchanged)
- [ ] Manual: trigger a turn — confirm `↑N ↓N` appears once on completion
- [ ] Manual: spawn a background agent — confirm chip with timer, and that it disappears on completion