### PR TITLE
feat(backend): sessions search endpoint (#1654)

### DIFF
--- a/crates/extensions/backend-admin/src/chat/mod.rs
+++ b/crates/extensions/backend-admin/src/chat/mod.rs
@@ -16,8 +16,9 @@ pub mod error;
 pub mod model_catalog;
 mod router;
 pub mod service;
+pub mod snippet;
 
 pub use router::{
     BindChannelRequest, CreateSessionRequest, GetTraceQuery, ListMessagesQuery, ListSessionsQuery,
-    SetFavoritesRequest, UpdateSessionRequest, routes,
+    SearchSessionsQuery, SetFavoritesRequest, UpdateSessionRequest, routes,
 };

--- a/crates/extensions/backend-admin/src/chat/router.rs
+++ b/crates/extensions/backend-admin/src/chat/router.rs
@@ -26,6 +26,7 @@
 //! | `PUT`    | `/api/v1/chat/models/favorites`                      | Set favorite models    |
 //! | `POST`   | `/api/v1/chat/sessions`                              | Create a session       |
 //! | `GET`    | `/api/v1/chat/sessions`                              | List sessions          |
+//! | `GET`    | `/api/v1/chat/sessions/search`                       | Full-text search       |
 //! | `GET`    | `/api/v1/chat/sessions/{key}`                        | Get a session          |
 //! | `PATCH`  | `/api/v1/chat/sessions/{key}`                        | Update session fields  |
 //! | `DELETE` | `/api/v1/chat/sessions/{key}`                        | Delete a session       |
@@ -50,8 +51,16 @@ use utoipa_axum::{router::OpenApiRouter, routes};
 use crate::chat::{
     error::ChatError,
     model_catalog::ChatModel,
-    service::{ProviderInfo, SessionPatch, SessionService},
+    service::{ProviderInfo, SessionPatch, SessionSearchResponse, SessionService},
 };
+
+/// Default `limit` for search requests when the client does not supply
+/// one. Chosen to match the typical session-list page size so the UI can
+/// render both in a single column without pagination.
+const SEARCH_DEFAULT_LIMIT: usize = 20;
+/// Upper bound on `limit` — protects the backend from expensive
+/// full-text queries triggered by a malformed or hostile client.
+const SEARCH_MAX_LIMIT: usize = 100;
 
 /// Parse an optional thinking-level string from a create-session body.
 ///
@@ -216,6 +225,18 @@ pub struct SetFavoritesRequest {
     pub model_ids: Vec<String>,
 }
 
+/// Query parameters for `GET /sessions/search`.
+#[derive(Debug, Deserialize, utoipa::ToSchema)]
+pub struct SearchSessionsQuery {
+    /// Free-form search query. An empty or whitespace-only value yields
+    /// an empty hit list with 200 (not 400) so the UI can bind directly
+    /// to an input's change event without debouncing.
+    pub q:     Option<String>,
+    /// Maximum number of hits to return. Defaults to `20`, clamped to
+    /// `[1, 100]`.
+    pub limit: Option<usize>,
+}
+
 /// Query parameters for `GET /sessions/{key}/messages`.
 #[derive(Debug, Deserialize, utoipa::ToSchema)]
 pub struct ListMessagesQuery {
@@ -262,6 +283,7 @@ fn model_routes(service: SessionService) -> OpenApiRouter {
 fn session_routes(service: SessionService) -> OpenApiRouter {
     OpenApiRouter::new()
         .routes(routes!(create_session, list_sessions))
+        .routes(routes!(search_sessions))
         .routes(routes!(get_session, update_session, delete_session))
         .routes(routes!(list_messages, clear_messages))
         .routes(routes!(get_cascade_trace))
@@ -377,6 +399,34 @@ async fn list_sessions(
 ) -> Result<Json<Vec<SessionEntry>>, ChatError> {
     let sessions = service.list_sessions(q.limit, q.offset).await?;
     Ok(Json(sessions))
+}
+
+/// `GET /api/v1/chat/sessions/search` — full-text search across session
+/// messages. Returns at most one hit per session.
+#[utoipa::path(
+    get,
+    path = "/api/v1/chat/sessions/search",
+    tag = "chat",
+    params(
+        ("q" = Option<String>, Query, description = "Free-form search query"),
+        ("limit" = Option<usize>, Query, description = "Maximum hits to return (default 20, clamped to [1,100])"),
+    ),
+    responses(
+        (status = 200, description = "Search hits", body = SessionSearchResponse),
+    )
+)]
+#[instrument(skip(service))]
+async fn search_sessions(
+    State(service): State<SessionService>,
+    Query(q): Query<SearchSessionsQuery>,
+) -> Result<Json<SessionSearchResponse>, ChatError> {
+    let query = q.q.unwrap_or_default();
+    let limit = q
+        .limit
+        .unwrap_or(SEARCH_DEFAULT_LIMIT)
+        .clamp(1, SEARCH_MAX_LIMIT);
+    let response = service.search_sessions(&query, limit).await?;
+    Ok(Json(response))
 }
 
 /// `GET /api/v1/chat/sessions/{key}` — get a single session.

--- a/crates/extensions/backend-admin/src/chat/service.rs
+++ b/crates/extensions/backend-admin/src/chat/service.rs
@@ -311,6 +311,41 @@ fn apply_session_patch(session: &mut SessionEntry, patch: &SessionPatch) -> bool
         | assign(&mut session.system_prompt, &patch.system_prompt)
 }
 
+/// One matched message surfaced by
+/// [`SessionService::search_sessions`].
+///
+/// The hit is a projection of a single [`TapEntry`] plus a pre-rendered
+/// snippet so the web UI can render a search result list directly from
+/// the JSON payload without re-reading the tape.
+#[derive(Debug, Clone, serde::Serialize, utoipa::ToSchema)]
+pub struct SessionSearchHit {
+    /// Session key (also the tape name) this message belongs to.
+    pub session_key:   String,
+    /// Display title of the session, falling back to `session_key` when
+    /// no title is set. The UI should render this as the result's
+    /// clickable label.
+    pub session_title: String,
+    /// HTML-escaped text with the first matched query token wrapped in
+    /// `<mark>…</mark>`. Safe to insert into the DOM via `innerHTML`.
+    pub snippet:       String,
+    /// Role of the matched message: `"user"`, `"assistant"`, or
+    /// `"other"` for system/tool/developer messages.
+    pub role:          String,
+    /// Wall-clock time of the underlying tape entry, in milliseconds
+    /// since the Unix epoch.
+    pub timestamp_ms:  i64,
+    /// Monotonic tape-entry ID — exposed so the UI can deep-link into a
+    /// specific message inside the session view.
+    pub seq:           u64,
+}
+
+/// Response body for `GET /api/v1/chat/sessions/search`.
+#[derive(Debug, Clone, serde::Serialize, utoipa::ToSchema)]
+pub struct SessionSearchResponse {
+    /// Top-ranked hits, one per session.
+    pub hits: Vec<SessionSearchHit>,
+}
+
 /// Central orchestrator for session-based AI chat.
 ///
 /// `SessionService` ties together two concerns:
@@ -342,6 +377,18 @@ pub struct SessionService {
 }
 
 impl SessionService {
+    /// Hard ceiling on how many sessions we scan in a single request.
+    const SEARCH_SESSION_SCAN_CAP: i64 = 500;
+    // -- full-text search ---------------------------------------------------
+
+    /// Minimum number of sessions we inspect when scanning for matches.
+    ///
+    /// The `limit` argument bounds the returned hits, but we search a
+    /// larger window of sessions so one heavily-used session cannot
+    /// monopolise the top `limit` slots (we keep only the best hit per
+    /// session, so searching more sessions improves result diversity).
+    const SEARCH_SESSION_SCAN_MULTIPLIER: i64 = 3;
+
     /// Create a new chat service with the given dependencies.
     #[must_use]
     pub fn new(
@@ -713,6 +760,82 @@ impl SessionService {
         })
     }
 
+    /// Search recent sessions for messages matching `query` (full-text).
+    ///
+    /// Scans up to `SEARCH_SESSION_SCAN_CAP` of the most recently
+    /// updated sessions, asks the tape service for ranked matches inside
+    /// each, and keeps only the single highest-ranked hit per session
+    /// before clamping to `limit`. One-hit-per-session keeps the result
+    /// list varied: the underlying FTS ranker tends to cluster many hits
+    /// inside one long thread, which otherwise drowns out other matches.
+    ///
+    /// An empty or whitespace-only `query` short-circuits to an empty
+    /// response — this is treated as "user cleared the search box", not
+    /// as a validation error.
+    #[instrument(skip(self))]
+    pub async fn search_sessions(
+        &self,
+        query: &str,
+        limit: usize,
+    ) -> Result<SessionSearchResponse, ChatError> {
+        let trimmed = query.trim();
+        if trimmed.is_empty() || limit == 0 {
+            return Ok(SessionSearchResponse { hits: Vec::new() });
+        }
+
+        let scan_limit = (limit as i64)
+            .saturating_mul(Self::SEARCH_SESSION_SCAN_MULTIPLIER)
+            .min(Self::SEARCH_SESSION_SCAN_CAP)
+            .max(limit as i64);
+
+        let sessions = self.session_index.list_sessions(scan_limit, 0).await?;
+
+        // Per-session search bound. The service ranks inside a tape so
+        // we only need the top few candidates before picking the best
+        // one whose payload yields a usable role/text.
+        let per_session_limit = 3usize;
+
+        let mut hits: Vec<(f64, SessionSearchHit)> = Vec::new();
+        for session in &sessions {
+            let tape_name = session.key.to_string();
+            let entries = match self
+                .tape_service
+                .search(&tape_name, trimmed, per_session_limit, false)
+                .await
+            {
+                Ok(entries) => entries,
+                Err(e) => {
+                    tracing::warn!(
+                        session = %session.key,
+                        error = %e,
+                        "tape search failed, skipping session"
+                    );
+                    continue;
+                }
+            };
+
+            // `entries` is ordered by relevance; pick the first one
+            // whose payload decodes into a message we can project.
+            let Some((rank, hit)) = entries.iter().enumerate().find_map(|(idx, entry)| {
+                project_search_hit(entry, session, trimmed).map(|h| (idx, h))
+            }) else {
+                continue;
+            };
+
+            // Lower `rank` = better; negate so a max-heap-style sort by
+            // `score.partial_cmp` puts the best hits first.
+            let score = -(rank as f64);
+            hits.push((score, hit));
+        }
+
+        hits.sort_by(|a, b| b.0.partial_cmp(&a.0).unwrap_or(std::cmp::Ordering::Equal));
+        hits.truncate(limit);
+
+        Ok(SessionSearchResponse {
+            hits: hits.into_iter().map(|(_, h)| h).collect(),
+        })
+    }
+
     // -- channel bindings ---------------------------------------------------
 
     /// Bind an external channel (e.g. Telegram chat) to a session key.
@@ -891,6 +1014,57 @@ fn tap_entries_to_chat_messages(entries: &[TapEntry]) -> Vec<ChatMessage> {
         }
     }
     messages
