### PR TITLE
fix(data-feeds): persist runtime status + last_error to DB (#1705)

### DIFF
--- a/crates/app/src/lib.rs
+++ b/crates/app/src/lib.rs
@@ -388,6 +388,12 @@ pub async fn start_with_options(
         Arc::new(crate::feed_store::SqliteFeedStore::new(pool.clone()));
     let feed_svc = rara_backend_admin::data_feeds::DataFeedSvc::new(pool.clone());
 
+    // Install the status reporter so runtime transitions (running / idle /
+    // error + last_error) persist back to the `data_feeds` table.
+    feed_registry.set_reporter(Arc::new(
+        rara_backend_admin::data_feeds::SvcStatusReporter::new(feed_svc.clone()),
+    ));
+
     // Restore feed configs from database into registry.
     match feed_svc.list_feeds().await {
         Ok(configs) => {

--- a/crates/extensions/backend-admin/src/data_feeds/mod.rs
+++ b/crates/extensions/backend-admin/src/data_feeds/mod.rs
@@ -19,8 +19,10 @@
 //! and the in-memory
 //! [`DataFeedRegistry`](rara_kernel::data_feed::DataFeedRegistry).
 
+pub mod reporter;
 pub mod router;
 pub mod service;
 
+pub use reporter::SvcStatusReporter;
 pub use router::{DataFeedRouterState, data_feed_routes, start_feed_task};
 pub use service::DataFeedSvc;

--- a/crates/extensions/backend-admin/src/data_feeds/reporter.rs
+++ b/crates/extensions/backend-admin/src/data_feeds/reporter.rs
@@ -1,0 +1,45 @@
+// Copyright 2025 Rararulab
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! [`SvcStatusReporter`] — bridges the kernel's [`StatusReporter`] callback
+//! to [`DataFeedSvc::update_status`] so runtime transitions persist to the
+//! `data_feeds` table.
+
+use async_trait::async_trait;
+use rara_kernel::data_feed::{FeedStatus, StatusReporter};
+use tracing::warn;
+
+use super::DataFeedSvc;
+
+/// [`StatusReporter`] that writes transitions through [`DataFeedSvc`].
+///
+/// Errors are logged and swallowed — a failing status write must never
+/// crash the polling loop or task spawner that triggered it.
+pub struct SvcStatusReporter {
+    svc: DataFeedSvc,
+}
+
+impl SvcStatusReporter {
+    /// Build a reporter backed by the given service.
+    pub fn new(svc: DataFeedSvc) -> Self { Self { svc } }
+}
+
+#[async_trait]
+impl StatusReporter for SvcStatusReporter {
+    async fn report(&self, name: &str, status: FeedStatus, last_error: Option<String>) {
+        if let Err(e) = self.svc.update_status(name, status, last_error).await {
+            warn!(feed = name, %status, error = %e, "failed to persist feed status");
+        }
+    }
+}

--- a/crates/extensions/backend-admin/src/data_feeds/router.rs
+++ b/crates/extensions/backend-admin/src/data_feeds/router.rs
@@ -354,6 +354,17 @@ async fn toggle_feed(
     // Start task if now enabled, stop already handled by remove above.
     if feed.enabled {
         start_feed_task(&feed, &state.registry);
+    } else {
+        // Disabled: explicitly drop runtime status to Idle and clear any
+        // stale last_error so the UI doesn't show "error" on a feed the
+        // user just turned off.
+        if let Err(e) = state
+            .svc
+            .update_status(&feed.name, FeedStatus::Idle, None)
+            .await
+        {
+            warn!(name = %feed.name, error = %e, "failed to persist idle status on toggle-off");
+        }
     }
 
     Ok(Json(feed))
@@ -432,7 +443,7 @@ async fn get_event(
 /// Polling feeds spawn a background tokio task. Webhook feeds are passive
 /// (handled by the webhook axum route). WebSocket feeds are not yet
 /// implemented.
-pub fn start_feed_task(config: &DataFeedConfig, registry: &DataFeedRegistry) {
+pub fn start_feed_task(config: &DataFeedConfig, registry: &Arc<DataFeedRegistry>) {
     match config.feed_type {
         FeedType::Polling => {
             let source = match PollingSource::from_config(config) {
@@ -442,19 +453,35 @@ pub fn start_feed_task(config: &DataFeedConfig, registry: &DataFeedRegistry) {
                         feed = %config.name, error = %e,
                         "failed to create polling source from config"
                     );
+                    // Surface config-parse failures so the UI reflects reality.
+                    registry.report_error(&config.name, format!("config parse failed: {e}"));
                     return;
                 }
             };
 
+            // Attach the registry's reporter (if any) so transient fetch
+            // errors land in the `data_feeds` row.
+            let source = match registry.reporter() {
+                Some(r) => source.with_reporter(r),
+                None => source,
+            };
+
             let cancel = CancellationToken::new();
+            // set_running also fires a Running transition through the
+            // reporter, so GET /api/v1/data-feeds reflects the spawn.
             registry.set_running(config.name.clone(), cancel.clone());
 
             let event_tx = registry.event_tx();
             let name = config.name.clone();
+            let registry = registry.clone();
 
             tokio::spawn(async move {
-                if let Err(e) = source.run(event_tx, cancel).await {
-                    warn!(feed = %name, error = %e, "feed task exited with error");
+                match source.run(event_tx, cancel).await {
+                    Ok(()) => registry.clear_running(&name),
+                    Err(e) => {
+                        warn!(feed = %name, error = %e, "feed task exited with error");
+                        registry.report_error(&name, e.to_string());
+                    }
                 }
                 info!(feed = %name, "polling feed task stopped");
             });

--- a/crates/extensions/backend-admin/src/data_feeds/service.rs
+++ b/crates/extensions/backend-admin/src/data_feeds/service.rs
@@ -146,6 +146,34 @@ impl DataFeedSvc {
         Ok(result.rows_affected() > 0)
     }
 
+    /// Update the runtime `status` and `last_error` columns for a feed,
+    /// looked up by unique name.
+    ///
+    /// Called via the [`StatusReporter`] wiring so the `data_feeds` table
+    /// reflects the actual runtime state (running / idle / error) rather
+    /// than the stale value written at creation time.
+    ///
+    /// [`StatusReporter`]: rara_kernel::data_feed::StatusReporter
+    #[instrument(skip(self))]
+    pub async fn update_status(
+        &self,
+        name: &str,
+        status: FeedStatus,
+        last_error: Option<String>,
+    ) -> anyhow::Result<bool> {
+        let now = Timestamp::now().to_string();
+        let result = sqlx::query(
+            "UPDATE data_feeds SET status = ?1, last_error = ?2, updated_at = ?3 WHERE name = ?4",
+        )
+        .bind(status.to_string())
+        .bind(&last_error)
+        .bind(&now)
+        .bind(name)
+        .execute(&self.pool)
+        .await?;
+        Ok(result.rows_affected() > 0)
+    }
+
     /// Toggle the enabled flag for a feed. Returns `true` if updated.
     #[instrument(skip(self))]
     pub async fn toggle_feed(&self, id: &str) -> anyhow::Result<bool> {

--- a/crates/kernel/src/data_feed/mod.rs
+++ b/crates/kernel/src/data_feed/mod.rs
@@ -34,6 +34,7 @@ mod event;
 mod feed;
 pub mod polling;
 mod registry;
+mod status_reporter;
 mod store;
 pub mod webhook;
 
@@ -41,4 +42,5 @@ pub use config::{AuthConfig, DataFeedConfig, FeedStatus, FeedType};
 pub use event::{FeedEvent, FeedEventId};
 pub use feed::DataFeed;
 pub use registry::DataFeedRegistry;
+pub use status_reporter::{StatusReporter, StatusReporterRef};
 pub use store::{FeedFilter, FeedStore, FeedStoreRef};

--- a/crates/kernel/src/data_feed/polling.rs
+++ b/crates/kernel/src/data_feed/polling.rs
@@ -18,7 +18,14 @@
 //! [`FeedEvent`] payload. No response parsing — the subscribing agent
 //! interprets the payload with its own intelligence.
 
-use std::{collections::HashMap, time::Duration};
+use std::{
+    collections::HashMap,
+    sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    },
+    time::Duration,
+};
 
 use async_trait::async_trait;
 use jiff::Timestamp;
@@ -28,7 +35,10 @@ use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
 use tracing::{instrument, warn};
 
-use super::{DataFeed, DataFeedConfig, FeedEvent, FeedEventId, config::AuthConfig};
+use super::{
+    DataFeed, DataFeedConfig, FeedEvent, FeedEventId, FeedStatus, StatusReporterRef,
+    config::AuthConfig,
+};
 
 // ---------------------------------------------------------------------------
 // PollingTransport — transport-specific config
@@ -88,6 +98,12 @@ pub struct PollingSource {
     auth:      Option<AuthConfig>,
     /// Shared HTTP client.
     client:    reqwest::Client,
+    /// Optional status reporter for DB write-back of fetch errors.
+    reporter:  Option<StatusReporterRef>,
+    /// Latched flag: the last reported status was [`FeedStatus::Error`].
+    /// Used to debounce the reporter — we only write on transitions, not
+    /// on every poll.
+    in_error:  Arc<AtomicBool>,
 }
 
 impl PollingSource {
@@ -107,7 +123,48 @@ impl PollingSource {
             transport,
             auth: config.auth.clone(),
             client,
+            reporter: None,
+            in_error: Arc::new(AtomicBool::new(false)),
         })
+    }
+
+    /// Attach a [`StatusReporter`](super::StatusReporter) so transient
+    /// fetch failures are persisted to the `data_feeds` row as
+    /// [`FeedStatus::Error`] with the error message, and the first
+    /// success afterwards clears the error.
+    #[must_use]
+    pub fn with_reporter(mut self, reporter: StatusReporterRef) -> Self {
+        self.reporter = Some(reporter);
+        self
+    }
+
+    /// Record a fetch error: persist [`FeedStatus::Error`] only on the
+    /// first failure in a streak (transitions), and log on every one.
+    fn record_error(&self, message: String) {
+        warn!(error = %message, "poll fetch failed");
+        if !self.in_error.swap(true, Ordering::SeqCst)
+            && let Some(reporter) = self.reporter.clone()
+        {
+            let name = self.name.clone();
+            tokio::spawn(async move {
+                reporter
+                    .report(&name, FeedStatus::Error, Some(message))
+                    .await;
+            });
+        }
+    }
+
+    /// Record a successful poll. If the previous state was error, push
+    /// [`FeedStatus::Running`] with cleared `last_error`.
+    fn record_success(&self) {
+        if self.in_error.swap(false, Ordering::SeqCst)
+            && let Some(reporter) = self.reporter.clone()
+        {
+            let name = self.name.clone();
+            tokio::spawn(async move {
+                reporter.report(&name, FeedStatus::Running, None).await;
+            });
+        }
     }
 }
 
@@ -175,7 +232,7 @@ impl PollingSource {
         let url = match self.build_url() {
             Ok(u) => u,
             Err(e) => {
-                warn!(error = %e, "failed to build poll URL");
+                self.record_error(format!("failed to build poll URL: {e}"));
                 return true;
             }
         };
@@ -200,21 +257,21 @@ impl PollingSource {
         let response = match request.send().await {
             Ok(r) => r,
             Err(e) => {
-                warn!(error = %e, "poll fetch failed");
+                self.record_error(format!("poll fetch failed: {e}"));
                 return true;
             }
         };
 
         let status = response.status();
         if !status.is_success() {
-            warn!(%status, "poll received non-success status");
+            self.record_error(format!("poll received non-success status: {status}"));
             return true;
         }
 
         let body = match response.bytes().await {
             Ok(b) => b,
             Err(e) => {
-                warn!(error = %e, "failed to read poll response body");
+                self.record_error(format!("failed to read poll response body: {e}"));
                 return true;
             }
         };
@@ -245,6 +302,10 @@ impl PollingSource {
             tracing::info!("event channel closed, stopping poll loop");
             return false;
         }
+
+        // Fetch + parse succeeded — clear any prior error latch so the DB
+        // reflects a healthy feed again.
+        self.record_success();
 
         true
     }

--- a/crates/kernel/src/data_feed/registry.rs
+++ b/crates/kernel/src/data_feed/registry.rs
@@ -36,7 +36,7 @@ use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
 use tracing::info;
 
-use super::{DataFeedConfig, FeedEvent};
+use super::{DataFeedConfig, FeedEvent, StatusReporterRef};
 
 /// Manages registered data feeds and their runtime state.
 ///
@@ -50,6 +50,11 @@ pub struct DataFeedRegistry {
     /// Cancel tokens for running feed tasks, keyed by feed name.
     /// Populated externally when a concrete feed task is spawned.
     running:  Arc<Mutex<HashMap<String, CancellationToken>>>,
+    /// Optional hook for persisting status transitions to the `data_feeds`
+    /// table. When absent, runtime status lives only in memory — callers
+    /// can still drive DB writes manually, but the kernel will not nudge
+    /// them.
+    reporter: Arc<Mutex<Option<StatusReporterRef>>>,
 }
 
 impl DataFeedRegistry {
@@ -62,8 +67,22 @@ impl DataFeedRegistry {
             configs: Arc::new(Mutex::new(HashMap::new())),
             event_tx,
             running: Arc::new(Mutex::new(HashMap::new())),
+            reporter: Arc::new(Mutex::new(None)),
         }
     }
+
+    /// Install a [`StatusReporter`](super::StatusReporter) for DB
+    /// write-back of runtime status transitions.
+    ///
+    /// Intended to be called once during bootstrap by the application
+    /// layer (e.g. backend-admin) that owns the persistence service.
+    pub fn set_reporter(&self, reporter: StatusReporterRef) {
+        *self.reporter.lock() = Some(reporter);
+    }
+
+    /// Return a clone of the installed
+    /// [`StatusReporter`](super::StatusReporter), if any.
+    pub fn reporter(&self) -> Option<StatusReporterRef> { self.reporter.lock().clone() }
 
     /// Register a new data feed configuration.
     ///
@@ -139,9 +158,13 @@ impl DataFeedRegistry {
     /// Register a cancellation token for a running feed task.
     ///
     /// Called by the feed spawner after `tokio::spawn`-ing the feed's
-    /// `run` future.
+    /// `run` future. If a [`StatusReporter`](super::StatusReporter) is
+    /// installed, this spawns a best-effort report of
+    /// [`FeedStatus::Running`](super::FeedStatus::Running) so the DB
+    /// reflects reality.
     pub fn set_running(&self, name: String, token: CancellationToken) {
-        self.running.lock().insert(name, token);
+        self.running.lock().insert(name.clone(), token);
+        self.spawn_report(name, super::FeedStatus::Running, None);
     }
 
     /// Check whether a feed has a running task.
@@ -150,7 +173,31 @@ impl DataFeedRegistry {
     /// Remove the cancellation token for a feed that has stopped.
     ///
     /// Called when a feed task completes (either normally or due to error).
-    pub fn clear_running(&self, name: &str) { self.running.lock().remove(name); }
+    /// Reports [`FeedStatus::Idle`](super::FeedStatus::Idle) through the
+    /// installed reporter. Use [`report_error`](Self::report_error) instead
+    /// if the task exited due to a fatal error.
+    pub fn clear_running(&self, name: &str) {
+        self.running.lock().remove(name);
+        self.spawn_report(name.to_owned(), super::FeedStatus::Idle, None);
+    }
+
+    /// Report a terminal error for a feed's runtime. Clears the cancel
+    /// token and persists `FeedStatus::Error` with `last_error = message`.
+    pub fn report_error(&self, name: &str, message: String) {
+        self.running.lock().remove(name);
+        self.spawn_report(name.to_owned(), super::FeedStatus::Error, Some(message));
+    }
+
+    /// Spawn a fire-and-forget status report. Does nothing when no
+    /// reporter is installed; the kernel must never block or panic on a
+    /// failed DB write.
+    fn spawn_report(&self, name: String, status: super::FeedStatus, last_error: Option<String>) {
+        if let Some(reporter) = self.reporter() {
+            tokio::spawn(async move {
+                reporter.report(&name, status, last_error).await;
+            });
+        }
+    }
 }
 
 #[cfg(test)]
@@ -257,5 +304,83 @@ mod tests {
 
         registry.register(make_config("x")).unwrap();
         assert_eq!(registry.configs().len(), registry.list().len());
+    }
+
+    // ---- Reporter wiring ---------------------------------------------------
+
+    use async_trait::async_trait;
+    use tokio::sync::Mutex as AsyncMutex;
+
+    use crate::data_feed::StatusReporter;
+
+    #[derive(Default)]
+    struct RecordingReporter {
+        events: AsyncMutex<Vec<(String, FeedStatus, Option<String>)>>,
+    }
+
+    #[async_trait]
+    impl StatusReporter for RecordingReporter {
+        async fn report(&self, name: &str, status: FeedStatus, last_error: Option<String>) {
+            self.events
+                .lock()
+                .await
+                .push((name.to_owned(), status, last_error));
+        }
+    }
+
+    #[tokio::test]
+    async fn set_running_reports_running_through_reporter() {
+        let (tx, _rx) = mpsc::channel(16);
+        let registry = DataFeedRegistry::new(tx);
+        let reporter = Arc::new(RecordingReporter::default());
+        registry.set_reporter(reporter.clone());
+
+        let token = CancellationToken::new();
+        registry.set_running("alpha".to_owned(), token);
+
+        // Give the spawned report a tick to land.
+        tokio::task::yield_now().await;
+        tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+
+        let events = reporter.events.lock().await;
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].0, "alpha");
+        assert_eq!(events[0].1, FeedStatus::Running);
+        assert!(events[0].2.is_none());
+    }
+
+    #[tokio::test]
+    async fn clear_running_reports_idle_through_reporter() {
+        let (tx, _rx) = mpsc::channel(16);
+        let registry = DataFeedRegistry::new(tx);
+        let reporter = Arc::new(RecordingReporter::default());
+        registry.set_reporter(reporter.clone());
+
+        registry.set_running("beta".to_owned(), CancellationToken::new());
+        registry.clear_running("beta");
+
+        tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+
+        let events = reporter.events.lock().await;
+        assert_eq!(events.len(), 2);
+        assert_eq!(events[1].1, FeedStatus::Idle);
+        assert!(events[1].2.is_none());
+    }
+
+    #[tokio::test]
+    async fn report_error_propagates_message() {
+        let (tx, _rx) = mpsc::channel(16);
+        let registry = DataFeedRegistry::new(tx);
+        let reporter = Arc::new(RecordingReporter::default());
+        registry.set_reporter(reporter.clone());
+
+        registry.set_running("gamma".to_owned(), CancellationToken::new());
+        registry.report_error("gamma", "boom".to_owned());
+
+        tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+
+        let events = reporter.events.lock().await;
+        assert_eq!(events.last().unwrap().1, FeedStatus::Error);
+        assert_eq!(events.last().unwrap().2.as_deref(), Some("boom"));
     }
 }

--- a/crates/kernel/src/data_feed/status_reporter.rs
+++ b/crates/kernel/src/data_feed/status_reporter.rs
@@ -1,0 +1,46 @@
+// Copyright 2025 Rararulab
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! [`StatusReporter`] — callback for persisting runtime status transitions.
+//!
+//! The kernel's data feed machinery tracks runtime state purely in memory
+//! (cancellation tokens in [`DataFeedRegistry`](super::DataFeedRegistry)).
+//! Persisting status transitions to the `data_feeds` table is the
+//! responsibility of the caller (backend-admin), wired in via this trait
+//! so the kernel never reaches into SQLx or the service layer.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+
+use super::FeedStatus;
+
+/// Persist a feed's runtime status transition.
+///
+/// Implementations typically perform a single `UPDATE` on the `data_feeds`
+/// table. Errors are expected to be logged by the implementor — callers
+/// of this trait do not propagate failures, because a failing status
+/// write must never crash the polling loop or task spawner.
+#[async_trait]
+pub trait StatusReporter: Send + Sync {
+    /// Report a status transition for the feed identified by `name`.
+    ///
+    /// `last_error` is `Some(msg)` only for [`FeedStatus::Error`] — for
+    /// [`FeedStatus::Idle`] and [`FeedStatus::Running`] it should be
+    /// `None`, which also clears any previous error.
+    async fn report(&self, name: &str, status: FeedStatus, last_error: Option<String>);
+}
+
+/// Shared reference type for [`StatusReporter`] implementations.
+pub type StatusReporterRef = Arc<dyn StatusReporter>;


### PR DESCRIPTION
## Summary

`DataFeedRegistry::set_running` only inserted a `CancellationToken` in an
in-memory map — so `GET /api/v1/data-feeds` kept reporting the stale
creation-time status even when polling was persisting thousands of events.
This change wires a `StatusReporter` callback from kernel to backend-admin
so runtime transitions (running / idle / error + `last_error`) flow into
the `data_feeds` row:

- New `StatusReporter` trait + `StatusReporterRef` in `rara_kernel::data_feed`.
- `DataFeedRegistry::{set_reporter, reporter, report_error}` + `set_running` /
  `clear_running` now fire the reporter. Kernel stays SQLx-free.
- `PollingSource::with_reporter` debounces transient fetch failures —
  writes on `healthy → error` / `error → healthy` transitions only, not
  every poll.
- `DataFeedSvc::update_status(name, status, last_error)` — single UPDATE
  keyed by unique name.
- `SvcStatusReporter` in backend-admin bridges the two; installed from
  app bootstrap.
- `start_feed_task` takes `&Arc<DataFeedRegistry>` so the spawned task
  can `clear_running` / `report_error` on exit. `toggle_feed` clears
  status to Idle when disabling.
- 3 new `#[tokio::test]`s on the registry verify reporter fires for
  Running / Idle / Error with correct `last_error` payload.

## Type of change

| Type | Label |
|------|-------|
| Bug fix | `bug` |

## Component

`backend`

## Closes

Closes #1705

## Test plan

- [x] `cargo check --all --all-targets` passes
- [x] `cargo test -p rara-kernel data_feed::registry` — 10 tests (3 new) pass
- [x] `prek run --all-files` — cargo check / fmt / clippy / doc all green
- [ ] Manual: create polling feed on live instance, confirm `status=running`
      in `GET /api/v1/data-feeds`; kill network, confirm `status=error` +
      `last_error` populated; restore network, confirm recovery to `running`.