### PR TITLE
feat(kernel): unified agent registry — {driver, model} pair resolution (#1635)

### DIFF
--- a/crates/kernel/AGENT.md
+++ b/crates/kernel/AGENT.md
@@ -1,5 +1,19 @@
 # rara-kernel — Agent Guidelines
 
+## Agent LLM Resolution Contract — `llm/registry.rs`
+
+The unified entry point for resolving an agent's LLM binding is
+[`DriverRegistry::resolve_agent`] in `crates/kernel/src/llm/registry.rs`.
+It returns a [`ResolvedAgent { driver, model, manifest }`] triple read from
+`agents.<name>.{driver, model}` in YAML, with fallback to the manifest's
+`provider_hint`/`model` and finally the provider default. New consumers
+MUST go through `resolve_agent` so the driver and the model come from a
+single consistent source — the split-config bug that motivated #1635
+(driver resolved via the registry, model resolved via a flat settings key
+like `knowledge.extractor_model`) should not reappear. The legacy
+`DriverRegistry::resolve` tuple API is kept as a thin shim for existing
+callers; migration is tracked in follow-up issues under Epic #1631.
+
 ## Critical: StreamDelta Event Ordering in `openai.rs`
 
 ### The Invariant

--- a/crates/kernel/src/llm/mod.rs
+++ b/crates/kernel/src/llm/mod.rs
@@ -40,7 +40,9 @@ pub use driver::{
     LlmEmbedder, LlmEmbedderRef, LlmModelLister, LlmModelListerRef,
 };
 pub use openai::{OpenAiDriver, is_local_url};
-pub use registry::{DriverRegistry, DriverRegistryRef, ProviderModelConfig};
+pub use registry::{
+    AgentLlmConfig, DriverRegistry, DriverRegistryRef, ProviderModelConfig, ResolvedAgent,
+};
 pub use scripted::ScriptedLlmDriver;
 pub use stream::StreamDelta;
 pub use types::*;

--- a/crates/kernel/src/llm/registry.rs
+++ b/crates/kernel/src/llm/registry.rs
@@ -17,7 +17,21 @@
 //! [`DriverRegistry`] manages named [`LlmDriver`](super::LlmDriver) instances
 //! with per-agent override support for driver and model selection.
 //!
-//! Resolution priority:
+//! # Resolution contract (`resolve_agent`, introduced in #1635)
+//!
+//! Agents declare their LLM binding in YAML under
+//! `agents.<name>.{driver, model}`. The registry's
+//! [`DriverRegistry::resolve_agent`] returns a [`ResolvedAgent`] with
+//! the driver instance, the exact model, and a manifest snapshot, so
+//! callers never see a driver resolved one way and a model resolved
+//! another. Priority:
+//!
+//! ```text
+//! Driver: agents.<name>.driver > agent_overrides > manifest.provider_hint > default_driver
+//! Model:  agents.<name>.model  > agent_overrides > manifest.model         > provider_models[driver].default_model
+//! ```
+//!
+//! # Legacy `resolve` (kept as a thin shim)
 //!
 //! ```text
 //! Driver: agent_overrides > manifest.provider_hint > default_driver
@@ -32,7 +46,7 @@ use std::{
 use snafu::OptionExt;
 
 use super::{catalog::OpenRouterCatalog, driver::LlmDriverRef};
-use crate::error;
+use crate::{agent::AgentManifest, error};
 
 /// Shared reference to the [`DriverRegistry`].
 pub type DriverRegistryRef = Arc<DriverRegistry>;
@@ -52,6 +66,12 @@ struct DriverRegistryState {
     default_driver:  String,
     provider_models: HashMap<String, ProviderModelConfig>,
     agent_overrides: HashMap<String, AgentDriverConfig>,
+    /// Per-agent `{driver, model}` pair loaded from `agents.<name>.*` YAML.
+    ///
+    /// This is the new unified source of truth introduced by the agent
+    /// registry refactor (issue #1635). Existing `agent_overrides` remain
+    /// until consumers migrate in follow-up issues.
+    agent_configs:   HashMap<String, AgentLlmConfig>,
 }
 
 /// Per-agent LLM driver configuration override.
@@ -64,6 +84,36 @@ pub struct AgentDriverConfig {
     pub driver: Option<String>,
     /// Override model identifier (e.g., `"qwen3:32b"`).
     pub model:  Option<String>,
+}
+
+/// Unified per-agent LLM config read from `agents.<name>.*` YAML.
+///
+/// Unlike [`AgentDriverConfig`] (which is a legacy override layered on
+/// top of a manifest), this represents the full `{driver, model}` pair
+/// that [`DriverRegistry::resolve_agent`] will return for an agent.
+#[derive(Debug, Clone, Default)]
+pub struct AgentLlmConfig {
+    /// Driver name (e.g., `"openrouter"`, `"ollama"`).
+    pub driver: Option<String>,
+    /// Model identifier (e.g., `"qwen3:32b"`).
+    pub model:  Option<String>,
+}
+
+/// Fully-resolved LLM binding for an agent.
+///
+/// Produced by [`DriverRegistry::resolve_agent`]. Holds the driver
+/// instance, the exact model identifier, and a clone of the agent's
+/// manifest so callers have a single consistent snapshot — eliminating
+/// the historical split between a driver resolved one way and a model
+/// string resolved another (see issue #1635).
+#[derive(Clone, bon::Builder)]
+pub struct ResolvedAgent {
+    /// Shared driver instance capable of serving the agent's requests.
+    pub driver:   LlmDriverRef,
+    /// Concrete model identifier to pass to the driver.
+    pub model:    String,
+    /// Snapshot of the manifest used for resolution.
+    pub manifest: AgentManifest,
 }
 
 /// Named driver map with default selection and per-agent overrides.
@@ -82,6 +132,7 @@ impl DriverRegistry {
                 default_driver:  default_driver.into(),
                 provider_models: HashMap::new(),
                 agent_overrides: HashMap::new(),
+                agent_configs:   HashMap::new(),
             }),
             catalog,
         }
