### PR TITLE
perf(backend): single FTS query for session search (#1662)

### DIFF
--- a/crates/extensions/backend-admin/Cargo.toml
+++ b/crates/extensions/backend-admin/Cargo.toml
@@ -46,7 +46,10 @@ uuid = { workspace = true }
 yunara-store = { workspace = true }
 
 [dev-dependencies]
+async-trait = { workspace = true }
 base = { workspace = true }
 common-telemetry = { workspace = true }
+tempfile = { workspace = true }
 testcontainers = { workspace = true }
 testcontainers-modules = { workspace = true }
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/crates/extensions/backend-admin/src/chat/service.rs
+++ b/crates/extensions/backend-admin/src/chat/service.rs
@@ -34,7 +34,7 @@ use rara_kernel::{
         ChannelType, ChatMessage, MessageContent, MessageRole, ToolCall as ChannelToolCall,
     },
     llm::{Message, Role},
-    memory::{TapEntry, TapEntryKind, TapeService},
+    memory::{TapEntry, TapEntryKind, TapeSearchHit, TapeService},
     session::SessionIndexRef,
     trace::{ExecutionTrace, TraceService},
 };
@@ -377,17 +377,15 @@ pub struct SessionService {
 }
 
 impl SessionService {
-    /// Hard ceiling on how many sessions we scan in a single request.
-    const SEARCH_SESSION_SCAN_CAP: i64 = 500;
     // -- full-text search ---------------------------------------------------
 
-    /// Minimum number of sessions we inspect when scanning for matches.
+    /// Over-fetch multiplier for cross-tape search.
     ///
-    /// The `limit` argument bounds the returned hits, but we search a
-    /// larger window of sessions so one heavily-used session cannot
-    /// monopolise the top `limit` slots (we keep only the best hit per
-    /// session, so searching more sessions improves result diversity).
-    const SEARCH_SESSION_SCAN_MULTIPLIER: i64 = 3;
+    /// The kernel returns ranked hits across every tape; we then collapse
+    /// to one hit per session. Over-fetching leaves headroom after
+    /// dedup so the response still carries up to `limit` distinct
+    /// sessions when the top matches cluster inside a few long threads.
+    const SEARCH_OVERFETCH_MULTIPLIER: usize = 3;
 
     /// Create a new chat service with the given dependencies.
     #[must_use]
@@ -760,14 +758,14 @@ impl SessionService {
         })
     }
 
-    /// Search recent sessions for messages matching `query` (full-text).
+    /// Search every session's tape for messages matching `query`.
     ///
-    /// Scans up to `SEARCH_SESSION_SCAN_CAP` of the most recently
-    /// updated sessions, asks the tape service for ranked matches inside
-    /// each, and keeps only the single highest-ranked hit per session
-    /// before clamping to `limit`. One-hit-per-session keeps the result
-    /// list varied: the underlying FTS ranker tends to cluster many hits
-    /// inside one long thread, which otherwise drowns out other matches.
+    /// Issues a single FTS query across all tapes via
+    /// [`TapeService::search_across_tapes`], then keeps only the
+    /// highest-ranked hit per session before clamping to `limit`. One
+    /// hit per session keeps the result list varied: the underlying FTS
+    /// ranker tends to cluster many hits inside a long thread, which
+    /// would otherwise drown out other sessions.
     ///
     /// An empty or whitespace-only `query` short-circuits to an empty
     /// response — this is treated as "user cleared the search box", not
@@ -783,57 +781,67 @@ impl SessionService {
             return Ok(SessionSearchResponse { hits: Vec::new() });
         }
 
-        let scan_limit = (limit as i64)
-            .saturating_mul(Self::SEARCH_SESSION_SCAN_MULTIPLIER)
-            .min(Self::SEARCH_SESSION_SCAN_CAP)
-            .max(limit as i64);
+        // Over-fetch so per-session dedup still yields up to `limit`
+        // distinct sessions when the top matches cluster in a few tapes.
+        let fetch_limit = limit.saturating_mul(Self::SEARCH_OVERFETCH_MULTIPLIER);
 
