### PR TITLE
fix(web): reserve scroll padding for in-progress live card (#1675)

### DIFF
--- a/web/src/hooks/AGENT.md
+++ b/web/src/hooks/AGENT.md
@@ -1,0 +1,32 @@
+# web/src/hooks — Agent Guidelines
+
+## Purpose
+
+Custom React hooks shared across rara web pages.
+
+## Architecture
+
+Real files in this directory (one line each):
+
+- `loading-hints.ts` — poetic placeholder strings + `randomLoadingHint()`, mirrors the Telegram channel's loading copy so both feel cohesive.
+- `use-dock-store.ts` — in-memory dock state machine (sessions, blocks, mutations, history) for the agent dock UI.
+- `use-live-card-height.ts` — `ResizeObserver`-driven publisher of the in-progress agent live-card height to a CSS custom property on `<main>`, so pi-web-ui's scroll viewport reserves padding for the floating overlay.
+- `use-local-storage.ts` — typed `useState`-style wrapper over `window.localStorage` with JSON serialization.
+- `use-server-status.ts` — context hook exposing `{ isOnline, isChecking }` for the global server-status banner.
+- `use-session-delete.ts` — wires the pure `decidePostDeleteAction` helper into the chat page's switch/create-new side effects so the dispatch is unit-testable.
+- `use-session-timeline.ts` — react-query backed timeline state for a chat session: turns → timeline items, live-state tracking, loading hints.
+- `use-theme.ts` — `useSyncExternalStore`-based theme hook (`light` / `dark` / `system`) with `localStorage` persistence and `prefers-color-scheme` subscription.
+
+## Critical Invariants
+
+- Hooks that observe DOM elements which mount conditionally (e.g. behind a guard like `!isInitializing`) MUST take the element as a parameter (via `useState` + callback ref in the parent), not a `useRef`. `useRef` mutations don't re-run effects, so a ref-based observer attaches only on the lucky render where the element exists. `useLiveCardHeight` is the canonical example.
+- Any hook that writes a CSS custom property MUST clear it on unmount, so removing the consumer doesn't leak the value into the next session.
+
+## What NOT To Do
+
+- Do NOT use `useRef<HTMLElement>` for elements that are conditionally mounted — the observer will silently miss the late mount. Use `useState` + a callback ref so the effect re-runs when the element appears.
+- Do NOT call `setState` from inside `ResizeObserver` / `MutationObserver` callbacks without batching (`requestAnimationFrame` or React 18 auto-batching). Synchronous re-renders inside the observer cause infinite loops.
+
+## Dependencies
+
+Nothing exotic — `react`, native DOM observer APIs (`ResizeObserver`, `MutationObserver`, `matchMedia`), `@tanstack/react-query` for server-state hooks.

--- a/web/src/hooks/use-live-card-height.ts
+++ b/web/src/hooks/use-live-card-height.ts
@@ -1,0 +1,81 @@
+import { useEffect, useRef } from 'react';
+
+/**
+ * CSS custom property name written on the target element. The chat CSS
+ * reads this from `<main>` to reserve scroll padding inside pi-web-ui's
+ * message viewport equal to the live card's measured height, so the
+ * user's just-sent message stays visible above the floating card.
+ */
+const CSS_VAR = '--rara-live-card-h';
+
+/**
+ * ResizeObserver-backed measurement of the in-progress agent live card.
+ *
+ * The live card is `position: absolute` and overlays the bottom of
+ * pi-web-ui's message list (see `.rara-live-slot` in `index.css`).
+ * Without compensation, pi-web-ui's auto-scroll lands the latest user
+ * bubble directly under the card. This hook publishes the card's live
+ * pixel height to a CSS variable on `targetRef`; the CSS rule then
+ * pads pi-web-ui's scroll content by that amount, which (a) gives the
+ * user bubble room to sit above the card and (b) — because pi-web-ui
+ * watches its content's resize to drive auto-scroll — automatically
+ * scrolls the bubble into view above the overlay.
+ *
+ * `cardRef` may be null (no active run); in that case the variable is
+ * cleared so the chat returns to its normal layout.
+ */
+export function useLiveCardHeight(
+  cardRef: React.RefObject<HTMLElement | null>,
+  targetRef: React.RefObject<HTMLElement | null>,
+) {
+  // Track the last value we wrote so the cleanup can restore the prior
+  // state instead of unconditionally wiping a value another caller set.
+  const lastWrittenRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    const target = targetRef.current;
+    const card = cardRef.current;
+    if (!target) return;
+
+    const clear = () => {
+      target.style.removeProperty(CSS_VAR);
+      lastWrittenRef.current = null;
+    };
+
+    if (!card) {
+      clear();
+      return clear;
+    }
+
+    const write = (px: number) => {
+      // Round to integer px — sub-pixel values cause layout thrash on
+      // some browsers and the live card's height never genuinely needs
+      // sub-pixel precision.
+      const value = `${Math.max(0, Math.round(px))}px`;
+      if (lastWrittenRef.current === value) return;
+      target.style.setProperty(CSS_VAR, value);
+      lastWrittenRef.current = value;
+    };
+
+    const observer = new ResizeObserver((entries) => {
+      for (const entry of entries) {
+        // borderBoxSize is widely supported and matches `offsetHeight`
+        // semantics (includes padding+border, excludes margin).
+        const box = entry.borderBoxSize?.[0];
+        const height = box ? box.blockSize : entry.contentRect.height;
+        write(height);
+      }
+    });
+
+    // Seed immediately so the first paint already has padding — without
+    // this the first user message can flash under the card before the
+    // observer fires.
+    write(card.getBoundingClientRect().height);
+    observer.observe(card);
+
+    return () => {
+      observer.disconnect();
+      clear();
+    };
+  }, [cardRef, targetRef]);
+}

