### PR TITLE
refactor(kernel): agent fallback chain (#1670)

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -70,12 +70,19 @@ knowledge:
   similarity_threshold: 0.85
 
 # ---------------------------------------------------------------------------
-# Per-agent `{driver, model}` bindings (unified registry — #1635/#1636/#1637)
+# Per-agent `{driver, model}` bindings (unified registry — #1635/#1636/#1637,
+# relaxed in #1670)
 # ---------------------------------------------------------------------------
 #
-# Every background agent that calls the LLM is resolved via
-# `DriverRegistry::resolve_agent` keyed by its manifest name. The entries
-# below are REQUIRED — missing entries fail boot with an actionable error.
+# The entire `agents:` section is OPTIONAL. Resolution order per agent:
+#   1. settings DB override (runtime mutation via `agents.<name>.{driver,model}`)
+#   2. YAML `agents.<name>.{driver, model}` (this block)
+#   3. `llm.default_provider` + that provider's `default_model` (fallback)
+#
+# Omit the block entirely and every background agent — `knowledge_extractor`,
+# `title_gen`, etc. — inherits the default provider's default model, just like
+# the main user-facing agent. Add an entry here only when you want to pin a
+# specific agent to a different provider or model.
 #
 # Optional `max_output_chars` caps a headless agent's free-form output
 # without a rebuild (currently consumed by `title_gen`).

--- a/crates/app/src/boot.rs
+++ b/crates/app/src/boot.rs
@@ -461,14 +461,18 @@ async fn build_driver_registry(
 
     // -- unified per-agent configs (agents.<name>.{driver, model}) --------------
     //
-    // Introduced in #1636, extended by #1637. The `agents.*` namespace is the
-    // post-refactor binding consumed by `DriverRegistry::resolve_agent`. Unlike
-    // the legacy `llm.agent_overrides.*` keys, these live alongside other
-    // per-agent knobs (e.g. `agents.title_gen.max_output_chars`) and form the
-    // single `{driver, model, manifest}` snapshot used at call sites.
+    // Introduced in #1636, extended by #1637, relaxed in #1670. The `agents.*`
+    // namespace is the post-refactor binding consumed by
+    // `DriverRegistry::resolve_agent`. Unlike the legacy `llm.agent_overrides.*`
+    // keys, these live alongside other per-agent knobs (e.g.
+    // `agents.title_gen.max_output_chars`) and form the single
+    // `{driver, model, manifest}` snapshot used at call sites.
     //
-    // Boot fails fast for the knowledge extractor if its driver/model are
-    // missing — the prod failure in #1629 showed we cannot silently fall back.
+    // Entries here may come from YAML *or* from runtime mutations to the
+    // settings KV store. When an agent has no entry at all,
+    // `resolve_agent` falls through to the manifest and finally the default
+    // provider's default model — the same resolution path used by the main
+    // user-facing agent.
     let unified_agent_names: BTreeSet<&str> = all_settings
         .keys()
         .filter_map(|k| k.strip_prefix("agents."))
@@ -494,13 +498,28 @@ async fn build_driver_registry(
         }
     }
 
-    // Fail boot when any required background agent is missing an explicit
-    // `{driver, model}` pair. Silent fallbacks are forbidden by the project's
-    // "no config defaults in Rust" rule — and the prod failure in #1629 / #1636
-    // showed that a mismatched default silently breaks the knowledge
-    // extraction pipeline.
-    ensure_required_agent_configs(&all_settings, REQUIRED_BACKGROUND_AGENTS)
-        .map_err(|e| anyhow::anyhow!("{e}"))?;
+    // Surface which background agents are about to inherit the default
+    // `{provider, model}` pair so operators can audit resolution decisions
+    // without enabling debug logging. Missing entries are no longer a boot
+    // failure (see #1670) — the main agent already inherits via the same
+    // fallback chain and users may legitimately want the heavy reasoning
+    // model for extraction/titles.
+    for &agent in BACKGROUND_AGENTS_WITH_FALLBACK {
+        let has_driver = all_settings
+            .get(&format!("agents.{agent}.driver"))
+            .is_some_and(|v| !v.trim().is_empty());
+        let has_model = all_settings
+            .get(&format!("agents.{agent}.model"))
+            .is_some_and(|v| !v.trim().is_empty());
+        if !has_driver && !has_model {
+            info!(
+                agent,
+                provider = %default_provider,
+                model = %default_model,
+                "agent inherits default LLM binding (no agents.{agent}.{{driver,model}} configured)"
+            );
+        }
+    }
 
     // -- codex (ChatGPT backend via OAuth) — uses Responses API ----------------
 
@@ -928,131 +947,34 @@ async fn init_knowledge_service(
 }
 
 // =========================================================================
-// Background agent config validation (#1638)
+// Background agent fallback audit (#1670)
 // =========================================================================
 
-/// Background agents whose `{driver, model}` pair MUST be present in
-/// `agents.<name>` for the kernel to boot. Missing entries fail boot with
-/// an actionable error instead of falling back to a hardcoded default
-/// (see `docs/guides/anti-patterns.md` — "no config defaults in Rust").
+/// Background agents that inherit `llm.default_provider` + its default
+/// model when their `agents.<name>.{driver, model}` pair is omitted.
 ///
+/// Boot emits a single info-level line per agent on the fallback path so
+/// operators can audit resolution decisions without enabling debug logs.
 /// The list mirrors what `kernel.rs` resolves via `resolve_agent` for
 /// headless background work:
 /// - `knowledge_extractor` — memory extraction pipeline (#1636)
 /// - `title_gen` — session title auto-generation (#1637)
-const REQUIRED_BACKGROUND_AGENTS: &[&str] = &["knowledge_extractor", "title_gen"];
-
-/// Verify every agent in `required` has a non-empty `driver` and `model`
-/// in the flattened settings map. Returns a single error message naming
-/// every unconfigured agent so operators see the full picture at once.
-fn ensure_required_agent_configs(
-    settings: &HashMap<String, String>,
-    required: &[&str],
-) -> Result<(), String> {
-    let missing: Vec<String> = required
-        .iter()
-        .filter(|name| {
-            let driver = settings
-                .get(&format!("agents.{name}.driver"))
-                .filter(|v| !v.trim().is_empty());
-            let model = settings
-                .get(&format!("agents.{name}.model"))
-                .filter(|v| !v.trim().is_empty());
-            driver.is_none() || model.is_none()
-        })
-        .map(|name| (*name).to_string())
-        .collect();
-
-    if missing.is_empty() {
-        return Ok(());
-    }
-
-    let example: String = missing
-        .iter()
-        .map(|n| format!("  {n}:\n    driver: \"openai\"\n    model: \"gpt-4o-mini\""))
-        .collect::<Vec<_>>()
-        .join("\n");
-    Err(format!(
-        "missing required agent config: {names} — every background agent needs an explicit \
-         `{{driver, model}}` pair in config.yaml. See config.example.yaml for the full shape. \
-         Add:\n\nagents:\n{example}\n",
-        names = missing.join(", "),
-    ))
-}
+///
+/// Missing entries are no longer a boot failure (#1670 reverted the
+/// #1638 hard-fail): the main user-facing agent already inherits via the
+/// same fallback chain, and users may legitimately want the heavy
+/// reasoning model for extraction/titles.
+const BACKGROUND_AGENTS_WITH_FALLBACK: &[&str] = &["knowledge_extractor", "title_gen"];
 
 #[cfg(test)]
-mod boot_validation_tests {
+mod boot_fallback_tests {
     use super::*;
 
-    fn full_agent_settings() -> HashMap<String, String> {
-        let mut m = HashMap::new();
-        m.insert(
-            "agents.knowledge_extractor.driver".into(),
-            "openrouter".into(),
-        );
-        m.insert(
-            "agents.knowledge_extractor.model".into(),
-            "gpt-4o-mini".into(),
-        );
-        m.insert("agents.title_gen.driver".into(), "openai".into());
-        m.insert("agents.title_gen.model".into(), "gpt-4o-mini".into());
-        m
-    }
-
     #[test]
-    fn ok_when_all_required_agents_configured() {
-        let settings = full_agent_settings();
-        ensure_required_agent_configs(&settings, REQUIRED_BACKGROUND_AGENTS).expect("boot ok");
-    }
-
-    #[test]
-    fn fails_when_knowledge_extractor_missing() {
-        let mut settings = full_agent_settings();
-        settings.remove("agents.knowledge_extractor.driver");
-        settings.remove("agents.knowledge_extractor.model");
-        let err = ensure_required_agent_configs(&settings, REQUIRED_BACKGROUND_AGENTS)
-            .expect_err("must fail");
-        assert!(
-            err.contains("knowledge_extractor"),
-            "err should name the missing agent: {err}"
-        );
-    }
-
-    #[test]
-    fn fails_when_title_gen_missing() {
-        let mut settings = full_agent_settings();
-        settings.remove("agents.title_gen.driver");
-        settings.remove("agents.title_gen.model");
-        let err = ensure_required_agent_configs(&settings, REQUIRED_BACKGROUND_AGENTS)
-            .expect_err("must fail");
-        assert!(
-            err.contains("title_gen"),
-            "err should name the missing agent: {err}"
-        );
-    }
-
-    #[test]
-    fn fails_when_driver_present_but_model_empty() {
-        let mut settings = full_agent_settings();
-        settings.insert("agents.title_gen.model".into(), "   ".into());
-        let err = ensure_required_agent_configs(&settings, REQUIRED_BACKGROUND_AGENTS)
-            .expect_err("must fail — empty model is same as missing");
-        assert!(err.contains("title_gen"));
-    }
-
-    /// Regression: the legacy `memory.knowledge.extractor_model` key must
-    /// not paper over a missing `agents.knowledge_extractor.model`. The
-    /// validator only looks at the unified `agents.*` namespace.
-    #[test]
-    fn legacy_extractor_model_key_does_not_satisfy_agents_requirement() {
-        let mut settings = full_agent_settings();
-        settings.remove("agents.knowledge_extractor.model");
-        settings.insert(
-            "memory.knowledge.extractor_model".into(),
-            "legacy-model".into(),
-        );
-        let err = ensure_required_agent_configs(&settings, REQUIRED_BACKGROUND_AGENTS)
-            .expect_err("legacy key must not satisfy the unified shape");
-        assert!(err.contains("knowledge_extractor"));
+    fn fallback_list_includes_known_background_agents() {
+        // Sanity check — the audit log depends on this list staying in sync
+        // with what `kernel.rs` actually resolves via `resolve_agent`.
+        assert!(BACKGROUND_AGENTS_WITH_FALLBACK.contains(&"knowledge_extractor"));
+        assert!(BACKGROUND_AGENTS_WITH_FALLBACK.contains(&"title_gen"));
     }
 }

--- a/crates/domain/shared/src/settings/mod.rs
+++ b/crates/domain/shared/src/settings/mod.rs
@@ -53,6 +53,24 @@ pub mod keys {
     pub const KNOWLEDGE_EMBEDDING_DIMENSIONS: &str = "memory.knowledge.embedding_dimensions";
     pub const KNOWLEDGE_SEARCH_TOP_K: &str = "memory.knowledge.search_top_k";
     pub const KNOWLEDGE_SIMILARITY_THRESHOLD: &str = "memory.knowledge.similarity_threshold";
+
+    /// Prefix for the unified per-agent LLM binding — `{prefix}.<agent>.driver`
+    /// selects the provider and `{prefix}.<agent>.model` the exact model.
+    ///
+    /// These keys are optional. When unset, `DriverRegistry::resolve_agent`
+    /// falls through to `agents.<name>` YAML, the manifest, and finally the
+    /// default provider's default model. Operators can mutate them at runtime
+    /// via the settings KV store and the change propagates through the
+    /// `settings.subscribe()` reload path — no restart needed.
+    pub const AGENTS_PREFIX: &str = "agents";
+
+    /// Settings key for the driver override of a named agent. See
+    /// [`AGENTS_PREFIX`] for the fallback contract.
+    pub fn agent_driver_key(agent: &str) -> String { format!("{AGENTS_PREFIX}.{agent}.driver") }
+
+    /// Settings key for the model override of a named agent. See
+    /// [`AGENTS_PREFIX`] for the fallback contract.
+    pub fn agent_model_key(agent: &str) -> String { format!("{AGENTS_PREFIX}.{agent}.model") }
 }
 
 /// Unified trait for reading and writing flat KV settings.

--- a/crates/kernel/AGENT.md
+++ b/crates/kernel/AGENT.md
@@ -4,24 +4,38 @@
 
 The unified entry point for resolving an agent's LLM binding is
 [`DriverRegistry::resolve_agent`] in `crates/kernel/src/llm/registry.rs`.
-It returns a [`ResolvedAgent { driver, model, manifest }`] triple read from
-`agents.<name>.{driver, model}` in YAML, with fallback to the manifest's
-`provider_hint`/`model` and finally the provider default. New consumers
-MUST go through `resolve_agent` so the driver and the model come from a
-single consistent source — the split-config bug that motivated #1635
-(driver resolved via the registry, model resolved via a flat settings key
-like `memory.knowledge.extractor_model`) should not reappear. That legacy
-flat key was removed in #1638; no fallback remains in Rust, missing
-`agents.<name>.{driver, model}` fails boot. The legacy
-`DriverRegistry::resolve` tuple API is kept as a thin shim for existing
-callers; migration is tracked in follow-up issues under Epic #1631.
+It returns a [`ResolvedAgent { driver, model, manifest }`] triple. New
+consumers MUST go through `resolve_agent` so the driver and the model
+come from a single consistent source — the split-config bug that
+motivated #1635 (driver resolved via the registry, model resolved via a
+flat settings key like `memory.knowledge.extractor_model`) should not
+reappear. The legacy `DriverRegistry::resolve` tuple API is kept as a
+thin shim for existing callers; migration is tracked in follow-up issues
+under Epic #1631.
+
+Resolution order, per agent (revised in #1670):
+
+1. `settings` DB entry `agents.<name>.{driver, model}` — runtime override,
+   picked up on the next call without restart (the settings store notifies
+   the registry reload path in `crates/app/src/boot.rs`).
+2. YAML `agents.<name>.{driver, model}`.
+3. Manifest `provider_hint` / `model`.
+4. `llm.default_provider` + that provider's `default_model`.
+
+Missing entries are NOT a boot error: the #1638 hard-fail for
+`knowledge_extractor` / `title_gen` was reverted in #1670 — background
+agents inherit the default provider's default model the same way the
+main user-facing agent does. Boot logs one info line per agent on the
+fallback path so operators can audit the inheritance without enabling
+debug logging.
 
 ### Migrated consumers
 
 - `memory/knowledge/extractor.rs` — #1636 / #1629. Reads
-  `agents.knowledge_extractor.{driver, model}`. Boot fails fast if the
-  pair is missing. `extract_knowledge` now takes a `&ResolvedAgent` so
-  driver + model can never disagree. Example config:
+  `agents.knowledge_extractor.{driver, model}`, falling back to the
+  default provider's default model when unset (#1670).
+  `extract_knowledge` takes a `&ResolvedAgent` so driver + model can
+  never disagree. Example config:
 
   ```yaml
   agents:

--- a/crates/kernel/src/llm/registry.rs
+++ b/crates/kernel/src/llm/registry.rs
@@ -424,6 +424,66 @@ mod tests {
         }
     }
 
+    /// #1670: when no YAML entry and no settings override exist for an
+    /// agent, `resolve_agent` must fall through to the default provider's
+    /// default model — the same inheritance chain the main agent uses.
+    #[test]
+    fn resolve_agent_inherits_default_when_no_entry() {
+        let reg = registry_with_providers();
+
+        // `blank` has no agent_config, no agent_override, no manifest model
+        // and no manifest provider_hint. The resolver must pick the default
+        // driver ("openrouter") and its default model ("gpt-4o").
+        let m = manifest("blank");
+        let resolved = reg.resolve_agent(&m).expect("resolve_agent");
+        assert_eq!(resolved.model, "gpt-4o");
+    }
+
+    /// #1670: runtime settings override wins over YAML — i.e. mutating the
+    /// `agent_config` entry between `resolve_agent` calls takes effect on
+    /// the next call without re-constructing the registry.
+    #[test]
+    fn resolve_agent_runtime_override_takes_precedence() {
+        let reg = registry_with_providers();
+
+        // Baseline: fallback to provider default.
+        let m = manifest("knowledge_extractor");
+        assert_eq!(
+            reg.resolve_agent(&m).expect("baseline").model,
+            "gpt-4o",
+            "without any override, inherit provider default"
+        );
+
+        // Simulate a YAML entry being synced into the registry.
+        reg.set_agent_config(
+            "knowledge_extractor",
+            AgentLlmConfig {
+                driver: Some("ollama".into()),
+                model:  Some("qwen3:32b".into()),
+            },
+        );
+        assert_eq!(
+            reg.resolve_agent(&m).expect("yaml").model,
+            "qwen3:32b",
+            "YAML entry wins over provider default"
+        );
+
+        // Simulate a runtime mutation (settings.db write hot-reloaded into
+        // the registry) replacing the YAML entry with a new pair.
+        reg.set_agent_config(
+            "knowledge_extractor",
+            AgentLlmConfig {
+                driver: Some("openrouter".into()),
+                model:  Some("gpt-4o-mini".into()),
+            },
+        );
+        let resolved = reg.resolve_agent(&m).expect("runtime override");
+        assert_eq!(
+            resolved.model, "gpt-4o-mini",
+            "runtime mutation picked up on next resolve_agent call"
+        );
+    }
+
     #[test]
     fn legacy_resolve_shim_still_works() {
         let reg = registry_with_providers();


### PR DESCRIPTION
## Summary

Revert the #1638 boot-fail for `knowledge_extractor` and `title_gen`. Background agents now inherit `llm.default_provider` + its `default_model` when their `agents.<name>.{driver, model}` pair is omitted — matching the resolution chain the main user-facing agent already uses.

Resolution order for any agent:

1. settings DB override (`agents.<name>.driver` / `.model`)
2. YAML `agents.<name>.{driver, model}`
3. manifest `provider_hint` / `model`
4. `llm.default_provider` + that provider's `default_model`

Booting with no `agents:` YAML section now succeeds.

## Type of change

| Type | Label |
|------|-------|
| Refactor | `refactor` |

## Component

`core`

## Closes

Closes #1670

## Test plan

- [x] `cargo test -p rara-kernel -p rara-app --lib` passes (581 tests)
- [x] `prek run --all-files` passes
- [x] New unit tests cover default-fallback and runtime-override paths
- [x] Verified: boot with no `agents:` section succeeds (resolve_agent falls through to `llm.default_provider.default_model`)