### PR TITLE
refactor(kernel): unified background-agent framework (#1631)

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -1,0 +1,111 @@
+# Example rara configuration.
+#
+# Copy to `~/.config/rara/config.yaml` (see `rara_paths::config_file()`) or
+# to `./config.yaml` next to the binary. All required keys must be present;
+# rara will fail to boot with an explicit error if a required field is
+# missing. There are NO hardcoded defaults in Rust code — this file is the
+# single source of truth for every tunable.
+
+# ---------------------------------------------------------------------------
+# HTTP + gRPC servers (required)
+# ---------------------------------------------------------------------------
+
+http:
+  bind_address: "127.0.0.1:25555"
+
+grpc:
+  bind_address: "127.0.0.1:50051"
+  server_address: "127.0.0.1:50051"
+
+# ---------------------------------------------------------------------------
+# Configured users — platform identity mappings (required, non-empty)
+# ---------------------------------------------------------------------------
+
+users:
+  - name: "you"
+    role: root
+    platforms:
+      - type: telegram
+        user_id: "1234567890"
+
+# ---------------------------------------------------------------------------
+# Mita proactive agent (required)
+# ---------------------------------------------------------------------------
+
+mita:
+  heartbeat_interval: "30m"
+
+# ---------------------------------------------------------------------------
+# LLM provider registry — seeded to the settings store at startup
+# ---------------------------------------------------------------------------
+
+llm:
+  default_provider: "openrouter"
+  providers:
+    openrouter:
+      base_url: "https://openrouter.ai/api/v1"
+      api_key: "sk-or-..."
+      default_model: "anthropic/claude-3.5-sonnet"
+    openai:
+      base_url: "https://api.openai.com/v1"
+      api_key: "sk-..."
+      default_model: "gpt-4o-mini"
+    minimax:
+      base_url: "https://api.minimax.io/v1"
+      api_key: "mm-..."
+      default_model: "MiniMax-M2.7"
+
+# ---------------------------------------------------------------------------
+# Knowledge layer — long-term memory extraction
+# ---------------------------------------------------------------------------
+#
+# The extractor's LLM binding lives in the `agents:` block below
+# (`knowledge_extractor`), NOT here. Any legacy `extractor_model` key is
+# silently ignored (#1638).
+
+knowledge:
+  embedding_model: "text-embedding-3-small"
+  embedding_dimensions: 1536
+  search_top_k: 10
+  similarity_threshold: 0.85
+
+# ---------------------------------------------------------------------------
+# Per-agent `{driver, model}` bindings (unified registry — #1635/#1636/#1637)
+# ---------------------------------------------------------------------------
+#
+# Every background agent that calls the LLM is resolved via
+# `DriverRegistry::resolve_agent` keyed by its manifest name. The entries
+# below are REQUIRED — missing entries fail boot with an actionable error.
+#
+# Optional `max_output_chars` caps a headless agent's free-form output
+# without a rebuild (currently consumed by `title_gen`).
+
+agents:
+  rara:
+    driver: minimax
+    model: MiniMax-M2.7
+  knowledge_extractor:
+    driver: openai
+    model: gpt-4o-mini
+  title_gen:
+    driver: openai
+    model: gpt-4o-mini
+    max_output_chars: 50
+
+# ---------------------------------------------------------------------------
+# Optional integrations — remove or leave commented out if unused
+# ---------------------------------------------------------------------------
+
+# telegram:
+#   bot_token: "123456:ABC..."
+#   chat_id: "1234567890"
+#   group_policy: "mention_or_small_group"
+#   notification_channel_id: "-1001234567890"
+
+# wechat:
+#   account_id: "your-account-id"
+#   base_url: "https://api.wechat.example/v1"
+
+# composio:
+#   api_key: "cmp_..."
+#   entity_id: "workspace-default"

--- a/crates/agents/src/lib.rs
+++ b/crates/agents/src/lib.rs
@@ -56,6 +56,7 @@ static RARA_MANIFEST: LazyLock<AgentManifest> = LazyLock::new(|| AgentManifest {
     tool_call_limit:        None,
     worker_timeout_secs:    None,
     max_continuations:      Some(10),
+    max_output_chars:       None,
 });
 
 /// Build the **rara** agent manifest — the default user-facing chat agent.
@@ -85,6 +86,7 @@ static NANA_MANIFEST: LazyLock<AgentManifest> = LazyLock::new(|| AgentManifest {
     tool_call_limit:        None,
     worker_timeout_secs:    None,
     max_continuations:      Some(0),
+    max_output_chars:       None,
 });
 
 /// Build the **nana** agent manifest — a chat-only companion for regular users.
@@ -115,6 +117,7 @@ static WORKER_MANIFEST: LazyLock<AgentManifest> = LazyLock::new(|| AgentManifest
     tool_call_limit:        None,
     worker_timeout_secs:    None,
     max_continuations:      Some(0),
+    max_output_chars:       None,
 });
 
 /// Build the **worker** agent manifest — a lightweight sub-agent for task
@@ -157,6 +160,7 @@ static MITA_MANIFEST: LazyLock<AgentManifest> = LazyLock::new(|| AgentManifest {
     tool_call_limit:        None,
     worker_timeout_secs:    None,
     max_continuations:      Some(0),
+    max_output_chars:       None,
 });
 
 /// Build the **mita** agent manifest — a background proactive agent that
@@ -168,6 +172,46 @@ pub fn mita() -> &'static AgentManifest { &MITA_MANIFEST }
 // manifest must be visible to the `DriverRegistry::resolve_agent` call
 // site there, and `rara-kernel` sits below `rara-agents` in the
 // dependency DAG. See `crates/kernel/src/memory/knowledge/manifest.rs`.
+
+// ---------------------------------------------------------------------------
+// title_gen — background agent that auto-generates short session titles
+// ---------------------------------------------------------------------------
+
+/// Default character cap for auto-generated session titles.
+///
+/// Titles longer than this are truncated (never silently discarded) by the
+/// kernel's title generator. The value lives on the manifest so operators can
+/// override it via `agents.title_gen.max_output_chars` YAML without a rebuild.
+const TITLE_GEN_DEFAULT_MAX_CHARS: usize = 50;
+
+static TITLE_GEN_MANIFEST: LazyLock<AgentManifest> = LazyLock::new(|| AgentManifest {
+    name:                   "title_gen".to_string(),
+    role:                   AgentRole::Worker,
+    description:            "Background agent that generates short human-readable session titles \
+                             from the first user/assistant exchange."
+        .to_string(),
+    model:                  None,
+    system_prompt:          String::new(),
+    soul_prompt:            None,
+    provider_hint:          None,
+    max_iterations:         Some(1),
+    tools:                  vec![],
+    excluded_tools:         vec![],
+    max_children:           Some(0),
+    max_context_tokens:     None,
+    priority:               Priority::default(),
+    metadata:               serde_json::Value::Null,
+    sandbox:                None,
+    default_execution_mode: None,
+    tool_call_limit:        None,
+    worker_timeout_secs:    None,
+    max_continuations:      Some(0),
+    max_output_chars:       Some(TITLE_GEN_DEFAULT_MAX_CHARS),
+});
+
+/// Build the **title_gen** agent manifest — the background session-title
+/// generator invoked by the kernel after the first successful turn.
+pub fn title_gen() -> &'static AgentManifest { &TITLE_GEN_MANIFEST }
 
 // ---------------------------------------------------------------------------
 // ScheduledJob — dedicated agent for scheduled task execution
@@ -206,6 +250,7 @@ pub fn scheduled_job(job_id: &str, trigger_summary: &str, message: &str) -> Agen
         tool_call_limit:        None,
         worker_timeout_secs:    None,
         max_continuations:      Some(0),
+        max_output_chars:       None,
     }
 }
 

--- a/crates/agents/src/lib.rs
+++ b/crates/agents/src/lib.rs
@@ -163,6 +163,12 @@ static MITA_MANIFEST: LazyLock<AgentManifest> = LazyLock::new(|| AgentManifest {
 /// observes sessions and dispatches instructions to Rara.
 pub fn mita() -> &'static AgentManifest { &MITA_MANIFEST }
 
+// Knowledge extractor manifest lives in `rara_kernel::memory::knowledge`
+// because the extraction pipeline itself is defined in the kernel — the
+// manifest must be visible to the `DriverRegistry::resolve_agent` call
+// site there, and `rara-kernel` sits below `rara-agents` in the
+// dependency DAG. See `crates/kernel/src/memory/knowledge/manifest.rs`.
+
 // ---------------------------------------------------------------------------
 // ScheduledJob — dedicated agent for scheduled task execution
 // ---------------------------------------------------------------------------

--- a/crates/app/src/boot.rs
+++ b/crates/app/src/boot.rs
@@ -18,7 +18,10 @@
 //! resolvers, manifests, mcp, composio, skills) into a single module with
 //! private helpers and a public `boot()` entry point.
 
-use std::{collections::BTreeSet, sync::Arc};
+use std::{
+    collections::{BTreeSet, HashMap},
+    sync::Arc,
+};
 
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
@@ -491,26 +494,13 @@ async fn build_driver_registry(
         }
     }
 
-    // Required binding: the knowledge extractor must have both driver + model
-    // so resolve_agent() never falls back to a mismatched default. Fail boot
-    // with an actionable error if missing.
-    {
-        let name = rara_kernel::memory::knowledge::KNOWLEDGE_EXTRACTOR_NAME;
-        let driver = all_settings
-            .get(&format!("agents.{name}.driver"))
-            .filter(|v| !v.trim().is_empty());
-        let model = all_settings
-            .get(&format!("agents.{name}.model"))
-            .filter(|v| !v.trim().is_empty());
-        if driver.is_none() || model.is_none() {
-            anyhow::bail!(
-                "agents.{name}.{{driver, model}} must be configured in config.yaml — the \
-                 knowledge extraction pipeline requires an explicit driver + model pair (see \
-                 issue #1636). Example:\n\nagents:\n  {name}:\n    driver: \"openrouter\"\n    \
-                 model: \"gpt-4o-mini\"\n"
-            );
-        }
-    }
+    // Fail boot when any required background agent is missing an explicit
+    // `{driver, model}` pair. Silent fallbacks are forbidden by the project's
+    // "no config defaults in Rust" rule — and the prod failure in #1629 / #1636
+    // showed that a mismatched default silently breaks the knowledge
+    // extraction pipeline.
+    ensure_required_agent_configs(&all_settings, REQUIRED_BACKGROUND_AGENTS)
+        .map_err(|e| anyhow::anyhow!("{e}"))?;
 
     // -- codex (ChatGPT backend via OAuth) — uses Responses API ----------------
 
@@ -555,8 +545,6 @@ async fn build_driver_registry(
 // =========================================================================
 // Private: InMemoryUserStore
 // =========================================================================
-
-use std::collections::HashMap;
 
 use rara_kernel::{
     error::Result as KernelResult,
@@ -919,11 +907,6 @@ async fn init_knowledge_service(
             anyhow::anyhow!("{} is not configured", keys::KNOWLEDGE_SIMILARITY_THRESHOLD)
         })?
         .parse()?;
-    let extractor_model = settings
-        .get(keys::KNOWLEDGE_EXTRACTOR_MODEL)
-        .await
-        .ok_or_else(|| anyhow::anyhow!("{} is not configured", keys::KNOWLEDGE_EXTRACTOR_MODEL))?;
-
     let config = KnowledgeConfig::builder()
         .embedding_dimensions(embedding_dimensions)
         .search_top_k(search_top_k)
@@ -941,6 +924,135 @@ async fn init_knowledge_service(
         pool,
         embedding_svc,
         config,
-        extractor_model,
     }))
