### PR TITLE
feat(ui): surface Scheduler in Settings with responsive grid (#1683)

### DIFF
--- a/web/src/components/settings/SettingsPanel.tsx
+++ b/web/src/components/settings/SettingsPanel.tsx
@@ -18,6 +18,7 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import {
   Bot,
   BookOpen,
+  CalendarClock,
   ExternalLink,
   Eye,
   EyeOff,
@@ -69,6 +70,7 @@ import { useTheme, type Theme } from '@/hooks/use-theme';
 import { cn } from '@/lib/utils';
 import Agents from '@/pages/Agents';
 import McpServers from '@/pages/McpServers';
+import Scheduler from '@/pages/Scheduler';
 import Skills from '@/pages/Skills';
 
 /** Admin settings section identifiers. Exported so the floating modal can deep-link into a specific tab. */
@@ -81,7 +83,8 @@ export type SettingsPage =
   | 'channels'
   | 'tools'
   | 'security'
-  | 'data-feeds';
+  | 'data-feeds'
+  | 'scheduler';
 
 type ToastState = { kind: 'success' | 'error'; message: string } | null;
 
@@ -589,6 +592,7 @@ const SETTINGS_PAGES: readonly SettingsPage[] = [
   'tools',
   'security',
   'data-feeds',
+  'scheduler',
 ];
 
 /**
@@ -774,6 +778,12 @@ export default function SettingsPanel({
       label: 'Data Feeds',
       icon: <Radio className="h-4 w-4" />,
       summary: 'External event sources',
+    },
+    {
+      id: 'scheduler',
+      label: 'Scheduler',
+      icon: <CalendarClock className="h-4 w-4" />,
+      summary: 'Cron tasks and run history',
     },
   ];
 
@@ -1514,6 +1524,13 @@ export default function SettingsPanel({
         {activeCategory === 'data-feeds' && (
           <div className="data-panel p-4">
             <DataFeedsPanel />
+          </div>
+        )}
+
+        {/* ── Scheduler ── */}
+        {activeCategory === 'scheduler' && (
+          <div className="data-panel p-4">
+            <Scheduler />
           </div>
         )}
       </div>

--- a/web/src/pages/Scheduler.tsx
+++ b/web/src/pages/Scheduler.tsx
@@ -194,7 +194,7 @@ export function DomainSchedulerPanel() {
   return (
     <div className="space-y-4">
       {tasksQuery.isLoading ? (
-        <div className="space-y-4">
+        <div className="grid grid-cols-1 gap-4 md:grid-cols-[repeat(auto-fill,minmax(360px,1fr))]">
           {Array.from({ length: 3 }).map((_, i) => (
             <Card key={i} className="data-panel">
               <CardContent className="p-6 space-y-4">
@@ -220,7 +220,7 @@ export function DomainSchedulerPanel() {
           </CardContent>
         </Card>
       ) : (
-        <div className="space-y-4">
+        <div className="grid grid-cols-1 gap-4 md:grid-cols-[repeat(auto-fill,minmax(360px,1fr))]">
           {tasksQuery.data.map((task) => (
             <TaskCard key={task.id} task={task} />
           ))}


### PR DESCRIPTION
## Summary

- Add `scheduler` tab to Settings panel with `CalendarClock` icon; routes to the existing `Scheduler` page component
- Convert `DomainSchedulerPanel` card list from vertical stack to responsive grid (`auto-fill, minmax(360px, 1fr)`) so wide screens don't waste space
- Apply grid to skeleton state too to avoid layout shift

## Type of change

| Type | Label |
|------|-------|
| Enhancement | `enhancement` |

## Component

`ui`

## Closes

Closes #1683

## Test plan

- [x] `npm run build` in `web/` passes
- [x] Scheduler tab visible in Settings sidebar
- [x] Cards reflow responsively on wide viewport
- [x] Existing enable/disable + history expand still work