### PR TITLE
fix(deps): pin zlob to 1.3.2 for zig 0.16 compatibility (#1665)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -288,6 +288,13 @@ fff-search = { git = "https://github.com/dmtrKovalenko/fff.nvim", rev = "ea1f980
 fff-grep = { git = "https://github.com/dmtrKovalenko/fff.nvim", rev = "ea1f9802d7879345f02bef72bcadecd7252b8add" }
 fff-query-parser = { git = "https://github.com/dmtrKovalenko/fff.nvim", rev = "ea1f9802d7879345f02bef72bcadecd7252b8add", default-features = false }
 
+# zlob is a transitive dep of fff-search (feature = "zlob"); declaring it here
+# pins the version across the workspace because `Cargo.lock` is gitignored.
+# 1.3.2 is the first zlob release targeting zig 0.16's `Build.Step.Compile`
+# API (the `linkLibC()` method call was removed upstream); 1.3.0 only compiles
+# on zig 0.15. Bump this in lockstep with the CI runner's zig toolchain.
+zlob = "=1.3.2"
+
 rara-tool-macro = { path = "crates/common/tool-macro" }
 yunara-store = { path = "crates/common/yunara-store" }
 

--- a/crates/app/Cargo.toml
+++ b/crates/app/Cargo.toml
@@ -57,6 +57,9 @@ rara-soul.workspace = true
 rara-tool-macro.workspace = true
 fff-search = { workspace = true }
 fff-query-parser = { workspace = true }
+# Direct dep (not imported) to activate the workspace-level `=1.3.2` pin on
+# this transitive; see the note in the workspace `[dependencies]`.
+zlob = { workspace = true }
 regex.workspace = true
 reqwest = { workspace = true }
 schemars.workspace = true


### PR DESCRIPTION
## Summary

`Cargo.lock` is gitignored workspace-wide, so zlob resolves freshly on every build.
- zlob 1.3.0 uses the pre-zig-0.16 `Build.Step.Compile.linkLibC()` API — fails to build on zig 0.16
- zlob 1.3.2 uses the post-0.16 `std.Io.Threaded` API — fails to build on zig 0.15.2
Neither version is portable across both toolchains; must pick one and hold it via an explicit pin.

Adds `zlob = "=1.3.2"` to the workspace `[dependencies]` and includes `zlob = { workspace = true }` as a direct (unused) dep in `crates/app` so the constraint actually propagates to resolution (transitive-only workspace entries are templates and do not bind). When the CI runner is bumped to zig 0.16 the pin continues to hold.

Verified: blew away `Cargo.lock`, re-resolved from scratch, `cargo check -p rara-app` compiles clean on zig 0.16.0 (homebrew).

## Type of change

| Type | Label |
|------|-------|
| Bug fix | `bug` |

## Component

`ci`

## Closes

Closes #1665

## Test plan

- [x] `cargo check -p rara-app` on zig 0.16.0 passes
- [x] `prek run --all-files` green (check / fmt / clippy / doc / AGENT.md)
- [ ] CI Rust workflow will still fail until the runner's zig is upgraded to 0.16.0 (separate infra task, noted in commit body)