### PR TITLE
chore(kernel): purge hardcoded model defaults, YAML-only agent config (#1638)

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -1,0 +1,111 @@
+# Example rara configuration.
+#
+# Copy to `~/.config/rara/config.yaml` (see `rara_paths::config_file()`) or
+# to `./config.yaml` next to the binary. All required keys must be present;
+# rara will fail to boot with an explicit error if a required field is
+# missing. There are NO hardcoded defaults in Rust code — this file is the
+# single source of truth for every tunable.
+
+# ---------------------------------------------------------------------------
+# HTTP + gRPC servers (required)
+# ---------------------------------------------------------------------------
+
+http:
+  bind_address: "127.0.0.1:25555"
+
+grpc:
+  bind_address: "127.0.0.1:50051"
+  server_address: "127.0.0.1:50051"
+
+# ---------------------------------------------------------------------------
+# Configured users — platform identity mappings (required, non-empty)
+# ---------------------------------------------------------------------------
+
+users:
+  - name: "you"
+    role: root
+    platforms:
+      - type: telegram
+        user_id: "1234567890"
+
+# ---------------------------------------------------------------------------
+# Mita proactive agent (required)
+# ---------------------------------------------------------------------------
+
+mita:
+  heartbeat_interval: "30m"
+
+# ---------------------------------------------------------------------------
+# LLM provider registry — seeded to the settings store at startup
+# ---------------------------------------------------------------------------
+
+llm:
+  default_provider: "openrouter"
+  providers:
+    openrouter:
+      base_url: "https://openrouter.ai/api/v1"
+      api_key: "sk-or-..."
+      default_model: "anthropic/claude-3.5-sonnet"
+    openai:
+      base_url: "https://api.openai.com/v1"
+      api_key: "sk-..."
+      default_model: "gpt-4o-mini"
+    minimax:
+      base_url: "https://api.minimax.io/v1"
+      api_key: "mm-..."
+      default_model: "MiniMax-M2.7"
+
+# ---------------------------------------------------------------------------
+# Knowledge layer — long-term memory extraction
+# ---------------------------------------------------------------------------
+#
+# The extractor's LLM binding lives in the `agents:` block below
+# (`knowledge_extractor`), NOT here. Any legacy `extractor_model` key is
+# silently ignored (#1638).
+
+knowledge:
+  embedding_model: "text-embedding-3-small"
+  embedding_dimensions: 1536
+  search_top_k: 10
+  similarity_threshold: 0.85
+
+# ---------------------------------------------------------------------------
+# Per-agent `{driver, model}` bindings (unified registry — #1635/#1636/#1637)
+# ---------------------------------------------------------------------------
+#
+# Every background agent that calls the LLM is resolved via
+# `DriverRegistry::resolve_agent` keyed by its manifest name. The entries
+# below are REQUIRED — missing entries fail boot with an actionable error.
+#
+# Optional `max_output_chars` caps a headless agent's free-form output
+# without a rebuild (currently consumed by `title_gen`).
+
+agents:
+  rara:
+    driver: minimax
+    model: MiniMax-M2.7
+  knowledge_extractor:
+    driver: openai
+    model: gpt-4o-mini
+  title_gen:
+    driver: openai
+    model: gpt-4o-mini
+    max_output_chars: 50
+
+# ---------------------------------------------------------------------------
+# Optional integrations — remove or leave commented out if unused
+# ---------------------------------------------------------------------------
+
+# telegram:
+#   bot_token: "123456:ABC..."
+#   chat_id: "1234567890"
+#   group_policy: "mention_or_small_group"
+#   notification_channel_id: "-1001234567890"
+
+# wechat:
+#   account_id: "your-account-id"
+#   base_url: "https://api.wechat.example/v1"
+
+# composio:
+#   api_key: "cmp_..."
+#   entity_id: "workspace-default"

--- a/crates/app/src/boot.rs
+++ b/crates/app/src/boot.rs
@@ -18,7 +18,10 @@
 //! resolvers, manifests, mcp, composio, skills) into a single module with
 //! private helpers and a public `boot()` entry point.
 
-use std::{collections::BTreeSet, sync::Arc};
+use std::{
+    collections::{BTreeSet, HashMap},
+    sync::Arc,
+};
 
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
@@ -491,26 +494,13 @@ async fn build_driver_registry(
         }
     }
 
