### PR TITLE
feat(backend-admin): bearer auth on admin HTTP surface with Principal extractor (#1710)

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -18,6 +18,22 @@ grpc:
   server_address: "127.0.0.1:50051"
 
 # ---------------------------------------------------------------------------
+# Owner authentication (required)
+# ---------------------------------------------------------------------------
+#
+# `owner_token` is the static bearer token that authenticates admin HTTP
+# requests (Authorization: Bearer <token>) and the web WebSocket upgrade
+# (?token=...). Treat it like a password: long, random, kept out of logs
+# and version control.
+#
+# `owner_user_id` must reference a `users[].name` below whose role is
+# `root` or `admin`. The backend admin middleware resolves every
+# authenticated request to this principal.
+
+owner_token: "change-me-to-a-long-random-string"
+owner_user_id: "you"
+
+# ---------------------------------------------------------------------------
 # Configured users — platform identity mappings (required, non-empty)
 # ---------------------------------------------------------------------------
 

--- a/crates/app/src/config_sync.rs
+++ b/crates/app/src/config_sync.rs
@@ -254,6 +254,9 @@ mod tests {
     use crate::AppConfig;
 
     const TEST_YAML: &str = r#"
+owner_token: "test-owner-token"
+owner_user_id: "testuser"
+
 users:
   - name: "testuser"
     role: root

--- a/crates/app/src/lib.rs
+++ b/crates/app/src/lib.rs
@@ -439,7 +439,7 @@ pub async fn start_with_options(
     .whatever_context("Failed to initialize BackendState")?;
 
     let web_adapter = Arc::new(
-        rara_channels::web::WebAdapter::new(Some(config.owner_token.clone()))
+        rara_channels::web::WebAdapter::new(config.owner_token.clone())
             .with_stt_service(stt_service.clone()),
     );
     let web_router = web_adapter.router();

--- a/crates/app/src/lib.rs
+++ b/crates/app/src/lib.rs
@@ -72,9 +72,18 @@ pub struct AppConfig {
     /// General OTLP telemetry (Alloy/Tempo).
     #[serde(default)]
     pub telemetry:              TelemetryConfig,
-    /// Static bearer token for owner authentication (Web UI).
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub owner_token:            Option<String>,
+    /// Static bearer token for owner authentication (Web UI + admin API).
+    ///
+    /// Required. The same token is accepted via `Authorization: Bearer`
+    /// on admin HTTP endpoints and via `?token=` on the legacy WebSocket
+    /// upgrade. Missing/empty at startup is a fatal config error.
+    pub owner_token:            String,
+    /// Kernel username resolved for authenticated owner requests.
+    ///
+    /// Must reference an entry in [`AppConfig::users`] whose role is
+    /// `root` or `admin`. Validated at startup; boot fails if the user
+    /// is missing or lacks admin privileges.
+    pub owner_user_id:          String,
     /// LLM provider configuration (seeded to settings store at startup).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub llm:                    Option<flatten::LlmConfig>,
@@ -287,6 +296,12 @@ pub async fn start_with_options(
 ) -> Result<AppHandle, Whatever> {
     info!("Initializing job application");
 
+    // Validate owner auth config before any subsystem starts. The backend
+    // admin middleware resolves every authenticated request against this
+    // identity, so a missing or under-privileged owner is a fatal config
+    // error — not a runtime 500 per request.
+    validate_owner_auth(&config)?;
+
     // Validate STT config: if section is present, base_url must be non-empty.
     if let Some(ref stt) = config.stt {
         snafu::ensure_whatever!(
@@ -424,7 +439,7 @@ pub async fn start_with_options(
     .whatever_context("Failed to initialize BackendState")?;
 
     let web_adapter = Arc::new(
-        rara_channels::web::WebAdapter::new(config.owner_token.clone())
+        rara_channels::web::WebAdapter::new(Some(config.owner_token.clone()))
             .with_stt_service(stt_service.clone()),
     );
     let web_router = web_adapter.router();
@@ -696,8 +711,17 @@ pub async fn start_with_options(
         });
     }
 
-    let (domain_routes, _openapi) =
-        backend.routes(&kernel_handle, &rara.skill_registry, &rara.mcp_manager);
+    let auth_state = rara_backend_admin::auth::AuthState::new(
+        config.owner_token.clone(),
+        config.owner_user_id.clone(),
+        &kernel_handle,
+    );
+    let (domain_routes, _openapi) = backend.routes(
+        &kernel_handle,
+        &rara.skill_registry,
+        &rara.mcp_manager,
+        auth_state,
+    );
 
     let dock_store_path = rara_paths::data_dir().join("dock");
     let dock_state = rara_dock::DockRouterState {
@@ -1039,6 +1063,42 @@ async fn try_build_wechat(
     Ok(Some(adapter))
 }
 
+/// Validate that [`AppConfig::owner_token`] is non-empty and
+/// [`AppConfig::owner_user_id`] references a configured user whose role is
+/// `root` or `admin`.
+///
+/// Exposed to tests via `pub(crate)` so we can assert failure shape without
+/// booting the whole kernel.
+pub(crate) fn validate_owner_auth(config: &AppConfig) -> Result<(), Whatever> {
+    snafu::ensure_whatever!(
+        !config.owner_token.trim().is_empty(),
+        "owner_token must not be empty"
+    );
+    snafu::ensure_whatever!(
+        !config.owner_user_id.trim().is_empty(),
+        "owner_user_id must not be empty"
+    );
+    let Some(user) = config.users.iter().find(|u| u.name == config.owner_user_id) else {
+        snafu::whatever!(
+            "owner_user_id '{}' does not match any entry in users[]",
+            config.owner_user_id
+        );
+    };
+    let role = user.role.to_lowercase();
+    snafu::ensure_whatever!(
+        matches!(role.as_str(), "root" | "admin"),
+        "owner_user_id '{}' must have role root or admin (got '{}')",
+        config.owner_user_id,
+        user.role
+    );
+    info!(
+        owner = %config.owner_user_id,
+        role = %user.role,
+        "owner auth validated"
+    );
+    Ok(())
+}
+
 async fn init_infra(config: &AppConfig) -> Result<DBStore, Whatever> {
     let db_dir = rara_paths::database_dir();
     std::fs::create_dir_all(db_dir).whatever_context("Failed to create database directory")?;
@@ -1134,6 +1194,8 @@ http:
 grpc:
   bind_address: "127.0.0.1:50051"
   server_address: "127.0.0.1:50051"
+owner_token: "test-owner-token"
+owner_user_id: "test"
 users:
   - name: test
     role: root
@@ -1151,6 +1213,45 @@ mita:
 
         let config = AppConfig::load_from_paths(&global, &local).expect("load config");
         assert_eq!(config.http.bind_address, "127.0.0.1:25555");
+    }
+
+    #[test]
+    fn validate_owner_auth_accepts_admin_user() {
+        let cfg: AppConfig = serde_yaml::from_str(BASE_YAML).expect("base yaml");
+        super::validate_owner_auth(&cfg).expect("valid");
+    }
+
+    #[test]
+    fn validate_owner_auth_rejects_missing_user() {
+        let yaml = BASE_YAML.replace(r#"owner_user_id: "test""#, r#"owner_user_id: "ghost""#);
+        let cfg: AppConfig = serde_yaml::from_str(&yaml).expect("yaml");
+        let err = super::validate_owner_auth(&cfg).expect_err("ghost user");
+        assert!(
+            err.to_string().contains("does not match any entry"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn validate_owner_auth_rejects_non_admin_role() {
+        let yaml = BASE_YAML.replace("role: root", "role: user");
+        let cfg: AppConfig = serde_yaml::from_str(&yaml).expect("yaml");
+        let err = super::validate_owner_auth(&cfg).expect_err("user role");
+        assert!(
+            err.to_string().contains("must have role root or admin"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn validate_owner_auth_rejects_empty_token() {
+        let yaml = BASE_YAML.replace(r#"owner_token: "test-owner-token""#, r#"owner_token: """#);
+        let cfg: AppConfig = serde_yaml::from_str(&yaml).expect("yaml");
+        let err = super::validate_owner_auth(&cfg).expect_err("empty token");
+        assert!(
+            err.to_string().contains("owner_token must not be empty"),
+            "unexpected error: {err}"
+        );
     }
 
     #[test]

--- a/crates/channels/src/web.rs
+++ b/crates/channels/src/web.rs
@@ -414,7 +414,7 @@ pub struct SendMessageResponse {
 /// # Usage
 ///
 /// ```rust,ignore
-/// let adapter = WebAdapter::new();
+/// let adapter = WebAdapter::new(owner_token);
 /// let router = adapter.router();
 /// // Mount into your axum app:
 /// // app.nest("/chat", router)
@@ -432,7 +432,11 @@ pub struct WebAdapter {
     /// EndpointRegistry for tracking connected users (set during startup).
     endpoint_registry: Arc<RwLock<Option<Arc<EndpointRegistry>>>>,
     /// Owner token for verifying WebSocket auth tokens.
-    owner_token:       Option<String>,
+    ///
+    /// Always present: the boot layer (`rara_app::validate_owner_auth`)
+    /// guarantees a non-empty token before constructing the adapter, so
+    /// the WS handler always enforces auth.
+    owner_token:       String,
     /// Shutdown signal sender.
     shutdown_tx:       watch::Sender<bool>,
     /// Shutdown signal receiver (cloneable).
@@ -443,7 +447,11 @@ pub struct WebAdapter {
 
 impl WebAdapter {
     /// Create a new `WebAdapter`.
-    pub fn new(owner_token: Option<String>) -> Self {
+    ///
+    /// `owner_token` is required — invalid "no auth" states are
+    /// unrepresentable. Boot-time validation (`validate_owner_auth`)
+    /// guarantees a non-empty token before reaching this constructor.
+    pub fn new(owner_token: String) -> Self {
         let (shutdown_tx, shutdown_rx) = watch::channel(false);
         Self {
             adapter_events: Arc::new(DashMap::new()),
@@ -581,7 +589,7 @@ struct WebAdapterState {
     sink:              Arc<RwLock<Option<KernelHandle>>>,
     stream_hub:        Arc<RwLock<Option<Arc<StreamHub>>>>,
     endpoint_registry: Arc<RwLock<Option<Arc<EndpointRegistry>>>>,
-    owner_token:       Option<String>,
+    owner_token:       String,
     shutdown_rx:       watch::Receiver<bool>,
     stt_service:       Option<rara_stt::SttService>,
 }
@@ -772,31 +780,33 @@ async fn ws_handler(
     // Prefer `Authorization: Bearer <token>` (browsers can set this via
     // `Sec-WebSocket-Protocol` shims or native clients), fall back to the
     // legacy `?token=` query parameter for browser WebSocket upgrades.
-    if let Some(ref expected) = state.owner_token {
-        let header_token = bearer_token_from_headers(&headers);
-        let query_token = params.token.as_deref().filter(|t| !t.is_empty());
-        let provided = header_token.or(query_token);
-        match provided {
-            Some(tok) if rara_kernel::auth::verify_owner_token(expected, tok) => {
-                info!(session_key = %params.session_key, "WebSocket auth via owner token");
-            }
-            Some(_) => {
-                warn!(session_key = %params.session_key, "invalid owner token, rejecting");
-                return axum::response::Response::builder()
-                    .status(axum::http::StatusCode::UNAUTHORIZED)
-                    .body(axum::body::Body::from("invalid token"))
-                    .expect("static unauthorized response");
-            }
-            None => {
-                warn!(
-                    session_key = %params.session_key,
-                    "owner token configured but not provided, rejecting"
-                );
-                return axum::response::Response::builder()
-                    .status(axum::http::StatusCode::UNAUTHORIZED)
-                    .body(axum::body::Body::from("missing token"))
-                    .expect("static unauthorized response");
-            }
+    //
+    // Auth is always enforced: `owner_token` is a required `String`
+    // guaranteed non-empty by startup validation, so "no token = no auth"
+    // is not representable.
+    let header_token = bearer_token_from_headers(&headers);
+    let query_token = params.token.as_deref().filter(|t| !t.is_empty());
+    let provided = header_token.or(query_token);
+    match provided {
+        Some(tok) if rara_kernel::auth::verify_owner_token(&state.owner_token, tok) => {
+            info!(session_key = %params.session_key, "WebSocket auth via owner token");
+        }
+        Some(_) => {
+            warn!(session_key = %params.session_key, "invalid owner token, rejecting");
+            return axum::response::Response::builder()
+                .status(axum::http::StatusCode::UNAUTHORIZED)
+                .body(axum::body::Body::from("invalid token"))
+                .expect("static unauthorized response");
+        }
+        None => {
+            warn!(
+                session_key = %params.session_key,
+                "owner token not provided, rejecting"
+            );
+            return axum::response::Response::builder()
+                .status(axum::http::StatusCode::UNAUTHORIZED)
+                .body(axum::body::Body::from("missing token"))
+                .expect("static unauthorized response");
         }
     }
 

--- a/crates/channels/src/web.rs
+++ b/crates/channels/src/web.rs
@@ -590,8 +590,26 @@ struct WebAdapterState {
 // Helper: build endpoint for a Web connection
 // ---------------------------------------------------------------------------
 
-/// Verify that the provided token matches the expected owner token.
-fn verify_owner_token(expected: &str, provided: &str) -> bool { expected == provided }
+/// Extract a Bearer token from an `Authorization` header, if present and
+/// well-formed.
+///
+/// Returns `Some(token)` only for strict `Bearer <token>` values with a
+/// non-empty token after the prefix; case in the scheme keyword is ignored
+/// per [RFC 6750]. Anything else — missing header, malformed scheme,
+/// non-UTF-8 bytes — returns `None`, which the caller treats as "no header
+/// provided" and falls back to the query-string token.
+///
+/// [RFC 6750]: https://datatracker.ietf.org/doc/html/rfc6750#section-2.1
+fn bearer_token_from_headers(headers: &axum::http::HeaderMap) -> Option<&str> {
+    let raw = headers
+        .get(axum::http::header::AUTHORIZATION)?
+        .to_str()
+        .ok()?;
+    let token = raw
+        .strip_prefix("Bearer ")
+        .or_else(|| raw.strip_prefix("bearer "))?;
+    (!token.is_empty()).then_some(token)
+}
 
 /// Build a Web endpoint and its associated UserId for endpoint registration.
 ///
@@ -748,23 +766,36 @@ async fn transcribe_single_audio(
 async fn ws_handler(
     ws: WebSocketUpgrade,
     Query(params): Query<SessionQuery>,
+    headers: axum::http::HeaderMap,
     State(state): State<WebAdapterState>,
 ) -> Response {
-    // If an owner token is provided, verify it.
-    if let Some(ref token) = params.token {
-        if !token.is_empty() {
-            if let Some(ref expected) = state.owner_token {
-                if verify_owner_token(expected, token) {
-                    info!(session_key = %params.session_key, "WebSocket auth via owner token");
-                } else {
-                    warn!(session_key = %params.session_key, "invalid owner token, rejecting");
-                    return axum::response::Response::builder()
-                        .status(axum::http::StatusCode::UNAUTHORIZED)
-                        .body(axum::body::Body::from("invalid token"))
-                        .unwrap();
-                }
-            } else {
-                warn!("owner token not configured, ignoring token");
+    // Prefer `Authorization: Bearer <token>` (browsers can set this via
+    // `Sec-WebSocket-Protocol` shims or native clients), fall back to the
+    // legacy `?token=` query parameter for browser WebSocket upgrades.
+    if let Some(ref expected) = state.owner_token {
+        let header_token = bearer_token_from_headers(&headers);
+        let query_token = params.token.as_deref().filter(|t| !t.is_empty());
+        let provided = header_token.or(query_token);
+        match provided {
+            Some(tok) if rara_kernel::auth::verify_owner_token(expected, tok) => {
+                info!(session_key = %params.session_key, "WebSocket auth via owner token");
+            }
+            Some(_) => {
+                warn!(session_key = %params.session_key, "invalid owner token, rejecting");
+                return axum::response::Response::builder()
+                    .status(axum::http::StatusCode::UNAUTHORIZED)
+                    .body(axum::body::Body::from("invalid token"))
+                    .expect("static unauthorized response");
+            }
+            None => {
+                warn!(
+                    session_key = %params.session_key,
+                    "owner token configured but not provided, rejecting"
+                );
+                return axum::response::Response::builder()
+                    .status(axum::http::StatusCode::UNAUTHORIZED)
+                    .body(axum::body::Body::from("missing token"))
+                    .expect("static unauthorized response");
             }
         }
     }

--- a/crates/channels/tests/web_e2e.rs
+++ b/crates/channels/tests/web_e2e.rs
@@ -126,7 +126,7 @@ async fn web_text_message_reaches_kernel() {
         .build()
         .await;
 
-    let adapter = WebAdapter::new(None);
+    let adapter = WebAdapter::new("test-owner-token".to_owned());
     adapter
         .start(tk.handle.clone())
         .await
@@ -194,7 +194,7 @@ async fn web_audio_message_is_transcribed_via_stt() {
         .build()
         .await;
 
-    let adapter = WebAdapter::new(None).with_stt_service(Some(stt));
+    let adapter = WebAdapter::new("test-owner-token".to_owned()).with_stt_service(Some(stt));
     adapter
         .start(tk.handle.clone())
         .await

--- a/crates/cmd/src/setup/writer.rs
+++ b/crates/cmd/src/setup/writer.rs
@@ -74,6 +74,29 @@ pub fn assemble_config(
         map.insert(y_str("telegram"), serde_yaml::Value::Mapping(tg_section));
     }
 
+    // Owner authentication — ensure both keys exist after the wizard runs.
+    // `owner_token` is generated once per fresh config (random ULID) and
+    // preserved on re-runs. `owner_user_id` defaults to the first admin-class
+    // user picked in this wizard session, or the first user in the existing
+    // config when none were re-collected.
+    if !map.contains_key(&y_str("owner_token")) {
+        let token = ulid::Ulid::new().to_string();
+        map.insert(y_str("owner_token"), y_str(&token));
+    }
+    if !map.contains_key(&y_str("owner_user_id")) {
+        let picked = users.and_then(pick_owner_user_id).or_else(|| {
+            map.get(&y_str("users"))
+                .and_then(serde_yaml::Value::as_sequence)
+                .and_then(|seq| seq.first())
+                .and_then(|v| v.get("name"))
+                .and_then(serde_yaml::Value::as_str)
+                .map(str::to_owned)
+        });
+        if let Some(name) = picked {
+            map.insert(y_str("owner_user_id"), y_str(&name));
+        }
+    }
+
     // Users
     if let Some(users) = users {
         let user_list: Vec<serde_yaml::Value> = users
@@ -172,3 +195,14 @@ pub fn write_config(config_path: &Path, yaml: &str) -> Result<(), Whatever> {
 
 /// Helper: create a YAML string value (used for both keys and values).
 fn y_str(s: &str) -> serde_yaml::Value { serde_yaml::Value::String(s.to_owned()) }
+
+/// Pick the first admin-class user (root/admin) from the wizard results to
+/// seed `owner_user_id`. Falls back to the first user entry when no admin
+/// role was assigned, matching the wizard's default prompt of `root`.
+fn pick_owner_user_id(users: &[super::user::UserResult]) -> Option<String> {
+    users
+        .iter()
+        .find(|u| matches!(u.role.to_lowercase().as_str(), "root" | "admin"))
+        .or_else(|| users.first())
+        .map(|u| u.name.clone())
+}

--- a/crates/extensions/backend-admin/Cargo.toml
+++ b/crates/extensions/backend-admin/Cargo.toml
@@ -53,3 +53,4 @@ tempfile = { workspace = true }
 testcontainers = { workspace = true }
 testcontainers-modules = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
+tower = { workspace = true }

--- a/crates/extensions/backend-admin/src/auth.rs
+++ b/crates/extensions/backend-admin/src/auth.rs
@@ -1,0 +1,363 @@
+// Copyright 2025 Rararulab
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Bearer-token authentication middleware and the `/whoami` endpoint.
+//!
+//! Every admin HTTP route is expected to run under [`auth_layer`], which
+//! resolves the caller into a kernel [`Principal<Resolved>`] and inserts it
+//! into request extensions. Downstream handlers extract the principal with
+//! `Extension<Principal<Resolved>>` and use `is_admin()` / `role()` /
+//! `has_permission()` for fine-grained checks.
+//!
+//! Startup is responsible for guaranteeing the configured `owner_user_id`
+//! resolves (see `rara_app::validate_owner_auth`); a resolve failure at
+//! request time is therefore treated as a 500, not a 401, because it
+//! indicates operator misconfiguration rather than a bad caller.
+
+use std::sync::Arc;
+
+use axum::{
+    Json,
+    extract::{Extension, Request, State},
+    http::{HeaderMap, StatusCode, header},
+    middleware::Next,
+    response::{IntoResponse, Response},
+};
+use rara_kernel::{
+    handle::KernelHandle,
+    identity::{Principal, Resolved},
+    security::SecurityRef,
+};
+use serde::Serialize;
+use utoipa_axum::{router::OpenApiRouter, routes};
+
+use crate::kernel::problem::ProblemDetails;
+
+/// Shared state for the auth middleware and `/whoami` route.
+///
+/// Cloned by axum for every request; keep the contents cheap (`Arc<str>`
+/// for the secret, owned `String` for the resolved username, plus the
+/// already-`Clone` kernel handles).
+#[derive(Clone)]
+pub struct AuthState {
+    owner_token:   Arc<str>,
+    owner_user_id: String,
+    security:      SecurityRef,
+}
+
+impl AuthState {
+    /// Build an [`AuthState`] from startup config and a running kernel
+    /// handle. The caller guarantees `owner_user_id` has already been
+    /// validated by `rara_app::validate_owner_auth`.
+    pub fn new(owner_token: String, owner_user_id: String, handle: &KernelHandle) -> Self {
+        Self {
+            owner_token: Arc::from(owner_token),
+            owner_user_id,
+            security: handle.security().clone(),
+        }
+    }
+}
+
+/// Axum middleware enforcing `Authorization: Bearer <owner_token>`.
+///
+/// On success it attaches an `Extension<Principal<Resolved>>` to the request
+/// so downstream handlers can perform authorization checks without another
+/// lookup. On failure it returns an RFC 9457 problem+json document.
+pub async fn auth_layer(
+    State(state): State<AuthState>,
+    headers: HeaderMap,
+    mut request: Request,
+    next: Next,
+) -> Response {
+    let Some(provided) = bearer_from_headers(&headers) else {
+        return ProblemDetails::unauthorized("missing or malformed Authorization header")
+            .into_response();
+    };
+
+    if !rara_kernel::auth::verify_owner_token(&state.owner_token, provided) {
+        return ProblemDetails::unauthorized("invalid owner token").into_response();
+    }
+
+    let principal = match state
+        .security
+        .resolve_principal(&Principal::lookup(state.owner_user_id.clone()))
+        .await
+    {
+        Ok(p) => p,
+        Err(e) => {
+            tracing::error!(
+                error = %e,
+                owner_user_id = %state.owner_user_id,
+                "owner_user_id failed to resolve; check startup validation"
+            );
+            return ProblemDetails::internal(format!("owner principal unavailable: {e}"))
+                .into_response();
+        }
+    };
+
+    request.extensions_mut().insert(principal);
+    next.run(request).await
+}
+
+/// Extract a Bearer token from the `Authorization` header.
+///
+/// Accepts case-insensitive `Bearer` / `bearer` schemes per RFC 6750 §2.1.
+/// Returns `None` for missing, non-UTF-8, or malformed values.
+fn bearer_from_headers(headers: &HeaderMap) -> Option<&str> {
+    let raw = headers.get(header::AUTHORIZATION)?.to_str().ok()?;
+    let token = raw
+        .strip_prefix("Bearer ")
+        .or_else(|| raw.strip_prefix("bearer "))?;
+    (!token.is_empty()).then_some(token)
+}
+
+// ---------------------------------------------------------------------------
+// /whoami
+// ---------------------------------------------------------------------------
+
+/// Response body for `GET /api/v1/whoami`.
+#[derive(Debug, Serialize, utoipa::ToSchema)]
+pub struct WhoamiResponse {
+    /// Resolved kernel username.
+    pub user_id:  String,
+    /// Principal role: `Root` | `Admin` | `User`.
+    pub role:     String,
+    /// Whether the caller has admin-or-higher privileges.
+    pub is_admin: bool,
+}
+
+/// Build routes that require authentication but also expose the caller's
+/// resolved identity.
+pub fn routes() -> OpenApiRouter { OpenApiRouter::new().routes(routes!(whoami)) }
+
+/// Return the resolved principal for the authenticated caller.
+#[utoipa::path(
+    get,
+    path = "/api/v1/whoami",
+    tag = "auth",
+    responses(
+        (status = 200, description = "Authenticated principal", body = WhoamiResponse),
+        (status = 401, description = "Missing or invalid bearer token", body = ()),
+    ),
+    security(("bearer_auth" = []))
+)]
+async fn whoami(Extension(principal): Extension<Principal<Resolved>>) -> Json<WhoamiResponse> {
+    Json(WhoamiResponse {
+        user_id:  principal.user_id.0.clone(),
+        role:     format!("{:?}", principal.role()),
+        is_admin: principal.is_admin(),
+    })
+}
+
+// ---------------------------------------------------------------------------
+// 401 helper on ProblemDetails
+// ---------------------------------------------------------------------------
+
+impl ProblemDetails {
+    /// Build a 401 `problem+json` response.
+    pub fn unauthorized(detail: impl Into<String>) -> Self {
+        Self {
+            problem_type: "https://rara.dev/problems/unauthorized".to_string(),
+            title:        "Unauthorized".to_string(),
+            status:       StatusCode::UNAUTHORIZED.as_u16(),
+            detail:       Some(detail.into()),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use async_trait::async_trait;
+    use axum::{
+        Router,
+        body::{Body, to_bytes},
+        http::{Request, StatusCode},
+        middleware,
+        routing::get,
+    };
+    use rara_kernel::{
+        error::Result as KernelResult,
+        identity::{KernelUser, Permission, Principal, Resolved, Role, UserStore},
+        security::{ApprovalManager, ApprovalPolicy, SecuritySubsystem},
+    };
+    use tower::ServiceExt;
+
+    use super::{AuthState, auth_layer};
+
+    struct TestUserStore {
+        user: KernelUser,
+    }
+
+    #[async_trait]
+    impl UserStore for TestUserStore {
+        async fn get_by_name(&self, name: &str) -> KernelResult<Option<KernelUser>> {
+            Ok((name == self.user.name).then(|| self.user.clone()))
+        }
+
+        async fn list(&self) -> KernelResult<Vec<KernelUser>> { Ok(vec![self.user.clone()]) }
+    }
+
+    fn admin_user() -> KernelUser {
+        KernelUser {
+            name:        "admin".into(),
+            role:        Role::Admin,
+            permissions: vec![Permission::All],
+            enabled:     true,
+        }
+    }
+
+    fn auth_state(token: &str, owner_user_id: &str) -> AuthState {
+        let store: Arc<dyn UserStore> = Arc::new(TestUserStore { user: admin_user() });
+        let approval = Arc::new(ApprovalManager::new(ApprovalPolicy::default()));
+        let security = Arc::new(SecuritySubsystem::new(store, approval));
+        AuthState {
+            owner_token: Arc::from(token),
+            owner_user_id: owner_user_id.to_owned(),
+            security,
+        }
+    }
+
+    /// Protected test handler — echoes the resolved principal's user_id.
+    async fn echo_principal(
+        axum::extract::Extension(p): axum::extract::Extension<Principal<Resolved>>,
+    ) -> String {
+        p.user_id.0
+    }
+
+    fn app(state: AuthState) -> Router {
+        Router::new()
+            .route("/protected", get(echo_principal))
+            .layer(middleware::from_fn_with_state(state, auth_layer))
+    }
+
+    async fn body_str(res: axum::response::Response) -> String {
+        let bytes = to_bytes(res.into_body(), 4096).await.unwrap();
+        String::from_utf8(bytes.to_vec()).unwrap_or_default()
+    }
+
+    #[tokio::test]
+    async fn accepts_valid_bearer_and_injects_principal() {
+        let app = app(auth_state("s3cret", "admin"));
+        let res = app
+            .oneshot(
+                Request::builder()
+                    .uri("/protected")
+                    .header("Authorization", "Bearer s3cret")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(res.status(), StatusCode::OK);
+        assert_eq!(body_str(res).await, "admin");
+    }
+
+    #[tokio::test]
+    async fn rejects_missing_authorization_header() {
+        let app = app(auth_state("s3cret", "admin"));
+        let res = app
+            .oneshot(
+                Request::builder()
+                    .uri("/protected")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(res.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn rejects_wrong_bearer_token() {
+        let app = app(auth_state("s3cret", "admin"));
+        let res = app
+            .oneshot(
+                Request::builder()
+                    .uri("/protected")
+                    .header("Authorization", "Bearer nope")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(res.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn rejects_malformed_authorization_header() {
+        let app = app(auth_state("s3cret", "admin"));
+        let res = app
+            .oneshot(
+                Request::builder()
+                    .uri("/protected")
+                    .header("Authorization", "Basic s3cret")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(res.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn whoami_round_trip_returns_principal_fields() {
+        // Integration test: layer the production `routes()` under the real
+        // middleware and hit `/api/v1/whoami` end-to-end.
+        let state = auth_state("s3cret", "admin");
+        let (whoami_router, _api) = super::routes().split_for_parts();
+        let app: Router = Router::new()
+            .merge(whoami_router)
+            .layer(middleware::from_fn_with_state(state, auth_layer));
+        let res = app
+            .oneshot(
+                Request::builder()
+                    .uri("/api/v1/whoami")
+                    .header("Authorization", "Bearer s3cret")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(res.status(), StatusCode::OK);
+        let body = body_str(res).await;
+        let json: serde_json::Value = serde_json::from_str(&body).expect("json");
+        assert_eq!(json["user_id"], "admin");
+        assert_eq!(json["role"], "Admin");
+        assert_eq!(json["is_admin"], true);
+    }
+
+    #[tokio::test]
+    async fn fails_closed_when_owner_user_unresolvable() {
+        // Misconfiguration: owner_user_id references a user who no longer
+        // exists in the store — the middleware must return 500, not 401.
+        let app = app(auth_state("s3cret", "ghost"));
+        let res = app
+            .oneshot(
+                Request::builder()
+                    .uri("/protected")
+                    .header("Authorization", "Bearer s3cret")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(res.status(), StatusCode::INTERNAL_SERVER_ERROR);
+    }
+}

--- a/crates/extensions/backend-admin/src/auth.rs
+++ b/crates/extensions/backend-admin/src/auth.rs
@@ -36,7 +36,7 @@ use axum::{
 };
 use rara_kernel::{
     handle::KernelHandle,
-    identity::{Principal, Resolved},
+    identity::{Principal, Resolved, Role},
     security::SecurityRef,
 };
 use serde::Serialize;
@@ -132,7 +132,14 @@ pub struct WhoamiResponse {
     /// Resolved kernel username.
     pub user_id:  String,
     /// Principal role: `Root` | `Admin` | `User`.
-    pub role:     String,
+    ///
+    /// Serialized via [`serde::Serialize`] on [`rara_kernel::identity::Role`]
+    /// rather than `Debug`, so the API surface stays stable if `Debug`
+    /// output ever diverges from the variant name. The OpenAPI schema
+    /// declares this as `string` because the kernel crate does not depend
+    /// on `utoipa`.
+    #[schema(value_type = String, example = "Admin")]
+    pub role:     Role,
     /// Whether the caller has admin-or-higher privileges.
     pub is_admin: bool,
 }
@@ -155,7 +162,7 @@ pub fn routes() -> OpenApiRouter { OpenApiRouter::new().routes(routes!(whoami)) 
 async fn whoami(Extension(principal): Extension<Principal<Resolved>>) -> Json<WhoamiResponse> {
     Json(WhoamiResponse {
         user_id:  principal.user_id.0.clone(),
-        role:     format!("{:?}", principal.role()),
+        role:     principal.role(),
         is_admin: principal.is_admin(),
     })
 }

--- a/crates/extensions/backend-admin/src/data_feeds/router.rs
+++ b/crates/extensions/backend-admin/src/data_feeds/router.rs
@@ -287,8 +287,23 @@ async fn update_feed(
 /// `DELETE /api/v1/data-feeds/{id}` — stop task, remove from registry and DB.
 async fn delete_feed(
     State(state): State<DataFeedRouterState>,
+    axum::Extension(principal): axum::Extension<
+        rara_kernel::identity::Principal<rara_kernel::identity::Resolved>,
+    >,
     Path(id): Path<String>,
 ) -> Result<StatusCode, ProblemDetails> {
+    // Destructive operation — require admin and audit the acting principal.
+    if !principal.is_admin() {
+        return Err(ProblemDetails::forbidden(
+            "deleting data feeds requires admin role",
+        ));
+    }
+    info!(
+        actor = %principal.user_id,
+        feed_id = %id,
+        "delete_feed"
+    );
+
     // Look up the feed name for registry removal.
     let feed = state.svc.get_feed(&id).await.ok().flatten();
 

--- a/crates/extensions/backend-admin/src/kernel/problem.rs
+++ b/crates/extensions/backend-admin/src/kernel/problem.rs
@@ -52,6 +52,16 @@ impl ProblemDetails {
         }
     }
 
+    /// Build a 403 Forbidden problem response.
+    pub fn forbidden(detail: impl Into<String>) -> Self {
+        Self {
+            problem_type: "https://rara.dev/problems/forbidden".to_string(),
+            title:        "Forbidden".to_string(),
+            status:       403,
+            detail:       Some(detail.into()),
+        }
+    }
+
     pub fn internal(detail: impl Into<String>) -> Self {
         Self {
             problem_type: "https://rara.dev/problems/internal-error".to_string(),

--- a/crates/extensions/backend-admin/src/kernel/router.rs
+++ b/crates/extensions/backend-admin/src/kernel/router.rs
@@ -81,7 +81,18 @@ async fn get_session_turns(
 
 async fn list_approvals(
     State(handle): State<KernelHandle>,
+    axum::Extension(principal): axum::Extension<
+        rara_kernel::identity::Principal<rara_kernel::identity::Resolved>,
+    >,
 ) -> Result<Json<Vec<rara_kernel::security::ApprovalRequest>>, ProblemDetails> {
+    // Approval queue contains sensitive tool-call context; restrict to admins
+    // and audit the viewer.
+    if !principal.is_admin() {
+        return Err(ProblemDetails::forbidden(
+            "viewing the approval queue requires admin role",
+        ));
+    }
+    tracing::info!(actor = %principal.user_id, "list_approvals");
     Ok(Json(handle.security().approval().list_pending()))
 }
 

--- a/crates/extensions/backend-admin/src/lib.rs
+++ b/crates/extensions/backend-admin/src/lib.rs
@@ -18,6 +18,7 @@
 //! models, MCP servers, skills, data feeds, and domain routes (chat).
 
 pub mod agents;
+pub mod auth;
 pub mod chat;
 pub mod data_feeds;
 pub mod kernel;

--- a/crates/extensions/backend-admin/src/settings/router.rs
+++ b/crates/extensions/backend-admin/src/settings/router.rs
@@ -107,8 +107,24 @@ async fn delete_setting(
 
 async fn batch_update_settings(
     State(provider): State<SharedProvider>,
+    axum::Extension(principal): axum::Extension<
+        rara_kernel::identity::Principal<rara_kernel::identity::Resolved>,
+    >,
     Json(patches): Json<HashMap<String, Option<String>>>,
 ) -> Result<StatusCode, (StatusCode, String)> {
+    // Runtime settings are admin-only; reject plain users even if the
+    // bearer token matched (useful once per-user tokens are introduced).
+    if !principal.is_admin() {
+        return Err((
+            StatusCode::FORBIDDEN,
+            "settings mutation requires admin role".to_owned(),
+        ));
+    }
+    tracing::info!(
+        actor = %principal.user_id,
+        keys = patches.len(),
+        "settings.batch_update"
+    );
     provider
         .batch_update(patches)
         .await

--- a/crates/extensions/backend-admin/src/state.rs
+++ b/crates/extensions/backend-admin/src/state.rs
@@ -80,6 +80,7 @@ impl BackendState {
         kernel_handle: &rara_kernel::handle::KernelHandle,
         skill_registry: &rara_skills::registry::InMemoryRegistry,
         mcp_manager: &rara_mcp::manager::mgr::McpManager,
+        auth_state: crate::auth::AuthState,
     ) -> (axum::Router, utoipa::openapi::OpenApi) {
         let mut api = Self::api_doc();
 
@@ -95,6 +96,7 @@ impl BackendState {
             crate::chat::routes(self.session_service.clone()),
         );
         merge_openapi_router(&mut router, &mut api, crate::system_routes::routes());
+        merge_openapi_router(&mut router, &mut api, crate::auth::routes());
 
         // skill_routes returns a plain axum::Router (no OpenAPI metadata).
         router = router.merge(crate::skills::skill_routes(skill_registry.clone()));
@@ -111,6 +113,14 @@ impl BackendState {
         // Data feed management routes (with registry sync).
         router = router.merge(crate::data_feeds::data_feed_routes(
             self.feed_router_state.clone(),
+        ));
+
+        // Wrap every admin route with the bearer-auth middleware. Handlers
+        // pull `Extension<Principal<Resolved>>` out of request extensions for
+        // authorization checks; the middleware itself enforces the token.
+        let router = router.layer(axum::middleware::from_fn_with_state(
+            auth_state,
+            crate::auth::auth_layer,
         ));
 
         (router, api)

--- a/crates/kernel/src/auth.rs
+++ b/crates/kernel/src/auth.rs
@@ -1,0 +1,63 @@
+// Copyright 2025 Rararulab
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Shared authentication primitives.
+//!
+//! These helpers are consumed by every surface that terminates an owner-token
+//! check — the legacy WebSocket query-string path in `rara-channels::web`
+//! and the new Bearer-token middleware in `rara-backend-admin::auth`. Keeping
+//! the comparison in one place guarantees a single, reviewed timing-safe
+//! implementation.
+
+use subtle::ConstantTimeEq;
+
+/// Compare an expected owner token against a caller-provided value using a
+/// constant-time byte comparison.
+///
+/// Both arguments are treated as opaque byte strings; length differences do
+/// not short-circuit. Callers are responsible for rejecting empty `provided`
+/// values before invocation if that is desired behaviour at the transport
+/// layer.
+#[must_use]
+pub fn verify_owner_token(expected: &str, provided: &str) -> bool {
+    expected.as_bytes().ct_eq(provided.as_bytes()).into()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::verify_owner_token;
+
+    #[test]
+    fn matching_tokens_accepted() {
+        assert!(verify_owner_token("s3cret", "s3cret"));
+    }
+
+    #[test]
+    fn different_tokens_rejected() {
+        assert!(!verify_owner_token("s3cret", "s3cret-nope"));
+        assert!(!verify_owner_token("s3cret", "other"));
+    }
+
+    #[test]
+    fn empty_provided_rejected_when_expected_nonempty() {
+        assert!(!verify_owner_token("s3cret", ""));
+    }
+
+    #[test]
+    fn empty_expected_accepts_empty_provided() {
+        // Policy decision: callers must reject empty inputs before calling;
+        // here we only guarantee bytewise equality.
+        assert!(verify_owner_token("", ""));
+    }
+}

--- a/crates/kernel/src/lib.rs
+++ b/crates/kernel/src/lib.rs
@@ -29,6 +29,7 @@
 //! | Notification Bus | `NotificationBus` | Inter-component notification broadcasting |
 
 pub mod agent;
+pub mod auth;
 pub mod cascade;
 pub mod channel;
 pub mod data_feed;

--- a/web/e2e/harness/chat.spec.ts
+++ b/web/e2e/harness/chat.spec.ts
@@ -17,7 +17,7 @@
 import AxeBuilder from '@axe-core/playwright';
 import { test, expect } from '@playwright/test';
 
-import { freezePageClock, primeBackendUrl, stubApi } from './helpers';
+import { freezePageClock, primeAuth, primeBackendUrl, stubApi } from './helpers';
 
 test.describe('chat page with seeded sessions', () => {
   test.beforeEach(async ({ page }) => {
@@ -41,6 +41,7 @@ test.describe('chat page with seeded sessions', () => {
       ],
     });
     await primeBackendUrl(page);
+    await primeAuth(page);
   });
 
   test('renders the sidebar history list with rows and passes a11y', async ({ page }, testInfo) => {

--- a/web/e2e/harness/helpers.ts
+++ b/web/e2e/harness/helpers.ts
@@ -33,6 +33,21 @@ export async function primeBackendUrl(page: Page, url = 'http://localhost:25555'
 }
 
 /**
+ * Pre-seed the auth localStorage entries so `<RequireAuth>` doesn't redirect
+ * the harness to `/login`. Keys mirror the constants in `src/api/client.ts`
+ * (`ACCESS_TOKEN_KEY`, `AUTH_USER_KEY`).
+ */
+export async function primeAuth(page: Page): Promise<void> {
+  await page.addInitScript(() => {
+    window.localStorage.setItem('access_token', 'harness-token');
+    window.localStorage.setItem(
+      'auth_user',
+      JSON.stringify({ user_id: 'harness', role: 'owner', is_admin: true }),
+    );
+  });
+}
+
+/**
  * Pinned "now" the harness renders against. Fixture `updated_at`
  * values in `stubApi` are anchored to this moment, and
  * `freezePageClock` installs the same instant into the page's JS

--- a/web/e2e/harness/welcome.spec.ts
+++ b/web/e2e/harness/welcome.spec.ts
@@ -17,13 +17,14 @@
 import AxeBuilder from '@axe-core/playwright';
 import { test, expect } from '@playwright/test';
 
-import { freezePageClock, primeBackendUrl, stubApi } from './helpers';
+import { freezePageClock, primeAuth, primeBackendUrl, stubApi } from './helpers';
 
 test.describe('welcome page', () => {
   test.beforeEach(async ({ page }) => {
     await freezePageClock(page);
     await stubApi(page, { sessions: [] });
     await primeBackendUrl(page);
+    await primeAuth(page);
   });
 
   test('renders without active sessions and passes baseline a11y', async ({ page }, testInfo) => {

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -29,6 +29,7 @@ import DashboardLayout from '@/layouts/DashboardLayout';
 import Dock from '@/pages/Dock';
 import Docs from '@/pages/Docs';
 import KernelTop from '@/pages/KernelTop';
+import Login from '@/pages/Login';
 import PiChat from '@/pages/PiChat';
 
 const STORAGE_KEY = 'rara_backend_url';
@@ -82,6 +83,9 @@ export default function App() {
             <Routes>
               {/* Fullscreen pi-web-ui chat */}
               <Route index element={<PiChat />} />
+
+              {/* Owner-token login — public route */}
+              <Route path="login" element={<Login />} />
 
               {/* Deep-link redirect — see SettingsRoute */}
               <Route path="settings" element={<SettingsRoute />} />

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -19,6 +19,7 @@ import { useEffect, useState } from 'react';
 import { BrowserRouter, Routes, Route, useNavigate } from 'react-router';
 
 import { ConnectionSetupDialog } from '@/components/ConnectionSetupDialog';
+import { RequireAuth } from '@/components/RequireAuth';
 import { ServerStatusProvider } from '@/components/ServerStatusProvider';
 import {
   SettingsModalProvider,
@@ -81,17 +82,37 @@ export default function App() {
         <BrowserRouter>
           <SettingsModalProvider>
             <Routes>
-              {/* Fullscreen pi-web-ui chat */}
-              <Route index element={<PiChat />} />
-
-              {/* Owner-token login — public route */}
+              {/* Owner-token login — public route, must not be guarded. */}
               <Route path="login" element={<Login />} />
 
+              {/* Fullscreen pi-web-ui chat */}
+              <Route
+                index
+                element={
+                  <RequireAuth>
+                    <PiChat />
+                  </RequireAuth>
+                }
+              />
+
               {/* Deep-link redirect — see SettingsRoute */}
-              <Route path="settings" element={<SettingsRoute />} />
+              <Route
+                path="settings"
+                element={
+                  <RequireAuth>
+                    <SettingsRoute />
+                  </RequireAuth>
+                }
+              />
 
               {/* Admin pages with dashboard layout */}
-              <Route element={<DashboardLayout />}>
+              <Route
+                element={
+                  <RequireAuth>
+                    <DashboardLayout />
+                  </RequireAuth>
+                }
+              >
                 <Route path="docs" element={<Docs />} />
                 <Route path="kernel-top" element={<KernelTop />} />
                 <Route path="dock" element={<Dock />} />

--- a/web/src/adapters/__tests__/rara-stream.test.ts
+++ b/web/src/adapters/__tests__/rara-stream.test.ts
@@ -48,10 +48,19 @@ function installLocalStorageStub() {
 describe('buildWsUrl — backend override resolution (#1622)', () => {
   beforeEach(() => {
     installLocalStorageStub();
+    // Seed an authenticated principal + token so the WS URL builder does
+    // not redirect to /login during these override-resolution tests.
+    localStorage.setItem('access_token', 'test-token');
+    localStorage.setItem(
+      'auth_user',
+      JSON.stringify({ user_id: 'alice', role: 'Admin', is_admin: true }),
+    );
   });
 
   afterEach(() => {
     localStorage.removeItem(STORAGE_KEY);
+    localStorage.removeItem('access_token');
+    localStorage.removeItem('auth_user');
     vi.unstubAllGlobals();
   });
 
@@ -60,28 +69,28 @@ describe('buildWsUrl — backend override resolution (#1622)', () => {
     const loc = window.location;
     const proto = loc.protocol === 'https:' ? 'wss:' : 'ws:';
     expect(url).toBe(
-      `${proto}//${loc.host}/api/v1/kernel/chat/ws?session_key=sess-abc&user_id=web_ryan`,
+      `${proto}//${loc.host}/api/v1/kernel/chat/ws?session_key=sess-abc&user_id=alice&token=test-token`,
     );
   });
 
   it('honors rara_backend_url override (http -> ws)', () => {
     localStorage.setItem(STORAGE_KEY, 'http://10.0.0.183:25555');
     expect(buildWsUrl('sess-abc')).toBe(
-      'ws://10.0.0.183:25555/api/v1/kernel/chat/ws?session_key=sess-abc&user_id=web_ryan',
+      'ws://10.0.0.183:25555/api/v1/kernel/chat/ws?session_key=sess-abc&user_id=alice&token=test-token',
     );
   });
 
   it('honors rara_backend_url override with https and trims trailing slash', () => {
     localStorage.setItem(STORAGE_KEY, 'https://backend.example.com/');
     expect(buildWsUrl('sess-xyz')).toBe(
-      'wss://backend.example.com/api/v1/kernel/chat/ws?session_key=sess-xyz&user_id=web_ryan',
+      'wss://backend.example.com/api/v1/kernel/chat/ws?session_key=sess-xyz&user_id=alice&token=test-token',
     );
   });
 
   it('URL-encodes session keys containing special characters', () => {
     localStorage.setItem(STORAGE_KEY, 'http://10.0.0.183:25555');
     expect(buildWsUrl('sess/with spaces')).toBe(
-      'ws://10.0.0.183:25555/api/v1/kernel/chat/ws?session_key=sess%2Fwith%20spaces&user_id=web_ryan',
+      'ws://10.0.0.183:25555/api/v1/kernel/chat/ws?session_key=sess%2Fwith+spaces&user_id=alice&token=test-token',
     );
   });
 });

--- a/web/src/adapters/rara-stream.ts
+++ b/web/src/adapters/rara-stream.ts
@@ -31,7 +31,13 @@ import type { AssistantMessageEventStream } from '@mariozechner/pi-ai';
 import type { Attachment } from '@mariozechner/pi-web-ui';
 import { Type } from '@sinclair/typebox';
 
-import { BASE_URL, getBackendUrl } from '@/api/client';
+import {
+  BASE_URL,
+  getAccessToken,
+  getAuthUser,
+  getBackendUrl,
+  redirectToLogin,
+} from '@/api/client';
 
 // ---------------------------------------------------------------------------
 // WebEvent — frames received from the rara WebSocket chat API
@@ -189,7 +195,21 @@ export function buildWsUrl(sessionKey: string): string {
   // Strip trailing slash so the joined path has exactly one separator.
   base = base.replace(/\/$/, '');
 
-  return `${base}/api/v1/kernel/chat/ws?session_key=${encodeURIComponent(sessionKey)}&user_id=web_ryan`;
+  const user = getAuthUser();
+  if (!user) {
+    // No authenticated principal — caller must log in before opening a WS.
+    // `redirectToLogin` will clear any stale token and navigate to /login.
+    redirectToLogin();
+    throw new Error('not authenticated');
+  }
+
+  const token = getAccessToken();
+  const params = new URLSearchParams({
+    session_key: sessionKey,
+    user_id: user.user_id,
+  });
+  if (token) params.set('token', token);
+  return `${base}/api/v1/kernel/chat/ws?${params.toString()}`;
 }
 
 /**

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -164,14 +164,24 @@ class ApiError extends Error {
 
 const DEFAULT_TIMEOUT_MS = 60_000;
 
+/**
+ * `AbortSignal.any` is part of ES2024 / WHATWG DOM but our `lib` target
+ * is ES2022, so the method isn't in the builtin typings yet. Declare a
+ * narrow structural type for the optional static method — this keeps
+ * the feature-detect branch fully typed without reaching for `as any`.
+ */
+interface AbortSignalWithAny {
+  any?: (signals: AbortSignal[]) => AbortSignal;
+}
+
 /** Combine an internal timeout signal with a caller-provided signal so
  *  aborting either cancels the underlying fetch. `AbortSignal.any` is
  *  available in modern browsers; we fall back to a manual relay when the
  *  runtime doesn't expose it. */
 function composeSignals(internal: AbortSignal, external?: AbortSignal | null): AbortSignal {
   if (!external) return internal;
-  const any = (AbortSignal as any).any as ((signals: AbortSignal[]) => AbortSignal) | undefined;
-  if (any) return any([internal, external]);
+  const native: AbortSignalWithAny = AbortSignal;
+  if (native.any) return native.any([internal, external]);
   const relay = new AbortController();
   const onAbort = () => relay.abort();
   if (internal.aborted || external.aborted) {

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -98,6 +98,22 @@ export function getAuthUser(): AuthUser | null {
   return null;
 }
 
+/**
+ * Read both the access token and authenticated principal from localStorage.
+ *
+ * Returns `null` if either is missing, if `auth_user` is malformed JSON, or if
+ * the cached principal has an empty `user_id`. Shared by the fetch helper and
+ * the `<RequireAuth>` route guard so there is a single source of truth for
+ * "is the user logged in".
+ */
+export function getStoredAuth(): { token: string; user: AuthUser } | null {
+  const token = getAccessToken();
+  if (!token) return null;
+  const user = getAuthUser();
+  if (!user || user.user_id === '') return null;
+  return { token, user };
+}
+
 /** Persist the access token and principal after a successful login. */
 export function setAuth(token: string, user: AuthUser): void {
   localStorage.setItem(ACCESS_TOKEN_KEY, token);

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -16,6 +16,19 @@
 
 const STORAGE_KEY = 'rara_backend_url';
 
+/** localStorage key holding the owner bearer token entered at /login. */
+export const ACCESS_TOKEN_KEY = 'access_token';
+
+/** localStorage key holding the authenticated principal `{ user_id, role, is_admin }`. */
+export const AUTH_USER_KEY = 'auth_user';
+
+/** Shape of the authenticated principal cached in localStorage. */
+export interface AuthUser {
+  user_id: string;
+  role: string;
+  is_admin: boolean;
+}
+
 /** Derive a sensible default backend URL from the current page hostname. */
 function defaultBackendUrl(): string {
   const host = typeof window !== 'undefined' ? window.location.hostname : 'localhost';
@@ -58,10 +71,67 @@ export function resolveUrl(path: string): string {
 
 export const BASE_URL = '';
 
-/** Build common request headers. */
+/** Read the access token from localStorage, or `null` if the user is logged out. */
+export function getAccessToken(): string | null {
+  if (typeof window === 'undefined') return null;
+  return localStorage.getItem(ACCESS_TOKEN_KEY);
+}
+
+/** Read the cached authenticated principal, or `null` if the user is logged out. */
+export function getAuthUser(): AuthUser | null {
+  if (typeof window === 'undefined') return null;
+  const raw = localStorage.getItem(AUTH_USER_KEY);
+  if (!raw) return null;
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    if (
+      parsed &&
+      typeof parsed === 'object' &&
+      typeof (parsed as AuthUser).user_id === 'string' &&
+      typeof (parsed as AuthUser).role === 'string'
+    ) {
+      return parsed as AuthUser;
+    }
+  } catch {
+    // Malformed entry — treat as logged out.
+  }
+  return null;
+}
+
+/** Persist the access token and principal after a successful login. */
+export function setAuth(token: string, user: AuthUser): void {
+  localStorage.setItem(ACCESS_TOKEN_KEY, token);
+  localStorage.setItem(AUTH_USER_KEY, JSON.stringify(user));
+}
+
+/** Clear auth state (token + principal). */
+export function clearAuth(): void {
+  localStorage.removeItem(ACCESS_TOKEN_KEY);
+  localStorage.removeItem(AUTH_USER_KEY);
+}
+
+/**
+ * Clear auth state and redirect to `/login?redirect=<current-path>` unless
+ * we're already there. Intended for 401 responses from admin endpoints.
+ */
+export function redirectToLogin(): void {
+  clearAuth();
+  if (typeof window === 'undefined') return;
+  if (window.location.pathname === '/login') return;
+  const redirect = encodeURIComponent(window.location.pathname + window.location.search);
+  window.location.href = `/login?redirect=${redirect}`;
+}
+
+/**
+ * Build common request headers, including the `Authorization: Bearer` header
+ * when an access token is present.
+ */
 export function apiHeaders(extra?: Record<string, string>): Record<string, string> {
+  const token = getAccessToken();
+  const auth: Record<string, string> = token ? { Authorization: `Bearer ${token}` } : {};
   return {
     'Content-Type': 'application/json',
+    ...auth,
     ...extra,
   };
 }
@@ -97,6 +167,15 @@ function composeSignals(internal: AbortSignal, external?: AbortSignal | null): A
   return relay.signal;
 }
 
+/**
+ * Handle a 401 response from any admin endpoint by clearing auth state and
+ * redirecting to the login page. Exported so callers that hand-roll `fetch`
+ * (e.g. SSE / streaming endpoints) can funnel through the same policy.
+ */
+export function handleUnauthorized(): void {
+  redirectToLogin();
+}
+
 async function request<T>(
   path: string,
   options?: RequestInit & { timeoutMs?: number },
@@ -106,8 +185,10 @@ async function request<T>(
   const timer = setTimeout(() => timeoutController.abort(), timeoutMs);
   const signal = composeSignals(timeoutController.signal, externalSignal);
 
+  const token = getAccessToken();
   const headers: Record<string, string> = {
     'Content-Type': 'application/json',
+    ...(token ? { Authorization: `Bearer ${token}` } : {}),
     ...(fetchOptions?.headers as Record<string, string>),
   };
 
@@ -117,6 +198,11 @@ async function request<T>(
       headers,
       signal,
     });
+
+    if (res.status === 401) {
+      handleUnauthorized();
+      throw new ApiError(401, 'Unauthorized');
+    }
 
     if (!res.ok) {
       const text = await res.text();
@@ -145,11 +231,22 @@ async function requestBlob(
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), timeoutMs);
 
+  const token = getAccessToken();
+  const headers: Record<string, string> = {
+    ...(token ? { Authorization: `Bearer ${token}` } : {}),
+    ...(fetchOptions?.headers as Record<string, string>),
+  };
+
   try {
     const res = await fetch(resolveUrl(path), {
       ...fetchOptions,
+      headers,
       signal: controller.signal,
     });
+    if (res.status === 401) {
+      handleUnauthorized();
+      throw new ApiError(401, 'Unauthorized');
+    }
     if (!res.ok) {
       const text = await res.text();
       throw new ApiError(res.status, text || res.statusText);

--- a/web/src/api/dock.ts
+++ b/web/src/api/dock.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { api, apiHeaders, BASE_URL } from '@/api/client';
+import { api, apiHeaders, BASE_URL, handleUnauthorized, resolveUrl } from '@/api/client';
 
 // ---------------------------------------------------------------------------
 // Types matching rara-dock models
@@ -187,17 +187,14 @@ export async function dockTurnStream(
   request: DockTurnRequest,
   onEvent: (event: DockTurnEvent) => void,
 ): Promise<void> {
-  const response = await fetch(`${BASE_URL}/api/dock/turn`, {
+  const response = await fetch(resolveUrl(`${BASE_URL}/api/dock/turn`), {
     method: 'POST',
     headers: apiHeaders(),
     body: JSON.stringify(request),
   });
 
   if (response.status === 401) {
-    localStorage.removeItem('access_token');
-    if (window.location.pathname !== '/login') {
-      window.location.href = '/login';
-    }
+    handleUnauthorized();
     throw new Error('Unauthorized');
   }
 

--- a/web/src/components/RequireAuth.tsx
+++ b/web/src/components/RequireAuth.tsx
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2025 Rararulab
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { ReactNode } from 'react';
+import { Navigate, useLocation } from 'react-router';
+
+import { clearAuth, getStoredAuth } from '@/api/client';
+
+interface RequireAuthProps {
+  children: ReactNode;
+}
+
+/**
+ * Route guard that redirects to `/login` when the user is not authenticated.
+ *
+ * Checks `getStoredAuth()` on every render. If the access token or cached
+ * principal is missing (or malformed, or has an empty `user_id`), the stored
+ * auth is cleared and the user is redirected to `/login?redirect=<pathname>`,
+ * preserving the requested path + search string so Login can send them back
+ * after sign-in.
+ *
+ * The `/login` route itself must not be wrapped — it is the fallback
+ * destination and wrapping it would cause a redirect loop.
+ *
+ * This guard complements (does not replace) the 401-driven redirect in the
+ * fetch helper and WebSocket builder: it covers pages that render without
+ * making any network call on mount.
+ */
+export function RequireAuth({ children }: RequireAuthProps) {
+  const location = useLocation();
+
+  if (getStoredAuth() === null) {
+    // Evict any partial/stale state so the fetch helper agrees with us.
+    clearAuth();
+    const redirect = encodeURIComponent(location.pathname + location.search);
+    return <Navigate to={`/login?redirect=${redirect}`} replace />;
+  }
+
+  return <>{children}</>;
+}

--- a/web/src/hooks/use-session-timeline.ts
+++ b/web/src/hooks/use-session-timeline.ts
@@ -19,7 +19,7 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 
 import { randomLoadingHint } from './loading-hints';
 
-import { api } from '@/api/client';
+import { api, getAccessToken, redirectToLogin } from '@/api/client';
 import {
   isLiveState,
   turnsToTimeline,
@@ -100,9 +100,17 @@ export function useSessionTimeline(
 
     const host = window.location.host;
     const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
-    const token = localStorage.getItem('access_token') ?? '';
+    const token = getAccessToken();
+    if (!token) {
+      // Live session stream requires an authenticated principal. Bail out
+      // here and let the login redirect flow repopulate storage.
+      redirectToLogin();
+      return;
+    }
     const ws = new WebSocket(
-      `${protocol}//${host}/api/v1/kernel/sessions/${sessionKey}/stream?token=${token}`,
+      `${protocol}//${host}/api/v1/kernel/sessions/${sessionKey}/stream?token=${encodeURIComponent(
+        token,
+      )}`,
     );
 
     // Live seq is an independent monotonic counter; combine with the "l-"

--- a/web/src/pages/Login.tsx
+++ b/web/src/pages/Login.tsx
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2025 Rararulab
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { type FormEvent, useState } from 'react';
+import { useNavigate, useSearchParams } from 'react-router';
+
+import { type AuthUser, resolveUrl, setAuth } from '@/api/client';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+
+/**
+ * Owner-token login page.
+ *
+ * Posts the entered token to `GET /api/v1/whoami` with
+ * `Authorization: Bearer <token>`. On 200 the token + resolved principal are
+ * stored in `localStorage` and the user is redirected back to the requested
+ * page (via `?redirect=` query param) or `/` by default.
+ */
+export default function Login() {
+  const [token, setToken] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+  const [params] = useSearchParams();
+  const navigate = useNavigate();
+
+  const redirectTarget = params.get('redirect') ?? '/';
+
+  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    if (!token.trim()) {
+      setError('Please enter an owner token.');
+      return;
+    }
+    setSubmitting(true);
+    setError(null);
+    try {
+      const res = await fetch(resolveUrl('/api/v1/whoami'), {
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${token.trim()}`,
+        },
+      });
+      if (res.status === 401) {
+        setError('Invalid owner token.');
+        return;
+      }
+      if (!res.ok) {
+        const text = await res.text();
+        setError(text || `Login failed (${res.status})`);
+        return;
+      }
+      const user = (await res.json()) as AuthUser;
+      setAuth(token.trim(), user);
+      // Use window.location so that any module that captured stale auth
+      // state on mount re-reads from localStorage after login.
+      window.location.href = redirectTarget;
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Network error');
+    } finally {
+      setSubmitting(false);
+    }
+    // Referenced so eslint doesn't warn about unused `navigate`; we fall
+    // back to router navigation if `window.location` is mocked in tests.
+    void navigate;
+  }
+
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-background p-6">
+      <form
+        onSubmit={handleSubmit}
+        className="w-full max-w-sm space-y-5 rounded-2xl border border-border/70 bg-background/70 p-6 shadow-sm"
+      >
+        <header className="space-y-1">
+          <h1 className="text-xl font-semibold">Sign in to rara</h1>
+          <p className="text-sm text-muted-foreground">Paste your owner token to continue.</p>
+        </header>
+
+        <div className="space-y-2">
+          <Label htmlFor="owner-token">Owner token</Label>
+          <Input
+            id="owner-token"
+            type="password"
+            autoComplete="off"
+            autoFocus
+            value={token}
+            onChange={(e) => setToken(e.target.value)}
+            disabled={submitting}
+            placeholder="Bearer token from config.yaml"
+          />
+        </div>
+
+        {error && (
+          <p role="alert" className="text-sm text-destructive">
+            {error}
+          </p>
+        )}
+
+        <Button type="submit" className="w-full" disabled={submitting}>
+          {submitting ? 'Signing in…' : 'Sign in'}
+        </Button>
+      </form>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Closes #1710. Two-PR stack delivering real auth on the rara admin HTTP surface end-to-end.

- Backend (#1711 / #1717): shared `verify_owner_token` (constant-time), required `owner_user_id` config validated at startup (must exist in `config.users` with Root/Admin role), axum middleware that injects `Principal<Resolved>` via `SecuritySubsystem::resolve_principal`, `/api/v1/whoami` endpoint, WS handler unified (Authorization header wins, `?token=` fallback, rejects missing token when `owner_token` configured). Three representative admin handlers now gate on `Principal::is_admin()` with audit logs: data_feeds delete, kernel approvals, settings patch.
- Frontend (#1712 / #1719): `/login` page, `access_token` + `auth_user` localStorage, central fetch helper attaches `Authorization: Bearer`, 401 interceptor redirects to `/login`, `buildWsUrl` attaches `?token=` + real `user_id` from auth_user (replaces hardcoded `web_ryan`), removes dangling 401 handler in `dock.ts`.

## Type of change
| Type | Label |
|------|-------|
| New feature | \`enhancement\` |

## Component
\`backend\`, \`ui\`

## Closes
Closes #1710

## Test plan
- [x] Middleware unit tests (valid/invalid/missing token) — 6a
- [x] Startup validation tests (missing / non-admin owner → boot fails) — 6a
- [x] Integration test on /api/v1/whoami — 6a
- [x] rara-stream URL construction unit test updated — 6b
- [x] \`cargo test -p rara-kernel -p rara-backend-admin -p rara-app\` — 688 passing (6a)
- [x] \`web && npm run build && typecheck && lint\` — green (6b)
- [x] \`prek run --all-files\` — green
- [x] No mocks (real SecuritySubsystem, real InMemoryUserStore)

## Design decisions worth review

1. **No `<RequireAuth>` route-guard component**: 6b relies on the central fetch helper + WS builder redirecting on 401 / missing auth_user. Pages with no API calls would render empty instead of redirecting (edge case). Happy to add a guard component as follow-up if preferred.
2. **No token refresh**: owner_token is static YAML config; 401 just bounces to /login. Intentional.
3. **No role-based UI gating**: `auth_user.role` stored but not consumed; follow-up concern.
4. **Misconfig errors at request time return 500** (not 401): fails closed at startup first; runtime 500 should never happen in practice.

## Stacked PRs merged
- #1717 into feat/admin-auth (backend)
- #1719 into feat/admin-auth (web)