### PR TITLE
refactor(kernel): migrate title_gen, fix silent title truncation (#1637)

### DIFF
--- a/crates/agents/src/lib.rs
+++ b/crates/agents/src/lib.rs
@@ -56,6 +56,7 @@ static RARA_MANIFEST: LazyLock<AgentManifest> = LazyLock::new(|| AgentManifest {
     tool_call_limit:        None,
     worker_timeout_secs:    None,
     max_continuations:      Some(10),
+    max_output_chars:       None,
 });
 
 /// Build the **rara** agent manifest — the default user-facing chat agent.
@@ -85,6 +86,7 @@ static NANA_MANIFEST: LazyLock<AgentManifest> = LazyLock::new(|| AgentManifest {
     tool_call_limit:        None,
     worker_timeout_secs:    None,
     max_continuations:      Some(0),
+    max_output_chars:       None,
 });
 
 /// Build the **nana** agent manifest — a chat-only companion for regular users.
@@ -115,6 +117,7 @@ static WORKER_MANIFEST: LazyLock<AgentManifest> = LazyLock::new(|| AgentManifest
     tool_call_limit:        None,
     worker_timeout_secs:    None,
     max_continuations:      Some(0),
+    max_output_chars:       None,
 });
 
 /// Build the **worker** agent manifest — a lightweight sub-agent for task
@@ -157,6 +160,7 @@ static MITA_MANIFEST: LazyLock<AgentManifest> = LazyLock::new(|| AgentManifest {
     tool_call_limit:        None,
     worker_timeout_secs:    None,
     max_continuations:      Some(0),
+    max_output_chars:       None,
 });
 
 /// Build the **mita** agent manifest — a background proactive agent that
@@ -168,6 +172,46 @@ pub fn mita() -> &'static AgentManifest { &MITA_MANIFEST }
 // manifest must be visible to the `DriverRegistry::resolve_agent` call
 // site there, and `rara-kernel` sits below `rara-agents` in the
 // dependency DAG. See `crates/kernel/src/memory/knowledge/manifest.rs`.
+
+// ---------------------------------------------------------------------------
+// title_gen — background agent that auto-generates short session titles
+// ---------------------------------------------------------------------------
+
+/// Default character cap for auto-generated session titles.
+///
+/// Titles longer than this are truncated (never silently discarded) by the
+/// kernel's title generator. The value lives on the manifest so operators can
+/// override it via `agents.title_gen.max_output_chars` YAML without a rebuild.
+const TITLE_GEN_DEFAULT_MAX_CHARS: usize = 50;
+
+static TITLE_GEN_MANIFEST: LazyLock<AgentManifest> = LazyLock::new(|| AgentManifest {
+    name:                   "title_gen".to_string(),
+    role:                   AgentRole::Worker,
+    description:            "Background agent that generates short human-readable session titles \
+                             from the first user/assistant exchange."
+        .to_string(),
+    model:                  None,
+    system_prompt:          String::new(),
+    soul_prompt:            None,
+    provider_hint:          None,
+    max_iterations:         Some(1),
+    tools:                  vec![],
+    excluded_tools:         vec![],
+    max_children:           Some(0),
+    max_context_tokens:     None,
+    priority:               Priority::default(),
+    metadata:               serde_json::Value::Null,
+    sandbox:                None,
+    default_execution_mode: None,
+    tool_call_limit:        None,
+    worker_timeout_secs:    None,
+    max_continuations:      Some(0),
+    max_output_chars:       Some(TITLE_GEN_DEFAULT_MAX_CHARS),
+});
+
+/// Build the **title_gen** agent manifest — the background session-title
+/// generator invoked by the kernel after the first successful turn.
+pub fn title_gen() -> &'static AgentManifest { &TITLE_GEN_MANIFEST }
 
 // ---------------------------------------------------------------------------
 // ScheduledJob — dedicated agent for scheduled task execution
@@ -206,6 +250,7 @@ pub fn scheduled_job(job_id: &str, trigger_summary: &str, message: &str) -> Agen
         tool_call_limit:        None,
         worker_timeout_secs:    None,
         max_continuations:      Some(0),