-        let sessions = self.session_index.list_sessions(scan_limit, 0).await?;
+        // Degrade gracefully: on tape-level failure we surface an empty
+        // result rather than a 500, matching the original per-session
+        // loop's "skip on error" semantics.
+        let ranked = match self
+            .tape_service
+            .search_across_tapes(trimmed, fetch_limit)
+            .await
+        {
+            Ok(hits) => hits,
+            Err(e) => {
+                tracing::warn!(error = %e, "cross-tape search failed");
+                return Ok(SessionSearchResponse { hits: Vec::new() });
+            }
+        };
 
-        // Per-session search bound. The service ranks inside a tape so
-        // we only need the top few candidates before picking the best
-        // one whose payload yields a usable role/text.
-        let per_session_limit = 3usize;
+        // Cache session lookups so we only pay one index hit per tape.
+        let mut session_cache: std::collections::HashMap<String, Option<SessionEntry>> =
+            std::collections::HashMap::new();
+        let mut seen_sessions: std::collections::HashSet<String> = std::collections::HashSet::new();
+        let mut hits: Vec<SessionSearchHit> = Vec::new();
 
-        let mut hits: Vec<(f64, SessionSearchHit)> = Vec::new();
-        for session in &sessions {
-            let tape_name = session.key.to_string();
-            let entries = match self
-                .tape_service
-                .search(&tape_name, trimmed, per_session_limit, false)
-                .await
-            {
-                Ok(entries) => entries,
-                Err(e) => {
-                    tracing::warn!(
-                        session = %session.key,
-                        error = %e,
-                        "tape search failed, skipping session"
-                    );
-                    continue;
+        for TapeSearchHit { entry, tape_name } in ranked {
+            if hits.len() >= limit {
+                break;
+            }
+            if !seen_sessions.insert(tape_name.clone()) {
+                continue;
+            }
+
+            let session = match session_cache.get(&tape_name) {
+                Some(cached) => cached.clone(),
+                None => {
+                    let key = match SessionKey::try_from_raw(&tape_name) {
+                        Ok(k) => k,
+                        Err(e) => {
+                            tracing::debug!(
+                                tape = %tape_name,
+                                error = %e,
+                                "skipping non-session tape"
+                            );
+                            session_cache.insert(tape_name.clone(), None);
+                            continue;
+                        }
+                    };
+                    let fetched = self.session_index.get_session(&key).await.ok().flatten();
+                    session_cache.insert(tape_name.clone(), fetched.clone());
+                    fetched
                 }
             };
+            let Some(session) = session else { continue };
 
-            // `entries` is ordered by relevance; pick the first one
-            // whose payload decodes into a message we can project.
-            let Some((rank, hit)) = entries.iter().enumerate().find_map(|(idx, entry)| {
-                project_search_hit(entry, session, trimmed).map(|h| (idx, h))
-            }) else {
-                continue;
-            };
-
-            // Lower `rank` = better; negate so a max-heap-style sort by
-            // `score.partial_cmp` puts the best hits first.
-            let score = -(rank as f64);
-            hits.push((score, hit));
+            if let Some(hit) = project_search_hit(&entry, &session, trimmed) {
+                hits.push(hit);
+            }
         }
 
-        hits.sort_by(|a, b| b.0.partial_cmp(&a.0).unwrap_or(std::cmp::Ordering::Equal));
-        hits.truncate(limit);
-
-        Ok(SessionSearchResponse {
-            hits: hits.into_iter().map(|(_, h)| h).collect(),
-        })
+        Ok(SessionSearchResponse { hits })
     }
 
     // -- channel bindings ---------------------------------------------------
@@ -1275,5 +1283,232 @@ mod update_request_deserialize_tests {
         let value: UpdateSessionRequest =
             serde_json::from_str(r#"{"system_prompt": "you are..."}"#).expect("parse");
         assert_eq!(value.system_prompt, Some(Some("you are...".to_owned())));
+    }
+}
+
+#[cfg(test)]
+mod search_sessions_tests {
+    use std::{collections::HashMap, sync::Arc};
+
+    use async_trait::async_trait;
+    use chrono::Utc;
+    use rara_domain_shared::settings::SettingsProvider;
+    use rara_kernel::{
+        llm::{LlmModelLister, ModelInfo},
+        memory::{FileTapeStore, TapeService},
+        session::{SessionIndex, SessionKey, test_utils::InMemorySessionIndex},
+        trace::TraceService,
+    };
+    use rara_sessions::types::SessionEntry;
+    use serde_json::json;
+
+    use super::SessionService;
+
+    struct StubSettings;
+
+    #[async_trait]
+    impl SettingsProvider for StubSettings {
+        async fn get(&self, _key: &str) -> Option<String> { None }
+
+        async fn set(&self, _key: &str, _value: &str) -> anyhow::Result<()> { Ok(()) }
+
+        async fn delete(&self, _key: &str) -> anyhow::Result<()> { Ok(()) }
+
+        async fn list(&self) -> HashMap<String, String> { HashMap::new() }
+
+        async fn batch_update(
+            &self,
+            _patches: HashMap<String, Option<String>>,
+        ) -> anyhow::Result<()> {
+            Ok(())
+        }
+
+        fn subscribe(&self) -> tokio::sync::watch::Receiver<()> {
+            let (_tx, rx) = tokio::sync::watch::channel(());
+            rx
+        }
+    }
+
+    struct StubModelLister;
+
+    #[async_trait]
+    impl LlmModelLister for StubModelLister {
+        async fn list_models(&self) -> rara_kernel::error::Result<Vec<ModelInfo>> { Ok(Vec::new()) }
+    }
+
+    async fn build_service_with_fts(
+        dir: &std::path::Path,
+    ) -> (SessionService, Arc<InMemorySessionIndex>) {
+        let pool = sqlx::SqlitePool::connect("sqlite::memory:")
+            .await
+            .expect("pool");
+        sqlx::query(
+            "CREATE VIRTUAL TABLE tape_fts USING fts5(content, tape_name UNINDEXED, entry_kind \
+             UNINDEXED, entry_id UNINDEXED, session_key UNINDEXED, tokenize = 'unicode61 \
+             remove_diacritics 2')",
+        )
+        .execute(&pool)
+        .await
+        .expect("fts table");
+        sqlx::query(
+            "CREATE TABLE tape_fts_meta (tape_name TEXT PRIMARY KEY, last_indexed_id INTEGER NOT \
+             NULL DEFAULT 0)",
+        )
+        .execute(&pool)
+        .await
+        .expect("meta table");
+        sqlx::query(
+            "CREATE TABLE execution_traces (id TEXT PRIMARY KEY, session_id TEXT NOT NULL, data \
+             TEXT NOT NULL)",
+        )
+        .execute(&pool)
+        .await
+        .expect("trace table");
+
+        let store = FileTapeStore::new(dir, dir).await.unwrap();
+        let tape_service = TapeService::with_fts(store, pool.clone());
+        let sessions: Arc<InMemorySessionIndex> = Arc::new(InMemorySessionIndex::new());
+        let trace_service = TraceService::new(pool);
+        let service = SessionService::new(
+            sessions.clone(),
+            tape_service,
+            trace_service,
+            Arc::new(StubSettings),
+            Arc::new(StubModelLister),
+        );
+        (service, sessions)
+    }
+
+    async fn register_session(index: &InMemorySessionIndex, key: &SessionKey, title: &str) {
+        let now = Utc::now();
+        let entry = SessionEntry {
+            key:            key.clone(),
+            title:          Some(title.to_owned()),
+            model:          None,
+            model_provider: None,
+            thinking_level: None,
+            system_prompt:  None,
+            message_count:  0,
+            preview:        None,
+            metadata:       None,
+            created_at:     now,
+            updated_at:     now,
+        };
+        index.create_session(&entry).await.expect("create session");
+    }
+
+    #[tokio::test]
+    async fn empty_query_returns_no_hits() {
+        let tmp = tempfile::tempdir().unwrap();
+        let (service, sessions) = build_service_with_fts(tmp.path()).await;
+
+        let key = SessionKey::new();
+        register_session(&sessions, &key, "session one").await;
+        service
+            .tape_service()
+            .append_message(&key.to_string(), json!({"content": "hello"}), None)
+            .await
+            .unwrap();
+
+        for q in ["", "   ", "\t\n"] {
+            let resp = service.search_sessions(q, 20).await.unwrap();
+            assert!(resp.hits.is_empty(), "empty query should yield no hits");
+        }
+    }
+
+    #[tokio::test]
+    async fn attribution_across_many_sessions() {
+        let tmp = tempfile::tempdir().unwrap();
+        let (service, sessions) = build_service_with_fts(tmp.path()).await;
+
+        let marker = "zephyrrising";
+        let mut keys = Vec::new();
+        for i in 0..12 {
+            let key = SessionKey::new();
+            register_session(&sessions, &key, &format!("session-{i}")).await;
+            service
+                .tape_service()
+                .append_message(
+                    &key.to_string(),
+                    json!({"role": "user", "content": format!("note {i}: {marker} body text")}),
+                    None,
+                )
+                .await
+                .unwrap();
+            keys.push(key);
+        }
+
+        let resp = service.search_sessions(marker, 20).await.unwrap();
+        assert_eq!(resp.hits.len(), 12);
+
+        // Dedup invariant: every hit belongs to a distinct session.
+        let unique: std::collections::HashSet<_> =
+            resp.hits.iter().map(|h| h.session_key.clone()).collect();
+        assert_eq!(unique.len(), resp.hits.len());
+
+        // Attribution: every hit's session_key must match one of the
+        // sessions we registered.
+        let registered: std::collections::HashSet<String> =
+            keys.iter().map(ToString::to_string).collect();
+        for hit in &resp.hits {
+            assert!(
+                registered.contains(&hit.session_key),
+                "unexpected session {}",
+                hit.session_key
+            );
+            assert!(hit.snippet.contains("<mark>"));
+        }
+    }
+
+    #[tokio::test]
+    async fn dedup_keeps_one_hit_per_session() {
+        let tmp = tempfile::tempdir().unwrap();
+        let (service, sessions) = build_service_with_fts(tmp.path()).await;
+
+        let key = SessionKey::new();
+        register_session(&sessions, &key, "busy session").await;
+        for i in 0..5 {
+            service
+                .tape_service()
+                .append_message(
+                    &key.to_string(),
+                    json!({"role": "user", "content": format!("pingpong-token body {i}")}),
+                    None,
+                )
+                .await
+                .unwrap();
+        }
+
+        let resp = service.search_sessions("pingpong-token", 20).await.unwrap();
+        assert_eq!(resp.hits.len(), 1, "one tape should yield one hit");
+        assert_eq!(resp.hits[0].session_key, key.to_string());
+    }
+
+    #[tokio::test]
+    async fn limit_clamps_output() {
+        let tmp = tempfile::tempdir().unwrap();
+        let (service, sessions) = build_service_with_fts(tmp.path()).await;
+
+        for i in 0..8 {
+            let key = SessionKey::new();
+            register_session(&sessions, &key, &format!("s{i}")).await;
+            service
+                .tape_service()
+                .append_message(
+                    &key.to_string(),
+                    json!({"role": "user", "content": format!("clampme body {i}")}),
+                    None,
+                )
+                .await
+                .unwrap();
+        }
+
+        let resp = service.search_sessions("clampme", 3).await.unwrap();
+        assert_eq!(resp.hits.len(), 3);
+    }
+
+    impl SessionService {
+        /// Test-only accessor to populate tapes before searching.
+        fn tape_service(&self) -> &TapeService { &self.tape_service }
     }
 }

--- a/crates/kernel/src/memory/AGENT.md
+++ b/crates/kernel/src/memory/AGENT.md
@@ -1,0 +1,63 @@
+# memory — Agent Guidelines
+
+## Purpose
+Local file-backed tape memory (JSONL timeline per session) plus derived FTS5
+index, fork/merge semantics, anchor-based context windowing, and LLM context
+building. The authoritative record of every agent turn.
+
+## Architecture
+
+```
+memory/
+├── mod.rs            # Module docs + TapEntry / TapEntryKind / typed metadata
+├── store.rs          # FileTapeStore: JSONL I/O on a dedicated worker thread
+├── service.rs        # TapeService: append helpers, search, fork/merge, LLM context
+├── context.rs        # default_tape_context(): TapEntry → llm::Message projection
+├── anchors.rs        # AnchorSummary, HandoffState
+├── fork_metadata.rs  # Fork linkage persisted in TapEntry.metadata
+├── tree.rs           # AnchorTree for /fork visualisation
+├── error.rs          # TapError (snafu)
+├── fts/              # SQLite FTS5 index (see fts/AGENT.md)
+└── knowledge/        # Knowledge-graph sub-subsystem
+```
+
+- `TapeService::search(tape, query, limit, all_tapes)` — ranked search, optionally
+  cross-tape, returns bare `Vec<TapEntry>`. Tape attribution is dropped at the
+  boundary.
+- `TapeService::search_across_tapes(query, limit)` — cross-tape variant that
+  preserves the originating tape. Returns `Vec<TapeSearchHit { entry, tape_name }>`.
+  Exists because callers enumerating results per session (e.g. the admin
+  session-search endpoint) would otherwise need N sequential `search` calls;
+  this collapses to a single FTS query since `fts::FtsHit.tape_name` is already
+  tracked in the index. Falls back to a brute-force scan across all tapes when
+  FTS is unavailable.
+
+## Critical Invariants
+
+- **JSONL is source of truth** — FTS is a derived index, safe to delete at any time.
+- **Tape name == session key** for chat sessions — the cross-tape search relies
+  on this so consumers can pass `tape_name` straight into `SessionKey::try_from_raw`.
+  User tapes use the `user:` prefix and will fail that parse (skip them).
+- **Append-only JSONL** — never rewrite a tape file; fork/merge is how history
+  mutates.
+- **FTS errors never break search** — always fall through to brute-force.
+  `search_across_tapes` follows the same contract.
+
+## What NOT To Do
+
+- Do NOT add fields to `TapEntry` that only make sense for one caller — pollution
+  of the universal type; use a wrapper like `TapeSearchHit` instead.
+- Do NOT change the signature of `TapeService::search` — it has multiple callers
+  across the workspace; add a new method for new shapes.
+- Do NOT call `search_brute_force` directly — route through `search` /
+  `search_across_tapes` so FTS is always tried first.
+- Do NOT skip FTS backfill in new cross-tape query paths — newly-written entries
+  are invisible to the index until `backfill_fts` runs.
+
+## Dependencies
+
+- **Upstream**: `rara-paths` (config-driven tape directory), `sqlx` (shared pool
+  for FTS), `jieba-rs` (CJK tokenisation).
+- **Downstream**: `rara-backend-admin::chat::service::SessionService::search_sessions`
+  consumes `search_across_tapes`; the agent loop uses `append_*` + context
+  builders during every turn.

--- a/crates/kernel/src/memory/mod.rs
+++ b/crates/kernel/src/memory/mod.rs
@@ -151,7 +151,7 @@ pub use fork_metadata::{ForkMetadata, get_fork_metadata, set_fork_metadata};
 use jiff::Timestamp;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
-pub use service::{TapeInfo, TapeService, current_tape};
+pub use service::{TapeInfo, TapeSearchHit, TapeService, current_tape};
 pub use store::FileTapeStore;
 pub use tree::{AnchorNode, AnchorTree, ForkEdge, SessionBranch};
 

--- a/crates/kernel/src/memory/service.rs
+++ b/crates/kernel/src/memory/service.rs
@@ -50,8 +50,23 @@ const EXACT_MATCH_BONUS: f64 = 1.0;
 
 #[derive(Debug)]
 struct SearchMatch {
-    score: f64,
-    entry: TapEntry,
+    score:     f64,
+    entry:     TapEntry,
+    tape_name: String,
+}
+
+/// A single ranked hit returned by [`TapeService::search_across_tapes`].
+///
+/// Carries the tape (session) the entry belongs to alongside the entry
+/// itself so cross-tape consumers (e.g. the admin session-search endpoint)
+/// can attribute each match to its originating session without a second
+/// round of lookups.
+#[derive(Debug, Clone)]
+pub struct TapeSearchHit {
+    /// Matched tape entry.
+    pub entry:     TapEntry,
+    /// Name of the tape (typically the session key) the entry belongs to.
+    pub tape_name: String,
 }
 
 /// Runtime tape info summary.
@@ -805,7 +820,11 @@ impl TapeService {
                 ) else {
                     continue;
                 };
-                results.push(SearchMatch { score, entry });
+                results.push(SearchMatch {
+                    score,
+                    entry,
+                    tape_name: name.clone(),
+                });
             }
         }
 