-    // Required binding: the knowledge extractor must have both driver + model
-    // so resolve_agent() never falls back to a mismatched default. Fail boot
-    // with an actionable error if missing.
-    {
-        let name = rara_kernel::memory::knowledge::KNOWLEDGE_EXTRACTOR_NAME;
-        let driver = all_settings
-            .get(&format!("agents.{name}.driver"))
-            .filter(|v| !v.trim().is_empty());
-        let model = all_settings
-            .get(&format!("agents.{name}.model"))
-            .filter(|v| !v.trim().is_empty());
-        if driver.is_none() || model.is_none() {
-            anyhow::bail!(
-                "agents.{name}.{{driver, model}} must be configured in config.yaml — the \
-                 knowledge extraction pipeline requires an explicit driver + model pair (see \
-                 issue #1636). Example:\n\nagents:\n  {name}:\n    driver: \"openrouter\"\n    \
-                 model: \"gpt-4o-mini\"\n"
-            );
-        }
-    }
+    // Fail boot when any required background agent is missing an explicit
+    // `{driver, model}` pair. Silent fallbacks are forbidden by the project's
+    // "no config defaults in Rust" rule — and the prod failure in #1629 / #1636
+    // showed that a mismatched default silently breaks the knowledge
+    // extraction pipeline.
+    ensure_required_agent_configs(&all_settings, REQUIRED_BACKGROUND_AGENTS)
+        .map_err(|e| anyhow::anyhow!("{e}"))?;
 
     // -- codex (ChatGPT backend via OAuth) — uses Responses API ----------------
 
@@ -555,8 +545,6 @@ async fn build_driver_registry(
 // =========================================================================
 // Private: InMemoryUserStore
 // =========================================================================
-
-use std::collections::HashMap;
 
 use rara_kernel::{
     error::Result as KernelResult,
@@ -919,11 +907,6 @@ async fn init_knowledge_service(
             anyhow::anyhow!("{} is not configured", keys::KNOWLEDGE_SIMILARITY_THRESHOLD)
         })?
         .parse()?;
-    let extractor_model = settings
-        .get(keys::KNOWLEDGE_EXTRACTOR_MODEL)
-        .await
-        .ok_or_else(|| anyhow::anyhow!("{} is not configured", keys::KNOWLEDGE_EXTRACTOR_MODEL))?;
-
     let config = KnowledgeConfig::builder()
         .embedding_dimensions(embedding_dimensions)
         .search_top_k(search_top_k)
@@ -941,6 +924,135 @@ async fn init_knowledge_service(
         pool,
         embedding_svc,
         config,
-        extractor_model,
     }))