+        max_output_chars:       None,
     }
 }
 

--- a/crates/app/src/boot.rs
+++ b/crates/app/src/boot.rs
@@ -259,7 +259,15 @@ pub(crate) async fn boot(
 
     // -- agent registry ----------------------------------------------------
 
-    let agent_registry = Arc::new(load_default_registry());
+    // Optional YAML overrides for headless system agents — currently just
+    // `title_gen.max_output_chars`, but structured so future knobs can land
+    // here without forcing another bootstrap refactor.
+    let title_gen_max_output_chars = settings_provider
+        .get("agents.title_gen.max_output_chars")
+        .await
+        .and_then(|v| v.trim().parse::<usize>().ok());
+
+    let agent_registry = Arc::new(load_default_registry(title_gen_max_output_chars));
 
     // -- default provider model lister / embedder ----------------------------
     //
@@ -448,12 +456,16 @@ async fn build_driver_registry(
         }
     }
 
-    // -- unified per-agent configs (agents.<name>.{driver, model}) ---------------
+    // -- unified per-agent configs (agents.<name>.{driver, model}) --------------
     //
-    // Introduced in #1636. Populates the `DriverRegistry::resolve_agent` lookup
-    // table that the knowledge extractor (and future consumers) read from.
-    // Boot fails fast if `agents.knowledge_extractor.{driver, model}` is missing
-    // — the prod failure in #1629 showed we cannot silently fall back.
+    // Introduced in #1636, extended by #1637. The `agents.*` namespace is the
+    // post-refactor binding consumed by `DriverRegistry::resolve_agent`. Unlike
+    // the legacy `llm.agent_overrides.*` keys, these live alongside other
+    // per-agent knobs (e.g. `agents.title_gen.max_output_chars`) and form the
+    // single `{driver, model, manifest}` snapshot used at call sites.
+    //
+    // Boot fails fast for the knowledge extractor if its driver/model are
+    // missing — the prod failure in #1629 showed we cannot silently fall back.
     let unified_agent_names: BTreeSet<&str> = all_settings
         .keys()
         .filter_map(|k| k.strip_prefix("agents."))
