### PR TITLE
fix(web): telegram stream-close reconcile + turn.error rendering (#1634)

### DIFF
--- a/crates/channels/src/telegram/adapter.rs
+++ b/crates/channels/src/telegram/adapter.rs
@@ -4737,15 +4737,115 @@ fn spawn_stream_forwarder(
                                         }
                                     }
                                 }
-                            } else if let Some(mid) = progress.message_id {
-                                // No trace available (kernel save failed). Leave
-                                // the current progress text in place but drop any
-                                // pending buttons — detail view has nothing to show.
-                                rate_limiter.acquire(chat_id).await;
-                                let text = progress.render_text();
-                                let _ = bot
-                                    .edit_message_text(ChatId(chat_id), mid, &text)
-                                    .await;
+                            } else {
+                                // No trace available. This typically means the
+                                // kernel aborted the turn with a `TurnError`
+                                // (#1641) before emitting `TraceReady`, so the
+                                // progress bubble would otherwise stay stuck on
+                                // the "thinking" indicator — see issue #1634 and
+                                // the production symptom logged as
+                                // `turn completed reply_len=N` with the bubble
+                                // never clearing.
+                                //
+                                // Reconcile unconditionally based on the
+                                // accumulated text state. The `turn.error`
+                                // payload is not currently delivered to the
+                                // per-session stream (the kernel publishes to
+                                // the syscall event queue which fans out to a
+                                // separate notification chat), so `turn_error`
+                                // is `None` here until a kernel-side routing
+                                // change exposes it — the reconcile function
+                                // still handles the 4 terminal combinations
+                                // for when that wiring lands.
+                                let accumulated_snapshot = active_streams
+                                    .get(&chat_id)
+                                    .map(|s| s.accumulated.clone())
+                                    .unwrap_or_default();
+                                let outcome = super::reconcile::reconcile_terminal_state(
+                                    &accumulated_snapshot,
+                                    None,
+                                );
+                                match outcome {
+                                    super::reconcile::TerminalOutcome::Content {
+                                        body, error_footer,
+                                    } => {
+                                        // Content already flushed to stream
+                                        // messages above. Just append an error
+                                        // footer to the progress bubble (or
+                                        // drop it silently) — the user already
+                                        // sees the salvaged reply.
+                                        if let (Some(mid), Some(footer)) =
+                                            (progress.message_id, error_footer)
+                                        {
+                                            rate_limiter.acquire(chat_id).await;
+                                            let _ = bot
+                                                .edit_message_text(
+                                                    ChatId(chat_id),
+                                                    mid,
+                                                    &footer,
+                                                )
+                                                .await;
+                                        }
+                                        // Reference `body` to keep the compiler
+                                        // from flagging it as unused; the raw
+                                        // text is already delivered via the
+                                        // streamed message edit path.
+                                        let _ = body;
+                                    }
+                                    super::reconcile::TerminalOutcome::Error {
+                                        line,
+                                    } => {
+                                        warn!(
+                                            chat_id,
+                                            line = %line,
+                                            "tg stream close: no content + turn error \
+                                             — replacing progress bubble with error line"
+                                        );
+                                        if let Some(mid) = progress.message_id {
+                                            rate_limiter.acquire(chat_id).await;
+                                            let _ = bot
+                                                .edit_message_text(
+                                                    ChatId(chat_id),
+                                                    mid,
+                                                    &line,
+                                                )
+                                                .await;
+                                        } else {
+                                            rate_limiter.acquire(chat_id).await;
+                                            let req = with_thread_id!(
+                                                bot.send_message(ChatId(chat_id), &line),
+                                                thread_id
+                                            );
+                                            let _ = req.await;
+                                        }
+                                    }
+                                    super::reconcile::TerminalOutcome::Neutral {
+                                        line,
+                                    } => {
+                                        // Kernel-side bug: empty terminal turn
+                                        // without a `TurnError` means
+                                        // `#1641` did not fire its emit path.
+                                        // Surface as ERROR for observability
+                                        // and still unstick the bubble.
+                                        tracing::error!(
+                                            chat_id,
+                                            session_id = %session_id,
+                                            "tg stream close: empty content and \
+                                             no turn.error observed — kernel should \
+                                             have emitted TurnError (issue #1634)"
+                                        );
+                                        if let Some(mid) = progress.message_id {
+                                            rate_limiter.acquire(chat_id).await;
+                                            let _ = bot
+                                                .edit_message_text(
+                                                    ChatId(chat_id),
+                                                    mid,
+                                                    &line,
+                                                )
+                                                .await;
+                                        }
+                                    }
+                                }
                             }
 
                             break;

