### PR TITLE
feat(backend): add scheduler admin routes (#1689)

### DIFF
--- a/crates/extensions/backend-admin/src/scheduler/AGENT.md
+++ b/crates/extensions/backend-admin/src/scheduler/AGENT.md
@@ -1,0 +1,24 @@
+# scheduler — Agent Guidelines
+
+## Purpose
+HTTP admin surface over the kernel scheduler. Read-only curation: list/get/delete/trigger/history. No `POST /jobs` — creation is agent-tool-only so every scheduled job stays tied to a real session principal.
+
+## Architecture
+- `dto.rs` — wire DTOs (`JobView`) and the `TaskReportStatus → last_status` mapping.
+- `service.rs` — `SchedulerSvc`: reads go direct to `JobWheel` + `JobResultStore`; mutations (`RemoveJob`, `TriggerJob`) dispatch via the kernel event queue.
+- `router.rs` — axum handlers at `/api/v1/scheduler/jobs[/...]`, history limit clamp.
+
+## Critical Invariants
+- Auth is applied by the upstream `backend-admin` router layer. Do NOT add auth here — duplicating gates drifts between routes.
+- `last_status` mapping is load-bearing for the frontend: `Completed → "ok"`, `Failed → "failed"`, `NeedsApproval → "running"`, no latest result → `null`. Keep `status_label` authoritative.
+- `TriggerJob` must leave `next_at` untouched — the kernel enforces this in `JobWheel::trigger_now`; don't introduce client-side rewrites that fake it.
+- `Principal` must never appear in any response DTO. It's internal kernel state.
+
+## What NOT To Do
+- Do NOT add `POST /api/v1/scheduler/jobs` — creation bypasses session principals and breaks the audit trail (see epic #1686).
+- Do NOT reuse `Syscall::ListJobs` for the admin list — it's the session-scoped variant; use `ListAllJobs` or `KernelHandle::list_jobs(None)` so future permission tightening on the admin surface doesn't regress tool UX.
+- Do NOT expand `SchedulerError::JobNotFound` to cover generic kernel failures — the HTTP layer maps it to 404; folding infra errors in would silently convert 500s to 404s.
+
+## Dependencies
+- Upstream: `rara-kernel` (`KernelHandle`, `schedule::*`, `task_report::TaskReportStatus`, `event::Syscall`).
+- Downstream: `crate::state::BackendState::routes` mounts this via `scheduler_routes(handle)`.

--- a/crates/extensions/backend-admin/src/scheduler/dto.rs
+++ b/crates/extensions/backend-admin/src/scheduler/dto.rs
@@ -1,0 +1,107 @@
+// Copyright 2025 Rararulab
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Wire-level DTOs for the scheduler admin API.
+//!
+//! These types shape what goes over HTTP. They deliberately omit internal
+//! kernel state — notably `Principal`, which is security-sensitive and
+//! never appears in admin responses.
+
+use jiff::Timestamp;
+use rara_kernel::{
+    schedule::{JobEntry, JobResult, Trigger},
+    task_report::TaskReportStatus,
+};
+use serde::Serialize;
+
+/// Public wire shape of a scheduled job.
+///
+/// `Principal` is intentionally stripped — it's kernel-internal and must
+/// not leak to admin clients. `Trigger` passes through with the kernel's
+/// existing serde tags (`once` / `interval` / `cron`).
+#[derive(Debug, Serialize)]
+pub struct JobView {
+    /// Job identifier (stringified UUID).
+    pub id:          String,
+    /// When / how this job fires — kernel `Trigger` enum verbatim.
+    pub trigger:     Trigger,
+    /// Text injected as a `UserMessage` when the job fires.
+    pub message:     String,
+    /// Session the job is bound to.
+    pub session_key: String,
+    /// Routing tags propagated to `TaskNotification` on completion.
+    pub tags:        Vec<String>,
+    /// When this job was created.
+    pub created_at:  Timestamp,
+    /// Condensed status of the most recent execution.
+    ///
+    /// - `"ok"` — latest run completed successfully
+    /// - `"failed"` — latest run failed
+    /// - `"running"` — latest run awaits user approval (kernel
+    ///   [`TaskReportStatus::NeedsApproval`])
+    /// - `null` — the job has never executed (no results on disk)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub last_status: Option<&'static str>,
+    /// `completed_at` of the most recent execution, or `null` if absent.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub last_run_at: Option<Timestamp>,
+}
+
+impl JobView {
+    /// Build a [`JobView`] from a kernel [`JobEntry`] and (optionally) the
+    /// most recent [`JobResult`] for that job.
+    ///
+    /// The status mapping is authoritative — see this module's doc comment
+    /// for the rationale behind `NeedsApproval` → `"running"`.
+    pub fn from_job(job: JobEntry, latest: Option<&JobResult>) -> Self {
+        let last_status = latest.map(|r| status_label(r.status));
+        let last_run_at = latest.map(|r| r.completed_at);
+        Self {
+            id: job.id.to_string(),
+            trigger: job.trigger,
+            message: job.message,
+            session_key: job.session_key.to_string(),
+            tags: job.tags,
+            created_at: job.created_at,
+            last_status,
+            last_run_at,
+        }
+    }
+}
+
+/// Map a kernel [`TaskReportStatus`] to the wire-level status label.
+///
+/// `NeedsApproval` folds into `"running"` so the admin UI shows jobs
+/// blocked on user approval as still in-flight rather than finished.
+/// Keep this mapping stable — frontend code pattern-matches on the
+/// literal strings.
+pub fn status_label(status: TaskReportStatus) -> &'static str {
+    match status {
+        TaskReportStatus::Completed => "ok",
+        TaskReportStatus::Failed => "failed",
+        TaskReportStatus::NeedsApproval => "running",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn status_label_covers_every_variant() {
+        assert_eq!(status_label(TaskReportStatus::Completed), "ok");
+        assert_eq!(status_label(TaskReportStatus::Failed), "failed");
+        assert_eq!(status_label(TaskReportStatus::NeedsApproval), "running");
+    }
+}

--- a/crates/extensions/backend-admin/src/scheduler/mod.rs
+++ b/crates/extensions/backend-admin/src/scheduler/mod.rs
@@ -12,18 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! # rara-backend-admin
+//! HTTP admin surface for the kernel scheduler.
 //!
-//! Unified HTTP admin routes for all backend subsystems: settings,
-//! models, MCP servers, skills, data feeds, and domain routes (chat).
+//! Exposes read-only curation of scheduled jobs under
+//! `/api/v1/scheduler/*`. Creation is intentionally NOT exposed here —
+//! jobs are only registered via the agent-facing `schedule` tool so the
+//! audit trail stays tied to the originating session's principal.
 
-pub mod agents;
-pub mod chat;
-pub mod data_feeds;
-pub mod kernel;
-pub mod mcp;
-pub mod scheduler;
-pub mod settings;
-pub mod skills;
-pub mod state;
-pub mod system_routes;
+pub mod dto;
+pub mod router;
+pub mod service;
+
+pub use router::scheduler_routes;
+pub use service::SchedulerSvc;

--- a/crates/extensions/backend-admin/src/scheduler/router.rs
+++ b/crates/extensions/backend-admin/src/scheduler/router.rs
@@ -1,0 +1,186 @@
+// Copyright 2025 Rararulab
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! HTTP handlers for the scheduler admin API.
+//!
+//! | Method | Path                                     | Description                      |
+//! |--------|------------------------------------------|----------------------------------|
+//! | GET    | `/api/v1/scheduler/jobs`                 | list jobs across all sessions    |
+//! | GET    | `/api/v1/scheduler/jobs/{id}`            | get a single job                 |
+//! | DELETE | `/api/v1/scheduler/jobs/{id}`            | remove a job                     |
+//! | POST   | `/api/v1/scheduler/jobs/{id}/trigger`    | fire a job without advancing     |
+//! | GET    | `/api/v1/scheduler/jobs/{id}/history`    | paged execution history          |
+//!
+//! No `POST /jobs` route — creation is intentionally agent-tool-only so
+//! every scheduled job stays attributable to a real session principal.
+
+use axum::{
+    Json, Router,
+    extract::{Path, Query, State},
+    http::StatusCode,
+    routing::{get, post},
+};
+use rara_kernel::{
+    handle::KernelHandle,
+    schedule::{JobId, JobResult},
+};
+use serde::Deserialize;
+
+use super::{
+    dto::JobView,
+    service::{SchedulerError, SchedulerSvc},
+};
+use crate::kernel::problem::ProblemDetails;
+
+/// Default history page size when `?limit=` is omitted.
+const HISTORY_LIMIT_DEFAULT: usize = 50;
+/// Hard cap on history page size — prevents the admin from paging a huge
+/// result set in one request.
+const HISTORY_LIMIT_MAX: usize = 200;
+
+/// Build the `/api/v1/scheduler/*` router.
+///
+/// Auth is applied by the upstream backend-admin layer — this router
+/// trusts its caller is already authenticated and authorised.
+pub fn scheduler_routes(handle: KernelHandle) -> Router {
+    let svc = SchedulerSvc::new(handle);
+    Router::new()
+        .route("/api/v1/scheduler/jobs", get(list_jobs))
+        .route(
+            "/api/v1/scheduler/jobs/{id}",
+            get(get_job).delete(delete_job),
+        )
+        .route("/api/v1/scheduler/jobs/{id}/trigger", post(trigger_job))
+        .route("/api/v1/scheduler/jobs/{id}/history", get(job_history))
+        .with_state(svc)
+}
+
+// ---------------------------------------------------------------------------
+// Request types
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Deserialize)]
+struct HistoryQuery {
+    /// Requested page size — clamped to `[1, HISTORY_LIMIT_MAX]` and
+    /// defaulted to [`HISTORY_LIMIT_DEFAULT`] when absent.
+    limit: Option<usize>,
+}
+
+// ---------------------------------------------------------------------------
+// Handlers
+// ---------------------------------------------------------------------------
+
+async fn list_jobs(State(svc): State<SchedulerSvc>) -> Json<Vec<JobView>> {
+    Json(svc.list_jobs().await)
+}
+
+async fn get_job(
+    State(svc): State<SchedulerSvc>,
+    Path(id): Path<String>,
+) -> Result<Json<JobView>, ProblemDetails> {
+    let job_id = parse_job_id(&id)?;
+    svc.get_job(&job_id).await.map(Json).map_err(into_problem)
+}
+
+async fn delete_job(
+    State(svc): State<SchedulerSvc>,
+    Path(id): Path<String>,
+) -> Result<StatusCode, ProblemDetails> {
+    let job_id = parse_job_id(&id)?;
+    svc.delete_job(&job_id).await.map_err(into_problem)?;
+    Ok(StatusCode::NO_CONTENT)
+}
+
+async fn trigger_job(
+    State(svc): State<SchedulerSvc>,
+    Path(id): Path<String>,
+) -> Result<Json<JobView>, ProblemDetails> {
+    let job_id = parse_job_id(&id)?;
+    svc.trigger_job(&job_id)
+        .await
+        .map(Json)
+        .map_err(into_problem)
+}
+
+async fn job_history(
+    State(svc): State<SchedulerSvc>,
+    Path(id): Path<String>,
+    Query(q): Query<HistoryQuery>,
+) -> Result<Json<Vec<JobResult>>, ProblemDetails> {
+    let job_id = parse_job_id(&id)?;
+    let limit = clamp_history_limit(q.limit);
+    Ok(Json(svc.history(&job_id, limit).await))
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Parse a stringified [`JobId`] or produce a 400 Problem.
+fn parse_job_id(raw: &str) -> Result<JobId, ProblemDetails> {
+    JobId::try_from_raw(raw)
+        .map_err(|e| ProblemDetails::bad_request(format!("invalid job id: {e}")))
+}
+
+/// Translate service errors into RFC 9457 problem responses.
+///
+/// `JobNotFound` → 404 so the admin UI can render a clean empty state
+/// instead of an opaque 500.
+fn into_problem(err: SchedulerError) -> ProblemDetails {
+    match err {
+        SchedulerError::JobNotFound { ref job_id } => {
+            ProblemDetails::not_found("Job Not Found", format!("no job with id: {job_id}"))
+        }
+        other => ProblemDetails::internal(other.to_string()),
+    }
+}
+
+/// Apply the documented default + clamp rules to a history-limit query
+/// parameter. Extracted so callers and tests share one definition.
+fn clamp_history_limit(raw: Option<usize>) -> usize {
+    raw.unwrap_or(HISTORY_LIMIT_DEFAULT)
+        .clamp(1, HISTORY_LIMIT_MAX)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn history_limit_defaults_when_absent() {
+        assert_eq!(clamp_history_limit(None), HISTORY_LIMIT_DEFAULT);
+    }
+
+    #[test]
+    fn history_limit_is_clamped_high() {
+        assert_eq!(clamp_history_limit(Some(10_000)), HISTORY_LIMIT_MAX);
+    }
+
+    #[test]
+    fn history_limit_is_clamped_low() {
+        // 0 is nonsensical — admin UIs that accidentally send it still
+        // get at least one row rather than an empty page masquerading as
+        // "no history."
+        assert_eq!(clamp_history_limit(Some(0)), 1);
+    }
+
+    #[test]
+    fn history_limit_passes_through_valid_values() {
+        assert_eq!(clamp_history_limit(Some(25)), 25);
+        assert_eq!(
+            clamp_history_limit(Some(HISTORY_LIMIT_MAX)),
+            HISTORY_LIMIT_MAX
+        );
+    }
+}

--- a/crates/extensions/backend-admin/src/scheduler/service.rs
+++ b/crates/extensions/backend-admin/src/scheduler/service.rs
@@ -1,0 +1,187 @@
+// Copyright 2025 Rararulab
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Service layer for the scheduler admin API.
+//!
+//! Read paths (`list_jobs`, `get_job`, `history`) go straight to the
+//! kernel's in-memory `JobWheel` and the on-disk `JobResultStore` — no
+//! syscall round-trip is required because these operations are pure
+//! lookups.
+//!
+//! Mutations (`delete_job`, `trigger_job`) flow through the kernel event
+//! queue so the single-writer invariant on the wheel is preserved and the
+//! `TriggerJob` path emits the same `ScheduledTask` event a natural
+//! drain would produce.
+
+use rara_kernel::{
+    event::{KernelEventEnvelope, Syscall},
+    handle::KernelHandle,
+    schedule::{JobEntry, JobId, JobResult},
+    session::SessionKey,
+};
+use snafu::{ResultExt, Snafu};
+use tokio::sync::oneshot;
+use tracing::instrument;
+
+use super::dto::JobView;
+
+/// Service-level errors surfaced to the HTTP handlers.
+#[derive(Debug, Snafu)]
+#[snafu(visibility(pub(crate)))]
+pub enum SchedulerError {
+    /// No job with the supplied ID exists on the wheel.
+    #[snafu(display("job not found: {job_id}"))]
+    JobNotFound { job_id: String },
+    /// Kernel dropped the syscall reply channel — event queue or kernel
+    /// shut down mid-call.
+    #[snafu(display("kernel dropped reply channel: {source}"))]
+    ReplyDropped { source: oneshot::error::RecvError },
+    /// Event queue is full or closed; the syscall was not delivered.
+    #[snafu(display("event queue unavailable: {message}"))]
+    EventQueue { message: String },
+    /// Kernel returned an error executing the syscall.
+    #[snafu(display("kernel syscall failed: {source}"))]
+    Kernel {
+        source: rara_kernel::error::KernelError,
+    },
+}
+
+/// Per-crate result alias.
+pub type Result<T> = std::result::Result<T, SchedulerError>;
+
+/// Scheduler admin service.
+///
+/// Owns nothing — it's a thin adapter over a cloned [`KernelHandle`]. Cheap
+/// to clone (two `Arc` bumps) so each HTTP handler can take it by value.
+#[derive(Clone)]
+pub struct SchedulerSvc {
+    handle: KernelHandle,
+}
+
+impl SchedulerSvc {
+    /// Construct a service bound to the given kernel handle.
+    pub fn new(handle: KernelHandle) -> Self { Self { handle } }
+
+    /// List every scheduled job across all sessions.
+    ///
+    /// Derives `last_status` / `last_run_at` per job by calling
+    /// [`rara_kernel::schedule::JobResultStore::read_latest`]. Each lookup
+    /// is an OpenDAL `list` + single `read`, so this scales linearly with
+    /// the number of jobs — acceptable for an admin curation surface.
+    #[instrument(skip_all)]
+    pub async fn list_jobs(&self) -> Vec<JobView> {
+        let jobs = self.handle.list_jobs(None);
+        let store = self.handle.job_result_store();
+        let mut out = Vec::with_capacity(jobs.len());
+        for job in jobs {
+            let latest = store.read_latest(&job.id).await;
+            out.push(JobView::from_job(job, latest.as_ref()));
+        }
+        out
+    }
+
+    /// Fetch a single job view by ID, or return
+    /// [`SchedulerError::JobNotFound`].
+    #[instrument(skip_all, fields(%job_id))]
+    pub async fn get_job(&self, job_id: &JobId) -> Result<JobView> {
+        let job = self.find_job(job_id)?;
+        let latest = self.handle.job_result_store().read_latest(job_id).await;
+        Ok(JobView::from_job(job, latest.as_ref()))
+    }
+
+    /// Remove a job from the wheel via the `RemoveJob` syscall.
+    ///
+    /// Returns [`SchedulerError::JobNotFound`] if the kernel reports the
+    /// job was not on the wheel.
+    #[instrument(skip_all, fields(%job_id))]
+    pub async fn delete_job(&self, job_id: &JobId) -> Result<()> {
+        let (tx, rx) = oneshot::channel();
+        self.push_syscall(Syscall::RemoveJob {
+            job_id:   *job_id,
+            reply_tx: tx,
+        })?;
+        match rx.await.context(ReplyDroppedSnafu)? {
+            Ok(()) => Ok(()),
+            // The kernel returns a generic `KernelError::Other` for missing
+            // jobs; translate to the typed 404 variant here so the HTTP
+            // layer can distinguish a legitimate miss from an infra fault.
+            Err(_) => Err(SchedulerError::JobNotFound {
+                job_id: job_id.to_string(),
+            }),
+        }
+    }
+
+    /// Fire a job on demand without advancing its `next_at`.
+    ///
+    /// Returns the refreshed [`JobView`] so the HTTP layer can respond with
+    /// the post-trigger state. The `next_at` in the view is unchanged from
+    /// before the call — that invariant is enforced inside the kernel by
+    /// [`rara_kernel::schedule::JobWheel::trigger_now`].
+    #[instrument(skip_all, fields(%job_id))]
+    pub async fn trigger_job(&self, job_id: &JobId) -> Result<JobView> {
+        let (tx, rx) = oneshot::channel();
+        self.push_syscall(Syscall::TriggerJob {
+            job_id:   *job_id,
+            reply_tx: tx,
+        })?;
+        match rx.await.context(ReplyDroppedSnafu)? {
+            Ok(()) => self.get_job(job_id).await,
+            Err(_) => Err(SchedulerError::JobNotFound {
+                job_id: job_id.to_string(),
+            }),
+        }
+    }
+
+    /// Read up to `limit` most recent execution results for `job_id`,
+    /// newest first.
+    #[instrument(skip_all, fields(%job_id, limit))]
+    pub async fn history(&self, job_id: &JobId, limit: usize) -> Vec<JobResult> {
+        let mut results = self.handle.job_result_store().read(job_id).await;
+        // `JobResultStore::read` yields ascending-by-time; admin callers
+        // want newest-first paging so they don't have to flip the slice
+        // themselves.
+        results.reverse();
+        results.truncate(limit);
+        results
+    }
+
+    // -- internals ----------------------------------------------------------
+
+    /// Look up a job on the wheel by ID.
+    fn find_job(&self, job_id: &JobId) -> Result<JobEntry> {
+        self.handle
+            .list_jobs(None)
+            .into_iter()
+            .find(|j| j.id == *job_id)
+            .ok_or_else(|| SchedulerError::JobNotFound {
+                job_id: job_id.to_string(),
+            })
+    }
+
+    /// Push a session-scoped syscall on behalf of the admin route.
+    ///
+    /// The admin surface has no real session, but the scheduler syscalls
+    /// we use here (`RemoveJob`, `TriggerJob`) operate directly on the
+    /// wheel and ignore `syscall_sender` — a fresh `SessionKey` is
+    /// sufficient to route the envelope through the queue.
+    fn push_syscall(&self, syscall: Syscall) -> Result<()> {
+        let envelope = KernelEventEnvelope::session_command(SessionKey::new(), syscall);
+        self.handle
+            .event_queue()
+            .try_push(envelope)
+            .map_err(|_| SchedulerError::EventQueue {
+                message: "event queue full or closed".into(),
+            })
+    }
+}

--- a/crates/extensions/backend-admin/src/state.rs
+++ b/crates/extensions/backend-admin/src/state.rs
@@ -108,6 +108,9 @@ impl BackendState {
         // Kernel observability routes (stats, sessions, approvals, audit).
         router = router.merge(crate::kernel::router::kernel_routes(kernel_handle.clone()));
 
+        // Scheduler admin routes — read-only curation of kernel jobs.
+        router = router.merge(crate::scheduler::scheduler_routes(kernel_handle.clone()));
+
         // Data feed management routes (with registry sync).
         router = router.merge(crate::data_feeds::data_feed_routes(
             self.feed_router_state.clone(),

--- a/crates/extensions/backend-admin/tests/scheduler.rs
+++ b/crates/extensions/backend-admin/tests/scheduler.rs
@@ -1,0 +1,163 @@
+// Copyright 2025 Rararulab
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Integration tests for the scheduler admin service.
+//!
+//! These exercise `SchedulerSvc` against a live kernel built by
+//! [`TestKernelBuilder`]. The tests focus on the wiring that cannot be
+//! covered by unit tests in `dto.rs` / `router.rs`:
+//!
+//! - Service round-trip against a real `KernelHandle` (not a mock).
+//! - 404 translation: missing jobs surface as `SchedulerError::JobNotFound`
+//!   through the syscall boundary.
+//! - History reads against the real OpenDAL-backed `JobResultStore`, including
+//!   the newest-first + limit-trimming contract.
+
+use jiff::Timestamp;
+use rara_backend_admin::scheduler::service::{SchedulerError, SchedulerSvc};
+use rara_kernel::{
+    schedule::{JobId, JobResult},
+    task_report::TaskReportStatus,
+    testing::TestKernelBuilder,
+};
+
+/// Fresh kernel: no jobs registered, the admin list is empty and lookups
+/// on a fabricated ID surface as `JobNotFound`.
+#[tokio::test]
+async fn list_on_empty_kernel_is_empty() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let tk = TestKernelBuilder::new(tmp.path()).build().await;
+    let svc = SchedulerSvc::new(tk.handle.clone());
+
+    let jobs = svc.list_jobs().await;
+    assert!(jobs.is_empty(), "expected empty kernel, got {jobs:?}");
+
+    tk.shutdown();
+}
+
+#[tokio::test]
+async fn get_missing_returns_job_not_found() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let tk = TestKernelBuilder::new(tmp.path()).build().await;
+    let svc = SchedulerSvc::new(tk.handle.clone());
+
+    let ghost = JobId::new();
+    let err = svc
+        .get_job(&ghost)
+        .await
+        .expect_err("ghost job must not be found");
+    assert!(
+        matches!(err, SchedulerError::JobNotFound { .. }),
+        "expected JobNotFound, got {err:?}"
+    );
+
+    tk.shutdown();
+}
+
+#[tokio::test]
+async fn delete_missing_returns_job_not_found() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let tk = TestKernelBuilder::new(tmp.path()).build().await;
+    let svc = SchedulerSvc::new(tk.handle.clone());
+
+    let ghost = JobId::new();
+    let err = svc
+        .delete_job(&ghost)
+        .await
+        .expect_err("delete on ghost id must fail");
+    assert!(
+        matches!(err, SchedulerError::JobNotFound { .. }),
+        "expected JobNotFound, got {err:?}"
+    );
+
+    tk.shutdown();
+}
+
+#[tokio::test]
+async fn trigger_missing_returns_job_not_found() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let tk = TestKernelBuilder::new(tmp.path()).build().await;
+    let svc = SchedulerSvc::new(tk.handle.clone());
+
+    let ghost = JobId::new();
+    let err = svc
+        .trigger_job(&ghost)
+        .await
+        .expect_err("trigger on ghost id must fail");
+    assert!(
+        matches!(err, SchedulerError::JobNotFound { .. }),
+        "expected JobNotFound, got {err:?}"
+    );
+
+    tk.shutdown();
+}
+
+/// Exercise the OpenDAL-backed `JobResultStore` through the service's
+/// history method: insert three results out-of-order, then assert the
+/// service returns them newest-first and honours `limit`.
+///
+/// The store is reached via `KernelHandle::job_result_store()` — this
+/// verifies both the new accessor wiring and the service's own
+/// reverse+truncate contract.
+#[tokio::test]
+async fn history_returns_newest_first_and_respects_limit() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let tk = TestKernelBuilder::new(tmp.path()).build().await;
+    let svc = SchedulerSvc::new(tk.handle.clone());
+
+    let job_id = JobId::new();
+    let store = tk.handle.job_result_store().clone();
+
+    // Seed three results with increasing completion timestamps.
+    let base = Timestamp::from_second(1_800_000_000).expect("fixed ts");
+    for offset in [0, 60, 120] {
+        let completed_at = Timestamp::from_second(base.as_second() + offset).unwrap();
+        store
+            .append(&JobResult {
+                job_id,
+                task_id: uuid::Uuid::new_v4(),
+                task_type: "test".into(),
+                tags: vec![],
+                status: TaskReportStatus::Completed,
+                summary: format!("run at {completed_at}"),
+                result: serde_json::json!({"at": completed_at.as_second()}),
+                action_taken: None,
+                completed_at,
+            })
+            .await
+            .expect("append result");
+    }
+
+    // limit=2 should return the two newest (offset 120 then 60).
+    let page = svc.history(&job_id, 2).await;
+    assert_eq!(page.len(), 2, "limit should cap at 2");
+    assert_eq!(
+        page[0].completed_at.as_second(),
+        base.as_second() + 120,
+        "newest result should come first"
+    );
+    assert_eq!(
+        page[1].completed_at.as_second(),
+        base.as_second() + 60,
+        "second-newest should follow"
+    );
+
+    // limit larger than result count returns all three, still newest-first.
+    let page = svc.history(&job_id, 50).await;
+    assert_eq!(page.len(), 3);
+    assert_eq!(page[0].completed_at.as_second(), base.as_second() + 120);
+    assert_eq!(page[2].completed_at.as_second(), base.as_second());
+
+    tk.shutdown();
+}

