### PR TITLE
feat(llm): MiniMax-M2 streaming robustness — driver + kernel + adapter (#1630)

### DIFF
--- a/crates/channels/src/telegram/adapter.rs
+++ b/crates/channels/src/telegram/adapter.rs
@@ -4737,15 +4737,115 @@ fn spawn_stream_forwarder(
                                         }
                                     }
                                 }
-                            } else if let Some(mid) = progress.message_id {
-                                // No trace available (kernel save failed). Leave
-                                // the current progress text in place but drop any
-                                // pending buttons — detail view has nothing to show.
-                                rate_limiter.acquire(chat_id).await;
-                                let text = progress.render_text();
-                                let _ = bot
-                                    .edit_message_text(ChatId(chat_id), mid, &text)
-                                    .await;
+                            } else {
+                                // No trace available. This typically means the
+                                // kernel aborted the turn with a `TurnError`
+                                // (#1641) before emitting `TraceReady`, so the
+                                // progress bubble would otherwise stay stuck on
+                                // the "thinking" indicator — see issue #1634 and
+                                // the production symptom logged as
+                                // `turn completed reply_len=N` with the bubble
+                                // never clearing.
+                                //
+                                // Reconcile unconditionally based on the
+                                // accumulated text state. The `turn.error`
+                                // payload is not currently delivered to the
+                                // per-session stream (the kernel publishes to
+                                // the syscall event queue which fans out to a
+                                // separate notification chat), so `turn_error`
+                                // is `None` here until a kernel-side routing
+                                // change exposes it — the reconcile function
+                                // still handles the 4 terminal combinations
+                                // for when that wiring lands.
+                                let accumulated_snapshot = active_streams
+                                    .get(&chat_id)
+                                    .map(|s| s.accumulated.clone())
+                                    .unwrap_or_default();
+                                let outcome = super::reconcile::reconcile_terminal_state(
+                                    &accumulated_snapshot,
+                                    None,
+                                );
+                                match outcome {
+                                    super::reconcile::TerminalOutcome::Content {
+                                        body, error_footer,
+                                    } => {
+                                        // Content already flushed to stream
+                                        // messages above. Just append an error
+                                        // footer to the progress bubble (or
+                                        // drop it silently) — the user already
+                                        // sees the salvaged reply.
+                                        if let (Some(mid), Some(footer)) =
+                                            (progress.message_id, error_footer)
+                                        {
+                                            rate_limiter.acquire(chat_id).await;
+                                            let _ = bot
+                                                .edit_message_text(
+                                                    ChatId(chat_id),
+                                                    mid,
+                                                    &footer,
+                                                )
+                                                .await;
+                                        }
+                                        // Reference `body` to keep the compiler
+                                        // from flagging it as unused; the raw
+                                        // text is already delivered via the
+                                        // streamed message edit path.
+                                        let _ = body;
+                                    }
+                                    super::reconcile::TerminalOutcome::Error {
+                                        line,
+                                    } => {
+                                        warn!(
+                                            chat_id,
+                                            line = %line,
+                                            "tg stream close: no content + turn error \
+                                             — replacing progress bubble with error line"
+                                        );
+                                        if let Some(mid) = progress.message_id {
+                                            rate_limiter.acquire(chat_id).await;
+                                            let _ = bot
+                                                .edit_message_text(
+                                                    ChatId(chat_id),
+                                                    mid,
+                                                    &line,
+                                                )
+                                                .await;
+                                        } else {
+                                            rate_limiter.acquire(chat_id).await;
+                                            let req = with_thread_id!(
+                                                bot.send_message(ChatId(chat_id), &line),
+                                                thread_id
+                                            );
+                                            let _ = req.await;
+                                        }
+                                    }
+                                    super::reconcile::TerminalOutcome::Neutral {
+                                        line,
+                                    } => {
+                                        // Kernel-side bug: empty terminal turn
+                                        // without a `TurnError` means
+                                        // `#1641` did not fire its emit path.
+                                        // Surface as ERROR for observability
+                                        // and still unstick the bubble.
+                                        tracing::error!(
+                                            chat_id,
+                                            session_id = %session_id,
+                                            "tg stream close: empty content and \
+                                             no turn.error observed — kernel should \
+                                             have emitted TurnError (issue #1634)"
+                                        );
+                                        if let Some(mid) = progress.message_id {
+                                            rate_limiter.acquire(chat_id).await;
+                                            let _ = bot
+                                                .edit_message_text(
+                                                    ChatId(chat_id),
+                                                    mid,
+                                                    &line,
+                                                )
+                                                .await;
+                                        }
+                                    }
+                                }
                             }
 
                             break;

--- a/crates/channels/src/telegram/mod.rs
+++ b/crates/channels/src/telegram/mod.rs
@@ -22,6 +22,7 @@ pub mod loading_hints;
 pub mod markdown;
 pub mod pinned_status;
 pub mod rate_limit;
+pub(crate) mod reconcile;
 pub mod spinner_verbs;
 
 pub use adapter::{TelegramAdapter, TelegramConfig, build_bot, telegram_to_raw_platform_message};