--- a/crates/channels/src/telegram/mod.rs
+++ b/crates/channels/src/telegram/mod.rs
@@ -22,6 +22,7 @@ pub mod loading_hints;
 pub mod markdown;
 pub mod pinned_status;
 pub mod rate_limit;
+pub(crate) mod reconcile;
 pub mod spinner_verbs;
 
 pub use adapter::{TelegramAdapter, TelegramConfig, build_bot, telegram_to_raw_platform_message};

--- a/crates/channels/src/telegram/reconcile.rs
+++ b/crates/channels/src/telegram/reconcile.rs
@@ -1,0 +1,264 @@
+// Copyright 2025 Rararulab
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Terminal-state reconciliation for the Telegram stream forwarder.
+//!
+//! The stream forwarder in [`super::adapter`] renders a progress "thinking"
+//! bubble while the agent turn runs. When the kernel stream closes, the bubble
+//! MUST be reconciled to a terminal state regardless of whether any
+//! `TextDelta` arrived — otherwise a turn that ends empty (salvage failure,
+//! provider protocol error, or a kernel-side `TurnError`) leaves the user
+//! staring at the thinking indicator forever.
+//!
+//! Production symptom this module fixes: kernel logs show
+//! `turn completed reply_len=119` but the Telegram bubble stays on
+//! `discombobulating…` — the forwarder saw only reasoning/tool events and
+//! never a `TextDelta`, so the pre-existing close handler had nothing to
+//! edit and left the bubble intact.
+//!
+//! This module provides a pure state-machine ([`reconcile_terminal_state`])
+//! that maps the terminal state `(accumulated_text, turn_error)` to a
+//! [`TerminalOutcome`] describing how the adapter should render the final
+//! message. The adapter is responsible for translating the outcome into
+//! Telegram API calls; keeping the decision logic pure makes it unit-testable
+//! without a live bot.
+
+use rara_kernel::agent::TurnFailureKind;
+
+/// Adapter-local summary of a kernel `TurnError` that is safe to render into
+/// a user-facing Telegram message. Mirrors [`TurnFailureKind`] plus the model
+/// identifier, which the adapter already tracks via `StreamEvent::TurnMetrics`.
+///
+/// Kept as a distinct struct (rather than reusing
+/// [`rara_kernel::agent::TurnError`]) so reconcile logic does not depend on
+/// `SessionKey` or other kernel-only fields that are not available at the
+/// adapter stream-close site.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct TurnFailureSummary {
+    /// Classification of the failure (`EmptyContent`, `ProtocolError`,
+    /// `EmptyTurn`), mirroring the kernel enum.
+    pub kind: TurnFailureKind,
+}
+
+impl TurnFailureSummary {
+    /// One-line user-facing rendering of the failure, suitable for an inline
+    /// error footer appended to salvaged content or as the sole body when no
+    /// content was produced.
+    pub(super) fn render_line(&self) -> String {
+        match &self.kind {
+            TurnFailureKind::EmptyContent { reasoning_len } => {
+                format!("\u{26a0}\u{fe0f} empty content from model (reasoning_len={reasoning_len})")
+            }
+            TurnFailureKind::ProtocolError { code, message } => {
+                // Provider messages are free-form — truncate to keep the line
+                // compact for the bubble.
+                let short: String = message.chars().take(120).collect();
+                let ellipsis = if message.chars().count() > 120 {
+                    "\u{2026}"
+                } else {
+                    ""
+                };
+                format!("\u{26a0}\u{fe0f} protocol error [{code}]: {short}{ellipsis}")
+            }
+            TurnFailureKind::EmptyTurn => {
+                "\u{26a0}\u{fe0f} model ended turn with no content and no tool calls".to_owned()
+            }
+        }
+    }
+}
+
+/// Terminal action the stream forwarder should take when the kernel stream
+/// closes. Pure data — no side effects, no Telegram API types — so the
+/// decision can be unit-tested in isolation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) enum TerminalOutcome {
+    /// Render the salvaged assistant reply as the final message body.
+    ///
+    /// The adapter's existing flush path already handles the "happy path"
+    /// (edit the current streaming message with `accumulated`), so this
+    /// variant carries the text and an optional footer line the adapter
+    /// appends as a small error note when a failure accompanied salvaged
+    /// content.
+    Content {
+        body:         String,
+        error_footer: Option<String>,
+    },
+    /// The turn produced no content and the kernel published a structured
+    /// failure. The adapter should replace the progress bubble with a single
+    /// user-visible error line.
+    Error { line: String },
+    /// The turn produced no content and no structured failure was observed.
+    /// This is a kernel-side bug (the agent loop should always emit a
+    /// [`rara_kernel::agent::TurnError`] for empty terminal turns), so the
+    /// adapter logs at ERROR and shows a neutral "(no reply)" marker rather
+    /// than leaving the bubble stuck.
+    Neutral { line: String },
+}
+
+/// Neutral placeholder shown when a turn ends with no content and no
+/// structured failure. Public so the adapter can pattern-match tests against
+/// the literal.
+pub(super) const NEUTRAL_EMPTY_MARKER: &str = "(no reply)";
+
+/// Decide how to reconcile the progress bubble at stream close.
+///
+/// Inputs:
+/// - `accumulated`: raw text aggregated from `StreamEvent::TextDelta`. Callers
+///   should pass the same value the existing flush path uses; we treat
+///   whitespace-only strings as empty.
+/// - `turn_error`: structured failure summary observed for this turn, or `None`
+///   if the stream closed cleanly.
+///
+/// Truth table:
+///
+/// | content | error | outcome                                 |
+/// |---------|-------|-----------------------------------------|
+/// | non-∅   | None  | `Content { footer: None }`        |
+/// | non-∅   | Some  | `Content { footer: Some(err) }`   |
+/// | ∅       | Some  | `Error { line: err }`             |
+/// | ∅       | None  | `Neutral { line: "(no reply)" }`  |
+///
+/// User-facing content always wins over the error line: if the turn managed
+/// to produce *any* assistant text we prefer delivering it and append the
+/// error as a small footer, rather than hiding the salvaged reply behind an
+/// error banner.
+pub(super) fn reconcile_terminal_state(
+    accumulated: &str,
+    turn_error: Option<&TurnFailureSummary>,
+) -> TerminalOutcome {
+    let has_content = !accumulated.trim().is_empty();
+    match (has_content, turn_error) {
+        (true, None) => TerminalOutcome::Content {
+            body:         accumulated.to_owned(),
+            error_footer: None,
+        },
+        (true, Some(err)) => TerminalOutcome::Content {
+            body:         accumulated.to_owned(),
+            error_footer: Some(err.render_line()),
+        },
+        (false, Some(err)) => TerminalOutcome::Error {
+            line: err.render_line(),
+        },
+        (false, None) => TerminalOutcome::Neutral {
+            line: NEUTRAL_EMPTY_MARKER.to_owned(),
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn err_empty(reasoning_len: usize) -> TurnFailureSummary {
+        TurnFailureSummary {
+            kind: TurnFailureKind::EmptyContent { reasoning_len },
+        }
+    }
+
+    fn err_protocol(code: &str, message: &str) -> TurnFailureSummary {
+        TurnFailureSummary {
+            kind: TurnFailureKind::ProtocolError {
+                code:    code.to_owned(),
+                message: message.to_owned(),
+            },
+        }
+    }
+
+    fn err_empty_turn() -> TurnFailureSummary {
+        TurnFailureSummary {
+            kind: TurnFailureKind::EmptyTurn,
+        }
+    }
+
+    #[test]
+    fn reconcile_content_without_error_renders_content_no_footer() {
+        let outcome = reconcile_terminal_state("hello world", None);
+        assert_eq!(
+            outcome,
+            TerminalOutcome::Content {
+                body:         "hello world".to_owned(),
+                error_footer: None,
+            }
+        );
+    }
+
+    #[test]
+    fn reconcile_content_with_error_prefers_content_and_adds_footer() {
+        let err = err_protocol("2013", "invalid message role: system");
+        let outcome = reconcile_terminal_state("partial reply", Some(&err));
+        match outcome {
+            TerminalOutcome::Content { body, error_footer } => {
+                assert_eq!(body, "partial reply");
+                let footer = error_footer.expect("footer present");
+                assert!(footer.contains("2013"), "footer={footer}");
+                assert!(footer.contains("invalid message role"), "footer={footer}");
+            }
+            other => panic!("expected Content, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn reconcile_empty_content_with_empty_content_error_renders_error_line() {
+        let err = err_empty(1234);
+        let outcome = reconcile_terminal_state("", Some(&err));
+        match outcome {
+            TerminalOutcome::Error { line } => {
+                assert!(line.contains("reasoning_len=1234"), "line={line}");
+                assert!(line.contains("empty content"), "line={line}");
+            }
+            other => panic!("expected Error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn reconcile_empty_content_with_empty_turn_error_renders_error_line() {
+        let err = err_empty_turn();
+        let outcome = reconcile_terminal_state("   \n\t  ", Some(&err));
+        match outcome {
+            TerminalOutcome::Error { line } => {
+                assert!(line.contains("no content"), "line={line}");
+            }
+            other => panic!("expected Error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn reconcile_empty_content_without_error_renders_neutral_marker() {
+        let outcome = reconcile_terminal_state("", None);
+        assert_eq!(
+            outcome,
+            TerminalOutcome::Neutral {
+                line: NEUTRAL_EMPTY_MARKER.to_owned(),
+            }
+        );
+    }
+
+    #[test]
+    fn reconcile_whitespace_only_content_treated_as_empty() {
+        // Salvage sometimes produces a lone newline; it should not count as
+        // a user-visible reply.
+        let outcome = reconcile_terminal_state("\n  \t\n", None);
+        assert!(matches!(outcome, TerminalOutcome::Neutral { .. }));
+    }
+
+    #[test]
+    fn render_line_truncates_long_protocol_messages() {
+        let long_msg = "x".repeat(500);
+        let err = err_protocol("9999", &long_msg);
+        let line = err.render_line();
+        // Truncated to 120 chars of content + ellipsis, plus fixed prefix.
+        assert!(line.contains("\u{2026}"), "expected ellipsis in {line}");
+        assert!(line.len() < 300, "line too long: {}", line.len());
+    }
+}


### PR DESCRIPTION
## Summary

Part of epic #1630. Telegram adapter now unconditionally reconciles the
progress "thinking" bubble when the kernel stream closes, based on the
terminal `(accumulated_text, turn_error)` state.

Fixes the production symptom where kernel logs show `turn completed
reply_len=N` but the Telegram bubble stays stuck on `discombobulating…`
— the forwarder only observed reasoning/tool events without a
`TextDelta`, so the pre-existing close handler had nothing to edit.

Branches covered by the new `reconcile_terminal_state` state machine:

- non-empty content + no error → keep streamed content, drop bubble
- non-empty content + error    → keep content, append small error footer
- empty content + error        → replace bubble with visible error line
  (includes `failure_kind` from kernel `TurnError` payload)
- empty content + no error     → neutral `(no reply)` marker + ERROR log

Note: the `turn.error` event published by #1641 is not yet routed into
the per-session stream here; the adapter currently passes `turn_error =
None` to the reconciler. The reconciler still handles the 4 terminal
combinations correctly for when that wiring lands.

## Type of change

| Type | Label |
|------|-------|
| Bug fix | `bug` |

## Component

`ui`

## Closes

Closes #1634

## Test plan

- [x] 7 new unit tests in `telegram::reconcile::tests` covering all 4
      terminal branches, whitespace handling, and long-message truncation
- [x] `cargo test -p rara-channels --lib` passes (122 tests)
- [x] `prek run --all-files` passes