### PR TITLE
fix(web): only show trace buttons on final assistant of turn (#1672)

### DIFF
--- a/web/src/pages/AGENT.md
+++ b/web/src/pages/AGENT.md
@@ -1,0 +1,83 @@
+# web/src/pages — Agent Guidelines
+
+## Purpose
+
+React page-level components that mount pi-web-ui's Lit web components
+(`pi-chat-panel`, etc.) and bridge them to rara's storage and streaming layers.
+
+## Architecture
+
+- `PiChat.tsx` — primary chat page; mounts `<pi-chat-panel>`, registers a custom
+  message renderer that adds the trace button when an assistant message is
+  flagged as the final one of its turn.
+- `pi-chat-messages.ts` — pure conversion from rara's `ChatMessageData` shape
+  (see `@/api/types`) into pi-agent-core `Message` objects. Owns
+  `assistantSeqByRef` (a `WeakMap<AssistantMessage, number>`) and the
+  `finalAssistantIndices` helper that computes which assistant per turn is the
+  "final" one.
+- `pi-chat-messages.test.ts` — unit tests for the conversion + final-assistant
+  gating logic.
+- Other pages (`Agents.tsx`, `Skills.tsx`, `McpServers.tsx`, etc.) follow the
+  same Lit-component-bridge pattern at smaller scale.
+
+Data flow for trace buttons:
+
+```
+ChatMessageData[]                     (server)
+      │
+      ▼
+toAgentMessages()                     (writes assistantSeqByRef)
+      │
+      ▼
+AssistantMessage[]  ──────────────►   pi-web-ui renderer
+      │                                       │
+      └── same WeakMap import ────────────────┘
+                                              │
+                                              ▼
+                                  seq !== undefined ⇒ show trace button
+```
+
+## Critical Invariants
+
+- **WeakMap singleton via ES module identity.** `assistantSeqByRef` lives in
+  `pi-chat-messages.ts`, is written by `toAgentMessages`, and is read by the
+  renderer registered in `PiChat.tsx`. Both sides MUST import from the same
+  module path so ES module semantics give them the same `WeakMap` instance. If
+  a future contributor copies the `WeakMap` declaration into another module
+  (or shadows the import), the renderer will look up keys in a different map
+  and silently never show trace buttons.
+
+- **Final-assistant gating only (#1672).** `assistantSeqByRef` registration
+  happens ONLY for the final assistant of each turn. The renderer derives
+  `showButtons = seq !== undefined`. Do NOT add a second registration site
+  without updating the gating logic — every registered ref becomes a visible
+  trace button.
+
+- **Object-identity preservation in `toAgentMessages`.** The function must
+  preserve the object identity of the `AssistantMessage` references it pushes
+  into `result` and registers in the WeakMap. pi-web-ui's renderer receives
+  the same references and looks them up by identity; cloning before
+  registration silently breaks the lookup.
+
+## What NOT To Do
+
+- Do NOT inline a copy of `assistantSeqByRef` in another module — breaks
+  WeakMap identity, silently disables trace buttons.
+- Do NOT register intermediate (tool-call-only) assistant messages in
+  `assistantSeqByRef` — defeats #1672. If you need per-iteration trace access,
+  add a different mechanism (e.g. a separate keyed map), do not expand the
+  buttons gate.
+- Do NOT clone or spread (`{ ...msg }`) the `AssistantMessage` between
+  registration and the renderer — WeakMap keys are by identity, not by value.
+- Do NOT move the `assistantSeqByRef` declaration to a barrel/re-export file
+  without keeping the canonical instance in `pi-chat-messages.ts`; re-exports
+  are fine, redeclarations are not.
+
+## Dependencies
+
+- `@/api/types` — rara backend message shape (`ChatMessageData`,
+  `ChatToolCallData`).
+- `@mariozechner/pi-ai`, `@mariozechner/pi-agent-core` — message types
+  (`AssistantMessage`, `Message`) consumed by pi-web-ui.
+- `@mariozechner/pi-web-ui` — Lit components (`pi-chat-panel`, etc.) that
+  render the converted messages and call back into the registered renderer.

--- a/web/src/pages/PiChat.tsx
+++ b/web/src/pages/PiChat.tsx
@@ -15,15 +15,6 @@
  */
 
 import { Agent } from '@mariozechner/pi-agent-core';
-import type { AgentMessage } from '@mariozechner/pi-agent-core';
-import type {
-  UserMessage,
-  AssistantMessage,
-  TextContent,
-  ThinkingContent,
-  ToolCall,
-  ToolResultMessage,
-} from '@mariozechner/pi-ai';
 import {
   AppStorage,
   setAppStorage,
@@ -39,8 +30,6 @@ import {
   // `registerToolRenderer("extract_document", ...)` side effect so
   // pi-mono can render server-triggered document-extraction tool calls.
   extractDocumentTool,
-  type Attachment,
-  type UserMessageWithAttachments,
 } from '@mariozechner/pi-web-ui';
 import { html } from 'lit';
 import { useEffect, useRef, useCallback, useState } from 'react';
@@ -49,6 +38,8 @@ import { useEffect, useRef, useCallback, useState } from 'react';
 // `registerToolRenderer` side effect) in the bundle. The actual tool
 // object is executed server-side; the renderer is what matters here.
 void extractDocumentTool;
+
+import { assistantSeqByRef, toAgentMessages } from './pi-chat-messages';
 
 import { RaraStorageBackend } from '@/adapters/rara-storage';
 import { createRaraStreamFn } from '@/adapters/rara-stream';
@@ -152,217 +143,6 @@ function asThinkingLevel(level: string | undefined): ThinkingLevel | null {
     default:
       return null;
   }
-}
-
-/**
- * Detect whether a tool-result payload represents a failure. Mirrors the
- * backend's `is_failure_result` in `crates/app/src/tools/artifacts.rs`: a
- * bare string starting with `Error:` (pi-mono convention) or a JSON object
- * with an `error` key (kernel-serialized anyhow error).
- */
-function isToolFailure(text: string): boolean {
-  const trimmed = text.trimStart();
-  if (trimmed.startsWith('Error:')) return true;
-  try {
-    const parsed = JSON.parse(trimmed);
-    return (
-      typeof parsed === 'object' && parsed !== null && !Array.isArray(parsed) && 'error' in parsed
-    );
-  } catch {
-    return false;
-  }
-}
-
-function mimeToFilename(mimeType: string, index: number): string {
-  const ext = mimeType.split('/')[1] || 'bin';
-  return `session-image-${index + 1}.${ext}`;
-}
-
-/** Zeroed usage — rara tracks usage server-side. */
-const EMPTY_USAGE = {
-  input: 0,
-  output: 0,
-  cacheRead: 0,
-  cacheWrite: 0,
-  totalTokens: 0,
-  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-};
-
-/**
- * Parse assistant text into ThinkingContent + TextContent blocks.
- * `<think>reasoning</think>answer` → [{type:"thinking",...}, {type:"text",...}]
- */
-function parseAssistantContent(raw: string): (TextContent | ThinkingContent)[] {
-  const blocks: (TextContent | ThinkingContent)[] = [];
-  const re = /<think>([\s\S]*?)<\/think>/g;
-  let cursor = 0;
-  let match: RegExpExecArray | null;
-
-  while ((match = re.exec(raw)) !== null) {
-    // Text before this <think> block
-    const before = raw.slice(cursor, match.index).trim();
-    if (before) blocks.push({ type: 'text', text: before });
-    // Thinking content
-    const thinking = (match[1] ?? '').trim();
-    if (thinking) blocks.push({ type: 'thinking', thinking });
-    cursor = match.index + match[0].length;
-  }
-
-  // Remaining text after the last </think>
-  const tail = raw.slice(cursor).trim();
-  if (tail) blocks.push({ type: 'text', text: tail });
-
-  return blocks;
-}
-
-/**
- * WeakMap from assistant `AgentMessage` object references to their
- * persisted `seq`. Populated by {@link toAgentMessages} and read by the
- * Lit assistant-message renderer when the user clicks the "📊 详情"
- * button — the seq is then embedded on the dispatched CustomEvent so
- * the React layer can call the trace endpoint directly without any
- * timestamp-based lookup (which collided at second resolution).
- *
- * Keyed by object identity: the same references flow from
- * `toAgentMessages` → `agent.replaceMessages(...)` → pi-web-ui's
- * renderer, so the renderer sees the exact keys set here.
- */
-const assistantSeqByRef = new WeakMap<AgentMessage, number>();
-
-/**
- * Convert rara ChatMessageData to pi-agent-core AgentMessage for display.
- *
- * Assistant messages are registered in {@link assistantSeqByRef} keyed by
- * object identity so the Lit renderer can resolve each rendered message
- * back to its persisted `seq` without a lossy timestamp lookup.
- */
-function toAgentMessages(msgs: ChatMessageData[]): AgentMessage[] {
-  const result: AgentMessage[] = [];
-  // Track the last assistant message so "tool" role messages can attach ToolCall items.
-  let lastAssistant: AssistantMessage | null = null;
-
-  for (const m of msgs) {
-    const ts = new Date(m.created_at).getTime();
-
-    if (m.role === 'user') {
-      lastAssistant = null;
-      if (typeof m.content === 'string') {
-        result.push({ role: 'user', content: m.content, timestamp: ts } as UserMessage);
-      } else {
-        const text = m.content
-          .filter((b): b is { type: 'text'; text: string } => b.type === 'text')
-          .map((b) => b.text)
-          .join('\n');
-        const attachments: Attachment[] = m.content.flatMap((b, index): Attachment[] => {
-          if (b.type !== 'image_base64') return [];
-          return [
-            {
-              id: `${m.seq}-image-${index}`,
-              type: 'image',
-              fileName: mimeToFilename(b.media_type, index),
-              mimeType: b.media_type,
-              size: Math.floor((b.data.length * 3) / 4),
-              content: b.data,
-              preview: b.data,
-            },
-          ];
-        });
-
-        if (attachments.length > 0) {
-          result.push({
-            role: 'user-with-attachments',
-            content: text,
-            attachments,
-            timestamp: ts,
-          } as UserMessageWithAttachments as AgentMessage);
-        } else {
-          result.push({ role: 'user', content: text, timestamp: ts } as UserMessage);
-        }
-      }
-    } else if (m.role === 'assistant') {
-      const raw =
-        typeof m.content === 'string'
-          ? m.content
-          : m.content
-              .filter((b): b is { type: 'text'; text: string } => b.type === 'text')
-              .map((b) => b.text)
-              .join('\n');
-      const content: (TextContent | ThinkingContent | ToolCall)[] = parseAssistantContent(raw);
-      // Surface persisted tool-call requests so pi-web-ui reducers (and the
-      // artifacts panel's reconstructFromMessages) can see them.
-      if (m.tool_calls && m.tool_calls.length > 0) {
-        for (const tc of m.tool_calls) {
-          const args =
-            tc.arguments && typeof tc.arguments === 'object'
-              ? (tc.arguments as Record<string, unknown>)
-              : {};
-          content.push({
-            type: 'toolCall',
-            id: tc.id,
-            name: tc.name,
-            arguments: args,
-          });
-        }
-      }
-      const assistant: AssistantMessage = {
-        role: 'assistant',
-        content,
-        api: 'messages',
-        provider: 'anthropic',
-        model: 'unknown',
-        usage: EMPTY_USAGE,
-        stopReason: 'stop',
-        timestamp: ts,
-      };
-      lastAssistant = assistant;
-      assistantSeqByRef.set(assistant, m.seq);
-      result.push(assistant);
-    } else if (m.role === 'tool') {
-      // Tool call from the assistant — attach as ToolCall to the last AssistantMessage.
-      if (lastAssistant && m.tool_call_id && m.tool_name) {
-        let args: Record<string, unknown> = {};
-        try {
-          const raw = typeof m.content === 'string' ? m.content : JSON.stringify(m.content);
-          args = JSON.parse(raw);
-        } catch {
-          /* use empty args */
-        }
-        const toolCall: ToolCall = {
-          type: 'toolCall',
-          id: m.tool_call_id,
-          name: m.tool_name,
-          arguments: args,
-        };
-        lastAssistant.content.push(toolCall);
-      }
-    } else if (m.role === 'tool_result') {
-      // Tool result — emit as a separate ToolResultMessage. Preserve the
-      // backend's failure markers so ArtifactsPanel.reconstructFromMessages
-      // (which only replays successful ops) skips failed calls on reload.
-      // The kernel serializes failures in two shapes: a bare string starting
-      // with "Error:" (pi-mono convention) and JSON objects with an `error`
-      // key (produced by the anyhow -> ToolOutput path).
-      if (m.tool_call_id && m.tool_name) {
-        const text =
-          typeof m.content === 'string'
-            ? m.content
-            : m.content
-                .filter((b): b is { type: 'text'; text: string } => b.type === 'text')
-                .map((b) => b.text)
-                .join('\n');
-        const toolResult: ToolResultMessage = {
-          role: 'toolResult',
-          toolCallId: m.tool_call_id,
-          toolName: m.tool_name,
-          content: text ? [{ type: 'text', text }] : [],
-          isError: isToolFailure(text),
-          timestamp: ts,
-        };
-        result.push(toolResult as AgentMessage);
-      }
-    }
-  }
-  return result;
 }
 
 /**

--- a/web/src/pages/__tests__/pi-chat-messages.test.ts
+++ b/web/src/pages/__tests__/pi-chat-messages.test.ts
@@ -1,0 +1,152 @@
+/*
+ * Copyright 2025 Rararulab
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { AssistantMessage } from '@mariozechner/pi-ai';
+import { describe, expect, it } from 'vitest';
+
+import { assistantSeqByRef, finalAssistantIndices, toAgentMessages } from '../pi-chat-messages';
+
+import type { ChatMessageData, ChatToolCallData } from '@/api/types';
+
+const ISO = '2025-01-01T00:00:00Z';
+
+function user(seq: number, text = 'hi'): ChatMessageData {
+  return { seq, role: 'user', content: text, created_at: ISO };
+}
+
+function assistantText(seq: number, text = 'reply'): ChatMessageData {
+  return { seq, role: 'assistant', content: text, created_at: ISO };
+}
+
+function assistantToolCall(seq: number, toolName = 'do_thing'): ChatMessageData {
+  const call: ChatToolCallData = {
+    id: `tc-${seq}`,
+    name: toolName,
+    arguments: {},
+  };
+  return {
+    seq,
+    role: 'assistant',
+    content: '',
+    tool_calls: [call],
+    created_at: ISO,
+  };
+}
+
+function toolResult(seq: number, callSeq: number, toolName = 'do_thing'): ChatMessageData {
+  return {
+    seq,
+    role: 'tool_result',
+    content: 'ok',
+    tool_call_id: `tc-${callSeq}`,
+    tool_name: toolName,
+    created_at: ISO,
+  };
+}
+
+function isRegistered(msg: AssistantMessage | undefined): boolean {
+  if (!msg) throw new Error('expected an assistant message');
+  return assistantSeqByRef.get(msg) !== undefined;
+}
+
+function expectAssistant(msg: AssistantMessage | undefined): AssistantMessage {
+  if (!msg) throw new Error('expected an assistant message');
+  return msg;
+}
+
+function assistants(out: ReturnType<typeof toAgentMessages>): AssistantMessage[] {
+  return out.filter((m): m is AssistantMessage => m.role === 'assistant');
+}
+
+describe('finalAssistantIndices', () => {
+  it('marks the only assistant of a single complete turn', () => {
+    const msgs = [user(1), assistantText(2)];
+    expect(finalAssistantIndices(msgs)).toEqual(new Set([1]));
+  });
+
+  it('marks only the last assistant when intermediate ones are tool-call-only', () => {
+    const msgs = [user(1), assistantToolCall(2), assistantText(3)];
+    expect(finalAssistantIndices(msgs)).toEqual(new Set([2]));
+  });
+
+  it('handles tool_result interleave between intermediate and final assistant', () => {
+    const msgs = [user(1), assistantToolCall(2), toolResult(3, 2), assistantText(4)];
+    expect(finalAssistantIndices(msgs)).toEqual(new Set([3]));
+  });
+
+  it('marks the final assistant of every turn across multiple turns', () => {
+    const msgs = [user(1), assistantText(2), user(3), assistantToolCall(4), assistantText(5)];
+    expect(finalAssistantIndices(msgs)).toEqual(new Set([1, 4]));
+  });
+
+  it('marks the trailing tool-call-only assistant on an open (incomplete) turn', () => {
+    const msgs = [user(1), assistantToolCall(2)];
+    expect(finalAssistantIndices(msgs)).toEqual(new Set([1]));
+  });
+});
+
+describe('toAgentMessages — trace button registration (#1672)', () => {
+  it('registers the lone assistant of a [user, assistant(text)] turn', () => {
+    const out = toAgentMessages([user(1), assistantText(2)]);
+    const [a] = assistants(out);
+    expect(isRegistered(a)).toBe(true);
+    expect(assistantSeqByRef.get(expectAssistant(a))).toBe(2);
+  });
+
+  it('registers only the final assistant in [user, assistant(tool_call), assistant(text)]', () => {
+    const out = toAgentMessages([user(1), assistantToolCall(2), assistantText(3)]);
+    const [intermediate, final] = assistants(out);
+    expect(isRegistered(intermediate)).toBe(false);
+    expect(isRegistered(final)).toBe(true);
+    expect(assistantSeqByRef.get(expectAssistant(final))).toBe(3);
+  });
+
+  it('registers only the final assistant when a tool_result is interleaved', () => {
+    const out = toAgentMessages([
+      user(1),
+      assistantToolCall(2),
+      toolResult(3, 2),
+      assistantText(4),
+    ]);
+    const [intermediate, final] = assistants(out);
+    expect(isRegistered(intermediate)).toBe(false);
+    expect(isRegistered(final)).toBe(true);
+    expect(assistantSeqByRef.get(expectAssistant(final))).toBe(4);
+  });
+
+  it('registers the final assistant of every turn but not intermediate ones', () => {
+    const out = toAgentMessages([
+      user(1),
+      assistantText(2),
+      user(3),
+      assistantToolCall(4),
+      assistantText(5),
+    ]);
+    const [first, intermediate, last] = assistants(out);
+    expect(isRegistered(first)).toBe(true);
+    expect(assistantSeqByRef.get(expectAssistant(first))).toBe(2);
+    expect(isRegistered(intermediate)).toBe(false);
+    expect(isRegistered(last)).toBe(true);
+    expect(assistantSeqByRef.get(expectAssistant(last))).toBe(5);
+  });
+
+  it('registers the trailing tool-call-only assistant on an open turn', () => {
+    const out = toAgentMessages([user(1), assistantToolCall(2)]);
+    const [a] = assistants(out);
+    expect(isRegistered(a)).toBe(true);
+    expect(assistantSeqByRef.get(expectAssistant(a))).toBe(2);
+  });
+});

--- a/web/src/pages/__tests__/pi-chat-messages.test.ts
+++ b/web/src/pages/__tests__/pi-chat-messages.test.ts
@@ -96,6 +96,16 @@ describe('finalAssistantIndices', () => {
     const msgs = [user(1), assistantToolCall(2)];
     expect(finalAssistantIndices(msgs)).toEqual(new Set([1]));
   });
+
+  it('treats a no-op user with no assistant as inert and marks only the next turn', () => {
+    const msgs = [user(1), user(2), assistantText(3)];
+    expect(finalAssistantIndices(msgs)).toEqual(new Set([2]));
+  });
+
+  it('marks the last tool-call-only assistant on an open turn with multiple tool-call assistants', () => {
+    const msgs = [user(1), assistantToolCall(2), assistantToolCall(3)];
+    expect(finalAssistantIndices(msgs)).toEqual(new Set([2]));
+  });
 });
 
 describe('toAgentMessages — trace button registration (#1672)', () => {

--- a/web/src/pages/pi-chat-messages.ts
+++ b/web/src/pages/pi-chat-messages.ts
@@ -1,0 +1,279 @@
+/*
+ * Copyright 2025 Rararulab
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { AgentMessage } from '@mariozechner/pi-agent-core';
+import type {
+  AssistantMessage,
+  TextContent,
+  ThinkingContent,
+  ToolCall,
+  ToolResultMessage,
+  UserMessage,
+} from '@mariozechner/pi-ai';
+import type { Attachment, UserMessageWithAttachments } from '@mariozechner/pi-web-ui';
+
+import type { ChatMessageData } from '@/api/types';
+
+/**
+ * Detect whether a tool-result payload represents a failure. Mirrors the
+ * backend's `is_failure_result` in `crates/app/src/tools/artifacts.rs`: a
+ * bare string starting with `Error:` (pi-mono convention) or a JSON object
+ * with an `error` key (kernel-serialized anyhow error).
+ */
+function isToolFailure(text: string): boolean {
+  const trimmed = text.trimStart();
+  if (trimmed.startsWith('Error:')) return true;
+  try {
+    const parsed = JSON.parse(trimmed);
+    return (
+      typeof parsed === 'object' && parsed !== null && !Array.isArray(parsed) && 'error' in parsed
+    );
+  } catch {
+    return false;
+  }
+}
+
+function mimeToFilename(mimeType: string, index: number): string {
+  const ext = mimeType.split('/')[1] || 'bin';
+  return `session-image-${index + 1}.${ext}`;
+}
+
+/** Zeroed usage — rara tracks usage server-side. */
+const EMPTY_USAGE = {
+  input: 0,
+  output: 0,
+  cacheRead: 0,
+  cacheWrite: 0,
+  totalTokens: 0,
+  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+};
+
+/**
+ * Parse assistant text into ThinkingContent + TextContent blocks.
+ * `<think>reasoning</think>answer` → [{type:"thinking",...}, {type:"text",...}]
+ */
+function parseAssistantContent(raw: string): (TextContent | ThinkingContent)[] {
+  const blocks: (TextContent | ThinkingContent)[] = [];
+  const re = /<think>([\s\S]*?)<\/think>/g;
+  let cursor = 0;
+  let match: RegExpExecArray | null;
+
+  while ((match = re.exec(raw)) !== null) {
+    const before = raw.slice(cursor, match.index).trim();
+    if (before) blocks.push({ type: 'text', text: before });
+    const thinking = (match[1] ?? '').trim();
+    if (thinking) blocks.push({ type: 'thinking', thinking });
+    cursor = match.index + match[0].length;
+  }
+
+  const tail = raw.slice(cursor).trim();
+  if (tail) blocks.push({ type: 'text', text: tail });
+
+  return blocks;
+}
+
+/**
+ * WeakMap from assistant `AgentMessage` object references to their
+ * persisted `seq`. Populated by {@link toAgentMessages} and read by the
+ * Lit assistant-message renderer when the user clicks one of the per-turn
+ * trace buttons — the seq is then embedded on the dispatched CustomEvent
+ * so the React layer can call the trace endpoint directly without any
+ * timestamp-based lookup (which collided at second resolution).
+ *
+ * Keyed by object identity: the same references flow from
+ * `toAgentMessages` → `agent.replaceMessages(...)` → pi-web-ui's
+ * renderer, so the renderer sees the exact keys set here.
+ *
+ * Only the **final** assistant message of each turn is registered —
+ * intermediate tool-call-only iterations are deliberately omitted so
+ * trace buttons render exactly once per user-facing reply (#1672).
+ */
+export const assistantSeqByRef = new WeakMap<AgentMessage, number>();
+
+/**
+ * For each turn (a contiguous run of non-user messages bounded by the
+ * next user message or the end of the list), return the index in `msgs`
+ * of the last `assistant`-role message in that turn. Indices not in the
+ * returned set correspond to intermediate tool-call-only iterations
+ * within a turn — they should remain visible as bubbles but carry no
+ * trace buttons (see #1672).
+ *
+ * The trailing turn (no closing user message) is also included, so an
+ * in-progress turn whose only frame so far is tool-call-only still gets
+ * buttons rather than no buttons until the final reply lands.
+ */
+export function finalAssistantIndices(msgs: ChatMessageData[]): Set<number> {
+  const finals = new Set<number>();
+  let lastAssistantIdx: number | null = null;
+  for (let i = 0; i < msgs.length; i++) {
+    const m = msgs[i];
+    if (!m) continue;
+    const role = m.role;
+    if (role === 'user') {
+      if (lastAssistantIdx !== null) finals.add(lastAssistantIdx);
+      lastAssistantIdx = null;
+    } else if (role === 'assistant') {
+      lastAssistantIdx = i;
+    }
+  }
+  if (lastAssistantIdx !== null) finals.add(lastAssistantIdx);
+  return finals;
+}
+
+/**
+ * Convert rara `ChatMessageData` rows into pi-agent-core `AgentMessage`s
+ * for display in the chat panel.
+ *
+ * Only the **final** assistant message of each turn is registered in
+ * {@link assistantSeqByRef}; intermediate tool-call-only assistant
+ * iterations are still emitted as bubbles but carry no trace buttons.
+ * See {@link finalAssistantIndices} and #1672.
+ */
+export function toAgentMessages(msgs: ChatMessageData[]): AgentMessage[] {
+  const result: AgentMessage[] = [];
+  // Track the last assistant message so "tool" role messages can attach ToolCall items.
+  let lastAssistant: AssistantMessage | null = null;
+  const finals = finalAssistantIndices(msgs);
+
+  for (let i = 0; i < msgs.length; i++) {
+    const m = msgs[i];
+    if (!m) continue;
+    const ts = new Date(m.created_at).getTime();
+
+    if (m.role === 'user') {
+      lastAssistant = null;
+      if (typeof m.content === 'string') {
+        result.push({ role: 'user', content: m.content, timestamp: ts } as UserMessage);
+      } else {
+        const text = m.content
+          .filter((b): b is { type: 'text'; text: string } => b.type === 'text')
+          .map((b) => b.text)
+          .join('\n');
+        const attachments: Attachment[] = m.content.flatMap((b, index): Attachment[] => {
+          if (b.type !== 'image_base64') return [];
+          return [
+            {
+              id: `${m.seq}-image-${index}`,
+              type: 'image',
+              fileName: mimeToFilename(b.media_type, index),
+              mimeType: b.media_type,
+              size: Math.floor((b.data.length * 3) / 4),
+              content: b.data,
+              preview: b.data,
+            },
+          ];
+        });
+
+        if (attachments.length > 0) {
+          result.push({
+            role: 'user-with-attachments',
+            content: text,
+            attachments,
+            timestamp: ts,
+          } as UserMessageWithAttachments as AgentMessage);
+        } else {
+          result.push({ role: 'user', content: text, timestamp: ts } as UserMessage);
+        }
+      }
+    } else if (m.role === 'assistant') {
+      const raw =
+        typeof m.content === 'string'
+          ? m.content
+          : m.content
+              .filter((b): b is { type: 'text'; text: string } => b.type === 'text')
+              .map((b) => b.text)
+              .join('\n');
+      const content: (TextContent | ThinkingContent | ToolCall)[] = parseAssistantContent(raw);
+      // Surface persisted tool-call requests so pi-web-ui reducers (and the
+      // artifacts panel's reconstructFromMessages) can see them.
+      if (m.tool_calls && m.tool_calls.length > 0) {
+        for (const tc of m.tool_calls) {
+          const args =
+            tc.arguments && typeof tc.arguments === 'object'
+              ? (tc.arguments as Record<string, unknown>)
+              : {};
+          content.push({
+            type: 'toolCall',
+            id: tc.id,
+            name: tc.name,
+            arguments: args,
+          });
+        }
+      }
+      const assistant: AssistantMessage = {
+        role: 'assistant',
+        content,
+        api: 'messages',
+        provider: 'anthropic',
+        model: 'unknown',
+        usage: EMPTY_USAGE,
+        stopReason: 'stop',
+        timestamp: ts,
+      };
+      lastAssistant = assistant;
+      // Only the final assistant of each turn carries trace buttons —
+      // intermediate tool-call-only iterations stay anonymous (#1672).
+      if (finals.has(i)) {
+        assistantSeqByRef.set(assistant, m.seq);
+      }
+      result.push(assistant);
+    } else if (m.role === 'tool') {
+      // Tool call from the assistant — attach as ToolCall to the last AssistantMessage.
+      if (lastAssistant && m.tool_call_id && m.tool_name) {
+        let args: Record<string, unknown> = {};
+        try {
+          const raw = typeof m.content === 'string' ? m.content : JSON.stringify(m.content);
+          args = JSON.parse(raw);
+        } catch {
+          /* use empty args */
+        }
+        const toolCall: ToolCall = {
+          type: 'toolCall',
+          id: m.tool_call_id,
+          name: m.tool_name,
+          arguments: args,
+        };
+        lastAssistant.content.push(toolCall);
+      }
+    } else if (m.role === 'tool_result') {
+      // Tool result — emit as a separate ToolResultMessage. Preserve the
+      // backend's failure markers so ArtifactsPanel.reconstructFromMessages
+      // (which only replays successful ops) skips failed calls on reload.
+      // The kernel serializes failures in two shapes: a bare string starting
+      // with "Error:" (pi-mono convention) and JSON objects with an `error`
+      // key (produced by the anyhow -> ToolOutput path).
+      if (m.tool_call_id && m.tool_name) {
+        const text =
+          typeof m.content === 'string'
+            ? m.content
+            : m.content
+                .filter((b): b is { type: 'text'; text: string } => b.type === 'text')
+                .map((b) => b.text)
+                .join('\n');
+        const toolResult: ToolResultMessage = {
+          role: 'toolResult',
+          toolCallId: m.tool_call_id,
+          toolName: m.tool_name,
+          content: text ? [{ type: 'text', text }] : [],
+          isError: isToolFailure(text),
+          timestamp: ts,
+        };
+        result.push(toolResult as AgentMessage);
+      }
+    }
+  }
+  return result;
+}


### PR DESCRIPTION
## Summary

The chat history view rendered the per-turn "📊 详情" + "🔍 Cascade" buttons on every persisted assistant bubble, including intermediate tool-call-only iterations within a single user turn. Buttons should appear once per turn, on the final assistant message that represents the user-facing reply.

Root cause: `toAgentMessages` in `web/src/pages/PiChat.tsx` registered every assistant message into `assistantSeqByRef`; the Lit renderer keys button visibility off membership in that map.

Fix (option C from design discussion): only register the final assistant of each turn (turn boundary = next user message or end-of-list). Intermediate iterations stay visible as bubbles but carry no buttons. A trailing open turn (no closing user message yet) still registers its last assistant so an in-progress tool-call-only turn doesn't lose buttons.

Refactor: extract `toAgentMessages`, `assistantSeqByRef`, and the new `finalAssistantIndices` helper into `web/src/pages/pi-chat-messages.ts` so they can be unit-tested without pulling in PiChat's heavy side-effect imports (lit, web components, storage adapters).

## Type of change

| Type | Label |
|------|-------|
| Bug fix | `bug` |

## Component

`ui`

## Closes

Closes #1672

## Test plan

- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
- [x] `npm test` passes (10 new tests in `pi-chat-messages.test.ts`)
- [x] `npm run build` passes