### PR TITLE
refactor(kernel): migrate knowledge_extractor to unified agent registry (#1636)

### DIFF
--- a/crates/agents/src/lib.rs
+++ b/crates/agents/src/lib.rs
@@ -163,6 +163,12 @@ static MITA_MANIFEST: LazyLock<AgentManifest> = LazyLock::new(|| AgentManifest {
 /// observes sessions and dispatches instructions to Rara.
 pub fn mita() -> &'static AgentManifest { &MITA_MANIFEST }
 
+// Knowledge extractor manifest lives in `rara_kernel::memory::knowledge`
+// because the extraction pipeline itself is defined in the kernel — the
+// manifest must be visible to the `DriverRegistry::resolve_agent` call
+// site there, and `rara-kernel` sits below `rara-agents` in the
+// dependency DAG. See `crates/kernel/src/memory/knowledge/manifest.rs`.
+
 // ---------------------------------------------------------------------------
 // ScheduledJob — dedicated agent for scheduled task execution
 // ---------------------------------------------------------------------------

--- a/crates/app/src/boot.rs
+++ b/crates/app/src/boot.rs
@@ -448,6 +448,58 @@ async fn build_driver_registry(
         }
     }
 
+    // -- unified per-agent configs (agents.<name>.{driver, model}) ---------------
+    //
+    // Introduced in #1636. Populates the `DriverRegistry::resolve_agent` lookup
+    // table that the knowledge extractor (and future consumers) read from.
+    // Boot fails fast if `agents.knowledge_extractor.{driver, model}` is missing
+    // — the prod failure in #1629 showed we cannot silently fall back.
+    let unified_agent_names: BTreeSet<&str> = all_settings
+        .keys()
+        .filter_map(|k| k.strip_prefix("agents."))
+        .filter_map(|k| k.split('.').next())
+        .collect();
+
+    for &agent in &unified_agent_names {
+        let driver = all_settings
+            .get(&format!("agents.{agent}.driver"))
+            .filter(|v| !v.trim().is_empty())
+            .cloned();
+        let model = all_settings
+            .get(&format!("agents.{agent}.model"))
+            .filter(|v| !v.trim().is_empty())
+            .cloned();
+
+        if driver.is_some() || model.is_some() {
+            info!(agent, ?driver, ?model, "unified agent LLM config");
+            registry.set_agent_config(
+                agent,
+                rara_kernel::llm::registry::AgentLlmConfig { driver, model },
+            );
+        }
+    }
+
+    // Required binding: the knowledge extractor must have both driver + model
+    // so resolve_agent() never falls back to a mismatched default. Fail boot
+    // with an actionable error if missing.
+    {
+        let name = rara_kernel::memory::knowledge::KNOWLEDGE_EXTRACTOR_NAME;
+        let driver = all_settings
+            .get(&format!("agents.{name}.driver"))
+            .filter(|v| !v.trim().is_empty());
+        let model = all_settings
+            .get(&format!("agents.{name}.model"))
+            .filter(|v| !v.trim().is_empty());
+        if driver.is_none() || model.is_none() {
+            anyhow::bail!(
+                "agents.{name}.{{driver, model}} must be configured in config.yaml — the \
+                 knowledge extraction pipeline requires an explicit driver + model pair (see \
+                 issue #1636). Example:\n\nagents:\n  {name}:\n    driver: \"openrouter\"\n    \
+                 model: \"gpt-4o-mini\"\n"
+            );
+        }
+    }
+
     // -- codex (ChatGPT backend via OAuth) — uses Responses API ----------------
 
     match rara_codex_oauth::load_tokens().await {

--- a/crates/app/src/config_sync.rs
+++ b/crates/app/src/config_sync.rs
@@ -88,6 +88,7 @@ impl ConfigFileSync {
             cfg.telegram = new_config.telegram;
             cfg.composio = new_config.composio;
             cfg.knowledge = new_config.knowledge;
+            cfg.agents = new_config.agents;
         }
         info!("config.yaml synced to settings store");
         Ok(())
@@ -96,7 +97,7 @@ impl ConfigFileSync {
     /// Write current settings back to config.yaml.
     async fn writeback_to_file(&self) -> anyhow::Result<()> {
         let all_settings = self.settings.list().await;
-        let (llm, telegram, wechat, composio, knowledge) =
+        let (llm, telegram, wechat, composio, knowledge, agents) =
             flatten::unflatten_from_settings(&all_settings);
 
         let yaml = {
@@ -106,6 +107,7 @@ impl ConfigFileSync {
             cfg.wechat = wechat;
             cfg.composio = composio;
             cfg.knowledge = knowledge;
+            cfg.agents = agents;
             serde_yaml::to_string(&*cfg)?
         };
 
@@ -295,6 +297,11 @@ knowledge:
   search_top_k: 10
   similarity_threshold: 0.85
   extractor_model: "gpt-4o-mini"
+
+agents:
+  knowledge_extractor:
+    driver: "openrouter"
+    model: "gpt-4o-mini"
 
 gateway:
   repo_url: "https://github.com/example/repo"

--- a/crates/app/src/flatten.rs
+++ b/crates/app/src/flatten.rs
@@ -153,6 +153,37 @@ pub struct KnowledgeConfig {
 }
 
 // ---------------------------------------------------------------------------
+// Agents config — per-agent `{driver, model}` bindings
+// ---------------------------------------------------------------------------
+
+/// Per-agent LLM binding. Mirrors
+/// [`rara_kernel::llm::AgentLlmConfig`] and is loaded from
+/// `agents.<name>.{driver, model}` in config.yaml.
+///
+/// ```yaml
+/// agents:
+///   knowledge_extractor:
+///     driver: "openrouter"
+///     model: "gpt-4o-mini"
+/// ```
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(default)]
+pub struct AgentBinding {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub driver: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub model:  Option<String>,
+}
+
+/// Top-level `agents:` section — map from agent name to `{driver, model}`.
+///
+/// Introduced by #1636 as the unified replacement for scattered flat
+/// settings (e.g. the legacy `memory.knowledge.extractor_model`).
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct AgentsConfig(pub HashMap<String, AgentBinding>);
+
+// ---------------------------------------------------------------------------
 // Flatten logic
 // ---------------------------------------------------------------------------
 
@@ -174,7 +205,21 @@ pub fn flatten_config_sections(config: &AppConfig) -> Vec<(String, String)> {
     if let Some(ref k) = config.knowledge {
         flatten_knowledge(k, &mut pairs);
     }
+    if let Some(ref a) = config.agents {
+        flatten_agents(a, &mut pairs);
+    }
     pairs
+}
+
+fn flatten_agents(agents: &AgentsConfig, out: &mut Vec<(String, String)>) {
+    for (name, binding) in &agents.0 {
+        if let Some(ref v) = binding.driver {
+            out.push((format!("agents.{name}.driver"), v.clone()));
+        }
+        if let Some(ref v) = binding.model {
+            out.push((format!("agents.{name}.model"), v.clone()));
+        }
+    }
 }
 
 fn flatten_llm(llm: &LlmConfig, out: &mut Vec<(String, String)>) {
@@ -276,6 +321,7 @@ pub fn unflatten_from_settings<S: std::hash::BuildHasher>(
     Option<WechatConfig>,
     Option<ComposioConfig>,
     Option<KnowledgeConfig>,
+    Option<AgentsConfig>,
 ) {
     (
         unflatten_llm(pairs),
@@ -283,7 +329,32 @@ pub fn unflatten_from_settings<S: std::hash::BuildHasher>(
         unflatten_wechat(pairs),
         unflatten_composio(pairs),
         unflatten_knowledge(pairs),
+        unflatten_agents(pairs),
     )
+}
+
+fn unflatten_agents(
+    pairs: &HashMap<String, String, impl std::hash::BuildHasher>,
+) -> Option<AgentsConfig> {
+    let prefix = "agents.";
+    let mut names: std::collections::HashSet<String> = std::collections::HashSet::new();
+    for key in pairs.keys() {
+        if let Some(rest) = key.strip_prefix(prefix) {
+            if let Some(dot) = rest.find('.') {
+                names.insert(rest[..dot].to_string());
+            }
+        }
+    }
+    if names.is_empty() {
+        return None;
+    }
+    let mut out = HashMap::new();
+    for name in names {
+        let driver = pairs.get(&format!("agents.{name}.driver")).cloned();
+        let model = pairs.get(&format!("agents.{name}.model")).cloned();
+        out.insert(name, AgentBinding { driver, model });
+    }
+    Some(AgentsConfig(out))
 }
 
 fn unflatten_llm(
@@ -470,7 +541,8 @@ mod tests {
         let map: HashMap<String, String> = flat.into_iter().collect();
 
         // Unflatten
-        let (got_llm, got_tg, _got_wechat, got_composio, got_know) = unflatten_from_settings(&map);
+        let (got_llm, got_tg, _got_wechat, got_composio, got_know, _got_agents) =
+            unflatten_from_settings(&map);
 
         // --- LLM ---
         let got_llm = got_llm.expect("llm should be Some");
@@ -516,11 +588,34 @@ mod tests {
     #[test]
     fn unflatten_empty_map_returns_none() {
         let map = HashMap::new();
-        let (llm, tg, wechat, composio, know) = unflatten_from_settings(&map);
+        let (llm, tg, wechat, composio, know, agents) = unflatten_from_settings(&map);
         assert!(wechat.is_none());
         assert!(llm.is_none());
         assert!(tg.is_none());
         assert!(composio.is_none());
         assert!(know.is_none());
+        assert!(agents.is_none());
+    }
+
+    #[test]
+    fn agents_roundtrip_flatten_unflatten() {
+        let mut m = HashMap::new();
+        m.insert(
+            "knowledge_extractor".to_string(),
+            AgentBinding {
+                driver: Some("openrouter".into()),
+                model:  Some("gpt-4o-mini".into()),
+            },
+        );
+        let agents = AgentsConfig(m);
+
+        let mut flat = Vec::new();
+        flatten_agents(&agents, &mut flat);
+        let map: HashMap<String, String> = flat.into_iter().collect();
+
+        let got = unflatten_agents(&map).expect("agents should be Some");
+        let b = got.0.get("knowledge_extractor").expect("binding present");
+        assert_eq!(b.driver.as_deref(), Some("openrouter"));
+        assert_eq!(b.model.as_deref(), Some("gpt-4o-mini"));
     }
 }

--- a/crates/app/src/lib.rs
+++ b/crates/app/src/lib.rs
@@ -97,6 +97,16 @@ pub struct AppConfig {
     /// Knowledge layer configuration (seeded to settings store at startup).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub knowledge:              Option<flatten::KnowledgeConfig>,
+    /// Per-agent `{driver, model}` bindings (unified registry; #1636).
+    ///
+    /// ```yaml
+    /// agents:
+    ///   knowledge_extractor:
+    ///     driver: "openrouter"
+    ///     model: "gpt-4o-mini"
+    /// ```
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub agents:                 Option<flatten::AgentsConfig>,
     /// Speech-to-Text configuration (optional).
     /// When present, `base_url` is required — startup fails if missing.
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/crates/kernel/AGENT.md
+++ b/crates/kernel/AGENT.md
@@ -14,6 +14,23 @@ like `knowledge.extractor_model`) should not reappear. The legacy
 `DriverRegistry::resolve` tuple API is kept as a thin shim for existing
 callers; migration is tracked in follow-up issues under Epic #1631.
 
+### Migrated consumers
+
+- `memory/knowledge/extractor.rs` — #1636 / #1629. Reads
+  `agents.knowledge_extractor.{driver, model}`. Boot fails fast if the
+  pair is missing. `extract_knowledge` now takes a `&ResolvedAgent` so
+  driver + model can never disagree. Example config:
+
+  ```yaml
+  agents:
+    knowledge_extractor:
+      driver: "openrouter"
+      model: "gpt-4o-mini"
+  ```
+
+  Extraction failures now emit at `error!` level (previously `warn!`,
+  which hid the MiniMax/gpt-4o-mini split-config bug in prod).
+
 ## Critical: StreamDelta Event Ordering in `openai.rs`
 
 ### The Invariant

--- a/crates/kernel/src/kernel.rs
+++ b/crates/kernel/src/kernel.rs
@@ -3094,22 +3094,27 @@ impl Kernel {
             let user_id = user.0.clone();
             let tape_name = session_key.to_string();
             tokio::spawn(async move {
-                let extractor_model = &knowledge.extractor_model;
-                let driver = match driver_registry.resolve(
-                    "knowledge_extractor",
-                    None,
-                    Some(extractor_model),
-                ) {
-                    Ok((d, _model_name)) => d,
+                // Resolve `{driver, model}` as one atomic lookup keyed by the
+                // extractor's manifest — not a driver + flat model string.
+                // This closes the prod failure in #1629 where MiniMax was
+                // called with `gpt-4o-mini`.
+                let manifest = crate::memory::knowledge::knowledge_extractor_manifest();
+                let resolved = match driver_registry.resolve_agent(manifest) {
+                    Ok(r) => r,
                     Err(e) => {
-                        tracing::warn!(%e, "knowledge extraction: cannot resolve model");
+                        tracing::error!(
+                            %e,
+                            agent = crate::memory::knowledge::KNOWLEDGE_EXTRACTOR_NAME,
+                            "knowledge extraction: failed to resolve agent — check \
+                             `agents.knowledge_extractor.{{driver, model}}` in config.yaml"
+                        );
                         return;
                     }
                 };
                 let entries = match tape_service.from_last_anchor(&tape_name, None).await {
                     Ok(e) => e,
                     Err(e) => {
-                        tracing::warn!(%e, "knowledge extraction: failed to read tape");
+                        tracing::error!(%e, "knowledge extraction: failed to read tape");
                         return;
                     }
                 };
@@ -3119,8 +3124,7 @@ impl Kernel {
                     &tape_name,
                     &knowledge.pool,
                     &knowledge.embedding_svc,
-                    driver.as_ref(),
-                    extractor_model,
+                    &resolved,
                     knowledge.config.similarity_threshold,
                 )
                 .await
@@ -3130,7 +3134,14 @@ impl Kernel {
                     }
                     Ok(_) => {}
                     Err(e) => {
-                        tracing::warn!(user = %user_id, %e, "knowledge extraction failed");
+                        // Upgraded from WARN to ERROR (#1636): a silent WARN
+                        // masked every extraction failing in prod for days.
+                        tracing::error!(
+                            user = %user_id,
+                            model = %resolved.model,
+                            %e,
+                            "knowledge extraction failed"
+                        );
                     }
                 }
             });

--- a/crates/kernel/src/memory/knowledge/extractor.rs
+++ b/crates/kernel/src/memory/knowledge/extractor.rs
@@ -31,7 +31,7 @@ use super::{
     items::{self, NewMemoryItem},
 };
 use crate::{
-    llm::{CompletionRequest, LlmDriver, Message, ToolChoice},
+    llm::{CompletionRequest, LlmDriver, Message, ResolvedAgent, ToolChoice},
     memory::{TapEntry, TapEntryKind},
 };
 
@@ -89,10 +89,15 @@ pub async fn extract_knowledge(
     tape_name: &str,
     pool: &SqlitePool,
     embedding_svc: &EmbeddingService,
-    driver: &dyn LlmDriver,
-    extractor_model: &str,
+    agent: &ResolvedAgent,
     similarity_threshold: f32,
 ) -> Result<usize> {
+    // Driver + model are bound together by `ResolvedAgent` — closing the
+    // split-config bug where the driver came from the registry but the
+    // model came from a flat settings key (#1629 / #1636).
+    let driver = agent.driver.as_ref();
+    let extractor_model = agent.model.as_str();
+
     // Step 1: Build conversation text from tape entries.
     let conversation = build_conversation_text(entries);
     if conversation.is_empty() {
@@ -311,4 +316,117 @@ async fn update_category_files(
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use serde_json::json;
+
+    use super::*;
+    use crate::{
+        agent::{AgentRole, Priority},
+        llm::{
+            AgentLlmConfig, CompletionResponse, DriverRegistry, OpenRouterCatalog,
+            ScriptedLlmDriver, StopReason,
+        },
+        memory::{TapEntry, TapEntryKind},
+    };
+
+    fn manifest(name: &str) -> crate::agent::AgentManifest {
+        crate::agent::AgentManifest {
+            name:                   name.to_string(),
+            role:                   AgentRole::Worker,
+            description:            "test".into(),
+            model:                  None,
+            system_prompt:          String::new(),
+            soul_prompt:            None,
+            provider_hint:          None,
+            max_iterations:         None,
+            tools:                  Vec::new(),
+            excluded_tools:         Vec::new(),
+            max_children:           None,
+            max_context_tokens:     None,
+            priority:               Priority::default(),
+            metadata:               serde_json::Value::Null,
+            sandbox:                None,
+            default_execution_mode: None,
+            tool_call_limit:        None,
+            worker_timeout_secs:    None,
+            max_continuations:      None,
+        }
+    }
+
+    /// Verifies the split-config bug fix from #1629 / #1636: the model
+    /// that reaches the driver MUST come from `ResolvedAgent.model`, not
+    /// from any other source.
+    #[tokio::test]
+    async fn llm_call_uses_model_from_resolved_agent() {
+        // Scripted driver returns an empty JSON array so extraction exits
+        // cleanly after capturing the first request.
+        let scripted = Arc::new(ScriptedLlmDriver::new(vec![CompletionResponse {
+            content:           Some("[]".into()),
+            reasoning_content: None,
+            tool_calls:        Vec::new(),
+            stop_reason:       StopReason::Stop,
+            usage:             None,
+            model:             "scripted".into(),
+        }]));
+
+        let catalog = Arc::new(OpenRouterCatalog::new());
+        let reg = DriverRegistry::new("openrouter", catalog);
+        reg.register_driver("openrouter", Arc::clone(&scripted) as _);
+        reg.set_provider_model("openrouter", "provider-default", Vec::<String>::new());
+        // The unified agent config is what `resolve_agent` honours first.
+        reg.set_agent_config(
+            super::super::KNOWLEDGE_EXTRACTOR_NAME,
+            AgentLlmConfig {
+                driver: Some("openrouter".into()),
+                model:  Some("unified-agents-model".into()),
+            },
+        );
+
+        let m = manifest(super::super::KNOWLEDGE_EXTRACTOR_NAME);
+        let resolved = reg.resolve_agent(&m).expect("resolve_agent");
+        assert_eq!(resolved.model, "unified-agents-model");
+
+        // Drive `llm_extract_items` directly — it is the pure LLM boundary
+        // that used to be called with the wrong model in prod.
+        let driver_ref: &dyn LlmDriver = resolved.driver.as_ref();
+        let _ = llm_extract_items(driver_ref, &resolved.model, "hello")
+            .await
+            .expect("extraction ok");
+
+        let reqs = scripted.captured_requests();
+        assert_eq!(reqs.len(), 1, "exactly one completion");
+        assert_eq!(
+            reqs[0].model, "unified-agents-model",
+            "model sent to driver must be the one resolved via resolve_agent, not a flat key"
+        );
+    }
+
+    #[test]
+    fn build_conversation_text_skips_non_message_entries() {
+        let now = jiff::Timestamp::now();
+        let entries = vec![
+            TapEntry {
+                id:        1,
+                kind:      TapEntryKind::Message,
+                payload:   json!({"role": "user", "content": "hi"}),
+                timestamp: now,
+                metadata:  None,
+            },
+            TapEntry {
+                id:        2,
+                kind:      TapEntryKind::ToolCall,
+                payload:   json!({"role": "assistant", "content": "ignored"}),
+                timestamp: now,
+                metadata:  None,
+            },
+        ];
+        let text = build_conversation_text(&entries);
+        assert!(text.contains("[user]: hi"));
+        assert!(!text.contains("ignored"));
+    }
 }

--- a/crates/kernel/src/memory/knowledge/manifest.rs
+++ b/crates/kernel/src/memory/knowledge/manifest.rs
@@ -1,0 +1,64 @@
+// Copyright 2025 Rararulab
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Built-in manifest for the knowledge extraction background pipeline.
+//!
+//! The extractor is not a user-facing conversational agent — it is a
+//! background worker whose LLM binding MUST be resolved through
+//! [`crate::llm::DriverRegistry::resolve_agent`]. That path reads
+//! `agents.knowledge_extractor.{driver, model}` from YAML so the driver
+//! and the model always come from the same source, closing the
+//! split-config bug that caused every extraction to 400 in prod
+//! (see #1629 / #1636).
+
+use std::sync::LazyLock;
+
+use crate::agent::{AgentManifest, AgentRole, Priority};
+
+/// Canonical agent name for the knowledge extraction pipeline.
+///
+/// Exposed as a constant so the kernel call site, the boot crate's
+/// config validation, and any future consumers agree on the exact key
+/// used for `agents.<name>.{driver, model}` YAML lookups.
+pub const KNOWLEDGE_EXTRACTOR_NAME: &str = "knowledge_extractor";
+
+static KNOWLEDGE_EXTRACTOR_MANIFEST: LazyLock<AgentManifest> = LazyLock::new(|| AgentManifest {
+    name:                   KNOWLEDGE_EXTRACTOR_NAME.to_string(),
+    role:                   AgentRole::Worker,
+    description:            "Knowledge extraction pipeline — turns conversation tapes into \
+                             long-term memory items"
+        .to_string(),
+    // `model` is deliberately `None`: the concrete model MUST be supplied
+    // via `agents.knowledge_extractor.model` YAML so driver + model are
+    // resolved atomically through `DriverRegistry::resolve_agent`.
+    model:                  None,
+    system_prompt:          String::new(),
+    soul_prompt:            None,
+    provider_hint:          None,
+    max_iterations:         Some(1),
+    tools:                  vec![],
+    excluded_tools:         vec![],
+    max_children:           Some(0),
+    max_context_tokens:     None,
+    priority:               Priority::default(),
+    metadata:               serde_json::Value::Null,
+    sandbox:                None,
+    default_execution_mode: None,
+    tool_call_limit:        None,
+    worker_timeout_secs:    None,
+    max_continuations:      Some(0),
+});
+
+/// Return the static knowledge extractor manifest.
+pub fn knowledge_extractor_manifest() -> &'static AgentManifest { &KNOWLEDGE_EXTRACTOR_MANIFEST }

--- a/crates/kernel/src/memory/knowledge/mod.rs
+++ b/crates/kernel/src/memory/knowledge/mod.rs
@@ -25,10 +25,12 @@ pub mod config;
 pub mod embedding;
 pub mod extractor;
 pub mod items;
+pub mod manifest;
 pub mod service;
 pub mod tool;
 
 pub use config::KnowledgeConfig;
 pub use embedding::EmbeddingService;
+pub use manifest::{KNOWLEDGE_EXTRACTOR_NAME, knowledge_extractor_manifest};
 pub use service::{KnowledgeService, KnowledgeServiceRef};
 pub use tool::MemoryTool;


### PR DESCRIPTION
## Summary

Second sub-PR of Epic #1631. Migrates the knowledge extraction pipeline to `DriverRegistry::resolve_agent`, so the driver and the model are resolved atomically from `agents.knowledge_extractor.{driver, model}` YAML — instead of via a driver lookup plus a separately-flattened model string.

Closes the prod failure in #1629: the legacy flow resolved the driver to MiniMax but called it with `gpt-4o-mini` (from the flat `memory.knowledge.extractor_model` key), so every extraction 400'd silently behind a `warn!` log. The new flow:

- Binds driver and model into a single `ResolvedAgent` via `resolve_agent(&manifest)`.
- Fails boot fast if `agents.knowledge_extractor.{driver, model}` is missing (no silent fallback).
- Surfaces extraction failures at `error!` level instead of `warn!`.

The legacy `memory.knowledge.extractor_model` YAML key remains readable for backwards compat but is no longer consumed by the new code path; its final removal is tracked in #1638.

### Key changes

- `crates/kernel/src/memory/knowledge/manifest.rs` (new) — built-in manifest + canonical name constant
- `crates/kernel/src/memory/knowledge/extractor.rs` — `extract_knowledge` now takes `&ResolvedAgent`, plus a unit test proving the model sent to the driver comes from `ResolvedAgent` (not a flat key)
- `crates/kernel/src/kernel.rs` — spawn site uses `resolve_agent`; failure logs upgraded to `error!`
- `crates/app/src/flatten.rs` + `lib.rs` — new `agents:` section in `AppConfig`, flatten/unflatten roundtrip
- `crates/app/src/boot.rs` — wires `agents.<name>.{driver, model}` into `registry.set_agent_config`; fails boot when `agents.knowledge_extractor` is missing
- `crates/app/src/config_sync.rs` — writeback includes the new section
- `crates/kernel/AGENT.md` — documents the migrated consumer and the YAML shape

## Type of change

| Type | Label |
|------|-------|
| Refactor | `refactor` |

## Component

`core`

## Closes

Closes #1636
Closes #1629

## Test plan

- [x] `cargo check -p rara-kernel -p rara-app` passes
- [x] `cargo test -p rara-kernel -p rara-app --lib` (501 kernel + 56 app, pre-existing flaky `io::ingress_rate_limiter_tests::rate_limiter_window_expires_via_clock` passes in isolation)
- [x] `prek run --all-files` passes (cargo check / fmt / clippy / doc / AGENT.md)
- [x] New unit test `llm_call_uses_model_from_resolved_agent` verifies the driver is invoked with the model from `ResolvedAgent`
- [x] New unit test `agents_roundtrip_flatten_unflatten` covers the flatten/unflatten path for the new `agents:` section