### PR TITLE
chore(deps): unified dep bump (#1677)

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 22
       - name: Install dependencies
@@ -29,7 +29,7 @@ jobs:
       - name: Build
         working-directory: site
         run: npm run build
-      - uses: actions/upload-pages-artifact@v3
+      - uses: actions/upload-pages-artifact@v5
         with:
           path: site/dist
 
@@ -41,4 +41,4 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/web-ci.yml
+++ b/.github/workflows/web-ci.yml
@@ -25,7 +25,7 @@ jobs:
         working-directory: web
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: npm
@@ -53,7 +53,7 @@ jobs:
         working-directory: web
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: npm

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -164,12 +164,12 @@ dirs = "^6"
 eventsource-stream = "0.2"
 futures = "^0.3"
 hex = "0.4"
-hmac = "0.12"
+hmac = "0.13"
 http = "^1"
 hyper = { version = "1", features = ["full"] }
 image = { version = "0.25", default-features = false, features = ["jpeg", "png", "webp", "gif"] }
 indexmap = "2"
-jieba-rs = "0.7"
+jieba-rs = "0.9"
 jiff = { version = "^0.2", features = ["serde"] }
 jsonwebtoken = "9"
 lazy_static = "^1.4"
@@ -190,7 +190,7 @@ opendal = { version = "0.52", features = ["services-fs", "services-memory"] }
 parking_lot = "0.12"
 prost = "^0.14"
 protobuf = "^3.7"
-rand = "0.9"
+rand = "0.10"
 rapidfuzz = "0.5"
 ratatui = { version = "0.29", features = ["crossterm"] }
 regex = "1"
@@ -201,7 +201,7 @@ schemars = "^1.2"
 serde = { version = "^1.0", features = ["derive"] }
 serde_json = "1.0.143"
 serde_yaml = "0.9"
-sha2 = "0.10"
+sha2 = "0.11"
 shadow-rs = "1.2"
 smart-default = "0.7"
 snafu = "^0.9"

--- a/crates/channels/Cargo.toml
+++ b/crates/channels/Cargo.toml
@@ -12,7 +12,7 @@ base64 = { workspace = true }
 chrono = { workspace = true }
 dashmap = "6"
 futures = { workspace = true }
-governor = "0.7"
+governor = "0.10"
 image = { workspace = true }
 jiff = { workspace = true }
 rand = { workspace = true }

--- a/crates/channels/src/telegram/loading_hints.rs
+++ b/crates/channels/src/telegram/loading_hints.rs
@@ -19,7 +19,7 @@
 //! zero coupling to I/O transport — it is purely a UI concern owned by
 //! one channel.
 
-use rand::Rng;
+use rand::RngExt;
 
 /// Pool of poetic Chinese loading messages.
 pub const HINTS: &[&str] = &[

--- a/crates/channels/src/telegram/spinner_verbs.rs
+++ b/crates/channels/src/telegram/spinner_verbs.rs
@@ -21,7 +21,7 @@
 //! on each progress render so the message visibly changes even when the
 //! underlying tool state has not.
 
-use rand::Rng;
+use rand::RngExt;
 
 /// Full verb pool — copied verbatim from Claude Code's
 /// `src/constants/spinnerVerbs.ts`.

--- a/crates/integrations/mcp/Cargo.toml
+++ b/crates/integrations/mcp/Cargo.toml
@@ -16,6 +16,7 @@ async-trait.workspace = true
 base.workspace = true
 bon.workspace = true
 futures.workspace = true
+hex.workspace = true
 jiff.workspace = true
 oauth2.workspace = true
 rara-kernel.workspace = true

--- a/crates/integrations/mcp/src/oauth.rs
+++ b/crates/integrations/mcp/src/oauth.rs
@@ -332,7 +332,8 @@ impl StoredOAuthTokens {
             serde_json::to_string(&payload).context("failed to serialize store key payload")?;
 
         let hash = Sha256::digest(serialized.as_bytes());
-        let prefix = &format!("{hash:x}")[..16];
+        let hex_hash = hex::encode(hash);
+        let prefix = &hex_hash[..16];
         Ok(format!("{server_name}|{prefix}"))
     }
 

--- a/crates/kernel/Cargo.toml
+++ b/crates/kernel/Cargo.toml
@@ -24,7 +24,7 @@ base.workspace = true
 base64.workspace = true
 bon.workspace = true
 chrono.workspace = true
-cron = "0.15"
+cron = "0.16"
 crossbeam-queue.workspace = true
 dashmap = "6"
 derive_more = { workspace = true }

--- a/crates/kernel/src/data_feed/webhook.rs
+++ b/crates/kernel/src/data_feed/webhook.rs
@@ -52,7 +52,7 @@ use axum::{
     response::IntoResponse,
     routing::post,
 };
-use hmac::{Hmac, Mac};
+use hmac::{Hmac, KeyInit, Mac};
 use jiff::Timestamp;
 use parking_lot::Mutex;
 use serde::{Deserialize, Serialize};
@@ -410,7 +410,7 @@ mod tests {
         body::Body,
         http::{Request, StatusCode},
     };
-    use hmac::{Hmac, Mac};
+    use hmac::{Hmac, KeyInit, Mac};
     use sha2::Sha256;
     use tokio::sync::mpsc;
     use tower::ServiceExt;

--- a/crates/skills/Cargo.toml
+++ b/crates/skills/Cargo.toml
@@ -21,6 +21,7 @@ chrono.workspace = true
 dirs.workspace = true
 flate2 = "1"
 fs2 = "0.4"
+hex.workspace = true
 notify-debouncer-full = "0.7"
 percent-encoding = "2"
 rara-paths.workspace = true

--- a/crates/skills/src/hash.rs
+++ b/crates/skills/src/hash.rs
@@ -25,5 +25,5 @@ use crate::error::{IoSnafu, Result};
 pub fn file_hash(path: &Path) -> Result<String> {
     let content = std::fs::read(path).context(IoSnafu)?;
     let digest = Sha256::digest(&content);
-    Ok(format!("{digest:x}"))
+    Ok(hex::encode(digest))
 }


### PR DESCRIPTION
## Summary

Fold 9 of 10 open dependabot PRs into a single unified bump, fixing
call-site breakage from the generic-array migration (sha2/hmac) and
the rand 0.10 trait rename. One dependabot PR (agent-client-protocol)
is deferred because upstream shipped a full SDK redesign.

### Cargo bumps
- governor 0.7 -> 0.10 (no API change for our usage)
- jieba-rs 0.7 -> 0.9 (no API change)
- hmac 0.12 -> 0.13 (import `KeyInit` for `new_from_slice`)
- rand 0.9 -> 0.10 (`Rng` trait renamed to `RngExt`)
- sha2 0.10 -> 0.11 (digest output no longer impls `LowerHex`;
  switched to `hex::encode` in `rara-skills` and `rara-mcp`)
- cron 0.15 -> 0.16 (no API change)

### GitHub Actions bumps
- actions/setup-node 4 -> 6
- actions/upload-pages-artifact 3 -> 5
- actions/deploy-pages 4 -> 5

### Deferred
- agent-client-protocol 0.10 -> 0.11 (#1656): upstream shipped a
  full SDK redesign (all types relocated to `schema::`, connection
  API reworked, `ClientSideConnection` removed). Migration exceeds
  the scope of a dep-bump PR and will ship as a separate follow-up.
  The #1656 dependabot PR remains open.

## Type of change

| Type | Label |
|------|-------|
| Chore | `chore` |

## Component

`ci`

## Closes

Closes #1677
Closes #1660
Closes #1658
Closes #1657
Closes #1331
Closes #1016
Closes #1015
Closes #1363
Closes #1100
Closes #1099

## Test plan

- [x] `cargo check --workspace --all-targets` clean
- [x] `cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings` clean
- [x] `cargo +nightly fmt --all -- --check` clean
- [x] `RUSTDOCFLAGS="-D warnings" cargo +nightly doc --workspace --no-deps --document-private-items` clean
- [x] `cargo nextest run --workspace` — 989 passed, 3 skipped