### PR TITLE
fix: use cluster-internal DNS for sccache endpoint

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -17,7 +17,7 @@ env:
   RUSTC_WRAPPER: sccache
   SCCACHE_BUCKET: sccache
   SCCACHE_REGION: us-east-1
-  SCCACHE_ENDPOINT: http://10.0.0.167:9000
+  SCCACHE_ENDPOINT: http://minio.rara.svc.cluster.local:9000
   SCCACHE_S3_USE_SSL: "false"
   AWS_ACCESS_KEY_ID: minioadmin
   AWS_SECRET_ACCESS_KEY: minioadmin


### PR DESCRIPTION
## Summary

Replace hardcoded IP `10.0.0.167` in `.github/workflows/rust.yml` with the Kubernetes cluster-internal DNS `minio.rara.svc.cluster.local`. This avoids CI breakage when the MinIO pod IP changes.

## Type of change

| Type | Label |
|------|-------|
| Chore | `chore` |

## Component

`ci`

## Closes

Closes #1707

## Test plan

- [x] Workflow YAML syntax valid (single-line change)
- [ ] Next CI run resolves the DNS and uses sccache successfully