### PR TITLE
feat(kernel): reject empty turns, route failures to error bus (#1633)

### DIFF
--- a/crates/kernel/src/agent/mod.rs
+++ b/crates/kernel/src/agent/mod.rs
@@ -21,6 +21,9 @@ pub(crate) mod repetition;
 pub mod runner;
 pub mod scheduled;
 mod talk_normal;
+pub mod turn_error;
+
+pub use turn_error::{TURN_ERROR_EVENT_TYPE, TurnError, TurnFailureKind};
 
 /// Maximum **byte** length for child/worker agent results passed back to
 /// the parent context.  Child agents are instructed to self-summarize
@@ -1493,6 +1496,11 @@ pub(crate) async fn run_agent_loop(
         let mut has_tool_calls = false;
         let mut last_usage: Option<llm::Usage> = None;
         let mut last_stop_reason: Option<llm::StopReason> = None;
+        // Most recent driver-reported stream failure for this iteration.
+        // `None` on a healthy stream. When `Some(_)` after the stream closes,
+        // the iteration is converted into a `TurnError` and published on the
+        // event bus instead of writing an empty record to tape.
+        let mut stream_failure: Option<llm::StreamFailure> = None;
         // Per-iteration reasoning timer — set on the first ReasoningDelta,
         // settled (added to cumulative_thinking_ms) on either:
         //   a) the first TextDelta (reasoning → content transition), or
@@ -1594,12 +1602,12 @@ pub(crate) async fn run_agent_loop(
                     }
                 }
                 llm::StreamDelta::Failure(failure) => {
-                    // Driver-reported stream failure. Log + fall through;
-                    // the subsequent Done event still closes the turn. Richer
-                    // handling (tape suppression, user-facing error) is
-                    // addressed in the next sub-PR of the streaming-robustness
-                    // epic; behavior here must remain identical to pre-PR.
+                    // Driver-reported stream failure. Retain the latest one
+                    // for post-stream handling (event-bus publication + tape
+                    // suppression) and fall through — the subsequent `Done`
+                    // event still closes the stream cleanly.
                     warn!(iteration, ?failure, "driver reported stream failure");
+                    stream_failure = Some(failure);
                 }
                 llm::StreamDelta::Done { stop_reason, usage } => {
                     if stop_reason == llm::StopReason::ToolCalls && pending_tool_calls.is_empty() {
@@ -2007,6 +2015,51 @@ pub(crate) async fn run_agent_loop(
                     .await;
                 continue;
             }
+            // Reject empty terminal turns: nudges and recoveries had their
+            // chance; writing an empty `[assistant]:` record to tape would
+            // strand the user with no reply AND poison subsequent context
+            // rebuilds. Convert to a structured `TurnError`, publish it on
+            // the event bus for downstream consumers (telegram adapter,
+            // `/status`), and fail the turn so the caller can surface the
+            // failure instead of delivering an empty message.
+            if accumulated_text.trim().is_empty() || stream_failure.is_some() {
+                let failure_kind = stream_failure
+                    .take()
+                    .map(turn_error::TurnFailureKind::from)
+                    .unwrap_or(turn_error::TurnFailureKind::EmptyTurn);
+                let summary = turn_error::TurnError::short_summary(&failure_kind, model.as_str());
+                let turn_err = turn_error::TurnError::builder()
+                    .session_key(session_key)
+                    .model(model.to_string())
+                    .iteration(iteration)
+                    .failure_kind(failure_kind)
+                    .message(summary.clone())
+                    .build();
+
+                error!(
+                    iteration,
+                    model = model.as_str(),
+                    summary = %summary,
+                    "turn terminated with no usable assistant content — emitting TurnError"
+                );
+
+                match serde_json::to_value(&turn_err) {
+                    Ok(payload) => {
+                        if let Err(e) = handle
+                            .publish_event(session_key, turn_error::TURN_ERROR_EVENT_TYPE, payload)
+                            .await
+                        {
+                            warn!(error = %e, "failed to publish turn.error event");
+                        }
+                    }
+                    Err(e) => {
+                        warn!(error = %e, "failed to serialize TurnError payload");
+                    }
+                }
+
+                return Err(KernelError::AgentExecution { message: summary });
+            }
+
             // Persist final assistant message to tape.
             let meta = serde_json::to_value(crate::memory::LlmEntryMetadata {
                 rara_message_id: rara_message_id.to_string(),

--- a/crates/kernel/src/agent/turn_error.rs
+++ b/crates/kernel/src/agent/turn_error.rs
@@ -1,0 +1,156 @@
+// Copyright 2025 Rararulab
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Structured error reported for a failed LLM turn.
+//!
+//! A [`TurnError`] is emitted when a turn cannot produce a usable assistant
+//! reply — either because the driver surfaced a [`crate::llm::StreamFailure`]
+//! or because the iteration terminated with empty content and no tool calls
+//! after all recovery attempts were exhausted.
+//!
+//! [`TurnError`] is published to the kernel event bus (event type
+//! `turn.error`) so downstream consumers (telegram adapter, `/status`
+//! endpoint, observability sinks) can surface the failure to the user rather
+//! than leaving them staring at an empty "thinking" indicator.
+
+use serde::{Deserialize, Serialize};
+
+use crate::{llm::StreamFailure, session::SessionKey};
+
+/// Event type label used when publishing [`TurnError`] to the kernel event
+/// bus via [`crate::handle::KernelHandle::publish_event`].
+pub const TURN_ERROR_EVENT_TYPE: &str = "turn.error";
+
+/// Classification of the root cause of a failed turn.
+///
+/// This mirrors [`StreamFailure`] where possible, plus additional kinds that
+/// are only detectable after the stream closes (e.g. an iteration ending
+/// with no content and no tool calls despite a clean `Done` signal).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum TurnFailureKind {
+    /// The driver closed the stream without assistant content, even after
+    /// attempting salvage from the reasoning buffer.
+    EmptyContent {
+        /// Size of the reasoning buffer at close. `0` when the failure was
+        /// detected by the agent loop itself rather than by the driver.
+        reasoning_len: usize,
+    },
+    /// The provider returned a non-retryable protocol error.
+    ProtocolError {
+        /// Provider-specific error code (e.g. MiniMax `"2013"`).
+        code:    String,
+        /// Provider-specific human-readable message.
+        message: String,
+    },
+    /// The iteration terminated with no text and no tool calls after all
+    /// recovery paths were exhausted (nudges, auto-fold + retry, etc.).
+    EmptyTurn,
+}
+
+impl From<StreamFailure> for TurnFailureKind {
+    fn from(value: StreamFailure) -> Self {
+        match value {
+            StreamFailure::EmptyContent { reasoning_len } => Self::EmptyContent { reasoning_len },
+            StreamFailure::ProtocolError { code, message } => Self::ProtocolError { code, message },
+        }
+    }
+}
+
+/// Structured description of a failed turn, suitable for publishing on the
+/// kernel event bus and surfacing to the user.
+///
+/// Construct via [`TurnError::builder`] and serialize into the event payload
+/// with `serde_json::to_value`. The payload MUST include a non-empty
+/// `message` field so the `PublishEvent` syscall does not drop it.
+#[derive(Debug, Clone, Serialize, Deserialize, bon::Builder)]
+pub struct TurnError {
+    /// Session that owned the failed turn.
+    pub session_key:  SessionKey,
+    /// Model identifier used for the turn (e.g. `"minimax/m2"`).
+    pub model:        String,
+    /// Provider request ID when available — otherwise `None`.
+    pub request_id:   Option<String>,
+    /// Iteration index within the turn at which the failure surfaced.
+    pub iteration:    usize,
+    /// Structured failure classification.
+    pub failure_kind: TurnFailureKind,
+    /// Human-readable summary used as the notification `message` body.
+    /// Required: the `PublishEvent` syscall drops payloads with an empty
+    /// `message` field.
+    pub message:      String,
+}
+
+impl TurnError {
+    /// Short human-readable tag for logging and the `message` field.
+    pub fn short_summary(failure_kind: &TurnFailureKind, model: &str) -> String {
+        match failure_kind {
+            TurnFailureKind::EmptyContent { reasoning_len } => {
+                format!(
+                    "model `{model}` produced no assistant content (reasoning_len={reasoning_len})"
+                )
+            }
+            TurnFailureKind::ProtocolError { code, message } => {
+                format!("provider `{model}` protocol error [{code}]: {message}")
+            }
+            TurnFailureKind::EmptyTurn => {
+                format!("model `{model}` ended turn with no content and no tool calls")
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn from_stream_failure_empty_content() {
+        let kind: TurnFailureKind = StreamFailure::EmptyContent { reasoning_len: 42 }.into();
+        assert_eq!(kind, TurnFailureKind::EmptyContent { reasoning_len: 42 });
+    }
+
+    #[test]
+    fn from_stream_failure_protocol_error() {
+        let kind: TurnFailureKind = StreamFailure::ProtocolError {
+            code:    "2013".into(),
+            message: "invalid message role: system".into(),
+        }
+        .into();
+        assert_eq!(
+            kind,
+            TurnFailureKind::ProtocolError {
+                code:    "2013".into(),
+                message: "invalid message role: system".into(),
+            }
+        );
+    }
+
+    #[test]
+    fn builder_round_trips_serde() {
+        let err = TurnError::builder()
+            .session_key(SessionKey::new())
+            .model("minimax/m2".to_string())
+            .iteration(3)
+            .failure_kind(TurnFailureKind::EmptyTurn)
+            .message("turn failed".to_string())
+            .build();
+        let value = serde_json::to_value(&err).expect("serialize");
+        let back: TurnError = serde_json::from_value(value).expect("deserialize");
+        assert_eq!(back.model, err.model);
+        assert_eq!(back.iteration, err.iteration);
+        assert_eq!(back.failure_kind, TurnFailureKind::EmptyTurn);
+        assert_eq!(back.message, "turn failed");
+    }
+}

--- a/crates/kernel/src/memory/context.rs
+++ b/crates/kernel/src/memory/context.rs
@@ -374,6 +374,50 @@ pub fn merge_leading_system_messages(messages: Vec<Message>) -> Vec<Message> {
     result
 }
 
+/// Prefix inserted when a non-leading system message is rewritten as a
+/// user-role message to satisfy providers that reject mid-stream `system`
+/// roles (e.g. MiniMax `invalid message role: system (2013)`).
+const SYSTEM_NOTE_PREFIX: &str = "[system note] ";
+
+/// Normalize the message list so that `Role::System` appears **only** at
+/// position 0.
+///
+/// Rationale: some providers (notably MiniMax) reject any chat-completion
+/// request that contains a `system` role after the first message with HTTP
+/// 400 `invalid message role: system (2013)`. Tape-driven context rebuilds
+/// can legitimately interleave system-role metadata (anchor summaries, user
+/// memory, ad-hoc system notes) into the middle of the stream, so we must
+/// rewrite any non-leading occurrence before dispatch.
+///
+/// Strategy:
+/// 1. Collapse every leading system message (position 0..k) into a single
+///    concatenated system message via [`merge_leading_system_messages`].
+/// 2. Rewrite any remaining `Role::System` message into a `Role::User` message
+///    prefixed with [`SYSTEM_NOTE_PREFIX`] so the semantic intent (out-of-band
+///    instruction) is preserved without abusing the `system` role the provider
+///    rejects.
+///
+/// The `user`-with-prefix form is a deliberate trade-off: an alternative
+/// would be to silently merge mid-stream system content back into the
+/// leading prompt, but that destroys the message's position in the
+/// conversation timeline. Preserving position as a `user` turn keeps the
+/// LLM's chronological reasoning intact.
+pub fn collapse_system_messages(messages: Vec<Message>) -> Vec<Message> {
+    let merged = merge_leading_system_messages(messages);
+    merged
+        .into_iter()
+        .enumerate()
+        .map(|(idx, msg)| {
+            if idx > 0 && msg.role == crate::llm::Role::System {
+                let text = msg.content.as_text().to_owned();
+                Message::user(format!("{SYSTEM_NOTE_PREFIX}{text}"))
+            } else {
+                msg
+            }
+        })
+        .collect()
+}
+
 #[cfg(test)]
 mod tests {
     use jiff::Timestamp;
@@ -765,6 +809,69 @@ mod tests {
         let merged = merge_leading_system_messages(messages);
         assert_eq!(merged.len(), 1);
         assert_eq!(merged[0].content.as_text(), "a\n\n---\n\nb");
+    }
+
+    #[test]
+    fn collapse_system_messages_merges_leading_and_rewrites_midstream() {
+        let messages = vec![
+            Message::system("prompt"),
+            Message::system("[User Memory]\nnotes"),
+            Message::user("hi"),
+            Message::assistant("hello"),
+            Message::system("mid-stream hint"),
+            Message::user("bye"),
+        ];
+        let out = collapse_system_messages(messages);
+        // One leading system, the rest mid-stream system has been rewritten.
+        let system_count = out.iter().filter(|m| m.role == Role::System).count();
+        assert_eq!(system_count, 1, "only position 0 should carry Role::System");
+        assert_eq!(out[0].role, Role::System);
+        assert!(out[0].content.as_text().contains("prompt"));
+        assert!(out[0].content.as_text().contains("[User Memory]"));
+        // Mid-stream system is now a user message with the prefix marker.
+        let rewritten = out
+            .iter()
+            .find(|m| m.role == Role::User && m.content.as_text().starts_with("[system note] "));
+        let rewritten = rewritten.expect("mid-stream system should be rewritten as user");
+        assert!(rewritten.content.as_text().contains("mid-stream hint"));
+    }
+
+    #[test]
+    fn collapse_system_messages_round_trip_no_midstream_system() {
+        let messages = vec![
+            Message::system("prompt"),
+            Message::user("hi"),
+            Message::assistant("hello"),
+        ];
+        let out = collapse_system_messages(messages.clone());
+        assert_eq!(out.len(), messages.len());
+        assert_eq!(out[0].role, Role::System);
+        assert_eq!(out[1].role, Role::User);
+        assert_eq!(out[2].role, Role::Assistant);
+    }
+
+    #[test]
+    fn collapse_system_messages_empty() {
+        assert!(collapse_system_messages(vec![]).is_empty());
+    }
+
+    #[test]
+    fn collapse_system_messages_multiple_midstream() {
+        let messages = vec![
+            Message::system("prompt"),
+            Message::user("hi"),
+            Message::system("hint A"),
+            Message::system("hint B"),
+            Message::assistant("ok"),
+        ];
+        let out = collapse_system_messages(messages);
+        let system_count = out.iter().filter(|m| m.role == Role::System).count();
+        assert_eq!(system_count, 1);
+        let rewritten: Vec<_> = out
+            .iter()
+            .filter(|m| m.role == Role::User && m.content.as_text().starts_with("[system note] "))
+            .collect();
+        assert_eq!(rewritten.len(), 2);
     }
 
     #[test]

--- a/crates/kernel/src/memory/service.rs
+++ b/crates/kernel/src/memory/service.rs
@@ -370,10 +370,12 @@ impl TapeService {
         };
         messages.extend(history);
 
-        // Merge all leading system messages into one for providers with strict
-        // chat templates (e.g. Qwen via llama.cpp) that require a single
-        // system message at position 0.
-        Ok(super::context::merge_leading_system_messages(messages))
+        // Collapse every `system` role into position 0: merge leading system
+        // messages and rewrite any mid-stream `system` message as a prefixed
+        // `user` turn. This is mandatory for providers that reject non-first
+        // system roles (MiniMax `invalid message role: system (2013)`) and
+        // safe for providers that tolerate them.
+        Ok(super::context::collapse_system_messages(messages))
     }
 
     // -----------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Second sub-PR of streaming-robustness epic #1630. Builds on #1639.

- Consume `StreamDelta::Failure` in the agent loop and route empty/protocol-error turns to a structured `TurnError` published on the kernel event bus (`turn.error`) via `KernelHandle::publish_event`, instead of the previous `warn!`-and-fall-through placeholder.
- Reject empty terminal turns before the tape write: no more empty `[assistant]:` records. Failing iterations return `KernelError::AgentExecution` so the caller surfaces the failure to the user.
- Add `context::collapse_system_messages`: merges leading `system` messages into position 0 and rewrites any mid-stream `system` message as a `user` turn prefixed with `[system note] `. This makes MiniMax 400 `invalid message role: system (2013)` impossible to produce at the message-assembly layer. Wired into `TapeService::rebuild_messages_for_llm`.
- Unit tests: `TurnFailureKind` conversion from `StreamFailure`, `TurnError` serde round-trip, four `collapse_system_messages` scenarios.

Telegram adapter integration is out of scope — tracked in #1634, which will consume the `turn.error` event.

## Type of change

| Type | Label |
|------|-------|
| New feature | `enhancement` |

## Component

`core`

## Closes

Closes #1633

## Test plan

- [x] `cargo test -p rara-kernel` — 550 passed
- [x] `prek run --all-files` — all hooks pass
- [x] New unit tests cover conversion, serde round-trip, and system-message collapse