### PR TITLE
feat(backend-admin): bearer auth middleware + Principal extractor (#1711)

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -18,6 +18,22 @@ grpc:
   server_address: "127.0.0.1:50051"
 
 # ---------------------------------------------------------------------------
+# Owner authentication (required)
+# ---------------------------------------------------------------------------
+#
+# `owner_token` is the static bearer token that authenticates admin HTTP
+# requests (Authorization: Bearer <token>) and the web WebSocket upgrade
+# (?token=...). Treat it like a password: long, random, kept out of logs
+# and version control.
+#
+# `owner_user_id` must reference a `users[].name` below whose role is
+# `root` or `admin`. The backend admin middleware resolves every
+# authenticated request to this principal.
+
+owner_token: "change-me-to-a-long-random-string"
+owner_user_id: "you"
+
+# ---------------------------------------------------------------------------
 # Configured users — platform identity mappings (required, non-empty)
 # ---------------------------------------------------------------------------
 

--- a/crates/app/src/config_sync.rs
+++ b/crates/app/src/config_sync.rs
@@ -254,6 +254,9 @@ mod tests {
     use crate::AppConfig;
 
     const TEST_YAML: &str = r#"
+owner_token: "test-owner-token"
+owner_user_id: "testuser"
+
 users:
   - name: "testuser"
     role: root

--- a/crates/app/src/lib.rs
+++ b/crates/app/src/lib.rs
@@ -72,9 +72,18 @@ pub struct AppConfig {
     /// General OTLP telemetry (Alloy/Tempo).
     #[serde(default)]
     pub telemetry:              TelemetryConfig,
-    /// Static bearer token for owner authentication (Web UI).
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub owner_token:            Option<String>,
+    /// Static bearer token for owner authentication (Web UI + admin API).
+    ///
+    /// Required. The same token is accepted via `Authorization: Bearer`
+    /// on admin HTTP endpoints and via `?token=` on the legacy WebSocket
+    /// upgrade. Missing/empty at startup is a fatal config error.
+    pub owner_token:            String,
+    /// Kernel username resolved for authenticated owner requests.
+    ///
+    /// Must reference an entry in [`AppConfig::users`] whose role is
+    /// `root` or `admin`. Validated at startup; boot fails if the user
+    /// is missing or lacks admin privileges.
+    pub owner_user_id:          String,
     /// LLM provider configuration (seeded to settings store at startup).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub llm:                    Option<flatten::LlmConfig>,
@@ -287,6 +296,12 @@ pub async fn start_with_options(
 ) -> Result<AppHandle, Whatever> {
     info!("Initializing job application");
 
+    // Validate owner auth config before any subsystem starts. The backend
+    // admin middleware resolves every authenticated request against this
+    // identity, so a missing or under-privileged owner is a fatal config
+    // error — not a runtime 500 per request.
+    validate_owner_auth(&config)?;
+
     // Validate STT config: if section is present, base_url must be non-empty.
     if let Some(ref stt) = config.stt {
         snafu::ensure_whatever!(
@@ -424,7 +439,7 @@ pub async fn start_with_options(
     .whatever_context("Failed to initialize BackendState")?;
 
     let web_adapter = Arc::new(
-        rara_channels::web::WebAdapter::new(config.owner_token.clone())
+        rara_channels::web::WebAdapter::new(Some(config.owner_token.clone()))
             .with_stt_service(stt_service.clone()),
     );
     let web_router = web_adapter.router();
@@ -696,8 +711,17 @@ pub async fn start_with_options(
         });
     }
 
-    let (domain_routes, _openapi) =
-        backend.routes(&kernel_handle, &rara.skill_registry, &rara.mcp_manager);
+    let auth_state = rara_backend_admin::auth::AuthState::new(
+        config.owner_token.clone(),
+        config.owner_user_id.clone(),
+        &kernel_handle,
+    );
+    let (domain_routes, _openapi) = backend.routes(
+        &kernel_handle,
+        &rara.skill_registry,
+        &rara.mcp_manager,
+        auth_state,
+    );
 
     let dock_store_path = rara_paths::data_dir().join("dock");
     let dock_state = rara_dock::DockRouterState {
@@ -1039,6 +1063,42 @@ async fn try_build_wechat(
     Ok(Some(adapter))
 }
 
+/// Validate that [`AppConfig::owner_token`] is non-empty and
+/// [`AppConfig::owner_user_id`] references a configured user whose role is
+/// `root` or `admin`.
+///
+/// Exposed to tests via `pub(crate)` so we can assert failure shape without
+/// booting the whole kernel.
+pub(crate) fn validate_owner_auth(config: &AppConfig) -> Result<(), Whatever> {
+    snafu::ensure_whatever!(
+        !config.owner_token.trim().is_empty(),
+        "owner_token must not be empty"
+    );
+    snafu::ensure_whatever!(
+        !config.owner_user_id.trim().is_empty(),
+        "owner_user_id must not be empty"
+    );
+    let Some(user) = config.users.iter().find(|u| u.name == config.owner_user_id) else {
+        snafu::whatever!(
+            "owner_user_id '{}' does not match any entry in users[]",
+            config.owner_user_id
+        );
+    };
+    let role = user.role.to_lowercase();
+    snafu::ensure_whatever!(
+        matches!(role.as_str(), "root" | "admin"),
+        "owner_user_id '{}' must have role root or admin (got '{}')",
+        config.owner_user_id,
+        user.role
+    );
+    info!(
+        owner = %config.owner_user_id,
+        role = %user.role,
+        "owner auth validated"
+    );
+    Ok(())
+}
+
 async fn init_infra(config: &AppConfig) -> Result<DBStore, Whatever> {
     let db_dir = rara_paths::database_dir();
     std::fs::create_dir_all(db_dir).whatever_context("Failed to create database directory")?;
@@ -1134,6 +1194,8 @@ http:
 grpc:
   bind_address: "127.0.0.1:50051"
   server_address: "127.0.0.1:50051"
+owner_token: "test-owner-token"
+owner_user_id: "test"
 users:
   - name: test
     role: root
@@ -1151,6 +1213,45 @@ mita:
 
         let config = AppConfig::load_from_paths(&global, &local).expect("load config");
         assert_eq!(config.http.bind_address, "127.0.0.1:25555");
+    }
+
+    #[test]
+    fn validate_owner_auth_accepts_admin_user() {
+        let cfg: AppConfig = serde_yaml::from_str(BASE_YAML).expect("base yaml");
+        super::validate_owner_auth(&cfg).expect("valid");
+    }
+
+    #[test]
+    fn validate_owner_auth_rejects_missing_user() {
+        let yaml = BASE_YAML.replace(r#"owner_user_id: "test""#, r#"owner_user_id: "ghost""#);
+        let cfg: AppConfig = serde_yaml::from_str(&yaml).expect("yaml");
+        let err = super::validate_owner_auth(&cfg).expect_err("ghost user");
+        assert!(
+            err.to_string().contains("does not match any entry"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn validate_owner_auth_rejects_non_admin_role() {
+        let yaml = BASE_YAML.replace("role: root", "role: user");
+        let cfg: AppConfig = serde_yaml::from_str(&yaml).expect("yaml");
+        let err = super::validate_owner_auth(&cfg).expect_err("user role");
+        assert!(
+            err.to_string().contains("must have role root or admin"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn validate_owner_auth_rejects_empty_token() {
+        let yaml = BASE_YAML.replace(r#"owner_token: "test-owner-token""#, r#"owner_token: """#);
+        let cfg: AppConfig = serde_yaml::from_str(&yaml).expect("yaml");
+        let err = super::validate_owner_auth(&cfg).expect_err("empty token");
+        assert!(
+            err.to_string().contains("owner_token must not be empty"),
+            "unexpected error: {err}"
+        );
     }
 
     #[test]

--- a/crates/channels/src/web.rs
+++ b/crates/channels/src/web.rs
@@ -590,8 +590,26 @@ struct WebAdapterState {
 // Helper: build endpoint for a Web connection
 // ---------------------------------------------------------------------------
 
-/// Verify that the provided token matches the expected owner token.
-fn verify_owner_token(expected: &str, provided: &str) -> bool { expected == provided }
+/// Extract a Bearer token from an `Authorization` header, if present and
+/// well-formed.
+///
+/// Returns `Some(token)` only for strict `Bearer <token>` values with a
+/// non-empty token after the prefix; case in the scheme keyword is ignored
+/// per [RFC 6750]. Anything else — missing header, malformed scheme,
+/// non-UTF-8 bytes — returns `None`, which the caller treats as "no header
+/// provided" and falls back to the query-string token.
+///
+/// [RFC 6750]: https://datatracker.ietf.org/doc/html/rfc6750#section-2.1
+fn bearer_token_from_headers(headers: &axum::http::HeaderMap) -> Option<&str> {
+    let raw = headers
+        .get(axum::http::header::AUTHORIZATION)?
+        .to_str()
+        .ok()?;
+    let token = raw
+        .strip_prefix("Bearer ")
+        .or_else(|| raw.strip_prefix("bearer "))?;
+    (!token.is_empty()).then_some(token)
+}
 
 /// Build a Web endpoint and its associated UserId for endpoint registration.
 ///
@@ -748,23 +766,36 @@ async fn transcribe_single_audio(
 async fn ws_handler(
     ws: WebSocketUpgrade,
     Query(params): Query<SessionQuery>,
+    headers: axum::http::HeaderMap,
     State(state): State<WebAdapterState>,
 ) -> Response {
-    // If an owner token is provided, verify it.
-    if let Some(ref token) = params.token {
-        if !token.is_empty() {
-            if let Some(ref expected) = state.owner_token {
-                if verify_owner_token(expected, token) {
-                    info!(session_key = %params.session_key, "WebSocket auth via owner token");
-                } else {
-                    warn!(session_key = %params.session_key, "invalid owner token, rejecting");
-                    return axum::response::Response::builder()
-                        .status(axum::http::StatusCode::UNAUTHORIZED)
-                        .body(axum::body::Body::from("invalid token"))
-                        .unwrap();
-                }
-            } else {
-                warn!("owner token not configured, ignoring token");
+    // Prefer `Authorization: Bearer <token>` (browsers can set this via
+    // `Sec-WebSocket-Protocol` shims or native clients), fall back to the
+    // legacy `?token=` query parameter for browser WebSocket upgrades.
+    if let Some(ref expected) = state.owner_token {
+        let header_token = bearer_token_from_headers(&headers);
+        let query_token = params.token.as_deref().filter(|t| !t.is_empty());
+        let provided = header_token.or(query_token);
+        match provided {
+            Some(tok) if rara_kernel::auth::verify_owner_token(expected, tok) => {
+                info!(session_key = %params.session_key, "WebSocket auth via owner token");
+            }
+            Some(_) => {
+                warn!(session_key = %params.session_key, "invalid owner token, rejecting");
+                return axum::response::Response::builder()
+                    .status(axum::http::StatusCode::UNAUTHORIZED)
+                    .body(axum::body::Body::from("invalid token"))
+                    .expect("static unauthorized response");
+            }
+            None => {
+                warn!(
+                    session_key = %params.session_key,
+                    "owner token configured but not provided, rejecting"
+                );
+                return axum::response::Response::builder()
+                    .status(axum::http::StatusCode::UNAUTHORIZED)
+                    .body(axum::body::Body::from("missing token"))
+                    .expect("static unauthorized response");
             }
         }
     }

--- a/crates/cmd/src/setup/writer.rs
+++ b/crates/cmd/src/setup/writer.rs
@@ -74,6 +74,29 @@ pub fn assemble_config(
         map.insert(y_str("telegram"), serde_yaml::Value::Mapping(tg_section));
     }
 
+    // Owner authentication — ensure both keys exist after the wizard runs.
+    // `owner_token` is generated once per fresh config (random ULID) and
+    // preserved on re-runs. `owner_user_id` defaults to the first admin-class
+    // user picked in this wizard session, or the first user in the existing
+    // config when none were re-collected.
+    if !map.contains_key(&y_str("owner_token")) {
+        let token = ulid::Ulid::new().to_string();
+        map.insert(y_str("owner_token"), y_str(&token));
+    }
+    if !map.contains_key(&y_str("owner_user_id")) {
+        let picked = users.and_then(pick_owner_user_id).or_else(|| {
+            map.get(&y_str("users"))
+                .and_then(serde_yaml::Value::as_sequence)
+                .and_then(|seq| seq.first())
+                .and_then(|v| v.get("name"))
+                .and_then(serde_yaml::Value::as_str)
+                .map(str::to_owned)
+        });
+        if let Some(name) = picked {
+            map.insert(y_str("owner_user_id"), y_str(&name));
+        }
+    }
+
     // Users
     if let Some(users) = users {
         let user_list: Vec<serde_yaml::Value> = users
@@ -172,3 +195,14 @@ pub fn write_config(config_path: &Path, yaml: &str) -> Result<(), Whatever> {
 
 /// Helper: create a YAML string value (used for both keys and values).
 fn y_str(s: &str) -> serde_yaml::Value { serde_yaml::Value::String(s.to_owned()) }
+
+/// Pick the first admin-class user (root/admin) from the wizard results to
+/// seed `owner_user_id`. Falls back to the first user entry when no admin
+/// role was assigned, matching the wizard's default prompt of `root`.
+fn pick_owner_user_id(users: &[super::user::UserResult]) -> Option<String> {
+    users
+        .iter()
+        .find(|u| matches!(u.role.to_lowercase().as_str(), "root" | "admin"))
+        .or_else(|| users.first())
+        .map(|u| u.name.clone())
+}

--- a/crates/extensions/backend-admin/Cargo.toml
+++ b/crates/extensions/backend-admin/Cargo.toml
@@ -53,3 +53,4 @@ tempfile = { workspace = true }
 testcontainers = { workspace = true }
 testcontainers-modules = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
+tower = { workspace = true }

--- a/crates/extensions/backend-admin/src/auth.rs
+++ b/crates/extensions/backend-admin/src/auth.rs
@@ -1,0 +1,363 @@
+// Copyright 2025 Rararulab
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Bearer-token authentication middleware and the `/whoami` endpoint.
+//!
+//! Every admin HTTP route is expected to run under [`auth_layer`], which
+//! resolves the caller into a kernel [`Principal<Resolved>`] and inserts it
+//! into request extensions. Downstream handlers extract the principal with
+//! `Extension<Principal<Resolved>>` and use `is_admin()` / `role()` /
+//! `has_permission()` for fine-grained checks.
+//!
+//! Startup is responsible for guaranteeing the configured `owner_user_id`
+//! resolves (see `rara_app::validate_owner_auth`); a resolve failure at
+//! request time is therefore treated as a 500, not a 401, because it
+//! indicates operator misconfiguration rather than a bad caller.
+
+use std::sync::Arc;
+
+use axum::{
+    Json,
+    extract::{Extension, Request, State},
+    http::{HeaderMap, StatusCode, header},
+    middleware::Next,
+    response::{IntoResponse, Response},
+};
+use rara_kernel::{
+    handle::KernelHandle,
+    identity::{Principal, Resolved},
+    security::SecurityRef,
+};
+use serde::Serialize;
+use utoipa_axum::{router::OpenApiRouter, routes};
+
+use crate::kernel::problem::ProblemDetails;
+
+/// Shared state for the auth middleware and `/whoami` route.
+///
+/// Cloned by axum for every request; keep the contents cheap (`Arc<str>`
+/// for the secret, owned `String` for the resolved username, plus the
+/// already-`Clone` kernel handles).
+#[derive(Clone)]
+pub struct AuthState {
+    owner_token:   Arc<str>,
+    owner_user_id: String,
+    security:      SecurityRef,
+}
+
+impl AuthState {
+    /// Build an [`AuthState`] from startup config and a running kernel
+    /// handle. The caller guarantees `owner_user_id` has already been
+    /// validated by `rara_app::validate_owner_auth`.
+    pub fn new(owner_token: String, owner_user_id: String, handle: &KernelHandle) -> Self {
+        Self {
+            owner_token: Arc::from(owner_token),
+            owner_user_id,
+            security: handle.security().clone(),
+        }
+    }
+}
+
+/// Axum middleware enforcing `Authorization: Bearer <owner_token>`.
+///
+/// On success it attaches an `Extension<Principal<Resolved>>` to the request
+/// so downstream handlers can perform authorization checks without another
+/// lookup. On failure it returns an RFC 9457 problem+json document.
+pub async fn auth_layer(
+    State(state): State<AuthState>,
+    headers: HeaderMap,
+    mut request: Request,
+    next: Next,
+) -> Response {
+    let Some(provided) = bearer_from_headers(&headers) else {
+        return ProblemDetails::unauthorized("missing or malformed Authorization header")
+            .into_response();
+    };
+
+    if !rara_kernel::auth::verify_owner_token(&state.owner_token, provided) {
+        return ProblemDetails::unauthorized("invalid owner token").into_response();
+    }
+
+    let principal = match state
+        .security
+        .resolve_principal(&Principal::lookup(state.owner_user_id.clone()))
+        .await
+    {
+        Ok(p) => p,
+        Err(e) => {
+            tracing::error!(
+                error = %e,
+                owner_user_id = %state.owner_user_id,
+                "owner_user_id failed to resolve; check startup validation"
+            );
+            return ProblemDetails::internal(format!("owner principal unavailable: {e}"))
+                .into_response();
+        }
+    };
+
+    request.extensions_mut().insert(principal);
+    next.run(request).await
+}
+
+/// Extract a Bearer token from the `Authorization` header.
+///
+/// Accepts case-insensitive `Bearer` / `bearer` schemes per RFC 6750 §2.1.
+/// Returns `None` for missing, non-UTF-8, or malformed values.
+fn bearer_from_headers(headers: &HeaderMap) -> Option<&str> {
+    let raw = headers.get(header::AUTHORIZATION)?.to_str().ok()?;
+    let token = raw
+        .strip_prefix("Bearer ")
+        .or_else(|| raw.strip_prefix("bearer "))?;
+    (!token.is_empty()).then_some(token)
+}
+
+// ---------------------------------------------------------------------------
+// /whoami
+// ---------------------------------------------------------------------------
+
+/// Response body for `GET /api/v1/whoami`.
+#[derive(Debug, Serialize, utoipa::ToSchema)]
+pub struct WhoamiResponse {
+    /// Resolved kernel username.
+    pub user_id:  String,
+    /// Principal role: `Root` | `Admin` | `User`.
+    pub role:     String,
+    /// Whether the caller has admin-or-higher privileges.
+    pub is_admin: bool,
+}
+
+/// Build routes that require authentication but also expose the caller's
+/// resolved identity.
+pub fn routes() -> OpenApiRouter { OpenApiRouter::new().routes(routes!(whoami)) }
+
+/// Return the resolved principal for the authenticated caller.
+#[utoipa::path(
+    get,
+    path = "/api/v1/whoami",
+    tag = "auth",
+    responses(
+        (status = 200, description = "Authenticated principal", body = WhoamiResponse),
+        (status = 401, description = "Missing or invalid bearer token", body = ()),
+    ),
+    security(("bearer_auth" = []))
+)]
+async fn whoami(Extension(principal): Extension<Principal<Resolved>>) -> Json<WhoamiResponse> {
+    Json(WhoamiResponse {
+        user_id:  principal.user_id.0.clone(),
+        role:     format!("{:?}", principal.role()),
+        is_admin: principal.is_admin(),
+    })
+}
+
+// ---------------------------------------------------------------------------
+// 401 helper on ProblemDetails
+// ---------------------------------------------------------------------------
+
+impl ProblemDetails {
+    /// Build a 401 `problem+json` response.
+    pub fn unauthorized(detail: impl Into<String>) -> Self {
+        Self {
+            problem_type: "https://rara.dev/problems/unauthorized".to_string(),
+            title:        "Unauthorized".to_string(),
+            status:       StatusCode::UNAUTHORIZED.as_u16(),
+            detail:       Some(detail.into()),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use async_trait::async_trait;
+    use axum::{
+        Router,
+        body::{Body, to_bytes},
+        http::{Request, StatusCode},
+        middleware,
+        routing::get,
+    };
+    use rara_kernel::{
+        error::Result as KernelResult,
+        identity::{KernelUser, Permission, Principal, Resolved, Role, UserStore},
+        security::{ApprovalManager, ApprovalPolicy, SecuritySubsystem},
+    };
+    use tower::ServiceExt;
+
+    use super::{AuthState, auth_layer};
+
+    struct TestUserStore {
+        user: KernelUser,
+    }
+
+    #[async_trait]
+    impl UserStore for TestUserStore {
+        async fn get_by_name(&self, name: &str) -> KernelResult<Option<KernelUser>> {
+            Ok((name == self.user.name).then(|| self.user.clone()))
+        }
+
+        async fn list(&self) -> KernelResult<Vec<KernelUser>> { Ok(vec![self.user.clone()]) }
+    }
+
+    fn admin_user() -> KernelUser {
+        KernelUser {
+            name:        "admin".into(),
+            role:        Role::Admin,
+            permissions: vec![Permission::All],
+            enabled:     true,
+        }
+    }
+
+    fn auth_state(token: &str, owner_user_id: &str) -> AuthState {
+        let store: Arc<dyn UserStore> = Arc::new(TestUserStore { user: admin_user() });
+        let approval = Arc::new(ApprovalManager::new(ApprovalPolicy::default()));
+        let security = Arc::new(SecuritySubsystem::new(store, approval));
+        AuthState {
+            owner_token: Arc::from(token),
+            owner_user_id: owner_user_id.to_owned(),
+            security,
+        }
+    }
+
+    /// Protected test handler — echoes the resolved principal's user_id.
+    async fn echo_principal(
+        axum::extract::Extension(p): axum::extract::Extension<Principal<Resolved>>,
+    ) -> String {
+        p.user_id.0
+    }
+
+    fn app(state: AuthState) -> Router {
+        Router::new()
+            .route("/protected", get(echo_principal))
+            .layer(middleware::from_fn_with_state(state, auth_layer))
+    }
+
+    async fn body_str(res: axum::response::Response) -> String {
+        let bytes = to_bytes(res.into_body(), 4096).await.unwrap();
+        String::from_utf8(bytes.to_vec()).unwrap_or_default()
+    }
+
+    #[tokio::test]
+    async fn accepts_valid_bearer_and_injects_principal() {
+        let app = app(auth_state("s3cret", "admin"));
+        let res = app
+            .oneshot(
+                Request::builder()
+                    .uri("/protected")
+                    .header("Authorization", "Bearer s3cret")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(res.status(), StatusCode::OK);
+        assert_eq!(body_str(res).await, "admin");
+    }
+
+    #[tokio::test]
+    async fn rejects_missing_authorization_header() {
+        let app = app(auth_state("s3cret", "admin"));
+        let res = app
+            .oneshot(
+                Request::builder()
+                    .uri("/protected")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(res.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn rejects_wrong_bearer_token() {
+        let app = app(auth_state("s3cret", "admin"));
+        let res = app
+            .oneshot(
+                Request::builder()
+                    .uri("/protected")
+                    .header("Authorization", "Bearer nope")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(res.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn rejects_malformed_authorization_header() {
+        let app = app(auth_state("s3cret", "admin"));
+        let res = app
+            .oneshot(
+                Request::builder()
+                    .uri("/protected")
+                    .header("Authorization", "Basic s3cret")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(res.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn whoami_round_trip_returns_principal_fields() {
+        // Integration test: layer the production `routes()` under the real
+        // middleware and hit `/api/v1/whoami` end-to-end.
+        let state = auth_state("s3cret", "admin");
+        let (whoami_router, _api) = super::routes().split_for_parts();
+        let app: Router = Router::new()
+            .merge(whoami_router)
+            .layer(middleware::from_fn_with_state(state, auth_layer));
+        let res = app
+            .oneshot(
+                Request::builder()
+                    .uri("/api/v1/whoami")
+                    .header("Authorization", "Bearer s3cret")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(res.status(), StatusCode::OK);
+        let body = body_str(res).await;
+        let json: serde_json::Value = serde_json::from_str(&body).expect("json");
+        assert_eq!(json["user_id"], "admin");
+        assert_eq!(json["role"], "Admin");
+        assert_eq!(json["is_admin"], true);
+    }
+
+    #[tokio::test]
+    async fn fails_closed_when_owner_user_unresolvable() {
+        // Misconfiguration: owner_user_id references a user who no longer
+        // exists in the store — the middleware must return 500, not 401.
+        let app = app(auth_state("s3cret", "ghost"));
+        let res = app
+            .oneshot(
+                Request::builder()
+                    .uri("/protected")
+                    .header("Authorization", "Bearer s3cret")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(res.status(), StatusCode::INTERNAL_SERVER_ERROR);
+    }
+}

--- a/crates/extensions/backend-admin/src/data_feeds/router.rs
+++ b/crates/extensions/backend-admin/src/data_feeds/router.rs
@@ -287,8 +287,23 @@ async fn update_feed(
 /// `DELETE /api/v1/data-feeds/{id}` — stop task, remove from registry and DB.
 async fn delete_feed(
     State(state): State<DataFeedRouterState>,
+    axum::Extension(principal): axum::Extension<
+        rara_kernel::identity::Principal<rara_kernel::identity::Resolved>,
+    >,
     Path(id): Path<String>,
 ) -> Result<StatusCode, ProblemDetails> {
+    // Destructive operation — require admin and audit the acting principal.
+    if !principal.is_admin() {
+        return Err(ProblemDetails::forbidden(
+            "deleting data feeds requires admin role",
+        ));
+    }
+    info!(
+        actor = %principal.user_id,
+        feed_id = %id,
+        "delete_feed"
+    );
+
     // Look up the feed name for registry removal.
     let feed = state.svc.get_feed(&id).await.ok().flatten();
 

--- a/crates/extensions/backend-admin/src/kernel/problem.rs
+++ b/crates/extensions/backend-admin/src/kernel/problem.rs
@@ -52,6 +52,16 @@ impl ProblemDetails {
         }
     }
 
+    /// Build a 403 Forbidden problem response.
+    pub fn forbidden(detail: impl Into<String>) -> Self {
+        Self {
+            problem_type: "https://rara.dev/problems/forbidden".to_string(),
+            title:        "Forbidden".to_string(),
+            status:       403,
+            detail:       Some(detail.into()),
+        }
+    }
+
     pub fn internal(detail: impl Into<String>) -> Self {
         Self {
             problem_type: "https://rara.dev/problems/internal-error".to_string(),

--- a/crates/extensions/backend-admin/src/kernel/router.rs
+++ b/crates/extensions/backend-admin/src/kernel/router.rs
@@ -81,7 +81,18 @@ async fn get_session_turns(
 
 async fn list_approvals(
     State(handle): State<KernelHandle>,
+    axum::Extension(principal): axum::Extension<
+        rara_kernel::identity::Principal<rara_kernel::identity::Resolved>,
+    >,
 ) -> Result<Json<Vec<rara_kernel::security::ApprovalRequest>>, ProblemDetails> {
+    // Approval queue contains sensitive tool-call context; restrict to admins
+    // and audit the viewer.
+    if !principal.is_admin() {
+        return Err(ProblemDetails::forbidden(
+            "viewing the approval queue requires admin role",
+        ));
+    }
+    tracing::info!(actor = %principal.user_id, "list_approvals");
     Ok(Json(handle.security().approval().list_pending()))
 }
 

--- a/crates/extensions/backend-admin/src/lib.rs
+++ b/crates/extensions/backend-admin/src/lib.rs
@@ -18,6 +18,7 @@
 //! models, MCP servers, skills, data feeds, and domain routes (chat).
 
 pub mod agents;
+pub mod auth;
 pub mod chat;
 pub mod data_feeds;
 pub mod kernel;

--- a/crates/extensions/backend-admin/src/settings/router.rs
+++ b/crates/extensions/backend-admin/src/settings/router.rs
@@ -107,8 +107,24 @@ async fn delete_setting(
 
 async fn batch_update_settings(
     State(provider): State<SharedProvider>,
+    axum::Extension(principal): axum::Extension<
+        rara_kernel::identity::Principal<rara_kernel::identity::Resolved>,
+    >,
     Json(patches): Json<HashMap<String, Option<String>>>,
 ) -> Result<StatusCode, (StatusCode, String)> {
+    // Runtime settings are admin-only; reject plain users even if the
+    // bearer token matched (useful once per-user tokens are introduced).
+    if !principal.is_admin() {
+        return Err((
+            StatusCode::FORBIDDEN,
+            "settings mutation requires admin role".to_owned(),
+        ));
+    }
+    tracing::info!(
+        actor = %principal.user_id,
+        keys = patches.len(),
+        "settings.batch_update"
+    );
     provider
         .batch_update(patches)
         .await

--- a/crates/extensions/backend-admin/src/state.rs
+++ b/crates/extensions/backend-admin/src/state.rs
@@ -80,6 +80,7 @@ impl BackendState {
         kernel_handle: &rara_kernel::handle::KernelHandle,
         skill_registry: &rara_skills::registry::InMemoryRegistry,
         mcp_manager: &rara_mcp::manager::mgr::McpManager,
+        auth_state: crate::auth::AuthState,
     ) -> (axum::Router, utoipa::openapi::OpenApi) {
         let mut api = Self::api_doc();
 
@@ -95,6 +96,7 @@ impl BackendState {
             crate::chat::routes(self.session_service.clone()),
         );
         merge_openapi_router(&mut router, &mut api, crate::system_routes::routes());
+        merge_openapi_router(&mut router, &mut api, crate::auth::routes());
 
         // skill_routes returns a plain axum::Router (no OpenAPI metadata).
         router = router.merge(crate::skills::skill_routes(skill_registry.clone()));
@@ -111,6 +113,14 @@ impl BackendState {
         // Data feed management routes (with registry sync).
         router = router.merge(crate::data_feeds::data_feed_routes(
             self.feed_router_state.clone(),
+        ));
+
+        // Wrap every admin route with the bearer-auth middleware. Handlers
+        // pull `Extension<Principal<Resolved>>` out of request extensions for
+        // authorization checks; the middleware itself enforces the token.
+        let router = router.layer(axum::middleware::from_fn_with_state(
+            auth_state,
+            crate::auth::auth_layer,
         ));
 
         (router, api)

--- a/crates/kernel/src/auth.rs
+++ b/crates/kernel/src/auth.rs
@@ -1,0 +1,63 @@
+// Copyright 2025 Rararulab
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Shared authentication primitives.
+//!
+//! These helpers are consumed by every surface that terminates an owner-token
+//! check — the legacy WebSocket query-string path in `rara-channels::web`
+//! and the new Bearer-token middleware in `rara-backend-admin::auth`. Keeping
+//! the comparison in one place guarantees a single, reviewed timing-safe
+//! implementation.
+
+use subtle::ConstantTimeEq;
+
+/// Compare an expected owner token against a caller-provided value using a
+/// constant-time byte comparison.
+///
+/// Both arguments are treated as opaque byte strings; length differences do
+/// not short-circuit. Callers are responsible for rejecting empty `provided`
+/// values before invocation if that is desired behaviour at the transport
+/// layer.
+#[must_use]
+pub fn verify_owner_token(expected: &str, provided: &str) -> bool {
+    expected.as_bytes().ct_eq(provided.as_bytes()).into()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::verify_owner_token;
+
+    #[test]
+    fn matching_tokens_accepted() {
+        assert!(verify_owner_token("s3cret", "s3cret"));
+    }
+
+    #[test]
+    fn different_tokens_rejected() {
+        assert!(!verify_owner_token("s3cret", "s3cret-nope"));
+        assert!(!verify_owner_token("s3cret", "other"));
+    }
+
+    #[test]
+    fn empty_provided_rejected_when_expected_nonempty() {
+        assert!(!verify_owner_token("s3cret", ""));
+    }
+
+    #[test]
+    fn empty_expected_accepts_empty_provided() {
+        // Policy decision: callers must reject empty inputs before calling;
+        // here we only guarantee bytewise equality.
+        assert!(verify_owner_token("", ""));
+    }
+}

--- a/crates/kernel/src/lib.rs
+++ b/crates/kernel/src/lib.rs
@@ -29,6 +29,7 @@
 //! | Notification Bus | `NotificationBus` | Inter-component notification broadcasting |
 
 pub mod agent;
+pub mod auth;
 pub mod cascade;
 pub mod channel;
 pub mod data_feed;


### PR DESCRIPTION
## Summary

Part of #1710. Backend half of admin HTTP auth.

- Kernel: shared `verify_owner_token` using constant-time compare
- Config: required `owner_user_id` (must exist in `config.users` with Root/Admin role; validated at boot)
- Middleware: axum layer wrapping all `backend-admin` routes — extracts `Authorization: Bearer`, resolves `Principal<Resolved>` via `SecuritySubsystem`, injects as Extension
- `/api/v1/whoami` endpoint for the web client to identify itself post-login
- WS handler unified: accepts both `Authorization` header and legacy `?token=` query param, rejects missing token

## Type of change
| Type | Label |
|------|-------|
| New feature | `enhancement` |

## Component
`backend`

## Closes
Closes #1711

## Test plan
- [x] Middleware unit tests (valid/invalid/missing token)
- [x] Startup validation tests (missing owner / non-admin owner → boot fails)
- [x] Integration test against /api/v1/whoami
- [x] `prek run --all-files` passes
- [x] No mocks — real SecuritySubsystem + real InMemoryUserStore