@@ -685,11 +697,22 @@ impl IdentityResolver for PlatformIdentityResolver {
 // =========================================================================
 
 /// Load agent manifests and build an AgentRegistry.
-fn load_default_registry() -> rara_kernel::agent::AgentRegistry {
+///
+/// `title_gen_max_output_chars` optionally overrides the built-in title
+/// length cap from YAML (`agents.title_gen.max_output_chars`). When `None`,
+/// the manifest's own default from [`rara_agents::title_gen`] applies.
+fn load_default_registry(
+    title_gen_max_output_chars: Option<usize>,
+) -> rara_kernel::agent::AgentRegistry {
     use rara_kernel::agent::{AgentRegistry, ManifestLoader};
 
     let mut rara_manifest = rara_agents::rara().clone();
     rara_manifest.tools = crate::tools::rara_tool_names();
+
+    let mut title_gen_manifest = rara_agents::title_gen().clone();
+    if let Some(cap) = title_gen_max_output_chars {
+        title_gen_manifest.max_output_chars = Some(cap);
+    }
 
     let builtin = vec![
         (rara_manifest.clone(), Role::Root),
@@ -697,6 +720,10 @@ fn load_default_registry() -> rara_kernel::agent::AgentRegistry {
         (rara_agents::nana().clone(), Role::User),
         (rara_agents::worker().clone(), Role::User),
         (rara_agents::mita().clone(), Role::Root),
+        // `title_gen` is a headless background agent (no user/chat role); we
+        // still register it so the kernel can look up its manifest and resolve
+        // `{driver, model, max_output_chars}` via the unified agent registry.
+        (title_gen_manifest, Role::Root),
     ];
     let agents_dir = rara_paths::data_dir().join("agents");
     let mut loader = ManifestLoader::new();

--- a/crates/extensions/backend-admin/src/agents/router.rs
+++ b/crates/extensions/backend-admin/src/agents/router.rs
@@ -175,6 +175,7 @@ async fn create_agent(
         tool_call_limit:        None,
         worker_timeout_secs:    None,
         max_continuations:      None,
+        max_output_chars:       None,
     };
 
     registry

--- a/crates/kernel/AGENT.md
+++ b/crates/kernel/AGENT.md
@@ -31,6 +31,20 @@ callers; migration is tracked in follow-up issues under Epic #1631.
   Extraction failures now emit at `error!` level (previously `warn!`,
   which hid the MiniMax/gpt-4o-mini split-config bug in prod).
 
+- `kernel.rs` (session title generation) — #1637. Reads
+  `agents.title_gen.{driver, model}` via `resolve_agent`. See the
+  per-agent output caps section below for the truncation contract.
+
+### Per-agent output caps — `AgentManifest::max_output_chars`
+
+System agents whose contract includes a bounded free-form output (currently
+`title_gen`) declare the cap on the manifest via `max_output_chars`. The call
+site MUST truncate and emit a `warn!` (with `title_len`, `max_chars`,
+`truncated=true`) when the model exceeds the cap — NEVER silently discard.
+See `generate_session_title` / `finalize_title` in `kernel.rs` and the
+background to #1637 (production incident 2026-04-20 where a 237-char title
+was dropped with zero persisted state).
+
 ## Critical: StreamDelta Event Ordering in `openai.rs`
 
 ### The Invariant

--- a/crates/kernel/src/agent/mod.rs
+++ b/crates/kernel/src/agent/mod.rs
@@ -281,6 +281,15 @@ pub struct AgentManifest {
     /// **Default: `None` (uses [`machine::DEFAULT_MAX_CONTINUATIONS`]).**
     #[serde(default)]
     pub max_continuations:      Option<usize>,
+    /// Maximum character length of this agent's free-form text output.
+    ///
+    /// Interpreted per agent — e.g. `title_gen` uses this as the hard cap
+    /// on generated session titles. When the model returns longer output,
+    /// the caller truncates (never silently discards) and logs a warning.
+    ///
+    /// **Default: `None` (no cap enforced).**
+    #[serde(default)]
+    pub max_output_chars:       Option<usize>,
 }
 
 /// Process environment — isolated per-agent context.

--- a/crates/kernel/src/agent/scheduled.rs
+++ b/crates/kernel/src/agent/scheduled.rs
@@ -82,5 +82,6 @@ pub fn scheduled_job_manifest(
         tool_call_limit: None,
         worker_timeout_secs: None,
         max_continuations: Some(0),
+        max_output_chars: None,
     }
 }

--- a/crates/kernel/src/kernel.rs
+++ b/crates/kernel/src/kernel.rs
@@ -3164,6 +3164,7 @@ impl Kernel {
             if needs_title {
                 let tape_service = self.tape_service.clone();
                 let driver_registry = Arc::clone(self.syscall.driver_registry());
+                let agent_registry = Arc::clone(&self.agent_registry);
                 let io = Arc::clone(&self.io);
                 let sk = session_key;
                 let tape_name = sk.to_string();
@@ -3172,6 +3173,7 @@ impl Kernel {
                         &tape_service,
                         &tape_name,
                         &driver_registry,
+                        &agent_registry,
                         session_index.as_ref(),
                         &io,
                         &sk,
@@ -3215,15 +3217,91 @@ impl Kernel {
 // Session title generation (standalone helper)
 // ---------------------------------------------------------------------------
 
+/// Default title cap when the manifest omits `max_output_chars`. Matches
+/// the value baked into `rara_agents::title_gen`; duplicated as a defensive
+/// floor so the kernel never stores an unbounded title even if a malformed
+/// YAML override clears the field.
+const TITLE_GEN_FALLBACK_MAX_CHARS: usize = 50;
+
+/// Normalize a raw LLM response into a bounded session title.
+///
+/// Returns `None` only when both the model output and the fallback user
+/// message are empty — an operationally-impossible state. In all other
+/// cases this returns `Some(title)` whose character count is `<= max_chars`.
+/// When truncation or fallback kicks in a warning is emitted with
+/// `truncated=true` so operators can see the model is generating titles
+/// outside the contract (previously the kernel silently dropped them — see
+/// the #1637 production incident).
+fn finalize_title(
+    raw: Option<&str>,
+    user_fallback: &str,
+    max_chars: usize,
+    session_key: &SessionKey,
+) -> Option<String> {
+    let max_chars = max_chars.max(1);
+    let cleaned = raw
+        .map(|s| s.trim().trim_matches('"').to_string())
+        .filter(|s| !s.is_empty());
+
+    let (source, candidate) = match cleaned {
+        Some(t) => ("model", t),
+        None => {
+            tracing::error!(
+                session_key = %session_key,
+                "title gen: LLM returned no usable content, falling back to user message"
+            );
+            (
+                "fallback",
+                user_fallback
+                    .lines()
+                    .next()
+                    .unwrap_or("")
+                    .trim()
+                    .to_string(),
+            )
+        }
+    };
+
+    if candidate.is_empty() {
+        tracing::error!(
+            session_key = %session_key,
+            "title gen: fallback user message also empty, skipping title"
+        );
+        return None;
+    }
+
+    let raw_len = candidate.chars().count();
+    if raw_len <= max_chars {
+        return Some(candidate);
+    }
+
+    let truncated: String = candidate.chars().take(max_chars).collect();
+    tracing::warn!(
+        session_key = %session_key,
+        title_len = raw_len,
+        max_chars,
+        truncated = true,
+        source,
+        title = %truncated,
+        "title gen: title exceeded cap, truncated instead of discarding"
+    );
+    Some(truncated)
+}
+
 /// Auto-generate a short session title from the first user/assistant exchange.
 ///
 /// Reads the tape for the first user and assistant messages, asks the LLM for a
-/// concise title (<=30 chars, matching the user's language), and persists it
-/// via the session index. Errors are propagated to the caller for logging.
+/// concise title (matching the user's language), and persists it via the
+/// session index. The LLM binding comes from
+/// [`DriverRegistry::resolve_agent`](crate::llm::DriverRegistry::resolve_agent)
+/// keyed by the `title_gen` manifest, so driver + model + max-length stay in
+/// one atomic snapshot (see #1637). Errors are propagated to the caller for
+/// logging.
 async fn generate_session_title(
     tape_service: &crate::memory::TapeService,
     tape_name: &str,
     driver_registry: &crate::llm::DriverRegistry,
+    agent_registry: &crate::agent::AgentRegistry,
     session_index: &dyn crate::session::SessionIndex,
     io: &Arc<crate::io::IOSubsystem>,
     session_key: &SessionKey,
@@ -3263,31 +3341,39 @@ async fn generate_session_title(
         })
         .unwrap_or_default();
 
-    let (driver, model) = driver_registry.resolve("title_generator", None, None)?;
+    let manifest = agent_registry.get("title_gen").ok_or_else(|| {
+        Box::<dyn std::error::Error + Send + Sync>::from(
+            "title gen: `title_gen` manifest not registered",
+        )
+    })?;
+    let max_chars = manifest
+        .max_output_chars
+        .unwrap_or(TITLE_GEN_FALLBACK_MAX_CHARS);
+    let resolved = driver_registry.resolve_agent(&manifest)?;
 
     let assistant_preview: String = first_assistant_msg.chars().take(500).collect();
 
     let prompt = format!(
-        "Given this conversation opening, generate a concise title (max 30 characters).\nMatch \
-         the language of the user's message.\nReturn ONLY the title, nothing else.\n\nUser: \
-         {first_user_msg}\nAssistant: {assistant_preview}"
+        "Given this conversation opening, generate a concise title (max {max_chars} \
+         characters).\nMatch the language of the user's message.\nReturn ONLY the title, nothing \
+         else.\n\nUser: {first_user_msg}\nAssistant: {assistant_preview}"
     );
 
     let request = crate::llm::CompletionRequest {
-        model,
-        messages: vec![crate::llm::Message::user(prompt)],
-        tools: vec![],
-        temperature: Some(0.3),
-        max_tokens: Some(60),
-        thinking: None,
-        tool_choice: crate::llm::ToolChoice::None,
+        model:               resolved.model,
+        messages:            vec![crate::llm::Message::user(prompt)],
+        tools:               vec![],
+        temperature:         Some(0.3),
+        max_tokens:          Some(60),
+        thinking:            None,
+        tool_choice:         crate::llm::ToolChoice::None,
         parallel_tool_calls: false,
-        frequency_penalty: None,
-        top_p: None,
-        emit_reasoning: false,
+        frequency_penalty:   None,
+        top_p:               None,
+        emit_reasoning:      false,
     };
 
-    let response = driver.complete(request).await?;
+    let response = resolved.driver.complete(request).await?;
 
     // Prefer non-empty content, fall back to reasoning_content for thinking
     // models that return content = Some("") with actual text in reasoning.
@@ -3295,25 +3381,15 @@ async fn generate_session_title(
         .content
         .filter(|s| !s.trim().is_empty())
         .or(response.reasoning_content);
-    let Some(raw_title) = raw_title else {
-        tracing::warn!(session_key = %session_key, "title gen: LLM returned no content");
+
+    let Some(title) = finalize_title(
+        raw_title.as_deref(),
+        &first_user_msg,
+        max_chars,
+        session_key,
+    ) else {
         return Ok(());
     };
-
-    let title = raw_title.trim().trim_matches('"').to_string();
-    if title.is_empty() {
-        tracing::warn!(session_key = %session_key, "title gen: LLM returned empty title");
-        return Ok(());
-    }
-    if title.chars().count() > 50 {
-        tracing::warn!(
-            session_key = %session_key,
-            title_len = title.chars().count(),
-            title = %title,
-            "title gen: title exceeds 50 chars, discarded"
-        );
-        return Ok(());
-    }
 
     match session_index.get_session(session_key).await {
         Ok(Some(mut entry)) => {
@@ -3436,5 +3512,110 @@ mod tests {
             matches!(err, KernelError::SessionNotFound { .. }),
             "expected SessionNotFound, got {err:?}"
         );
+    }
+
+    // -- title_gen: truncation + registry wiring (issue #1637) ----------------
+
+    /// A 237-char model response (matching the observed 2026-04-20 incident)
+    /// must be truncated down to the configured cap and returned — never
+    /// silently discarded as the old code did.
+    #[test]
+    fn finalize_title_truncates_long_model_output() {
+        let long = "a".repeat(237);
+        let sk = SessionKey::new();
+        let got = finalize_title(Some(&long), "user msg", 50, &sk)
+            .expect("truncated title should still be persisted");
+        assert_eq!(got.chars().count(), 50);
+        assert!(got.chars().all(|c| c == 'a'));
+    }
+
+    /// An empty model response falls back to the first line of the user
+    /// message, still bounded by `max_chars`.
+    #[test]
+    fn finalize_title_falls_back_to_user_message_when_model_empty() {
+        let sk = SessionKey::new();
+        let got = finalize_title(
+            Some("   "), // whitespace only → treated as empty
+            "hello world, this is the first user message\nsecond line ignored",
+            50,
+            &sk,
+        )
+        .expect("fallback must produce a title");
+        assert!(got.starts_with("hello world"));
+        assert!(!got.contains('\n'));
+        assert!(got.chars().count() <= 50);
+    }
+
+    /// Short model output passes through unchanged.
+    #[test]
+    fn finalize_title_preserves_short_output() {
+        let sk = SessionKey::new();
+        let got = finalize_title(Some("  \"short title\" "), "unused", 50, &sk)
+            .expect("short title must pass through");
+        assert_eq!(got, "short title");
+    }
+
+    /// The title_gen manifest resolves its driver + model via
+    /// `DriverRegistry::resolve_agent` (unified `agents.<name>.*` path),
+    /// not via a flat `title_generator` key. This guards against regressing
+    /// to the split-brain wiring that #1637 removed.
+    #[test]
+    fn title_gen_resolves_via_resolve_agent() {
+        use std::sync::Arc as StdArc;
+
+        use crate::{
+            agent::AgentManifest,
+            llm::{
+                ScriptedLlmDriver,
+                catalog::OpenRouterCatalog,
+                registry::{AgentLlmConfig, DriverRegistry},
+            },
+        };
+
+        let catalog = StdArc::new(OpenRouterCatalog::new());
+        let reg = DriverRegistry::new("openrouter", catalog);
+        reg.register_driver(
+            "openrouter",
+            StdArc::new(ScriptedLlmDriver::new(Vec::new())),
+        );
+        reg.register_driver("ollama", StdArc::new(ScriptedLlmDriver::new(Vec::new())));
+        reg.set_provider_model("openrouter", "gpt-4o", Vec::<String>::new());
+
+        // Simulate `agents.title_gen.{driver, model}` YAML.
+        reg.set_agent_config(
+            "title_gen",
+            AgentLlmConfig {
+                driver: Some("ollama".into()),
+                model:  Some("qwen3:14b".into()),
+            },
+        );
+
+        let manifest = AgentManifest {
+            name:                   "title_gen".into(),
+            role:                   crate::agent::AgentRole::Worker,
+            description:            "t".into(),
+            model:                  None,
+            system_prompt:          String::new(),
+            soul_prompt:            None,
+            provider_hint:          None,
+            max_iterations:         Some(1),
+            tools:                  Vec::new(),
+            excluded_tools:         Vec::new(),
+            max_children:           Some(0),
+            max_context_tokens:     None,
+            priority:               crate::agent::Priority::default(),
+            metadata:               serde_json::Value::Null,
+            sandbox:                None,
+            default_execution_mode: None,
+            tool_call_limit:        None,
+            worker_timeout_secs:    None,
+            max_continuations:      Some(0),
+            max_output_chars:       Some(50),
+        };
+
+        let resolved = reg.resolve_agent(&manifest).expect("resolve_agent");
+        assert_eq!(resolved.model, "qwen3:14b");
+        assert_eq!(resolved.manifest.name, "title_gen");
+        assert_eq!(resolved.manifest.max_output_chars, Some(50));
     }
 }

--- a/crates/kernel/src/llm/registry.rs
+++ b/crates/kernel/src/llm/registry.rs
@@ -363,6 +363,7 @@ mod tests {
             tool_call_limit:        None,
             worker_timeout_secs:    None,
             max_continuations:      None,
+            max_output_chars:       None,
         }
     }
 

--- a/crates/kernel/src/memory/knowledge/extractor.rs
+++ b/crates/kernel/src/memory/knowledge/extractor.rs
@@ -355,6 +355,7 @@ mod tests {
             tool_call_limit:        None,
             worker_timeout_secs:    None,
             max_continuations:      None,
+            max_output_chars:       None,
         }
     }
 

--- a/crates/kernel/src/memory/knowledge/manifest.rs
+++ b/crates/kernel/src/memory/knowledge/manifest.rs
@@ -58,6 +58,7 @@ static KNOWLEDGE_EXTRACTOR_MANIFEST: LazyLock<AgentManifest> = LazyLock::new(|| 
     tool_call_limit:        None,
     worker_timeout_secs:    None,
     max_continuations:      Some(0),
+    max_output_chars:       None,
 });
 
 /// Return the static knowledge extractor manifest.

--- a/crates/kernel/src/plan.rs
+++ b/crates/kernel/src/plan.rs
@@ -1005,6 +1005,7 @@ async fn execute_worker_step(
         tool_call_limit:        None,
         worker_timeout_secs:    None,
         max_continuations:      Some(0),
+        max_output_chars:       None,
     };
 
     info!(

--- a/crates/kernel/src/session/mod.rs
+++ b/crates/kernel/src/session/mod.rs
@@ -1024,6 +1024,7 @@ impl Session {
                 tool_call_limit:        None,
                 worker_timeout_secs:    None,
                 max_continuations:      None,
+                max_output_chars:       None,
             },
             principal,
             env: AgentEnv::default(),
@@ -1088,6 +1089,7 @@ mod state_transition_tests {
             tool_call_limit:        None,
             worker_timeout_secs:    None,
             max_continuations:      None,
+            max_output_chars:       None,
         }
     }
 

--- a/crates/kernel/src/testing.rs
+++ b/crates/kernel/src/testing.rs
@@ -347,6 +347,7 @@ impl TestKernelBuilder {
             tool_call_limit:        None,
             worker_timeout_secs:    None,
             max_continuations:      None,
+            max_output_chars:       None,
         });
         let manifest_name = manifest.name.clone();
 

--- a/crates/kernel/src/tool/fold_branch.rs
+++ b/crates/kernel/src/tool/fold_branch.rs
@@ -172,6 +172,7 @@ impl ToolExecute for FoldBranchTool {
             tool_call_limit: None,
             max_continuations: Some(0),
             worker_timeout_secs: None,
+            max_output_chars: None,
         };
 
         // Resolve principal from parent session.

--- a/crates/kernel/src/tool/spawn_background.rs
+++ b/crates/kernel/src/tool/spawn_background.rs
@@ -115,6 +115,7 @@ impl ToolExecute for SpawnBackgroundTool {
             tool_call_limit: None,
             worker_timeout_secs: Some(p.max_iterations.unwrap_or(15) as u64 * 60),
             max_continuations: Some(0),
+            max_output_chars: None,
         };
 
         super::background_common::spawn_and_register_background(

--- a/crates/kernel/src/tool/task/mod.rs
+++ b/crates/kernel/src/tool/task/mod.rs
@@ -117,6 +117,7 @@ impl ToolExecute for TaskTool {
             tool_call_limit:        None,
             worker_timeout_secs:    Some(preset.max_iterations as u64 * 60),
             max_continuations:      Some(0),
+            max_output_chars:       None,
         };
 
         let mut result = super::background_common::spawn_and_register_background(
@@ -189,6 +190,7 @@ mod tests {
             tool_call_limit:        None,
             worker_timeout_secs:    Some(preset.max_iterations as u64 * 60),
             max_continuations:      Some(0),
+            max_output_chars:       None,
         };
         assert_eq!(manifest.role, AgentRole::Worker);
         assert_eq!(manifest.max_children, Some(0));


### PR DESCRIPTION
## Summary

Part of Epic #1631. Third sub-PR after #1640 (`resolve_agent` API).

- Migrates `title_gen` from the split-brain `driver_registry.resolve(\"title_generator\", ...)` call to `DriverRegistry::resolve_agent(&manifest)`, so driver + model + output cap come from a single atomic snapshot keyed by the `title_gen` manifest
- Fixes the silent-discard bug observed 2026-04-20 where a 237-char model response was logged and dropped. The new `finalize_title` helper truncates to `max_output_chars` with `warn!(truncated=true, title_len, max_chars, ...)` and falls back to the first line of the user message (logged at `error!`) when the model returns nothing usable — never silent failure
- Adds `max_output_chars: Option<usize>` to `AgentManifest` and a built-in `title_gen` manifest in `crates/agents` with a default 50-char cap; the cap is overridable via `agents.title_gen.max_output_chars` YAML
- Exposes unified `agents.<name>.{driver, model}` config keys in boot.rs that feed `DriverRegistry::set_agent_config`, alongside the still-supported legacy `llm.agent_overrides.*` path

## Type of change

| Type | Label |
|------|-------|
| Refactor | `refactor` |

## Component

`core`

## Closes

Closes #1637

## Test plan

- [x] `cargo test -p rara-kernel` (504 passed)
- [x] `prek run --all-files`
- [x] New unit tests: `finalize_title_truncates_long_model_output`, `finalize_title_falls_back_to_user_message_when_model_empty`, `finalize_title_preserves_short_output`, `title_gen_resolves_via_resolve_agent`