--- a/web/src/hooks/use-live-card-height.ts
+++ b/web/src/hooks/use-live-card-height.ts
@@ -15,26 +15,31 @@ const CSS_VAR = '--rara-live-card-h';
  * pi-web-ui's message list (see `.rara-live-slot` in `index.css`).
  * Without compensation, pi-web-ui's auto-scroll lands the latest user
  * bubble directly under the card. This hook publishes the card's live
- * pixel height to a CSS variable on `targetRef`; the CSS rule then
- * pads pi-web-ui's scroll content by that amount, which (a) gives the
- * user bubble room to sit above the card and (b) — because pi-web-ui
- * watches its content's resize to drive auto-scroll — automatically
- * scrolls the bubble into view above the overlay.
+ * pixel height to a CSS variable on `target`; the CSS rule then pads
+ * pi-web-ui's scroll content by that amount, which (a) gives the user
+ * bubble room to sit above the card and (b) — because pi-web-ui watches
+ * its content's resize to drive auto-scroll — automatically scrolls the
+ * bubble into view above the overlay.
  *
- * `cardRef` may be null (no active run); in that case the variable is
+ * Accepts the elements directly (not refs) because the live-card
+ * wrapper mounts conditionally — once `isInitializing` flips false in
+ * the parent. `useRef` mutations don't re-run effects, so a ref-based
+ * API would attach the ResizeObserver only on the lucky render where
+ * `cardRef.current` happens to be set; usually the wrapper appears in
+ * a later render and the observer is never wired. Passing the actual
+ * elements (set via callback refs in the parent) makes the effect
+ * re-run whenever the wrapper mounts/unmounts — which is the entire
+ * point of this hook.
+ *
+ * `card` may be null (no active run); in that case the variable is
  * cleared so the chat returns to its normal layout.
  */
-export function useLiveCardHeight(
-  cardRef: React.RefObject<HTMLElement | null>,
-  targetRef: React.RefObject<HTMLElement | null>,
-) {
+export function useLiveCardHeight(card: HTMLElement | null, target: HTMLElement | null) {
   // Track the last value we wrote so the cleanup can restore the prior
   // state instead of unconditionally wiping a value another caller set.
   const lastWrittenRef = useRef<string | null>(null);
 
   useEffect(() => {
-    const target = targetRef.current;
-    const card = cardRef.current;
     if (!target) return;
 
     const clear = () => {
@@ -77,5 +82,5 @@ export function useLiveCardHeight(
       observer.disconnect();
       clear();
     };
-  }, [cardRef, targetRef]);
+  }, [card, target]);
 }

