### PR TITLE
refactor(kernel): unify parse_duration between tool and router (#1706)

### DIFF
--- a/crates/extensions/backend-admin/src/data_feeds/router.rs
+++ b/crates/extensions/backend-admin/src/data_feeds/router.rs
@@ -37,9 +37,10 @@ use axum::{
     http::StatusCode,
     routing::{get, put},
 };
-use jiff::{Timestamp, ToSpan};
+use jiff::Timestamp;
 use rara_kernel::data_feed::{
-    DataFeed, DataFeedConfig, DataFeedRegistry, FeedStatus, FeedType, polling::PollingSource,
+    DataFeed, DataFeedConfig, DataFeedRegistry, FeedStatus, FeedType, parse_duration_ago,
+    polling::PollingSource,
 };
 use serde::{Deserialize, Deserializer, Serialize};
 use tokio_util::sync::CancellationToken;
@@ -470,34 +471,4 @@ pub fn start_feed_task(config: &DataFeedConfig, registry: &DataFeedRegistry) {
             );
         }
     }
-}
-
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
-/// Parse a human-friendly duration string (e.g. `"1h"`, `"24h"`, `"7d"`)
-/// and return the timestamp that many units ago from now.
-fn parse_duration_ago(s: &str) -> anyhow::Result<Timestamp> {
-    let s = s.trim();
-    if s.is_empty() {
-        anyhow::bail!("empty duration string");
-    }
-
-    let (num_str, unit) = s.split_at(s.len() - 1);
-    let n: i64 = num_str
-        .parse()
-        .map_err(|_| anyhow::anyhow!("invalid number in duration: {s}"))?;
-
-    let span = match unit {
-        "s" => n.seconds(),
-        "m" => n.minutes(),
-        "h" => n.hours(),
-        "d" => n.days(),
-        _ => anyhow::bail!("unsupported duration unit '{unit}', expected s/m/h/d"),
-    };
-
-    let now = Timestamp::now();
-    let past = now.checked_sub(span)?;
-    Ok(past)
 }

--- a/crates/kernel/src/data_feed/mod.rs
+++ b/crates/kernel/src/data_feed/mod.rs
@@ -35,6 +35,7 @@ mod feed;
 pub mod polling;
 mod registry;
 mod store;
+mod time;
 pub mod webhook;
 
 pub use config::{AuthConfig, DataFeedConfig, FeedStatus, FeedType};
@@ -42,3 +43,4 @@ pub use event::{FeedEvent, FeedEventId};
 pub use feed::DataFeed;
 pub use registry::DataFeedRegistry;
 pub use store::{FeedFilter, FeedStore, FeedStoreRef};
+pub use time::parse_duration_ago;

