### PR TITLE
feat(web): hermes-style tool chips (#1646)

### DIFF
--- a/web/src/components/agent-live/SingleAgentLiveCard.tsx
+++ b/web/src/components/agent-live/SingleAgentLiveCard.tsx
@@ -14,14 +14,13 @@
  * limitations under the License.
  */
 
-import { Bot, ChevronDown, Maximize2, Square } from 'lucide-react';
-import { useEffect, useRef, useState, type KeyboardEvent } from 'react';
+import { AlertCircle, Bot, CheckCircle2, ChevronDown, Maximize2, Square } from 'lucide-react';
+import { useEffect, useMemo, useRef, useState, type KeyboardEvent } from 'react';
 
 import type { LiveRun } from './live-run-store';
 import { formatDuration } from './time-format';
 
 import type { TimelineItem } from '@/api/kernel-types';
-import { TimelineRow } from '@/components/kernel/TimelineRow';
 import { redactObject } from '@/lib/redact';
 import { cn } from '@/lib/utils';
 
@@ -70,7 +69,8 @@ export function SingleAgentLiveCard({ run, agentName = 'rara', onOpenTranscript,
 
   const elapsed = (run.endedAt ?? nowTick) - run.startedAt;
   const headerLabel = `${agentName} is working`;
-  const redactedItems = run.items.map(redactItem);
+  const redactedItems = useMemo(() => run.items.map(redactItem), [run.items]);
+  const chips = useMemo(() => buildToolChips(redactedItems), [redactedItems]);
 
   const onHeaderKey = (ev: KeyboardEvent<HTMLDivElement>) => {
     if (ev.key === 'Enter' || ev.key === ' ') {
@@ -145,7 +145,11 @@ export function SingleAgentLiveCard({ run, agentName = 'rara', onOpenTranscript,
 
       {expanded && (
         <div className="relative border-t border-border/50">
-          <div ref={scrollerRef} onScroll={onScroll} className="max-h-[320px] overflow-y-auto">
+          <div
+            ref={scrollerRef}
+            onScroll={onScroll}
+            className="max-h-[213px] overflow-y-auto [-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+          >
             {redactedItems.length === 0 ? (
               <div className="flex items-center gap-2 px-4 py-3 text-xs text-muted-foreground">
                 <span
@@ -155,9 +159,9 @@ export function SingleAgentLiveCard({ run, agentName = 'rara', onOpenTranscript,
                 <span className="truncate">{stageLabel(run.currentStage)}</span>
               </div>
             ) : (
-              <div className="divide-y divide-border/40">
-                {redactedItems.map((item) => (
-                  <TimelineRow key={`l-${item.seq}`} item={item} />
+              <div className="flex flex-col gap-1 px-3 py-2">
+                {chips.map((chip) => (
+                  <ToolChip key={`l-${chip.seq}`} chip={chip} />
                 ))}
               </div>
             )}
@@ -189,6 +193,135 @@ function redactItem(item: TimelineItem): TimelineItem {
     return { ...item, input: redactObject(item.input) as Record<string, unknown> };
   }
   return item;
+}
+
+interface ToolChipModel {
+  /** Source `tool_use` seq — used as React key. */
+  seq: number;
+  tool: string;
+  /** Derived short preview from the (redacted) input. Empty if nothing useful. */
+  preview: string;
+  status: 'running' | 'completed' | 'errored';
+  /** Short error text when `status === 'errored'`. Replaces the preview in the UI. */
+  errorText?: string;
+}
+
+/**
+ * Fold timeline items into one chip per `tool_use`, pairing each use with the
+ * nearest following `tool_result` / `error` that shares the same `tool` name.
+ *
+ * Pairing note: `TimelineItem` deliberately does not expose the backend
+ * `tool_call_id` (see `live-run-store.ts` WeakMap comment), so pairing is a
+ * best-effort name-order heuristic. If the same tool is invoked twice before
+ * the first result lands, chips briefly share state — acceptable for a live
+ * indicator.
+ *
+ * Newest chip first (hermes pattern) so the most recent activity sits at the
+ * top of the compact panel.
+ */
+function buildToolChips(items: readonly TimelineItem[]): ToolChipModel[] {
+  const chips: ToolChipModel[] = [];
+  for (let i = 0; i < items.length; i++) {
+    const use = items[i];
+    if (!use || use.kind !== 'tool_use' || !use.tool) continue;
+    const toolName = use.tool;
+    // Default to running when no pairing follow-up is found; a tool_use
+    // without a matching tool_result/error is still in-flight from the UI's
+    // perspective even if streaming has technically stopped.
+    let status: ToolChipModel['status'] = 'running';
+    let errorText: string | undefined;
+    for (let j = i + 1; j < items.length; j++) {
+      const follow = items[j];
+      if (!follow) continue;
+      if (follow.kind === 'tool_result' && follow.tool === toolName) {
+        status = follow.success === false ? 'errored' : 'completed';
+        if (status === 'errored' && follow.output) errorText = clip(follow.output);
+        break;
+      }
+      if (follow.kind === 'error') {
+        status = 'errored';
+        errorText = clip(follow.content ?? '');
+        break;
+      }
+    }
+    const chip: ToolChipModel = {
+      seq: use.seq,
+      tool: toolName,
+      preview: derivePreview(use.input),
+      status,
+    };
+    if (errorText !== undefined) chip.errorText = errorText;
+    chips.push(chip);
+  }
+  return chips.reverse();
+}
+
+/** Keys to try in priority order when deriving a short preview from tool input. */
+const PREVIEW_KEYS = [
+  'query',
+  'file_path',
+  'path',
+  'pattern',
+  'description',
+  'command',
+  'prompt',
+  'skill',
+] as const;
+
+function derivePreview(input: Record<string, unknown> | undefined): string {
+  if (!input) return '';
+  for (const key of PREVIEW_KEYS) {
+    const v = input[key];
+    if (typeof v === 'string' && v.length > 0) {
+      const shaped = key === 'file_path' || key === 'path' ? shortenPath(v) : v;
+      return clip(shaped);
+    }
+  }
+  for (const v of Object.values(input)) {
+    if (typeof v === 'string' && v.length > 0) return clip(v);
+  }
+  return '';
+}
+
+/** Clip long strings to ~110 chars with a trailing ellipsis. */
+function clip(s: string): string {
+  const limit = 110;
+  const flat = s.replace(/\s+/g, ' ').trim();
+  return flat.length > limit ? flat.slice(0, limit) + '…' : flat;
+}
+
+/** Render long paths as `…/<last-two-segments>` to keep chips one-line. */
+function shortenPath(p: string): string {
+  const parts = p.split('/').filter(Boolean);
+  if (parts.length <= 2) return p;
+  return '…/' + parts.slice(-2).join('/');
+}
+
+function ToolChip({ chip }: { chip: ToolChipModel }) {
+  const body = chip.status === 'errored' && chip.errorText ? chip.errorText : chip.preview;
+  return (
+    <div className="flex items-center gap-2 rounded-sm bg-muted/40 px-2 py-1 text-[11px]">
+      <StatusIcon status={chip.status} />
+      <span className="shrink-0 font-mono text-foreground">{chip.tool}</span>
+      {body && <span className="min-w-0 flex-1 truncate text-muted-foreground">{body}</span>}
+    </div>
+  );
+}
+
+function StatusIcon({ status }: { status: ToolChipModel['status'] }) {
+  if (status === 'running') {
+    return (
+      <span
+        role="status"
+        aria-label="running"
+        className="inline-block h-3 w-3 shrink-0 animate-spin rounded-full border border-muted-foreground/30 border-t-muted-foreground"
+      />
+    );
+  }
+  if (status === 'completed') {
+    return <CheckCircle2 aria-label="completed" className="h-3 w-3 shrink-0 text-emerald-500" />;
+  }
+  return <AlertCircle aria-label="errored" className="h-3 w-3 shrink-0 text-destructive" />;
 }
 
 /**

--- a/web/src/components/agent-live/__tests__/SingleAgentLiveCard.test.tsx
+++ b/web/src/components/agent-live/__tests__/SingleAgentLiveCard.test.tsx
@@ -14,11 +14,13 @@
  * limitations under the License.
  */
 
-import { render, screen } from '@testing-library/react';
+import { render, screen, within } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 
 import type { LiveRun } from '../live-run-store';
 import { SingleAgentLiveCard } from '../SingleAgentLiveCard';
+
+import type { TimelineItem } from '@/api/kernel-types';
 
 function runFixture(overrides: Partial<LiveRun> = {}): LiveRun {
   return {
@@ -35,20 +37,31 @@ function runFixture(overrides: Partial<LiveRun> = {}): LiveRun {
   };
 }
 
+function toolUse(seq: number, tool: string, input: Record<string, unknown>): TimelineItem {
+  return { seq, turn: 0, kind: 'tool_use', tool, input, streaming: true };
+}
+
+function toolResult(seq: number, tool: string, success: boolean, output?: string): TimelineItem {
+  return { seq, turn: 0, kind: 'tool_result', tool, success, output };
+}
+
+function errorItem(seq: number, content: string): TimelineItem {
+  return { seq, turn: 0, kind: 'error', content };
+}
+
 describe('SingleAgentLiveCard', () => {
   it('shows a generic working placeholder when the run has no items or stage', () => {
     render(<SingleAgentLiveCard run={runFixture()} onOpenTranscript={vi.fn()} />);
     expect(screen.getByText('正在处理…')).toBeInTheDocument();
   });
 
-  it('renders the current stage text when set', () => {
+  it('renders the current stage text when set and no items', () => {
     render(
       <SingleAgentLiveCard
         run={runFixture({ currentStage: 'Waiting for LLM response (iteration 2)...' })}
         onOpenTranscript={vi.fn()}
       />,
     );
-    // Appears both in header subtitle and body row.
     expect(
       screen.getAllByText(/Waiting for LLM response \(iteration 2\)\.\.\./).length,
     ).toBeGreaterThan(0);
@@ -62,5 +75,82 @@ describe('SingleAgentLiveCard', () => {
       />,
     );
     expect(screen.getAllByText('思考中…').length).toBeGreaterThan(0);
+  });
+
+  it('renders a running chip with tool name + preview while the use is unpaired', () => {
+    render(
+      <SingleAgentLiveCard
+        run={runFixture({
+          items: [toolUse(1, 'grep', { query: 'fn main' })],
+        })}
+        onOpenTranscript={vi.fn()}
+      />,
+    );
+    expect(screen.getByText('grep')).toBeInTheDocument();
+    expect(screen.getByText('fn main')).toBeInTheDocument();
+    expect(screen.getByRole('status', { name: 'running' })).toBeInTheDocument();
+  });
+
+  it('shows a completed icon once a successful tool_result is paired', () => {
+    render(
+      <SingleAgentLiveCard
+        run={runFixture({
+          items: [
+            toolUse(1, 'grep', { query: 'fn main' }),
+            toolResult(2, 'grep', true, 'match.rs:10'),
+          ],
+        })}
+        onOpenTranscript={vi.fn()}
+      />,
+    );
+    expect(screen.getByLabelText('completed')).toBeInTheDocument();
+  });
+
+  it('shows an errored icon when tool_result.success is false', () => {
+    render(
+      <SingleAgentLiveCard
+        run={runFixture({
+          items: [
+            toolUse(1, 'grep', { query: 'fn main' }),
+            toolResult(2, 'grep', false, 'permission denied'),
+          ],
+        })}
+        onOpenTranscript={vi.fn()}
+      />,
+    );
+    expect(screen.getByLabelText('errored')).toBeInTheDocument();
+    expect(screen.getByText('permission denied')).toBeInTheDocument();
+  });
+
+  it('shows an errored icon with error text when paired with an error item', () => {
+    render(
+      <SingleAgentLiveCard
+        run={runFixture({
+          items: [toolUse(1, 'grep', { query: 'fn main' }), errorItem(2, 'kernel crashed')],
+        })}
+        onOpenTranscript={vi.fn()}
+      />,
+    );
+    expect(screen.getByLabelText('errored')).toBeInTheDocument();
+    expect(screen.getByText('kernel crashed')).toBeInTheDocument();
+  });
+
+  it('renders newest tool_use chip first', () => {
+    const { container } = render(
+      <SingleAgentLiveCard
+        run={runFixture({
+          items: [
+            toolUse(1, 'grep', { query: 'older' }),
+            toolUse(2, 'read', { file_path: '/etc/hosts' }),
+          ],
+        })}
+        onOpenTranscript={vi.fn()}
+      />,
+    );
+    const names = Array.from(container.querySelectorAll('.font-mono')).map(
+      (n) => within(n as HTMLElement).queryByText(/./)?.textContent ?? n.textContent,
+    );
+    expect(names[0]).toBe('read');
+    expect(names[1]).toBe('grep');
   });
 });


### PR DESCRIPTION
## Summary

- Replace the verbose `TimelineRow` list inside the in-progress live card with a compact chip panel inspired by hermes' `streaming-indicator`.
- Fold each `tool_use` with its nearest following `tool_result` / `error` into a one-line chip: status icon + monospace tool name + short input preview. Newest on top.
- Preview extracts a string from well-known input keys (`query`, `file_path`, `path`, `pattern`, `description`, `command`, `prompt`, `skill`) on the already-redacted input; file paths are shortened to `…/<last-two-segments>`; long strings clip at ~110 chars.
- Scroller capped at `~213px` with native scrollbar hidden to keep the live card unobtrusive.
- `AgentTranscriptDialog` and `TaskRunHistory` still render the full `TimelineRow` view; only the live card body changes.

## Pairing caveat

`TimelineItem` deliberately does not expose the backend `tool_call_id` (see WeakMap comment in `live-run-store.ts`), so pairing is a best-effort name-order heuristic documented in the helper's JSDoc. Parallel invocations of the same tool will briefly share state — acceptable for a compact live indicator.

## Type of change

| Type | Label |
|------|-------|
| New feature | `enhancement` |

## Component

`ui`

## Closes

Closes #1646

## Test plan

- [x] `npx vitest run src` passes (all 55 tests, 7 for this component)
- [x] `npx tsc -b --noEmit` clean
- [x] `npx eslint src/components/agent-live` clean
- [x] `npx prettier --check "src/**/*.{ts,tsx}"` clean
- [x] `npm run build` clean
- [x] Visual verification: drove the Vite dev server against the live backend at `10.0.0.183:25555` via playwright, triggered a turn that used `tape-search` + `discover-tools`, captured running + post-completion states.

## Screenshots

Captured on the live backend; files live under the worktree root (`tool-chips-running.png`, `tool-chips-completed.png`) and are not committed to the repo. Summary of what they show:

- `tool-chips-running.png` — live card with 4 chips visible (`tape-search`, `tape-search`, `discover-tools`, `discover-tools`) with preview text; top two rows already show `CheckCircle2` (green), bottom two show running spinners. Header chip reads `4 tools · 21s`.
- `tool-chips-completed.png` — taken after the run finished; live card is gone (as designed — the component only renders while the run is active) and execution history sidebar increments to `(2)`. Completion state on the chips themselves is additionally covered by unit tests (`screen.getByLabelText('completed')` — see `SingleAgentLiveCard.test.tsx`).

## Unit-test coverage of DOM states

Per task guidance, the chip states are pinned by DOM-level assertions:

- Running chip: `screen.getByRole('status', { name: 'running' })`
- Completed chip: `screen.getByLabelText('completed')`
- Errored chip (both `success: false` and `error` item): `screen.getByLabelText('errored')` + error text in body
- Ordering: newest `tool_use` rendered first