### PR TITLE
fix(ci): fix rust 1.95 clippy lints (#1667)

### DIFF
--- a/crates/app/src/gateway/executor.rs
+++ b/crates/app/src/gateway/executor.rs
@@ -96,7 +96,7 @@ pub struct UpdateExecutor {
 }
 
 /// Build timeout: 10 minutes.
-const BUILD_TIMEOUT: Duration = Duration::from_secs(600);
+const BUILD_TIMEOUT: Duration = Duration::from_mins(10);
 
 impl UpdateExecutor {
     /// Create a new executor.

--- a/crates/app/src/gateway/monitor.rs
+++ b/crates/app/src/gateway/monitor.rs
@@ -159,7 +159,7 @@ impl ProcessMonitor {
             return vec![];
         }
         if let Some(last) = self.last_alert_at {
-            if last.elapsed() < std::time::Duration::from_secs(60) {
+            if last.elapsed() < std::time::Duration::from_mins(1) {
                 return vec![];
             }
         }

--- a/crates/app/src/gateway/supervisor.rs
+++ b/crates/app/src/gateway/supervisor.rs
@@ -189,7 +189,7 @@ impl SupervisorService {
 
             // Reset restart counter if healthy for long enough.
             if let Some(ts) = self.last_healthy {
-                if ts.elapsed() >= Duration::from_secs(60) {
+                if ts.elapsed() >= Duration::from_mins(1) {
                     if self.restart_count > 0 {
                         info!("Agent healthy for 60s — resetting restart counter");
                     }

--- a/crates/app/src/lib.rs
+++ b/crates/app/src/lib.rs
@@ -183,7 +183,7 @@ pub struct GatewayConfig {
 
 mod gateway_defaults {
     use std::time::Duration;
-    pub fn check_interval() -> Duration { Duration::from_secs(300) }
+    pub fn check_interval() -> Duration { Duration::from_mins(5) }
     pub fn health_timeout() -> u64 { 30 }
     pub fn health_poll_interval() -> Duration { Duration::from_secs(2) }
     pub fn max_restart_attempts() -> u32 { 3 }

--- a/crates/app/src/tools/find_files.rs
+++ b/crates/app/src/tools/find_files.rs
@@ -138,7 +138,7 @@ fn find_files_in_process(
         .collect();
 
     // Sort by modification time, newest first.
-    matched.sort_by(|a, b| b.1.cmp(&a.1));
+    matched.sort_by_key(|b| std::cmp::Reverse(b.1));
 
     let total_found = matched.len();
     let truncated = total_found > limit;

--- a/crates/channels/src/telegram/adapter.rs
+++ b/crates/channels/src/telegram/adapter.rs
@@ -275,7 +275,7 @@ const SMALL_GROUP_THRESHOLD: u32 = 3;
 const INITIAL_RETRY_DELAY: std::time::Duration = std::time::Duration::from_secs(2);
 
 /// Maximum retry delay for exponential backoff.
-const MAX_RETRY_DELAY: std::time::Duration = std::time::Duration::from_secs(60);
+const MAX_RETRY_DELAY: std::time::Duration = std::time::Duration::from_mins(1);
 
 /// Minimum time between successive streaming edits, regardless of delta
 /// size. Acts as a coalescing floor so pathological sub-ms bursts (from
@@ -2892,7 +2892,7 @@ async fn dispatch_user_question(
     let text = if question.options.is_some() {
         format!("<b>❓ Agent Question</b>\n\n{body}")
     } else {
-        format!("<b>❓ Agent Question</b>\n\n{body}\n\n<i>Reply to this message to answer.</i>",)
+        format!("<b>❓ Agent Question</b>\n\n{body}\n\n<i>Reply to this message to answer.</i>")
     };
 
     let send_result = if let Some(ref options) = question.options {
@@ -4935,7 +4935,7 @@ fn spawn_stream_forwarder(
         let cid = chat_id;
         let epoch = my_epoch;
         tokio::spawn(async move {
-            tokio::time::sleep(std::time::Duration::from_secs(120)).await;
+            tokio::time::sleep(std::time::Duration::from_mins(2)).await;
             let removed = streams.remove_if(&cid, |_, state| state.epoch == epoch);
             if removed.is_some() {
                 warn!(

--- a/crates/channels/src/telegram/commands/kernel_client.rs
+++ b/crates/channels/src/telegram/commands/kernel_client.rs
@@ -632,7 +632,7 @@ mod tests {
         ) -> Result<Vec<SessionEntry>, SessionError> {
             let mut sessions: Vec<SessionEntry> =
                 self.sessions.iter().map(|entry| entry.clone()).collect();
-            sessions.sort_by(|a, b| b.updated_at.cmp(&a.updated_at));
+            sessions.sort_by_key(|b| std::cmp::Reverse(b.updated_at));
             let start = offset.max(0) as usize;
             let take = limit.max(0) as usize;
             Ok(sessions.into_iter().skip(start).take(take).collect())

--- a/crates/channels/src/wechat/api.rs
+++ b/crates/channels/src/wechat/api.rs
@@ -197,7 +197,7 @@ impl WeixinApiClient {
         self.post_form_with_timeout(
             "ilink/bot/get_qrcode_status",
             &[("qrcode", qrcode_id), ("bot_type", "3")],
-            Duration::from_secs(60),
+            Duration::from_mins(1),
         )
         .await
     }

--- a/crates/channels/src/wechat/login.rs
+++ b/crates/channels/src/wechat/login.rs
@@ -41,7 +41,7 @@ use super::{
 };
 
 /// Maximum time to wait for the user to scan the QR code.
-const LOGIN_TIMEOUT: Duration = Duration::from_secs(300);
+const LOGIN_TIMEOUT: Duration = Duration::from_mins(5);
 
 /// Width/height of the generated QR code PNG in pixels.
 const QR_IMAGE_SIZE: u32 = 512;

--- a/crates/cmd/src/chat/app.rs
+++ b/crates/cmd/src/chat/app.rs
@@ -1696,7 +1696,7 @@ mod tests {
     #[test]
     fn format_tool_duration_seconds() {
         assert_eq!(
-            super::format_tool_duration(std::time::Duration::from_millis(1000)),
+            super::format_tool_duration(std::time::Duration::from_secs(1)),
             "1.0s"
         );
         assert_eq!(

--- a/crates/cmd/src/top/app.rs
+++ b/crates/cmd/src/top/app.rs
@@ -120,23 +120,19 @@ impl App {
                 self.tab = Tab::SessionDetails;
                 self.scroll_offset = 0;
             }
-            KeyCode::Tab => {
-                if self.tab == Tab::SessionDetails {
-                    self.session_state.focus = match self.session_state.focus {
-                        PanelFocus::SessionList => PanelFocus::Gantt,
-                        PanelFocus::Gantt => PanelFocus::SessionTree,
-                        PanelFocus::SessionTree => PanelFocus::SessionList,
-                    };
-                }
+            KeyCode::Tab if self.tab == Tab::SessionDetails => {
+                self.session_state.focus = match self.session_state.focus {
+                    PanelFocus::SessionList => PanelFocus::Gantt,
+                    PanelFocus::Gantt => PanelFocus::SessionTree,
+                    PanelFocus::SessionTree => PanelFocus::SessionList,
+                };
             }
-            KeyCode::BackTab => {
-                if self.tab == Tab::SessionDetails {
-                    self.session_state.focus = match self.session_state.focus {
-                        PanelFocus::SessionList => PanelFocus::SessionTree,
-                        PanelFocus::Gantt => PanelFocus::SessionList,
-                        PanelFocus::SessionTree => PanelFocus::Gantt,
-                    };
-                }
+            KeyCode::BackTab if self.tab == Tab::SessionDetails => {
+                self.session_state.focus = match self.session_state.focus {
+                    PanelFocus::SessionList => PanelFocus::SessionTree,
+                    PanelFocus::Gantt => PanelFocus::SessionList,
+                    PanelFocus::SessionTree => PanelFocus::Gantt,
+                };
             }
             KeyCode::Up | KeyCode::Char('k') => {
                 if self.tab == Tab::SessionDetails {
@@ -155,15 +151,14 @@ impl App {
                     }
                 }
             }
-            KeyCode::Enter => {
+            KeyCode::Enter
                 if self.tab == Tab::SessionDetails
                     && self.session_state.focus == PanelFocus::SessionList
-                    && !self.session_state.sessions.is_empty()
-                {
-                    // Jump focus to Gantt panel on Enter from session list
-                    self.session_state.focus = PanelFocus::Gantt;
-                    self.session_state.gantt_selected = 0;
-                }
+                    && !self.session_state.sessions.is_empty() =>
+            {
+                // Jump focus to Gantt panel on Enter from session list
+                self.session_state.focus = PanelFocus::Gantt;
+                self.session_state.gantt_selected = 0;
             }
             KeyCode::Char('r') | KeyCode::Char('R') => {
                 // refresh is handled externally; this is just a signal

--- a/crates/common/crawl4ai/src/lib.rs
+++ b/crates/common/crawl4ai/src/lib.rs
@@ -73,7 +73,7 @@ impl Crawl4AiClient {
     /// Defaults to `http://localhost:11235` if not specified.
     pub fn new(base_url: &str) -> Self {
         let client = reqwest::Client::builder()
-            .timeout(Duration::from_secs(60))
+            .timeout(Duration::from_mins(1))
             .build()
             .expect("build reqwest client for Crawl4AI");
         Self::with_client(base_url, client)

--- a/crates/drivers/stt/src/process.rs
+++ b/crates/drivers/stt/src/process.rs
@@ -15,7 +15,7 @@ use super::SttConfig;
 
 /// Maximum time to wait for the whisper-server `/health` endpoint to become
 /// reachable after spawning the process.
-const HEALTH_TIMEOUT: Duration = Duration::from_secs(60);
+const HEALTH_TIMEOUT: Duration = Duration::from_mins(1);
 
 /// Interval between consecutive health-check polls during startup.
 const HEALTH_POLL_INTERVAL: Duration = Duration::from_secs(1);

--- a/crates/extensions/backend-admin/src/chat/model_catalog.rs
+++ b/crates/extensions/backend-admin/src/chat/model_catalog.rs
@@ -30,7 +30,7 @@ use tokio::sync::Mutex;
 use tracing::{debug, warn};
 
 /// Cache time-to-live — 5 minutes.
-const CACHE_TTL: Duration = Duration::from_secs(5 * 60);
+const CACHE_TTL: Duration = Duration::from_mins(5);
 
 // ---------------------------------------------------------------------------
 // Public types

--- a/crates/extensions/backend-admin/src/system_routes.rs
+++ b/crates/extensions/backend-admin/src/system_routes.rs
@@ -142,7 +142,7 @@ async fn browse_directory(
         });
     }
 
-    entries.sort_by(|a, b| a.name.to_lowercase().cmp(&b.name.to_lowercase()));
+    entries.sort_by_key(|a| a.name.to_lowercase());
 
     let parent_path = dir.parent().map(|p| p.to_string_lossy().to_string());
 

--- a/crates/integrations/composio/src/lib.rs
+++ b/crates/integrations/composio/src/lib.rs
@@ -33,7 +33,7 @@ pub struct V3;
 
 fn build_http_client() -> Client {
     Client::builder()
-        .timeout(std::time::Duration::from_secs(60))
+        .timeout(std::time::Duration::from_mins(1))
         .connect_timeout(std::time::Duration::from_secs(10))
         .build()
         .unwrap_or_default()

--- a/crates/integrations/mcp/src/manager/managed_client.rs
+++ b/crates/integrations/mcp/src/manager/managed_client.rs
@@ -85,7 +85,7 @@ const DEFAULT_STARTUP_TIMEOUT_SECS: u64 = 30;
 /// Default timeout for individual tool calls (seconds).
 const DEFAULT_TOOL_TIMEOUT_SECS: u64 = 60;
 /// TTL for the per-server tool cache.
-const TOOLS_CACHE_TTL: Duration = Duration::from_secs(300);
+const TOOLS_CACHE_TTL: Duration = Duration::from_mins(5);
 
 // ── AsyncManagedClient ──────────────────────────────────────────────
 

--- a/crates/kernel/src/agent/mod.rs
+++ b/crates/kernel/src/agent/mod.rs
@@ -2985,7 +2985,7 @@ pub(crate) async fn run_agent_loop(
             // 120s hard timeout — treats expiry the same as an explicit Stop.
             let decision = tokio::select! {
                 result = tokio::time::timeout(
-                    std::time::Duration::from_secs(120),
+                    std::time::Duration::from_mins(2),
                     rx,
                 ) => result,
                 _ = turn_cancel.cancelled() => {

--- a/crates/kernel/src/data_feed/webhook.rs
+++ b/crates/kernel/src/data_feed/webhook.rs
@@ -103,7 +103,7 @@ pub struct WebhookState {
 }
 
 /// TTL for idempotency cache entries.
-const IDEMPOTENCY_TTL: Duration = Duration::from_secs(3600);
+const IDEMPOTENCY_TTL: Duration = Duration::from_hours(1);
 
 impl WebhookState {
     /// Create a new webhook state.

--- a/crates/kernel/src/io.rs
+++ b/crates/kernel/src/io.rs
@@ -1563,7 +1563,7 @@ impl IngressRateLimiter {
     /// Returns `Ok(())` if allowed, `Err(IOError::RateLimited)` if exceeded.
     pub fn check_rate(&self, key: &str) -> Result<(), IOError> {
         let now = (self.now_fn)();
-        let window = std::time::Duration::from_secs(60);
+        let window = std::time::Duration::from_mins(1);
 
         let mut entry = self.buckets.entry(key.to_string()).or_default();
         entry.retain(|ts| now.duration_since(*ts) < window);
@@ -1587,7 +1587,7 @@ impl IngressRateLimiter {
     /// to reclaim memory from users who have gone idle.
     pub fn gc(&self) {
         let now = (self.now_fn)();
-        let window = std::time::Duration::from_secs(60);
+        let window = std::time::Duration::from_mins(1);
         self.buckets.retain(|_, v| {
             v.retain(|ts| now.duration_since(*ts) < window);
             !v.is_empty()

--- a/crates/kernel/src/kernel.rs
+++ b/crates/kernel/src/kernel.rs
@@ -122,14 +122,14 @@ pub struct KernelConfig {
     /// Must be greater than any individual tool's own timeout (e.g. bash
     /// defaults to 120 s) so per-tool timeouts fire first and only the
     /// offending tool is killed rather than the entire wave.
-    #[default(_code = "Duration::from_secs(180)")]
+    #[default(_code = "Duration::from_mins(3)")]
     pub tool_execution_timeout:  Duration,
     /// Default per-tool timeout applied when a tool's
     /// `execution_timeout()` returns `None`.
     ///
     /// Must be strictly less than `tool_execution_timeout` so the per-tool
     /// timeout fires before the global wave timeout.
-    #[default(_code = "Duration::from_secs(120)")]
+    #[default(_code = "Duration::from_mins(2)")]
     pub default_tool_timeout:    Duration,
     /// Maximum number of KV entries per agent (0 = unlimited).
     /// Applies to the agent-scoped namespace only.
@@ -263,7 +263,7 @@ impl Kernel {
             config.default_tool_timeout = config
                 .tool_execution_timeout
                 .checked_sub(margin)
-                .unwrap_or(Duration::from_secs(60));
+                .unwrap_or(Duration::from_mins(1));
         }
         info!(
             max_concurrency = config.max_concurrency,
@@ -543,12 +543,12 @@ impl Kernel {
                     .into_iter()
                     .flatten()
                     .min()
-                    .unwrap_or(tokio::time::Instant::now() + std::time::Duration::from_secs(3600));
+                    .unwrap_or(tokio::time::Instant::now() + std::time::Duration::from_hours(1));
 
                 tokio::time::sleep_until(earliest)
             } else {
                 // Non-zero processors never wake for scheduling.
-                tokio::time::sleep(std::time::Duration::from_secs(86400))
+                tokio::time::sleep(std::time::Duration::from_hours(24))
             };
             tokio::pin!(scheduler_sleep);
 

--- a/crates/kernel/src/llm/codex.rs
+++ b/crates/kernel/src/llm/codex.rs
@@ -48,7 +48,7 @@ impl CodexDriver {
     /// `chatgpt-account-id` (set up by `CodexCredentialResolver`).
     pub fn new(resolver: LlmCredentialResolverRef) -> Self {
         let inner =
-            OpenAiDriver::with_credential_resolver(resolver, std::time::Duration::from_secs(120))
+            OpenAiDriver::with_credential_resolver(resolver, std::time::Duration::from_mins(2))
                 .with_api_format(ApiFormat::Responses)
                 .with_base_url_override(CODEX_BASE_URL)
                 .with_request_path_override("/codex/responses");

--- a/crates/kernel/src/llm/kimi.rs
+++ b/crates/kernel/src/llm/kimi.rs
@@ -38,7 +38,7 @@ impl KimiCodeDriver {
     /// Create a new Kimi Code driver with a credential resolver.
     pub fn new(resolver: LlmCredentialResolverRef) -> Self {
         let inner =
-            OpenAiDriver::with_credential_resolver(resolver, std::time::Duration::from_secs(120));
+            OpenAiDriver::with_credential_resolver(resolver, std::time::Duration::from_mins(2));
         Self { inner }
     }
 }

--- a/crates/kernel/src/llm/openai.rs
+++ b/crates/kernel/src/llm/openai.rs
@@ -142,7 +142,7 @@ const RATE_LIMIT_MAX_RETRIES: u32 = 2;
 /// Initial backoff delay for rate-limited retries.
 const RATE_LIMIT_INITIAL_DELAY: Duration = Duration::from_secs(5);
 /// Maximum backoff delay for rate-limited retries.
-const RATE_LIMIT_MAX_DELAY: Duration = Duration::from_secs(60);
+const RATE_LIMIT_MAX_DELAY: Duration = Duration::from_mins(1);
 
 impl OpenAiDriver {
     /// Default SSE idle timeout (90 s). If no SSE event arrives within this
@@ -163,7 +163,7 @@ impl OpenAiDriver {
     fn build_http_client(no_proxy: bool) -> reqwest::Client {
         let mut builder = reqwest::Client::builder()
             .connect_timeout(Duration::from_secs(10))
-            .timeout(Duration::from_secs(300));
+            .timeout(Duration::from_mins(5));
         if no_proxy {
             builder = builder.no_proxy();
         }

--- a/crates/kernel/src/plan.rs
+++ b/crates/kernel/src/plan.rs
@@ -496,7 +496,7 @@ pub(crate) async fn run_plan_loop(
 
             let decision = tokio::select! {
                 result = tokio::time::timeout(
-                    std::time::Duration::from_secs(120),
+                    std::time::Duration::from_mins(2),
                     rx,
                 ) => result,
                 _ = turn_cancel.cancelled() => {

--- a/crates/kernel/src/session/mod.rs
+++ b/crates/kernel/src/session/mod.rs
@@ -685,7 +685,7 @@ impl SessionTable {
     /// `IdleCheck` evicts them from the table. Chosen to give the kernel UI
     /// enough time to surface recently-finished runs in the Dormant group
     /// while still bounding memory growth for long-running processes.
-    pub const TERMINAL_TTL: std::time::Duration = std::time::Duration::from_secs(300);
+    pub const TERMINAL_TTL: std::time::Duration = std::time::Duration::from_mins(5);
 
     /// Create an empty process table.
     pub fn new() -> Self {

--- a/crates/kernel/src/session/test_utils.rs
+++ b/crates/kernel/src/session/test_utils.rs
@@ -59,7 +59,7 @@ impl SessionIndex for InMemorySessionIndex {
     ) -> Result<Vec<SessionEntry>, SessionError> {
         let mut entries: Vec<SessionEntry> =
             self.sessions.iter().map(|entry| entry.clone()).collect();
-        entries.sort_by(|a, b| b.updated_at.cmp(&a.updated_at));
+        entries.sort_by_key(|b| std::cmp::Reverse(b.updated_at));
         let start = offset.max(0) as usize;
         let take = limit.max(0) as usize;
         Ok(entries.into_iter().skip(start).take(take).collect())

--- a/crates/kernel/tests/anchor_checkout_e2e.rs
+++ b/crates/kernel/tests/anchor_checkout_e2e.rs
@@ -49,7 +49,7 @@ impl SessionIndex for TestSessionIndex {
     ) -> Result<Vec<SessionEntry>, SessionError> {
         let mut entries: Vec<SessionEntry> =
             self.sessions.iter().map(|r| r.value().clone()).collect();
-        entries.sort_by(|a, b| b.updated_at.cmp(&a.updated_at));
+        entries.sort_by_key(|b| std::cmp::Reverse(b.updated_at));
         entries.truncate(limit as usize);
         Ok(entries)
     }

--- a/crates/rara-dock/src/store.rs
+++ b/crates/rara-dock/src/store.rs
@@ -70,7 +70,7 @@ impl DockSessionStore {
         }
 
         // Sort by updated_at descending so the most recent session comes first.
-        docs.sort_by(|a, b| b.session.updated_at.cmp(&a.session.updated_at));
+        docs.sort_by_key(|b| std::cmp::Reverse(b.session.updated_at));
         Ok(docs)
     }
 

--- a/crates/sessions/src/file_index.rs
+++ b/crates/sessions/src/file_index.rs
@@ -160,7 +160,7 @@ impl SessionIndex for FileSessionIndex {
         }
 
         // Sort by updated_at descending.
-        entries.sort_by(|a, b| b.updated_at.cmp(&a.updated_at));
+        entries.sort_by_key(|b| std::cmp::Reverse(b.updated_at));
 
         // Apply offset and limit.
         let offset = offset.max(0) as usize;


### PR DESCRIPTION
## Summary

Fix 40 clippy warnings that block CI under `-D warnings` on rust 1.95.0. All changes are mechanical, applied per clippy's own suggestions — no behavior changes.

- 29x `duration_suboptimal_units`: `Duration::from_secs(60)` -> `from_mins(1)`, `from_secs(3600)` -> `from_hours(1)`, `from_millis(1000)` -> `from_secs(1)`, etc.
- 7x `unnecessary_sort_by`: `sort_by(|a, b| b.x.cmp(&a.x))` -> `sort_by_key(|b| std::cmp::Reverse(b.x))`.
- 3x collapsible `if` inside `match` in `crates/cmd/src/top/app.rs`: merge the guard into an `if` match-arm guard.
- 1x unnecessary trailing comma in `crates/channels/src/telegram/adapter.rs`.

## Type of change

| Type | Label |
|------|-------|
| Bug fix | `bug` |

## Component

`ci`

## Closes

Closes #1667

## Test plan

- [x] `cargo clippy --workspace --all-targets --no-deps -- -D warnings` passes
- [x] `cargo check --workspace --all-targets` passes
- [x] `cargo test --workspace --lib` passes
- [x] `prek run --all-files` passes