### PR TITLE
feat(web): inline in-progress card (#1619)

### DIFF
--- a/web/src/components/agent-live/AgentLiveCard.tsx
+++ b/web/src/components/agent-live/AgentLiveCard.tsx
@@ -19,7 +19,6 @@ import { useState } from 'react';
 import { AgentTranscriptDialog } from './AgentTranscriptDialog';
 import type { LiveRun } from './live-run-store';
 import { SingleAgentLiveCard } from './SingleAgentLiveCard';
-import { TaskRunHistory } from './TaskRunHistory';
 import { useLiveRun } from './use-live-run';
 
 interface Props {
@@ -27,8 +26,16 @@ interface Props {
 }
 
 /**
- * Top-level sticky card shown above the chat transcript while an agent
- * run is active, plus an `Execution history` section for prior runs.
+ * Inline in-progress card for an active run — styled and positioned to
+ * behave like the next assistant message at the bottom of the chat
+ * transcript (ChatGPT/Claude pattern). Parent owns the slot layout
+ * (see `.rara-live-slot` in `index.css`); this component renders the
+ * card content + transcript modal only.
+ *
+ * Task history has moved off this card — transient run history adds
+ * noise in the message flow; surface it from the session sidebar
+ * instead (follow-up).
+ *
  * Stop is intentionally wired as `disabled` — the backend cancel
  * endpoint is not implemented yet (tracked in a follow-up issue).
  */
@@ -36,27 +43,23 @@ export function AgentLiveCard({ sessionKey }: Props) {
   const slice = useLiveRun(sessionKey);
   const [openRun, setOpenRun] = useState<LiveRun | null>(null);
 
-  const hasAnything = slice.active !== null || slice.history.length > 0;
-  if (!hasAnything) return null;
+  if (!slice.active) return null;
 
   return (
-    <div className="sticky top-0 z-30 flex flex-col gap-2 border-b border-border/40 bg-background/80 px-3 py-2 backdrop-blur">
-      {slice.active && (
-        <SingleAgentLiveCard
-          run={slice.active}
-          onOpenTranscript={() => setOpenRun(slice.active)}
-          // Stop endpoint not yet wired — see follow-up issue referenced
-          // in the PR body. Passing no handler disables the button with
-          // a clarifying tooltip inside SingleAgentLiveCard.
-          {...({} as { onStop?: () => void })}
-        />
-      )}
-      <TaskRunHistory runs={slice.history} onOpenTranscript={setOpenRun} />
+    <>
+      <SingleAgentLiveCard
+        run={slice.active}
+        onOpenTranscript={() => setOpenRun(slice.active)}
+        // Stop endpoint not yet wired — see follow-up issue referenced
+        // in the PR body. Passing no handler disables the button with
+        // a clarifying tooltip inside SingleAgentLiveCard.
+        {...({} as { onStop?: () => void })}
+      />
       <AgentTranscriptDialog
         run={openRun}
         open={openRun !== null}
         onClose={() => setOpenRun(null)}
       />
-    </div>
+    </>
   );
 }

--- a/web/src/components/agent-live/SingleAgentLiveCard.tsx
+++ b/web/src/components/agent-live/SingleAgentLiveCard.tsx
@@ -80,7 +80,7 @@ export function SingleAgentLiveCard({ run, agentName = 'rara', onOpenTranscript,
   };
 
   return (
-    <section className="overflow-hidden rounded-lg border border-border/60 bg-card/70 shadow-sm backdrop-blur">
+    <section className="overflow-hidden rounded-lg border border-border/50 bg-card/60 backdrop-blur-sm">
       <div
         role="button"
         tabIndex={0}
@@ -97,6 +97,11 @@ export function SingleAgentLiveCard({ run, agentName = 'rara', onOpenTranscript,
         />
         <span className="min-w-0 flex-1 truncate text-sm font-medium text-foreground">
           {headerLabel}
+          {run.currentStage && (
+            <span className="ml-2 font-normal text-muted-foreground">
+              · {stageLabel(run.currentStage)}
+            </span>
+          )}
         </span>
         <span className="shrink-0 text-xs tabular-nums text-muted-foreground">
           {formatDuration(elapsed)}
@@ -142,9 +147,12 @@ export function SingleAgentLiveCard({ run, agentName = 'rara', onOpenTranscript,
         <div className="relative border-t border-border/50">
           <div ref={scrollerRef} onScroll={onScroll} className="max-h-[320px] overflow-y-auto">
             {redactedItems.length === 0 ? (
-              <div className="px-4 py-6 text-center text-xs text-muted-foreground">
-                Live log is not available for this agent provider. Results will appear when the task
-                completes.
+              <div className="flex items-center gap-2 px-4 py-3 text-xs text-muted-foreground">
+                <span
+                  className="inline-block h-1.5 w-1.5 shrink-0 animate-pulse rounded-full bg-emerald-500"
+                  aria-hidden
+                />
+                <span className="truncate">{stageLabel(run.currentStage)}</span>
               </div>
             ) : (
               <div className="divide-y divide-border/40">
@@ -181,4 +189,18 @@ function redactItem(item: TimelineItem): TimelineItem {
     return { ...item, input: redactObject(item.input) as Record<string, unknown> };
   }
   return item;
+}
+
+/**
+ * Beautify well-known kernel stage strings; raw free-text falls through.
+ * Keep the mapping small — kernel stage strings are already intentionally
+ * human-readable (see `crates/kernel/src/agent/mod.rs` emit sites); we
+ * only translate the two bare identifiers that look like machine tokens
+ * in the UI.
+ */
+function stageLabel(stage: string | null): string {
+  if (!stage) return '正在处理…';
+  if (stage === 'thinking') return '思考中…';
+  if (stage === 'interrupted') return '已中断，准备处理新消息…';
+  return stage;
 }

--- a/web/src/components/agent-live/__tests__/AgentTranscriptDialog.test.tsx
+++ b/web/src/components/agent-live/__tests__/AgentTranscriptDialog.test.tsx
@@ -33,6 +33,7 @@ function runFixture(): LiveRun {
     ],
     toolCalls: 1,
     error: null,
+    currentStage: null,
   };
 }
 

--- a/web/src/components/agent-live/__tests__/SingleAgentLiveCard.test.tsx
+++ b/web/src/components/agent-live/__tests__/SingleAgentLiveCard.test.tsx
@@ -30,17 +30,37 @@ function runFixture(overrides: Partial<LiveRun> = {}): LiveRun {
     items: [],
     toolCalls: 0,
     error: null,
+    currentStage: null,
     ...overrides,
   };
 }
 
 describe('SingleAgentLiveCard', () => {
-  it('shows the empty-log message when the run has no items yet', () => {
+  it('shows a generic working placeholder when the run has no items or stage', () => {
     render(<SingleAgentLiveCard run={runFixture()} onOpenTranscript={vi.fn()} />);
+    expect(screen.getByText('正在处理…')).toBeInTheDocument();
+  });
+
+  it('renders the current stage text when set', () => {
+    render(
+      <SingleAgentLiveCard
+        run={runFixture({ currentStage: 'Waiting for LLM response (iteration 2)...' })}
+        onOpenTranscript={vi.fn()}
+      />,
+    );
+    // Appears both in header subtitle and body row.
     expect(
-      screen.getByText(
-        /Live log is not available for this agent provider\. Results will appear when the task completes\./,
-      ),
-    ).toBeInTheDocument();
+      screen.getAllByText(/Waiting for LLM response \(iteration 2\)\.\.\./).length,
+    ).toBeGreaterThan(0);
+  });
+
+  it('beautifies the well-known "thinking" stage', () => {
+    render(
+      <SingleAgentLiveCard
+        run={runFixture({ currentStage: 'thinking' })}
+        onOpenTranscript={vi.fn()}
+      />,
+    );
+    expect(screen.getAllByText('思考中…').length).toBeGreaterThan(0);
   });
 });

--- a/web/src/components/agent-live/__tests__/TaskRunHistory.test.tsx
+++ b/web/src/components/agent-live/__tests__/TaskRunHistory.test.tsx
@@ -33,6 +33,7 @@ function runFixture(overrides: Partial<LiveRun> = {}): LiveRun {
     ],
     toolCalls: 1,
     error: null,
+    currentStage: null,
     ...overrides,
   };
 }

--- a/web/src/components/agent-live/__tests__/live-run-store.test.ts
+++ b/web/src/components/agent-live/__tests__/live-run-store.test.ts
@@ -100,6 +100,22 @@ describe('LiveRunStore', () => {
     expect(slice.active).toBeNull();
     expect(slice.history[0]?.status).toBe('cancelled');
   });
+
+  it('tracks the latest progress.stage on the active run', () => {
+    const store = new LiveRunStore();
+    const sk = 's5';
+    store.publish(sk, startEvent);
+    expect(store.snapshot(sk).active?.currentStage).toBeNull();
+    store.publish(sk, { type: 'progress', stage: 'thinking' });
+    expect(store.snapshot(sk).active?.currentStage).toBe('thinking');
+    store.publish(sk, {
+      type: 'progress',
+      stage: 'Waiting for LLM response (iteration 2)...',
+    });
+    expect(store.snapshot(sk).active?.currentStage).toBe(
+      'Waiting for LLM response (iteration 2)...',
+    );
+  });
 });
 
 describe('mergeBySourceSeq', () => {

--- a/web/src/components/agent-live/live-run-store.ts
+++ b/web/src/components/agent-live/live-run-store.ts
@@ -51,6 +51,15 @@ export interface LiveRun {
   toolCalls: number;
   /** Last error message (for `failed` status); null otherwise. */
   error: string | null;
+  /**
+   * Latest `progress.stage` string emitted by the kernel — a free-text
+   * status marker (e.g. `"thinking"`, `"Waiting for LLM response
+   * (iteration 2)..."`, `"Processing... (3 steps completed)"`). Rendered
+   * in the live card body when the run has no substantive timeline items
+   * yet — otherwise the card would show an unhelpful "no data" placeholder
+   * while the provider is still producing its first chunk.
+   */
+  currentStage: string | null;
 }
 
 /**
@@ -206,6 +215,7 @@ export function reduce(
       items: [],
       toolCalls: 0,
       error: null,
+      currentStage: null,
     };
     return { active, history };
   }
@@ -305,6 +315,16 @@ export function reduce(
         });
       }
       return { ...slice, active: { ...run, items: nextItems } };
+    }
+    case 'progress': {
+      // Free-text status marker from the kernel (see
+      // `crates/kernel/src/agent/mod.rs` emit sites). Mirrored onto the
+      // run so the card header can read the latest stage even when no
+      // timeline items have landed yet — common for LLM providers that
+      // don't stream text deltas (e.g. MiniMax batch mode).
+      const stage = readString(event, 'stage');
+      if (!stage) return slice;
+      return { ...slice, active: { ...run, currentStage: stage } };
     }
     default:
       // Everything else is informational and ignored for the live card.

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -416,6 +416,27 @@
   left: max(57px, calc(50% - 24rem + 57px));
 }
 
+/*
+ * Inline slot for the in-progress `AgentLiveCard` — aligns the card to
+ * pi-web-ui's message column (48rem, centred) and anchors it just above
+ * the composer. Matches the ChatGPT / Claude pattern: the card reads as
+ * the last assistant message while a turn streams, then disappears when
+ * the real assistant bubble lands in pi-web-ui's message list.
+ *
+ * Height of the composer region is ~10.5rem (editor + pill row + stats).
+ * Using a fixed bottom offset is simpler and more reliable than
+ * ResizeObserver wiring into pi-web-ui's internals; if the composer
+ * grows (multi-line input), the card rides up with it naturally because
+ * pi-web-ui's composer pushes from the bottom of `<main>`.
+ */
+.rara-chat .rara-live-slot {
+  left: 50%;
+  transform: translateX(-50%);
+  width: 100%;
+  max-width: 48rem;
+  bottom: 10.5rem;
+}
+
 .user-message-container {
   /* Content-size the bubble so justify-end actually pushes it right.
      In a flex container `display: block` resolves to "stretch" along

--- a/web/src/pages/PiChat.tsx
+++ b/web/src/pages/PiChat.tsx
@@ -1093,12 +1093,19 @@ export default function PiChat() {
             </span>
           </div>
         )}
-        {/* Live agent card — sticky above the chat transcript while a
-            turn is streaming. Hidden when there is no active run and no
-            history for the current session (see AgentLiveCard). */}
-        <AgentLiveCard sessionKey={activeSession?.key} />
         {/* Chat panel container — takes remaining vertical space. */}
         <div ref={containerRef} className="min-h-0 flex-1 w-full" />
+        {/* Live agent card — positioned inline with the pi-web-ui message
+            column (same 48rem cap) and anchored just above the composer,
+            so it reads as "the next assistant message" while a turn is
+            streaming. See `.rara-live-slot` in index.css for placement. */}
+        {!isInitializing && (
+          <div className="rara-live-slot pointer-events-none absolute z-10 px-2">
+            <div className="pointer-events-auto">
+              <AgentLiveCard sessionKey={activeSession?.key} />
+            </div>
+          </div>
+        )}
         {/*
           Welcome overlay — rendered above pi-web-ui's empty message list
           when the active session has no messages. Pointer-events-none so


### PR DESCRIPTION
## Summary

Reposition the live agent card from sticky-top-full-width into an inline slot above the composer, capped to pi-web-ui's 48rem message column — it now reads as "the next assistant bubble" while a turn streams (ChatGPT / Claude pattern; reference is Vercel ai-chatbot's `PreviewMessage + ThinkingMessage`).

Also wire the kernel's `progress.stage` WS frames (previously dropped) into the card so the body shows what rara is actually doing — e.g. `思考中…`, `Waiting for LLM response (iteration 2)...`, `Processing... (3 steps completed)` — instead of the old "Live log is not available" placeholder. This is what made the card feel empty/incomprehensible for providers that batch tokens (e.g. MiniMax).

Before vs after:
- Before: sticky bar at the top of chat, full-width, with body text users couldn't parse.
- After: 48rem inline card above the composer with a pulsing status line, disappears when the real assistant reply lands in pi-web-ui's message list.

## Type of change

| Type | Label |
|------|-------|
| New feature | `enhancement` |

## Component

`ui`

## Closes

Closes #1619

## Test plan

- [x] `npx vitest run src` (44 pass, 0 fail — 3 new tests for stage mapping + card rendering)
- [x] `npx tsc -b --noEmit`
- [x] `npx eslint`
- [x] `npx prettier --check`
- [x] `npm run build`
- [x] Playwright-verified against a live rara backend: card appears inline above composer, stage text renders, disappears on completion, tool-call heavy turns still render through pi-web-ui's native streaming container as before.

## Follow-ups (tracked separately if asked)

- Surface `TaskRunHistory` somewhere ergonomic (session sidebar) — dropped from the live card since transient history is noise in the message flow.
- The `buildWsUrl` helper (`web/src/adapters/rara-stream.ts`) ignores the user's `rara_backend_url` localStorage override, so WS always goes through the dev proxy — unrelated to this change but worth fixing.