+}
+
+// =========================================================================
+// Background agent config validation (#1638)
+// =========================================================================
+
+/// Background agents whose `{driver, model}` pair MUST be present in
+/// `agents.<name>` for the kernel to boot. Missing entries fail boot with
+/// an actionable error instead of falling back to a hardcoded default
+/// (see `docs/guides/anti-patterns.md` — "no config defaults in Rust").
+///
+/// The list mirrors what `kernel.rs` resolves via `resolve_agent` for
+/// headless background work:
+/// - `knowledge_extractor` — memory extraction pipeline (#1636)
+/// - `title_gen` — session title auto-generation (#1637)
+const REQUIRED_BACKGROUND_AGENTS: &[&str] = &["knowledge_extractor", "title_gen"];
+
+/// Verify every agent in `required` has a non-empty `driver` and `model`
+/// in the flattened settings map. Returns a single error message naming
+/// every unconfigured agent so operators see the full picture at once.
+fn ensure_required_agent_configs(
+    settings: &HashMap<String, String>,
+    required: &[&str],
+) -> Result<(), String> {
+    let missing: Vec<String> = required
+        .iter()
+        .filter(|name| {
+            let driver = settings
+                .get(&format!("agents.{name}.driver"))
+                .filter(|v| !v.trim().is_empty());
+            let model = settings
+                .get(&format!("agents.{name}.model"))
+                .filter(|v| !v.trim().is_empty());
+            driver.is_none() || model.is_none()
+        })
+        .map(|name| (*name).to_string())
+        .collect();
+
+    if missing.is_empty() {
+        return Ok(());
+    }
+
+    let example: String = missing
+        .iter()
+        .map(|n| format!("  {n}:\n    driver: \"openai\"\n    model: \"gpt-4o-mini\""))
+        .collect::<Vec<_>>()
+        .join("\n");
+    Err(format!(
+        "missing required agent config: {names} — every background agent needs an explicit \
+         `{{driver, model}}` pair in config.yaml. See config.example.yaml for the full shape. \
+         Add:\n\nagents:\n{example}\n",
+        names = missing.join(", "),
+    ))
+}
+
+#[cfg(test)]
+mod boot_validation_tests {
+    use super::*;
+
+    fn full_agent_settings() -> HashMap<String, String> {
+        let mut m = HashMap::new();
+        m.insert(
+            "agents.knowledge_extractor.driver".into(),
+            "openrouter".into(),
+        );
+        m.insert(
+            "agents.knowledge_extractor.model".into(),
+            "gpt-4o-mini".into(),
+        );
+        m.insert("agents.title_gen.driver".into(), "openai".into());
+        m.insert("agents.title_gen.model".into(), "gpt-4o-mini".into());
+        m
+    }
+
+    #[test]
+    fn ok_when_all_required_agents_configured() {
+        let settings = full_agent_settings();
+        ensure_required_agent_configs(&settings, REQUIRED_BACKGROUND_AGENTS).expect("boot ok");
+    }
+
+    #[test]
+    fn fails_when_knowledge_extractor_missing() {
+        let mut settings = full_agent_settings();
+        settings.remove("agents.knowledge_extractor.driver");
+        settings.remove("agents.knowledge_extractor.model");
+        let err = ensure_required_agent_configs(&settings, REQUIRED_BACKGROUND_AGENTS)
+            .expect_err("must fail");
+        assert!(
+            err.contains("knowledge_extractor"),
+            "err should name the missing agent: {err}"
+        );
+    }
+
+    #[test]
+    fn fails_when_title_gen_missing() {
+        let mut settings = full_agent_settings();
+        settings.remove("agents.title_gen.driver");
+        settings.remove("agents.title_gen.model");
+        let err = ensure_required_agent_configs(&settings, REQUIRED_BACKGROUND_AGENTS)
+            .expect_err("must fail");
+        assert!(
+            err.contains("title_gen"),
+            "err should name the missing agent: {err}"
+        );
+    }
+
+    #[test]
+    fn fails_when_driver_present_but_model_empty() {
+        let mut settings = full_agent_settings();
+        settings.insert("agents.title_gen.model".into(), "   ".into());
+        let err = ensure_required_agent_configs(&settings, REQUIRED_BACKGROUND_AGENTS)
+            .expect_err("must fail — empty model is same as missing");
+        assert!(err.contains("title_gen"));
+    }
+
+    /// Regression: the legacy `memory.knowledge.extractor_model` key must
+    /// not paper over a missing `agents.knowledge_extractor.model`. The
+    /// validator only looks at the unified `agents.*` namespace.
+    #[test]
+    fn legacy_extractor_model_key_does_not_satisfy_agents_requirement() {
+        let mut settings = full_agent_settings();
+        settings.remove("agents.knowledge_extractor.model");
+        settings.insert(
+            "memory.knowledge.extractor_model".into(),
+            "legacy-model".into(),
+        );
+        let err = ensure_required_agent_configs(&settings, REQUIRED_BACKGROUND_AGENTS)
+            .expect_err("legacy key must not satisfy the unified shape");
+        assert!(err.contains("knowledge_extractor"));
+    }
 }

--- a/crates/app/src/config_sync.rs
+++ b/crates/app/src/config_sync.rs
@@ -296,12 +296,15 @@ knowledge:
   embedding_dimensions: 1536
   search_top_k: 10
   similarity_threshold: 0.85