+}
+
+/// Map a kernel [`Role`] to the short, lowercase string the web UI
+/// expects on a search hit.
+fn role_label(role: Role) -> &'static str {
+    match role {
+        Role::User => "user",
+        Role::Assistant => "assistant",
+        // System / Developer / Tool messages are rare hits but can surface
+        // when the user searches for content embedded in a tool result;
+        // collapse the distinction so the UI has a single "other" bucket.
+        _ => "other",
+    }
+}
+
+/// Extract the plain text body of a [`Message`] for snippet generation.
+fn message_plain_text(msg: &Message) -> String { msg.content.as_text().to_owned() }
+
+/// Project a matched [`TapEntry`] into a [`SessionSearchHit`].
+///
+/// Returns `None` when the entry is not a decodable `Message` — we
+/// deliberately skip `ToolCall` / `ToolResult` / system metadata entries
+/// here because the search endpoint targets conversational content. A
+/// sibling user / assistant entry with overlapping text will usually
+/// be ranked alongside the skipped entry and picked up instead.
+fn project_search_hit(
+    entry: &TapEntry,
+    session: &SessionEntry,
+    query: &str,
+) -> Option<SessionSearchHit> {
+    if !matches!(entry.kind, TapEntryKind::Message) {
+        return None;
+    }
+    let msg: Message = serde_json::from_value(entry.payload.clone()).ok()?;
+    let text = message_plain_text(&msg);
+    let snippet = crate::chat::snippet::build_snippet(&text, query);
+    let session_key = session.key.to_string();
+    let session_title = session
+        .title
+        .as_ref()
+        .filter(|t| !t.trim().is_empty())
+        .cloned()
+        .unwrap_or_else(|| session_key.clone());
+    Some(SessionSearchHit {
+        session_key,
+        session_title,
+        snippet,
+        role: role_label(msg.role).to_owned(),
+        timestamp_ms: entry.timestamp.as_millisecond(),
+        seq: entry.id,
+    })
 }
 
 #[cfg(test)]

