### PR TITLE
fix(web): honor rara_backend_url for WS (#1622)

### DIFF
--- a/web/src/adapters/__tests__/rara-stream.test.ts
+++ b/web/src/adapters/__tests__/rara-stream.test.ts
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2025 Rararulab
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { buildWsUrl } from '../rara-stream';
+
+const STORAGE_KEY = 'rara_backend_url';
+
+// Node 22+ exposes a built-in `globalThis.localStorage` that shadows jsdom's
+// implementation and lacks `setItem`/`getItem` unless launched with
+// `--localstorage-file`. Tests here stub a minimal in-memory Storage so
+// `buildWsUrl`'s override probe runs against predictable state regardless
+// of the host Node version.
+function installLocalStorageStub() {
+  const store = new Map<string, string>();
+  const stub = {
+    getItem: (k: string) => (store.has(k) ? store.get(k)! : null),
+    setItem: (k: string, v: string) => {
+      store.set(k, String(v));
+    },
+    removeItem: (k: string) => {
+      store.delete(k);
+    },
+    clear: () => store.clear(),
+    key: (i: number) => Array.from(store.keys())[i] ?? null,
+    get length() {
+      return store.size;
+    },
+  };
+  vi.stubGlobal('localStorage', stub);
+  Object.defineProperty(window, 'localStorage', { value: stub, configurable: true });
+}
+
+describe('buildWsUrl — backend override resolution (#1622)', () => {
+  beforeEach(() => {
+    installLocalStorageStub();
+  });
+
+  afterEach(() => {
+    localStorage.removeItem(STORAGE_KEY);
+    vi.unstubAllGlobals();
+  });
+
+  it('falls back to window.location when no override is set', () => {
+    const url = buildWsUrl('sess-abc');
+    const loc = window.location;
+    const proto = loc.protocol === 'https:' ? 'wss:' : 'ws:';
+    expect(url).toBe(
+      `${proto}//${loc.host}/api/v1/kernel/chat/ws?session_key=sess-abc&user_id=web_ryan`,
+    );
+  });
+
+  it('honors rara_backend_url override (http -> ws)', () => {
+    localStorage.setItem(STORAGE_KEY, 'http://10.0.0.183:25555');
+    expect(buildWsUrl('sess-abc')).toBe(
+      'ws://10.0.0.183:25555/api/v1/kernel/chat/ws?session_key=sess-abc&user_id=web_ryan',
+    );
+  });
+
+  it('honors rara_backend_url override with https and trims trailing slash', () => {
+    localStorage.setItem(STORAGE_KEY, 'https://backend.example.com/');
+    expect(buildWsUrl('sess-xyz')).toBe(
+      'wss://backend.example.com/api/v1/kernel/chat/ws?session_key=sess-xyz&user_id=web_ryan',
+    );
+  });
+
+  it('URL-encodes session keys containing special characters', () => {
+    localStorage.setItem(STORAGE_KEY, 'http://10.0.0.183:25555');
+    expect(buildWsUrl('sess/with spaces')).toBe(
+      'ws://10.0.0.183:25555/api/v1/kernel/chat/ws?session_key=sess%2Fwith%20spaces&user_id=web_ryan',
+    );
+  });
+});

--- a/web/src/adapters/rara-stream.ts
+++ b/web/src/adapters/rara-stream.ts
@@ -31,7 +31,7 @@ import type { AssistantMessageEventStream } from '@mariozechner/pi-ai';
 import type { Attachment } from '@mariozechner/pi-web-ui';
 import { Type } from '@sinclair/typebox';
 
-import { BASE_URL } from '@/api/client';
+import { BASE_URL, getBackendUrl } from '@/api/client';
 
 // ---------------------------------------------------------------------------
 // WebEvent — frames received from the rara WebSocket chat API
@@ -161,21 +161,32 @@ function buildPartial(
 
 /**
  * Derive the WebSocket URL from the configured API base URL.
- * Converts http(s) to ws(s) and appends the chat WS path.
+ *
+ * Resolution order mirrors REST (`resolveUrl` in `api/client.ts`):
+ * 1. If the user has set a custom `rara_backend_url` in localStorage we
+ *    derive WS from that host so REST and WS target the same backend.
+ *    Without this, REST follows the override but WS always fell back to
+ *    `window.location`, producing "WebSocket connection error" whenever
+ *    the override pointed at a remote backend (issue #1622).
+ * 2. Otherwise honour an explicit compile-time `BASE_URL`.
+ * 3. Otherwise derive from the current page (Vite dev proxy path).
  */
 export function buildWsUrl(sessionKey: string): string {
-  let base = BASE_URL;
+  let base: string;
 
-  // When BASE_URL is empty, derive from current page location
-  if (!base) {
+  const override = typeof window !== 'undefined' ? localStorage.getItem('rara_backend_url') : null;
+
+  if (override) {
+    base = getBackendUrl().replace(/^http/, 'ws');
+  } else if ((BASE_URL as string).length > 0) {
+    base = (BASE_URL as string).replace(/^http/, 'ws');
+  } else {
     const loc = window.location;
     const proto = loc.protocol === 'https:' ? 'wss:' : 'ws:';
     base = `${proto}//${loc.host}`;
-  } else {
-    base = base.replace(/^http/, 'ws');
   }
 
-  // Strip trailing slash
+  // Strip trailing slash so the joined path has exactly one separator.
   base = base.replace(/\/$/, '');
 
   return `${base}/api/v1/kernel/chat/ws?session_key=${encodeURIComponent(sessionKey)}&user_id=web_ryan`;


### PR DESCRIPTION
## Summary

`buildWsUrl` in `web/src/adapters/rara-stream.ts` ignored the
`rara_backend_url` localStorage override and always derived the
WebSocket URL from `window.location`, while REST calls went to the
overridden host via `resolveUrl`. When a user pointed the frontend
at a remote backend, REST worked but WS failed with
"WebSocket connection error".

This change makes WS resolution mirror REST:

1. If `rara_backend_url` is set, derive WS from that URL (http→ws,
   https→wss, trim trailing slash).
2. Otherwise use `BASE_URL` if present.
3. Otherwise fall back to `window.location` (Vite dev proxy).

## Type of change

| Type | Label |
|------|-------|
| Bug fix | `bug` |

## Component

`ui`

## Closes

Closes #1622

## Test plan

- [x] `npx vitest run src` passes (45 tests)
- [x] `npx tsc -b --noEmit` passes
- [x] `npx eslint src/adapters src/api` clean
- [x] `npx prettier --check 'src/**/*.{ts,tsx}'` clean
- [x] New tests cover override (http + https trailing slash) and fallback