+}
+
+// =========================================================================
+// Background agent config validation (#1638)
+// =========================================================================
+
+/// Background agents whose `{driver, model}` pair MUST be present in
+/// `agents.<name>` for the kernel to boot. Missing entries fail boot with
+/// an actionable error instead of falling back to a hardcoded default
+/// (see `docs/guides/anti-patterns.md` — "no config defaults in Rust").
+///
+/// The list mirrors what `kernel.rs` resolves via `resolve_agent` for
+/// headless background work:
+/// - `knowledge_extractor` — memory extraction pipeline (#1636)
+/// - `title_gen` — session title auto-generation (#1637)
+const REQUIRED_BACKGROUND_AGENTS: &[&str] = &["knowledge_extractor", "title_gen"];
+
+/// Verify every agent in `required` has a non-empty `driver` and `model`
+/// in the flattened settings map. Returns a single error message naming
+/// every unconfigured agent so operators see the full picture at once.
+fn ensure_required_agent_configs(
+    settings: &HashMap<String, String>,
+    required: &[&str],
+) -> Result<(), String> {
+    let missing: Vec<String> = required
+        .iter()
+        .filter(|name| {
+            let driver = settings
+                .get(&format!("agents.{name}.driver"))
+                .filter(|v| !v.trim().is_empty());
+            let model = settings
+                .get(&format!("agents.{name}.model"))
+                .filter(|v| !v.trim().is_empty());
+            driver.is_none() || model.is_none()
+        })
+        .map(|name| (*name).to_string())
+        .collect();
+
+    if missing.is_empty() {
+        return Ok(());
+    }
+
+    let example: String = missing
+        .iter()
+        .map(|n| format!("  {n}:\n    driver: \"openai\"\n    model: \"gpt-4o-mini\""))
+        .collect::<Vec<_>>()
+        .join("\n");
+    Err(format!(
+        "missing required agent config: {names} — every background agent needs an explicit \
+         `{{driver, model}}` pair in config.yaml. See config.example.yaml for the full shape. \
+         Add:\n\nagents:\n{example}\n",
+        names = missing.join(", "),
+    ))
+}
+
+#[cfg(test)]
+mod boot_validation_tests {
+    use super::*;
+
+    fn full_agent_settings() -> HashMap<String, String> {
+        let mut m = HashMap::new();
+        m.insert(
+            "agents.knowledge_extractor.driver".into(),
+            "openrouter".into(),
+        );
+        m.insert(
+            "agents.knowledge_extractor.model".into(),
+            "gpt-4o-mini".into(),
+        );
+        m.insert("agents.title_gen.driver".into(), "openai".into());
+        m.insert("agents.title_gen.model".into(), "gpt-4o-mini".into());
+        m
+    }
+
+    #[test]
+    fn ok_when_all_required_agents_configured() {
+        let settings = full_agent_settings();
+        ensure_required_agent_configs(&settings, REQUIRED_BACKGROUND_AGENTS).expect("boot ok");
+    }
+
+    #[test]
+    fn fails_when_knowledge_extractor_missing() {
+        let mut settings = full_agent_settings();
+        settings.remove("agents.knowledge_extractor.driver");
+        settings.remove("agents.knowledge_extractor.model");
+        let err = ensure_required_agent_configs(&settings, REQUIRED_BACKGROUND_AGENTS)
+            .expect_err("must fail");
+        assert!(
+            err.contains("knowledge_extractor"),
+            "err should name the missing agent: {err}"
+        );
+    }
+
+    #[test]
+    fn fails_when_title_gen_missing() {
+        let mut settings = full_agent_settings();
+        settings.remove("agents.title_gen.driver");
+        settings.remove("agents.title_gen.model");
+        let err = ensure_required_agent_configs(&settings, REQUIRED_BACKGROUND_AGENTS)
+            .expect_err("must fail");
+        assert!(
+            err.contains("title_gen"),
+            "err should name the missing agent: {err}"
+        );
+    }
+
+    #[test]
+    fn fails_when_driver_present_but_model_empty() {
+        let mut settings = full_agent_settings();
+        settings.insert("agents.title_gen.model".into(), "   ".into());
+        let err = ensure_required_agent_configs(&settings, REQUIRED_BACKGROUND_AGENTS)
+            .expect_err("must fail — empty model is same as missing");
+        assert!(err.contains("title_gen"));
+    }
+
+    /// Regression: the legacy `memory.knowledge.extractor_model` key must
+    /// not paper over a missing `agents.knowledge_extractor.model`. The
+    /// validator only looks at the unified `agents.*` namespace.
+    #[test]
+    fn legacy_extractor_model_key_does_not_satisfy_agents_requirement() {
+        let mut settings = full_agent_settings();
+        settings.remove("agents.knowledge_extractor.model");
+        settings.insert(
+            "memory.knowledge.extractor_model".into(),
+            "legacy-model".into(),
+        );
+        let err = ensure_required_agent_configs(&settings, REQUIRED_BACKGROUND_AGENTS)
+            .expect_err("legacy key must not satisfy the unified shape");
+        assert!(err.contains("knowledge_extractor"));
+    }
 }

--- a/crates/app/src/boot.rs
+++ b/crates/app/src/boot.rs
@@ -448,6 +448,58 @@ async fn build_driver_registry(
         }
     }
 
