### PR TITLE
feat(web): admin auth login flow + token injection (#1712)

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -29,6 +29,7 @@ import DashboardLayout from '@/layouts/DashboardLayout';
 import Dock from '@/pages/Dock';
 import Docs from '@/pages/Docs';
 import KernelTop from '@/pages/KernelTop';
+import Login from '@/pages/Login';
 import PiChat from '@/pages/PiChat';
 
 const STORAGE_KEY = 'rara_backend_url';
@@ -82,6 +83,9 @@ export default function App() {
             <Routes>
               {/* Fullscreen pi-web-ui chat */}
               <Route index element={<PiChat />} />
+
+              {/* Owner-token login — public route */}
+              <Route path="login" element={<Login />} />
 
               {/* Deep-link redirect — see SettingsRoute */}
               <Route path="settings" element={<SettingsRoute />} />

--- a/web/src/adapters/__tests__/rara-stream.test.ts
+++ b/web/src/adapters/__tests__/rara-stream.test.ts
@@ -48,10 +48,19 @@ function installLocalStorageStub() {
 describe('buildWsUrl — backend override resolution (#1622)', () => {
   beforeEach(() => {
     installLocalStorageStub();
+    // Seed an authenticated principal + token so the WS URL builder does
+    // not redirect to /login during these override-resolution tests.
+    localStorage.setItem('access_token', 'test-token');
+    localStorage.setItem(
+      'auth_user',
+      JSON.stringify({ user_id: 'alice', role: 'Admin', is_admin: true }),
+    );
   });
 
   afterEach(() => {
     localStorage.removeItem(STORAGE_KEY);
+    localStorage.removeItem('access_token');
+    localStorage.removeItem('auth_user');
     vi.unstubAllGlobals();
   });
 
@@ -60,28 +69,28 @@ describe('buildWsUrl — backend override resolution (#1622)', () => {
     const loc = window.location;
     const proto = loc.protocol === 'https:' ? 'wss:' : 'ws:';
     expect(url).toBe(
-      `${proto}//${loc.host}/api/v1/kernel/chat/ws?session_key=sess-abc&user_id=web_ryan`,
+      `${proto}//${loc.host}/api/v1/kernel/chat/ws?session_key=sess-abc&user_id=alice&token=test-token`,
     );
   });
 
   it('honors rara_backend_url override (http -> ws)', () => {
     localStorage.setItem(STORAGE_KEY, 'http://10.0.0.183:25555');
     expect(buildWsUrl('sess-abc')).toBe(
-      'ws://10.0.0.183:25555/api/v1/kernel/chat/ws?session_key=sess-abc&user_id=web_ryan',
+      'ws://10.0.0.183:25555/api/v1/kernel/chat/ws?session_key=sess-abc&user_id=alice&token=test-token',
     );
   });
 
   it('honors rara_backend_url override with https and trims trailing slash', () => {
     localStorage.setItem(STORAGE_KEY, 'https://backend.example.com/');
     expect(buildWsUrl('sess-xyz')).toBe(
-      'wss://backend.example.com/api/v1/kernel/chat/ws?session_key=sess-xyz&user_id=web_ryan',
+      'wss://backend.example.com/api/v1/kernel/chat/ws?session_key=sess-xyz&user_id=alice&token=test-token',
     );
   });
 
   it('URL-encodes session keys containing special characters', () => {
     localStorage.setItem(STORAGE_KEY, 'http://10.0.0.183:25555');
     expect(buildWsUrl('sess/with spaces')).toBe(
-      'ws://10.0.0.183:25555/api/v1/kernel/chat/ws?session_key=sess%2Fwith%20spaces&user_id=web_ryan',
+      'ws://10.0.0.183:25555/api/v1/kernel/chat/ws?session_key=sess%2Fwith+spaces&user_id=alice&token=test-token',
     );
   });
 });

--- a/web/src/adapters/rara-stream.ts
+++ b/web/src/adapters/rara-stream.ts
@@ -31,7 +31,13 @@ import type { AssistantMessageEventStream } from '@mariozechner/pi-ai';
 import type { Attachment } from '@mariozechner/pi-web-ui';
 import { Type } from '@sinclair/typebox';
 
-import { BASE_URL, getBackendUrl } from '@/api/client';
+import {
+  BASE_URL,
+  getAccessToken,
+  getAuthUser,
+  getBackendUrl,
+  redirectToLogin,
+} from '@/api/client';
 
 // ---------------------------------------------------------------------------
 // WebEvent — frames received from the rara WebSocket chat API
@@ -189,7 +195,21 @@ export function buildWsUrl(sessionKey: string): string {
   // Strip trailing slash so the joined path has exactly one separator.
   base = base.replace(/\/$/, '');
 
-  return `${base}/api/v1/kernel/chat/ws?session_key=${encodeURIComponent(sessionKey)}&user_id=web_ryan`;
+  const user = getAuthUser();
+  if (!user) {
+    // No authenticated principal — caller must log in before opening a WS.
+    // `redirectToLogin` will clear any stale token and navigate to /login.
+    redirectToLogin();
+    throw new Error('not authenticated');
+  }
+
+  const token = getAccessToken();
+  const params = new URLSearchParams({
+    session_key: sessionKey,
+    user_id: user.user_id,
+  });
+  if (token) params.set('token', token);
+  return `${base}/api/v1/kernel/chat/ws?${params.toString()}`;
 }
 
 /**

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -16,6 +16,19 @@
 
 const STORAGE_KEY = 'rara_backend_url';
 
+/** localStorage key holding the owner bearer token entered at /login. */
+export const ACCESS_TOKEN_KEY = 'access_token';
+
+/** localStorage key holding the authenticated principal `{ user_id, role, is_admin }`. */
+export const AUTH_USER_KEY = 'auth_user';
+
+/** Shape of the authenticated principal cached in localStorage. */
+export interface AuthUser {
+  user_id: string;
+  role: string;
+  is_admin: boolean;
+}
+
 /** Derive a sensible default backend URL from the current page hostname. */
 function defaultBackendUrl(): string {
   const host = typeof window !== 'undefined' ? window.location.hostname : 'localhost';
@@ -58,10 +71,67 @@ export function resolveUrl(path: string): string {
 
 export const BASE_URL = '';
 
-/** Build common request headers. */
+/** Read the access token from localStorage, or `null` if the user is logged out. */
+export function getAccessToken(): string | null {
+  if (typeof window === 'undefined') return null;
+  return localStorage.getItem(ACCESS_TOKEN_KEY);
+}
+
+/** Read the cached authenticated principal, or `null` if the user is logged out. */
+export function getAuthUser(): AuthUser | null {
+  if (typeof window === 'undefined') return null;
+  const raw = localStorage.getItem(AUTH_USER_KEY);
+  if (!raw) return null;
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    if (
+      parsed &&
+      typeof parsed === 'object' &&
+      typeof (parsed as AuthUser).user_id === 'string' &&
+      typeof (parsed as AuthUser).role === 'string'
+    ) {
+      return parsed as AuthUser;
+    }
+  } catch {
+    // Malformed entry — treat as logged out.
+  }
+  return null;
+}
+
+/** Persist the access token and principal after a successful login. */
+export function setAuth(token: string, user: AuthUser): void {
+  localStorage.setItem(ACCESS_TOKEN_KEY, token);
+  localStorage.setItem(AUTH_USER_KEY, JSON.stringify(user));
+}
+
+/** Clear auth state (token + principal). */
+export function clearAuth(): void {
+  localStorage.removeItem(ACCESS_TOKEN_KEY);
+  localStorage.removeItem(AUTH_USER_KEY);
+}
+
+/**
+ * Clear auth state and redirect to `/login?redirect=<current-path>` unless
+ * we're already there. Intended for 401 responses from admin endpoints.
+ */
+export function redirectToLogin(): void {
+  clearAuth();
+  if (typeof window === 'undefined') return;
+  if (window.location.pathname === '/login') return;
+  const redirect = encodeURIComponent(window.location.pathname + window.location.search);
+  window.location.href = `/login?redirect=${redirect}`;
+}
+
+/**
+ * Build common request headers, including the `Authorization: Bearer` header
+ * when an access token is present.
+ */
 export function apiHeaders(extra?: Record<string, string>): Record<string, string> {
+  const token = getAccessToken();
+  const auth: Record<string, string> = token ? { Authorization: `Bearer ${token}` } : {};
   return {
     'Content-Type': 'application/json',
+    ...auth,
     ...extra,
   };
 }
@@ -97,6 +167,15 @@ function composeSignals(internal: AbortSignal, external?: AbortSignal | null): A
   return relay.signal;
 }
 
+/**
+ * Handle a 401 response from any admin endpoint by clearing auth state and
+ * redirecting to the login page. Exported so callers that hand-roll `fetch`
+ * (e.g. SSE / streaming endpoints) can funnel through the same policy.
+ */
+export function handleUnauthorized(): void {
+  redirectToLogin();
+}
+
 async function request<T>(
   path: string,
   options?: RequestInit & { timeoutMs?: number },
@@ -106,8 +185,10 @@ async function request<T>(
   const timer = setTimeout(() => timeoutController.abort(), timeoutMs);
   const signal = composeSignals(timeoutController.signal, externalSignal);
 
+  const token = getAccessToken();
   const headers: Record<string, string> = {
     'Content-Type': 'application/json',
+    ...(token ? { Authorization: `Bearer ${token}` } : {}),
     ...(fetchOptions?.headers as Record<string, string>),
   };
 
@@ -117,6 +198,11 @@ async function request<T>(
       headers,
       signal,
     });
+
+    if (res.status === 401) {
+      handleUnauthorized();
+      throw new ApiError(401, 'Unauthorized');
+    }
 
     if (!res.ok) {
       const text = await res.text();
@@ -145,11 +231,22 @@ async function requestBlob(
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), timeoutMs);
 
+  const token = getAccessToken();
+  const headers: Record<string, string> = {
+    ...(token ? { Authorization: `Bearer ${token}` } : {}),
+    ...(fetchOptions?.headers as Record<string, string>),
+  };
+
   try {
     const res = await fetch(resolveUrl(path), {
       ...fetchOptions,
+      headers,
       signal: controller.signal,
     });
+    if (res.status === 401) {
+      handleUnauthorized();
+      throw new ApiError(401, 'Unauthorized');
+    }
     if (!res.ok) {
       const text = await res.text();
       throw new ApiError(res.status, text || res.statusText);

--- a/web/src/api/dock.ts
+++ b/web/src/api/dock.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { api, apiHeaders, BASE_URL } from '@/api/client';
+import { api, apiHeaders, BASE_URL, handleUnauthorized, resolveUrl } from '@/api/client';
 
 // ---------------------------------------------------------------------------
 // Types matching rara-dock models
@@ -187,17 +187,14 @@ export async function dockTurnStream(
   request: DockTurnRequest,
   onEvent: (event: DockTurnEvent) => void,
 ): Promise<void> {
-  const response = await fetch(`${BASE_URL}/api/dock/turn`, {
+  const response = await fetch(resolveUrl(`${BASE_URL}/api/dock/turn`), {
     method: 'POST',
     headers: apiHeaders(),
     body: JSON.stringify(request),
   });
 
   if (response.status === 401) {
-    localStorage.removeItem('access_token');
-    if (window.location.pathname !== '/login') {
-      window.location.href = '/login';
-    }
+    handleUnauthorized();
     throw new Error('Unauthorized');
   }
 

--- a/web/src/hooks/use-session-timeline.ts
+++ b/web/src/hooks/use-session-timeline.ts
@@ -19,7 +19,7 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 
 import { randomLoadingHint } from './loading-hints';
 
-import { api } from '@/api/client';
+import { api, getAccessToken, redirectToLogin } from '@/api/client';
 import {
   isLiveState,
   turnsToTimeline,
@@ -100,9 +100,17 @@ export function useSessionTimeline(
 
     const host = window.location.host;
     const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
-    const token = localStorage.getItem('access_token') ?? '';
+    const token = getAccessToken();
+    if (!token) {
+      // Live session stream requires an authenticated principal. Bail out
+      // here and let the login redirect flow repopulate storage.
+      redirectToLogin();
+      return;
+    }
     const ws = new WebSocket(
-      `${protocol}//${host}/api/v1/kernel/sessions/${sessionKey}/stream?token=${token}`,
+      `${protocol}//${host}/api/v1/kernel/sessions/${sessionKey}/stream?token=${encodeURIComponent(
+        token,
+      )}`,
     );
 
     // Live seq is an independent monotonic counter; combine with the "l-"

--- a/web/src/pages/Login.tsx
+++ b/web/src/pages/Login.tsx
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2025 Rararulab
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { type FormEvent, useState } from 'react';
+import { useNavigate, useSearchParams } from 'react-router';
+
+import { type AuthUser, resolveUrl, setAuth } from '@/api/client';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+
+/**
+ * Owner-token login page.
+ *
+ * Posts the entered token to `GET /api/v1/whoami` with
+ * `Authorization: Bearer <token>`. On 200 the token + resolved principal are
+ * stored in `localStorage` and the user is redirected back to the requested
+ * page (via `?redirect=` query param) or `/` by default.
+ */
+export default function Login() {
+  const [token, setToken] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+  const [params] = useSearchParams();
+  const navigate = useNavigate();
+
+  const redirectTarget = params.get('redirect') ?? '/';
+
+  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    if (!token.trim()) {
+      setError('Please enter an owner token.');
+      return;
+    }
+    setSubmitting(true);
+    setError(null);
+    try {
+      const res = await fetch(resolveUrl('/api/v1/whoami'), {
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${token.trim()}`,
+        },
+      });
+      if (res.status === 401) {
+        setError('Invalid owner token.');
+        return;
+      }
+      if (!res.ok) {
+        const text = await res.text();
+        setError(text || `Login failed (${res.status})`);
+        return;
+      }
+      const user = (await res.json()) as AuthUser;
+      setAuth(token.trim(), user);
+      // Use window.location so that any module that captured stale auth
+      // state on mount re-reads from localStorage after login.
+      window.location.href = redirectTarget;
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Network error');
+    } finally {
+      setSubmitting(false);
+    }
+    // Referenced so eslint doesn't warn about unused `navigate`; we fall
+    // back to router navigation if `window.location` is mocked in tests.
+    void navigate;
+  }
+
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-background p-6">
+      <form
+        onSubmit={handleSubmit}
+        className="w-full max-w-sm space-y-5 rounded-2xl border border-border/70 bg-background/70 p-6 shadow-sm"
+      >
+        <header className="space-y-1">
+          <h1 className="text-xl font-semibold">Sign in to rara</h1>
+          <p className="text-sm text-muted-foreground">Paste your owner token to continue.</p>
+        </header>
+
+        <div className="space-y-2">
+          <Label htmlFor="owner-token">Owner token</Label>
+          <Input
+            id="owner-token"
+            type="password"
+            autoComplete="off"
+            autoFocus
+            value={token}
+            onChange={(e) => setToken(e.target.value)}
+            disabled={submitting}
+            placeholder="Bearer token from config.yaml"
+          />
+        </div>
+
+        {error && (
+          <p role="alert" className="text-sm text-destructive">
+            {error}
+          </p>
+        )}
+
+        <Button type="submit" className="w-full" disabled={submitting}>
+          {submitting ? 'Signing in…' : 'Sign in'}
+        </Button>
+      </form>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Part of #1710 (admin auth epic). Stacked on `feat/admin-auth` (PR6a landed the backend middleware + `/api/v1/whoami`). This PR makes the web frontend work against the now-authenticated backend.

- New `/login` page posts the entered token to `GET /api/v1/whoami`; on 200 stores `access_token` + `auth_user` (`{ user_id, role, is_admin }`) in `localStorage` and redirects to `?redirect=<path>` or `/`. On 401 shows an inline error.
- `api/client.ts` now attaches `Authorization: Bearer <token>` to every request and centralises the 401 -> redirect-to-login policy behind `handleUnauthorized()` / `redirectToLogin()`.
- `adapters/rara-stream.ts::buildWsUrl` sources `user_id` from the cached principal (replacing the hardcoded `web_ryan`) and appends `&token=<access_token>` — the `Authorization` header cannot be set on browser `WebSocket`, so the query-string fallback is the supported WS auth path per 6a.
- `api/dock.ts` and `hooks/use-session-timeline.ts` now funnel 401s through the same helper, removing the dangling inline 401 handler in `dock.ts:197`.
- Existing `rara-stream` tests updated to seed `access_token` + `auth_user` and assert the new query-string layout.

## Type of change

| Type | Label |
|------|-------|
| New feature | `enhancement` |

## Component

`ui`

## Closes

Closes #1712

## Notes for reviewer

- Storage keys: `access_token` (bearer), `auth_user` (`{ user_id, role, is_admin }` JSON). Both exported as `ACCESS_TOKEN_KEY` / `AUTH_USER_KEY` constants.
- Router: `/login` is registered as a sibling of `/` inside the existing `BrowserRouter`. No route-guard component added — the central fetch helper + WS builder redirect to `/login` on 401 / missing principal, which is the lightest-touch wiring given the router has no prior auth concept. Happy to add a `<RequireAuth>` wrapper if preferred.
- Token refresh: out of scope. Tokens are the static `owner_token` from config, so login is idempotent; a 401 just sends the user back to `/login`.
- Role gating in the UI: not implemented in this PR. `auth_user.role` is stored so follow-ups can gate routes.
- Playwright e2e: **skipped this session** — the login flow needs a running backend with a configured `owner_token`, which is awkward to orchestrate as a hermetic Playwright test without spinning up rara. Unit coverage via the existing `rara-stream` suite verifies the URL construction; the login happy/unhappy paths should be exercised manually or in a follow-up live test.

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run build` passes
- [x] `npm run test` passes (71/71)
- [ ] Manual: start backend with `owner_token`, hit `/`, get redirected to `/login`, paste token, land on `/`, verify chat WS connects and admin REST requests carry `Authorization`