### PR TITLE
refactor(kernel): session-centric StreamHub event bus (#1647)

### DIFF
--- a/crates/channels/AGENT.md
+++ b/crates/channels/AGENT.md
@@ -13,7 +13,7 @@ Concrete channel adapter implementations for the rara platform — bridges the k
   - `commands/` — Slash command handlers (`/session`, `/stop`, `/status`, `/tape`, `/help`, `/mcp`) and inline keyboard callback handlers.
   - `markdown.rs` — Telegram MarkdownV2 escaping utilities.
   - `mod.rs` — `TelegramConfig` (primary chat ID, group policy, allowed group).
-- `src/web.rs` — `WebAdapter` for the web chat UI. WebSocket + SSE streaming. Authenticated via owner token.
+- `src/web.rs` — `WebAdapter` for the web chat UI. WebSocket + SSE streaming. Authenticated via owner token. Each WS/SSE connection holds a **permanent** subscription to `StreamHub::subscribe_session_events` for its session — the subscription outlives individual streams so mid-turn interrupt + re-inject does not drop events (see #1647).
 - `src/terminal.rs` — `TerminalAdapter` for interactive CLI chat sessions.
 - `tool_display` — re-exported from `rara_kernel::trace::tool_display` (the canonical home, since these helpers render data persisted in `ExecutionTrace`). `rara_channels::tool_display::*` remains the import path for in-tree callers.
 - `src/lib.rs` — Crate root, re-exports adapter modules.
@@ -48,6 +48,7 @@ Concrete channel adapter implementations for the rara platform — bridges the k
 - Do NOT hardcode chat IDs or bot tokens — they come from runtime settings.
 - Do NOT use `bot.send_message()` / `bot.edit_message_text()` directly — **why:** bypasses `ChatRateLimiter`; Telegram will 429 and inline buttons will silently vanish in forum topics. Always call `rate_limiter.acquire(chat_id).await` first.
 - Do NOT construct `rara_kernel::trace::ExecutionTrace` locally or call `TraceService::save` from an adapter — **why:** trace assembly is kernel-owned (see `rara-kernel` AGENT.md "Execution Trace Ownership"). Adapters listen for `StreamEvent::TraceReady { trace_id }` and fetch the persisted row via `TraceService::get` when rendering compact summaries / cascade buttons.
+- Do NOT spawn a per-inbound-message `StreamHub::subscribe_session` forwarder in the web adapter — **why:** `subscribe_session` snapshots currently-open streams, so any stream opened later (e.g. after the kernel interrupts turn A and re-injects as turn B) goes unobserved. Long-lived WS/SSE connections subscribe once to the session-level bus via `StreamHub::subscribe_session_events` at connect time (see #1647).
 
 ## Dependencies
 

--- a/crates/channels/src/web.rs
+++ b/crates/channels/src/web.rs
@@ -18,9 +18,20 @@
 //!
 //! Unlike the Telegram adapter (which starts its own polling loop), the
 //! `WebAdapter` exposes an [`axum::Router`] that the host application mounts.
-//! The adapter tracks active sessions via [`DashMap`] with
-//! [`tokio::sync::broadcast`] channels for fan-out to multiple WebSocket and
-//! SSE connections.
+//!
+//! Each WebSocket / SSE connection has two event sources merged into a single
+//! per-connection `mpsc` channel that feeds the socket:
+//!
+//! 1. The kernel's **session-level** event bus
+//!    ([`StreamHub::subscribe_session_events`]) — a permanent subscription
+//!    taken at connect time that survives individual stream turnover. This is
+//!    the fix for #1647: when the kernel interrupts turn A (buffer+interrupt)
+//!    and re-injects as turn B, turn B opens a brand-new per-stream channel;
+//!    the session-level bus lets us keep streaming without re-subscribing on
+//!    every inbound message.
+//! 2. An adapter-local `DashMap<SessionKey, broadcast::Sender<WebEvent>>` for
+//!    events that never flow through the kernel: `Typing`, `Error`, `Phase`,
+//!    and outbound replies delivered via [`ChannelAdapter::send`].
 //!
 //! Inbound messages are handed to the kernel via [`KernelHandle`] in a
 //! fire-and-forget fashion. Outbound delivery is handled separately via
@@ -62,19 +73,23 @@ use rara_kernel::{
     identity::UserId,
     io::{
         EgressError, Endpoint, EndpointAddress, EndpointRegistry, InteractionType,
-        PlatformOutbound, RawPlatformMessage, ReplyContext, StreamEvent,
+        PlatformOutbound, RawPlatformMessage, ReplyContext, StreamEvent, StreamHub,
     },
+    session::SessionKey,
 };
 use serde::{Deserialize, Serialize};
-use tokio::sync::{RwLock, broadcast, watch};
+use tokio::sync::{RwLock, broadcast, mpsc, watch};
 use tracing::{debug, error, info, warn};
 
 // ---------------------------------------------------------------------------
 // Constants
 // ---------------------------------------------------------------------------
 
-/// Default broadcast channel capacity per session.
-const BROADCAST_CAPACITY: usize = 256;
+/// Per-session broadcast capacity for adapter-local events (Typing, Error,
+/// Phase, outbound replies) that do NOT flow through the kernel's
+/// [`StreamHub`]. Kernel stream events reach WS/SSE via
+/// [`StreamHub::subscribe_session_events`], which uses its own capacity.
+const ADAPTER_EVENT_CAPACITY: usize = 256;
 
 // ---------------------------------------------------------------------------
 // SSE event types (serialized as JSON in SSE data field)
@@ -353,6 +368,9 @@ fn stream_event_to_web_event(event: StreamEvent) -> Option<WebEvent> {
         StreamEvent::LoopBreakerTriggered { .. } => None, // informational only
         StreamEvent::ToolOutput { .. } => None,    // live preview, not persisted
         StreamEvent::TraceReady { trace_id } => Some(WebEvent::TraceReady { trace_id }),
+        // Terminal marker from StreamHub::close — surface as per-turn Done.
+        // The session-level bus itself stays open across turns.
+        StreamEvent::StreamClosed { .. } => Some(WebEvent::Done),
     }
 }
 
@@ -402,12 +420,15 @@ pub struct SendMessageResponse {
 /// // app.nest("/chat", router)
 /// ```
 pub struct WebAdapter {
-    /// Active sessions: session_key -> broadcast sender for outbound events.
-    sessions:          Arc<DashMap<String, broadcast::Sender<String>>>,
+    /// Per-session broadcast sender for adapter-local events (Typing, Error,
+    /// Phase, outbound replies from `ChannelAdapter::send`). Kernel stream
+    /// events bypass this map — they flow directly from
+    /// [`StreamHub::subscribe_session_events`] into each WS/SSE task.
+    adapter_events:    Arc<DashMap<SessionKey, broadcast::Sender<WebEvent>>>,
     /// KernelHandle for dispatching inbound messages (set during `start`).
     sink:              Arc<RwLock<Option<KernelHandle>>>,
     /// StreamHub for subscribing to real-time token deltas.
-    stream_hub:        Arc<RwLock<Option<Arc<rara_kernel::io::StreamHub>>>>,
+    stream_hub:        Arc<RwLock<Option<Arc<StreamHub>>>>,
     /// EndpointRegistry for tracking connected users (set during startup).
     endpoint_registry: Arc<RwLock<Option<Arc<EndpointRegistry>>>>,
     /// Owner token for verifying WebSocket auth tokens.
@@ -425,7 +446,7 @@ impl WebAdapter {
     pub fn new(owner_token: Option<String>) -> Self {
         let (shutdown_tx, shutdown_rx) = watch::channel(false);
         Self {
-            sessions: Arc::new(DashMap::new()),
+            adapter_events: Arc::new(DashMap::new()),
             sink: Arc::new(RwLock::new(None)),
             stream_hub: Arc::new(RwLock::new(None)),
             endpoint_registry: Arc::new(RwLock::new(None)),
@@ -451,7 +472,7 @@ impl WebAdapter {
     /// ```
     pub fn router(&self) -> Router {
         let state = WebAdapterState {
-            sessions:          Arc::clone(&self.sessions),
+            adapter_events:    Arc::clone(&self.adapter_events),
             sink:              Arc::clone(&self.sink),
             stream_hub:        Arc::clone(&self.stream_hub),
             endpoint_registry: Arc::clone(&self.endpoint_registry),
@@ -505,62 +526,46 @@ impl WebAdapter {
         Ok(())
     }
 
-    /// Get or create a broadcast channel for the given session key.
-    fn get_or_create_session(
-        sessions: &DashMap<String, broadcast::Sender<String>>,
-        session_key: &str,
-    ) -> broadcast::Sender<String> {
-        sessions
-            .entry(session_key.to_owned())
-            .or_insert_with(|| {
-                let (tx, _rx) = broadcast::channel(BROADCAST_CAPACITY);
-                tx
-            })
+    /// Get or create the per-session adapter-event broadcast sender.
+    ///
+    /// Kept deliberately minimal — the heavy fan-out path (kernel stream
+    /// events) runs directly off [`StreamHub::subscribe_session_events`], so
+    /// this bus only carries adapter-local events (Typing, Error, Phase,
+    /// outbound replies).
+    fn get_or_create_adapter_bus(
+        buses: &DashMap<SessionKey, broadcast::Sender<WebEvent>>,
+        session_key: SessionKey,
+    ) -> broadcast::Sender<WebEvent> {
+        buses
+            .entry(session_key)
+            .or_insert_with(|| broadcast::channel(ADAPTER_EVENT_CAPACITY).0)
             .clone()
     }
 
-    /// Broadcast a serialized event to all subscribers of a session.
-    fn broadcast_event(
-        sessions: &DashMap<String, broadcast::Sender<String>>,
-        session_key: &str,
-        event: &WebEvent,
+    /// Publish an adapter-local event to all WS/SSE tasks subscribed to
+    /// `session_key`. Silently drops if no bus exists (no consumers yet).
+    fn publish_adapter_event(
+        buses: &DashMap<SessionKey, broadcast::Sender<WebEvent>>,
+        session_key: &SessionKey,
+        event: WebEvent,
     ) {
-        if let Some(tx) = sessions.get(session_key) {
-            let json = match serde_json::to_string(event) {
-                Ok(j) => j,
-                Err(e) => {
-                    error!(session_key, error = %e, "failed to serialize web event");
-                    return;
-                }
-            };
-            let receiver_count = tx.receiver_count();
-            let event_kind: &'static str = event.into();
-            tracing::debug!(
-                session_key,
-                receiver_count,
+        let Some(tx) = buses.get(session_key) else {
+            return;
+        };
+        let event_kind: &'static str = (&event).into();
+        let receiver_count = tx.receiver_count();
+        tracing::debug!(
+            session_key = %session_key,
+            receiver_count,
+            event_kind,
+            "web publish_adapter_event"
+        );
+        if tx.send(event).is_err() {
+            tracing::warn!(
+                session_key = %session_key,
                 event_kind,
-                "web broadcast_event"
+                "web publish: no active receivers"
             );
-            match tx.send(json) {
-                Ok(delivered) => {
-                    if delivered != receiver_count {
-                        tracing::warn!(
-                            session_key,
-                            event_kind,
-                            delivered,
-                            receiver_count,
-                            "web broadcast: delivered count != receiver_count"
-                        );
-                    }
-                }
-                Err(_) => {
-                    tracing::warn!(
-                        session_key,
-                        event_kind,
-                        "web broadcast: no active receivers (tx.send returned Err)"
-                    );
-                }
-            }
         }
     }
 }
@@ -572,9 +577,9 @@ impl WebAdapter {
 /// Shared state passed to axum route handlers.
 #[derive(Clone)]
 struct WebAdapterState {
-    sessions:          Arc<DashMap<String, broadcast::Sender<String>>>,
+    adapter_events:    Arc<DashMap<SessionKey, broadcast::Sender<WebEvent>>>,
     sink:              Arc<RwLock<Option<KernelHandle>>>,
-    stream_hub:        Arc<RwLock<Option<Arc<rara_kernel::io::StreamHub>>>>,
+    stream_hub:        Arc<RwLock<Option<Arc<StreamHub>>>>,
     endpoint_registry: Arc<RwLock<Option<Arc<EndpointRegistry>>>>,
     owner_token:       Option<String>,
     shutdown_rx:       watch::Receiver<bool>,
@@ -775,41 +780,118 @@ async fn ws_handler(
 async fn handle_ws(socket: WebSocket, params: SessionQuery, state: WebAdapterState) {
     let (mut ws_tx, mut ws_rx) = socket.split();
 
-    // Subscribe to broadcast for this session.
-    let tx = WebAdapter::get_or_create_session(&state.sessions, &params.session_key);
-    let mut rx = tx.subscribe();
-
-    let session_key = params.session_key.clone();
-    let mut shutdown_rx = state.shutdown_rx.clone();
+    let session_key_str = params.session_key.clone();
+    let session_key = match SessionKey::try_from_raw(&session_key_str) {
+        Ok(k) => k,
+        Err(e) => {
+            warn!(session_key = %session_key_str, error = %e, "invalid session key on WS");
+            return;
+        }
+    };
 
     // Register this connection in the EndpointRegistry.
-    register_endpoint(&state.endpoint_registry, &params.user_id, &session_key).await;
+    register_endpoint(&state.endpoint_registry, &params.user_id, &session_key_str).await;
 
-    // Task: forward broadcast events to the WebSocket client.
+    // Per-WS event sink: both the kernel session bus forwarder and adapter
+    // event forwarder push into this single channel; the send task drains it
+    // and writes to the socket. One consumer → mpsc (no fan-out needed).
+    let (ws_event_tx, mut ws_event_rx) = mpsc::unbounded_channel::<WebEvent>();
+
+    // Subscribe to the adapter-local event bus (Typing / Error / Phase /
+    // outbound replies). Created lazily so we can publish from other tasks
+    // (e.g. POST /messages) even before the first WS subscriber shows up —
+    // get_or_create ensures the sender exists before publishers try to emit.
+    let adapter_bus = WebAdapter::get_or_create_adapter_bus(&state.adapter_events, session_key);
+    let mut adapter_rx = adapter_bus.subscribe();
+
+    // Forwarder: adapter bus → per-WS mpsc.
+    let adapter_forwarder = {
+        let ws_event_tx = ws_event_tx.clone();
+        let skey = session_key_str.clone();
+        tokio::spawn(async move {
+            loop {
+                match adapter_rx.recv().await {
+                    Ok(ev) => {
+                        if ws_event_tx.send(ev).is_err() {
+                            break;
+                        }
+                    }
+                    Err(broadcast::error::RecvError::Lagged(n)) => {
+                        warn!(session_key = %skey, skipped = n, "adapter bus lagged");
+                    }
+                    Err(broadcast::error::RecvError::Closed) => break,
+                }
+            }
+        })
+    };
+
+    // Forwarder: kernel session event bus → per-WS mpsc. The session bus
+    // outlives individual streams so this subscription survives mid-turn
+    // interrupt + reinject, which is exactly the #1647 bug fix.
+    let stream_forwarder = {
+        let ws_event_tx = ws_event_tx.clone();
+        let stream_hub = Arc::clone(&state.stream_hub);
+        let skey = session_key_str.clone();
+        tokio::spawn(async move {
+            let hub = {
+                let guard = stream_hub.read().await;
+                match guard.as_ref() {
+                    Some(h) => Arc::clone(h),
+                    None => return,
+                }
+            };
+            let mut rx = hub.subscribe_session_events(&session_key);
+            loop {
+                match rx.recv().await {
+                    Ok(event) => {
+                        let Some(web_event) = stream_event_to_web_event(event) else {
+                            continue;
+                        };
+                        if ws_event_tx.send(web_event).is_err() {
+                            break;
+                        }
+                    }
+                    Err(broadcast::error::RecvError::Lagged(n)) => {
+                        warn!(session_key = %skey, skipped = n, "session event bus lagged");
+                    }
+                    // The session bus is never closed by the hub (intentional
+                    // — it outlives streams). Reaching Closed means every
+                    // sender was dropped, which can only happen during hub
+                    // teardown.
+                    Err(broadcast::error::RecvError::Closed) => break,
+                }
+            }
+        })
+    };
+
+    // Drop the extra sender held here so that when both forwarders exit, the
+    // mpsc receiver sees a clean close and the send task can terminate.
+    drop(ws_event_tx);
+
+    let mut shutdown_rx = state.shutdown_rx.clone();
+
+    // Send task: drain ws_event_rx → socket.
     let send_task = {
-        let session_key = session_key.clone();
+        let session_key_str = session_key_str.clone();
         tokio::spawn(async move {
             loop {
                 tokio::select! {
-                    msg = rx.recv() => {
-                        match msg {
-                            Ok(text) => {
-                                if ws_tx.send(Message::Text(text.into())).await.is_err() {
-                                    debug!(session_key, "WebSocket send failed, closing");
-                                    break;
-                                }
+                    msg = ws_event_rx.recv() => {
+                        let Some(event) = msg else { break; };
+                        let json = match serde_json::to_string(&event) {
+                            Ok(j) => j,
+                            Err(e) => {
+                                error!(session_key = %session_key_str, error = %e, "serialize web event");
+                                continue;
                             }
-                            Err(broadcast::error::RecvError::Lagged(n)) => {
-                                warn!(session_key, skipped = n, "WebSocket receiver lagged");
-                            }
-                            Err(broadcast::error::RecvError::Closed) => {
-                                debug!(session_key, "broadcast channel closed");
-                                break;
-                            }
+                        };
+                        if ws_tx.send(Message::Text(json.into())).await.is_err() {
+                            debug!(session_key = %session_key_str, "WebSocket send failed, closing");
+                            break;
                         }
                     }
                     _ = shutdown_rx.changed() => {
-                        debug!(session_key, "shutdown signal received, closing WebSocket sender");
+                        debug!(session_key = %session_key_str, "shutdown signal received");
                         break;
                     }
                 }
@@ -817,12 +899,11 @@ async fn handle_ws(socket: WebSocket, params: SessionQuery, state: WebAdapterSta
         })
     };
 
-    // Task: read messages from the WebSocket client, dispatch to sink.
+    // Recv task: read client frames, dispatch to kernel.
     let recv_task = {
         let sink = Arc::clone(&state.sink);
-        let stream_hub = Arc::clone(&state.stream_hub);
-        let sessions = Arc::clone(&state.sessions);
-        let session_key = session_key.clone();
+        let adapter_events = Arc::clone(&state.adapter_events);
+        let session_key_str = session_key_str.clone();
         let user_id = params.user_id.clone();
         let stt_service = state.stt_service.clone();
         tokio::spawn(async move {
@@ -830,7 +911,7 @@ async fn handle_ws(socket: WebSocket, params: SessionQuery, state: WebAdapterSta
                 let text = match msg {
                     Message::Text(t) => t.to_string(),
                     Message::Close(_) => {
-                        debug!(session_key, "WebSocket client closed connection");
+                        debug!(session_key = %session_key_str, "client closed WS");
                         break;
                     }
                     _ => continue,
@@ -841,164 +922,72 @@ async fn handle_ws(socket: WebSocket, params: SessionQuery, state: WebAdapterSta
                 }
 
                 let payload = parse_inbound_text_frame(&text);
-                // Transcribe any audio blocks before submitting to the kernel.
                 let content = transcribe_audio_blocks(payload.content, &stt_service).await;
-                let raw = build_raw_platform_message(&session_key, &user_id, content);
+                let raw = build_raw_platform_message(&session_key_str, &user_id, content);
 
                 let guard = sink.read().await;
-                if let Some(ref s) = *guard {
-                    // Send typing indicator before processing.
-                    WebAdapter::broadcast_event(&sessions, &session_key, &WebEvent::Typing);
-                    // Resolve identity + session first (like TG adapter),
-                    // then submit separately. This gives us the kernel-
-                    // resolved session key needed by the stream forwarder.
-                    //
-                    // When no channel binding exists yet (first message),
-                    // resolve() returns session_key = None. Patch it with
-                    // the URL-provided key (a valid UUID from the sessions
-                    // API) so the kernel reuses the existing session
-                    // instead of creating a duplicate.
-                    match s.resolve(raw).await {
-                        Ok(mut msg) => {
-                            if msg.session_key_opt().is_none() {
-                                if let Ok(sk) =
-                                    rara_kernel::session::SessionKey::try_from_raw(&session_key)
-                                {
-                                    msg.set_session_key(sk);
-                                }
-                            }
-                            let resolved_key = msg
-                                .session_key_opt()
-                                .map(|k| k.to_string())
-                                .unwrap_or_else(|| session_key.clone());
-                            if let Err(e) = s.submit_message(msg) {
-                                error!(session_key, error = %e, "submit_message failed");
-                                WebAdapter::broadcast_event(
-                                    &sessions,
-                                    &session_key,
-                                    &WebEvent::Error {
-                                        message: e.to_string(),
-                                    },
-                                );
-                            } else {
-                                // Spawn a stream forwarder to bridge StreamHub → WebSocket.
-                                spawn_stream_forwarder(
-                                    Arc::clone(&stream_hub),
-                                    Arc::clone(&sessions),
-                                    resolved_key,
-                                );
-                            }
+                let Some(ref s) = *guard else {
+                    warn!(session_key = %session_key_str, "sink not set");
+                    WebAdapter::publish_adapter_event(
+                        &adapter_events,
+                        &session_key,
+                        WebEvent::Error {
+                            message: "adapter not started".to_owned(),
+                        },
+                    );
+                    continue;
+                };
+
+                WebAdapter::publish_adapter_event(&adapter_events, &session_key, WebEvent::Typing);
+
+                // When no channel binding exists yet (first message),
+                // resolve() returns session_key = None. Patch it with the
+                // URL-provided key so the kernel reuses the existing session.
+                match s.resolve(raw).await {
+                    Ok(mut msg) => {
+                        if msg.session_key_opt().is_none() {
+                            msg.set_session_key(session_key);
                         }
-                        Err(e) => {
-                            error!(session_key, error = %e, "resolve failed");
-                            WebAdapter::broadcast_event(
-                                &sessions,
+                        if let Err(e) = s.submit_message(msg) {
+                            error!(session_key = %session_key_str, error = %e, "submit_message failed");
+                            WebAdapter::publish_adapter_event(
+                                &adapter_events,
                                 &session_key,
-                                &WebEvent::Error {
+                                WebEvent::Error {
                                     message: e.to_string(),
                                 },
                             );
                         }
+                        // No per-message forwarder spawn needed — the
+                        // per-WS stream_forwarder above is already
+                        // subscribed to the session-level bus and will see
+                        // events from every stream opened on this session.
                     }
-                } else {
-                    warn!(session_key, "sink not set, cannot dispatch message");
-                    WebAdapter::broadcast_event(
-                        &sessions,
-                        &session_key,
-                        &WebEvent::Error {
-                            message: "adapter not started".to_owned(),
-                        },
-                    );
+                    Err(e) => {
+                        error!(session_key = %session_key_str, error = %e, "resolve failed");
+                        WebAdapter::publish_adapter_event(
+                            &adapter_events,
+                            &session_key,
+                            WebEvent::Error {
+                                message: e.to_string(),
+                            },
+                        );
+                    }
                 }
             }
         })
     };
 
-    // Wait for either task to finish, then abort the other.
+    // Wait for recv or send to finish, then tear down the others.
     tokio::select! {
         _ = send_task => {}
         _ = recv_task => {}
     }
+    adapter_forwarder.abort();
+    stream_forwarder.abort();
 
-    // Unregister this connection from the EndpointRegistry.
-    unregister_endpoint(&state.endpoint_registry, &params.user_id, &session_key).await;
-
-    info!(session_key, "WebSocket connection closed");
-}
-
-// ---------------------------------------------------------------------------
-// StreamHub → WebSocket forwarder
-// ---------------------------------------------------------------------------
-
-/// Spawn a background task that subscribes to StreamHub for the given session
-/// and forwards `StreamEvent`s as `WebEvent`s through the session broadcast.
-///
-/// The session runtime opens streams asynchronously, so we poll
-/// `subscribe_session()` with a short delay until streams appear.
-fn spawn_stream_forwarder(
-    stream_hub: Arc<RwLock<Option<Arc<rara_kernel::io::StreamHub>>>>,
-    sessions: Arc<DashMap<String, broadcast::Sender<String>>>,
-    session_key: String,
-) {
-    tokio::spawn(async move {
-        let hub = {
-            let guard = stream_hub.read().await;
-            match guard.as_ref() {
-                Some(hub) => Arc::clone(hub),
-                None => return, // No StreamHub configured
-            }
-        };
-
-        let session_id = match rara_kernel::session::SessionKey::try_from_raw(&session_key) {
-            Ok(id) => id,
-            Err(_) => {
-                tracing::warn!(session_key = %session_key, "invalid session key for stream forwarder");
-                return;
-            }
-        };
-
-        // Poll until stream appears (session runtime opens it asynchronously).
-        let mut attempts = 0;
-        let subs = loop {
-            let s = hub.subscribe_session(&session_id);
-            if !s.is_empty() || attempts > 50 {
-                break s;
-            }
-            attempts += 1;
-            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
-        };
-
-        if subs.is_empty() {
-            debug!(session_key, "no streams found after polling");
-            return;
-        }
-
-        let ws_receiver_count = sessions
-            .get(&session_key)
-            .map(|tx| tx.receiver_count())
-            .unwrap_or(0);
-        tracing::info!(
-            session_key,
-            stream_subs = subs.len(),
-            ws_receiver_count,
-            "stream_forwarder: subscribed"
-        );
-
-        for (_stream_id, mut rx) in subs {
-            let sessions = Arc::clone(&sessions);
-            let session_key = session_key.clone();
-            tokio::spawn(async move {
-                while let Ok(event) = rx.recv().await {
-                    let Some(web_event) = stream_event_to_web_event(event) else {
-                        continue;
-                    };
-                    WebAdapter::broadcast_event(&sessions, &session_key, &web_event);
-                }
-                // Stream closed — send Done event.
-                WebAdapter::broadcast_event(&sessions, &session_key, &WebEvent::Done);
-            });
-        }
-    });
+    unregister_endpoint(&state.endpoint_registry, &params.user_id, &session_key_str).await;
+    info!(session_key = %session_key_str, "WebSocket connection closed");
 }
 
 // ---------------------------------------------------------------------------
@@ -1008,10 +997,17 @@ fn spawn_stream_forwarder(
 async fn sse_handler(
     Query(params): Query<SessionQuery>,
     State(state): State<WebAdapterState>,
-) -> Sse<impl Stream<Item = Result<Event, std::convert::Infallible>>> {
+) -> Response {
     info!(session_key = %params.session_key, "SSE connection opened");
 
-    // Register this connection in the EndpointRegistry.
+    let session_key = match SessionKey::try_from_raw(&params.session_key) {
+        Ok(k) => k,
+        Err(e) => {
+            warn!(session_key = %params.session_key, error = %e, "invalid session key on SSE");
+            return (axum::http::StatusCode::BAD_REQUEST, "invalid session key").into_response();
+        }
+    };
+
     register_endpoint(
         &state.endpoint_registry,
         &params.user_id,
@@ -1019,39 +1015,86 @@ async fn sse_handler(
     )
     .await;
 
-    let tx = WebAdapter::get_or_create_session(&state.sessions, &params.session_key);
-    let rx = tx.subscribe();
+    // Same two-source merge as WS: adapter bus + kernel session bus → mpsc.
+    let (ev_tx, ev_rx) = mpsc::unbounded_channel::<WebEvent>();
+
+    let adapter_bus = WebAdapter::get_or_create_adapter_bus(&state.adapter_events, session_key);
+    let mut adapter_rx = adapter_bus.subscribe();
+    {
+        let ev_tx = ev_tx.clone();
+        let skey = params.session_key.clone();
+        tokio::spawn(async move {
+            loop {
+                match adapter_rx.recv().await {
+                    Ok(ev) => {
+                        if ev_tx.send(ev).is_err() {
+                            break;
+                        }
+                    }
+                    Err(broadcast::error::RecvError::Lagged(n)) => {
+                        warn!(session_key = %skey, skipped = n, "SSE adapter bus lagged");
+                    }
+                    Err(broadcast::error::RecvError::Closed) => break,
+                }
+            }
+        });
+    }
+
+    {
+        let ev_tx = ev_tx.clone();
+        let stream_hub = Arc::clone(&state.stream_hub);
+        let skey = params.session_key.clone();
+        tokio::spawn(async move {
+            let hub = {
+                let guard = stream_hub.read().await;
+                match guard.as_ref() {
+                    Some(h) => Arc::clone(h),
+                    None => return,
+                }
+            };
+            let mut rx = hub.subscribe_session_events(&session_key);
+            loop {
+                match rx.recv().await {
+                    Ok(event) => {
+                        let Some(we) = stream_event_to_web_event(event) else {
+                            continue;
+                        };
+                        if ev_tx.send(we).is_err() {
+                            break;
+                        }
+                    }
+                    Err(broadcast::error::RecvError::Lagged(n)) => {
+                        warn!(session_key = %skey, skipped = n, "SSE stream bus lagged");
+                    }
+                    Err(broadcast::error::RecvError::Closed) => break,
+                }
+            }
+        });
+    }
+
+    drop(ev_tx);
+
     let shutdown_rx = state.shutdown_rx.clone();
     let registry_for_cleanup = Arc::clone(&state.endpoint_registry);
     let user_for_cleanup = params.user_id.clone();
     let key_for_cleanup = params.session_key.clone();
 
     let stream = futures::stream::unfold(
-        (rx, shutdown_rx, params.session_key.clone()),
+        (ev_rx, shutdown_rx, params.session_key.clone()),
         |(mut rx, mut shutdown_rx, session_key)| async move {
             tokio::select! {
                 msg = rx.recv() => {
-                    match msg {
-                        Ok(data) => {
-                            let event: Result<Event, std::convert::Infallible> =
-                                Ok(Event::default().data(data));
-                            Some((event, (rx, shutdown_rx, session_key)))
+                    let event = msg?;
+                    let json = match serde_json::to_string(&event) {
+                        Ok(j) => j,
+                        Err(e) => {
+                            error!(session_key, error = %e, "serialize SSE event");
+                            return None;
                         }
-                        Err(broadcast::error::RecvError::Lagged(n)) => {
-                            warn!(session_key, skipped = n, "SSE receiver lagged");
-                            let err_event = serde_json::json!({
-                                "type": "error",
-                                "message": format!("missed {n} events")
-                            });
-                            let event: Result<Event, std::convert::Infallible> =
-                                Ok(Event::default().data(err_event.to_string()));
-                            Some((event, (rx, shutdown_rx, session_key)))
-                        }
-                        Err(broadcast::error::RecvError::Closed) => {
-                            debug!(session_key, "broadcast channel closed, ending SSE stream");
-                            None
-                        }
-                    }
+                    };
+                    let out: Result<Event, std::convert::Infallible> =
+                        Ok(Event::default().data(json));
+                    Some((out, (rx, shutdown_rx, session_key)))
                 }
                 _ = shutdown_rx.changed() => {
                     debug!(session_key, "shutdown signal, ending SSE stream");
@@ -1075,7 +1118,9 @@ async fn sse_handler(
         _cleanup: cleanup_tx,
     };
 
-    Sse::new(stream).keep_alive(KeepAlive::default())
+    Sse::new(stream)
+        .keep_alive(KeepAlive::default())
+        .into_response()
 }
 
 /// Wrapper that holds a oneshot sender — when this stream is dropped, the
@@ -1111,33 +1156,45 @@ async fn send_message_handler(
     );
 
     let SendMessageRequest {
-        session_key,
+        session_key: session_key_str,
         user_id,
         content,
     } = body;
 
-    // Ensure session broadcast exists.
-    WebAdapter::get_or_create_session(&state.sessions, &session_key);
+    let session_key = match SessionKey::try_from_raw(&session_key_str) {
+        Ok(k) => k,
+        Err(_) => {
+            return (
+                axum::http::StatusCode::BAD_REQUEST,
+                "invalid session_key".to_owned(),
+            )
+                .into_response();
+        }
+    };
 
-    let raw = build_raw_platform_message(&session_key, &user_id, content);
+    // Ensure the adapter bus exists so the Typing indicator below reaches
+    // currently-connected WS/SSE subscribers (if any).
+    WebAdapter::get_or_create_adapter_bus(&state.adapter_events, session_key);
+
+    let raw = build_raw_platform_message(&session_key_str, &user_id, content);
 
     let guard = state.sink.read().await;
     match &*guard {
         Some(sink) => {
-            // Broadcast typing indicator.
-            WebAdapter::broadcast_event(&state.sessions, &session_key, &WebEvent::Typing);
-
+            WebAdapter::publish_adapter_event(
+                &state.adapter_events,
+                &session_key,
+                WebEvent::Typing,
+            );
             match sink.ingest(raw).await {
                 Ok(()) => {
-                    spawn_stream_forwarder(
-                        Arc::clone(&state.stream_hub),
-                        Arc::clone(&state.sessions),
-                        session_key.clone(),
-                    );
+                    // No forwarder to spawn — each WS/SSE is permanently
+                    // subscribed to the session's event bus via
+                    // StreamHub::subscribe_session_events.
                     axum::Json(SendMessageResponse { accepted: true }).into_response()
                 }
                 Err(e) => {
-                    error!(session_key = %session_key, error = %e, "ingest failed");
+                    error!(session_key = %session_key_str, error = %e, "ingest failed");
                     let status = axum::http::StatusCode::INTERNAL_SERVER_ERROR;
                     (status, e.to_string()).into_response()
                 }
@@ -1192,13 +1249,20 @@ impl ChannelAdapter for WebAdapter {
     fn channel_type(&self) -> ChannelType { ChannelType::Web }
 
     async fn send(&self, endpoint: &Endpoint, msg: PlatformOutbound) -> Result<(), EgressError> {
-        let broadcast_key = match &endpoint.address {
+        let connection_id = match &endpoint.address {
             EndpointAddress::Web { connection_id } => connection_id.as_str(),
             _ => return Ok(()),
         };
+        let Ok(session_key) = SessionKey::try_from_raw(connection_id) else {
+            warn!(
+                connection_id,
+                "web endpoint has non-UUID connection_id; dropping outbound"
+            );
+            return Ok(());
+        };
 
         let event = platform_outbound_to_web_event(msg);
-        WebAdapter::broadcast_event(&self.sessions, broadcast_key, &event);
+        WebAdapter::publish_adapter_event(&self.adapter_events, &session_key, event);
         Ok(())
     }
 
@@ -1212,24 +1276,30 @@ impl ChannelAdapter for WebAdapter {
     }
 
     async fn stop(&self) -> Result<(), KernelError> {
-        info!("WebAdapter stopping — clearing sessions");
+        info!("WebAdapter stopping — clearing adapter_events");
         let _ = self.shutdown_tx.send(true);
         let mut guard = self.sink.write().await;
         *guard = None;
-        self.sessions.clear();
+        self.adapter_events.clear();
         Ok(())
     }
 
     async fn typing_indicator(&self, session_key: &str) -> Result<(), KernelError> {
-        WebAdapter::broadcast_event(&self.sessions, session_key, &WebEvent::Typing);
+        let Ok(key) = SessionKey::try_from_raw(session_key) else {
+            return Ok(());
+        };
+        WebAdapter::publish_adapter_event(&self.adapter_events, &key, WebEvent::Typing);
         Ok(())
     }
 
     async fn set_phase(&self, session_key: &str, phase: AgentPhase) -> Result<(), KernelError> {
-        WebAdapter::broadcast_event(
-            &self.sessions,
-            session_key,
-            &WebEvent::Phase {
+        let Ok(key) = SessionKey::try_from_raw(session_key) else {
+            return Ok(());
+        };
+        WebAdapter::publish_adapter_event(
+            &self.adapter_events,
+            &key,
+            WebEvent::Phase {
                 phase: phase.to_string(),
             },
         );

--- a/crates/cmd/src/chat/mod.rs
+++ b/crates/cmd/src/chat/mod.rs
@@ -1023,6 +1023,9 @@ fn stream_event_to_cli_event(event: StreamEvent) -> CliEvent {
         StreamEvent::TraceReady { trace_id } => CliEvent::Progress {
             text: format!("Trace saved: {trace_id}"),
         },
+        // The CLI forwarder observes stream closure via RecvError::Closed
+        // and emits its own Done — the explicit marker is redundant here.
+        StreamEvent::StreamClosed { .. } => CliEvent::Done,
     }
 }
 

--- a/crates/cmd/src/chat/mod.rs
+++ b/crates/cmd/src/chat/mod.rs
@@ -178,16 +178,24 @@ fn spawn_stream_forwarder(
                     for (stream_id, mut rx) in subscriptions {
                         if active_streams.contains(&stream_id) {
                             while let Ok(event) = rx.try_recv() {
-                                let _ = adapter.send_cli_event(stream_event_to_cli_event(event));
+                                if let Some(cli_event) = stream_event_to_cli_event(event) {
+                                    let _ = adapter.send_cli_event(cli_event);
+                                }
                             }
                             continue;
                         }
 
                         active_streams.insert(stream_id.clone());
                         let adapter = adapter.clone();
+                        // Single source of `CliEvent::Done` per turn: only the
+                        // `RecvError::Closed` path below emits it. The
+                        // `StreamClosed` mapper returns `None` so we don't
+                        // double-fire Done (PR #1647 N6).
                         let handle = tokio::spawn(async move {
                             while let Ok(event) = rx.recv().await {
-                                let _ = adapter.send_cli_event(stream_event_to_cli_event(event));
+                                if let Some(cli_event) = stream_event_to_cli_event(event) {
+                                    let _ = adapter.send_cli_event(cli_event);
+                                }
                             }
                             let _ = adapter.send_cli_event(CliEvent::Done);
                         });
@@ -904,8 +912,16 @@ async fn get_or_create_cli_session(
     Ok(created.key)
 }
 
-fn stream_event_to_cli_event(event: StreamEvent) -> CliEvent {
-    match event {
+/// Map a kernel [`StreamEvent`] to a [`CliEvent`] for the terminal UI.
+///
+/// Returns `None` when the event has no terminal-UI representation. In
+/// particular, `StreamEvent::StreamClosed` is intentionally mapped to
+/// `None` — the forwarder task in [`spawn_stream_forwarder`] already emits
+/// a single `CliEvent::Done` when the per-stream `broadcast::Receiver`
+/// observes `RecvError::Closed`. Emitting `Done` from both sources would
+/// produce two `Done` events per turn (see PR #1647 N6).
+fn stream_event_to_cli_event(event: StreamEvent) -> Option<CliEvent> {
+    Some(match event {
         StreamEvent::TextDelta { text } => CliEvent::TextDelta { text },
         StreamEvent::ReasoningDelta { text } => CliEvent::ReasoningDelta { text },
         StreamEvent::ToolCallStart {
@@ -1024,9 +1040,10 @@ fn stream_event_to_cli_event(event: StreamEvent) -> CliEvent {
             text: format!("Trace saved: {trace_id}"),
         },
         // The CLI forwarder observes stream closure via RecvError::Closed
-        // and emits its own Done — the explicit marker is redundant here.
-        StreamEvent::StreamClosed { .. } => CliEvent::Done,
-    }
+        // and emits its own Done — returning None here prevents a duplicate
+        // Done from the explicit terminal marker (see fn doc comment).
+        StreamEvent::StreamClosed { .. } => return None,
+    })
 }
 
 async fn send_cli_message(
@@ -1208,7 +1225,7 @@ mod tests {
 
         assert!(matches!(
             stream_event_to_cli_event(event),
-            CliEvent::ReasoningDelta { text } if text == "internal"
+            Some(CliEvent::ReasoningDelta { text }) if text == "internal"
         ));
     }
 
@@ -1220,8 +1237,19 @@ mod tests {
 
         assert!(matches!(
             stream_event_to_cli_event(event),
-            CliEvent::TextDelta { text } if text == "hello"
+            Some(CliEvent::TextDelta { text }) if text == "hello"
         ));
+    }
+
+    /// `StreamClosed` must map to `None` so the CLI forwarder's
+    /// `RecvError::Closed` handler is the single source of `CliEvent::Done`.
+    /// See PR #1647 N6 — prior behaviour double-fired `Done` per turn.
+    #[test]
+    fn stream_closed_does_not_emit_done() {
+        let event = StreamEvent::StreamClosed {
+            stream_id: "abc".to_owned(),
+        };
+        assert!(stream_event_to_cli_event(event).is_none());
     }
 
     #[test]

--- a/crates/kernel/AGENT.md
+++ b/crates/kernel/AGENT.md
@@ -388,7 +388,7 @@ Flow:
 
 ### The Invariant
 
-The session-level `session_events` bus entry is **reaped when both conditions hold**: (1) no active per-stream entries remain for the session in `session_streams`, AND (2) no `broadcast::Receiver` holds the session sender open (`receiver_count() == 0`). Before #1647 the entry was intentionally never removed; the "persist for the lifetime of the hub" comment is obsolete.
+The session-level `session_events` bus entry is **reaped as a point-in-time decision, made atomically under the `session_events` shard write lock** via `DashMap::remove_if`, when both conditions hold inside the closure: (1) no active per-stream entries remain for the session in `session_streams`, AND (2) no `broadcast::Receiver` holds the session sender open (`receiver_count() == 0`). Checking `session_streams` emptiness *inside* the `remove_if` closure — not before calling it — is load-bearing: it guarantees a concurrent `open()` that has already inserted into `session_streams` cannot have its about-to-be-bridged bus reaped out from under it. Before #1647 the entry was intentionally never removed; the "persist for the lifetime of the hub" comment is obsolete.
 
 ### Why This Matters
 
@@ -402,4 +402,5 @@ Each kernel turn calls `StreamHub::open(session)` which gets-or-creates a `broad
 ### What NOT To Do
 
 - Do NOT emit `StreamEvent::StreamClosed` from `close_session()` — that path is only called from `open()` to reap zombies from pre-empted turns. Emitting a terminal marker there would cause session-level subscribers (web `WebEvent::Done`) to finalize the previous turn's UI mid-flight when the user sends a follow-up message before the first turn completes. Normal turn completion goes through `close()` which DOES emit the marker.
-- Do NOT hold a DashMap `get()` guard across a `remove()` on the same map — DashMap shards are `RwLock`-based and a read guard across a write on the same shard deadlocks. `reap_session_bus_if_idle` scopes the `get()` guard in a block so it drops before `remove()`.
+- Do NOT hold a DashMap `get()` guard across a `remove()` on the same map — DashMap shards are `RwLock`-based and a read guard across a write on the same shard deadlocks. `reap_session_bus_if_idle` uses `remove_if` so the receiver-count check and the removal happen atomically under the shard write lock with no nested same-shard lock.
+- Do NOT replace the `remove_if` closure with a pre-check + `remove()` pair — the non-atomic variant has a TOCTOU window where a concurrent `subscribe_session_events` can attach a fresh receiver to a sender the reaper then deletes, silently losing every subsequent event for that session.

--- a/crates/kernel/AGENT.md
+++ b/crates/kernel/AGENT.md
@@ -381,3 +381,25 @@ Flow:
 - Do NOT construct `ExecutionTrace` literals in channel adapters — trace content must be built from the kernel's event stream, not from channel-local bookkeeping. Channels receive `StreamEvent::TraceReady` and look up the persisted row via `TraceService::get`.
 - Do NOT call `TraceService::save` outside `kernel.rs`'s turn driver — double-saves create duplicate rows and desynchronize the `TraceReady` signal.
 - Do NOT attach the `TraceBuilder` to the `StreamHandle` mid-turn — early events (`TurnStarted`, first `UsageUpdate`) would be dropped, producing an incomplete trace.
+
+---
+
+## Critical: StreamHub Session Bus Lifecycle in `io.rs`
+
+### The Invariant
+
+The session-level `session_events` bus entry is **reaped when both conditions hold**: (1) no active per-stream entries remain for the session in `session_streams`, AND (2) no `broadcast::Receiver` holds the session sender open (`receiver_count() == 0`). Before #1647 the entry was intentionally never removed; the "persist for the lifetime of the hub" comment is obsolete.
+
+### Why This Matters
+
+Each kernel turn calls `StreamHub::open(session)` which gets-or-creates a `broadcast::Sender<StreamEvent>` of capacity 4096 and spawns a bridge task forwarding per-stream events into it. Without reaping, long-running kernels leaked one 4096-slot sender per session that ever existed. The two-sided condition (no streams AND no subscribers) preserves the #1647 invariant that a WS/SSE subscriber attached between turns keeps the bus alive across stream turnover.
+
+### Consequences
+
+- A subscriber attached between streams keeps the bus alive; the next `open()` rejoins the same bus — mid-turn interrupt + reinject still works.
+- If no subscriber is attached and every stream closes, the bus is reaped. A later `subscribe_session_events` on the same key transparently recreates it — correct behaviour, because a subscriber arriving after reap receives only events from the next stream (no stale replay).
+
+### What NOT To Do
+
+- Do NOT emit `StreamEvent::StreamClosed` from `close_session()` — that path is only called from `open()` to reap zombies from pre-empted turns. Emitting a terminal marker there would cause session-level subscribers (web `WebEvent::Done`) to finalize the previous turn's UI mid-flight when the user sends a follow-up message before the first turn completes. Normal turn completion goes through `close()` which DOES emit the marker.
+- Do NOT hold a DashMap `get()` guard across a `remove()` on the same map — DashMap shards are `RwLock`-based and a read guard across a write on the same shard deadlocks. `reap_session_bus_if_idle` scopes the `get()` guard in a block so it drops before `remove()`.

--- a/crates/kernel/src/io.rs
+++ b/crates/kernel/src/io.rs
@@ -1147,12 +1147,18 @@ pub const STREAM_HUB_BROADCAST_CAPACITY: usize = 4096;
 /// [`StreamHub::subscribe_session_events`] keep receiving events across stream
 /// turnover — critical for long-lived WS/SSE connections that must survive
 /// mid-turn interruption + re-injection (see issue #1647).
+///
+/// The session bus entry is reaped when no active streams remain on the
+/// session AND no active session-bus subscribers are holding it open. A later
+/// [`subscribe_session_events`](Self::subscribe_session_events) on the same
+/// key transparently re-creates the entry.
 pub struct StreamHub {
     streams:         DashMap<StreamId, StreamEntry>,
     /// Reverse index: session_key → active stream IDs for O(1) lookup.
     session_streams: DashMap<SessionKey, Vec<StreamId>>,
-    /// Session-level event bus — outlives individual streams so long-lived
-    /// subscribers (WS/SSE) do not see `Closed` between turns.
+    /// Session-level event bus — reaped when no active streams AND no
+    /// session-bus subscribers remain; a later `subscribe_session_events`
+    /// re-creates it.
     session_events:  DashMap<SessionKey, broadcast::Sender<StreamEvent>>,
     capacity:        usize,
 }
@@ -1172,10 +1178,17 @@ impl StreamHub {
     ///
     /// Called by [`open`](Self::open) to ensure only one active stream per
     /// session. Any previously unclosed streams (e.g., from a hung agent
-    /// run) are cleaned up here.
+    /// run or a pre-empted turn) are cleaned up here.
     ///
-    /// Intentionally does NOT remove the session-level `session_events`
-    /// entry — that bus outlives individual streams (see [`StreamHub`] doc).
+    /// Does NOT emit a [`StreamEvent::StreamClosed`] for zombie streams —
+    /// pre-emption is not the genuine end of a turn, and emitting a terminal
+    /// marker here would cause session-level subscribers (web `Done` frame)
+    /// to finalize the previous turn's UI mid-flight (see issue #1647 N6/B3).
+    /// Normal turn completion routes through [`close`](Self::close) which
+    /// DOES emit the terminal marker.
+    ///
+    /// Reaps the session-level `session_events` entry if no active stream
+    /// and no subscribers remain on that bus.
     #[tracing::instrument(skip(self))]
     pub fn close_session(&self, session_key: &SessionKey) {
         // Remove the session entry first, releasing the DashMap shard lock.
@@ -1188,13 +1201,38 @@ impl StreamHub {
             tracing::debug!(count = ids.len(), "cleaning up zombie streams for session");
         }
         for id in &ids {
-            if let Some((_, entry)) = self.streams.remove(id) {
-                // Emit terminal marker so session-level subscribers observe
-                // the turn boundary before the per-stream sender drops.
-                let _ = entry.tx.send(StreamEvent::StreamClosed {
-                    stream_id: id.to_string(),
-                });
-            }
+            // Drop the per-stream entry without emitting StreamClosed —
+            // the bridge task observes RecvError::Closed and terminates
+            // naturally, which does not forward a spurious terminal frame.
+            let _ = self.streams.remove(id);
+        }
+        self.reap_session_bus_if_idle(session_key);
+    }
+
+    /// Reap the session-level event bus entry when no streams and no
+    /// subscribers remain on it.
+    ///
+    /// The two checks are independent DashMap lookups — the guard from the
+    /// first `get()` is dropped before the `remove()` to avoid the
+    /// well-known DashMap shard-lock deadlock when `get` and `remove`
+    /// target the same key.
+    fn reap_session_bus_if_idle(&self, session_key: &SessionKey) {
+        let session_empty = self
+            .session_streams
+            .get(session_key)
+            .map_or(true, |v| v.is_empty());
+        if !session_empty {
+            return;
+        }
+        // Compute `should_remove` inside a scoped block so the `get()` guard
+        // is dropped before `remove()` — holding a read guard across a
+        // write on the same DashMap key deadlocks.
+        let should_remove = {
+            let entry = self.session_events.get(session_key);
+            entry.map(|e| e.receiver_count() == 0).unwrap_or(false)
+        };
+        if should_remove {
+            self.session_events.remove(session_key);
         }
     }
 
@@ -1262,9 +1300,11 @@ impl StreamHub {
     /// emits a [`StreamEvent::StreamClosed`] so session-level subscribers can
     /// observe the turn boundary without seeing `RecvError::Closed`.
     ///
-    /// The session-level bus entry in `session_events` is intentionally NOT
-    /// removed here — it outlives individual streams so that the next turn's
-    /// stream can reuse the same session-level subscribers.
+    /// The session-level bus entry in `session_events` is reaped here when
+    /// both conditions hold: this was the last active stream on the session,
+    /// AND no subscriber is holding the session bus open. If a subscriber
+    /// remains, the entry persists so the next turn's stream rejoins the
+    /// same bus — preserving mid-turn interrupt + reinject behavior (#1647).
     #[tracing::instrument(skip(self))]
     pub fn close(&self, stream_id: &StreamId) {
         if let Some((_, entry)) = self.streams.remove(stream_id) {
@@ -1273,13 +1313,15 @@ impl StreamHub {
             let _ = entry.tx.send(StreamEvent::StreamClosed {
                 stream_id: stream_id.to_string(),
             });
-            if let Some(mut ids) = self.session_streams.get_mut(&entry.session_key) {
+            let session_key = entry.session_key;
+            if let Some(mut ids) = self.session_streams.get_mut(&session_key) {
                 ids.retain(|id| id != stream_id);
                 if ids.is_empty() {
                     drop(ids);
-                    self.session_streams.remove(&entry.session_key);
+                    self.session_streams.remove(&session_key);
                 }
             }
+            self.reap_session_bus_if_idle(&session_key);
         }
     }
 
@@ -2667,6 +2709,66 @@ mod stream_hub_tests {
             }
         }
         assert_eq!(texts, vec!["B1"]);
+    }
+
+    /// When no subscriber holds the session bus open, a completed stream
+    /// reaps the `session_events` entry along with its per-stream entry.
+    /// Prevents the unbounded growth reported in #1647 B1.
+    #[tokio::test]
+    async fn close_reaps_session_bus_when_no_subscribers() {
+        let hub = StreamHub::new(16);
+        let session = SessionKey::new();
+
+        let handle = hub.open(session);
+        // `open()` creates the session_events entry for bridging.
+        assert!(
+            hub.session_events.contains_key(&session),
+            "open() should create session bus entry"
+        );
+
+        hub.close(handle.stream_id());
+
+        assert!(
+            !hub.session_events.contains_key(&session),
+            "close() should reap session bus when no subscribers remain"
+        );
+        assert!(
+            !hub.session_streams.contains_key(&session),
+            "close() should remove empty session_streams entry"
+        );
+    }
+
+    /// A subscriber attached between streams keeps the session bus alive
+    /// across the gap. After the subscriber is dropped, the next
+    /// open-then-close cycle reaps the bus entry.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn subscriber_keeps_session_bus_alive_across_streams() {
+        let hub = StreamHub::new(16);
+        let session = SessionKey::new();
+
+        // Turn A with an attached subscriber.
+        let rx = hub.subscribe_session_events(&session);
+        let handle_a = hub.open(session);
+        hub.close(handle_a.stream_id());
+
+        // Subscriber still holds the bus — entry must remain.
+        assert!(
+            hub.session_events.contains_key(&session),
+            "session bus must survive close() while a subscriber is attached"
+        );
+
+        // Drop the subscriber; the sender still lives in session_events so
+        // receiver_count drops to 0.
+        drop(rx);
+
+        // A new stream opens + closes with nobody listening on the bus.
+        let handle_b = hub.open(session);
+        hub.close(handle_b.stream_id());
+
+        assert!(
+            !hub.session_events.contains_key(&session),
+            "session bus should reap once all streams and subscribers are gone"
+        );
     }
 }
 

--- a/crates/kernel/src/io.rs
+++ b/crates/kernel/src/io.rs
@@ -1212,28 +1212,28 @@ impl StreamHub {
     /// Reap the session-level event bus entry when no streams and no
     /// subscribers remain on it.
     ///
-    /// The two checks are independent DashMap lookups — the guard from the
-    /// first `get()` is dropped before the `remove()` to avoid the
-    /// well-known DashMap shard-lock deadlock when `get` and `remove`
-    /// target the same key.
+    /// The predicate inside `remove_if` runs while the `session_events`
+    /// shard write lock is held, so the `receiver_count() == 0` check and
+    /// the removal are atomic with respect to concurrent
+    /// `subscribe_session_events` / `open()` on the same key — both of
+    /// which acquire the same shard's write lock via `entry().or_insert_with`
+    /// and therefore serialize with us.
+    ///
+    /// We additionally re-check `session_streams` emptiness inside the
+    /// closure so a concurrent `open()` that has already inserted into
+    /// `session_streams` but not yet reached its own `session_events`
+    /// get-or-create cannot have its about-to-be-bridged bus reaped out
+    /// from under it. `session_streams` lives on a different DashMap, so
+    /// taking its read guard while holding the `session_events` shard
+    /// write lock is safe — no shared shard, no lock-order cycle.
     fn reap_session_bus_if_idle(&self, session_key: &SessionKey) {
-        let session_empty = self
-            .session_streams
-            .get(session_key)
-            .map_or(true, |v| v.is_empty());
-        if !session_empty {
-            return;
-        }
-        // Compute `should_remove` inside a scoped block so the `get()` guard
-        // is dropped before `remove()` — holding a read guard across a
-        // write on the same DashMap key deadlocks.
-        let should_remove = {
-            let entry = self.session_events.get(session_key);
-            entry.map(|e| e.receiver_count() == 0).unwrap_or(false)
-        };
-        if should_remove {
-            self.session_events.remove(session_key);
-        }
+        self.session_events.remove_if(session_key, |_, sender| {
+            sender.receiver_count() == 0
+                && self
+                    .session_streams
+                    .get(session_key)
+                    .map_or(true, |v| v.is_empty())
+        });
     }
 
     /// Open a new stream for an agent execution run.
@@ -1300,11 +1300,12 @@ impl StreamHub {
     /// emits a [`StreamEvent::StreamClosed`] so session-level subscribers can
     /// observe the turn boundary without seeing `RecvError::Closed`.
     ///
-    /// The session-level bus entry in `session_events` is reaped here when
-    /// both conditions hold: this was the last active stream on the session,
-    /// AND no subscriber is holding the session bus open. If a subscriber
-    /// remains, the entry persists so the next turn's stream rejoins the
-    /// same bus — preserving mid-turn interrupt + reinject behavior (#1647).
+    /// The session-level bus entry in `session_events` is reaped here,
+    /// atomically under the shard write lock, when both conditions hold:
+    /// this was the last active stream on the session, AND no subscriber
+    /// is holding the session bus open. If a subscriber remains, the entry
+    /// survives so the next turn's stream rejoins the same bus — preserving
+    /// mid-turn interrupt + reinject behavior (#1647).
     #[tracing::instrument(skip(self))]
     pub fn close(&self, stream_id: &StreamId) {
         if let Some((_, entry)) = self.streams.remove(stream_id) {
@@ -1347,8 +1348,10 @@ impl StreamHub {
     /// for long-lived subscribers (WS/SSE) that must keep receiving events
     /// when the kernel interrupts turn A and re-injects as turn B.
     ///
-    /// The bus is created on demand and persists for the lifetime of the
-    /// hub. A terminal [`StreamEvent::StreamClosed`] is delivered on each
+    /// The bus is created on demand. It is reaped atomically when both the
+    /// session's stream list is empty AND the bus has no subscribers; a
+    /// later `subscribe_session_events` or `open()` transparently re-creates
+    /// it. A terminal [`StreamEvent::StreamClosed`] is delivered on each
     /// stream completion so consumers can emit their own per-turn "done"
     /// signals.
     pub fn subscribe_session_events(
@@ -2769,6 +2772,78 @@ mod stream_hub_tests {
             !hub.session_events.contains_key(&session),
             "session bus should reap once all streams and subscribers are gone"
         );
+    }
+
+    /// Regression test for the TOCTOU race between `close()`-triggered reap
+    /// and a concurrent `subscribe_session_events`.
+    ///
+    /// The pre-fix implementation did a non-atomic `get().receiver_count()`
+    /// check followed by `remove()`. A subscriber attaching in the window
+    /// between the two operations would see its sender deleted, silently
+    /// losing every subsequent event on the next turn.
+    ///
+    /// The current `remove_if`-based implementation holds the shard write
+    /// lock across the check+remove, serializing against the subscribe
+    /// path's `entry().or_insert_with()` on the same key. A subscriber that
+    /// wins the race must see the next turn's events; a subscriber that
+    /// loses the race simply creates a fresh bus for the next turn.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn concurrent_close_and_subscribe_does_not_lose_bus() {
+        // Run many iterations so scheduler interleavings exercise both
+        // orderings of the close() reap vs subscribe() attach.
+        for _ in 0..256 {
+            let hub = Arc::new(StreamHub::new(64));
+            let session = SessionKey::new();
+
+            // Turn A: open and emit, then race close() against subscribe().
+            let handle_a = hub.open(session);
+            handle_a.emit(StreamEvent::TextDelta {
+                text: "A1".to_owned(),
+            });
+
+            let hub_close = hub.clone();
+            let stream_id = handle_a.stream_id().clone();
+            let close_task = tokio::spawn(async move {
+                hub_close.close(&stream_id);
+            });
+
+            let hub_sub = hub.clone();
+            let subscribe_task = tokio::spawn(async move {
+                // Yield to encourage interleaving with close()'s reap path.
+                tokio::task::yield_now().await;
+                hub_sub.subscribe_session_events(&session)
+            });
+
+            close_task.await.expect("close task");
+            let mut rx = subscribe_task.await.expect("subscribe task");
+
+            // Turn B: whichever side won the race, the subscriber MUST see
+            // turn-B events. Either it attached before reap (same bus) or
+            // after reap (a fresh bus created by open() below).
+            let handle_b = hub.open(session);
+            handle_b.emit(StreamEvent::TextDelta {
+                text: "B1".to_owned(),
+            });
+            hub.close(handle_b.stream_id());
+
+            let mut got_b1 = false;
+            let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(1);
+            while tokio::time::Instant::now() < deadline {
+                let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+                match tokio::time::timeout(remaining, rx.recv()).await {
+                    Ok(Ok(StreamEvent::TextDelta { text })) if text == "B1" => {
+                        got_b1 = true;
+                        break;
+                    }
+                    Ok(Ok(_)) => {}
+                    Ok(Err(_)) | Err(_) => break,
+                }
+            }
+            assert!(
+                got_b1,
+                "subscriber must observe turn-B event regardless of reap/subscribe ordering"
+            );
+        }
     }
 }
 

--- a/crates/kernel/src/io.rs
+++ b/crates/kernel/src/io.rs
@@ -1037,6 +1037,18 @@ pub enum StreamEvent {
         /// [`TraceService::save`](crate::trace::TraceService::save).
         trace_id: String,
     },
+    /// Terminal marker emitted by [`StreamHub::close`] immediately before the
+    /// per-stream broadcast sender is dropped.
+    ///
+    /// Per-stream subscribers naturally see `RecvError::Closed` when the
+    /// sender drops; this variant exists so that **session-level** subscribers
+    /// (via [`StreamHub::subscribe_session_events`]) — whose bus outlives
+    /// individual streams — can still observe turn completion to emit their
+    /// own terminal signal (e.g. the web `WebEvent::Done` frame).
+    StreamClosed {
+        /// The stream that just closed.
+        stream_id: String,
+    },
 }
 
 // ---------------------------------------------------------------------------
@@ -1124,10 +1136,24 @@ pub const STREAM_HUB_BROADCAST_CAPACITY: usize = 4096;
 ///
 /// Manages the lifecycle of per-execution streams and provides
 /// subscription endpoints for egress/frontends.
+///
+/// # Session-level event bus
+///
+/// Beyond per-stream broadcast channels, the hub maintains a **session-level**
+/// event bus (`session_events`) whose lifetime is independent of individual
+/// streams. Each time [`StreamHub::open`] creates a new per-stream sender, a
+/// small bridge task forwards every emitted [`StreamEvent`] to the shared
+/// session-level sender. Subscribers attached via
+/// [`StreamHub::subscribe_session_events`] keep receiving events across stream
+/// turnover — critical for long-lived WS/SSE connections that must survive
+/// mid-turn interruption + re-injection (see issue #1647).
 pub struct StreamHub {
     streams:         DashMap<StreamId, StreamEntry>,
     /// Reverse index: session_key → active stream IDs for O(1) lookup.
     session_streams: DashMap<SessionKey, Vec<StreamId>>,
+    /// Session-level event bus — outlives individual streams so long-lived
+    /// subscribers (WS/SSE) do not see `Closed` between turns.
+    session_events:  DashMap<SessionKey, broadcast::Sender<StreamEvent>>,
     capacity:        usize,
 }
 
@@ -1137,6 +1163,7 @@ impl StreamHub {
         Self {
             streams: DashMap::new(),
             session_streams: DashMap::new(),
+            session_events: DashMap::new(),
             capacity,
         }
     }
@@ -1146,6 +1173,9 @@ impl StreamHub {
     /// Called by [`open`](Self::open) to ensure only one active stream per
     /// session. Any previously unclosed streams (e.g., from a hung agent
     /// run) are cleaned up here.
+    ///
+    /// Intentionally does NOT remove the session-level `session_events`
+    /// entry — that bus outlives individual streams (see [`StreamHub`] doc).
     #[tracing::instrument(skip(self))]
     pub fn close_session(&self, session_key: &SessionKey) {
         // Remove the session entry first, releasing the DashMap shard lock.
@@ -1158,13 +1188,25 @@ impl StreamHub {
             tracing::debug!(count = ids.len(), "cleaning up zombie streams for session");
         }
         for id in &ids {
-            self.streams.remove(id);
+            if let Some((_, entry)) = self.streams.remove(id) {
+                // Emit terminal marker so session-level subscribers observe
+                // the turn boundary before the per-stream sender drops.
+                let _ = entry.tx.send(StreamEvent::StreamClosed {
+                    stream_id: id.to_string(),
+                });
+            }
         }
     }
 
     /// Open a new stream for an agent execution run.
     ///
     /// Returns a [`StreamHandle`] that the executor uses to emit events.
+    ///
+    /// Also spawns a bridge task that forwards every event emitted on the
+    /// per-stream broadcast channel into the session-level event bus (see
+    /// [`subscribe_session_events`](Self::subscribe_session_events)). The
+    /// bridge task terminates naturally when the per-stream sender is dropped
+    /// (typically via [`close`](Self::close)).
     #[tracing::instrument(skip(self), fields(stream_id = tracing::field::Empty))]
     pub fn open(&self, session_key: SessionKey) -> StreamHandle {
         // Clean up any zombie streams from previous (hung) agent runs.
@@ -1181,6 +1223,31 @@ impl StreamHub {
             .entry(session_key)
             .or_default()
             .push(stream_id.clone());
+
+        // Get-or-create the session-level bus and spawn a bridge task from
+        // the per-stream sender into it. The bus outlives the per-stream
+        // sender intentionally so mid-turn interrupt+reinject does not drop
+        // long-lived WS/SSE subscribers.
+        let session_tx = self
+            .session_events
+            .entry(session_key)
+            .or_insert_with(|| broadcast::channel(self.capacity).0)
+            .clone();
+        let mut bridge_rx = tx.subscribe();
+        tokio::spawn(async move {
+            loop {
+                match bridge_rx.recv().await {
+                    Ok(ev) => {
+                        let _ = session_tx.send(ev);
+                    }
+                    Err(broadcast::error::RecvError::Lagged(n)) => {
+                        tracing::warn!(skipped = n, "stream→session bridge lagged; events dropped");
+                    }
+                    Err(broadcast::error::RecvError::Closed) => break,
+                }
+            }
+        });
+
         StreamHandle {
             stream_id,
             tx,
@@ -1191,10 +1258,21 @@ impl StreamHub {
     /// Close a stream by its ID.
     ///
     /// This is precise — only the specified stream is removed, not other
-    /// streams on the same session.
+    /// streams on the same session. Before dropping the per-stream sender,
+    /// emits a [`StreamEvent::StreamClosed`] so session-level subscribers can
+    /// observe the turn boundary without seeing `RecvError::Closed`.
+    ///
+    /// The session-level bus entry in `session_events` is intentionally NOT
+    /// removed here — it outlives individual streams so that the next turn's
+    /// stream can reuse the same session-level subscribers.
     #[tracing::instrument(skip(self))]
     pub fn close(&self, stream_id: &StreamId) {
         if let Some((_, entry)) = self.streams.remove(stream_id) {
+            // Fire the terminal marker before the per-stream sender drops so
+            // the bridge task observes it and forwards it to session_events.
+            let _ = entry.tx.send(StreamEvent::StreamClosed {
+                stream_id: stream_id.to_string(),
+            });
             if let Some(mut ids) = self.session_streams.get_mut(&entry.session_key) {
                 ids.retain(|id| id != stream_id);
                 if ids.is_empty() {
@@ -1217,6 +1295,28 @@ impl StreamHub {
                 }
             }
         }
+    }
+
+    /// Subscribe to the **session-level** event bus.
+    ///
+    /// The returned receiver observes every [`StreamEvent`] emitted by any
+    /// stream opened on this session — including streams that are opened
+    /// *after* this call, and surviving across stream turnover. Use this
+    /// for long-lived subscribers (WS/SSE) that must keep receiving events
+    /// when the kernel interrupts turn A and re-injects as turn B.
+    ///
+    /// The bus is created on demand and persists for the lifetime of the
+    /// hub. A terminal [`StreamEvent::StreamClosed`] is delivered on each
+    /// stream completion so consumers can emit their own per-turn "done"
+    /// signals.
+    pub fn subscribe_session_events(
+        &self,
+        session_key: &SessionKey,
+    ) -> broadcast::Receiver<StreamEvent> {
+        self.session_events
+            .entry(*session_key)
+            .or_insert_with(|| broadcast::channel(self.capacity).0)
+            .subscribe()
     }
 
     /// Subscribe to all active streams for a given session.
@@ -2424,8 +2524,8 @@ mod ingress_rate_limiter_tests {
 mod stream_hub_tests {
     use super::*;
 
-    #[test]
-    fn open_cleans_up_zombie_streams() {
+    #[tokio::test]
+    async fn open_cleans_up_zombie_streams() {
         let hub = StreamHub::new(16);
         let session = SessionKey::new();
 
@@ -2464,6 +2564,109 @@ mod stream_hub_tests {
         // Closing a session with no streams should not panic.
         hub.close_session(&session);
         assert!(hub.subscribe_session(&session).is_empty());
+    }
+
+    /// Session-level subscriber attached BEFORE any stream opens sees events
+    /// from BOTH streams on the same session — the forwarder survives stream
+    /// turnover. This is the core property the web adapter relies on to keep
+    /// streaming after mid-turn interrupt + reinject (#1647).
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn session_events_bus_survives_stream_turnover() {
+        let hub = StreamHub::new(64);
+        let session = SessionKey::new();
+
+        // Subscribe BEFORE the first stream opens.
+        let mut rx = hub.subscribe_session_events(&session);
+
+        // Turn A.
+        let handle_a = hub.open(session);
+        handle_a.emit(StreamEvent::TextDelta {
+            text: "A1".to_owned(),
+        });
+        handle_a.emit(StreamEvent::TextDelta {
+            text: "A2".to_owned(),
+        });
+        hub.close(handle_a.stream_id());
+
+        // Turn B — fresh StreamHub::open, fresh per-stream sender.
+        let handle_b = hub.open(session);
+        handle_b.emit(StreamEvent::TextDelta {
+            text: "B1".to_owned(),
+        });
+        hub.close(handle_b.stream_id());
+
+        // Drain with a bounded wait so slow bridge tasks don't flake the test.
+        let mut texts = Vec::new();
+        let mut closed = 0;
+        let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(2);
+        while texts.len() < 3 || closed < 2 {
+            let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+            if remaining.is_zero() {
+                break;
+            }
+            match tokio::time::timeout(remaining, rx.recv()).await {
+                Ok(Ok(StreamEvent::TextDelta { text })) => texts.push(text),
+                Ok(Ok(StreamEvent::StreamClosed { .. })) => closed += 1,
+                Ok(Ok(_)) => {}
+                Ok(Err(_)) => break,
+                Err(_) => break,
+            }
+        }
+        // Ordering across the two per-stream bridges is not guaranteed
+        // (they run on independent tasks), but every event from both turns
+        // must reach the subscriber — that's the bug fix for #1647.
+        texts.sort();
+        assert_eq!(
+            texts,
+            vec!["A1".to_owned(), "A2".to_owned(), "B1".to_owned()]
+        );
+        assert_eq!(closed, 2, "should see one StreamClosed per stream");
+    }
+
+    /// A subscriber attached AFTER the first stream has closed still receives
+    /// events from the next stream opened on the same session.
+    ///
+    /// Uses the multi-threaded runtime so the bridge tasks spawned during
+    /// turn A actually drain before we subscribe — on the current-thread
+    /// runtime, the bridge could still be holding queued A-events at the
+    /// moment subscribe runs, which would mask the property under test.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn late_subscriber_still_receives_next_stream_events() {
+        let hub = StreamHub::new(64);
+        let session = SessionKey::new();
+
+        // Turn A: run and close before anyone subscribes.
+        let handle_a = hub.open(session);
+        handle_a.emit(StreamEvent::TextDelta {
+            text: "A1".to_owned(),
+        });
+        hub.close(handle_a.stream_id());
+
+        // Let the turn-A bridge fully drain before we subscribe so the new
+        // receiver does not pick up A's tail.
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+
+        // Subscribe now — AFTER the first stream closed but BEFORE turn B.
+        let mut rx = hub.subscribe_session_events(&session);
+
+        // Turn B.
+        let handle_b = hub.open(session);
+        handle_b.emit(StreamEvent::TextDelta {
+            text: "B1".to_owned(),
+        });
+        hub.close(handle_b.stream_id());
+
+        let mut texts = Vec::new();
+        let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(2);
+        while texts.is_empty() && tokio::time::Instant::now() < deadline {
+            let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+            match tokio::time::timeout(remaining, rx.recv()).await {
+                Ok(Ok(StreamEvent::TextDelta { text })) => texts.push(text),
+                Ok(Ok(_)) => {}
+                Ok(Err(_)) | Err(_) => break,
+            }
+        }
+        assert_eq!(texts, vec!["B1"]);
     }
 }
 

--- a/crates/kernel/src/trace/builder.rs
+++ b/crates/kernel/src/trace/builder.rs
@@ -268,7 +268,8 @@ impl TraceBuilder {
             | StreamEvent::ToolCallLimit { .. }
             | StreamEvent::ToolCallLimitResolved { .. }
             | StreamEvent::LoopBreakerTriggered { .. }
-            | StreamEvent::TraceReady { .. } => {}
+            | StreamEvent::TraceReady { .. }
+            | StreamEvent::StreamClosed { .. } => {}
         }
     }
 


### PR DESCRIPTION
## Summary

Fixes the multi-browser chat bug where opening the same session in two browsers caused both pages to stop receiving LLM responses after any concurrent inbound message.

Root cause: `WebAdapter::spawn_stream_forwarder` snapshotted active streams via `StreamHub::subscribe_session` once per inbound message. When the kernel interrupted turn A (`deliver_to_session` buffer+interrupt path) and re-injected as turn B, `StreamHub::open` created a fresh per-stream channel, but no forwarder was watching it — events went to /dev/null.

This PR adopts an opencode-style **session-centric event bus** that outlives individual streams:

- `StreamHub` now owns a session-level `broadcast::Sender<StreamEvent>` per session. `open()` spawns a bridge task from the new per-stream sender into it; `close()` / `close_session()` emit a new `StreamEvent::StreamClosed` terminal marker so session-level subscribers can see turn boundaries without the session bus itself closing.
- New `StreamHub::subscribe_session_events(&SessionKey)` returns a broadcast receiver that observes events from every stream opened on the session, including future ones.
- `WebAdapter` rewrites WS + SSE forwarding. Each connection takes **one permanent** subscription at connect time. The per-message forwarder is gone. Adapter-local events (`Typing`, `Error`, `Phase`, outbound replies) flow through a separate per-session `DashMap<SessionKey, broadcast::Sender<WebEvent>>`; both sources merge into a per-WS `mpsc::UnboundedSender<WebEvent>` that feeds the socket.
- Deleted `BROADCAST_CAPACITY`, `WebAdapter::sessions`, `get_or_create_session`, `broadcast_event`, and `spawn_stream_forwarder`.
- Telegram / CLI / backend-admin / dock continue to use `subscribe_session` unchanged.

## Type of change

| Type | Label |
|------|-------|
| Refactor | `refactor` |

## Component

`core`

## Closes

Closes #1647

## Test plan

- [x] New `session_events_bus_survives_stream_turnover` — subscribes BEFORE turn A, sees events from both turn A and turn B after close/reopen
- [x] New `late_subscriber_still_receives_next_stream_events` — subscribes AFTER turn A closes, still receives turn B events
- [x] `cargo test -p rara-kernel -p rara-channels` (654 passed, 10 ignored)
- [x] `cargo check --all --all-targets` clean
- [x] `cargo +nightly fmt --all -- --check` clean
- [x] `cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings` clean
- [x] `RUSTDOCFLAGS="-D warnings" cargo +nightly doc --workspace --no-deps --document-private-items` clean
- [ ] Manual multi-browser repro: open session in two tabs, send inbound while turn in flight, verify both tabs keep streaming after interrupt+reinject