-  extractor_model: "gpt-4o-mini"
 
 agents:
   knowledge_extractor:
     driver: "openrouter"
     model: "gpt-4o-mini"
+  title_gen:
+    driver: "openai"
+    model: "gpt-4o-mini"
+    max_output_chars: 50
 
 gateway:
   repo_url: "https://github.com/example/repo"

--- a/crates/app/src/flatten.rs
+++ b/crates/app/src/flatten.rs
@@ -129,13 +129,16 @@ pub struct ComposioConfig {
 
 /// Knowledge layer configuration section in config.yaml.
 ///
+/// The extractor LLM binding lives in the unified `agents.knowledge_extractor`
+/// block — see [`AgentsConfig`]. Any legacy `knowledge.extractor_model` key
+/// in a user's YAML is silently ignored (unknown field).
+///
 /// ```yaml
 /// knowledge:
 ///   embedding_model: "text-embedding-3-small"
 ///   embedding_dimensions: 1536
 ///   search_top_k: 10
 ///   similarity_threshold: 0.85
-///   extractor_model: "gpt-4o-mini"
 /// ```
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(default)]
@@ -148,8 +151,6 @@ pub struct KnowledgeConfig {
     pub search_top_k:         Option<u32>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub similarity_threshold: Option<f32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub extractor_model:      Option<String>,
 }
 
 // ---------------------------------------------------------------------------
@@ -160,19 +161,29 @@ pub struct KnowledgeConfig {
 /// [`rara_kernel::llm::AgentLlmConfig`] and is loaded from
 /// `agents.<name>.{driver, model}` in config.yaml.
 ///
+/// Optional `max_output_chars` lets operators cap a headless agent's
+/// free-form output without a rebuild (currently consumed by
+/// `title_gen`; see `kernel/AGENT.md`).
+///
 /// ```yaml
 /// agents:
 ///   knowledge_extractor:
 ///     driver: "openrouter"
 ///     model: "gpt-4o-mini"
+///   title_gen:
+///     driver: "openai"
+///     model: "gpt-4o-mini"
+///     max_output_chars: 50
 /// ```
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(default)]
 pub struct AgentBinding {
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub driver: Option<String>,
+    pub driver:           Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub model:  Option<String>,
+    pub model:            Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max_output_chars: Option<usize>,
 }
 
 /// Top-level `agents:` section — map from agent name to `{driver, model}`.
@@ -218,6 +229,9 @@ fn flatten_agents(agents: &AgentsConfig, out: &mut Vec<(String, String)>) {
         }
         if let Some(ref v) = binding.model {
             out.push((format!("agents.{name}.model"), v.clone()));
+        }
+        if let Some(v) = binding.max_output_chars {
+            out.push((format!("agents.{name}.max_output_chars"), v.to_string()));
         }
     }
 }
@@ -300,9 +314,6 @@ fn flatten_knowledge(k: &KnowledgeConfig, out: &mut Vec<(String, String)>) {
     if let Some(v) = k.similarity_threshold {
         out.push((keys::KNOWLEDGE_SIMILARITY_THRESHOLD.into(), v.to_string()));
     }
-    if let Some(ref v) = k.extractor_model {
-        out.push((keys::KNOWLEDGE_EXTRACTOR_MODEL.into(), v.clone()));
-    }
 }
 
 // ---------------------------------------------------------------------------
@@ -352,7 +363,17 @@ fn unflatten_agents(
     for name in names {
         let driver = pairs.get(&format!("agents.{name}.driver")).cloned();
         let model = pairs.get(&format!("agents.{name}.model")).cloned();
-        out.insert(name, AgentBinding { driver, model });
+        let max_output_chars = pairs
+            .get(&format!("agents.{name}.max_output_chars"))
+            .and_then(|v| v.parse::<usize>().ok());
+        out.insert(
+            name,
+            AgentBinding {
+                driver,
+                model,
+                max_output_chars,
+            },
+        );
     }
     Some(AgentsConfig(out))
 }
