### PR TITLE
feat(sandbox): add rara-sandbox crate with boxlite backend (#1698)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -102,6 +102,12 @@ needless_for_each = "allow"
 
 [workspace]
 resolver = "3"
+# `crates/sandbox` is intentionally excluded: its `boxlite` git dep brings in
+# `rusqlite = "0.37"` (links = "sqlite3", via `libsqlite3-sys 0.35`), which
+# collides with the workspace's `sqlx = "0.8"` (`libsqlite3-sys 0.30`).
+# Cargo forbids two crates sharing the same `links` value. Integration with
+# the rest of the workspace is tracked in issue #1700.
+exclude = ["crates/sandbox"]
 members = [
     "api",
     "crates/app",

--- a/crates/sandbox/AGENT.md
+++ b/crates/sandbox/AGENT.md
@@ -1,0 +1,113 @@
+# rara-sandbox — Agent Guidelines
+
+## Purpose
+
+Hardware-isolated code execution for rara tools, wrapping the
+[boxlite](https://github.com/boxlite-ai/boxlite) microVM runtime behind a
+small concrete API.
+
+## Architecture
+
+- `src/lib.rs` — public re-exports only.
+- `src/config.rs` — `SandboxConfig` (creation parameters) and `ExecRequest`
+  (one-shot command description). Both use `bon::Builder`.
+- `src/sandbox.rs` — `Sandbox` handle + `ExecOutcome`. Thin adapter over
+  `boxlite::BoxliteRuntime` + `LiteBox`.
+- `src/error.rs` — `SandboxError` (snafu) + `Result` alias. All boxlite
+  failures funnel through `SandboxError::Boxlite { source }`.
+
+Public surface (intentionally minimal, see #1697/#1698):
+
+- `Sandbox::create(SandboxConfig) -> Result<Sandbox>`
+- `Sandbox::exec(ExecRequest) -> Result<ExecOutcome>` where
+  `ExecOutcome::stdout: boxlite::ExecStdout` is a `futures::Stream<Item = String>`
+- `Sandbox::destroy(self) -> Result<()>`
+
+## Critical Invariants
+
+- **No `SandboxBackend` trait.** Issue #1697 was closed as YAGNI — concrete
+  `Sandbox` only. Adding a trait now would be speculative abstraction; it
+  can be extracted later if a second backend ever lands.
+- **No hardcoded rootfs image / paths.** The image reference is a required
+  `SandboxConfig` field; the application layer reads it from YAML and
+  passes it through. Do not add an `impl Default for SandboxConfig`.
+- **No noop impls, no mock backend.** `docs/guides/anti-patterns.md`
+  forbids silent `Ok(())` trait impls. If you need to test a caller
+  without a real VM, fake it at the caller boundary — not inside this
+  crate.
+- **`Sandbox::destroy` consumes `self`.** The boxlite box lives on in the
+  runtime state until `remove` is called; dropping the handle leaks the
+  box. Callers that forget `destroy` will accumulate boxes under the
+  configured boxlite home directory.
+- **All errors go through `snafu`.** Boxlite errors wrap via
+  `.context(BoxliteSnafu)?`. Do not introduce `thiserror` or manual
+  `impl Error`.
+
+## What NOT To Do
+
+- Do NOT bump boxlite to crates.io — **why:** upstream publish is broken
+  as of v0.8.2 (see boxlite CLAUDE.md). Stay on the git tag dependency
+  until upstream fixes their publishing pipeline.
+- Do NOT add a `Default` impl to `SandboxConfig` — **why:** hardcoded
+  defaults in Rust bypass the YAML-config discipline; agents will end up
+  silently running against `alpine:latest` from the wrong registry.
+- Do NOT re-export every boxlite type — **why:** the whole point of this
+  crate is to keep the Tool subsystem independent of boxlite's API churn.
+  If a caller needs a boxlite type that isn't re-exported, add a
+  purpose-specific wrapper instead of widening the surface.
+- Do NOT enable the integration test in CI — **why:** it requires the
+  runtime files staging from #1699 and a warm OCI image cache; failing in
+  CI would block every unrelated PR.
+- Do NOT call `boxlite::init_logging_for` from inside this crate —
+  **why:** tracing init is an application-layer concern; library crates
+  that install global subscribers fight the host's `tracing` setup.
+
+## Dependencies
+
+**Upstream (crates this crate depends on):**
+
+- `boxlite` — git dep at tag `v0.8.2`. Pulls four submodules transitively
+  (`bubblewrap`, `e2fsprogs`, `libkrun`, `libkrunfw`). Fresh `cargo
+  fetch` may be slow; this is normal.
+- `bon`, `futures`, `serde`, `snafu`, `tokio`, `tracing` — standard
+  workspace deps.
+
+**Downstream (crates that will depend on this one):**
+
+- `rara-kernel` tool subsystem — wiring happens in issue #1700. Not this
+  issue. Do not add a `rara-kernel` integration here; `rara-kernel` will
+  import `rara-sandbox` and build a `Tool` impl on top.
+
+## Boxlite Footguns (from the v0.8.2 spike)
+
+These are the things that bit the spike author and will bite the next
+person if they aren't written down.
+
+1. **crates.io publish broken upstream.** Cargo deps MUST use the git
+   tag form:
+   ```toml
+   boxlite = { git = "https://github.com/boxlite-ai/boxlite", tag = "v0.8.2" }
+   ```
+   Do not retry `boxlite = "0.8.2"` — it will look like it works until
+   link time.
+
+2. **Submodules are pulled transitively.** boxlite's build brings in
+   `bubblewrap`, `e2fsprogs`, `libkrun`, and `libkrunfw`. If your fresh
+   clone fails to build, check that `cargo` actually finished fetching
+   the submodules (`~/.cargo/git/checkouts/boxlite-*/` should have all
+   four under `deps/` or `src/`).
+
+3. **Runtime files need staging.** boxlite expects the following files
+   to be present at its runtime directory before the first box will
+   start:
+   - `boxlite-guest`
+   - `libkrunfw.dylib` (macOS) / `libkrunfw.so` (linux)
+   - `mke2fs`
+   - `boxlite-shim`
+   - `debugfs`
+
+   On macOS the directory is:
+   `~/Library/Application Support/boxlite/runtimes/v0.8.2/`.
+   Copy the artefacts from a boxlite release build into this path
+   before running the integration test. Automating this is tracked in
+   issue #1699.

--- a/crates/sandbox/Cargo.toml
+++ b/crates/sandbox/Cargo.toml
@@ -1,0 +1,42 @@
+# Standalone sub-workspace: see the root `Cargo.toml` `exclude` entry for
+# `crates/sandbox`. boxlite's `rusqlite = "0.37"` dependency links sqlite3
+# via libsqlite3-sys 0.35, which collides with the main workspace's
+# `sqlx = "0.8"` (libsqlite3-sys 0.30). Until issue #1700 decides how to
+# wire this into the kernel, `rara-sandbox` builds independently.
+[workspace]
+
+[package]
+name = "rara-sandbox"
+version = "0.0.1"
+edition = "2024"
+license = "Apache-2.0"
+authors = ["crrow"]
+repository = "https://github.com/rararulab/rara"
+homepage = "https://github.com/rararulab/rara"
+readme = "../../README.md"
+keywords = ["rust", "agent", "sandbox", "boxlite", "microvm"]
+categories = ["virtualization"]
+description = "Hardware-isolated code execution sandbox backed by boxlite (microVM)."
+publish = false
+
+[dependencies]
+bon = "^3.6"
+boxlite = { git = "https://github.com/boxlite-ai/boxlite", tag = "v0.8.2" }
+futures = "^0.3"
+serde = { version = "^1.0", features = ["derive"] }
+snafu = "^0.9"
+tokio = { version = "^1.45", features = ["full", "tracing"] }
+tracing = "^0.1"
+
+[dev-dependencies]
+tokio = { version = "^1.45", features = ["macros", "rt-multi-thread"] }
+
+[lints.rust]
+unsafe_code = "deny"
+
+[lints.clippy]
+all = { level = "warn", priority = -1 }
+pedantic = { level = "warn", priority = -1 }
+missing_errors_doc = "allow"
+must_use_candidate = "allow"
+module_name_repetitions = "allow"

--- a/crates/sandbox/src/config.rs
+++ b/crates/sandbox/src/config.rs
@@ -1,0 +1,57 @@
+//! Configuration types for sandbox creation and command execution.
+
+use std::time::Duration;
+
+use bon::Builder;
+use serde::{Deserialize, Serialize};
+
+/// Configuration describing how a [`Sandbox`](crate::Sandbox) should be
+/// provisioned.
+///
+/// Field values are passed through to boxlite without interpretation — in
+/// particular the rootfs image reference MUST already be resolvable by the
+/// host's boxlite image store. `rara-sandbox` never supplies a default image
+/// in Rust: the application layer is responsible for reading the image name
+/// from YAML config and passing it in here.
+///
+/// The struct derives [`Deserialize`] so application-layer code may load it
+/// straight from YAML, e.g.:
+///
+/// ```yaml
+/// sandbox:
+///   rootfs_image: "alpine:latest"
+///   name: "my-agent-sandbox"
+/// ```
+#[derive(Debug, Clone, Builder, Serialize, Deserialize)]
+pub struct SandboxConfig {
+    /// OCI image reference passed to boxlite as
+    /// [`RootfsSpec::Image`](boxlite::RootfsSpec::Image).
+    pub rootfs_image: String,
+
+    /// Optional human-readable box name. When `None`, boxlite generates one.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+}
+
+/// Description of a single command to run inside a [`Sandbox`](crate::Sandbox).
+///
+/// Mirrors the subset of [`boxlite::BoxCommand`] that rara actually uses
+/// today. Extra boxlite knobs (`tty`, `user`, `working_dir`) can be added here
+/// when a concrete caller needs them — not before, to keep the API surface
+/// minimal.
+#[derive(Debug, Clone, Builder)]
+pub struct ExecRequest {
+    /// Executable to invoke inside the sandbox (e.g. `"echo"`, `"python"`).
+    pub command: String,
+
+    /// Arguments to pass, in order. Empty vec means no args.
+    #[builder(default)]
+    pub args: Vec<String>,
+
+    /// Environment variables exported to the command.
+    #[builder(default)]
+    pub env: Vec<(String, String)>,
+
+    /// Optional hard timeout enforced by boxlite.
+    pub timeout: Option<Duration>,
+}

--- a/crates/sandbox/src/error.rs
+++ b/crates/sandbox/src/error.rs
@@ -1,0 +1,30 @@
+//! Typed errors for the sandbox crate.
+
+use snafu::prelude::*;
+
+/// Errors returned by [`Sandbox`](crate::Sandbox) operations.
+#[derive(Debug, Snafu)]
+#[snafu(visibility(pub))]
+pub enum SandboxError {
+    /// Failure bubbled up from the boxlite runtime.
+    ///
+    /// Covers VM provisioning, rootfs pulls, exec channel setup, and any
+    /// other failure reported by [`boxlite`]. Inspect the wrapped error for
+    /// the precise cause; boxlite does not (yet) provide a stable way to
+    /// categorise these programmatically.
+    #[snafu(display("boxlite runtime error: {source}"))]
+    Boxlite { source: boxlite::BoxliteError },
+
+    /// The requested stdout stream was already consumed.
+    ///
+    /// boxlite's [`Execution::stdout`](boxlite::Execution::stdout) returns
+    /// the stream handle by move on the first call and `None` thereafter.
+    /// Seeing this error means the caller (or a prior wrapper) already took
+    /// it; create a fresh [`ExecRequest`](crate::ExecRequest) instead of
+    /// trying to re-consume the same execution.
+    #[snafu(display("sandbox execution produced no stdout stream"))]
+    MissingStdout,
+}
+
+/// Convenience alias for results produced by this crate.
+pub type Result<T> = std::result::Result<T, SandboxError>;

--- a/crates/sandbox/src/lib.rs
+++ b/crates/sandbox/src/lib.rs
@@ -1,0 +1,53 @@
+//! Hardware-isolated code execution sandbox for rara.
+//!
+//! `rara-sandbox` wraps the [`boxlite`] microVM runtime and exposes a small,
+//! concrete API surface — `Sandbox`, `SandboxConfig`, `ExecRequest`, and
+//! `ExecOutcome` — that the kernel's Tool subsystem can use to run untrusted
+//! code with hardware-level isolation.
+//!
+//! # Design
+//!
+//! This crate intentionally exposes **concrete types** rather than a
+//! `SandboxBackend` trait. We expect exactly one backend (boxlite) for the
+//! foreseeable future; adding a trait now would be speculative abstraction
+//! (closed as YAGNI in #1697). If a second backend ever appears, the trait
+//! can be extracted without changing this crate's semantics.
+//!
+//! # Example
+//!
+//! ```no_run
+//! use futures::StreamExt;
+//! use rara_sandbox::{ExecRequest, Sandbox, SandboxConfig};
+//!
+//! # async fn demo() -> rara_sandbox::Result<()> {
+//! let config = SandboxConfig::builder()
+//!     .rootfs_image("alpine:latest".to_owned())
+//!     .build();
+//! let sandbox = Sandbox::create(config).await?;
+//! let mut outcome = sandbox
+//!     .exec(
+//!         ExecRequest::builder()
+//!             .command("echo")
+//!             .args(vec!["hi".to_owned()])
+//!             .build(),
+//!     )
+//!     .await?;
+//! while let Some(line) = outcome.stdout.next().await {
+//!     println!("{line}");
+//! }
+//! sandbox.destroy().await?;
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! See `AGENT.md` at the crate root for the boxlite integration footguns
+//! (git-only dependency, runtime file staging, submodules) that new agents
+//! working here need to know about.
+
+mod config;
+mod error;
+mod sandbox;
+
+pub use config::{ExecRequest, SandboxConfig};
+pub use error::{BoxliteSnafu, Result, SandboxError};
+pub use sandbox::{ExecOutcome, Sandbox};

--- a/crates/sandbox/src/sandbox.rs
+++ b/crates/sandbox/src/sandbox.rs
@@ -1,0 +1,125 @@
+//! Concrete [`Sandbox`] handle backed by a boxlite `LiteBox`.
+
+use boxlite::{
+    BoxCommand, BoxOptions, BoxliteRuntime, ExecStderr, ExecStdout, Execution, LiteBox, RootfsSpec,
+};
+use snafu::ResultExt;
+use tracing::instrument;
+
+use crate::{
+    config::{ExecRequest, SandboxConfig},
+    error::{BoxliteSnafu, MissingStdoutSnafu, Result},
+};
+
+/// Live handle to a hardware-isolated sandbox.
+///
+/// Owning a `Sandbox` implies the underlying boxlite VM has been created but
+/// not necessarily booted — boxlite starts the VM lazily on the first
+/// [`Sandbox::exec`] call. To reclaim resources, call [`Sandbox::destroy`];
+/// dropping the handle alone leaves the VM registered in the boxlite
+/// runtime's state.
+pub struct Sandbox {
+    /// Shared reference to the process-wide boxlite runtime. `default_runtime`
+    /// returns a `&'static` singleton, so the `'static` bound is free.
+    runtime:  &'static BoxliteRuntime,
+    /// boxlite's own handle to this specific box.
+    litebox:  LiteBox,
+    /// Cached name (if the caller supplied one) for use as the removal key.
+    box_name: Option<String>,
+}
+
+/// Streams and completion future returned by a single [`Sandbox::exec`] call.
+///
+/// Callers drive `stdout` / `stderr` to consume output and `await` the
+/// `execution` future (via [`Execution::wait`]) to obtain the exit status.
+///
+/// `stdout` is returned as a concrete [`ExecStdout`] which already
+/// implements [`futures::Stream<Item = String>`](futures::Stream), matching
+/// the API described in issue #1698.
+pub struct ExecOutcome {
+    /// Line-delimited stdout stream. Always present.
+    pub stdout:    ExecStdout,
+    /// Line-delimited stderr stream. `None` if boxlite declined to
+    /// materialise one (e.g. tty mode).
+    pub stderr:    Option<ExecStderr>,
+    /// The underlying boxlite execution handle. Call [`Execution::wait`] on
+    /// it after the streams drain to retrieve the exit status.
+    pub execution: Execution,
+}
+
+impl Sandbox {
+    /// Create a new sandbox from a [`SandboxConfig`].
+    ///
+    /// Uses boxlite's process-wide default runtime. The VM is registered but
+    /// not booted; the first [`Sandbox::exec`] call pays that cost.
+    #[instrument(skip_all, fields(image = %config.rootfs_image))]
+    pub async fn create(config: SandboxConfig) -> Result<Self> {
+        let runtime = BoxliteRuntime::default_runtime();
+        let options = BoxOptions {
+            rootfs: RootfsSpec::Image(config.rootfs_image),
+            ..Default::default()
+        };
+        let litebox = runtime
+            .create(options, config.name.clone())
+            .await
+            .context(BoxliteSnafu)?;
+        Ok(Self {
+            runtime,
+            litebox,
+            box_name: config.name,
+        })
+    }
+
+    /// Execute a single command inside the sandbox.
+    ///
+    /// Returns the stdout stream plus the underlying [`Execution`] handle so
+    /// callers retain access to stderr, stdin, and the exit status without
+    /// this crate having to re-export every boxlite surface.
+    #[instrument(skip_all, fields(command = %request.command))]
+    pub async fn exec(&self, request: ExecRequest) -> Result<ExecOutcome> {
+        let mut command = BoxCommand::new(request.command).args(request.args);
+        for (key, value) in request.env {
+            command = command.env(key, value);
+        }
+        if let Some(timeout) = request.timeout {
+            command = command.timeout(timeout);
+        }
+
+        let mut execution = self.litebox.exec(command).await.context(BoxliteSnafu)?;
+        // boxlite hands out stdout via `take`-style semantics; missing means
+        // another consumer already grabbed it — surface that as an error
+        // instead of silently degrading.
+        let stdout = execution.stdout().ok_or(MissingStdoutSnafu.build())?;
+        let stderr = execution.stderr();
+        Ok(ExecOutcome {
+            stdout,
+            stderr,
+            execution,
+        })
+    }
+
+    /// Remove the underlying box from the boxlite runtime.
+    ///
+    /// Uses `force = true` to tear down even if the VM is still running.
+    /// After this call the sandbox handle is consumed; create a new one if
+    /// further work is needed.
+    #[instrument(skip_all)]
+    pub async fn destroy(self) -> Result<()> {
+        // Prefer the user-supplied name, but fall back to the box ID because
+        // `name()` only exists when the caller passed one in `SandboxConfig`.
+        let key = self
+            .box_name
+            .unwrap_or_else(|| self.litebox.id().to_string());
+        self.runtime
+            .remove(&key, true)
+            .await
+            .context(BoxliteSnafu)?;
+        Ok(())
+    }
+
+    /// Read-only access to the wrapped boxlite handle.
+    ///
+    /// Exposed for integration tests and advanced callers that need a
+    /// boxlite knob we have not yet lifted into this crate's public API.
+    pub fn litebox(&self) -> &LiteBox { &self.litebox }
+}

--- a/crates/sandbox/tests/alpine_echo.rs
+++ b/crates/sandbox/tests/alpine_echo.rs
@@ -1,0 +1,48 @@
+//! End-to-end round-trip: create → exec `echo` → destroy.
+//!
+//! This test is `#[ignore]`d because it requires the boxlite runtime files
+//! (`boxlite-guest`, `libkrunfw.dylib`, `mke2fs`, `boxlite-shim`, `debugfs`)
+//! to be staged under the platform-specific runtime directory, and a local
+//! OCI image store that can resolve `alpine:latest`. Runtime-file staging
+//! is tracked in issue #1699; until that lands, CI cannot run this test
+//! from a fresh checkout.
+//!
+//! Run locally with:
+//!
+//! ```bash
+//! cargo test -p rara-sandbox -- --ignored alpine_echo_roundtrip
+//! ```
+
+use futures::StreamExt;
+use rara_sandbox::{ExecRequest, Sandbox, SandboxConfig};
+
+#[tokio::test]
+#[ignore = "requires boxlite runtime files (see issue #1699) and a local OCI image cache"]
+async fn alpine_echo_roundtrip() {
+    let config = SandboxConfig::builder()
+        .rootfs_image("alpine:latest".to_owned())
+        .build();
+
+    let sandbox = Sandbox::create(config)
+        .await
+        .expect("sandbox creation should succeed when runtime files are staged");
+
+    let request = ExecRequest::builder()
+        .command("echo".to_owned())
+        .args(vec!["Hello from BoxLite!".to_owned()])
+        .build();
+
+    let mut outcome = sandbox.exec(request).await.expect("exec should succeed");
+
+    let mut lines = Vec::new();
+    while let Some(line) = outcome.stdout.next().await {
+        lines.push(line);
+    }
+
+    assert!(
+        lines.iter().any(|l| l.contains("Hello from BoxLite!")),
+        "expected echo output, got: {lines:?}"
+    );
+
+    sandbox.destroy().await.expect("destroy should succeed");
+}


### PR DESCRIPTION
## Summary

Adds a new `rara-sandbox` crate that wraps boxlite v0.8.2 for
hardware-isolated code execution. Part of the boxlite-sandbox stack
(#1698).

Public surface (concrete types, no `SandboxBackend` trait — YAGNI,
per the closure of #1697):

- `Sandbox::create(SandboxConfig)` / `Sandbox::exec(ExecRequest)` /
  `Sandbox::destroy(self)`
- `ExecOutcome::stdout: boxlite::ExecStdout` (already implements
  `futures::Stream<Item = String>`)
- `SandboxError` via `snafu` with `BoxliteSnafu` context.

Integration test `alpine_echo_roundtrip` is marked `#[ignore]` — it
requires the runtime files from #1699 and a warm OCI image cache.

## Type of change

| Type | Label |
|------|-------|
| New feature | `enhancement` |

## Component

`core`

## Closes

Closes #1698

## Deviation from the plan

boxlite transitively depends on `rusqlite = "0.37"` (links =
`sqlite3`, via `libsqlite3-sys 0.35`). The main workspace uses
`sqlx = "0.8"` (via `libsqlite3-sys 0.30`). Cargo forbids two crates
sharing the same `links` value, so a straight workspace-member add
fails with `failed to select a version for libsqlite3-sys`.

Mitigation in this PR: `crates/sandbox` is a **standalone
sub-workspace** — the root `Cargo.toml` has `exclude =
["crates/sandbox"]`. Root `cargo check` / `clippy` / `doc` pass
untouched; `crates/sandbox` builds independently with the same
checks. Resolving the conflict (patching rusqlite, upgrading sqlx, or
isolating the sandbox behind a binary boundary) is a design decision
for the Tool subsystem wiring in #1700.

See `crates/sandbox/AGENT.md` for the three boxlite footguns from the
spike (crates.io publish broken, submodules, runtime file staging).

## Test plan

- [x] `cargo check --all --all-targets` passes (root workspace)
- [x] `cargo +nightly fmt --all -- --check` passes
- [x] `cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings` passes
- [x] `RUSTDOCFLAGS="-D warnings" cargo +nightly doc --workspace --no-deps --document-private-items` passes
- [x] `cargo check --all-targets` inside `crates/sandbox/` passes
- [x] `cargo clippy --all-targets --all-features --no-deps -- -D warnings` inside `crates/sandbox/` passes
- [x] `cargo test --no-run` inside `crates/sandbox/` builds the `#[ignore]`d integration test
- [ ] `alpine_echo_roundtrip` end-to-end (blocked on #1699 runtime staging; verified manually via the spike at `/tmp/boxlite-spike`)