--- a/crates/channels/src/telegram/reconcile.rs
+++ b/crates/channels/src/telegram/reconcile.rs
@@ -1,0 +1,264 @@
+// Copyright 2025 Rararulab
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Terminal-state reconciliation for the Telegram stream forwarder.
+//!
+//! The stream forwarder in [`super::adapter`] renders a progress "thinking"
+//! bubble while the agent turn runs. When the kernel stream closes, the bubble
+//! MUST be reconciled to a terminal state regardless of whether any
+//! `TextDelta` arrived — otherwise a turn that ends empty (salvage failure,
+//! provider protocol error, or a kernel-side `TurnError`) leaves the user
+//! staring at the thinking indicator forever.
+//!
+//! Production symptom this module fixes: kernel logs show
+//! `turn completed reply_len=119` but the Telegram bubble stays on
+//! `discombobulating…` — the forwarder saw only reasoning/tool events and
+//! never a `TextDelta`, so the pre-existing close handler had nothing to
+//! edit and left the bubble intact.
+//!
+//! This module provides a pure state-machine ([`reconcile_terminal_state`])
+//! that maps the terminal state `(accumulated_text, turn_error)` to a
+//! [`TerminalOutcome`] describing how the adapter should render the final
+//! message. The adapter is responsible for translating the outcome into
+//! Telegram API calls; keeping the decision logic pure makes it unit-testable
+//! without a live bot.
+
+use rara_kernel::agent::TurnFailureKind;
+
+/// Adapter-local summary of a kernel `TurnError` that is safe to render into
+/// a user-facing Telegram message. Mirrors [`TurnFailureKind`] plus the model
+/// identifier, which the adapter already tracks via `StreamEvent::TurnMetrics`.
+///
+/// Kept as a distinct struct (rather than reusing
+/// [`rara_kernel::agent::TurnError`]) so reconcile logic does not depend on
+/// `SessionKey` or other kernel-only fields that are not available at the
+/// adapter stream-close site.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct TurnFailureSummary {
+    /// Classification of the failure (`EmptyContent`, `ProtocolError`,
+    /// `EmptyTurn`), mirroring the kernel enum.
+    pub kind: TurnFailureKind,
+}
+
+impl TurnFailureSummary {
+    /// One-line user-facing rendering of the failure, suitable for an inline
+    /// error footer appended to salvaged content or as the sole body when no
+    /// content was produced.
+    pub(super) fn render_line(&self) -> String {
+        match &self.kind {
+            TurnFailureKind::EmptyContent { reasoning_len } => {
+                format!("\u{26a0}\u{fe0f} empty content from model (reasoning_len={reasoning_len})")
+            }
+            TurnFailureKind::ProtocolError { code, message } => {
+                // Provider messages are free-form — truncate to keep the line
+                // compact for the bubble.
+                let short: String = message.chars().take(120).collect();
+                let ellipsis = if message.chars().count() > 120 {
+                    "\u{2026}"
+                } else {
+                    ""
+                };
+                format!("\u{26a0}\u{fe0f} protocol error [{code}]: {short}{ellipsis}")
+            }
+            TurnFailureKind::EmptyTurn => {
+                "\u{26a0}\u{fe0f} model ended turn with no content and no tool calls".to_owned()
+            }
+        }
+    }
+}
+
+/// Terminal action the stream forwarder should take when the kernel stream
+/// closes. Pure data — no side effects, no Telegram API types — so the
+/// decision can be unit-tested in isolation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) enum TerminalOutcome {
+    /// Render the salvaged assistant reply as the final message body.
+    ///
+    /// The adapter's existing flush path already handles the "happy path"
+    /// (edit the current streaming message with `accumulated`), so this
+    /// variant carries the text and an optional footer line the adapter
+    /// appends as a small error note when a failure accompanied salvaged
+    /// content.
+    Content {
+        body:         String,
+        error_footer: Option<String>,
+    },
+    /// The turn produced no content and the kernel published a structured
+    /// failure. The adapter should replace the progress bubble with a single
+    /// user-visible error line.
+    Error { line: String },
+    /// The turn produced no content and no structured failure was observed.
+    /// This is a kernel-side bug (the agent loop should always emit a
+    /// [`rara_kernel::agent::TurnError`] for empty terminal turns), so the
+    /// adapter logs at ERROR and shows a neutral "(no reply)" marker rather
+    /// than leaving the bubble stuck.
+    Neutral { line: String },
+}
+
+/// Neutral placeholder shown when a turn ends with no content and no
+/// structured failure. Public so the adapter can pattern-match tests against
+/// the literal.
+pub(super) const NEUTRAL_EMPTY_MARKER: &str = "(no reply)";
+
+/// Decide how to reconcile the progress bubble at stream close.
+///
+/// Inputs:
+/// - `accumulated`: raw text aggregated from `StreamEvent::TextDelta`. Callers
+///   should pass the same value the existing flush path uses; we treat
+///   whitespace-only strings as empty.
+/// - `turn_error`: structured failure summary observed for this turn, or `None`
+///   if the stream closed cleanly.
+///
+/// Truth table:
+///
+/// | content | error | outcome                                 |
+/// |---------|-------|-----------------------------------------|
+/// | non-∅   | None  | `Content { footer: None }`        |
+/// | non-∅   | Some  | `Content { footer: Some(err) }`   |
+/// | ∅       | Some  | `Error { line: err }`             |
+/// | ∅       | None  | `Neutral { line: "(no reply)" }`  |
+///
+/// User-facing content always wins over the error line: if the turn managed
+/// to produce *any* assistant text we prefer delivering it and append the
+/// error as a small footer, rather than hiding the salvaged reply behind an
+/// error banner.
+pub(super) fn reconcile_terminal_state(
+    accumulated: &str,
+    turn_error: Option<&TurnFailureSummary>,
+) -> TerminalOutcome {
+    let has_content = !accumulated.trim().is_empty();
+    match (has_content, turn_error) {
+        (true, None) => TerminalOutcome::Content {
+            body:         accumulated.to_owned(),
+            error_footer: None,
+        },
+        (true, Some(err)) => TerminalOutcome::Content {
+            body:         accumulated.to_owned(),
+            error_footer: Some(err.render_line()),
+        },
+        (false, Some(err)) => TerminalOutcome::Error {
+            line: err.render_line(),
+        },
+        (false, None) => TerminalOutcome::Neutral {
+            line: NEUTRAL_EMPTY_MARKER.to_owned(),
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn err_empty(reasoning_len: usize) -> TurnFailureSummary {
+        TurnFailureSummary {
+            kind: TurnFailureKind::EmptyContent { reasoning_len },
+        }
+    }
+
+    fn err_protocol(code: &str, message: &str) -> TurnFailureSummary {
+        TurnFailureSummary {
+            kind: TurnFailureKind::ProtocolError {
+                code:    code.to_owned(),
+                message: message.to_owned(),
+            },
+        }
+    }
+
+    fn err_empty_turn() -> TurnFailureSummary {
+        TurnFailureSummary {
+            kind: TurnFailureKind::EmptyTurn,
+        }
+    }
+
+    #[test]
+    fn reconcile_content_without_error_renders_content_no_footer() {
+        let outcome = reconcile_terminal_state("hello world", None);
+        assert_eq!(
+            outcome,
+            TerminalOutcome::Content {
+                body:         "hello world".to_owned(),
+                error_footer: None,
+            }
+        );
+    }
+
+    #[test]
+    fn reconcile_content_with_error_prefers_content_and_adds_footer() {
+        let err = err_protocol("2013", "invalid message role: system");
+        let outcome = reconcile_terminal_state("partial reply", Some(&err));
+        match outcome {
+            TerminalOutcome::Content { body, error_footer } => {
+                assert_eq!(body, "partial reply");
+                let footer = error_footer.expect("footer present");
+                assert!(footer.contains("2013"), "footer={footer}");
+                assert!(footer.contains("invalid message role"), "footer={footer}");
+            }
+            other => panic!("expected Content, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn reconcile_empty_content_with_empty_content_error_renders_error_line() {
+        let err = err_empty(1234);
+        let outcome = reconcile_terminal_state("", Some(&err));
+        match outcome {
+            TerminalOutcome::Error { line } => {
+                assert!(line.contains("reasoning_len=1234"), "line={line}");
+                assert!(line.contains("empty content"), "line={line}");
+            }
+            other => panic!("expected Error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn reconcile_empty_content_with_empty_turn_error_renders_error_line() {
+        let err = err_empty_turn();
+        let outcome = reconcile_terminal_state("   \n\t  ", Some(&err));
+        match outcome {
+            TerminalOutcome::Error { line } => {
+                assert!(line.contains("no content"), "line={line}");
+            }
+            other => panic!("expected Error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn reconcile_empty_content_without_error_renders_neutral_marker() {
+        let outcome = reconcile_terminal_state("", None);
+        assert_eq!(
+            outcome,
+            TerminalOutcome::Neutral {
+                line: NEUTRAL_EMPTY_MARKER.to_owned(),
+            }
+        );
+    }
+
+    #[test]
+    fn reconcile_whitespace_only_content_treated_as_empty() {
+        // Salvage sometimes produces a lone newline; it should not count as
+        // a user-visible reply.
+        let outcome = reconcile_terminal_state("\n  \t\n", None);
+        assert!(matches!(outcome, TerminalOutcome::Neutral { .. }));
+    }
+
+    #[test]
+    fn render_line_truncates_long_protocol_messages() {
+        let long_msg = "x".repeat(500);
+        let err = err_protocol("9999", &long_msg);
+        let line = err.render_line();
+        // Truncated to 120 chars of content + ellipsis, plus fixed prefix.
+        assert!(line.contains("\u{2026}"), "expected ellipsis in {line}");
+        assert!(line.len() < 300, "line too long: {}", line.len());
+    }
+}

--- a/crates/kernel/src/agent/mod.rs
+++ b/crates/kernel/src/agent/mod.rs
@@ -21,6 +21,9 @@ pub(crate) mod repetition;
 pub mod runner;
 pub mod scheduled;
 mod talk_normal;
+pub mod turn_error;
+
+pub use turn_error::{TURN_ERROR_EVENT_TYPE, TurnError, TurnFailureKind};
 
 /// Maximum **byte** length for child/worker agent results passed back to
 /// the parent context.  Child agents are instructed to self-summarize
@@ -1493,6 +1496,11 @@ pub(crate) async fn run_agent_loop(
         let mut has_tool_calls = false;
         let mut last_usage: Option<llm::Usage> = None;
         let mut last_stop_reason: Option<llm::StopReason> = None;
+        // Most recent driver-reported stream failure for this iteration.
+        // `None` on a healthy stream. When `Some(_)` after the stream closes,
+        // the iteration is converted into a `TurnError` and published on the
+        // event bus instead of writing an empty record to tape.
+        let mut stream_failure: Option<llm::StreamFailure> = None;
         // Per-iteration reasoning timer — set on the first ReasoningDelta,
         // settled (added to cumulative_thinking_ms) on either:
         //   a) the first TextDelta (reasoning → content transition), or
@@ -1594,12 +1602,12 @@ pub(crate) async fn run_agent_loop(
                     }
                 }
                 llm::StreamDelta::Failure(failure) => {
-                    // Driver-reported stream failure. Log + fall through;
-                    // the subsequent Done event still closes the turn. Richer
-                    // handling (tape suppression, user-facing error) is
-                    // addressed in the next sub-PR of the streaming-robustness
-                    // epic; behavior here must remain identical to pre-PR.
+                    // Driver-reported stream failure. Retain the latest one
+                    // for post-stream handling (event-bus publication + tape
+                    // suppression) and fall through — the subsequent `Done`
+                    // event still closes the stream cleanly.
                     warn!(iteration, ?failure, "driver reported stream failure");
+                    stream_failure = Some(failure);
                 }
                 llm::StreamDelta::Done { stop_reason, usage } => {
                     if stop_reason == llm::StopReason::ToolCalls && pending_tool_calls.is_empty() {
@@ -2007,6 +2015,51 @@ pub(crate) async fn run_agent_loop(
                     .await;
                 continue;
             }
+            // Reject empty terminal turns: nudges and recoveries had their
+            // chance; writing an empty `[assistant]:` record to tape would
+            // strand the user with no reply AND poison subsequent context
+            // rebuilds. Convert to a structured `TurnError`, publish it on
+            // the event bus for downstream consumers (telegram adapter,
+            // `/status`), and fail the turn so the caller can surface the
+            // failure instead of delivering an empty message.
+            if accumulated_text.trim().is_empty() || stream_failure.is_some() {
+                let failure_kind = stream_failure
+                    .take()
+                    .map(turn_error::TurnFailureKind::from)
+                    .unwrap_or(turn_error::TurnFailureKind::EmptyTurn);
+                let summary = turn_error::TurnError::short_summary(&failure_kind, model.as_str());
+                let turn_err = turn_error::TurnError::builder()
+                    .session_key(session_key)
+                    .model(model.to_string())
+                    .iteration(iteration)
+                    .failure_kind(failure_kind)
+                    .message(summary.clone())
+                    .build();
+
+                error!(
+                    iteration,
+                    model = model.as_str(),
+                    summary = %summary,
+                    "turn terminated with no usable assistant content — emitting TurnError"
+                );
+
+                match serde_json::to_value(&turn_err) {
+                    Ok(payload) => {
+                        if let Err(e) = handle
+                            .publish_event(session_key, turn_error::TURN_ERROR_EVENT_TYPE, payload)
+                            .await
+                        {
+                            warn!(error = %e, "failed to publish turn.error event");
+                        }
+                    }
+                    Err(e) => {
+                        warn!(error = %e, "failed to serialize TurnError payload");
+                    }
+                }
+
+                return Err(KernelError::AgentExecution { message: summary });
+            }
+
             // Persist final assistant message to tape.
             let meta = serde_json::to_value(crate::memory::LlmEntryMetadata {
                 rara_message_id: rara_message_id.to_string(),

--- a/crates/kernel/src/agent/mod.rs
+++ b/crates/kernel/src/agent/mod.rs
@@ -1593,6 +1593,14 @@ pub(crate) async fn run_agent_loop(
                         tc.arguments_buf.push_str(&arguments);
                     }
                 }
+                llm::StreamDelta::Failure(failure) => {
+                    // Driver-reported stream failure. Log + fall through;
+                    // the subsequent Done event still closes the turn. Richer
+                    // handling (tape suppression, user-facing error) is
+                    // addressed in the next sub-PR of the streaming-robustness
+                    // epic; behavior here must remain identical to pre-PR.
+                    warn!(iteration, ?failure, "driver reported stream failure");
+                }
                 llm::StreamDelta::Done { stop_reason, usage } => {
                     if stop_reason == llm::StopReason::ToolCalls && pending_tool_calls.is_empty() {
                         warn!(

--- a/crates/kernel/src/agent/turn_error.rs
+++ b/crates/kernel/src/agent/turn_error.rs
@@ -1,0 +1,156 @@
+// Copyright 2025 Rararulab
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Structured error reported for a failed LLM turn.
+//!
+//! A [`TurnError`] is emitted when a turn cannot produce a usable assistant
+//! reply — either because the driver surfaced a [`crate::llm::StreamFailure`]
+//! or because the iteration terminated with empty content and no tool calls
+//! after all recovery attempts were exhausted.
+//!
+//! [`TurnError`] is published to the kernel event bus (event type
+//! `turn.error`) so downstream consumers (telegram adapter, `/status`
+//! endpoint, observability sinks) can surface the failure to the user rather
+//! than leaving them staring at an empty "thinking" indicator.
+
+use serde::{Deserialize, Serialize};
+
+use crate::{llm::StreamFailure, session::SessionKey};
+
+/// Event type label used when publishing [`TurnError`] to the kernel event
+/// bus via [`crate::handle::KernelHandle::publish_event`].
+pub const TURN_ERROR_EVENT_TYPE: &str = "turn.error";
+
+/// Classification of the root cause of a failed turn.
+///
+/// This mirrors [`StreamFailure`] where possible, plus additional kinds that
+/// are only detectable after the stream closes (e.g. an iteration ending
+/// with no content and no tool calls despite a clean `Done` signal).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum TurnFailureKind {
+    /// The driver closed the stream without assistant content, even after
+    /// attempting salvage from the reasoning buffer.
+    EmptyContent {
+        /// Size of the reasoning buffer at close. `0` when the failure was
+        /// detected by the agent loop itself rather than by the driver.
+        reasoning_len: usize,
+    },
+    /// The provider returned a non-retryable protocol error.
+    ProtocolError {
+        /// Provider-specific error code (e.g. MiniMax `"2013"`).
+        code:    String,
+        /// Provider-specific human-readable message.
+        message: String,
+    },
+    /// The iteration terminated with no text and no tool calls after all
+    /// recovery paths were exhausted (nudges, auto-fold + retry, etc.).
+    EmptyTurn,
+}
+
+impl From<StreamFailure> for TurnFailureKind {
+    fn from(value: StreamFailure) -> Self {
+        match value {
+            StreamFailure::EmptyContent { reasoning_len } => Self::EmptyContent { reasoning_len },
+            StreamFailure::ProtocolError { code, message } => Self::ProtocolError { code, message },
+        }
+    }
+}
+
+/// Structured description of a failed turn, suitable for publishing on the
+/// kernel event bus and surfacing to the user.
+///
+/// Construct via [`TurnError::builder`] and serialize into the event payload
+/// with `serde_json::to_value`. The payload MUST include a non-empty
+/// `message` field so the `PublishEvent` syscall does not drop it.
+#[derive(Debug, Clone, Serialize, Deserialize, bon::Builder)]
+pub struct TurnError {
+    /// Session that owned the failed turn.
+    pub session_key:  SessionKey,
+    /// Model identifier used for the turn (e.g. `"minimax/m2"`).
+    pub model:        String,
+    /// Provider request ID when available — otherwise `None`.
+    pub request_id:   Option<String>,
+    /// Iteration index within the turn at which the failure surfaced.
+    pub iteration:    usize,
+    /// Structured failure classification.
+    pub failure_kind: TurnFailureKind,
+    /// Human-readable summary used as the notification `message` body.
+    /// Required: the `PublishEvent` syscall drops payloads with an empty
+    /// `message` field.
+    pub message:      String,
+}
+
+impl TurnError {
+    /// Short human-readable tag for logging and the `message` field.
+    pub fn short_summary(failure_kind: &TurnFailureKind, model: &str) -> String {
+        match failure_kind {
+            TurnFailureKind::EmptyContent { reasoning_len } => {
+                format!(
+                    "model `{model}` produced no assistant content (reasoning_len={reasoning_len})"
+                )
+            }
+            TurnFailureKind::ProtocolError { code, message } => {
+                format!("provider `{model}` protocol error [{code}]: {message}")
+            }
+            TurnFailureKind::EmptyTurn => {
+                format!("model `{model}` ended turn with no content and no tool calls")
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn from_stream_failure_empty_content() {
+        let kind: TurnFailureKind = StreamFailure::EmptyContent { reasoning_len: 42 }.into();
+        assert_eq!(kind, TurnFailureKind::EmptyContent { reasoning_len: 42 });
+    }
+
+    #[test]
+    fn from_stream_failure_protocol_error() {
+        let kind: TurnFailureKind = StreamFailure::ProtocolError {
+            code:    "2013".into(),
+            message: "invalid message role: system".into(),
+        }
+        .into();
+        assert_eq!(
+            kind,
+            TurnFailureKind::ProtocolError {
+                code:    "2013".into(),
+                message: "invalid message role: system".into(),
+            }
+        );
+    }
+
+    #[test]
+    fn builder_round_trips_serde() {
+        let err = TurnError::builder()
+            .session_key(SessionKey::new())
+            .model("minimax/m2".to_string())
+            .iteration(3)
+            .failure_kind(TurnFailureKind::EmptyTurn)
+            .message("turn failed".to_string())
+            .build();
+        let value = serde_json::to_value(&err).expect("serialize");
+        let back: TurnError = serde_json::from_value(value).expect("deserialize");
+        assert_eq!(back.model, err.model);
+        assert_eq!(back.iteration, err.iteration);
+        assert_eq!(back.failure_kind, TurnFailureKind::EmptyTurn);
+        assert_eq!(back.message, "turn failed");
+    }
+}

--- a/crates/kernel/src/llm/mod.rs
+++ b/crates/kernel/src/llm/mod.rs
@@ -42,5 +42,5 @@ pub use driver::{
 pub use openai::{OpenAiDriver, is_local_url};
 pub use registry::{DriverRegistry, DriverRegistryRef, ProviderModelConfig};
 pub use scripted::ScriptedLlmDriver;
-pub use stream::StreamDelta;
+pub use stream::{StreamDelta, StreamFailure};
 pub use types::*;

--- a/crates/kernel/src/llm/openai.rs
+++ b/crates/kernel/src/llm/openai.rs
@@ -1348,6 +1348,44 @@ async fn stream_responses_api(
         }
     }
 
+    // Stream-close salvage for the Responses API path. Providers routed
+    // through this format (currently OpenAI + clones) shouldn't hit the
+    // MiniMax failure mode, but the guard is symmetric with the chat
+    // completions path and costs nothing when reasoning is empty.
+    if state.accumulated_text.is_empty()
+        && !state.accumulated_reasoning.is_empty()
+        && !state.has_function_call
+    {
+        match salvage_after_think(&state.accumulated_reasoning) {
+            Some(salvaged) => {
+                tracing::warn!(
+                    reasoning_len = state.accumulated_reasoning.len(),
+                    salvaged_len = salvaged.len(),
+                    "Responses API stream closed with empty content; salvaged text after </think>"
+                );
+                let _ = tx
+                    .send(StreamDelta::TextDelta {
+                        text: salvaged.clone(),
+                    })
+                    .await;
+                state.accumulated_text.push_str(&salvaged);
+            }
+            None => {
+                tracing::warn!(
+                    reasoning_len = state.accumulated_reasoning.len(),
+                    "Responses API stream closed with empty content and no salvageable text"
+                );
+                let _ = tx
+                    .send(StreamDelta::Failure(
+                        super::stream::StreamFailure::EmptyContent {
+                            reasoning_len: state.accumulated_reasoning.len(),
+                        },
+                    ))
+                    .await;
+            }
+        }
+    }
+
     let _ = tx
         .send(StreamDelta::Done {
             stop_reason: state.final_stop,
@@ -1786,7 +1824,7 @@ impl StreamAccumulator {
         }
 
         let Self {
-            text,
+            mut text,
             reasoning,
             tools,
             stop_reason,
@@ -1794,6 +1832,43 @@ impl StreamAccumulator {
             ..
         } = self;
         let tool_calls = Self::collect_tools(tools);
+
+        // Stream-close salvage: some reasoning-capable providers (MiniMax-M2)
+        // emit the real answer inside `reasoning_content` after `</think>`
+        // and then close the stream without ever emitting `content`. When we
+        // see reasoning but no text, try to extract text after the last
+        // `</think>` tag; if that fails, surface a typed failure so upstream
+        // consumers can avoid writing an empty assistant record.
+        if text.is_empty() && !reasoning.is_empty() && tool_calls.is_empty() {
+            match salvage_after_think(&reasoning) {
+                Some(salvaged) => {
+                    tracing::warn!(
+                        reasoning_len = reasoning.len(),
+                        salvaged_len = salvaged.len(),
+                        "stream closed with empty content; salvaged text after </think>"
+                    );
+                    let _ = tx
+                        .send(StreamDelta::TextDelta {
+                            text: salvaged.clone(),
+                        })
+                        .await;
+                    text.push_str(&salvaged);
+                }
+                None => {
+                    tracing::warn!(
+                        reasoning_len = reasoning.len(),
+                        "stream closed with empty content and no salvageable text after </think>"
+                    );
+                    let _ = tx
+                        .send(StreamDelta::Failure(
+                            super::stream::StreamFailure::EmptyContent {
+                                reasoning_len: reasoning.len(),
+                            },
+                        ))
+                        .await;
+                }
+            }
+        }
 
         let _ = tx.send(StreamDelta::Done { stop_reason, usage }).await;
 
@@ -1813,6 +1888,28 @@ impl StreamAccumulator {
 // ---------------------------------------------------------------------------
 
 fn non_empty(s: String) -> Option<String> { if s.is_empty() { None } else { Some(s) } }
+
+/// Attempt to recover assistant text trailing the last `</think>` tag in a
+/// reasoning buffer.
+///
+/// Observed MiniMax-M2 failure mode: the model streams
+/// `reasoning_content` containing a complete `<think>...</think>` block (and
+/// sometimes the real answer in the same field after the closing tag), then
+/// closes the SSE stream without ever emitting `content`. Callers use this
+/// helper at stream close to salvage that trailing text.
+///
+/// Returns `None` when the buffer contains no `</think>` tag, or when the
+/// text after the last one is whitespace-only.
+fn salvage_after_think(reasoning: &str) -> Option<String> {
+    const CLOSE_TAG: &str = "</think>";
+    let tail = reasoning.rsplit_once(CLOSE_TAG).map(|(_, rest)| rest)?;
+    let trimmed = tail.trim();
+    if trimmed.is_empty() {
+        None
+    } else {
+        Some(trimmed.to_owned())
+    }
+}
 
 /// Truncate a string to at most `max_bytes` bytes without splitting a UTF-8
 /// code point.
@@ -2749,5 +2846,123 @@ mod tests {
         let data = r#"{"some":"data"}"#;
         let result = parse_responses_event("response.something.new", data, &tx, &mut state);
         assert!(result.is_none());
+    }
+
+    // -----------------------------------------------------------------
+    // Stream-close salvage (issue #1632)
+    // -----------------------------------------------------------------
+
+    #[test]
+    fn salvage_after_think_extracts_trailing_text() {
+        let reasoning = "<think>planning...</think>\nHere is the answer.";
+        let salvaged = salvage_after_think(reasoning).expect("should salvage");
+        assert_eq!(salvaged, "Here is the answer.");
+    }
+
+    #[test]
+    fn salvage_after_think_prefers_last_close_tag() {
+        // Defensive: malformed reasoning with multiple close tags — take the
+        // tail after the final one, matching real-world MiniMax output where
+        // the last </think> marks the transition to the answer.
+        let reasoning = "<think>step1</think>intermediate<think>step2</think>final answer";
+        let salvaged = salvage_after_think(reasoning).expect("should salvage");
+        assert_eq!(salvaged, "final answer");
+    }
+
+    #[test]
+    fn salvage_after_think_no_close_tag_returns_none() {
+        let reasoning = "unterminated reasoning with no close tag";
+        assert!(salvage_after_think(reasoning).is_none());
+    }
+
+    #[test]
+    fn salvage_after_think_whitespace_only_tail_returns_none() {
+        let reasoning = "<think>all thoughts</think>   \n\t  ";
+        assert!(salvage_after_think(reasoning).is_none());
+    }
+
+    #[tokio::test]
+    async fn finalize_salvages_reasoning_and_emits_text_delta() {
+        let (tx, mut rx) = mpsc::channel(32);
+        let mut acc = StreamAccumulator::new();
+        // Simulate a MiniMax-style stream: only reasoning_content arrived,
+        // and the answer sits after a closing </think> tag.
+        acc.reasoning
+            .push_str("<think>deliberating...</think>The capital is Paris.");
+
+        let response = acc.finalize(&tx, "minimax-m2".to_string()).await;
+
+        // The salvaged text must be emitted as a TextDelta before Done.
+        let first = rx.try_recv().expect("should receive a delta");
+        match first {
+            StreamDelta::TextDelta { text } => assert_eq!(text, "The capital is Paris."),
+            other => panic!("expected TextDelta, got {other:?}"),
+        }
+        let second = rx.try_recv().expect("should receive Done");
+        assert!(matches!(second, StreamDelta::Done { .. }));
+
+        assert_eq!(response.content.as_deref(), Some("The capital is Paris."));
+        assert!(response.reasoning_content.is_some());
+    }
+
+    #[tokio::test]
+    async fn finalize_emits_failure_when_salvage_fails() {
+        let (tx, mut rx) = mpsc::channel(32);
+        let mut acc = StreamAccumulator::new();
+        // Reasoning with no closing </think> tag — salvage must fail.
+        acc.reasoning
+            .push_str("<think>thinking forever without closing");
+
+        let response = acc.finalize(&tx, "minimax-m2".to_string()).await;
+
+        let first = rx.try_recv().expect("should receive failure");
+        match first {
+            StreamDelta::Failure(super::super::stream::StreamFailure::EmptyContent {
+                reasoning_len,
+            }) => {
+                assert!(reasoning_len > 0);
+            }
+            other => panic!("expected Failure::EmptyContent, got {other:?}"),
+        }
+        let second = rx.try_recv().expect("should receive Done");
+        assert!(matches!(second, StreamDelta::Done { .. }));
+
+        assert!(response.content.is_none());
+    }
+
+    #[tokio::test]
+    async fn finalize_no_reasoning_leaves_stream_unchanged() {
+        // Non-reasoning provider: both buffers empty. Salvage must not fire;
+        // the stream emits only Done.
+        let (tx, mut rx) = mpsc::channel(32);
+        let acc = StreamAccumulator::new();
+
+        let response = acc.finalize(&tx, "gpt-4o".to_string()).await;
+
+        let first = rx.try_recv().expect("should receive Done");
+        assert!(matches!(first, StreamDelta::Done { .. }));
+        assert!(rx.try_recv().is_err(), "no further deltas expected");
+
+        assert!(response.content.is_none());
+        assert!(response.reasoning_content.is_none());
+    }
+
+    #[tokio::test]
+    async fn finalize_with_text_skips_salvage() {
+        // Both text and reasoning present: salvage must NOT run, and no
+        // synthetic TextDelta or Failure must be emitted.
+        let (tx, mut rx) = mpsc::channel(32);
+        let mut acc = StreamAccumulator::new();
+        acc.text.push_str("already streamed");
+        acc.reasoning
+            .push_str("<think>ignored</think>trailing ignored");
+
+        let response = acc.finalize(&tx, "minimax-m2".to_string()).await;
+
+        let first = rx.try_recv().expect("should receive Done");
+        assert!(matches!(first, StreamDelta::Done { .. }));
+        assert!(rx.try_recv().is_err(), "no salvage delta expected");
+
+        assert_eq!(response.content.as_deref(), Some("already streamed"));
     }
 }

--- a/crates/kernel/src/llm/stream.rs
+++ b/crates/kernel/src/llm/stream.rs
@@ -16,6 +16,36 @@
 
 use super::types::{StopReason, Usage};
 
+/// Typed failure reasons reported by a driver at stream close.
+///
+/// Emitted as part of [`StreamDelta::Failure`] when the driver completes a
+/// stream but detects a condition that would otherwise silently produce an
+/// empty or malformed assistant turn. Consumers may use these signals to
+/// surface errors to the user instead of writing empty tape records.
+#[derive(Debug, Clone)]
+pub enum StreamFailure {
+    /// The provider closed the stream with no assistant content despite
+    /// emitting `reasoning_content` — typically MiniMax-M2 finishing the
+    /// `<think>` block and then hitting EOS before any real answer. The
+    /// driver already attempted salvage (extracting text after the last
+    /// `</think>` tag) and either found nothing or only whitespace.
+    EmptyContent {
+        /// Number of characters in the reasoning buffer at stream close —
+        /// useful for diagnostics and for consumers deciding whether to
+        /// retry vs. surface the failure.
+        reasoning_len: usize,
+    },
+    /// The provider returned a non-retryable protocol error (e.g. MiniMax
+    /// `system (2013)` HTTP 400). The driver propagates the provider's
+    /// error code and human-readable message.
+    ProtocolError {
+        /// Provider-specific error code (e.g. `"2013"`).
+        code:    String,
+        /// Provider-specific human-readable message.
+        message: String,
+    },
+}
+
 /// Events emitted during streaming LLM completion.
 ///
 /// The LLM driver sends these through an `mpsc::Sender<StreamDelta>` as
@@ -35,6 +65,12 @@ pub enum StreamDelta {
     },
     /// Incremental JSON fragment for an in-progress tool call's arguments.
     ToolCallArgumentsDelta { index: u32, arguments: String },
+    /// A typed failure signal emitted by the driver before `Done`.
+    ///
+    /// Consumers that do not understand a specific failure kind should log
+    /// and fall through — the following `Done` event will still close the
+    /// stream.
+    Failure(StreamFailure),
     /// The stream is complete.
     Done {
         stop_reason: StopReason,

--- a/crates/kernel/src/memory/context.rs
+++ b/crates/kernel/src/memory/context.rs
@@ -374,6 +374,50 @@ pub fn merge_leading_system_messages(messages: Vec<Message>) -> Vec<Message> {
     result
 }
 
+/// Prefix inserted when a non-leading system message is rewritten as a
+/// user-role message to satisfy providers that reject mid-stream `system`
+/// roles (e.g. MiniMax `invalid message role: system (2013)`).
+const SYSTEM_NOTE_PREFIX: &str = "[system note] ";
+
+/// Normalize the message list so that `Role::System` appears **only** at
+/// position 0.
+///
+/// Rationale: some providers (notably MiniMax) reject any chat-completion
+/// request that contains a `system` role after the first message with HTTP
+/// 400 `invalid message role: system (2013)`. Tape-driven context rebuilds
+/// can legitimately interleave system-role metadata (anchor summaries, user
+/// memory, ad-hoc system notes) into the middle of the stream, so we must
+/// rewrite any non-leading occurrence before dispatch.
+///
+/// Strategy:
+/// 1. Collapse every leading system message (position 0..k) into a single
+///    concatenated system message via [`merge_leading_system_messages`].
+/// 2. Rewrite any remaining `Role::System` message into a `Role::User` message
+///    prefixed with [`SYSTEM_NOTE_PREFIX`] so the semantic intent (out-of-band
+///    instruction) is preserved without abusing the `system` role the provider
+///    rejects.
+///
+/// The `user`-with-prefix form is a deliberate trade-off: an alternative
+/// would be to silently merge mid-stream system content back into the
+/// leading prompt, but that destroys the message's position in the
+/// conversation timeline. Preserving position as a `user` turn keeps the
+/// LLM's chronological reasoning intact.
+pub fn collapse_system_messages(messages: Vec<Message>) -> Vec<Message> {
+    let merged = merge_leading_system_messages(messages);
+    merged
+        .into_iter()
+        .enumerate()
+        .map(|(idx, msg)| {
+            if idx > 0 && msg.role == crate::llm::Role::System {
+                let text = msg.content.as_text().to_owned();
+                Message::user(format!("{SYSTEM_NOTE_PREFIX}{text}"))
+            } else {
+                msg
+            }
+        })
+        .collect()
+}
+
 #[cfg(test)]
 mod tests {
     use jiff::Timestamp;
@@ -765,6 +809,69 @@ mod tests {
         let merged = merge_leading_system_messages(messages);
         assert_eq!(merged.len(), 1);
         assert_eq!(merged[0].content.as_text(), "a\n\n---\n\nb");
+    }
+
+    #[test]
+    fn collapse_system_messages_merges_leading_and_rewrites_midstream() {
+        let messages = vec![
+            Message::system("prompt"),
+            Message::system("[User Memory]\nnotes"),
+            Message::user("hi"),
+            Message::assistant("hello"),
+            Message::system("mid-stream hint"),
+            Message::user("bye"),
+        ];
+        let out = collapse_system_messages(messages);
+        // One leading system, the rest mid-stream system has been rewritten.
+        let system_count = out.iter().filter(|m| m.role == Role::System).count();
+        assert_eq!(system_count, 1, "only position 0 should carry Role::System");
+        assert_eq!(out[0].role, Role::System);
+        assert!(out[0].content.as_text().contains("prompt"));
+        assert!(out[0].content.as_text().contains("[User Memory]"));
+        // Mid-stream system is now a user message with the prefix marker.
+        let rewritten = out
+            .iter()
+            .find(|m| m.role == Role::User && m.content.as_text().starts_with("[system note] "));
+        let rewritten = rewritten.expect("mid-stream system should be rewritten as user");
+        assert!(rewritten.content.as_text().contains("mid-stream hint"));
+    }
+
+    #[test]
+    fn collapse_system_messages_round_trip_no_midstream_system() {
+        let messages = vec![
+            Message::system("prompt"),
+            Message::user("hi"),
+            Message::assistant("hello"),
+        ];
+        let out = collapse_system_messages(messages.clone());
+        assert_eq!(out.len(), messages.len());
+        assert_eq!(out[0].role, Role::System);
+        assert_eq!(out[1].role, Role::User);
+        assert_eq!(out[2].role, Role::Assistant);
+    }
+
+    #[test]
+    fn collapse_system_messages_empty() {
+        assert!(collapse_system_messages(vec![]).is_empty());
+    }
+
+    #[test]
+    fn collapse_system_messages_multiple_midstream() {
+        let messages = vec![
+            Message::system("prompt"),
+            Message::user("hi"),
+            Message::system("hint A"),
+            Message::system("hint B"),
+            Message::assistant("ok"),
+        ];
+        let out = collapse_system_messages(messages);
+        let system_count = out.iter().filter(|m| m.role == Role::System).count();
+        assert_eq!(system_count, 1);
+        let rewritten: Vec<_> = out
+            .iter()
+            .filter(|m| m.role == Role::User && m.content.as_text().starts_with("[system note] "))
+            .collect();
+        assert_eq!(rewritten.len(), 2);
     }
 
     #[test]

--- a/crates/kernel/src/memory/service.rs
+++ b/crates/kernel/src/memory/service.rs
@@ -370,10 +370,12 @@ impl TapeService {
         };
         messages.extend(history);
 
-        // Merge all leading system messages into one for providers with strict
-        // chat templates (e.g. Qwen via llama.cpp) that require a single
-        // system message at position 0.
-        Ok(super::context::merge_leading_system_messages(messages))
+        // Collapse every `system` role into position 0: merge leading system
+        // messages and rewrite any mid-stream `system` message as a prefixed
+        // `user` turn. This is mandatory for providers that reject non-first
+        // system roles (MiniMax `invalid message role: system (2013)`) and
+        // safe for providers that tolerate them.
+        Ok(super::context::collapse_system_messages(messages))
     }
 
     // -----------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Closes #1630 (Epic A). Hardens the streaming path for reasoning-capable models so that no single failure mode results in a silent empty reply.

Motivation: MiniMax-M2 occasionally emits `reasoning_content` without `content`, or hits `max_tokens` inside `<think>`. Before this change, the tape captured empty `[assistant]:` records, Telegram stayed on `discombobulating...` forever, and protocol errors (e.g. `invalid message role: system (2013)`) never reached the user. Fix is layered so each layer stays valid in isolation.

Sub-PRs (all merged into this branch):

- **#1639** `feat(llm): stream-close salvage for empty content with reasoning buffer` — driver layer. `StreamFailure::EmptyContent { reasoning_len }` + `StreamFailure::ProtocolError { code, message }` emitted via `StreamDelta::Failure`. On stream close with empty content but non-empty reasoning buffer, attempts salvage after the last `</think>` tag.
- **#1641** `feat(kernel): reject empty turns, route failures to error bus` — kernel layer. Consumes `StreamDelta::Failure`, emits structured `TurnError` on the event bus, refuses to write empty-content-no-tool-call assistant turns to the tape. `context.rs::collapse_system_messages` merges / rewrites mid-stream `system` messages so MiniMax's `system (2013)` 400 is structurally impossible.
- **#1644** `fix(web): telegram stream-close reconcile + turn.error rendering` — adapter layer. New `reconcile.rs` state machine: non-empty content → final render; empty + error → visible error line; empty + no error → neutral `(no reply)` marker + ERROR log. The bubble can no longer get stuck.

## Type of change

| Type | Label |
|------|-------|
| New feature | `enhancement` |

## Component

`core`, `ui`

## Closes

Closes #1630
Supersedes #1627, #1628

## Follow-up

- #1645 — route `turn.error` kernel events to the per-session stream channel the TG adapter subscribes to (adapter code is ready, bridge not yet wired)

## Test plan

- [x] `cargo check -p rara-kernel -p rara-channels` — passes
- [x] `cargo test -p rara-kernel` — 550 pass
- [x] `cargo test -p rara-channels` — reconciler unit tests pass (4 terminal states + footer + truncation)
- [x] `prek run --all-files` — clean across all sub-PRs
- [ ] Manual: force a MiniMax empty-content turn, verify TG shows `(no reply)` with ERROR log instead of stuck bubble