--- a/web/src/hooks/use-live-card-height.ts
+++ b/web/src/hooks/use-live-card-height.ts
@@ -35,8 +35,8 @@ const CSS_VAR = '--rara-live-card-h';
  * cleared so the chat returns to its normal layout.
  */
 export function useLiveCardHeight(card: HTMLElement | null, target: HTMLElement | null) {
-  // Track the last value we wrote so the cleanup can restore the prior
-  // state instead of unconditionally wiping a value another caller set.
+  // Dedupe — skip writes when the value is unchanged to avoid layout
+  // thrash on identical resizes.
   const lastWrittenRef = useRef<string | null>(null);
 
   useEffect(() => {

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -470,6 +470,12 @@
  * scroll viewport is the belt-and-braces companion: it ensures any
  * native scroll-into-view (e.g. focus restoration) also clears the
  * overlay region.
+ *
+ * Invariant: this selector targets pi-web-ui ≥0.63 light DOM. On any
+ * pi-web-ui upgrade, verify that the `agent-interface > .overflow-y-auto > .max-w-3xl`
+ * chain still exists in the rendered DOM — if pi-web-ui changes its
+ * content-column class (e.g. `max-w-4xl`) or wraps the scroll viewport,
+ * this rule silently no-ops and #1675 regresses.
  */
 .rara-chat agent-interface .overflow-y-auto > .max-w-3xl {
   padding-bottom: var(--rara-live-card-h, 0);

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -456,6 +456,28 @@
   bottom: 10.5rem;
 }
 
+/*
+ * Reserve scroll space inside pi-web-ui's message column for the live
+ * card overlay. `--rara-live-card-h` is published on `<main>` by
+ * `useLiveCardHeight` (see `src/hooks/use-live-card-height.ts`) only
+ * while a run is active; defaults to 0 so the chat reads identically
+ * when no card is mounted.
+ *
+ * Padding the inner content (rather than the scroll viewport) makes
+ * pi-web-ui's content-resize ResizeObserver fire — that observer
+ * drives auto-scroll, which is exactly what lifts the user's just-sent
+ * bubble above the floating card. `scroll-padding-bottom` on the
+ * scroll viewport is the belt-and-braces companion: it ensures any
+ * native scroll-into-view (e.g. focus restoration) also clears the
+ * overlay region.
+ */
+.rara-chat agent-interface .overflow-y-auto > .max-w-3xl {
+  padding-bottom: var(--rara-live-card-h, 0);
+}
+.rara-chat agent-interface .overflow-y-auto {
+  scroll-padding-bottom: var(--rara-live-card-h, 0);
+}
+
 .user-message-container {
   /* Content-size the bubble so justify-end actually pushes it right.
      In a flex container `display: block` resolves to "stretch" along

--- a/web/src/pages/PiChat.tsx
+++ b/web/src/pages/PiChat.tsx
@@ -57,6 +57,7 @@ import { RaraModelDialog } from '@/components/RaraModelDialog';
 import { SessionSearchDialog } from '@/components/SessionSearchDialog';
 import { useSettingsModal } from '@/components/settings/SettingsModalProvider';
 import { VoiceRecorder } from '@/components/VoiceRecorder';
+import { useLiveCardHeight } from '@/hooks/use-live-card-height';
 import { useSessionDelete } from '@/hooks/use-session-delete';
 import { UNKNOWN_MODEL_SENTINEL, isUnknownModel, syntheticModel } from '@/lib/synthetic-model';
 import { registerRaraToolRenderers } from '@/tools/rara-tool-renderers';
@@ -271,6 +272,11 @@ function registerCascadeAssistantRenderer(agentResolver: () => Agent | null): vo
  */
 export default function PiChat() {
   const containerRef = useRef<HTMLDivElement>(null);
+  // Refs for live-card scroll-padding wiring: `liveCardRef` measures
+  // the rendered card; `mainRef` receives the `--rara-live-card-h`
+  // CSS variable that scopes the padding to this chat surface.
+  const liveCardRef = useRef<HTMLDivElement>(null);
+  const mainRef = useRef<HTMLElement>(null);
   const initRef = useRef(false);
   const agentRef = useRef<Agent | null>(null);
   const chatPanelRef = useRef<import('@mariozechner/pi-web-ui').ChatPanel | null>(null);
@@ -887,6 +893,11 @@ export default function PiChat() {
     };
   }, []);
 
+  // Reserve scroll padding inside pi-web-ui's message list equal to the
+  // live card's height while a run is active — see hook docstring and
+  // `.rara-chat agent-interface .max-w-3xl` rule in `index.css`.
+  useLiveCardHeight(liveCardRef, mainRef);
+
   return (
     <div
       className="rara-chat flex h-screen w-screen"
@@ -901,7 +912,7 @@ export default function PiChat() {
         onDeleteSession={handleSessionDeleted}
         refreshKey={sidebarRefreshKey}
       />
-      <main className="relative flex min-h-0 min-w-0 flex-1 flex-col">
+      <main ref={mainRef} className="relative flex min-h-0 min-w-0 flex-1 flex-col">
         {/* Session title header — shows the current conversation's
             title above its messages (kimi-style). Hidden during the
             welcome state since the RARA wordmark already serves as
@@ -921,7 +932,7 @@ export default function PiChat() {
             streaming. See `.rara-live-slot` in index.css for placement. */}
         {!isInitializing && (
           <div className="rara-live-slot pointer-events-none absolute z-10 px-2">
-            <div className="pointer-events-auto">
+            <div ref={liveCardRef} className="pointer-events-auto">
               <AgentLiveCard sessionKey={activeSession?.key} />
             </div>
           </div>

--- a/web/src/pages/PiChat.tsx
+++ b/web/src/pages/PiChat.tsx
@@ -272,11 +272,16 @@ function registerCascadeAssistantRenderer(agentResolver: () => Agent | null): vo
  */
 export default function PiChat() {
   const containerRef = useRef<HTMLDivElement>(null);
-  // Refs for live-card scroll-padding wiring: `liveCardRef` measures
-  // the rendered card; `mainRef` receives the `--rara-live-card-h`
-  // CSS variable that scopes the padding to this chat surface.
-  const liveCardRef = useRef<HTMLDivElement>(null);
-  const mainRef = useRef<HTMLElement>(null);
+  // Live-card scroll-padding wiring: `liveCardEl` measures the rendered
+  // card; `mainEl` receives the `--rara-live-card-h` CSS variable that
+  // scopes the padding to this chat surface. Both are tracked via
+  // `useState` + callback refs (rather than `useRef`) because the
+  // wrapper div mounts conditionally on `!isInitializing`; effect
+  // dependencies on `useRef` objects do not re-fire when `.current`
+  // mutates, so a ref-based wiring missed the late-mounting wrapper
+  // entirely and the CSS variable was never written.
+  const [liveCardEl, setLiveCardEl] = useState<HTMLDivElement | null>(null);
+  const [mainEl, setMainEl] = useState<HTMLElement | null>(null);
   const initRef = useRef(false);
   const agentRef = useRef<Agent | null>(null);
   const chatPanelRef = useRef<import('@mariozechner/pi-web-ui').ChatPanel | null>(null);
@@ -896,7 +901,7 @@ export default function PiChat() {
   // Reserve scroll padding inside pi-web-ui's message list equal to the
   // live card's height while a run is active — see hook docstring and
   // `.rara-chat agent-interface .max-w-3xl` rule in `index.css`.
-  useLiveCardHeight(liveCardRef, mainRef);
+  useLiveCardHeight(liveCardEl, mainEl);
 
   return (
     <div
@@ -912,7 +917,7 @@ export default function PiChat() {
         onDeleteSession={handleSessionDeleted}
         refreshKey={sidebarRefreshKey}
       />
-      <main ref={mainRef} className="relative flex min-h-0 min-w-0 flex-1 flex-col">
+      <main ref={setMainEl} className="relative flex min-h-0 min-w-0 flex-1 flex-col">
         {/* Session title header — shows the current conversation's
             title above its messages (kimi-style). Hidden during the
             welcome state since the RARA wordmark already serves as
@@ -932,7 +937,7 @@ export default function PiChat() {
             streaming. See `.rara-live-slot` in index.css for placement. */}
         {!isInitializing && (
           <div className="rara-live-slot pointer-events-none absolute z-10 px-2">
-            <div ref={liveCardRef} className="pointer-events-auto">
+            <div ref={setLiveCardEl} className="pointer-events-auto">
               <AgentLiveCard sessionKey={activeSession?.key} />
             </div>
           </div>


### PR DESCRIPTION
## Summary

Fixes #1675 where the floating `AgentLiveCard` (a `position: absolute; bottom: 10.5rem` overlay) hid the user's just-sent message. pi-web-ui auto-scrolls new messages to the bottom of its viewport, landing them directly under the card.

**Path B (no upstream hook)**. pi-web-ui v0.63 does not expose a slot, prop, or CSS variable for message-list bottom padding (verified by reading `node_modules/@mariozechner/pi-web-ui/dist/components/AgentInterface.js`). Implementation:

- New `useLiveCardHeight` hook (`web/src/hooks/use-live-card-height.ts`) ResizeObserves the live card and writes its pixel height to `--rara-live-card-h` on `<main>`. Clears the variable on unmount / when no card is mounted, so the chat returns to a normal layout when no run is active.
- CSS rule scoped to `.rara-chat agent-interface` pads the inner `.max-w-3xl` content and sets `scroll-padding-bottom` on the `.overflow-y-auto` viewport.
- Padding the inner content (not the outer container) is what makes this work: pi-web-ui's auto-scroll is driven by a `ResizeObserver` on `.max-w-3xl`, so growing it triggers a scroll-to-bottom that lifts the user bubble above the card.

**Composer position is unaffected.** The composer is a separate `.shrink-0` flex sibling of the scroll viewport inside `<agent-interface>`, not inside the padded element.

## Type of change

| Type | Label |
|------|-------|
| Bug fix | `bug` |

## Component

`ui`

## Closes

Closes #1675

## Test plan

- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
- [x] `npm run test` passes (71/71)
- [x] `npm run lint:css` passes
- [x] `npm run build` passes
- [ ] Manual verification: **not performed** — no backend was reachable from this worktree environment. Reviewer should send a message in an existing session and confirm the user bubble stays visible above the live card while a run is streaming.