--- a/crates/kernel/AGENT.md
+++ b/crates/kernel/AGENT.md
@@ -418,3 +418,11 @@ Each kernel turn calls `StreamHub::open(session)` which gets-or-creates a `broad
 - Do NOT emit `StreamEvent::StreamClosed` from `close_session()` — that path is only called from `open()` to reap zombies from pre-empted turns. Emitting a terminal marker there would cause session-level subscribers (web `WebEvent::Done`) to finalize the previous turn's UI mid-flight when the user sends a follow-up message before the first turn completes. Normal turn completion goes through `close()` which DOES emit the marker.
 - Do NOT hold a DashMap `get()` guard across a `remove()` on the same map — DashMap shards are `RwLock`-based and a read guard across a write on the same shard deadlocks. `reap_session_bus_if_idle` uses `remove_if` so the receiver-count check and the removal happen atomically under the shard write lock with no nested same-shard lock.
 - Do NOT replace the `remove_if` closure with a pre-check + `remove()` pair — the non-atomic variant has a TOCTOU window where a concurrent `subscribe_session_events` can attach a fresh receiver to a sender the reaper then deletes, silently losing every subsequent event for that session.
+
+---
+
+## Critical: Scheduler Admin Syscalls — `schedule.rs` + `syscall.rs`
+
+- `Syscall::TriggerJob` fires a job on demand by cloning its `JobEntry`, inserting it into the in-flight ledger with the standard lease, and pushing a `ScheduledTask` event. It MUST NOT mutate the wheel's `next_at` — recurring jobs continue on their regular cadence. The only in-flight mutation path that advances schedules is `drain_expired` → `reschedule_recurring`; `TriggerJob` deliberately bypasses it.
+- `Syscall::ListAllJobs` is an admin-only surface. The kernel does not authenticate it; the backend HTTP route is the auth boundary. Do NOT repurpose this variant for session-scoped tool calls — use `Syscall::ListJobs` there so future tightening of `ListAllJobs` permissions cannot regress tool UX.
+- `JobResultStore::read_latest` intentionally walks results newest-first and skips malformed entries, so a single corrupt tail object does not hide the rest of the history from the admin UI. Keep the fall-through behaviour when extending the store.

--- a/crates/kernel/src/event.rs
+++ b/crates/kernel/src/event.rs
@@ -217,6 +217,34 @@ pub enum Syscall {
         reply_tx: oneshot::Sender<crate::error::Result<Vec<crate::schedule::JobEntry>>>,
     },
 
+    /// List every scheduled job across all sessions — admin-only surface.
+    ///
+    /// Semantically distinct from [`Syscall::ListJobs`]: this variant exists
+    /// so the backend admin route has an unambiguous, auth-gated entry point
+    /// that cannot be reused by unprivileged session tools. The kernel does
+    /// no auth check itself — the HTTP layer is responsible for gating.
+    ListAllJobs {
+        #[debug(skip)]
+        #[serde(skip_serializing)]
+        reply_tx: oneshot::Sender<crate::error::Result<Vec<crate::schedule::JobEntry>>>,
+    },
+
+    /// Immediately fire a scheduled job without advancing its `next_at`.
+    ///
+    /// The job is cloned from the wheel (not removed), inserted into the
+    /// in-flight ledger with the standard lease, and dispatched through the
+    /// same `ScheduledTask` path that [`JobWheel::drain_expired`] uses. The
+    /// wheel's original schedule is untouched — recurring jobs still fire at
+    /// their next regular `next_at`.
+    ///
+    /// [`JobWheel::drain_expired`]: crate::schedule::JobWheel::drain_expired
+    TriggerJob {
+        job_id:   crate::schedule::JobId,
+        #[debug(skip)]
+        #[serde(skip_serializing)]
+        reply_tx: oneshot::Sender<crate::error::Result<()>>,
+    },
+
     // -- Task Report & Subscription --
     /// Register a notification subscription for the calling session.
     Subscribe {

--- a/crates/kernel/src/handle.rs
+++ b/crates/kernel/src/handle.rs
@@ -98,6 +98,12 @@ pub struct KernelHandle {
     trace_service:         crate::trace::TraceService,
     /// Shared job wheel for querying scheduled tasks.
     job_wheel:             Arc<parking_lot::Mutex<crate::schedule::JobWheel>>,
+    /// Append-only store for job execution results.
+    ///
+    /// Exposed so the backend admin route can derive `last_status` /
+    /// `last_run_at` and page execution history without a syscall — the
+    /// store is append-only and safe to read concurrently.
+    job_result_store:      Arc<crate::schedule::JobResultStore>,
     /// Provider for generating the skills prompt block.
     skill_prompt_provider: SkillPromptProvider,
     /// Data feed registry for managing external data sources.
@@ -128,6 +134,7 @@ impl KernelHandle {
         tape: crate::memory::TapeService,
         trace_service: crate::trace::TraceService,
         job_wheel: Arc<parking_lot::Mutex<crate::schedule::JobWheel>>,
+        job_result_store: Arc<crate::schedule::JobResultStore>,
         skill_prompt_provider: SkillPromptProvider,
         feed_registry: Option<Arc<crate::data_feed::DataFeedRegistry>>,
         feed_store: Option<crate::data_feed::FeedStoreRef>,
@@ -148,6 +155,7 @@ impl KernelHandle {
             tape,
             trace_service,
             job_wheel,
+            job_result_store,
             skill_prompt_provider,
             feed_registry,
             feed_store,
@@ -419,6 +427,16 @@ impl KernelHandle {
     /// List scheduled jobs, optionally filtered by session key.
     pub fn list_jobs(&self, session_key: Option<SessionKey>) -> Vec<crate::schedule::JobEntry> {
         self.job_wheel.lock().list(session_key.as_ref())
+    }
+
+    /// Access the append-only job result store.
+    ///
+    /// Surfaced for the backend admin route so it can read execution history
+    /// and derive `last_status` / `last_run_at` without a syscall round-trip.
+    /// Mutations still go through syscalls; this is read-only by convention
+    /// — the store itself is append-only.
+    pub fn job_result_store(&self) -> &Arc<crate::schedule::JobResultStore> {
+        &self.job_result_store
     }
 
     /// Generate the skills prompt block for injection into the agent system

--- a/crates/kernel/src/kernel.rs
+++ b/crates/kernel/src/kernel.rs
@@ -403,6 +403,7 @@ impl Kernel {
             self.tape_service.clone(),
             self.trace_service.clone(),
             self.syscall.job_wheel().clone(),
+            self.syscall.job_result_store().clone(),
             self.skill_prompt_provider.clone(),
             self.feed_registry.clone(),
             self.feed_store.clone(),

--- a/crates/kernel/src/schedule.rs
+++ b/crates/kernel/src/schedule.rs
@@ -582,6 +582,45 @@ impl JobWheel {
             .collect()
     }
 
+    /// Insert a manual-trigger copy of `job_id` into the in-flight ledger
+    /// without mutating the wheel's scheduled entry.
+    ///
+    /// Used by `Syscall::TriggerJob` to fire a job on demand. The original
+    /// entry's `next_at` is intentionally preserved so recurring jobs keep
+    /// their regular cadence after an out-of-band trigger. Persists the
+    /// ledger to disk on success.
+    ///
+    /// Returns the cloned [`JobEntry`] ready to be dispatched via
+    /// `ScheduledTask`, or `None` if no job with that ID is on the wheel.
+    /// If the same job is already in-flight the new lease overwrites it —
+    /// the agent runtime is responsible for handling overlapping executions.
+    pub fn trigger_now(&mut self, job_id: &JobId) -> Option<JobEntry> {
+        let key = *self.by_id.get(job_id)?;
+        let entry = self.jobs.get(&key)?.clone();
+
+        if self.in_flight.contains_key(job_id) {
+            warn!(
+                job_id = %job_id,
+                "trigger_now: job already in-flight; enqueueing overlapping execution"
+            );
+        }
+
+        let now = self.clock.now();
+        let lease_deadline = now
+            .checked_add(jiff::SignedDuration::from_secs(DEFAULT_LEASE_SECS))
+            .unwrap_or(now);
+        self.in_flight.insert(
+            entry.id,
+            InFlightEntry {
+                job: entry.clone(),
+                fired_at: now,
+                lease_deadline,
+            },
+        );
+        self.persist_in_flight();
+        Some(entry)
+    }
+
     /// Mark a job as completed, removing it from the in-flight ledger.
     ///
     /// Called when the execution agent's session ends (regardless of whether
@@ -778,32 +817,64 @@ impl JobResultStore {
     /// Read all execution results for a given job, ordered by completion
     /// time (lexicographic on the epoch filename).
     pub async fn read(&self, job_id: &JobId) -> Vec<JobResult> {
+        let entries = self.sorted_entries(job_id).await;
+        // `sorted_entries` returns ascending — `read` keeps that order.
+        let mut results = Vec::new();
+        for entry in entries {
+            if let Some(r) = self.read_one(entry.path()).await {
+                results.push(r);
+            }
+        }
+        results
+    }
+
+    /// Read the most recent execution result for a given job.
+    ///
+    /// Cheaper than `read` when the caller only needs the latest status —
+    /// the scheduler admin UI uses this to derive `last_status` without
+    /// paging the full history. Returns `None` if the job directory is
+    /// empty or every object fails to parse.
+    pub async fn read_latest(&self, job_id: &JobId) -> Option<JobResult> {
+        // Walk newest-first so a single malformed tail entry doesn't hide
+        // the rest of the history — skip and try the next one.
+        let entries = self.sorted_entries(job_id).await;
+        for entry in entries.into_iter().rev() {
+            if let Some(r) = self.read_one(entry.path()).await {
+                return Some(r);
+            }
+        }
+        None
+    }
+
+    /// List non-directory result objects under `{job_id}/`, sorted
+    /// ascending by path (epoch filenames sort chronologically).
+    async fn sorted_entries(&self, job_id: &JobId) -> Vec<opendal::Entry> {
         let prefix = format!("{job_id}/");
         let mut entries = match self.op.list(&prefix).await {
             Ok(v) => v,
             Err(_) => return Vec::new(),
         };
-        // Sort by path (epoch filenames sort chronologically).
+        entries.retain(|e| !e.metadata().is_dir());
         entries.sort_by(|a, b| a.path().cmp(b.path()));
+        entries
+    }
 
-        let mut results = Vec::new();
-        for entry in entries {
-            if entry.metadata().is_dir() {
-                continue;
-            }
-            match self.op.read(entry.path()).await {
-                Ok(buf) => match serde_json::from_slice::<JobResult>(&buf.to_vec()) {
-                    Ok(r) => results.push(r),
-                    Err(e) => {
-                        warn!(error = %e, path = entry.path(), "skipping malformed job result");
-                    }
-                },
+    /// Read and parse a single result object, logging and returning `None`
+    /// on read or parse failure.
+    async fn read_one(&self, path: &str) -> Option<JobResult> {
+        match self.op.read(path).await {
+            Ok(buf) => match serde_json::from_slice::<JobResult>(&buf.to_vec()) {
+                Ok(r) => Some(r),
                 Err(e) => {
-                    warn!(error = %e, path = entry.path(), "failed to read job result");
+                    warn!(error = %e, path = path, "skipping malformed job result");
+                    None
                 }
+            },
+            Err(e) => {
+                warn!(error = %e, path = path, "failed to read job result");
+                None
             }
         }
-        results
     }
 }
 
@@ -1227,5 +1298,147 @@ mod tests {
             back.lease_deadline.as_second(),
             t0().as_second() + DEFAULT_LEASE_SECS
         );
+    }
+
+    fn cron_entry(expr: &str, next_at: Timestamp) -> JobEntry {
+        JobEntry {
+            id:          JobId::new(),
+            trigger:     Trigger::Cron {
+                expr: expr.into(),
+                next_at,
+            },
+            message:     "cron".into(),
+            session_key: SessionKey::new(),
+            principal:   test_principal(),
+            created_at:  next_at,
+            tags:        vec![],
+        }
+    }
+
+    /// `trigger_now` must NOT advance the wheel entry's `next_at` — the
+    /// regular cadence survives an out-of-band fire.
+    #[test]
+    fn trigger_job_fires_without_advancing_next_at() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let path = tmp.path().join("jobs.json");
+        let clock = Arc::new(FakeClock::new(t0()));
+        let mut wheel = JobWheel::load_with_clock(path, clock.clone());
+
+        // Cron: next fire one hour from now.
+        let future_fire = Timestamp::from_second(t0().as_second() + 3600).unwrap();
+        let entry = cron_entry("0 * * * * *", future_fire);
+        let id = entry.id;
+        wheel.add(entry);
+
+        let fired = wheel.trigger_now(&id).expect("trigger_now should find job");
+        assert_eq!(fired.id, id);
+
+        // Wheel still holds the job with the original next_at.
+        let still_scheduled = wheel
+            .list(None)
+            .into_iter()
+            .find(|e| e.id == id)
+            .expect("job should remain on the wheel after manual trigger");
+        assert_eq!(
+            still_scheduled.trigger.next_at(),
+            future_fire,
+            "trigger_now must not mutate the wheel's scheduled next_at"
+        );
+
+        // And there is exactly one in-flight entry with the fresh lease.
+        assert_eq!(wheel.in_flight.len(), 1);
+        let ifl = &wheel.in_flight[&id];
+        assert_eq!(ifl.fired_at, t0());
+        assert_eq!(
+            ifl.lease_deadline.as_second(),
+            t0().as_second() + DEFAULT_LEASE_SECS
+        );
+    }
+
+    #[test]
+    fn trigger_job_missing_id_returns_none() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let path = tmp.path().join("jobs.json");
+        let mut wheel = JobWheel::load(path);
+        let ghost = JobId::new();
+        assert!(wheel.trigger_now(&ghost).is_none());
+        assert!(wheel.in_flight.is_empty());
+    }
+
+    /// `list(None)` returns jobs from every session — exercised by the
+    /// admin-only `Syscall::ListAllJobs` variant.
+    #[test]
+    fn list_all_jobs_crosses_sessions() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let path = tmp.path().join("jobs.json");
+        let mut wheel = JobWheel::load(path);
+
+        let mut a = make_entry(future(60));
+        a.session_key = SessionKey::new();
+        let mut b = make_entry(future(90));
+        b.session_key = SessionKey::new();
+        assert_ne!(a.session_key, b.session_key);
+        let id_a = a.id;
+        let id_b = b.id;
+
+        wheel.add(a);
+        wheel.add(b);
+
+        let all = wheel.list(None);
+        assert_eq!(all.len(), 2);
+        let ids: std::collections::HashSet<_> = all.iter().map(|e| e.id).collect();
+        assert!(ids.contains(&id_a));
+        assert!(ids.contains(&id_b));
+    }
+
+    fn make_result(job_id: JobId, completed_at: Timestamp) -> JobResult {
+        JobResult {
+            job_id,
+            task_id: Uuid::new_v4(),
+            task_type: "test".into(),
+            tags: vec![],
+            status: crate::task_report::TaskReportStatus::Completed,
+            summary: format!("run at {completed_at}"),
+            result: serde_json::json!({"at": completed_at.as_second()}),
+            action_taken: None,
+            completed_at,
+        }
+    }
+
+    #[tokio::test]
+    async fn read_latest_returns_most_recent() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let store = JobResultStore::new(tmp.path().to_path_buf());
+        let job_id = JobId::new();
+
+        let t1 = Timestamp::from_second(t0().as_second()).unwrap();
+        let t2 = Timestamp::from_second(t0().as_second() + 60).unwrap();
+        let t3 = Timestamp::from_second(t0().as_second() + 120).unwrap();
+
+        store
+            .append(&make_result(job_id, t1))
+            .await
+            .expect("append t1");
+        store
+            .append(&make_result(job_id, t2))
+            .await
+            .expect("append t2");
+        store
+            .append(&make_result(job_id, t3))
+            .await
+            .expect("append t3");
+
+        let latest = store
+            .read_latest(&job_id)
+            .await
+            .expect("read_latest should find the newest result");
+        assert_eq!(latest.completed_at, t3);
+    }
+
+    #[tokio::test]
+    async fn read_latest_empty_returns_none() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let store = JobResultStore::new(tmp.path().to_path_buf());
+        assert!(store.read_latest(&JobId::new()).await.is_none());
     }
 }

--- a/crates/kernel/src/syscall.rs
+++ b/crates/kernel/src/syscall.rs
@@ -132,6 +132,11 @@ impl SyscallDispatcher {
         &self.job_wheel
     }
 
+    /// Access the job result store (for admin-surface history reads).
+    pub fn job_result_store(&self) -> &Arc<crate::schedule::JobResultStore> {
+        &self.job_result_store
+    }
+
     // -- Dispatch -----------------------------------------------------------
 
     /// Handle a syscall from a session.

--- a/crates/kernel/src/syscall.rs
+++ b/crates/kernel/src/syscall.rs
@@ -505,6 +505,48 @@ impl SyscallDispatcher {
                 let jobs = wheel.list(None);
                 let _ = reply_tx.send(Ok(jobs));
             }
+            Syscall::ListAllJobs { reply_tx } => {
+                // Admin-only surface: the backend HTTP route is responsible
+                // for permission checks. The kernel itself is auth-agnostic
+                // here so the call stays a pure data read.
+                let wheel = self.job_wheel.lock();
+                let jobs = wheel.list(None);
+                let _ = reply_tx.send(Ok(jobs));
+            }
+            Syscall::TriggerJob { job_id, reply_tx } => {
+                let wheel_ref = self.job_wheel.clone();
+                let job_id_clone = job_id.clone();
+                let triggered = tokio::task::spawn_blocking(move || {
+                    let mut wheel = wheel_ref.lock();
+                    wheel.trigger_now(&job_id_clone)
+                })
+                .await
+                .unwrap_or_else(|e| {
+                    warn!(error = %e, "spawn_blocking panicked during TriggerJob");
+                    None
+                });
+
+                let result = match triggered {
+                    Some(job) => {
+                        info!(
+                            job_id = %job.id,
+                            session = %job.session_key,
+                            "manually triggered scheduled job"
+                        );
+                        // Dispatch via the same ScheduledTask event path
+                        // drain_expired uses so manual triggers and automatic
+                        // fires share one execution pipeline.
+                        let _ = kernel_handle
+                            .event_queue()
+                            .try_push(crate::event::KernelEventEnvelope::scheduled_task(job));
+                        Ok(())
+                    }
+                    None => Err(KernelError::Other {
+                        message: format!("job not found: {job_id}").into(),
+                    }),
+                };
+                let _ = reply_tx.send(result);
+            }
             Syscall::Subscribe {
                 match_tags,
                 on_receive,


### PR DESCRIPTION
## Summary

Part of epic #1686 (step 2/3). Stacked on #1692.

Add `backend-admin/scheduler/` module exposing 5 HTTP routes over the kernel scheduler:
- GET `/api/v1/scheduler/jobs` — list across sessions with `last_status` / `last_run_at` derived
- GET `/api/v1/scheduler/jobs/:id` — single job
- DELETE `/api/v1/scheduler/jobs/:id`
- POST `/api/v1/scheduler/jobs/:id/trigger` — immediate fire via kernel `TriggerJob` syscall
- GET `/api/v1/scheduler/jobs/:id/history?limit=N`

No POST `/jobs` — creation is agent-tool-only by design.

Supporting kernel change: expose `JobResultStore` on `KernelHandle` so the admin route can derive `last_status`/`last_run_at` and page history without a syscall round-trip.

## Type of change

| Type | Label |
|------|-------|
| Enhancement | \`enhancement\` |

## Component

\`backend\`

## Closes

Closes #1689

## Test plan

- [x] \`cargo test -p rara-backend-admin\` passes (45 tests, including new integration suite covering list/get/delete/trigger 404 and history newest-first + limit)
- [x] \`cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings\` passes
- [x] \`prek run --all-files\` passes
- [x] TriggerJob leaves \`next_at\` unchanged end-to-end (enforced kernel-side in \`JobWheel::trigger_now\`; verified by kernel unit test \`trigger_job_fires_without_advancing_next_at\` in #1692)