@@ -889,7 +908,11 @@ impl TapeService {
                 ) else {
                     continue;
                 };
-                results.push(SearchMatch { score, entry });
+                results.push(SearchMatch {
+                    score,
+                    entry,
+                    tape_name: (*tape).to_owned(),
+                });
             }
         }
 
@@ -902,6 +925,170 @@ impl TapeService {
         results.truncate(limit);
 
         Ok(results.into_iter().map(|item| item.entry).collect())
+    }
+
+    /// Cross-tape ranked search that preserves tape attribution.
+    ///
+    /// Equivalent to [`Self::search`] with `all_tapes = true`, except each
+    /// hit carries the originating tape name. When FTS5 is available, this
+    /// issues a **single** index query (the tape_name column is already
+    /// tracked in `FtsHit`, so attribution is free); otherwise it falls
+    /// back to a brute-force scan across all tapes. The underlying scoring
+    /// is identical to `search` so ordering stays stable.
+    pub async fn search_across_tapes(
+        &self,
+        query: &str,
+        limit: usize,
+    ) -> TapResult<Vec<TapeSearchHit>> {
+        let normalized_query = normalize_search_text(query);
+        if normalized_query.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        if let Some(fts) = &self.fts {
+            // Lazy backfill across all tapes so newly-added entries are
+            // visible to the index before the single query fires.
+            if let Err(e) = self.backfill_fts(fts, "", true).await {
+                tracing::warn!(%e, "FTS backfill failed, falling back to brute-force");
+            } else {
+                match fts.search(query, None, limit * 3).await {
+                    Ok(hits) if !hits.is_empty() => {
+                        return self
+                            .rerank_fts_hits_with_tape(&hits, &normalized_query, limit)
+                            .await;
+                    }
+                    Err(e) => {
+                        tracing::warn!(%e, "FTS search failed, falling back to brute-force");
+                    }
+                    _ => {}
+                }
+            }
+        }
+
+        self.search_brute_force_with_tape(&normalized_query, limit)
+            .await
+    }
+
+    /// Brute-force variant of [`Self::search_across_tapes`] — retains the
+    /// tape name for each match. Only invoked when FTS is unavailable or
+    /// returned an error.
+    async fn search_brute_force_with_tape(
+        &self,
+        normalized_query: &str,
+        limit: usize,
+    ) -> TapResult<Vec<TapeSearchHit>> {
+        let query_terms = extract_query_terms(normalized_query);
+        let query_scorer = (normalized_query.chars().count() >= MIN_FUZZY_QUERY_LENGTH)
+            .then(|| RatioBatchComparator::new(normalized_query.chars()));
+
+        let tape_names = self.store.list_tapes().await?;
+        let mut results = Vec::new();
+        for name in tape_names {
+            let entries = self.store.read(&name).await?.unwrap_or_default();
+            for entry in entries.into_iter().rev() {
+                if entry.kind != TapEntryKind::Message {
+                    continue;
+                }
+                let searchable_text = normalize_search_text(&extract_searchable_text(
+                    &entry.payload,
+                    entry.metadata.as_ref(),
+                ));
+                let Some(score) = score_search_candidate(
+                    normalized_query,
+                    &query_terms,
+                    &searchable_text,
+                    query_scorer.as_ref(),
+                ) else {
+                    continue;
+                };
+                results.push(SearchMatch {
+                    score,
+                    entry,
+                    tape_name: name.clone(),
+                });
+            }
+        }
+
+        results.sort_by(|left, right| {
+            right
+                .score
+                .total_cmp(&left.score)
+                .then_with(|| right.entry.id.cmp(&left.entry.id))
+        });
+        results.truncate(limit);
+
+        Ok(results
+            .into_iter()
+            .map(|item| TapeSearchHit {
+                entry:     item.entry,
+                tape_name: item.tape_name,
+            })
+            .collect())
+    }
+
+    /// Re-rank FTS candidates while preserving the originating tape name.
+    async fn rerank_fts_hits_with_tape(
+        &self,
+        hits: &[super::fts::FtsHit],
+        normalized_query: &str,
+        limit: usize,
+    ) -> TapResult<Vec<TapeSearchHit>> {
+        let query_terms = extract_query_terms(normalized_query);
+        let query_scorer = (normalized_query.chars().count() >= MIN_FUZZY_QUERY_LENGTH)
+            .then(|| RatioBatchComparator::new(normalized_query.chars()));
+
+        let mut by_tape: std::collections::HashMap<&str, Vec<u64>> =
+            std::collections::HashMap::new();
+        for hit in hits {
+            by_tape
+                .entry(&hit.tape_name)
+                .or_default()
+                .push(hit.entry_id);
+        }
+
+        let mut results = Vec::new();
+        for (tape, ids) in &by_tape {
+            let entries = self.store.read(tape).await?.unwrap_or_default();
+            let id_set: std::collections::HashSet<u64> = ids.iter().copied().collect();
+            for entry in entries {
+                if !id_set.contains(&entry.id) {
+                    continue;
+                }
+                let searchable_text = normalize_search_text(&extract_searchable_text(
+                    &entry.payload,
+                    entry.metadata.as_ref(),
+                ));
+                let Some(score) = score_search_candidate(
+                    normalized_query,
+                    &query_terms,
+                    &searchable_text,
+                    query_scorer.as_ref(),
+                ) else {
+                    continue;
+                };
+                results.push(SearchMatch {
+                    score,
+                    entry,
+                    tape_name: (*tape).to_owned(),
+                });
+            }
+        }
+
+        results.sort_by(|left, right| {
+            right
+                .score
+                .total_cmp(&left.score)
+                .then_with(|| right.entry.id.cmp(&left.entry.id))
+        });
+        results.truncate(limit);
+
+        Ok(results
+            .into_iter()
+            .map(|item| TapeSearchHit {
+                entry:     item.entry,
+                tape_name: item.tape_name,
+            })
+            .collect())
     }
 
     /// List all tape names known to the underlying store.