+    // -- unified per-agent configs (agents.<name>.{driver, model}) ---------------
+    //
+    // Introduced in #1636. Populates the `DriverRegistry::resolve_agent` lookup
+    // table that the knowledge extractor (and future consumers) read from.
+    // Boot fails fast if `agents.knowledge_extractor.{driver, model}` is missing
+    // — the prod failure in #1629 showed we cannot silently fall back.
+    let unified_agent_names: BTreeSet<&str> = all_settings
+        .keys()
+        .filter_map(|k| k.strip_prefix("agents."))
+        .filter_map(|k| k.split('.').next())
+        .collect();
+
+    for &agent in &unified_agent_names {
+        let driver = all_settings
+            .get(&format!("agents.{agent}.driver"))
+            .filter(|v| !v.trim().is_empty())
+            .cloned();
+        let model = all_settings
+            .get(&format!("agents.{agent}.model"))
+            .filter(|v| !v.trim().is_empty())
+            .cloned();
+
+        if driver.is_some() || model.is_some() {
+            info!(agent, ?driver, ?model, "unified agent LLM config");
+            registry.set_agent_config(
+                agent,
+                rara_kernel::llm::registry::AgentLlmConfig { driver, model },
+            );
+        }
+    }
+
+    // Required binding: the knowledge extractor must have both driver + model
+    // so resolve_agent() never falls back to a mismatched default. Fail boot
+    // with an actionable error if missing.
+    {
+        let name = rara_kernel::memory::knowledge::KNOWLEDGE_EXTRACTOR_NAME;
+        let driver = all_settings
+            .get(&format!("agents.{name}.driver"))
+            .filter(|v| !v.trim().is_empty());
+        let model = all_settings
+            .get(&format!("agents.{name}.model"))
+            .filter(|v| !v.trim().is_empty());
+        if driver.is_none() || model.is_none() {
+            anyhow::bail!(
+                "agents.{name}.{{driver, model}} must be configured in config.yaml — the \
+                 knowledge extraction pipeline requires an explicit driver + model pair (see \
+                 issue #1636). Example:\n\nagents:\n  {name}:\n    driver: \"openrouter\"\n    \
+                 model: \"gpt-4o-mini\"\n"
+            );
+        }
+    }
+
     // -- codex (ChatGPT backend via OAuth) — uses Responses API ----------------
 
     match rara_codex_oauth::load_tokens().await {

--- a/crates/app/src/boot.rs
+++ b/crates/app/src/boot.rs
@@ -259,7 +259,15 @@ pub(crate) async fn boot(
 
     // -- agent registry ----------------------------------------------------
 
-    let agent_registry = Arc::new(load_default_registry());
+    // Optional YAML overrides for headless system agents — currently just
+    // `title_gen.max_output_chars`, but structured so future knobs can land
+    // here without forcing another bootstrap refactor.
+    let title_gen_max_output_chars = settings_provider
+        .get("agents.title_gen.max_output_chars")
+        .await
+        .and_then(|v| v.trim().parse::<usize>().ok());
+
+    let agent_registry = Arc::new(load_default_registry(title_gen_max_output_chars));
 
     // -- default provider model lister / embedder ----------------------------
     //
@@ -448,12 +456,16 @@ async fn build_driver_registry(
         }
     }
 
-    // -- unified per-agent configs (agents.<name>.{driver, model}) ---------------
+    // -- unified per-agent configs (agents.<name>.{driver, model}) --------------
     //
-    // Introduced in #1636. Populates the `DriverRegistry::resolve_agent` lookup
-    // table that the knowledge extractor (and future consumers) read from.
-    // Boot fails fast if `agents.knowledge_extractor.{driver, model}` is missing
-    // — the prod failure in #1629 showed we cannot silently fall back.
+    // Introduced in #1636, extended by #1637. The `agents.*` namespace is the
+    // post-refactor binding consumed by `DriverRegistry::resolve_agent`. Unlike
+    // the legacy `llm.agent_overrides.*` keys, these live alongside other
+    // per-agent knobs (e.g. `agents.title_gen.max_output_chars`) and form the
+    // single `{driver, model, manifest}` snapshot used at call sites.
+    //
+    // Boot fails fast for the knowledge extractor if its driver/model are
+    // missing — the prod failure in #1629 showed we cannot silently fall back.
     let unified_agent_names: BTreeSet<&str> = all_settings
         .keys()
         .filter_map(|k| k.strip_prefix("agents."))
@@ -685,11 +697,22 @@ impl IdentityResolver for PlatformIdentityResolver {
 // =========================================================================
 
 /// Load agent manifests and build an AgentRegistry.
-fn load_default_registry() -> rara_kernel::agent::AgentRegistry {
+///
+/// `title_gen_max_output_chars` optionally overrides the built-in title
+/// length cap from YAML (`agents.title_gen.max_output_chars`). When `None`,
+/// the manifest's own default from [`rara_agents::title_gen`] applies.
+fn load_default_registry(
+    title_gen_max_output_chars: Option<usize>,
+) -> rara_kernel::agent::AgentRegistry {
     use rara_kernel::agent::{AgentRegistry, ManifestLoader};
 
     let mut rara_manifest = rara_agents::rara().clone();
     rara_manifest.tools = crate::tools::rara_tool_names();
+
+    let mut title_gen_manifest = rara_agents::title_gen().clone();
+    if let Some(cap) = title_gen_max_output_chars {
+        title_gen_manifest.max_output_chars = Some(cap);
+    }
 
     let builtin = vec![
         (rara_manifest.clone(), Role::Root),
@@ -697,6 +720,10 @@ fn load_default_registry() -> rara_kernel::agent::AgentRegistry {
         (rara_agents::nana().clone(), Role::User),
         (rara_agents::worker().clone(), Role::User),
         (rara_agents::mita().clone(), Role::Root),
+        // `title_gen` is a headless background agent (no user/chat role); we
+        // still register it so the kernel can look up its manifest and resolve
+        // `{driver, model, max_output_chars}` via the unified agent registry.
+        (title_gen_manifest, Role::Root),
     ];
     let agents_dir = rara_paths::data_dir().join("agents");
     let mut loader = ManifestLoader::new();

--- a/crates/app/src/config_sync.rs
+++ b/crates/app/src/config_sync.rs
@@ -296,12 +296,15 @@ knowledge:
   embedding_dimensions: 1536
   search_top_k: 10
   similarity_threshold: 0.85
-  extractor_model: "gpt-4o-mini"
 
 agents:
   knowledge_extractor:
     driver: "openrouter"
     model: "gpt-4o-mini"
+  title_gen:
+    driver: "openai"
+    model: "gpt-4o-mini"
+    max_output_chars: 50
 
 gateway:
   repo_url: "https://github.com/example/repo"

--- a/crates/app/src/config_sync.rs
+++ b/crates/app/src/config_sync.rs
@@ -88,6 +88,7 @@ impl ConfigFileSync {
             cfg.telegram = new_config.telegram;
             cfg.composio = new_config.composio;
             cfg.knowledge = new_config.knowledge;
+            cfg.agents = new_config.agents;
         }
         info!("config.yaml synced to settings store");
         Ok(())
@@ -96,7 +97,7 @@ impl ConfigFileSync {
     /// Write current settings back to config.yaml.
     async fn writeback_to_file(&self) -> anyhow::Result<()> {
         let all_settings = self.settings.list().await;
-        let (llm, telegram, wechat, composio, knowledge) =
+        let (llm, telegram, wechat, composio, knowledge, agents) =
             flatten::unflatten_from_settings(&all_settings);
 
         let yaml = {
@@ -106,6 +107,7 @@ impl ConfigFileSync {
             cfg.wechat = wechat;
             cfg.composio = composio;
             cfg.knowledge = knowledge;
+            cfg.agents = agents;
             serde_yaml::to_string(&*cfg)?
         };
 
@@ -295,6 +297,11 @@ knowledge:
   search_top_k: 10
   similarity_threshold: 0.85
   extractor_model: "gpt-4o-mini"
+
+agents:
+  knowledge_extractor:
+    driver: "openrouter"
+    model: "gpt-4o-mini"
 
 gateway:
   repo_url: "https://github.com/example/repo"

--- a/crates/app/src/flatten.rs
+++ b/crates/app/src/flatten.rs
@@ -153,6 +153,37 @@ pub struct KnowledgeConfig {
 }
 
 // ---------------------------------------------------------------------------
+// Agents config — per-agent `{driver, model}` bindings
+// ---------------------------------------------------------------------------
+
+/// Per-agent LLM binding. Mirrors
+/// [`rara_kernel::llm::AgentLlmConfig`] and is loaded from
+/// `agents.<name>.{driver, model}` in config.yaml.
+///
+/// ```yaml
+/// agents:
+///   knowledge_extractor:
+///     driver: "openrouter"
+///     model: "gpt-4o-mini"
+/// ```
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(default)]
+pub struct AgentBinding {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub driver: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub model:  Option<String>,
+}
+
+/// Top-level `agents:` section — map from agent name to `{driver, model}`.
+///
+/// Introduced by #1636 as the unified replacement for scattered flat
+/// settings (e.g. the legacy `memory.knowledge.extractor_model`).
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct AgentsConfig(pub HashMap<String, AgentBinding>);
+
+// ---------------------------------------------------------------------------
 // Flatten logic
 // ---------------------------------------------------------------------------
 
@@ -174,7 +205,21 @@ pub fn flatten_config_sections(config: &AppConfig) -> Vec<(String, String)> {
     if let Some(ref k) = config.knowledge {
         flatten_knowledge(k, &mut pairs);
     }
+    if let Some(ref a) = config.agents {
+        flatten_agents(a, &mut pairs);
+    }
     pairs
+}
+
+fn flatten_agents(agents: &AgentsConfig, out: &mut Vec<(String, String)>) {
+    for (name, binding) in &agents.0 {
+        if let Some(ref v) = binding.driver {
+            out.push((format!("agents.{name}.driver"), v.clone()));
+        }
+        if let Some(ref v) = binding.model {
+            out.push((format!("agents.{name}.model"), v.clone()));
+        }
+    }
 }
 
 fn flatten_llm(llm: &LlmConfig, out: &mut Vec<(String, String)>) {
@@ -276,6 +321,7 @@ pub fn unflatten_from_settings<S: std::hash::BuildHasher>(
     Option<WechatConfig>,
     Option<ComposioConfig>,
     Option<KnowledgeConfig>,
+    Option<AgentsConfig>,
 ) {
     (
         unflatten_llm(pairs),
@@ -283,7 +329,32 @@ pub fn unflatten_from_settings<S: std::hash::BuildHasher>(
         unflatten_wechat(pairs),
         unflatten_composio(pairs),
         unflatten_knowledge(pairs),
+        unflatten_agents(pairs),
     )
+}
+
+fn unflatten_agents(
+    pairs: &HashMap<String, String, impl std::hash::BuildHasher>,
+) -> Option<AgentsConfig> {
+    let prefix = "agents.";
+    let mut names: std::collections::HashSet<String> = std::collections::HashSet::new();
+    for key in pairs.keys() {
+        if let Some(rest) = key.strip_prefix(prefix) {
+            if let Some(dot) = rest.find('.') {
+                names.insert(rest[..dot].to_string());
+            }
+        }
+    }
+    if names.is_empty() {
+        return None;
+    }
+    let mut out = HashMap::new();
+    for name in names {
+        let driver = pairs.get(&format!("agents.{name}.driver")).cloned();
+        let model = pairs.get(&format!("agents.{name}.model")).cloned();
+        out.insert(name, AgentBinding { driver, model });
+    }
+    Some(AgentsConfig(out))
 }
 
 fn unflatten_llm(
@@ -470,7 +541,8 @@ mod tests {
         let map: HashMap<String, String> = flat.into_iter().collect();
 
         // Unflatten
-        let (got_llm, got_tg, _got_wechat, got_composio, got_know) = unflatten_from_settings(&map);
+        let (got_llm, got_tg, _got_wechat, got_composio, got_know, _got_agents) =
+            unflatten_from_settings(&map);
 
         // --- LLM ---
         let got_llm = got_llm.expect("llm should be Some");
@@ -516,11 +588,34 @@ mod tests {
     #[test]
     fn unflatten_empty_map_returns_none() {
         let map = HashMap::new();
-        let (llm, tg, wechat, composio, know) = unflatten_from_settings(&map);
+        let (llm, tg, wechat, composio, know, agents) = unflatten_from_settings(&map);
         assert!(wechat.is_none());
         assert!(llm.is_none());
         assert!(tg.is_none());
         assert!(composio.is_none());
         assert!(know.is_none());
+        assert!(agents.is_none());
+    }
+
+    #[test]
+    fn agents_roundtrip_flatten_unflatten() {
+        let mut m = HashMap::new();
+        m.insert(
+            "knowledge_extractor".to_string(),
+            AgentBinding {
+                driver: Some("openrouter".into()),
+                model:  Some("gpt-4o-mini".into()),
+            },
+        );
+        let agents = AgentsConfig(m);
+
+        let mut flat = Vec::new();
+        flatten_agents(&agents, &mut flat);
+        let map: HashMap<String, String> = flat.into_iter().collect();
+
+        let got = unflatten_agents(&map).expect("agents should be Some");
+        let b = got.0.get("knowledge_extractor").expect("binding present");
+        assert_eq!(b.driver.as_deref(), Some("openrouter"));
+        assert_eq!(b.model.as_deref(), Some("gpt-4o-mini"));
     }
 }

--- a/crates/app/src/flatten.rs
+++ b/crates/app/src/flatten.rs
@@ -129,13 +129,16 @@ pub struct ComposioConfig {
 
 /// Knowledge layer configuration section in config.yaml.
 ///
+/// The extractor LLM binding lives in the unified `agents.knowledge_extractor`
+/// block — see [`AgentsConfig`]. Any legacy `knowledge.extractor_model` key
+/// in a user's YAML is silently ignored (unknown field).
+///
 /// ```yaml
 /// knowledge:
 ///   embedding_model: "text-embedding-3-small"
 ///   embedding_dimensions: 1536
 ///   search_top_k: 10
 ///   similarity_threshold: 0.85
-///   extractor_model: "gpt-4o-mini"
 /// ```
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(default)]
@@ -148,8 +151,6 @@ pub struct KnowledgeConfig {
     pub search_top_k:         Option<u32>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub similarity_threshold: Option<f32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub extractor_model:      Option<String>,
 }
 
 // ---------------------------------------------------------------------------
@@ -160,19 +161,29 @@ pub struct KnowledgeConfig {
 /// [`rara_kernel::llm::AgentLlmConfig`] and is loaded from
 /// `agents.<name>.{driver, model}` in config.yaml.
 ///
+/// Optional `max_output_chars` lets operators cap a headless agent's
+/// free-form output without a rebuild (currently consumed by
+/// `title_gen`; see `kernel/AGENT.md`).
+///
 /// ```yaml
 /// agents:
 ///   knowledge_extractor:
 ///     driver: "openrouter"
 ///     model: "gpt-4o-mini"
+///   title_gen:
+///     driver: "openai"
+///     model: "gpt-4o-mini"
+///     max_output_chars: 50
 /// ```
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(default)]
 pub struct AgentBinding {
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub driver: Option<String>,
+    pub driver:           Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub model:  Option<String>,
+    pub model:            Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max_output_chars: Option<usize>,
 }
 
 /// Top-level `agents:` section — map from agent name to `{driver, model}`.
@@ -218,6 +229,9 @@ fn flatten_agents(agents: &AgentsConfig, out: &mut Vec<(String, String)>) {
         }
         if let Some(ref v) = binding.model {
             out.push((format!("agents.{name}.model"), v.clone()));
+        }
+        if let Some(v) = binding.max_output_chars {
+            out.push((format!("agents.{name}.max_output_chars"), v.to_string()));
         }
     }
 }
@@ -300,9 +314,6 @@ fn flatten_knowledge(k: &KnowledgeConfig, out: &mut Vec<(String, String)>) {
     if let Some(v) = k.similarity_threshold {
         out.push((keys::KNOWLEDGE_SIMILARITY_THRESHOLD.into(), v.to_string()));
     }
-    if let Some(ref v) = k.extractor_model {
-        out.push((keys::KNOWLEDGE_EXTRACTOR_MODEL.into(), v.clone()));
-    }
 }
 
 // ---------------------------------------------------------------------------
@@ -352,7 +363,17 @@ fn unflatten_agents(
     for name in names {
         let driver = pairs.get(&format!("agents.{name}.driver")).cloned();
         let model = pairs.get(&format!("agents.{name}.model")).cloned();
-        out.insert(name, AgentBinding { driver, model });
+        let max_output_chars = pairs
+            .get(&format!("agents.{name}.max_output_chars"))
+            .and_then(|v| v.parse::<usize>().ok());
+        out.insert(
+            name,
+            AgentBinding {
+                driver,
+                model,
+                max_output_chars,
+            },
+        );
     }
     Some(AgentsConfig(out))
 }
@@ -468,13 +489,11 @@ fn unflatten_knowledge(
     let similarity_threshold = pairs
         .get(keys::KNOWLEDGE_SIMILARITY_THRESHOLD)
         .and_then(|v| v.parse::<f32>().ok());
-    let extractor_model = pairs.get(keys::KNOWLEDGE_EXTRACTOR_MODEL).cloned();
 
     if embedding_model.is_none()
         && embedding_dimensions.is_none()
         && search_top_k.is_none()
         && similarity_threshold.is_none()
-        && extractor_model.is_none()
     {
         return None;
     }
@@ -484,7 +503,6 @@ fn unflatten_knowledge(
         embedding_dimensions,
         search_top_k,
         similarity_threshold,
-        extractor_model,
     })
 }
 
@@ -529,7 +547,6 @@ mod tests {
             embedding_dimensions: Some(1536),
             search_top_k:         Some(10),
             similarity_threshold: Some(0.85),
-            extractor_model:      Some("gpt-4o-mini".into()),
         };
 
         // Flatten
@@ -582,7 +599,6 @@ mod tests {
             got_know.similarity_threshold,
             knowledge.similarity_threshold
         );
-        assert_eq!(got_know.extractor_model, knowledge.extractor_model);
     }
 
     #[test]
@@ -603,8 +619,17 @@ mod tests {
         m.insert(
             "knowledge_extractor".to_string(),
             AgentBinding {
-                driver: Some("openrouter".into()),
-                model:  Some("gpt-4o-mini".into()),
+                driver:           Some("openrouter".into()),
+                model:            Some("gpt-4o-mini".into()),
+                max_output_chars: None,
+            },
+        );
+        m.insert(
+            "title_gen".to_string(),
+            AgentBinding {
+                driver:           Some("openai".into()),
+                model:            Some("gpt-4o-mini".into()),
+                max_output_chars: Some(50),
             },
         );
         let agents = AgentsConfig(m);
@@ -617,5 +642,28 @@ mod tests {
         let b = got.0.get("knowledge_extractor").expect("binding present");
         assert_eq!(b.driver.as_deref(), Some("openrouter"));
         assert_eq!(b.model.as_deref(), Some("gpt-4o-mini"));
+        assert_eq!(b.max_output_chars, None);
+        let t = got.0.get("title_gen").expect("title_gen binding present");
+        assert_eq!(t.driver.as_deref(), Some("openai"));
+        assert_eq!(t.model.as_deref(), Some("gpt-4o-mini"));
+        assert_eq!(t.max_output_chars, Some(50));
+    }
+
+    /// Regression: legacy `memory.knowledge.extractor_model` KV pairs must
+    /// be ignored silently — the key no longer exists in
+    /// [`KnowledgeConfig`]. `unflatten_from_settings` keeps no state for
+    /// unrecognised keys, so the output is unchanged from the empty case.
+    #[test]
+    fn legacy_extractor_model_key_is_ignored() {
+        let mut map = HashMap::new();
+        map.insert(
+            "memory.knowledge.extractor_model".to_string(),
+            "legacy-model".to_string(),
+        );
+        let (_llm, _tg, _wc, _cmp, know, _agents) = unflatten_from_settings(&map);
+        assert!(
+            know.is_none(),
+            "legacy extractor_model must not produce a KnowledgeConfig"
+        );
     }
 }

--- a/crates/app/src/lib.rs
+++ b/crates/app/src/lib.rs
@@ -97,6 +97,16 @@ pub struct AppConfig {
     /// Knowledge layer configuration (seeded to settings store at startup).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub knowledge:              Option<flatten::KnowledgeConfig>,
+    /// Per-agent `{driver, model}` bindings (unified registry; #1636).
+    ///
+    /// ```yaml
+    /// agents:
+    ///   knowledge_extractor:
+    ///     driver: "openrouter"
+    ///     model: "gpt-4o-mini"
+    /// ```
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub agents:                 Option<flatten::AgentsConfig>,
     /// Speech-to-Text configuration (optional).
     /// When present, `base_url` is required — startup fails if missing.
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/crates/domain/shared/src/settings/mod.rs
+++ b/crates/domain/shared/src/settings/mod.rs
@@ -53,7 +53,6 @@ pub mod keys {
     pub const KNOWLEDGE_EMBEDDING_DIMENSIONS: &str = "memory.knowledge.embedding_dimensions";
     pub const KNOWLEDGE_SEARCH_TOP_K: &str = "memory.knowledge.search_top_k";
     pub const KNOWLEDGE_SIMILARITY_THRESHOLD: &str = "memory.knowledge.similarity_threshold";
-    pub const KNOWLEDGE_EXTRACTOR_MODEL: &str = "memory.knowledge.extractor_model";
 }
 
 /// Unified trait for reading and writing flat KV settings.

--- a/crates/extensions/backend-admin/src/agents/router.rs
+++ b/crates/extensions/backend-admin/src/agents/router.rs
@@ -175,6 +175,7 @@ async fn create_agent(
         tool_call_limit:        None,
         worker_timeout_secs:    None,
         max_continuations:      None,
+        max_output_chars:       None,
     };
 
     registry

--- a/crates/kernel/AGENT.md
+++ b/crates/kernel/AGENT.md
@@ -14,6 +14,23 @@ like `knowledge.extractor_model`) should not reappear. The legacy
 `DriverRegistry::resolve` tuple API is kept as a thin shim for existing
 callers; migration is tracked in follow-up issues under Epic #1631.
 
+### Migrated consumers
+
+- `memory/knowledge/extractor.rs` — #1636 / #1629. Reads
+  `agents.knowledge_extractor.{driver, model}`. Boot fails fast if the
+  pair is missing. `extract_knowledge` now takes a `&ResolvedAgent` so
+  driver + model can never disagree. Example config:
+
+  ```yaml
+  agents:
+    knowledge_extractor:
+      driver: "openrouter"
+      model: "gpt-4o-mini"
+  ```
+
+  Extraction failures now emit at `error!` level (previously `warn!`,
+  which hid the MiniMax/gpt-4o-mini split-config bug in prod).
+
 ## Critical: StreamDelta Event Ordering in `openai.rs`
 
 ### The Invariant

--- a/crates/kernel/AGENT.md
+++ b/crates/kernel/AGENT.md
@@ -1,5 +1,19 @@
 # rara-kernel — Agent Guidelines
 
+## Agent LLM Resolution Contract — `llm/registry.rs`
+
+The unified entry point for resolving an agent's LLM binding is
+[`DriverRegistry::resolve_agent`] in `crates/kernel/src/llm/registry.rs`.
+It returns a [`ResolvedAgent { driver, model, manifest }`] triple read from
+`agents.<name>.{driver, model}` in YAML, with fallback to the manifest's
+`provider_hint`/`model` and finally the provider default. New consumers
+MUST go through `resolve_agent` so the driver and the model come from a
+single consistent source — the split-config bug that motivated #1635
+(driver resolved via the registry, model resolved via a flat settings key
+like `knowledge.extractor_model`) should not reappear. The legacy
+`DriverRegistry::resolve` tuple API is kept as a thin shim for existing
+callers; migration is tracked in follow-up issues under Epic #1631.
+
 ## Critical: StreamDelta Event Ordering in `openai.rs`
 
 ### The Invariant

--- a/crates/kernel/AGENT.md
+++ b/crates/kernel/AGENT.md
@@ -10,7 +10,9 @@ It returns a [`ResolvedAgent { driver, model, manifest }`] triple read from
 MUST go through `resolve_agent` so the driver and the model come from a
 single consistent source — the split-config bug that motivated #1635
 (driver resolved via the registry, model resolved via a flat settings key
-like `knowledge.extractor_model`) should not reappear. The legacy
+like `memory.knowledge.extractor_model`) should not reappear. That legacy
+flat key was removed in #1638; no fallback remains in Rust, missing
+`agents.<name>.{driver, model}` fails boot. The legacy
 `DriverRegistry::resolve` tuple API is kept as a thin shim for existing
 callers; migration is tracked in follow-up issues under Epic #1631.
 

--- a/crates/kernel/AGENT.md
+++ b/crates/kernel/AGENT.md
@@ -31,6 +31,20 @@ callers; migration is tracked in follow-up issues under Epic #1631.
   Extraction failures now emit at `error!` level (previously `warn!`,
   which hid the MiniMax/gpt-4o-mini split-config bug in prod).
 
+- `kernel.rs` (session title generation) — #1637. Reads
+  `agents.title_gen.{driver, model}` via `resolve_agent`. See the
+  per-agent output caps section below for the truncation contract.
+
+### Per-agent output caps — `AgentManifest::max_output_chars`
+
+System agents whose contract includes a bounded free-form output (currently
+`title_gen`) declare the cap on the manifest via `max_output_chars`. The call
+site MUST truncate and emit a `warn!` (with `title_len`, `max_chars`,
+`truncated=true`) when the model exceeds the cap — NEVER silently discard.
+See `generate_session_title` / `finalize_title` in `kernel.rs` and the
+background to #1637 (production incident 2026-04-20 where a 237-char title
+was dropped with zero persisted state).
+
 ## Critical: StreamDelta Event Ordering in `openai.rs`
 
 ### The Invariant

--- a/crates/kernel/src/agent/mod.rs
+++ b/crates/kernel/src/agent/mod.rs
@@ -281,6 +281,15 @@ pub struct AgentManifest {
     /// **Default: `None` (uses [`machine::DEFAULT_MAX_CONTINUATIONS`]).**
     #[serde(default)]
     pub max_continuations:      Option<usize>,
+    /// Maximum character length of this agent's free-form text output.
+    ///
+    /// Interpreted per agent — e.g. `title_gen` uses this as the hard cap
+    /// on generated session titles. When the model returns longer output,
+    /// the caller truncates (never silently discards) and logs a warning.
+    ///
+    /// **Default: `None` (no cap enforced).**
+    #[serde(default)]
+    pub max_output_chars:       Option<usize>,
 }
 
 /// Process environment — isolated per-agent context.

--- a/crates/kernel/src/agent/scheduled.rs
+++ b/crates/kernel/src/agent/scheduled.rs
@@ -82,5 +82,6 @@ pub fn scheduled_job_manifest(
         tool_call_limit: None,
         worker_timeout_secs: None,
         max_continuations: Some(0),
+        max_output_chars: None,
     }
 }

--- a/crates/kernel/src/kernel.rs
+++ b/crates/kernel/src/kernel.rs
@@ -3164,6 +3164,7 @@ impl Kernel {
             if needs_title {
                 let tape_service = self.tape_service.clone();
                 let driver_registry = Arc::clone(self.syscall.driver_registry());
+                let agent_registry = Arc::clone(&self.agent_registry);
                 let io = Arc::clone(&self.io);
                 let sk = session_key;
                 let tape_name = sk.to_string();
@@ -3172,6 +3173,7 @@ impl Kernel {
                         &tape_service,
                         &tape_name,
                         &driver_registry,
+                        &agent_registry,
                         session_index.as_ref(),
                         &io,
                         &sk,
@@ -3215,15 +3217,91 @@ impl Kernel {
 // Session title generation (standalone helper)
 // ---------------------------------------------------------------------------
 
+/// Default title cap when the manifest omits `max_output_chars`. Matches
+/// the value baked into `rara_agents::title_gen`; duplicated as a defensive
+/// floor so the kernel never stores an unbounded title even if a malformed
+/// YAML override clears the field.
+const TITLE_GEN_FALLBACK_MAX_CHARS: usize = 50;
+
+/// Normalize a raw LLM response into a bounded session title.
+///
+/// Returns `None` only when both the model output and the fallback user
+/// message are empty — an operationally-impossible state. In all other
+/// cases this returns `Some(title)` whose character count is `<= max_chars`.
+/// When truncation or fallback kicks in a warning is emitted with
+/// `truncated=true` so operators can see the model is generating titles
+/// outside the contract (previously the kernel silently dropped them — see
+/// the #1637 production incident).
+fn finalize_title(
+    raw: Option<&str>,
+    user_fallback: &str,
+    max_chars: usize,
+    session_key: &SessionKey,
+) -> Option<String> {
+    let max_chars = max_chars.max(1);
+    let cleaned = raw
+        .map(|s| s.trim().trim_matches('"').to_string())
+        .filter(|s| !s.is_empty());
+
+    let (source, candidate) = match cleaned {
+        Some(t) => ("model", t),
+        None => {
+            tracing::error!(
+                session_key = %session_key,
+                "title gen: LLM returned no usable content, falling back to user message"
+            );
+            (
+                "fallback",
+                user_fallback
+                    .lines()
+                    .next()
+                    .unwrap_or("")
+                    .trim()
+                    .to_string(),
+            )
+        }
+    };
+
+    if candidate.is_empty() {
+        tracing::error!(
+            session_key = %session_key,
+            "title gen: fallback user message also empty, skipping title"
+        );
+        return None;
+    }
+
+    let raw_len = candidate.chars().count();
+    if raw_len <= max_chars {
+        return Some(candidate);
+    }
+
+    let truncated: String = candidate.chars().take(max_chars).collect();
+    tracing::warn!(
+        session_key = %session_key,
+        title_len = raw_len,
+        max_chars,
+        truncated = true,
+        source,
+        title = %truncated,
+        "title gen: title exceeded cap, truncated instead of discarding"
+    );
+    Some(truncated)
+}
+
 /// Auto-generate a short session title from the first user/assistant exchange.
 ///
 /// Reads the tape for the first user and assistant messages, asks the LLM for a
-/// concise title (<=30 chars, matching the user's language), and persists it
-/// via the session index. Errors are propagated to the caller for logging.
+/// concise title (matching the user's language), and persists it via the
+/// session index. The LLM binding comes from
+/// [`DriverRegistry::resolve_agent`](crate::llm::DriverRegistry::resolve_agent)
+/// keyed by the `title_gen` manifest, so driver + model + max-length stay in
+/// one atomic snapshot (see #1637). Errors are propagated to the caller for
+/// logging.
 async fn generate_session_title(
     tape_service: &crate::memory::TapeService,
     tape_name: &str,
     driver_registry: &crate::llm::DriverRegistry,
+    agent_registry: &crate::agent::AgentRegistry,
     session_index: &dyn crate::session::SessionIndex,
     io: &Arc<crate::io::IOSubsystem>,
     session_key: &SessionKey,
@@ -3263,31 +3341,39 @@ async fn generate_session_title(
         })
         .unwrap_or_default();
 
-    let (driver, model) = driver_registry.resolve("title_generator", None, None)?;
+    let manifest = agent_registry.get("title_gen").ok_or_else(|| {
+        Box::<dyn std::error::Error + Send + Sync>::from(
+            "title gen: `title_gen` manifest not registered",
+        )
+    })?;
+    let max_chars = manifest
+        .max_output_chars
+        .unwrap_or(TITLE_GEN_FALLBACK_MAX_CHARS);
+    let resolved = driver_registry.resolve_agent(&manifest)?;
 
     let assistant_preview: String = first_assistant_msg.chars().take(500).collect();
 
     let prompt = format!(
-        "Given this conversation opening, generate a concise title (max 30 characters).\nMatch \
-         the language of the user's message.\nReturn ONLY the title, nothing else.\n\nUser: \
-         {first_user_msg}\nAssistant: {assistant_preview}"
+        "Given this conversation opening, generate a concise title (max {max_chars} \
+         characters).\nMatch the language of the user's message.\nReturn ONLY the title, nothing \
+         else.\n\nUser: {first_user_msg}\nAssistant: {assistant_preview}"
     );
 
     let request = crate::llm::CompletionRequest {
-        model,
-        messages: vec![crate::llm::Message::user(prompt)],
-        tools: vec![],
-        temperature: Some(0.3),
-        max_tokens: Some(60),
-        thinking: None,
-        tool_choice: crate::llm::ToolChoice::None,
+        model:               resolved.model,
+        messages:            vec![crate::llm::Message::user(prompt)],
+        tools:               vec![],
+        temperature:         Some(0.3),
+        max_tokens:          Some(60),
+        thinking:            None,
+        tool_choice:         crate::llm::ToolChoice::None,
         parallel_tool_calls: false,
-        frequency_penalty: None,
-        top_p: None,
-        emit_reasoning: false,
+        frequency_penalty:   None,
+        top_p:               None,
+        emit_reasoning:      false,
     };
 
-    let response = driver.complete(request).await?;
+    let response = resolved.driver.complete(request).await?;
 
     // Prefer non-empty content, fall back to reasoning_content for thinking
     // models that return content = Some("") with actual text in reasoning.
@@ -3295,25 +3381,15 @@ async fn generate_session_title(
         .content
         .filter(|s| !s.trim().is_empty())
         .or(response.reasoning_content);
-    let Some(raw_title) = raw_title else {
-        tracing::warn!(session_key = %session_key, "title gen: LLM returned no content");
+
+    let Some(title) = finalize_title(
+        raw_title.as_deref(),
+        &first_user_msg,
+        max_chars,
+        session_key,
+    ) else {
         return Ok(());
     };
-
-    let title = raw_title.trim().trim_matches('"').to_string();
-    if title.is_empty() {
-        tracing::warn!(session_key = %session_key, "title gen: LLM returned empty title");
-        return Ok(());
-    }
-    if title.chars().count() > 50 {
-        tracing::warn!(
-            session_key = %session_key,
-            title_len = title.chars().count(),
-            title = %title,
-            "title gen: title exceeds 50 chars, discarded"
-        );
-        return Ok(());
-    }
 
     match session_index.get_session(session_key).await {
         Ok(Some(mut entry)) => {
@@ -3436,5 +3512,110 @@ mod tests {
             matches!(err, KernelError::SessionNotFound { .. }),
             "expected SessionNotFound, got {err:?}"
         );
+    }
+
+    // -- title_gen: truncation + registry wiring (issue #1637) ----------------
+
+    /// A 237-char model response (matching the observed 2026-04-20 incident)
+    /// must be truncated down to the configured cap and returned — never
+    /// silently discarded as the old code did.
+    #[test]
+    fn finalize_title_truncates_long_model_output() {
+        let long = "a".repeat(237);
+        let sk = SessionKey::new();
+        let got = finalize_title(Some(&long), "user msg", 50, &sk)
+            .expect("truncated title should still be persisted");
+        assert_eq!(got.chars().count(), 50);
+        assert!(got.chars().all(|c| c == 'a'));
+    }
+
+    /// An empty model response falls back to the first line of the user
+    /// message, still bounded by `max_chars`.
+    #[test]
+    fn finalize_title_falls_back_to_user_message_when_model_empty() {
+        let sk = SessionKey::new();
+        let got = finalize_title(
+            Some("   "), // whitespace only → treated as empty
+            "hello world, this is the first user message\nsecond line ignored",
+            50,
+            &sk,
+        )
+        .expect("fallback must produce a title");
+        assert!(got.starts_with("hello world"));
+        assert!(!got.contains('\n'));
+        assert!(got.chars().count() <= 50);
+    }
+
+    /// Short model output passes through unchanged.
+    #[test]
+    fn finalize_title_preserves_short_output() {
+        let sk = SessionKey::new();
+        let got = finalize_title(Some("  \"short title\" "), "unused", 50, &sk)
+            .expect("short title must pass through");
+        assert_eq!(got, "short title");
+    }
+
+    /// The title_gen manifest resolves its driver + model via
+    /// `DriverRegistry::resolve_agent` (unified `agents.<name>.*` path),
+    /// not via a flat `title_generator` key. This guards against regressing
+    /// to the split-brain wiring that #1637 removed.
+    #[test]
+    fn title_gen_resolves_via_resolve_agent() {
+        use std::sync::Arc as StdArc;
+
+        use crate::{
+            agent::AgentManifest,
+            llm::{
+                ScriptedLlmDriver,
+                catalog::OpenRouterCatalog,
+                registry::{AgentLlmConfig, DriverRegistry},
+            },
+        };
+
+        let catalog = StdArc::new(OpenRouterCatalog::new());
+        let reg = DriverRegistry::new("openrouter", catalog);
+        reg.register_driver(
+            "openrouter",
+            StdArc::new(ScriptedLlmDriver::new(Vec::new())),
+        );
+        reg.register_driver("ollama", StdArc::new(ScriptedLlmDriver::new(Vec::new())));
+        reg.set_provider_model("openrouter", "gpt-4o", Vec::<String>::new());
+
+        // Simulate `agents.title_gen.{driver, model}` YAML.
+        reg.set_agent_config(
+            "title_gen",
+            AgentLlmConfig {
+                driver: Some("ollama".into()),
+                model:  Some("qwen3:14b".into()),
+            },
+        );
+
+        let manifest = AgentManifest {
+            name:                   "title_gen".into(),
+            role:                   crate::agent::AgentRole::Worker,
+            description:            "t".into(),
+            model:                  None,
+            system_prompt:          String::new(),
+            soul_prompt:            None,
+            provider_hint:          None,
+            max_iterations:         Some(1),
+            tools:                  Vec::new(),
+            excluded_tools:         Vec::new(),
+            max_children:           Some(0),
+            max_context_tokens:     None,
+            priority:               crate::agent::Priority::default(),
+            metadata:               serde_json::Value::Null,
+            sandbox:                None,
+            default_execution_mode: None,
+            tool_call_limit:        None,
+            worker_timeout_secs:    None,
+            max_continuations:      Some(0),
+            max_output_chars:       Some(50),
+        };
+
+        let resolved = reg.resolve_agent(&manifest).expect("resolve_agent");
+        assert_eq!(resolved.model, "qwen3:14b");
+        assert_eq!(resolved.manifest.name, "title_gen");
+        assert_eq!(resolved.manifest.max_output_chars, Some(50));
     }
 }

--- a/crates/kernel/src/kernel.rs
+++ b/crates/kernel/src/kernel.rs
@@ -3094,22 +3094,27 @@ impl Kernel {
             let user_id = user.0.clone();
             let tape_name = session_key.to_string();
             tokio::spawn(async move {
-                let extractor_model = &knowledge.extractor_model;
-                let driver = match driver_registry.resolve(
-                    "knowledge_extractor",
-                    None,
-                    Some(extractor_model),
-                ) {
-                    Ok((d, _model_name)) => d,
+                // Resolve `{driver, model}` as one atomic lookup keyed by the
+                // extractor's manifest — not a driver + flat model string.
+                // This closes the prod failure in #1629 where MiniMax was
+                // called with `gpt-4o-mini`.
+                let manifest = crate::memory::knowledge::knowledge_extractor_manifest();
+                let resolved = match driver_registry.resolve_agent(manifest) {
+                    Ok(r) => r,
                     Err(e) => {
-                        tracing::warn!(%e, "knowledge extraction: cannot resolve model");
+                        tracing::error!(
+                            %e,
+                            agent = crate::memory::knowledge::KNOWLEDGE_EXTRACTOR_NAME,
+                            "knowledge extraction: failed to resolve agent — check \
+                             `agents.knowledge_extractor.{{driver, model}}` in config.yaml"
+                        );
                         return;
                     }
                 };
                 let entries = match tape_service.from_last_anchor(&tape_name, None).await {
                     Ok(e) => e,
                     Err(e) => {
-                        tracing::warn!(%e, "knowledge extraction: failed to read tape");
+                        tracing::error!(%e, "knowledge extraction: failed to read tape");
                         return;
                     }
                 };
@@ -3119,8 +3124,7 @@ impl Kernel {
                     &tape_name,
                     &knowledge.pool,
                     &knowledge.embedding_svc,
-                    driver.as_ref(),
-                    extractor_model,
+                    &resolved,
                     knowledge.config.similarity_threshold,
                 )
                 .await
@@ -3130,7 +3134,14 @@ impl Kernel {
                     }
                     Ok(_) => {}
                     Err(e) => {
-                        tracing::warn!(user = %user_id, %e, "knowledge extraction failed");
+                        // Upgraded from WARN to ERROR (#1636): a silent WARN
+                        // masked every extraction failing in prod for days.
+                        tracing::error!(
+                            user = %user_id,
+                            model = %resolved.model,
+                            %e,
+                            "knowledge extraction failed"
+                        );
                     }
                 }
             });

--- a/crates/kernel/src/llm/mod.rs
+++ b/crates/kernel/src/llm/mod.rs
@@ -40,7 +40,9 @@ pub use driver::{
     LlmEmbedder, LlmEmbedderRef, LlmModelLister, LlmModelListerRef,
 };
 pub use openai::{OpenAiDriver, is_local_url};
-pub use registry::{DriverRegistry, DriverRegistryRef, ProviderModelConfig};
+pub use registry::{
+    AgentLlmConfig, DriverRegistry, DriverRegistryRef, ProviderModelConfig, ResolvedAgent,
+};
 pub use scripted::ScriptedLlmDriver;
 pub use stream::StreamDelta;
 pub use types::*;

--- a/crates/kernel/src/llm/registry.rs
+++ b/crates/kernel/src/llm/registry.rs
@@ -363,6 +363,7 @@ mod tests {
             tool_call_limit:        None,
             worker_timeout_secs:    None,
             max_continuations:      None,
+            max_output_chars:       None,
         }
     }
 

--- a/crates/kernel/src/llm/registry.rs
+++ b/crates/kernel/src/llm/registry.rs
@@ -17,7 +17,21 @@
 //! [`DriverRegistry`] manages named [`LlmDriver`](super::LlmDriver) instances
 //! with per-agent override support for driver and model selection.
 //!
-//! Resolution priority:
+//! # Resolution contract (`resolve_agent`, introduced in #1635)
+//!
+//! Agents declare their LLM binding in YAML under
+//! `agents.<name>.{driver, model}`. The registry's
+//! [`DriverRegistry::resolve_agent`] returns a [`ResolvedAgent`] with
+//! the driver instance, the exact model, and a manifest snapshot, so
+//! callers never see a driver resolved one way and a model resolved
+//! another. Priority:
+//!
+//! ```text
+//! Driver: agents.<name>.driver > agent_overrides > manifest.provider_hint > default_driver
+//! Model:  agents.<name>.model  > agent_overrides > manifest.model         > provider_models[driver].default_model
+//! ```
+//!
+//! # Legacy `resolve` (kept as a thin shim)
 //!
 //! ```text
 //! Driver: agent_overrides > manifest.provider_hint > default_driver
@@ -32,7 +46,7 @@ use std::{
 use snafu::OptionExt;
 
 use super::{catalog::OpenRouterCatalog, driver::LlmDriverRef};
-use crate::error;
+use crate::{agent::AgentManifest, error};
 
 /// Shared reference to the [`DriverRegistry`].
 pub type DriverRegistryRef = Arc<DriverRegistry>;
@@ -52,6 +66,12 @@ struct DriverRegistryState {
     default_driver:  String,
     provider_models: HashMap<String, ProviderModelConfig>,
     agent_overrides: HashMap<String, AgentDriverConfig>,
+    /// Per-agent `{driver, model}` pair loaded from `agents.<name>.*` YAML.
+    ///
+    /// This is the new unified source of truth introduced by the agent
+    /// registry refactor (issue #1635). Existing `agent_overrides` remain
+    /// until consumers migrate in follow-up issues.
+    agent_configs:   HashMap<String, AgentLlmConfig>,
 }
 
 /// Per-agent LLM driver configuration override.
@@ -64,6 +84,36 @@ pub struct AgentDriverConfig {
     pub driver: Option<String>,
     /// Override model identifier (e.g., `"qwen3:32b"`).
     pub model:  Option<String>,
+}
+
+/// Unified per-agent LLM config read from `agents.<name>.*` YAML.
+///
+/// Unlike [`AgentDriverConfig`] (which is a legacy override layered on
+/// top of a manifest), this represents the full `{driver, model}` pair
+/// that [`DriverRegistry::resolve_agent`] will return for an agent.
+#[derive(Debug, Clone, Default)]
+pub struct AgentLlmConfig {
+    /// Driver name (e.g., `"openrouter"`, `"ollama"`).
+    pub driver: Option<String>,
+    /// Model identifier (e.g., `"qwen3:32b"`).
+    pub model:  Option<String>,
+}
+
+/// Fully-resolved LLM binding for an agent.
+///
+/// Produced by [`DriverRegistry::resolve_agent`]. Holds the driver
+/// instance, the exact model identifier, and a clone of the agent's
+/// manifest so callers have a single consistent snapshot — eliminating
+/// the historical split between a driver resolved one way and a model
+/// string resolved another (see issue #1635).
+#[derive(Clone, bon::Builder)]
+pub struct ResolvedAgent {
+    /// Shared driver instance capable of serving the agent's requests.
+    pub driver:   LlmDriverRef,
+    /// Concrete model identifier to pass to the driver.
+    pub model:    String,
+    /// Snapshot of the manifest used for resolution.
+    pub manifest: AgentManifest,
 }
 
 /// Named driver map with default selection and per-agent overrides.
@@ -82,6 +132,7 @@ impl DriverRegistry {
                 default_driver:  default_driver.into(),
                 provider_models: HashMap::new(),
                 agent_overrides: HashMap::new(),
+                agent_configs:   HashMap::new(),
             }),
             catalog,
         }
@@ -117,6 +168,17 @@ impl DriverRegistry {
     pub fn set_agent_override(&self, agent_name: impl Into<String>, config: AgentDriverConfig) {
         let mut state = self.state.write().unwrap_or_else(|e| e.into_inner());
         state.agent_overrides.insert(agent_name.into(), config);
+    }
+
+    /// Set the unified `{driver, model}` config for an agent, as loaded
+    /// from `agents.<name>.*` YAML.
+    ///
+    /// Used by [`Self::resolve_agent`]. Independent of the legacy
+    /// [`Self::set_agent_override`] map — callers may populate either or
+    /// both during the migration period.
+    pub fn set_agent_config(&self, agent_name: impl Into<String>, config: AgentLlmConfig) {
+        let mut state = self.state.write().unwrap_or_else(|e| e.into_inner());
+        state.agent_configs.insert(agent_name.into(), config);
     }
 
     /// Resolve a driver + model for a given agent.
@@ -157,6 +219,57 @@ impl DriverRegistry {
             .context(error::ProviderNotConfiguredSnafu)?;
 
         Ok((Arc::clone(driver), model_name.to_string()))
+    }
+
+    /// Resolve a [`ResolvedAgent`] for the given manifest — the unified
+    /// `{driver, model, manifest}` entry point introduced by #1635.
+    ///
+    /// Resolution priority:
+    /// - **Driver**: `agents.<name>.driver` > `agent_overrides[name].driver`
+    ///   > `manifest.provider_hint` > `default_driver`
+    /// - **Model**:  `agents.<name>.model`  > `agent_overrides[name].model`
+    ///   > `manifest.model` > `provider_models[driver].default_model`
+    ///
+    /// The agent name is taken from `manifest.name`. The returned
+    /// `ResolvedAgent` carries a clone of the manifest so callers have a
+    /// single consistent snapshot — closing the historical split where
+    /// the driver was resolved via the registry but the model came from
+    /// a flat settings key (see the `knowledge_extractor` prod failure
+    /// that motivated this refactor).
+    pub fn resolve_agent(&self, manifest: &AgentManifest) -> error::Result<ResolvedAgent> {
+        let state = self.state.read().unwrap_or_else(|e| e.into_inner());
+        let agent_name = manifest.name.as_str();
+        let agent_cfg = state.agent_configs.get(agent_name);
+        let legacy_override = state.agent_overrides.get(agent_name);
+
+        let driver_name = agent_cfg
+            .and_then(|c| c.driver.as_deref())
+            .or_else(|| legacy_override.and_then(|c| c.driver.as_deref()))
+            .or(manifest.provider_hint.as_deref())
+            .unwrap_or(&state.default_driver);
+
+        let provider_default = state
+            .provider_models
+            .get(driver_name)
+            .map(|c| c.default_model.as_str());
+
+        let model_name = agent_cfg
+            .and_then(|c| c.model.as_deref())
+            .or_else(|| legacy_override.and_then(|c| c.model.as_deref()))
+            .or(manifest.model.as_deref())
+            .or(provider_default)
+            .unwrap_or("unknown");
+
+        let driver = state
+            .drivers
+            .get(driver_name)
+            .context(error::ProviderNotConfiguredSnafu)?;
+
+        Ok(ResolvedAgent {
+            driver:   Arc::clone(driver),
+            model:    model_name.to_string(),
+            manifest: manifest.clone(),
+        })
     }
 
     /// Get the default driver name.
@@ -218,5 +331,117 @@ impl DriverRegistry {
         let next_state = next.state.read().unwrap_or_else(|e| e.into_inner()).clone();
         let mut state = self.state.write().unwrap_or_else(|e| e.into_inner());
         *state = next_state;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        agent::{AgentRole, Priority},
+        llm::ScriptedLlmDriver,
+    };
+
+    fn manifest(name: &str) -> AgentManifest {
+        AgentManifest {
+            name:                   name.to_string(),
+            role:                   AgentRole::Chat,
+            description:            "test".to_string(),
+            model:                  None,
+            system_prompt:          "sp".to_string(),
+            soul_prompt:            None,
+            provider_hint:          None,
+            max_iterations:         None,
+            tools:                  Vec::new(),
+            excluded_tools:         Vec::new(),
+            max_children:           None,
+            max_context_tokens:     None,
+            priority:               Priority::default(),
+            metadata:               serde_json::Value::Null,
+            sandbox:                None,
+            default_execution_mode: None,
+            tool_call_limit:        None,
+            worker_timeout_secs:    None,
+            max_continuations:      None,
+        }
+    }
+
+    fn registry_with_providers() -> DriverRegistry {
+        let catalog = Arc::new(OpenRouterCatalog::new());
+        let reg = DriverRegistry::new("openrouter", catalog);
+        reg.register_driver("openrouter", Arc::new(ScriptedLlmDriver::new(Vec::new())));
+        reg.register_driver("ollama", Arc::new(ScriptedLlmDriver::new(Vec::new())));
+        reg.set_provider_model("openrouter", "gpt-4o", Vec::<String>::new());
+        reg.set_provider_model("ollama", "qwen3:32b", Vec::<String>::new());
+        reg
+    }
+
+    #[test]
+    fn resolve_agent_returns_agent_specific_pair() {
+        let reg = registry_with_providers();
+        reg.set_agent_config(
+            "knowledge_extractor",
+            AgentLlmConfig {
+                driver: Some("ollama".into()),
+                model:  Some("qwen3:14b".into()),
+            },
+        );
+
+        let m = manifest("knowledge_extractor");
+        let resolved = reg.resolve_agent(&m).expect("resolve_agent");
+        assert_eq!(resolved.model, "qwen3:14b");
+        assert_eq!(resolved.manifest.name, "knowledge_extractor");
+    }
+
+    #[test]
+    fn resolve_agent_falls_back_to_manifest_then_provider_default() {
+        let reg = registry_with_providers();
+
+        // Manifest-only model, no per-agent YAML config.
+        let mut m = manifest("rara");
+        m.model = Some("gpt-4o-mini".into());
+        let resolved = reg.resolve_agent(&m).expect("resolve_agent");
+        assert_eq!(resolved.model, "gpt-4o-mini");
+
+        // Pure fallback to provider default.
+        let m_empty = manifest("blank");
+        let resolved = reg.resolve_agent(&m_empty).expect("resolve_agent");
+        assert_eq!(resolved.model, "gpt-4o");
+    }
+
+    #[test]
+    fn resolve_agent_errors_when_driver_unknown() {
+        let catalog = Arc::new(OpenRouterCatalog::new());
+        let reg = DriverRegistry::new("missing", catalog);
+        // No driver registered.
+        let m = manifest("ghost");
+        let result = reg.resolve_agent(&m);
+        assert!(result.is_err(), "expected error for unknown driver");
+        match result {
+            Err(crate::error::KernelError::ProviderNotConfigured { .. }) => {}
+            other => panic!("unexpected result variant: {:?}", other.err()),
+        }
+    }
+
+    #[test]
+    fn legacy_resolve_shim_still_works() {
+        let reg = registry_with_providers();
+        reg.set_agent_override(
+            "rara",
+            AgentDriverConfig {
+                driver: Some("ollama".into()),
+                model:  Some("qwen3:32b".into()),
+            },
+        );
+
+        let (driver, model) = reg.resolve("rara", None, None).expect("resolve");
+        assert_eq!(model, "qwen3:32b");
+        // Driver reference is non-null — smoke check that the Arc resolved.
+        drop(driver);
+
+        // Unknown agent still falls back to the default driver + its default
+        // model, proving the legacy path is untouched by the new API.
+        let (_, model) = reg.resolve("unknown", None, None).expect("resolve");
+        assert_eq!(model, "gpt-4o");
     }
 }

--- a/crates/kernel/src/memory/knowledge/extractor.rs
+++ b/crates/kernel/src/memory/knowledge/extractor.rs
@@ -355,6 +355,7 @@ mod tests {
             tool_call_limit:        None,
             worker_timeout_secs:    None,
             max_continuations:      None,
+            max_output_chars:       None,
         }
     }
 

--- a/crates/kernel/src/memory/knowledge/extractor.rs
+++ b/crates/kernel/src/memory/knowledge/extractor.rs
@@ -31,7 +31,7 @@ use super::{
     items::{self, NewMemoryItem},
 };
 use crate::{
-    llm::{CompletionRequest, LlmDriver, Message, ToolChoice},
+    llm::{CompletionRequest, LlmDriver, Message, ResolvedAgent, ToolChoice},
     memory::{TapEntry, TapEntryKind},
 };
 
@@ -89,10 +89,15 @@ pub async fn extract_knowledge(
     tape_name: &str,
     pool: &SqlitePool,
     embedding_svc: &EmbeddingService,
-    driver: &dyn LlmDriver,
-    extractor_model: &str,
+    agent: &ResolvedAgent,
     similarity_threshold: f32,
 ) -> Result<usize> {
+    // Driver + model are bound together by `ResolvedAgent` — closing the
+    // split-config bug where the driver came from the registry but the
+    // model came from a flat settings key (#1629 / #1636).
+    let driver = agent.driver.as_ref();
+    let extractor_model = agent.model.as_str();
+
     // Step 1: Build conversation text from tape entries.
     let conversation = build_conversation_text(entries);
     if conversation.is_empty() {
@@ -311,4 +316,117 @@ async fn update_category_files(
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use serde_json::json;
+
+    use super::*;
+    use crate::{
+        agent::{AgentRole, Priority},
+        llm::{
+            AgentLlmConfig, CompletionResponse, DriverRegistry, OpenRouterCatalog,
+            ScriptedLlmDriver, StopReason,
+        },
+        memory::{TapEntry, TapEntryKind},
+    };
+
+    fn manifest(name: &str) -> crate::agent::AgentManifest {
+        crate::agent::AgentManifest {
+            name:                   name.to_string(),
+            role:                   AgentRole::Worker,
+            description:            "test".into(),
+            model:                  None,
+            system_prompt:          String::new(),
+            soul_prompt:            None,
+            provider_hint:          None,
+            max_iterations:         None,
+            tools:                  Vec::new(),
+            excluded_tools:         Vec::new(),
+            max_children:           None,
+            max_context_tokens:     None,
+            priority:               Priority::default(),
+            metadata:               serde_json::Value::Null,
+            sandbox:                None,
+            default_execution_mode: None,
+            tool_call_limit:        None,
+            worker_timeout_secs:    None,
+            max_continuations:      None,
+        }
+    }
+
+    /// Verifies the split-config bug fix from #1629 / #1636: the model
+    /// that reaches the driver MUST come from `ResolvedAgent.model`, not
+    /// from any other source.
+    #[tokio::test]
+    async fn llm_call_uses_model_from_resolved_agent() {
+        // Scripted driver returns an empty JSON array so extraction exits
+        // cleanly after capturing the first request.
+        let scripted = Arc::new(ScriptedLlmDriver::new(vec![CompletionResponse {
+            content:           Some("[]".into()),
+            reasoning_content: None,
+            tool_calls:        Vec::new(),
+            stop_reason:       StopReason::Stop,
+            usage:             None,
+            model:             "scripted".into(),
+        }]));
+
+        let catalog = Arc::new(OpenRouterCatalog::new());
+        let reg = DriverRegistry::new("openrouter", catalog);
+        reg.register_driver("openrouter", Arc::clone(&scripted) as _);
+        reg.set_provider_model("openrouter", "provider-default", Vec::<String>::new());
+        // The unified agent config is what `resolve_agent` honours first.
+        reg.set_agent_config(
+            super::super::KNOWLEDGE_EXTRACTOR_NAME,
+            AgentLlmConfig {
+                driver: Some("openrouter".into()),
+                model:  Some("unified-agents-model".into()),
+            },
+        );
+
+        let m = manifest(super::super::KNOWLEDGE_EXTRACTOR_NAME);
+        let resolved = reg.resolve_agent(&m).expect("resolve_agent");
+        assert_eq!(resolved.model, "unified-agents-model");
+
+        // Drive `llm_extract_items` directly — it is the pure LLM boundary
+        // that used to be called with the wrong model in prod.
+        let driver_ref: &dyn LlmDriver = resolved.driver.as_ref();
+        let _ = llm_extract_items(driver_ref, &resolved.model, "hello")
+            .await
+            .expect("extraction ok");
+
+        let reqs = scripted.captured_requests();
+        assert_eq!(reqs.len(), 1, "exactly one completion");
+        assert_eq!(
+            reqs[0].model, "unified-agents-model",
+            "model sent to driver must be the one resolved via resolve_agent, not a flat key"
+        );
+    }
+
+    #[test]
+    fn build_conversation_text_skips_non_message_entries() {
+        let now = jiff::Timestamp::now();
+        let entries = vec![
+            TapEntry {
+                id:        1,
+                kind:      TapEntryKind::Message,
+                payload:   json!({"role": "user", "content": "hi"}),
+                timestamp: now,
+                metadata:  None,
+            },
+            TapEntry {
+                id:        2,
+                kind:      TapEntryKind::ToolCall,
+                payload:   json!({"role": "assistant", "content": "ignored"}),
+                timestamp: now,
+                metadata:  None,
+            },
+        ];
+        let text = build_conversation_text(&entries);
+        assert!(text.contains("[user]: hi"));
+        assert!(!text.contains("ignored"));
+    }
 }

--- a/crates/kernel/src/memory/knowledge/manifest.rs
+++ b/crates/kernel/src/memory/knowledge/manifest.rs
@@ -1,0 +1,64 @@
+// Copyright 2025 Rararulab
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Built-in manifest for the knowledge extraction background pipeline.
+//!
+//! The extractor is not a user-facing conversational agent — it is a
+//! background worker whose LLM binding MUST be resolved through
+//! [`crate::llm::DriverRegistry::resolve_agent`]. That path reads
+//! `agents.knowledge_extractor.{driver, model}` from YAML so the driver
+//! and the model always come from the same source, closing the
+//! split-config bug that caused every extraction to 400 in prod
+//! (see #1629 / #1636).
+
+use std::sync::LazyLock;
+
+use crate::agent::{AgentManifest, AgentRole, Priority};
+
+/// Canonical agent name for the knowledge extraction pipeline.
+///
+/// Exposed as a constant so the kernel call site, the boot crate's
+/// config validation, and any future consumers agree on the exact key
+/// used for `agents.<name>.{driver, model}` YAML lookups.
+pub const KNOWLEDGE_EXTRACTOR_NAME: &str = "knowledge_extractor";
+
+static KNOWLEDGE_EXTRACTOR_MANIFEST: LazyLock<AgentManifest> = LazyLock::new(|| AgentManifest {
+    name:                   KNOWLEDGE_EXTRACTOR_NAME.to_string(),
+    role:                   AgentRole::Worker,
+    description:            "Knowledge extraction pipeline — turns conversation tapes into \
+                             long-term memory items"
+        .to_string(),
+    // `model` is deliberately `None`: the concrete model MUST be supplied
+    // via `agents.knowledge_extractor.model` YAML so driver + model are
+    // resolved atomically through `DriverRegistry::resolve_agent`.
+    model:                  None,
+    system_prompt:          String::new(),
+    soul_prompt:            None,
+    provider_hint:          None,
+    max_iterations:         Some(1),
+    tools:                  vec![],
+    excluded_tools:         vec![],
+    max_children:           Some(0),
+    max_context_tokens:     None,
+    priority:               Priority::default(),
+    metadata:               serde_json::Value::Null,
+    sandbox:                None,
+    default_execution_mode: None,
+    tool_call_limit:        None,
+    worker_timeout_secs:    None,
+    max_continuations:      Some(0),
+});
+
+/// Return the static knowledge extractor manifest.
+pub fn knowledge_extractor_manifest() -> &'static AgentManifest { &KNOWLEDGE_EXTRACTOR_MANIFEST }

--- a/crates/kernel/src/memory/knowledge/manifest.rs
+++ b/crates/kernel/src/memory/knowledge/manifest.rs
@@ -58,6 +58,7 @@ static KNOWLEDGE_EXTRACTOR_MANIFEST: LazyLock<AgentManifest> = LazyLock::new(|| 
     tool_call_limit:        None,
     worker_timeout_secs:    None,
     max_continuations:      Some(0),
+    max_output_chars:       None,
 });
 
 /// Return the static knowledge extractor manifest.

--- a/crates/kernel/src/memory/knowledge/mod.rs
+++ b/crates/kernel/src/memory/knowledge/mod.rs
@@ -25,10 +25,12 @@ pub mod config;
 pub mod embedding;
 pub mod extractor;
 pub mod items;
+pub mod manifest;
 pub mod service;
 pub mod tool;
 
 pub use config::KnowledgeConfig;
 pub use embedding::EmbeddingService;
+pub use manifest::{KNOWLEDGE_EXTRACTOR_NAME, knowledge_extractor_manifest};
 pub use service::{KnowledgeService, KnowledgeServiceRef};
 pub use tool::MemoryTool;

--- a/crates/kernel/src/memory/knowledge/service.rs
+++ b/crates/kernel/src/memory/knowledge/service.rs
@@ -22,12 +22,16 @@ use super::{EmbeddingService, KnowledgeConfig};
 
 /// Bundles the knowledge layer's runtime dependencies into a single handle
 /// that can be shared across the kernel.
+///
+/// The extractor agent's `{driver, model}` pair is **not** stored here — it
+/// is resolved per-call via
+/// [`DriverRegistry::resolve_agent`](crate::llm::DriverRegistry::resolve_agent)
+/// keyed by the `knowledge_extractor` manifest, so a single atomic snapshot
+/// reaches `extract_knowledge`. See #1636 / #1638.
 pub struct KnowledgeService {
-    pub pool:            SqlitePool,
-    pub embedding_svc:   Arc<EmbeddingService>,
-    pub config:          KnowledgeConfig,
-    /// LLM model name for memory extraction (from runtime settings).
-    pub extractor_model: String,
+    pub pool:          SqlitePool,
+    pub embedding_svc: Arc<EmbeddingService>,
+    pub config:        KnowledgeConfig,
 }
 
 impl KnowledgeService {

--- a/crates/kernel/src/plan.rs
+++ b/crates/kernel/src/plan.rs
@@ -1005,6 +1005,7 @@ async fn execute_worker_step(
         tool_call_limit:        None,
         worker_timeout_secs:    None,
         max_continuations:      Some(0),
+        max_output_chars:       None,
     };
 
     info!(

--- a/crates/kernel/src/session/mod.rs
+++ b/crates/kernel/src/session/mod.rs
@@ -1024,6 +1024,7 @@ impl Session {
                 tool_call_limit:        None,
                 worker_timeout_secs:    None,
                 max_continuations:      None,
+                max_output_chars:       None,
             },
             principal,
             env: AgentEnv::default(),
@@ -1088,6 +1089,7 @@ mod state_transition_tests {
             tool_call_limit:        None,
             worker_timeout_secs:    None,
             max_continuations:      None,
+            max_output_chars:       None,
         }
     }
 

--- a/crates/kernel/src/testing.rs
+++ b/crates/kernel/src/testing.rs
@@ -185,7 +185,6 @@ async fn stub_knowledge_service() -> crate::memory::knowledge::KnowledgeServiceR
         pool,
         embedding_svc: Arc::new(embedding_svc),
         config,
-        extractor_model: "scripted".to_string(),
     })
 }
 

--- a/crates/kernel/src/testing.rs
+++ b/crates/kernel/src/testing.rs
@@ -347,6 +347,7 @@ impl TestKernelBuilder {
             tool_call_limit:        None,
             worker_timeout_secs:    None,
             max_continuations:      None,
+            max_output_chars:       None,
         });
         let manifest_name = manifest.name.clone();
 

--- a/crates/kernel/src/tool/fold_branch.rs
+++ b/crates/kernel/src/tool/fold_branch.rs
@@ -172,6 +172,7 @@ impl ToolExecute for FoldBranchTool {
             tool_call_limit: None,
             max_continuations: Some(0),
             worker_timeout_secs: None,
+            max_output_chars: None,
         };
 
         // Resolve principal from parent session.

--- a/crates/kernel/src/tool/spawn_background.rs
+++ b/crates/kernel/src/tool/spawn_background.rs
@@ -115,6 +115,7 @@ impl ToolExecute for SpawnBackgroundTool {
             tool_call_limit: None,
             worker_timeout_secs: Some(p.max_iterations.unwrap_or(15) as u64 * 60),
             max_continuations: Some(0),
+            max_output_chars: None,
         };
 
         super::background_common::spawn_and_register_background(

--- a/crates/kernel/src/tool/task/mod.rs
+++ b/crates/kernel/src/tool/task/mod.rs
@@ -117,6 +117,7 @@ impl ToolExecute for TaskTool {
             tool_call_limit:        None,
             worker_timeout_secs:    Some(preset.max_iterations as u64 * 60),
             max_continuations:      Some(0),
+            max_output_chars:       None,
         };
 
         let mut result = super::background_common::spawn_and_register_background(
@@ -189,6 +190,7 @@ mod tests {
             tool_call_limit:        None,
             worker_timeout_secs:    Some(preset.max_iterations as u64 * 60),
             max_continuations:      Some(0),
+            max_output_chars:       None,
         };
         assert_eq!(manifest.role, AgentRole::Worker);
         assert_eq!(manifest.max_children, Some(0));


### PR DESCRIPTION
## Summary

Closes #1631 (Epic B). Promotes background agents (knowledge_extractor, title_gen) to first-class citizens with the same manifest + driver + model shape as the main agent, eliminating the split-brain config that caused silent failures.

Motivation: before this change, driver was resolved via `DriverRegistry` but model was a flat string like `memory.knowledge.extractor_model`. Prod incident: driver resolved to MiniMax, model stayed `gpt-4o-mini`, every extraction 400'd silently — no user memories were ever written. Same pattern would have bitten every future background agent.

Sub-PRs (all merged into this branch):

- **#1640** `feat(kernel): add resolve_agent api` — foundation. New `DriverRegistry::resolve_agent(&AgentManifest) -> Result<ResolvedAgent { driver, model, manifest }>`. Priority: `agents.<name>.{driver,model}` YAML > legacy overrides > manifest hint > provider default. Legacy `resolve()` kept as a shim.
- **#1642** `refactor(kernel): migrate knowledge_extractor to unified registry` — consumer migration. `extract_knowledge` takes `&ResolvedAgent` instead of `(driver, extractor_model)`. Closes #1629.
- **#1643** `refactor(kernel): migrate title_gen, fix silent title truncation` — consumer migration + bug fix. Over-length titles are truncated + warn-logged with `title_len` and `truncated=true`, never silently discarded. Empty model output falls back to the user message's first line with an ERROR log.
- **#1648** `chore(kernel): purge hardcoded model defaults, YAML-only agent config` — final cleanup. Removes legacy flat keys (`memory.knowledge.extractor_model` and friends). Boot fails fast with a single error listing every unconfigured background agent. Adds `config.example.yaml` at the repo root.

## Type of change

| Type | Label |
|------|-------|
| Refactor | `refactor` |

## Component

`core`

## Closes

Closes #1631
Closes #1629 (via #1642)
Supersedes the original quick-fix diagnosis that would have only patched the extractor model name

## Test plan

- [x] `cargo check -p rara-kernel -p rara-app` — passes
- [x] `cargo test -p rara-kernel --lib` — 506 pass
- [x] `cargo test -p rara-app --lib` — 62 pass, including boot-validation tests for missing `agents.knowledge_extractor` / `agents.title_gen`
- [x] `prek run --all-files` — clean across all sub-PRs
- [ ] Manual: boot with the new `config.example.yaml`, confirm knowledge extraction succeeds and title_gen produces a title within cap