@@ -468,13 +489,11 @@ fn unflatten_knowledge(
     let similarity_threshold = pairs
         .get(keys::KNOWLEDGE_SIMILARITY_THRESHOLD)
         .and_then(|v| v.parse::<f32>().ok());
-    let extractor_model = pairs.get(keys::KNOWLEDGE_EXTRACTOR_MODEL).cloned();
 
     if embedding_model.is_none()
         && embedding_dimensions.is_none()
         && search_top_k.is_none()
         && similarity_threshold.is_none()
-        && extractor_model.is_none()
     {
         return None;
     }
@@ -484,7 +503,6 @@ fn unflatten_knowledge(
         embedding_dimensions,
         search_top_k,
         similarity_threshold,
-        extractor_model,
     })
 }
 
@@ -529,7 +547,6 @@ mod tests {
             embedding_dimensions: Some(1536),
             search_top_k:         Some(10),
             similarity_threshold: Some(0.85),
-            extractor_model:      Some("gpt-4o-mini".into()),
         };
 
         // Flatten
@@ -582,7 +599,6 @@ mod tests {
             got_know.similarity_threshold,
             knowledge.similarity_threshold
         );
-        assert_eq!(got_know.extractor_model, knowledge.extractor_model);
     }
 
     #[test]
@@ -603,8 +619,17 @@ mod tests {
         m.insert(
             "knowledge_extractor".to_string(),
             AgentBinding {
-                driver: Some("openrouter".into()),
-                model:  Some("gpt-4o-mini".into()),
+                driver:           Some("openrouter".into()),
+                model:            Some("gpt-4o-mini".into()),
+                max_output_chars: None,
+            },
+        );
+        m.insert(
+            "title_gen".to_string(),
+            AgentBinding {
+                driver:           Some("openai".into()),
+                model:            Some("gpt-4o-mini".into()),
+                max_output_chars: Some(50),
             },
         );
         let agents = AgentsConfig(m);
@@ -617,5 +642,28 @@ mod tests {
         let b = got.0.get("knowledge_extractor").expect("binding present");
         assert_eq!(b.driver.as_deref(), Some("openrouter"));
         assert_eq!(b.model.as_deref(), Some("gpt-4o-mini"));
+        assert_eq!(b.max_output_chars, None);
+        let t = got.0.get("title_gen").expect("title_gen binding present");
+        assert_eq!(t.driver.as_deref(), Some("openai"));
+        assert_eq!(t.model.as_deref(), Some("gpt-4o-mini"));
+        assert_eq!(t.max_output_chars, Some(50));
+    }
+
+    /// Regression: legacy `memory.knowledge.extractor_model` KV pairs must
+    /// be ignored silently — the key no longer exists in
+    /// [`KnowledgeConfig`]. `unflatten_from_settings` keeps no state for
+    /// unrecognised keys, so the output is unchanged from the empty case.
+    #[test]
+    fn legacy_extractor_model_key_is_ignored() {
+        let mut map = HashMap::new();
+        map.insert(
+            "memory.knowledge.extractor_model".to_string(),
+            "legacy-model".to_string(),
+        );
+        let (_llm, _tg, _wc, _cmp, know, _agents) = unflatten_from_settings(&map);
+        assert!(
+            know.is_none(),
+            "legacy extractor_model must not produce a KnowledgeConfig"
+        );
     }
 }

--- a/crates/domain/shared/src/settings/mod.rs
+++ b/crates/domain/shared/src/settings/mod.rs
@@ -53,7 +53,6 @@ pub mod keys {
     pub const KNOWLEDGE_EMBEDDING_DIMENSIONS: &str = "memory.knowledge.embedding_dimensions";
     pub const KNOWLEDGE_SEARCH_TOP_K: &str = "memory.knowledge.search_top_k";
     pub const KNOWLEDGE_SIMILARITY_THRESHOLD: &str = "memory.knowledge.similarity_threshold";
-    pub const KNOWLEDGE_EXTRACTOR_MODEL: &str = "memory.knowledge.extractor_model";
 }
 
 /// Unified trait for reading and writing flat KV settings.

