### PR TITLE
feat(llm): stream-close salvage for empty content with reasoning buffer (#1632)

### DIFF
--- a/crates/kernel/src/agent/mod.rs
+++ b/crates/kernel/src/agent/mod.rs
@@ -1593,6 +1593,14 @@ pub(crate) async fn run_agent_loop(
                         tc.arguments_buf.push_str(&arguments);
                     }
                 }
+                llm::StreamDelta::Failure(failure) => {
+                    // Driver-reported stream failure. Log + fall through;
+                    // the subsequent Done event still closes the turn. Richer
+                    // handling (tape suppression, user-facing error) is
+                    // addressed in the next sub-PR of the streaming-robustness
+                    // epic; behavior here must remain identical to pre-PR.
+                    warn!(iteration, ?failure, "driver reported stream failure");
+                }
                 llm::StreamDelta::Done { stop_reason, usage } => {
                     if stop_reason == llm::StopReason::ToolCalls && pending_tool_calls.is_empty() {
                         warn!(

--- a/crates/kernel/src/llm/mod.rs
+++ b/crates/kernel/src/llm/mod.rs
@@ -42,5 +42,5 @@ pub use driver::{
 pub use openai::{OpenAiDriver, is_local_url};
 pub use registry::{DriverRegistry, DriverRegistryRef, ProviderModelConfig};
 pub use scripted::ScriptedLlmDriver;
-pub use stream::StreamDelta;
+pub use stream::{StreamDelta, StreamFailure};
 pub use types::*;

--- a/crates/kernel/src/llm/openai.rs
+++ b/crates/kernel/src/llm/openai.rs
@@ -1348,6 +1348,44 @@ async fn stream_responses_api(
         }
     }
 
+    // Stream-close salvage for the Responses API path. Providers routed
+    // through this format (currently OpenAI + clones) shouldn't hit the
+    // MiniMax failure mode, but the guard is symmetric with the chat
+    // completions path and costs nothing when reasoning is empty.
+    if state.accumulated_text.is_empty()
+        && !state.accumulated_reasoning.is_empty()
+        && !state.has_function_call
+    {
+        match salvage_after_think(&state.accumulated_reasoning) {
+            Some(salvaged) => {
+                tracing::warn!(
+                    reasoning_len = state.accumulated_reasoning.len(),
+                    salvaged_len = salvaged.len(),
+                    "Responses API stream closed with empty content; salvaged text after </think>"
+                );
+                let _ = tx
+                    .send(StreamDelta::TextDelta {
+                        text: salvaged.clone(),
+                    })
+                    .await;
+                state.accumulated_text.push_str(&salvaged);
+            }
+            None => {
+                tracing::warn!(
+                    reasoning_len = state.accumulated_reasoning.len(),
+                    "Responses API stream closed with empty content and no salvageable text"
+                );
+                let _ = tx
+                    .send(StreamDelta::Failure(
+                        super::stream::StreamFailure::EmptyContent {
+                            reasoning_len: state.accumulated_reasoning.len(),
+                        },
+                    ))
+                    .await;
+            }
+        }
+    }
+
     let _ = tx
         .send(StreamDelta::Done {
             stop_reason: state.final_stop,
@@ -1786,7 +1824,7 @@ impl StreamAccumulator {
         }
 
         let Self {
-            text,
+            mut text,
             reasoning,
             tools,
             stop_reason,
@@ -1794,6 +1832,43 @@ impl StreamAccumulator {
             ..
         } = self;
         let tool_calls = Self::collect_tools(tools);
+
+        // Stream-close salvage: some reasoning-capable providers (MiniMax-M2)
+        // emit the real answer inside `reasoning_content` after `</think>`
+        // and then close the stream without ever emitting `content`. When we
+        // see reasoning but no text, try to extract text after the last
+        // `</think>` tag; if that fails, surface a typed failure so upstream
+        // consumers can avoid writing an empty assistant record.
+        if text.is_empty() && !reasoning.is_empty() && tool_calls.is_empty() {
+            match salvage_after_think(&reasoning) {
+                Some(salvaged) => {
+                    tracing::warn!(
+                        reasoning_len = reasoning.len(),
+                        salvaged_len = salvaged.len(),
+                        "stream closed with empty content; salvaged text after </think>"
+                    );
+                    let _ = tx
+                        .send(StreamDelta::TextDelta {
+                            text: salvaged.clone(),
+                        })
+                        .await;
+                    text.push_str(&salvaged);
+                }
+                None => {
+                    tracing::warn!(
+                        reasoning_len = reasoning.len(),
+                        "stream closed with empty content and no salvageable text after </think>"
+                    );
+                    let _ = tx
+                        .send(StreamDelta::Failure(
+                            super::stream::StreamFailure::EmptyContent {
+                                reasoning_len: reasoning.len(),
+                            },
+                        ))
+                        .await;
+                }
+            }
+        }
 
         let _ = tx.send(StreamDelta::Done { stop_reason, usage }).await;
 
@@ -1813,6 +1888,28 @@ impl StreamAccumulator {
 // ---------------------------------------------------------------------------
 
 fn non_empty(s: String) -> Option<String> { if s.is_empty() { None } else { Some(s) } }
+
+/// Attempt to recover assistant text trailing the last `</think>` tag in a
+/// reasoning buffer.
+///
+/// Observed MiniMax-M2 failure mode: the model streams
+/// `reasoning_content` containing a complete `<think>...</think>` block (and
+/// sometimes the real answer in the same field after the closing tag), then
+/// closes the SSE stream without ever emitting `content`. Callers use this
+/// helper at stream close to salvage that trailing text.
+///
+/// Returns `None` when the buffer contains no `</think>` tag, or when the
+/// text after the last one is whitespace-only.
+fn salvage_after_think(reasoning: &str) -> Option<String> {
+    const CLOSE_TAG: &str = "</think>";
+    let tail = reasoning.rsplit_once(CLOSE_TAG).map(|(_, rest)| rest)?;
+    let trimmed = tail.trim();
+    if trimmed.is_empty() {
+        None
+    } else {
+        Some(trimmed.to_owned())
+    }
+}
 
 /// Truncate a string to at most `max_bytes` bytes without splitting a UTF-8
 /// code point.
@@ -2749,5 +2846,123 @@ mod tests {
         let data = r#"{"some":"data"}"#;
         let result = parse_responses_event("response.something.new", data, &tx, &mut state);
         assert!(result.is_none());
+    }
+
+    // -----------------------------------------------------------------
+    // Stream-close salvage (issue #1632)
+    // -----------------------------------------------------------------
+
+    #[test]
+    fn salvage_after_think_extracts_trailing_text() {
+        let reasoning = "<think>planning...</think>\nHere is the answer.";
+        let salvaged = salvage_after_think(reasoning).expect("should salvage");
+        assert_eq!(salvaged, "Here is the answer.");
+    }
+
+    #[test]
+    fn salvage_after_think_prefers_last_close_tag() {
+        // Defensive: malformed reasoning with multiple close tags — take the
+        // tail after the final one, matching real-world MiniMax output where
+        // the last </think> marks the transition to the answer.
+        let reasoning = "<think>step1</think>intermediate<think>step2</think>final answer";
+        let salvaged = salvage_after_think(reasoning).expect("should salvage");
+        assert_eq!(salvaged, "final answer");
+    }
+
+    #[test]
+    fn salvage_after_think_no_close_tag_returns_none() {
+        let reasoning = "unterminated reasoning with no close tag";
+        assert!(salvage_after_think(reasoning).is_none());
+    }
+
+    #[test]
+    fn salvage_after_think_whitespace_only_tail_returns_none() {
+        let reasoning = "<think>all thoughts</think>   \n\t  ";
+        assert!(salvage_after_think(reasoning).is_none());
+    }
+
+    #[tokio::test]
+    async fn finalize_salvages_reasoning_and_emits_text_delta() {
+        let (tx, mut rx) = mpsc::channel(32);
+        let mut acc = StreamAccumulator::new();
+        // Simulate a MiniMax-style stream: only reasoning_content arrived,
+        // and the answer sits after a closing </think> tag.
+        acc.reasoning
+            .push_str("<think>deliberating...</think>The capital is Paris.");
+
+        let response = acc.finalize(&tx, "minimax-m2".to_string()).await;
+
+        // The salvaged text must be emitted as a TextDelta before Done.
+        let first = rx.try_recv().expect("should receive a delta");
+        match first {
+            StreamDelta::TextDelta { text } => assert_eq!(text, "The capital is Paris."),
+            other => panic!("expected TextDelta, got {other:?}"),
+        }
+        let second = rx.try_recv().expect("should receive Done");
+        assert!(matches!(second, StreamDelta::Done { .. }));
+
+        assert_eq!(response.content.as_deref(), Some("The capital is Paris."));
+        assert!(response.reasoning_content.is_some());
+    }
+
+    #[tokio::test]
+    async fn finalize_emits_failure_when_salvage_fails() {
+        let (tx, mut rx) = mpsc::channel(32);
+        let mut acc = StreamAccumulator::new();
+        // Reasoning with no closing </think> tag — salvage must fail.
+        acc.reasoning
+            .push_str("<think>thinking forever without closing");
+
+        let response = acc.finalize(&tx, "minimax-m2".to_string()).await;
+
+        let first = rx.try_recv().expect("should receive failure");
+        match first {
+            StreamDelta::Failure(super::super::stream::StreamFailure::EmptyContent {
+                reasoning_len,
+            }) => {
+                assert!(reasoning_len > 0);
+            }
+            other => panic!("expected Failure::EmptyContent, got {other:?}"),
+        }
+        let second = rx.try_recv().expect("should receive Done");
+        assert!(matches!(second, StreamDelta::Done { .. }));
+
+        assert!(response.content.is_none());
+    }
+
+    #[tokio::test]
+    async fn finalize_no_reasoning_leaves_stream_unchanged() {
+        // Non-reasoning provider: both buffers empty. Salvage must not fire;
+        // the stream emits only Done.
+        let (tx, mut rx) = mpsc::channel(32);
+        let acc = StreamAccumulator::new();
+
+        let response = acc.finalize(&tx, "gpt-4o".to_string()).await;
+
+        let first = rx.try_recv().expect("should receive Done");
+        assert!(matches!(first, StreamDelta::Done { .. }));
+        assert!(rx.try_recv().is_err(), "no further deltas expected");
+
+        assert!(response.content.is_none());
+        assert!(response.reasoning_content.is_none());
+    }
+
+    #[tokio::test]
+    async fn finalize_with_text_skips_salvage() {
+        // Both text and reasoning present: salvage must NOT run, and no
+        // synthetic TextDelta or Failure must be emitted.
+        let (tx, mut rx) = mpsc::channel(32);
+        let mut acc = StreamAccumulator::new();
+        acc.text.push_str("already streamed");
+        acc.reasoning
+            .push_str("<think>ignored</think>trailing ignored");
+
+        let response = acc.finalize(&tx, "minimax-m2".to_string()).await;
+
+        let first = rx.try_recv().expect("should receive Done");
+        assert!(matches!(first, StreamDelta::Done { .. }));
+        assert!(rx.try_recv().is_err(), "no salvage delta expected");
+
+        assert_eq!(response.content.as_deref(), Some("already streamed"));
     }
 }

--- a/crates/kernel/src/llm/stream.rs
+++ b/crates/kernel/src/llm/stream.rs
@@ -16,6 +16,36 @@
 
 use super::types::{StopReason, Usage};
 
+/// Typed failure reasons reported by a driver at stream close.
+///
+/// Emitted as part of [`StreamDelta::Failure`] when the driver completes a
+/// stream but detects a condition that would otherwise silently produce an
+/// empty or malformed assistant turn. Consumers may use these signals to
+/// surface errors to the user instead of writing empty tape records.
+#[derive(Debug, Clone)]
+pub enum StreamFailure {
+    /// The provider closed the stream with no assistant content despite
+    /// emitting `reasoning_content` — typically MiniMax-M2 finishing the
+    /// `<think>` block and then hitting EOS before any real answer. The
+    /// driver already attempted salvage (extracting text after the last
+    /// `</think>` tag) and either found nothing or only whitespace.
+    EmptyContent {
+        /// Number of characters in the reasoning buffer at stream close —
+        /// useful for diagnostics and for consumers deciding whether to
+        /// retry vs. surface the failure.
+        reasoning_len: usize,
+    },
+    /// The provider returned a non-retryable protocol error (e.g. MiniMax
+    /// `system (2013)` HTTP 400). The driver propagates the provider's
+    /// error code and human-readable message.
+    ProtocolError {
+        /// Provider-specific error code (e.g. `"2013"`).
+        code:    String,
+        /// Provider-specific human-readable message.
+        message: String,
+    },
+}
+
 /// Events emitted during streaming LLM completion.
 ///
 /// The LLM driver sends these through an `mpsc::Sender<StreamDelta>` as
@@ -35,6 +65,12 @@ pub enum StreamDelta {
     },
     /// Incremental JSON fragment for an in-progress tool call's arguments.
     ToolCallArgumentsDelta { index: u32, arguments: String },
+    /// A typed failure signal emitted by the driver before `Done`.
+    ///
+    /// Consumers that do not understand a specific failure kind should log
+    /// and fall through — the following `Done` event will still close the
+    /// stream.
+    Failure(StreamFailure),
     /// The stream is complete.
     Done {
         stop_reason: StopReason,


### PR DESCRIPTION
## Summary

Part of #1630. MiniMax-M2 sometimes emits `reasoning_content` (the `<think>...</think>` payload) in SSE but hits EOS before producing `content`; the driver closed the stream as success with empty text, polluting the tape with empty assistant records and stranding the Telegram adapter on the progress bubble.

This sub-PR adds a driver-layer safety net:

- New `StreamDelta::Failure(StreamFailure)` event with `EmptyContent { reasoning_len }` + `ProtocolError { code, message }` variants (the latter is used by the next sub-PR #1633 for HTTP 400 `system (2013)`).
- At stream close, if `text.is_empty() && !reasoning.is_empty()`, try to extract text after the last `</think>` tag. On success emit it as a synthetic `TextDelta`; on failure emit `Failure::EmptyContent` before `Done`.
- Applied symmetrically to both chat completions and Responses API stream paths.
- Naturally gated by "reasoning was actually emitted" — non-reasoning providers never populate the reasoning buffer, so no provider-specific check is required.
- Agent loop logs `Failure` and falls through; behavior is identical pre/post PR. Richer handling (tape suppression, user-facing error) lands in the kernel sub-PR.

## Type of change

| Type | Label |
|------|-------|
| New feature | `enhancement` |

## Component

`core`

## Closes

Closes #1632

## Test plan

- [x] `cargo test -p rara-kernel --lib llm::openai::tests` passes (31 tests)
- [x] `prek run --all-files` passes (fmt, clippy, doc, check)
- [x] Unit tests cover: salvage success (trailing text after `</think>`), last-`</think>` preference, missing tag, whitespace-only tail, and the three finalize paths (salvage, failure, no-reasoning no-op, text-present skip)