--- a/crates/extensions/backend-admin/src/chat/snippet.rs
+++ b/crates/extensions/backend-admin/src/chat/snippet.rs
@@ -1,0 +1,304 @@
+// Copyright 2025 Rararulab
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Snippet generation for session full-text search results.
+//!
+//! Given the plain text of a matched message and the user's query, produce
+//! an HTML-escaped snippet with the first matched term wrapped in
+//! `<mark>…</mark>`. The snippet is bounded to a short window around the
+//! match so the UI can render it inline in a search result list.
+
+/// Maximum characters kept on either side of a match when the source text
+/// exceeds [`FULL_TEXT_THRESHOLD`].
+const SNIPPET_CONTEXT_CHARS: usize = 40;
+
+/// Texts shorter than this are returned in full (still escaped and
+/// `<mark>`-wrapped) without ellipses — readers benefit more from seeing
+/// the whole short message than a trimmed window.
+const FULL_TEXT_THRESHOLD: usize = 100;
+
+/// Fallback prefix length when no query token can be located in the text
+/// (e.g. FTS matched on a CJK compound the plain-text scanner cannot
+/// align to without a tokenizer).
+const FALLBACK_PREFIX_CHARS: usize = 80;
+
+/// Minimal HTML escape for `& < > " '`.
+///
+/// Stay self-contained — the `html_escape` crate is not a workspace
+/// dependency and pulling it in for five substitutions is not worth a
+/// version bump.
+pub fn escape_html(input: &str) -> String {
+    let mut out = String::with_capacity(input.len());
+    for ch in input.chars() {
+        match ch {
+            '&' => out.push_str("&amp;"),
+            '<' => out.push_str("&lt;"),
+            '>' => out.push_str("&gt;"),
+            '"' => out.push_str("&quot;"),
+            '\'' => out.push_str("&#x27;"),
+            other => out.push(other),
+        }
+    }
+    out
+}
+
+/// Build a search-result snippet for `text` highlighting the first
+/// whitespace-split token from `query` that appears (case-insensitively)
+/// in `text`.
+///
+/// Returns an empty string when `text` is empty. When no token can be
+/// located in the plain text, returns the first `FALLBACK_PREFIX_CHARS`
+/// escaped characters without a `<mark>` wrap — the FTS layer may match
+/// on tokenized CJK compounds that we cannot realign here without
+/// re-tokenizing.
+pub fn build_snippet(text: &str, query: &str) -> String {
+    if text.is_empty() {
+        return String::new();
+    }
+
+    let tokens: Vec<&str> = query.split_whitespace().collect();
+    let match_range = tokens
+        .iter()
+        .find_map(|tok| find_case_insensitive(text, tok));
+
+    let Some((start, end)) = match_range else {
+        return fallback_prefix(text);
+    };
+
+    // Short texts are returned in full with the match highlighted.
+    if text.chars().count() <= FULL_TEXT_THRESHOLD {
+        return wrap_match(text, start, end);
+    }
+
+    // Take ±SNIPPET_CONTEXT_CHARS characters around the match on a char
+    // boundary (`start`/`end` are byte indices, so we walk chars).
+    let (window_start, leading_ellipsis) = window_start(text, start);
+    let (window_end, trailing_ellipsis) = window_end(text, end);
+
+    let before = &text[window_start..start];
+    let matched = &text[start..end];
+    let after = &text[end..window_end];
+
+    let mut out = String::new();
+    if leading_ellipsis {
+        out.push('…');
+    }
+    out.push_str(&escape_html(before));
+    out.push_str("<mark>");
+    out.push_str(&escape_html(matched));
+    out.push_str("</mark>");
+    out.push_str(&escape_html(after));
+    if trailing_ellipsis {
+        out.push('…');
+    }
+    out
+}
+
+/// Locate `needle` inside `haystack` case-insensitively, returning the
+/// byte range `[start, end)` of the match in `haystack`. The match length
+/// is taken from `needle.len()` mapped back to char boundaries in the
+/// original string to keep `<mark>` wrapping aligned with UTF-8
+/// boundaries.
+fn find_case_insensitive(haystack: &str, needle: &str) -> Option<(usize, usize)> {
+    if needle.is_empty() {
+        return None;
+    }
+    let lower_hay = haystack.to_lowercase();
+    let lower_needle = needle.to_lowercase();
+    let start = lower_hay.find(&lower_needle)?;
+    // `to_lowercase` can change length for some codepoints; clamp the
+    // end to a char boundary in the original string by re-walking from
+    // `start` for `needle.chars().count()` characters.
+    let needle_char_count = lower_needle.chars().count();
+    let end = haystack[start..]
+        .char_indices()
+        .nth(needle_char_count)
+        .map(|(offset, _)| start + offset)
+        .unwrap_or(haystack.len());
+    Some((start, end))
+}
+
+/// Wrap the `[start, end)` byte range in `<mark>…</mark>` against the
+/// full (escaped) text. Used for short texts where no trimming applies.
+fn wrap_match(text: &str, start: usize, end: usize) -> String {
+    let before = &text[..start];
+    let matched = &text[start..end];
+    let after = &text[end..];
+    let mut out = String::new();
+    out.push_str(&escape_html(before));
+    out.push_str("<mark>");
+    out.push_str(&escape_html(matched));
+    out.push_str("</mark>");
+    out.push_str(&escape_html(after));
+    out
+}
+
+/// Fallback when no substring from `query` could be located in `text`.
+fn fallback_prefix(text: &str) -> String {
+    let end = text
+        .char_indices()
+        .nth(FALLBACK_PREFIX_CHARS)
+        .map(|(idx, _)| idx)
+        .unwrap_or(text.len());
+    let truncated = end < text.len();
+    let mut out = escape_html(&text[..end]);
+    if truncated {
+        out.push('…');
+    }
+    out
+}
+
+/// Walk backwards from `start` up to [`SNIPPET_CONTEXT_CHARS`] chars,
+/// returning the resulting byte index and whether a leading ellipsis is
+/// needed.
+fn window_start(text: &str, start: usize) -> (usize, bool) {
+    let before = &text[..start];
+    let char_count = before.chars().count();
+    if char_count <= SNIPPET_CONTEXT_CHARS {
+        return (0, false);
+    }
+    let skip = char_count - SNIPPET_CONTEXT_CHARS;
+    let idx = before
+        .char_indices()
+        .nth(skip)
+        .map(|(i, _)| i)
+        .unwrap_or(start);
+    (idx, true)
+}
+
+/// Walk forward from `end` up to [`SNIPPET_CONTEXT_CHARS`] chars,
+/// returning the resulting byte index and whether a trailing ellipsis is
+/// needed.
+fn window_end(text: &str, end: usize) -> (usize, bool) {
+    let after = &text[end..];
+    let char_count = after.chars().count();
+    if char_count <= SNIPPET_CONTEXT_CHARS {
+        return (text.len(), false);
+    }
+    let idx = after
+        .char_indices()
+        .nth(SNIPPET_CONTEXT_CHARS)
+        .map(|(i, _)| end + i)
+        .unwrap_or(text.len());
+    (idx, true)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn escape_handles_all_five_specials() {
+        assert_eq!(
+            escape_html("a & b < c > d \" e ' f"),
+            "a &amp; b &lt; c &gt; d &quot; e &#x27; f"
+        );
+    }
+
+    #[test]
+    fn empty_input_returns_empty() {
+        assert_eq!(build_snippet("", "anything"), "");
+    }
+
+    #[test]
+    fn no_match_returns_escaped_prefix() {
+        let text = "hello world";
+        let got = build_snippet(text, "zzz");
+        assert_eq!(got, "hello world");
+        assert!(!got.contains("<mark>"));
+    }
+
+    #[test]
+    fn no_match_long_text_is_truncated() {
+        let text = "a".repeat(200);
+        let got = build_snippet(&text, "zzz");
+        assert!(got.ends_with('…'));
+        assert!(!got.contains("<mark>"));
+    }
+
+    #[test]
+    fn short_text_returns_full_with_mark() {
+        let got = build_snippet("hello world", "world");
+        assert_eq!(got, "hello <mark>world</mark>");
+    }
+
+    #[test]
+    fn match_at_start_of_long_text() {
+        let mut text = String::from("rustlang ");
+        text.push_str(&"x".repeat(200));
+        let got = build_snippet(&text, "rustlang");
+        assert!(got.starts_with("<mark>rustlang</mark>"));
+        assert!(got.ends_with('…'));
+    }
+
+    #[test]
+    fn match_mid_long_text_has_both_ellipses() {
+        let mut text = String::new();
+        text.push_str(&"a".repeat(200));
+        text.push_str("needle");
+        text.push_str(&"b".repeat(200));
+        let got = build_snippet(&text, "needle");
+        assert!(got.starts_with('…'));
+        assert!(got.ends_with('…'));
+        assert!(got.contains("<mark>needle</mark>"));
+    }
+
+    #[test]
+    fn html_is_escaped_before_wrapping() {
+        let got = build_snippet("<script>alert('x')</script>", "alert");
+        assert!(
+            got.contains("&lt;script&gt;"),
+            "expected escaped opening tag, got: {got}"
+        );
+        assert!(
+            got.contains("<mark>alert</mark>"),
+            "expected unescaped mark wrap, got: {got}"
+        );
+        assert!(
+            !got.contains("<script>"),
+            "raw <script> must not appear in output: {got}"
+        );
+    }
+
+    #[test]
+    fn match_is_case_insensitive() {
+        let got = build_snippet("Hello World", "WORLD");
+        assert_eq!(got, "Hello <mark>World</mark>");
+    }
+
+    #[test]
+    fn first_whitespace_token_matches_first() {
+        // Both "foo" and "bar" appear; the scanner walks tokens in query
+        // order, so the first query token that resolves to a hit wins —
+        // independent of where each term sits in the source text.
+        let got = build_snippet("alpha bar beta foo", "foo bar");
+        assert!(
+            got.contains("<mark>foo</mark>"),
+            "expected first query token to win, got: {got}"
+        );
+    }
+
+    #[test]
+    fn cjk_text_is_handled_on_char_boundaries() {
+        let got = build_snippet("你好世界，rust 很好", "rust");
+        assert!(got.contains("<mark>rust</mark>"));
+    }
+
+    #[test]
+    fn empty_query_falls_back_to_prefix() {
+        let got = build_snippet("hello world", "");
+        assert_eq!(got, "hello world");
+        assert!(!got.contains("<mark>"));
+    }
+}


