### PR TITLE
feat(kernel): add ListAllJobs and TriggerJob syscalls for scheduler admin (#1688)

### DIFF
--- a/crates/kernel/AGENT.md
+++ b/crates/kernel/AGENT.md
@@ -418,3 +418,11 @@ Each kernel turn calls `StreamHub::open(session)` which gets-or-creates a `broad
 - Do NOT emit `StreamEvent::StreamClosed` from `close_session()` — that path is only called from `open()` to reap zombies from pre-empted turns. Emitting a terminal marker there would cause session-level subscribers (web `WebEvent::Done`) to finalize the previous turn's UI mid-flight when the user sends a follow-up message before the first turn completes. Normal turn completion goes through `close()` which DOES emit the marker.
 - Do NOT hold a DashMap `get()` guard across a `remove()` on the same map — DashMap shards are `RwLock`-based and a read guard across a write on the same shard deadlocks. `reap_session_bus_if_idle` uses `remove_if` so the receiver-count check and the removal happen atomically under the shard write lock with no nested same-shard lock.
 - Do NOT replace the `remove_if` closure with a pre-check + `remove()` pair — the non-atomic variant has a TOCTOU window where a concurrent `subscribe_session_events` can attach a fresh receiver to a sender the reaper then deletes, silently losing every subsequent event for that session.
+
+---
+
+## Critical: Scheduler Admin Syscalls — `schedule.rs` + `syscall.rs`
+
+- `Syscall::TriggerJob` fires a job on demand by cloning its `JobEntry`, inserting it into the in-flight ledger with the standard lease, and pushing a `ScheduledTask` event. It MUST NOT mutate the wheel's `next_at` — recurring jobs continue on their regular cadence. The only in-flight mutation path that advances schedules is `drain_expired` → `reschedule_recurring`; `TriggerJob` deliberately bypasses it.
+- `Syscall::ListAllJobs` is an admin-only surface. The kernel does not authenticate it; the backend HTTP route is the auth boundary. Do NOT repurpose this variant for session-scoped tool calls — use `Syscall::ListJobs` there so future tightening of `ListAllJobs` permissions cannot regress tool UX.
+- `JobResultStore::read_latest` intentionally walks results newest-first and skips malformed entries, so a single corrupt tail object does not hide the rest of the history from the admin UI. Keep the fall-through behaviour when extending the store.

--- a/crates/kernel/src/event.rs
+++ b/crates/kernel/src/event.rs
@@ -217,6 +217,34 @@ pub enum Syscall {
         reply_tx: oneshot::Sender<crate::error::Result<Vec<crate::schedule::JobEntry>>>,
     },
 
+    /// List every scheduled job across all sessions — admin-only surface.
+    ///
+    /// Semantically distinct from [`Syscall::ListJobs`]: this variant exists
+    /// so the backend admin route has an unambiguous, auth-gated entry point
+    /// that cannot be reused by unprivileged session tools. The kernel does
+    /// no auth check itself — the HTTP layer is responsible for gating.
+    ListAllJobs {
+        #[debug(skip)]
+        #[serde(skip_serializing)]
+        reply_tx: oneshot::Sender<crate::error::Result<Vec<crate::schedule::JobEntry>>>,
+    },
+
+    /// Immediately fire a scheduled job without advancing its `next_at`.
+    ///
+    /// The job is cloned from the wheel (not removed), inserted into the
+    /// in-flight ledger with the standard lease, and dispatched through the
+    /// same `ScheduledTask` path that [`JobWheel::drain_expired`] uses. The
+    /// wheel's original schedule is untouched — recurring jobs still fire at
+    /// their next regular `next_at`.
+    ///
+    /// [`JobWheel::drain_expired`]: crate::schedule::JobWheel::drain_expired
+    TriggerJob {
+        job_id:   crate::schedule::JobId,
+        #[debug(skip)]
+        #[serde(skip_serializing)]
+        reply_tx: oneshot::Sender<crate::error::Result<()>>,
+    },
+
     // -- Task Report & Subscription --
     /// Register a notification subscription for the calling session.
     Subscribe {

--- a/crates/kernel/src/schedule.rs
+++ b/crates/kernel/src/schedule.rs
@@ -582,6 +582,45 @@ impl JobWheel {
             .collect()
     }
 
+    /// Insert a manual-trigger copy of `job_id` into the in-flight ledger
+    /// without mutating the wheel's scheduled entry.
+    ///
+    /// Used by `Syscall::TriggerJob` to fire a job on demand. The original
+    /// entry's `next_at` is intentionally preserved so recurring jobs keep
+    /// their regular cadence after an out-of-band trigger. Persists the
+    /// ledger to disk on success.
+    ///
+    /// Returns the cloned [`JobEntry`] ready to be dispatched via
+    /// `ScheduledTask`, or `None` if no job with that ID is on the wheel.
+    /// If the same job is already in-flight the new lease overwrites it —
+    /// the agent runtime is responsible for handling overlapping executions.
+    pub fn trigger_now(&mut self, job_id: &JobId) -> Option<JobEntry> {
+        let key = *self.by_id.get(job_id)?;
+        let entry = self.jobs.get(&key)?.clone();
+
+        if self.in_flight.contains_key(job_id) {
+            warn!(
+                job_id = %job_id,
+                "trigger_now: job already in-flight; enqueueing overlapping execution"
+            );
+        }
+
+        let now = self.clock.now();
+        let lease_deadline = now
+            .checked_add(jiff::SignedDuration::from_secs(DEFAULT_LEASE_SECS))
+            .unwrap_or(now);
+        self.in_flight.insert(
+            entry.id,
+            InFlightEntry {
+                job: entry.clone(),
+                fired_at: now,
+                lease_deadline,
+            },
+        );
+        self.persist_in_flight();
+        Some(entry)
+    }
+
     /// Mark a job as completed, removing it from the in-flight ledger.
     ///
     /// Called when the execution agent's session ends (regardless of whether
@@ -778,32 +817,64 @@ impl JobResultStore {
     /// Read all execution results for a given job, ordered by completion
     /// time (lexicographic on the epoch filename).
     pub async fn read(&self, job_id: &JobId) -> Vec<JobResult> {
+        let entries = self.sorted_entries(job_id).await;
+        // `sorted_entries` returns ascending — `read` keeps that order.
+        let mut results = Vec::new();
+        for entry in entries {
+            if let Some(r) = self.read_one(entry.path()).await {
+                results.push(r);
+            }
+        }
+        results
+    }
+
+    /// Read the most recent execution result for a given job.
+    ///
+    /// Cheaper than `read` when the caller only needs the latest status —
+    /// the scheduler admin UI uses this to derive `last_status` without
+    /// paging the full history. Returns `None` if the job directory is
+    /// empty or every object fails to parse.
+    pub async fn read_latest(&self, job_id: &JobId) -> Option<JobResult> {
+        // Walk newest-first so a single malformed tail entry doesn't hide
+        // the rest of the history — skip and try the next one.
+        let entries = self.sorted_entries(job_id).await;
+        for entry in entries.into_iter().rev() {
+            if let Some(r) = self.read_one(entry.path()).await {
+                return Some(r);
+            }
+        }
+        None
+    }
+
+    /// List non-directory result objects under `{job_id}/`, sorted
+    /// ascending by path (epoch filenames sort chronologically).
+    async fn sorted_entries(&self, job_id: &JobId) -> Vec<opendal::Entry> {
         let prefix = format!("{job_id}/");
         let mut entries = match self.op.list(&prefix).await {
             Ok(v) => v,
             Err(_) => return Vec::new(),
         };
-        // Sort by path (epoch filenames sort chronologically).
+        entries.retain(|e| !e.metadata().is_dir());
         entries.sort_by(|a, b| a.path().cmp(b.path()));
+        entries
+    }
 
-        let mut results = Vec::new();
-        for entry in entries {
-            if entry.metadata().is_dir() {
-                continue;
-            }
-            match self.op.read(entry.path()).await {
-                Ok(buf) => match serde_json::from_slice::<JobResult>(&buf.to_vec()) {
-                    Ok(r) => results.push(r),
-                    Err(e) => {
-                        warn!(error = %e, path = entry.path(), "skipping malformed job result");
-                    }
-                },
+    /// Read and parse a single result object, logging and returning `None`
+    /// on read or parse failure.
+    async fn read_one(&self, path: &str) -> Option<JobResult> {
+        match self.op.read(path).await {
+            Ok(buf) => match serde_json::from_slice::<JobResult>(&buf.to_vec()) {
+                Ok(r) => Some(r),
                 Err(e) => {
-                    warn!(error = %e, path = entry.path(), "failed to read job result");
+                    warn!(error = %e, path = path, "skipping malformed job result");
+                    None
                 }
+            },
+            Err(e) => {
+                warn!(error = %e, path = path, "failed to read job result");
+                None
             }
         }
-        results
     }
 }
 
@@ -1227,5 +1298,147 @@ mod tests {
             back.lease_deadline.as_second(),
             t0().as_second() + DEFAULT_LEASE_SECS
         );
+    }
+
+    fn cron_entry(expr: &str, next_at: Timestamp) -> JobEntry {
+        JobEntry {
+            id:          JobId::new(),
+            trigger:     Trigger::Cron {
+                expr: expr.into(),
+                next_at,
+            },
+            message:     "cron".into(),
+            session_key: SessionKey::new(),
+            principal:   test_principal(),
+            created_at:  next_at,
+            tags:        vec![],
+        }
+    }
+
+    /// `trigger_now` must NOT advance the wheel entry's `next_at` — the
+    /// regular cadence survives an out-of-band fire.
+    #[test]
+    fn trigger_job_fires_without_advancing_next_at() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let path = tmp.path().join("jobs.json");
+        let clock = Arc::new(FakeClock::new(t0()));
+        let mut wheel = JobWheel::load_with_clock(path, clock.clone());
+
+        // Cron: next fire one hour from now.
+        let future_fire = Timestamp::from_second(t0().as_second() + 3600).unwrap();
+        let entry = cron_entry("0 * * * * *", future_fire);
+        let id = entry.id;
+        wheel.add(entry);
+
+        let fired = wheel.trigger_now(&id).expect("trigger_now should find job");
+        assert_eq!(fired.id, id);
+
+        // Wheel still holds the job with the original next_at.
+        let still_scheduled = wheel
+            .list(None)
+            .into_iter()
+            .find(|e| e.id == id)
+            .expect("job should remain on the wheel after manual trigger");
+        assert_eq!(
+            still_scheduled.trigger.next_at(),
+            future_fire,
+            "trigger_now must not mutate the wheel's scheduled next_at"
+        );
+
+        // And there is exactly one in-flight entry with the fresh lease.
+        assert_eq!(wheel.in_flight.len(), 1);
+        let ifl = &wheel.in_flight[&id];
+        assert_eq!(ifl.fired_at, t0());
+        assert_eq!(
+            ifl.lease_deadline.as_second(),
+            t0().as_second() + DEFAULT_LEASE_SECS
+        );
+    }
+
+    #[test]
+    fn trigger_job_missing_id_returns_none() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let path = tmp.path().join("jobs.json");
+        let mut wheel = JobWheel::load(path);
+        let ghost = JobId::new();
+        assert!(wheel.trigger_now(&ghost).is_none());
+        assert!(wheel.in_flight.is_empty());
+    }
+
+    /// `list(None)` returns jobs from every session — exercised by the
+    /// admin-only `Syscall::ListAllJobs` variant.
+    #[test]
+    fn list_all_jobs_crosses_sessions() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let path = tmp.path().join("jobs.json");
+        let mut wheel = JobWheel::load(path);
+
+        let mut a = make_entry(future(60));
+        a.session_key = SessionKey::new();
+        let mut b = make_entry(future(90));
+        b.session_key = SessionKey::new();
+        assert_ne!(a.session_key, b.session_key);
+        let id_a = a.id;
+        let id_b = b.id;
+
+        wheel.add(a);
+        wheel.add(b);
+
+        let all = wheel.list(None);
+        assert_eq!(all.len(), 2);
+        let ids: std::collections::HashSet<_> = all.iter().map(|e| e.id).collect();
+        assert!(ids.contains(&id_a));
+        assert!(ids.contains(&id_b));
+    }
+
+    fn make_result(job_id: JobId, completed_at: Timestamp) -> JobResult {
+        JobResult {
+            job_id,
+            task_id: Uuid::new_v4(),
+            task_type: "test".into(),
+            tags: vec![],
+            status: crate::task_report::TaskReportStatus::Completed,
+            summary: format!("run at {completed_at}"),
+            result: serde_json::json!({"at": completed_at.as_second()}),
+            action_taken: None,
+            completed_at,
+        }
+    }
+
+    #[tokio::test]
+    async fn read_latest_returns_most_recent() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let store = JobResultStore::new(tmp.path().to_path_buf());
+        let job_id = JobId::new();
+
+        let t1 = Timestamp::from_second(t0().as_second()).unwrap();
+        let t2 = Timestamp::from_second(t0().as_second() + 60).unwrap();
+        let t3 = Timestamp::from_second(t0().as_second() + 120).unwrap();
+
+        store
+            .append(&make_result(job_id, t1))
+            .await
+            .expect("append t1");
+        store
+            .append(&make_result(job_id, t2))
+            .await
+            .expect("append t2");
+        store
+            .append(&make_result(job_id, t3))
+            .await
+            .expect("append t3");
+
+        let latest = store
+            .read_latest(&job_id)
+            .await
+            .expect("read_latest should find the newest result");
+        assert_eq!(latest.completed_at, t3);
+    }
+
+    #[tokio::test]
+    async fn read_latest_empty_returns_none() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let store = JobResultStore::new(tmp.path().to_path_buf());
+        assert!(store.read_latest(&JobId::new()).await.is_none());
     }
 }

--- a/crates/kernel/src/syscall.rs
+++ b/crates/kernel/src/syscall.rs
@@ -505,6 +505,48 @@ impl SyscallDispatcher {
                 let jobs = wheel.list(None);
                 let _ = reply_tx.send(Ok(jobs));
             }
+            Syscall::ListAllJobs { reply_tx } => {
+                // Admin-only surface: the backend HTTP route is responsible
+                // for permission checks. The kernel itself is auth-agnostic
+                // here so the call stays a pure data read.
+                let wheel = self.job_wheel.lock();
+                let jobs = wheel.list(None);
+                let _ = reply_tx.send(Ok(jobs));
+            }
+            Syscall::TriggerJob { job_id, reply_tx } => {
+                let wheel_ref = self.job_wheel.clone();
+                let job_id_clone = job_id.clone();
+                let triggered = tokio::task::spawn_blocking(move || {
+                    let mut wheel = wheel_ref.lock();
+                    wheel.trigger_now(&job_id_clone)
+                })
+                .await
+                .unwrap_or_else(|e| {
+                    warn!(error = %e, "spawn_blocking panicked during TriggerJob");
+                    None
+                });
+
+                let result = match triggered {
+                    Some(job) => {
+                        info!(
+                            job_id = %job.id,
+                            session = %job.session_key,
+                            "manually triggered scheduled job"
+                        );
+                        // Dispatch via the same ScheduledTask event path
+                        // drain_expired uses so manual triggers and automatic
+                        // fires share one execution pipeline.
+                        let _ = kernel_handle
+                            .event_queue()
+                            .try_push(crate::event::KernelEventEnvelope::scheduled_task(job));
+                        Ok(())
+                    }
+                    None => Err(KernelError::Other {
+                        message: format!("job not found: {job_id}").into(),
+                    }),
+                };
+                let _ = reply_tx.send(result);
+            }
             Syscall::Subscribe {
                 match_tags,
                 on_receive,


### PR DESCRIPTION
## Summary

Part of epic #1686 (step 1/3). Adds the two kernel syscalls needed by the scheduler admin UI:
- `Syscall::ListAllJobs` — cross-session job listing (kernel does no auth; backend route gates it)
- `Syscall::TriggerJob` — immediate fire without advancing `next_at`; goes through standard in-flight ledger + dispatch
- `JobResultStore::read_latest` — derive `last_status` without paging full history

## Type of change

| Type | Label |
|------|-------|
| Enhancement | `enhancement` |

## Component

`core`

## Closes

Closes #1688

## Test plan

- [x] `cargo test -p rara-kernel` passes (5 new tests + existing)
- [x] `cargo clippy` passes with `-D warnings`
- [x] TriggerJob does not mutate wheel's `next_at`
- [x] ListAllJobs returns jobs across sessions