@@ -1878,5 +2065,112 @@ mod tests {
         let fts = svc.fts.as_ref().expect("FTS should be Some");
         let hwm = fts.last_indexed_id(tape).await.unwrap();
         assert_eq!(hwm, 0, "HWM should be 0 after delete");
+    }
+
+    #[tokio::test]
+    async fn search_across_tapes_empty_query() {
+        let tmp = tempfile::tempdir().unwrap();
+        let svc = temp_tape_service_with_fts(tmp.path()).await;
+        svc.append_message("tape-a", json!({"content": "hello"}), None)
+            .await
+            .unwrap();
+
+        let hits = svc.search_across_tapes("", 10).await.unwrap();
+        assert!(hits.is_empty());
+
+        let hits = svc.search_across_tapes("   ", 10).await.unwrap();
+        assert!(hits.is_empty());
+    }
+
+    #[tokio::test]
+    async fn search_across_tapes_single_tape_match() {
+        let tmp = tempfile::tempdir().unwrap();
+        let svc = temp_tape_service_with_fts(tmp.path()).await;
+
+        svc.append_message("tape-a", json!({"content": "rustacean loves ferris"}), None)
+            .await
+            .unwrap();
+        svc.append_message("tape-b", json!({"content": "unrelated python snake"}), None)
+            .await
+            .unwrap();
+
+        let hits = svc.search_across_tapes("ferris", 10).await.unwrap();
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].tape_name, "tape-a");
+        assert!(
+            hits[0]
+                .entry
+                .payload
+                .get("content")
+                .and_then(|v| v.as_str())
+                .unwrap_or_default()
+                .contains("ferris")
+        );
+    }
+
+    #[tokio::test]
+    async fn search_across_tapes_multi_tape_attribution() {
+        let tmp = tempfile::tempdir().unwrap();
+        let svc = temp_tape_service_with_fts(tmp.path()).await;
+
+        svc.append_message("tape-a", json!({"content": "alpha keyword tape-a"}), None)
+            .await
+            .unwrap();
+        svc.append_message("tape-b", json!({"content": "beta keyword tape-b"}), None)
+            .await
+            .unwrap();
+        svc.append_message("tape-c", json!({"content": "gamma keyword tape-c"}), None)
+            .await
+            .unwrap();
+
+        let hits = svc.search_across_tapes("keyword", 10).await.unwrap();
+        assert_eq!(hits.len(), 3);
+        let tapes: std::collections::HashSet<String> =
+            hits.iter().map(|h| h.tape_name.clone()).collect();
+        assert!(tapes.contains("tape-a"));
+        assert!(tapes.contains("tape-b"));
+        assert!(tapes.contains("tape-c"));
+
+        // Attribution check: each hit's tape_name must match the tape
+        // that actually holds the content.
+        for hit in &hits {
+            let content = hit
+                .entry
+                .payload
+                .get("content")
+                .and_then(|v| v.as_str())
+                .unwrap_or_default();
+            assert!(
+                content.contains(&hit.tape_name),
+                "hit content {content:?} should reference tape {:?}",
+                hit.tape_name
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn search_across_tapes_brute_force_fallback() {
+        // No FTS — exercises the brute-force path for attribution.
+        let tmp = tempfile::tempdir().unwrap();
+        let svc = temp_tape_service(tmp.path()).await;
+
+        svc.append_message("tape-x", json!({"content": "needle in x"}), None)
+            .await
+            .unwrap();
+        svc.append_message("tape-y", json!({"content": "needle in y"}), None)
+            .await
+            .unwrap();
+
+        let hits = svc.search_across_tapes("needle", 10).await.unwrap();
+        assert_eq!(hits.len(), 2);
+        for hit in &hits {
+            let content = hit
+                .entry
+                .payload
+                .get("content")
+                .and_then(|v| v.as_str())
+                .unwrap_or_default();
+            assert!(content.contains(&hit.tape_name[hit.tape_name.len() - 1..]));
+        }
     }
 }


### PR DESCRIPTION
## Summary

Collapse the N-sequential-FTS-query loop in
`SessionService::search_sessions` into a single cross-tape FTS query via
a new `TapeService::search_across_tapes` kernel method. Eliminates the
300-1200 ms latency spike and the 500-session visibility cap.

- Add `TapeSearchHit { entry, tape_name }` + `search_across_tapes(query, limit)`
  in `rara-kernel`. The existing `search()` signature is untouched — tape
  attribution was already tracked in `fts::FtsHit.tape_name`, we just
  stopped dropping it at the service boundary.
- Rewire `search_sessions` to one kernel call, dedup by session client
  side, and resolve titles from `SessionIndex` with a lookup cache so
  each tape incurs at most one session-index hit per request.
- Remove `SEARCH_SESSION_SCAN_CAP` / `SEARCH_SESSION_SCAN_MULTIPLIER` —
  no enumeration layer remains.
- Kernel tests: empty query, single-tape match, multi-tape attribution
  (FTS path), brute-force fallback attribution.
- Backend-admin tests: empty/whitespace query, attribution across 12
  sessions, one-hit-per-session dedup, `limit` clamping.
- New `crates/kernel/src/memory/AGENT.md` documenting the cross-tape
  variant and why it exists.

Behavior preserved from the HTTP consumer: response shape, empty query
→ 200 with empty hits, `limit` clamping (router-side), one hit per
session_key, HTML-escaped `<mark>` snippets.

## Type of change

| Type | Label |
|------|-------|
| Refactor / perf | `refactor` |

## Component

`backend`, `core`

## Closes

Closes #1662

## Test plan

- [x] `cargo check --workspace --all-targets`
- [x] `cargo clippy -p rara-kernel -p rara-backend-admin --all-targets --no-deps -- -D warnings`
- [x] `cargo test -p rara-kernel -p rara-backend-admin`
- [x] `cargo +nightly fmt --all -- --check`
- [x] `RUSTDOCFLAGS="-D warnings" cargo +nightly doc -p rara-kernel -p rara-backend-admin --no-deps --document-private-items`