### PR DESCRIPTION
## Summary

Part of #1653. Implements `GET /api/v1/chat/sessions/search?q=<text>&limit=20` for full-text search across recent session tapes, returning one hit per `session_key` with a pre-rendered HTML-escaped snippet.

- Scans up to 500 recent sessions, queries the tape FTS per session, keeps highest-ranked hit per session
- Snippet module: HTML-escape before `<mark>` wrap, CJK-safe char-boundary windowing, short-text full-return path, fallback prefix when no token aligns
- `limit` clamped to `[1, 100]`, default 20; empty `q` short-circuits to `{ hits: [] }` with 200
- Response projects role (user/assistant/other), `timestamp_ms`, `seq` so the UI can deep-link
- OpenAPI via `#[utoipa::path(...)]`; response body schema `SessionSearchResponse`

## Type of change

| Type | Label |
|------|-------|
| New feature | `enhancement` |

## Component

`backend`

## Closes

Closes #1654

## Test plan

- [x] `cargo test -p rara-backend-admin` passes (31 tests including 13 snippet cases)
- [x] `cargo clippy -p rara-backend-admin --all-targets --all-features --no-deps -- -D warnings` clean
- [x] `cargo +nightly fmt --all -- --check` clean
- [x] `RUSTDOCFLAGS="-D warnings" cargo +nightly doc -p rara-backend-admin --no-deps --document-private-items` clean