@@ -117,6 +168,17 @@ impl DriverRegistry {
     pub fn set_agent_override(&self, agent_name: impl Into<String>, config: AgentDriverConfig) {
         let mut state = self.state.write().unwrap_or_else(|e| e.into_inner());
         state.agent_overrides.insert(agent_name.into(), config);
+    }
+
+    /// Set the unified `{driver, model}` config for an agent, as loaded
+    /// from `agents.<name>.*` YAML.
+    ///
+    /// Used by [`Self::resolve_agent`]. Independent of the legacy
+    /// [`Self::set_agent_override`] map — callers may populate either or
+    /// both during the migration period.
+    pub fn set_agent_config(&self, agent_name: impl Into<String>, config: AgentLlmConfig) {
+        let mut state = self.state.write().unwrap_or_else(|e| e.into_inner());
+        state.agent_configs.insert(agent_name.into(), config);
     }
 
     /// Resolve a driver + model for a given agent.
@@ -157,6 +219,57 @@ impl DriverRegistry {
             .context(error::ProviderNotConfiguredSnafu)?;
 
         Ok((Arc::clone(driver), model_name.to_string()))
+    }
+
+    /// Resolve a [`ResolvedAgent`] for the given manifest — the unified
+    /// `{driver, model, manifest}` entry point introduced by #1635.
+    ///
+    /// Resolution priority:
+    /// - **Driver**: `agents.<name>.driver` > `agent_overrides[name].driver`
+    ///   > `manifest.provider_hint` > `default_driver`
+    /// - **Model**:  `agents.<name>.model`  > `agent_overrides[name].model`
+    ///   > `manifest.model` > `provider_models[driver].default_model`
+    ///
+    /// The agent name is taken from `manifest.name`. The returned
+    /// `ResolvedAgent` carries a clone of the manifest so callers have a
+    /// single consistent snapshot — closing the historical split where
+    /// the driver was resolved via the registry but the model came from
+    /// a flat settings key (see the `knowledge_extractor` prod failure
+    /// that motivated this refactor).
+    pub fn resolve_agent(&self, manifest: &AgentManifest) -> error::Result<ResolvedAgent> {
+        let state = self.state.read().unwrap_or_else(|e| e.into_inner());
+        let agent_name = manifest.name.as_str();
+        let agent_cfg = state.agent_configs.get(agent_name);
+        let legacy_override = state.agent_overrides.get(agent_name);
+
+        let driver_name = agent_cfg
+            .and_then(|c| c.driver.as_deref())
+            .or_else(|| legacy_override.and_then(|c| c.driver.as_deref()))
+            .or(manifest.provider_hint.as_deref())
+            .unwrap_or(&state.default_driver);
+
+        let provider_default = state
+            .provider_models
+            .get(driver_name)
+            .map(|c| c.default_model.as_str());
+
+        let model_name = agent_cfg
+            .and_then(|c| c.model.as_deref())
+            .or_else(|| legacy_override.and_then(|c| c.model.as_deref()))
+            .or(manifest.model.as_deref())
+            .or(provider_default)
+            .unwrap_or("unknown");
+
+        let driver = state
+            .drivers
+            .get(driver_name)
+            .context(error::ProviderNotConfiguredSnafu)?;
+
+        Ok(ResolvedAgent {
+            driver:   Arc::clone(driver),
+            model:    model_name.to_string(),
+            manifest: manifest.clone(),
+        })
     }
 
     /// Get the default driver name.
@@ -218,5 +331,117 @@ impl DriverRegistry {
         let next_state = next.state.read().unwrap_or_else(|e| e.into_inner()).clone();
         let mut state = self.state.write().unwrap_or_else(|e| e.into_inner());
         *state = next_state;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        agent::{AgentRole, Priority},
+        llm::ScriptedLlmDriver,
+    };
+
+    fn manifest(name: &str) -> AgentManifest {
+        AgentManifest {
+            name:                   name.to_string(),
+            role:                   AgentRole::Chat,
+            description:            "test".to_string(),
+            model:                  None,
+            system_prompt:          "sp".to_string(),
+            soul_prompt:            None,
+            provider_hint:          None,
+            max_iterations:         None,
+            tools:                  Vec::new(),
+            excluded_tools:         Vec::new(),
+            max_children:           None,
+            max_context_tokens:     None,
+            priority:               Priority::default(),
+            metadata:               serde_json::Value::Null,
+            sandbox:                None,
+            default_execution_mode: None,
+            tool_call_limit:        None,
+            worker_timeout_secs:    None,
+            max_continuations:      None,
+        }
+    }
+
+    fn registry_with_providers() -> DriverRegistry {
+        let catalog = Arc::new(OpenRouterCatalog::new());
+        let reg = DriverRegistry::new("openrouter", catalog);
+        reg.register_driver("openrouter", Arc::new(ScriptedLlmDriver::new(Vec::new())));
+        reg.register_driver("ollama", Arc::new(ScriptedLlmDriver::new(Vec::new())));
+        reg.set_provider_model("openrouter", "gpt-4o", Vec::<String>::new());
+        reg.set_provider_model("ollama", "qwen3:32b", Vec::<String>::new());
+        reg
+    }
+
+    #[test]
+    fn resolve_agent_returns_agent_specific_pair() {
+        let reg = registry_with_providers();
+        reg.set_agent_config(
+            "knowledge_extractor",
+            AgentLlmConfig {
+                driver: Some("ollama".into()),
+                model:  Some("qwen3:14b".into()),
+            },
+        );
+
+        let m = manifest("knowledge_extractor");
+        let resolved = reg.resolve_agent(&m).expect("resolve_agent");
+        assert_eq!(resolved.model, "qwen3:14b");
+        assert_eq!(resolved.manifest.name, "knowledge_extractor");
+    }
+
+    #[test]
+    fn resolve_agent_falls_back_to_manifest_then_provider_default() {
+        let reg = registry_with_providers();
+
+        // Manifest-only model, no per-agent YAML config.
+        let mut m = manifest("rara");
+        m.model = Some("gpt-4o-mini".into());
+        let resolved = reg.resolve_agent(&m).expect("resolve_agent");
+        assert_eq!(resolved.model, "gpt-4o-mini");
+
+        // Pure fallback to provider default.
+        let m_empty = manifest("blank");
+        let resolved = reg.resolve_agent(&m_empty).expect("resolve_agent");
+        assert_eq!(resolved.model, "gpt-4o");
+    }
+
+    #[test]
+    fn resolve_agent_errors_when_driver_unknown() {
+        let catalog = Arc::new(OpenRouterCatalog::new());
+        let reg = DriverRegistry::new("missing", catalog);
+        // No driver registered.
+        let m = manifest("ghost");
+        let result = reg.resolve_agent(&m);
+        assert!(result.is_err(), "expected error for unknown driver");
+        match result {
+            Err(crate::error::KernelError::ProviderNotConfigured { .. }) => {}
+            other => panic!("unexpected result variant: {:?}", other.err()),
+        }
+    }
+
+    #[test]
+    fn legacy_resolve_shim_still_works() {
+        let reg = registry_with_providers();
+        reg.set_agent_override(
+            "rara",
+            AgentDriverConfig {
+                driver: Some("ollama".into()),
+                model:  Some("qwen3:32b".into()),
+            },
+        );
+
+        let (driver, model) = reg.resolve("rara", None, None).expect("resolve");
+        assert_eq!(model, "qwen3:32b");
+        // Driver reference is non-null — smoke check that the Arc resolved.
+        drop(driver);
+
+        // Unknown agent still falls back to the default driver + its default
+        // model, proving the legacy path is untouched by the new API.
+        let (_, model) = reg.resolve("unknown", None, None).expect("resolve");
+        assert_eq!(model, "gpt-4o");
     }
 }