--- a/crates/kernel/AGENT.md
+++ b/crates/kernel/AGENT.md
@@ -10,7 +10,9 @@ It returns a [`ResolvedAgent { driver, model, manifest }`] triple read from
 MUST go through `resolve_agent` so the driver and the model come from a
 single consistent source — the split-config bug that motivated #1635
 (driver resolved via the registry, model resolved via a flat settings key
-like `knowledge.extractor_model`) should not reappear. The legacy
+like `memory.knowledge.extractor_model`) should not reappear. That legacy
+flat key was removed in #1638; no fallback remains in Rust, missing
+`agents.<name>.{driver, model}` fails boot. The legacy
 `DriverRegistry::resolve` tuple API is kept as a thin shim for existing
 callers; migration is tracked in follow-up issues under Epic #1631.
 

--- a/crates/kernel/src/memory/knowledge/service.rs
+++ b/crates/kernel/src/memory/knowledge/service.rs
@@ -22,12 +22,16 @@ use super::{EmbeddingService, KnowledgeConfig};
 
 /// Bundles the knowledge layer's runtime dependencies into a single handle
 /// that can be shared across the kernel.
+///
+/// The extractor agent's `{driver, model}` pair is **not** stored here — it
+/// is resolved per-call via
+/// [`DriverRegistry::resolve_agent`](crate::llm::DriverRegistry::resolve_agent)
+/// keyed by the `knowledge_extractor` manifest, so a single atomic snapshot
+/// reaches `extract_knowledge`. See #1636 / #1638.
 pub struct KnowledgeService {
-    pub pool:            SqlitePool,
-    pub embedding_svc:   Arc<EmbeddingService>,
-    pub config:          KnowledgeConfig,
-    /// LLM model name for memory extraction (from runtime settings).
-    pub extractor_model: String,
+    pub pool:          SqlitePool,
+    pub embedding_svc: Arc<EmbeddingService>,
+    pub config:        KnowledgeConfig,
 }
 
 impl KnowledgeService {

--- a/crates/kernel/src/testing.rs
+++ b/crates/kernel/src/testing.rs
@@ -185,7 +185,6 @@ async fn stub_knowledge_service() -> crate::memory::knowledge::KnowledgeServiceR
         pool,
         embedding_svc: Arc::new(embedding_svc),
         config,
-        extractor_model: "scripted".to_string(),
     })
 }
 


### PR DESCRIPTION
## Summary

Epic #1631 final sub-PR. After #1635/#1636/#1637 migrated every background LLM consumer to `DriverRegistry::resolve_agent`, the transitional flat key `memory.knowledge.extractor_model` and its Rust plumbing are dead weight. This PR removes them and enforces the "no config defaults in Rust" anti-pattern rule by failing boot when a required background agent is missing its `{driver, model}` pair.

- Delete `KNOWLEDGE_EXTRACTOR_MODEL` settings key, `KnowledgeConfig.extractor_model`, unused `KnowledgeService.extractor_model`, and the boot-time flat-key lookup.
- Replace the ad-hoc knowledge-extractor-only bail with a unit-testable `ensure_required_agent_configs` helper covering `knowledge_extractor` + `title_gen` together.
- Extend `AgentBinding` with `max_output_chars` so `agents.title_gen` is fully YAML-driven.
- Add `config.example.yaml` at the repo root with a complete unified `agents:` block.
- Regression tests: legacy flat key is silently ignored and does not satisfy the unified requirement.

## Type of change

| Type | Label |
|------|-------|
| Chore / cleanup | `chore` |

## Component

`core`

## Closes

Closes #1638

## Test plan

- [x] `cargo check --all --all-targets` passes
- [x] `cargo +nightly fmt --all -- --check` passes
- [x] `cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings` passes
- [x] `RUSTDOCFLAGS="-D warnings" cargo +nightly doc --workspace --no-deps --document-private-items` passes
- [x] `cargo test -p rara-kernel --lib` (506 passed)
- [x] `cargo test -p rara-app --lib` (62 passed, incl. new validation + legacy-key regression tests)