### PR TITLE
fix(web): align detail + add execution trace (#1608)

### DIFF
--- a/crates/app/src/lib.rs
+++ b/crates/app/src/lib.rs
@@ -395,9 +395,16 @@ pub async fn start_with_options(
         registry: feed_registry.clone(),
     };
 
+    // TraceService is shared between the kernel (which writes traces at
+    // turn end) and the backend session service (which reads them for
+    // the web "📊 详情" button). Create it once here so both sides see
+    // the same underlying pool.
+    let trace_service = rara_kernel::trace::TraceService::new(pool.clone());
+
     let backend = rara_backend_admin::state::BackendState::init(
         rara.session_index.clone(),
         rara.tape_service.clone(),
+        trace_service.clone(),
         settings_provider.clone(),
         settings_svc.clone(),
         rara.model_lister.clone(),
@@ -511,7 +518,7 @@ pub async fn start_with_options(
         io,
         rara.knowledge_service.clone(),
         mcp_tool_provider,
-        rara_kernel::trace::TraceService::new(pool.clone()),
+        trace_service,
         skill_prompt_provider,
     );
 

--- a/crates/extensions/backend-admin/src/chat/error.rs
+++ b/crates/extensions/backend-admin/src/chat/error.rs
@@ -38,6 +38,10 @@ pub enum ChatError {
     /// A session storage error occurred.
     #[snafu(display("session error: {message}"))]
     SessionError { message: String },
+
+    /// The requested resource does not exist (generic 404).
+    #[snafu(display("not found: {message}"))]
+    NotFound { message: String },
 }
 
 /// Convert a sessions-layer error into a chat-domain error.
@@ -68,7 +72,9 @@ impl From<rara_sessions::error::SessionError> for ChatError {
 impl axum::response::IntoResponse for ChatError {
     fn into_response(self) -> axum::response::Response {
         let status = match &self {
-            Self::SessionNotFound { .. } => axum::http::StatusCode::NOT_FOUND,
+            Self::SessionNotFound { .. } | Self::NotFound { .. } => {
+                axum::http::StatusCode::NOT_FOUND
+            }
             Self::InvalidRequest { .. } => axum::http::StatusCode::BAD_REQUEST,
             Self::SessionError { .. } => axum::http::StatusCode::INTERNAL_SERVER_ERROR,
         };

--- a/crates/extensions/backend-admin/src/chat/router.rs
+++ b/crates/extensions/backend-admin/src/chat/router.rs
@@ -40,6 +40,7 @@ use axum::{
 use rara_kernel::{
     cascade::CascadeTrace,
     channel::types::{ChannelType, ChatMessage},
+    trace::ExecutionTrace,
 };
 use rara_sessions::types::{ChannelBinding, SessionEntry, SessionKey, ThinkingLevel};
 use serde::{Deserialize, Deserializer};
@@ -264,6 +265,7 @@ fn session_routes(service: SessionService) -> OpenApiRouter {
         .routes(routes!(get_session, update_session, delete_session))
         .routes(routes!(list_messages, clear_messages))
         .routes(routes!(get_cascade_trace))
+        .routes(routes!(get_execution_trace))
         .routes(routes!(bind_channel))
         .routes(routes!(get_channel_binding))
         .with_state(service)
@@ -511,6 +513,36 @@ async fn get_cascade_trace(
 ) -> Result<Json<CascadeTrace>, ChatError> {
     let trace = service
         .get_cascade_trace(&parse_session_key(&key)?, q.seq)
+        .await?;
+    Ok(Json(trace))
+}
+
+/// `GET /api/v1/chat/sessions/{key}/execution-trace` — get the
+/// persisted [`ExecutionTrace`] for the turn that produced the message
+/// at `seq`. Mirrors the Telegram inline-button payload so the web UI
+/// can show the same rationale / thinking / plan / tools / usage
+/// summary without re-running the agent loop.
+#[utoipa::path(
+    get,
+    path = "/api/v1/chat/sessions/{key}/execution-trace",
+    tag = "chat",
+    params(
+        ("key" = String, Path, description = "Session key"),
+        ("seq" = usize, Query, description = "Message sequence number to trace"),
+    ),
+    responses(
+        (status = 200, description = "Execution trace", body = serde_json::Value),
+        (status = 404, description = "No trace recorded for the given message"),
+    )
+)]
+#[instrument(skip(service))]
+async fn get_execution_trace(
+    State(service): State<SessionService>,
+    Path(key): Path<String>,
+    Query(q): Query<GetTraceQuery>,
+) -> Result<Json<ExecutionTrace>, ChatError> {
+    let trace = service
+        .get_execution_trace(&parse_session_key(&key)?, q.seq)
         .await?;
     Ok(Json(trace))
 }

--- a/crates/extensions/backend-admin/src/chat/service.rs
+++ b/crates/extensions/backend-admin/src/chat/service.rs
@@ -36,6 +36,7 @@ use rara_kernel::{
     llm::{Message, Role},
     memory::{TapEntry, TapEntryKind, TapeService},
     session::SessionIndexRef,
+    trace::{ExecutionTrace, TraceService},
 };
 use rara_sessions::types::{ChannelBinding, SessionEntry, SessionKey, ThinkingLevel};
 use serde_json::Value;
@@ -330,6 +331,10 @@ pub struct SessionService {
     session_index:     SessionIndexRef,
     /// Tape service for append-only session recording.
     tape_service:      TapeService,
+    /// Persisted per-turn execution traces. Used by
+    /// [`Self::get_execution_trace`] to resolve a clicked assistant
+    /// message's seq back to its owning turn's trace.
+    trace_service:     TraceService,
     /// Cached catalog of models fetched from the LLM provider.
     model_catalog:     ModelCatalog,
     /// Settings provider for reading and writing flat KV settings.
@@ -342,12 +347,14 @@ impl SessionService {
     pub fn new(
         session_index: SessionIndexRef,
         tape_service: TapeService,
+        trace_service: TraceService,
         settings_provider: Arc<dyn SettingsProvider>,
         model_lister: rara_kernel::llm::LlmModelListerRef,
     ) -> Self {
         Self {
             session_index,
             tape_service,
+            trace_service,
             model_catalog: ModelCatalog::new(model_lister),
             settings_provider,
         }
@@ -616,6 +623,94 @@ impl SessionService {
         let message_id = format!("{}-{}", key, message_seq);
         let trace = build_cascade(turn_entries, &message_id);
         Ok(trace)
+    }
+
+    /// Fetch the persisted [`ExecutionTrace`] for a specific turn.
+    ///
+    /// The turn is identified by the seq of any message produced within
+    /// it (most commonly the assistant reply the user clicked on). We
+    /// find the owning user-message tape entry, read its
+    /// `rara_message_id` metadata, and look the trace up via
+    /// [`TraceService::find_trace_by_message_id`].
+    ///
+    /// Returns `InvalidRequest` when no user message precedes `seq` and
+    /// `NotFound` when no trace has been persisted for the resolved
+    /// turn (e.g. a legacy session recorded before trace storage existed).
+    #[instrument(skip(self))]
+    pub async fn get_execution_trace(
+        &self,
+        key: &SessionKey,
+        message_seq: usize,
+    ) -> Result<ExecutionTrace, ChatError> {
+        let tape_name = key.to_string();
+        let entries =
+            self.tape_service
+                .entries(&tape_name)
+                .await
+                .map_err(|e| ChatError::SessionError {
+                    message: format!("failed to read tape: {e}"),
+                })?;
+
+        // Walk the tape mirroring `tap_entries_to_chat_messages`'s seq
+        // counter so we can correlate `message_seq` back to the specific
+        // user-message TapEntry. We keep that entry's `metadata`
+        // (which is where `rara_message_id` is recorded) rather than
+        // re-deriving it — the kernel writes it at turn start and it
+        // uniquely keys the persisted trace row.
+        let i_seq = message_seq as i64;
+        let mut seq: i64 = 0;
+        let mut last_user_entry: Option<&TapEntry> = None;
+        for entry in &entries {
+            match entry.kind {
+                TapEntryKind::Message => {
+                    if let Ok(msg) = serde_json::from_value::<Message>(entry.payload.clone()) {
+                        seq += 1;
+                        if seq > i_seq {
+                            break;
+                        }
+                        if matches!(msg.role, Role::User) {
+                            last_user_entry = Some(entry);
+                        }
+                    }
+                }
+                TapEntryKind::ToolCall | TapEntryKind::ToolResult => {
+                    seq += 1;
+                    if seq > i_seq {
+                        break;
+                    }
+                }
+                _ => {}
+            }
+        }
+
+        let Some(user_entry) = last_user_entry else {
+            return Err(ChatError::InvalidRequest {
+                message: format!("no user message found for seq {message_seq}"),
+            });
+        };
+
+        let rara_message_id = user_entry
+            .metadata
+            .as_ref()
+            .and_then(|m| m.get("rara_message_id"))
+            .and_then(Value::as_str)
+            .ok_or_else(|| ChatError::NotFound {
+                message: format!(
+                    "user message at seq {message_seq} has no rara_message_id metadata"
+                ),
+            })?;
+
+        let trace = self
+            .trace_service
+            .find_trace_by_message_id(rara_message_id)
+            .await
+            .map_err(|e| ChatError::SessionError {
+                message: format!("failed to query execution trace: {e}"),
+            })?;
+
+        trace.map(|(_, t)| t).ok_or_else(|| ChatError::NotFound {
+            message: format!("no execution trace recorded for message {rara_message_id}"),
+        })
     }
 
     // -- channel bindings ---------------------------------------------------

--- a/crates/extensions/backend-admin/src/state.rs
+++ b/crates/extensions/backend-admin/src/state.rs
@@ -43,6 +43,7 @@ impl BackendState {
     pub async fn init(
         session_index: Arc<dyn rara_kernel::session::SessionIndex>,
         tape_service: rara_kernel::memory::TapeService,
+        trace_service: rara_kernel::trace::TraceService,
         settings_provider: Arc<dyn rara_domain_shared::settings::SettingsProvider>,
         settings_svc: crate::settings::SettingsSvc,
         model_lister: rara_kernel::llm::LlmModelListerRef,
@@ -55,6 +56,7 @@ impl BackendState {
         let session_service = crate::chat::service::SessionService::new(
             session_index,
             tape_service,
+            trace_service,
             settings_provider,
             model_lister,
         );

--- a/web/src/api/kernel-types.ts
+++ b/web/src/api/kernel-types.ts
@@ -447,3 +447,40 @@ export interface CascadeTrace {
   ticks:      CascadeTick[];
   summary:    CascadeSummary;
 }
+
+// ---------------------------------------------------------------------------
+// Execution trace
+// ---------------------------------------------------------------------------
+// Mirrors `rara_kernel::trace::ExecutionTrace` (crates/kernel/src/trace.rs).
+// Returned by `GET /api/v1/chat/sessions/{key}/execution-trace?seq={seq}` and
+// rendered by `<ExecutionTraceModal>` — the per-turn rationale / thinking /
+// plan / tools / usage summary, matching the Telegram "📊 详情" payload.
+
+/** Record of a single tool invocation within a turn. */
+export interface ToolTraceEntry {
+  name:        string;
+  /** Duration in milliseconds, when the invocation completed. */
+  duration_ms: number | null;
+  success:     boolean;
+  summary:     string;
+  error:       string | null;
+}
+
+/** Summary of a single agent turn execution. */
+export interface ExecutionTrace {
+  duration_secs:    number;
+  iterations:       number;
+  model:            string;
+  input_tokens:     number;
+  output_tokens:    number;
+  thinking_ms:      number;
+  /** Truncated reasoning text (first ~500 chars). */
+  thinking_preview: string;
+  /** Plan steps with status. */
+  plan_steps:       string[];
+  /** High-level rationale the LLM stated for this turn, when any. */
+  turn_rationale?:  string;
+  tools:            ToolTraceEntry[];
+  /** Rara internal message ID for end-to-end correlation. */
+  rara_message_id:  string;
+}

--- a/web/src/components/chat/ExecutionTraceModal.tsx
+++ b/web/src/components/chat/ExecutionTraceModal.tsx
@@ -1,0 +1,235 @@
+/*
+ * Copyright 2025 Rararulab
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useState } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import type { ExecutionTrace, ToolTraceEntry } from "@/api/kernel-types";
+
+/**
+ * Execution-trace viewer — opened from the "📊 详情" button on a
+ * completed assistant turn. Mirrors the Telegram renderer in
+ * `crates/channels/src/telegram/adapter.rs::render_trace_detail` so the
+ * two surfaces stay informationally consistent.
+ *
+ * Unlike the TG adapter (which truncates at 4000 chars to stay under
+ * the 4096-char Telegram message limit) the web modal shows the full
+ * trace — only individual long sections are collapsed behind an
+ * expander so the modal stays scannable.
+ */
+
+/**
+ * Inline collapse threshold (chars) — thinking preview longer than
+ * this starts collapsed. Matches {@link CascadeModal}'s threshold so
+ * the two modals feel consistent.
+ */
+const COLLAPSE_THRESHOLD = 600;
+
+interface Props {
+  open:    boolean;
+  trace:   ExecutionTrace | null;
+  loading: boolean;
+  error:   string | null;
+  onClose: () => void;
+}
+
+/** Modal wrapper + status switching (loading / error / empty / trace). */
+export function ExecutionTraceModal({ open, trace, loading, error, onClose }: Props) {
+  return (
+    <Dialog open={open} onOpenChange={(v) => { if (!v) onClose(); }}>
+      <DialogContent className="flex max-h-[85vh] w-[95vw] max-w-3xl flex-col gap-3 overflow-hidden">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <span aria-hidden>📊</span>
+            <span>Execution Trace</span>
+          </DialogTitle>
+          {trace && (
+            <DialogDescription>
+              {formatSummary(trace)}
+            </DialogDescription>
+          )}
+        </DialogHeader>
+        <div className="min-h-0 flex-1 overflow-y-auto pr-1">
+          {loading && (
+            <div className="flex items-center justify-center py-10 text-sm text-muted-foreground">
+              <div className="mr-2 h-4 w-4 animate-spin rounded-full border-2 border-muted-foreground/30 border-t-muted-foreground" />
+              加载中…
+            </div>
+          )}
+          {!loading && error && (
+            <div className="rounded-md border border-destructive/30 bg-destructive/10 p-3 text-sm text-destructive">
+              加载失败：{error}
+            </div>
+          )}
+          {!loading && !error && trace && <TraceBody trace={trace} />}
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function formatSummary(trace: ExecutionTrace): string {
+  const dur = `${trace.duration_secs}s`;
+  const tok = `↑${trace.input_tokens} ↓${trace.output_tokens}`;
+  const thinking = trace.thinking_ms > 0
+    ? ` · thought ${(trace.thinking_ms / 1000).toFixed(1)}s`
+    : "";
+  return `${dur} · ${tok}${thinking}`;
+}
+
+function TraceBody({ trace }: { trace: ExecutionTrace }) {
+  return (
+    <div className="flex flex-col gap-4 text-sm">
+      {trace.turn_rationale && trace.turn_rationale.trim().length > 0 && (
+        <Section emoji="💭" title="Rationale">
+          <blockquote className="border-l-2 border-border/60 pl-3 text-foreground/85 whitespace-pre-wrap break-words">
+            {trace.turn_rationale}
+          </blockquote>
+        </Section>
+      )}
+
+      {trace.thinking_preview.trim().length > 0 && (
+        <Section
+          emoji="🧠"
+          title={`Thinking (${(trace.thinking_ms / 1000).toFixed(1)}s)`}
+        >
+          <Collapsible text={trace.thinking_preview} />
+        </Section>
+      )}
+
+      {trace.plan_steps.length > 0 && (
+        <Section emoji="📋" title="Plan">
+          <ol className="ml-5 list-decimal space-y-1 text-foreground/85">
+            {trace.plan_steps.map((step, i) => (
+              <li key={i} className="whitespace-pre-wrap break-words">{step}</li>
+            ))}
+          </ol>
+        </Section>
+      )}
+
+      {trace.tools.length > 0 && (
+        <Section emoji="🔧" title="Tools">
+          <ul className="flex flex-col gap-1.5 border-l-2 border-border/60 pl-3">
+            {trace.tools.map((t, i) => <ToolRow key={i} tool={t} />)}
+          </ul>
+        </Section>
+      )}
+
+      <Section emoji="📊" title="Usage">
+        <div className="text-foreground/85">
+          {trace.iterations} iterations
+          {" · "}↑{trace.input_tokens}
+          {" "}↓{trace.output_tokens} tokens
+          {trace.model && <> · <code className="rounded bg-muted/60 px-1 py-0.5 font-mono text-xs">{trace.model}</code></>}
+        </div>
+      </Section>
+
+      <Section emoji="🆔" title="Message ID">
+        <code className="block rounded bg-muted/60 px-2 py-1 font-mono text-xs break-all">
+          {trace.rara_message_id}
+        </code>
+      </Section>
+    </div>
+  );
+}
+
+function Section({
+  emoji,
+  title,
+  children,
+}: {
+  emoji:    string;
+  title:    string;
+  children: React.ReactNode;
+}) {
+  return (
+    <section className="flex flex-col gap-1.5">
+      <header className="flex items-center gap-2 text-sm font-semibold">
+        <span aria-hidden>{emoji}</span>
+        <span>{title}</span>
+      </header>
+      <div className="text-sm">{children}</div>
+    </section>
+  );
+}
+
+function ToolRow({ tool }: { tool: ToolTraceEntry }) {
+  const icon = tool.success ? "✓" : "✗";
+  const iconCls = tool.success ? "text-emerald-600" : "text-destructive";
+  const dur =
+    tool.duration_ms !== null && tool.duration_ms !== undefined
+      ? formatDuration(tool.duration_ms)
+      : null;
+  return (
+    <li className="flex flex-col gap-0.5">
+      <div className="flex flex-wrap items-center gap-x-2 text-foreground/90">
+        <span className={`font-mono text-sm ${iconCls}`} aria-hidden>{icon}</span>
+        <code className="font-mono text-xs font-semibold">{tool.name}</code>
+        {dur && (
+          <span className="rounded bg-muted/60 px-1.5 py-0.5 font-mono text-[10px] text-muted-foreground">
+            {dur}
+          </span>
+        )}
+        {tool.summary && (
+          <span className="text-foreground/80">— {tool.summary}</span>
+        )}
+      </div>
+      {tool.error && (
+        <div className="ml-5 rounded border border-destructive/30 bg-destructive/10 px-2 py-1 text-xs text-destructive whitespace-pre-wrap break-words">
+          ⚠ {tool.error}
+        </div>
+      )}
+    </li>
+  );
+}
+
+function Collapsible({ text }: { text: string }) {
+  const [expanded, setExpanded] = useState(false);
+  const collapsible = text.length > COLLAPSE_THRESHOLD;
+  const body = !collapsible || expanded
+    ? text
+    : text.slice(0, COLLAPSE_THRESHOLD) + "…";
+  return (
+    <div>
+      <pre className="whitespace-pre-wrap break-words font-mono text-xs leading-relaxed text-foreground/85">
+        {body}
+      </pre>
+      {collapsible && (
+        <button
+          type="button"
+          onClick={() => setExpanded((v) => !v)}
+          className="mt-1 text-xs text-primary hover:underline"
+        >
+          {expanded ? "收起" : `展开（共 ${text.length} 字符）`}
+        </button>
+      )}
+    </div>
+  );
+}
+
+function formatDuration(ms: number): string {
+  if (ms < 1000) return `${ms}ms`;
+  const secs = ms / 1000;
+  if (secs < 60) return `${secs.toFixed(1)}s`;
+  const m = Math.floor(secs / 60);
+  const s = Math.floor(secs % 60);
+  return `${m}m${s}s`;
+}

--- a/web/src/pages/PiChat.tsx
+++ b/web/src/pages/PiChat.tsx
@@ -60,9 +60,10 @@ import { RaraModelDialog } from "@/components/RaraModelDialog";
 import { AlmaCaret } from "@/components/AlmaCaret";
 import { ChatSidebar } from "@/components/ChatSidebar";
 import { CascadeModal } from "@/components/chat/CascadeModal";
+import { ExecutionTraceModal } from "@/components/chat/ExecutionTraceModal";
 import { useSettingsModal } from "@/components/settings/SettingsModalProvider";
 import type { ProviderInfo } from "@/api/types";
-import type { CascadeTrace } from "@/api/kernel-types";
+import type { CascadeTrace, ExecutionTrace } from "@/api/kernel-types";
 import { UNKNOWN_MODEL_SENTINEL, isUnknownModel, syntheticModel } from "@/lib/synthetic-model";
 
 const ACTIVE_SESSION_KEY = "rara.activeSessionKey";
@@ -358,29 +359,46 @@ function toAgentMessages(msgs: ChatMessageData[]): AgentMessage[] {
 }
 
 /**
- * DOM event dispatched by the Lit assistant-message renderer when the
- * user clicks the "📊 详情" button. The React layer listens on
- * `document` and calls the trace endpoint with the carried `seq`
- * directly — no timestamp indirection (see {@link assistantSeqByRef}).
+ * DOM events dispatched by the Lit assistant-message renderer when the
+ * user clicks one of the per-turn detail buttons. Both carry the same
+ * `seq` payload (resolved via {@link assistantSeqByRef}) and are
+ * handled by parallel React effects below.
+ *
+ * Two separate events rather than one discriminated payload so each
+ * handler can own its own modal state without switching on a tag.
  */
 const CASCADE_TRACE_EVENT = "rara:cascade-trace";
+const EXECUTION_TRACE_EVENT = "rara:execution-trace";
 
-interface CascadeTraceEventDetail {
+interface TraceEventDetail {
   seq: number;
 }
 
 /**
  * Register a Lit message renderer that wraps pi-web-ui's built-in
- * `<assistant-message>` element and appends a "📊 详情" button. The
- * button dispatches a bubbling {@link CASCADE_TRACE_EVENT} carrying the
- * persisted `seq` directly — resolved via {@link assistantSeqByRef}
- * keyed by the rendered message's object identity.
+ * `<assistant-message>` element and appends two trace-detail buttons:
+ *
+ * - "📊 详情" → dispatches {@link EXECUTION_TRACE_EVENT}, opening a
+ *   high-level per-turn summary (rationale / thinking / plan / tools /
+ *   usage) matching Telegram's "📊 详情" button.
+ * - "🔍 Cascade" → dispatches {@link CASCADE_TRACE_EVENT}, opening the
+ *   tick-level tape replay (kept for debugging the agent loop; mirrors
+ *   Telegram's "🔍 Cascade" button).
+ *
+ * Both dispatch a bubbling CustomEvent carrying the persisted `seq`
+ * resolved via {@link assistantSeqByRef}; the React layer below owns
+ * the two modals separately.
  *
  * The renderer must rebuild the same `toolResultsById` lookup that
  * `MessageList` normally hands `<assistant-message>` — otherwise paired
  * tool results would not render under the call. The `agentResolver`
  * closure gives us that map at click time without re-registering on
  * every message-list change.
+ *
+ * Alignment note: the button row uses `pl-[2.75rem]` to match the
+ * assistant-message bubble's left padding (set in `index.css` to make
+ * room for rara's avatar). Without this the buttons would stick to the
+ * container's left edge and visually detach from the bubble above.
  *
  * Skips placeholder turns with no mapped seq (e.g. mid-stream assistant
  * frames not yet persisted) — there's no row to ask the trace endpoint
@@ -396,7 +414,7 @@ function registerCascadeAssistantRenderer(
   registerMessageRenderer("assistant", {
     render(message) {
       const seq = assistantSeqByRef.get(message);
-      const showButton = seq !== undefined;
+      const showButtons = seq !== undefined;
       // Rebuild the toolResult lookup from current agent state. Cheap
       // (a single linear scan) and avoids stale-closure bugs because the
       // resolver always hits the live agent ref.
@@ -410,6 +428,17 @@ function registerCascadeAssistantRenderer(
           }
         }
       }
+      const dispatchTrace = (eventName: string) => (e: Event) => {
+        e.stopPropagation();
+        if (seq === undefined) return;
+        const detail: TraceEventDetail = { seq };
+        document.dispatchEvent(
+          new CustomEvent<TraceEventDetail>(eventName, {
+            detail,
+            bubbles: true,
+          }),
+        );
+      };
       return html`
         <div class="rara-assistant-with-trace">
           <assistant-message
@@ -419,27 +448,26 @@ function registerCascadeAssistantRenderer(
             .toolResultsById=${resultByCallId}
             .hideToolCalls=${false}
           ></assistant-message>
-          ${showButton
+          ${showButtons
             ? html`
-                <div class="mt-1 flex justify-start pl-1">
+                <div class="mt-1 flex justify-start gap-1 pl-[2.75rem]">
                   <button
                     type="button"
-                    class="rara-cascade-trigger inline-flex items-center gap-1 rounded-md px-2 py-0.5 text-xs text-muted-foreground transition hover:bg-accent hover:text-foreground"
-                    title="查看本轮 cascade 执行详情"
-                    @click=${(e: Event) => {
-                      e.stopPropagation();
-                      if (seq === undefined) return;
-                      const detail: CascadeTraceEventDetail = { seq };
-                      document.dispatchEvent(
-                        new CustomEvent<CascadeTraceEventDetail>(
-                          CASCADE_TRACE_EVENT,
-                          { detail, bubbles: true },
-                        ),
-                      );
-                    }}
+                    class="rara-trace-trigger inline-flex items-center gap-1 rounded-md px-2 py-0.5 text-xs text-muted-foreground transition hover:bg-accent hover:text-foreground"
+                    title="查看本轮执行摘要（rationale / thinking / plan / tools / usage）"
+                    @click=${dispatchTrace(EXECUTION_TRACE_EVENT)}
                   >
                     <span aria-hidden>📊</span>
                     <span>详情</span>
+                  </button>
+                  <button
+                    type="button"
+                    class="rara-cascade-trigger inline-flex items-center gap-1 rounded-md px-2 py-0.5 text-xs text-muted-foreground transition hover:bg-accent hover:text-foreground"
+                    title="查看本轮 cascade 执行详情（tick-level tape replay）"
+                    @click=${dispatchTrace(CASCADE_TRACE_EVENT)}
+                  >
+                    <span aria-hidden>🔍</span>
+                    <span>Cascade</span>
                   </button>
                 </div>
               `
@@ -501,6 +529,13 @@ export default function PiChat() {
   const [cascadeTrace, setCascadeTrace] = useState<CascadeTrace | null>(null);
   const [cascadeLoading, setCascadeLoading] = useState(false);
   const [cascadeError, setCascadeError] = useState<string | null>(null);
+  // Execution-trace modal state — populated from the new "📊 详情"
+  // button (kept distinct from the cascade viewer so the user can pick
+  // the right lens per-click).
+  const [execTraceOpen, setExecTraceOpen] = useState(false);
+  const [execTrace, setExecTrace] = useState<ExecutionTrace | null>(null);
+  const [execTraceLoading, setExecTraceLoading] = useState(false);
+  const [execTraceError, setExecTraceError] = useState<string | null>(null);
 
   // Clear any stale reset-error banner whenever the model dialog is
   // closed — regardless of close path (backdrop click, successful
@@ -517,7 +552,7 @@ export default function PiChat() {
   // inline state in the modal rather than swallowing the click silently.
   useEffect(() => {
     const handler = (ev: Event) => {
-      const ce = ev as CustomEvent<CascadeTraceEventDetail>;
+      const ce = ev as CustomEvent<TraceEventDetail>;
       const seq = ce.detail?.seq;
       const sessionKey = agentRef.current?.sessionId;
       if (seq === undefined || !sessionKey) return;
@@ -542,6 +577,40 @@ export default function PiChat() {
     };
     document.addEventListener(CASCADE_TRACE_EVENT, handler);
     return () => document.removeEventListener(CASCADE_TRACE_EVENT, handler);
+  }, []);
+
+  // Bridge for the "📊 详情" button — fetches the persisted
+  // `ExecutionTrace` for the clicked turn. A 404 is surfaced as an
+  // inline error row rather than silently closing the modal so the
+  // user understands why the view is empty (e.g. legacy turn recorded
+  // before trace persistence existed).
+  useEffect(() => {
+    const handler = (ev: Event) => {
+      const ce = ev as CustomEvent<TraceEventDetail>;
+      const seq = ce.detail?.seq;
+      const sessionKey = agentRef.current?.sessionId;
+      if (seq === undefined || !sessionKey) return;
+      setExecTraceOpen(true);
+      setExecTrace(null);
+      setExecTraceError(null);
+      setExecTraceLoading(true);
+      api
+        .get<ExecutionTrace>(
+          `/api/v1/chat/sessions/${encodeURIComponent(sessionKey)}/execution-trace?seq=${seq}`,
+        )
+        .then((trace) => {
+          setExecTrace(trace);
+        })
+        .catch((e: unknown) => {
+          const msg = e instanceof Error ? e.message : String(e);
+          setExecTraceError(msg);
+        })
+        .finally(() => {
+          setExecTraceLoading(false);
+        });
+    };
+    document.addEventListener(EXECUTION_TRACE_EVENT, handler);
+    return () => document.removeEventListener(EXECUTION_TRACE_EVENT, handler);
   }, []);
 
   /** Switch the agent to a different session, loading its history. */
@@ -1088,6 +1157,13 @@ export default function PiChat() {
         loading={cascadeLoading}
         error={cascadeError}
         onClose={() => setCascadeOpen(false)}
+      />
+      <ExecutionTraceModal
+        open={execTraceOpen}
+        trace={execTrace}
+        loading={execTraceLoading}
+        error={execTraceError}
+        onClose={() => setExecTraceOpen(false)}
       />
     </div>
   );


### PR DESCRIPTION
## Summary

- Aligns the per-turn trace button row with the assistant bubble via `pl-[2.75rem]` (matches the avatar padding set in `index.css`), fixing the button's left-edge stickiness.
- Splits the single "📊 详情" button into two, matching Telegram: "📊 详情" opens a new `ExecutionTrace` view (rationale / thinking / plan / tools / usage); "🔍 Cascade" keeps the existing tick-level tape replay.
- Adds backend endpoint `GET /api/v1/chat/sessions/{key}/execution-trace?seq=N` that resolves the clicked message's owning user turn, reads `rara_message_id` from tape metadata, and calls `TraceService::find_trace_by_message_id`.
- Threads `TraceService` through `BackendState::init` → `SessionService` and adds a generic `ChatError::NotFound` variant (404) for turns with no persisted trace.
- Ports the Telegram `render_trace_detail` layout to React in `ExecutionTraceModal` without the 4000-char truncation — long thinking previews collapse behind a toggle instead.

## Type of change

| Type | Label |
|------|-------|
| Bug fix | `bug` |

## Component

`ui` + `core` (backend endpoint)

## Closes

Closes #1608

## Test plan

- [x] `cargo check --all --all-targets` passes
- [x] `npm run build` passes in `web/`
- [ ] Tested end-to-end in browser (pending CI)