--- a/crates/kernel/src/data_feed/time.rs
+++ b/crates/kernel/src/data_feed/time.rs
@@ -1,0 +1,135 @@
+// Copyright 2025 Rararulab
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Shared duration parsing for data-feed time-range queries.
+//!
+//! Both the in-process `query-feed` tool and the admin REST API accept
+//! human-friendly duration strings like `"30m"` or `"7d"` to build a "since"
+//! [`jiff::Timestamp`]. This module provides a single canonical parser so the
+//! two surfaces cannot drift on unit coverage or error wording.
+
+use jiff::{SignedDuration, Timestamp};
+
+/// Parse a human-friendly duration string (e.g. `"30s"`, `"15m"`, `"1h"`,
+/// `"7d"`) and return the timestamp that many units ago from now.
+///
+/// Supported units: `s` (seconds), `m` (minutes), `h` (hours), `d` (days).
+///
+/// Days are treated as fixed 86_400-second intervals — this avoids
+/// `jiff::Timestamp`'s prohibition on calendar units and matches the
+/// pragmatic "N days ago" meaning callers want for querying event windows.
+pub fn parse_duration_ago(s: &str) -> anyhow::Result<Timestamp> {
+    let s = s.trim();
+    if s.is_empty() {
+        anyhow::bail!("empty duration string");
+    }
+
+    let (num_str, unit) = s.split_at(s.len() - 1);
+    let n: i64 = num_str
+        .parse()
+        .map_err(|_| anyhow::anyhow!("invalid number in duration: {s}"))?;
+
+    let secs = match unit {
+        "s" => n,
+        "m" => n * 60,
+        "h" => n * 3600,
+        "d" => n * 86_400,
+        _ => anyhow::bail!("unsupported duration unit '{unit}', expected s/m/h/d"),
+    };
+
+    let now = Timestamp::now();
+    let past = now.checked_sub(SignedDuration::from_secs(secs))?;
+    Ok(past)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_duration_seconds() {
+        let ts = parse_duration_ago("45s").unwrap();
+        let now = Timestamp::now();
+        let diff = now.duration_since(ts);
+        assert!(
+            diff.as_secs() >= 43 && diff.as_secs() <= 47,
+            "expected ~45s, got {}s",
+            diff.as_secs()
+        );
+    }
+
+    #[test]
+    fn parse_duration_minutes() {
+        let ts = parse_duration_ago("30m").unwrap();
+        let now = Timestamp::now();
+        let diff = now.duration_since(ts);
+        let expected = 30 * 60;
+        assert!(
+            diff.as_secs() >= expected - 2 && diff.as_secs() <= expected + 2,
+            "expected ~{}s, got {}s",
+            expected,
+            diff.as_secs()
+        );
+    }
+
+    #[test]
+    fn parse_duration_hours() {
+        let ts = parse_duration_ago("1h").unwrap();
+        let now = Timestamp::now();
+        let diff = now.duration_since(ts);
+        assert!(
+            diff.as_secs() >= 3598 && diff.as_secs() <= 3602,
+            "expected ~3600s, got {}s",
+            diff.as_secs()
+        );
+    }
+
+    #[test]
+    fn parse_duration_days() {
+        let ts = parse_duration_ago("7d").unwrap();
+        let now = Timestamp::now();
+        let diff = now.duration_since(ts);
+        let expected = 7 * 86400;
+        assert!(
+            diff.as_secs() >= expected - 2 && diff.as_secs() <= expected + 2,
+            "expected ~{}s, got {}s",
+            expected,
+            diff.as_secs()
+        );
+    }
+
+    #[test]
+    fn parse_duration_empty() {
+        let err = parse_duration_ago("").unwrap_err();
+        assert!(err.to_string().contains("empty duration"), "got: {err}");
+    }
+
+    #[test]
+    fn parse_duration_invalid_unit() {
+        let err = parse_duration_ago("5x").unwrap_err();
+        assert!(
+            err.to_string().contains("unsupported duration unit"),
+            "got: {err}"
+        );
+    }
+
+    #[test]
+    fn parse_duration_invalid_number() {
+        let err = parse_duration_ago("abch").unwrap_err();
+        assert!(
+            err.to_string().contains("invalid number in duration"),
+            "got: {err}"
+        );
+    }
+}

--- a/crates/kernel/src/tool/data_feed.rs
+++ b/crates/kernel/src/tool/data_feed.rs
@@ -21,7 +21,7 @@ use serde::{Deserialize, Serialize};
 use tracing::debug;
 
 use crate::{
-    data_feed::{FeedFilter, FeedStoreRef},
+    data_feed::{FeedFilter, FeedStoreRef, parse_duration_ago},
     tool::{ToolContext, ToolExecute},
 };
 