### PR DESCRIPTION
## Summary

Part of Epic #1631. Adds `DriverRegistry::resolve_agent` returning a unified `ResolvedAgent { driver, model, manifest }` triple, sourced from `agents.<name>.{driver, model}` YAML with fallback to manifest hints and provider defaults.

Today background agents (knowledge_extractor, title_gen) pick up their driver via `DriverRegistry::resolve` but their model via a flat settings key like `knowledge.extractor_model`. In prod this caused the driver to resolve to MiniMax while the model stayed `gpt-4o-mini`, so every extraction silently 400'd. This PR adds the unified API; consumer migration is tracked in follow-up issues.

- `ResolvedAgent`, `AgentLlmConfig` re-exported from `llm::`
- `DriverRegistry::set_agent_config` to seed the new YAML shape
- Legacy `DriverRegistry::resolve` kept intact as a thin shim
- Unit tests: agent-specific pair, manifest/provider fallback, unknown-driver error, legacy shim
- `crates/kernel/AGENT.md` documents the new contract

## Type of change

| Type | Label |
|------|-------|
| New feature | `enhancement` |

## Component

`core`

## Closes

Closes #1635

## Test plan

- [x] `cargo check -p rara-kernel` passes
- [x] `cargo test -p rara-kernel --lib llm::registry::` — 4/4 passed
- [x] `prek run --all-files` green (check/fmt/clippy/doc/agent-md)