### PR TITLE
chore(ci): remove sccache env vars from workflow (#1715)

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -14,13 +14,6 @@ env:
   CARGO_INCREMENTAL: false
   CARGO_NET_RETRY: 10
   RUSTUP_MAX_RETRIES: 10
-  RUSTC_WRAPPER: sccache
-  SCCACHE_BUCKET: sccache
-  SCCACHE_REGION: us-east-1
-  SCCACHE_ENDPOINT: http://minio.rara.svc.cluster.local:9000
-  SCCACHE_S3_USE_SSL: "false"
-  AWS_ACCESS_KEY_ID: minioadmin
-  AWS_SECRET_ACCESS_KEY: minioadmin
 
 defaults:
   run:


### PR DESCRIPTION
sccache and MinIO credentials are now provided by the runner pod environment, so declaring them in the workflow is redundant. Keep the workflow minimal and let the runner control cache configuration.

Closes #1715

## Summary

<!-- Brief description of the changes -->

## Type of change

<!-- Check the one that applies and add the matching label to this PR -->

| Type | Label |
|------|-------|
| Bug fix | `bug` |
| New feature | `enhancement` |
| Breaking change | `breaking-change` |
| Refactor | `refactor` |
| CI / Infrastructure | `ci` |
| Maintenance | `chore` |
| Documentation | `documentation` |

## Component

<!-- Add the component label that best matches the area you changed -->
<!-- `core` · `backend` · `ui` · `extension` · `ci` -->

## Closes

<!-- REQUIRED: Link the issue this PR resolves. PR merge will auto-close the issue. -->
<!-- If no issue exists, create one first: gh issue create -->

Closes #

## Test plan

- [ ] `just test` passes
- [ ] `just lint` passes
- [ ] Tested locally