@@ -95,7 +95,11 @@ impl ToolExecute for QueryFeedTool {
         params: QueryFeedParams,
         _context: &ToolContext,
     ) -> anyhow::Result<QueryFeedResult> {
-        let since = params.since.as_deref().map(parse_duration).transpose()?;
+        let since = params
+            .since
+            .as_deref()
+            .map(parse_duration_ago)
+            .transpose()?;
         let limit = params.limit.unwrap_or(20).min(100);
 
         let filter = FeedFilter {
@@ -123,98 +127,5 @@ impl ToolExecute for QueryFeedTool {
             .collect();
 
         Ok(QueryFeedResult { events, count })
-    }
-}
-
-// ---------------------------------------------------------------------------
-// Duration parsing
-// ---------------------------------------------------------------------------
-
-/// Parse a human-friendly duration string into a [`jiff::Timestamp`] relative
-/// to now.
-///
-/// Supported formats: `"30m"`, `"1h"`, `"24h"`, `"7d"`.
-fn parse_duration(s: &str) -> anyhow::Result<jiff::Timestamp> {
-    let s = s.trim();
-    let (num_str, unit) = s.split_at(s.len().saturating_sub(1));
-    let num: i64 = num_str
-        .parse()
-        .map_err(|_| anyhow::anyhow!("invalid duration: '{s}'. Expected format: 1h, 24h, 7d"))?;
-
-    let secs = match unit {
-        "m" => num * 60,
-        "h" => num * 3600,
-        "d" => num * 86400,
-        _ => {
-            return Err(anyhow::anyhow!(
-                "unsupported duration unit in '{s}'. Use 'm' (minutes), 'h' (hours), or 'd' (days)"
-            ));
-        }
-    };
-
-    let now = jiff::Timestamp::now();
-    now.checked_sub(jiff::SignedDuration::from_secs(secs))
-        .map_err(|e| anyhow::anyhow!("duration overflow: {e}"))
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn parse_duration_hours() {
-        let ts = parse_duration("1h").unwrap();
-        let now = jiff::Timestamp::now();
-        let diff = now.duration_since(ts);
-        // Should be approximately 3600 seconds (allow 2s tolerance for test execution
-        // time).
-        assert!(
-            diff.as_secs() >= 3598 && diff.as_secs() <= 3602,
-            "expected ~3600s, got {}s",
-            diff.as_secs()
-        );
-    }
-
-    #[test]
-    fn parse_duration_days() {
-        let ts = parse_duration("7d").unwrap();
-        let now = jiff::Timestamp::now();
-        let diff = now.duration_since(ts);
-        let expected = 7 * 86400;
-        assert!(
-            diff.as_secs() >= expected - 2 && diff.as_secs() <= expected + 2,
-            "expected ~{}s, got {}s",
-            expected,
-            diff.as_secs()
-        );
-    }
-
-    #[test]
-    fn parse_duration_minutes() {
-        let ts = parse_duration("30m").unwrap();
-        let now = jiff::Timestamp::now();
-        let diff = now.duration_since(ts);
-        let expected = 30 * 60;
-        assert!(
-            diff.as_secs() >= expected - 2 && diff.as_secs() <= expected + 2,
-            "expected ~{}s, got {}s",
-            expected,
-            diff.as_secs()
-        );
-    }
-
-    #[test]
-    fn parse_duration_invalid_unit() {
-        let err = parse_duration("5x").unwrap_err();
-        assert!(
-            err.to_string().contains("unsupported duration unit"),
-            "got: {err}"
-        );
-    }
-
-    #[test]
-    fn parse_duration_invalid_number() {
-        let err = parse_duration("abch").unwrap_err();
-        assert!(err.to_string().contains("invalid duration"), "got: {err}");
     }
 }


### PR DESCRIPTION
## Summary

Consolidate the two parallel `parse_duration` helpers — one in the
`query-feed` tool (m/h/d) and one in the admin `data_feeds` router
(s/m/h/d) — into a single `rara_kernel::data_feed::parse_duration_ago`
with the superset (s/m/h/d). Both call sites now delegate to the
shared helper.

Also fixes a latent bug: the admin router's `?since=Nd` path previously
built a `jiff::Span` with calendar-unit days and passed it to
`Timestamp::checked_sub`, which jiff rejects. The shared helper computes
seconds via `SignedDuration::from_secs`, which works for all units.

## Type of change

| Type | Label |
|------|-------|
| Refactor | `refactor` |

## Component

`core`

## Closes

Closes #1706

## Test plan

- [x] `cargo check -p rara-kernel -p rara-backend-admin` passes
- [x] `cargo test -p rara-kernel data_feed::time` — 7 tests pass (s/m/h/d + empty/invalid unit/invalid number)
- [x] `prek run --all-files` passes (fmt, clippy, doc, check)