### PR TITLE
refactor(web): collapse toolcalls into per-turn cards (#1718)

### DIFF
--- a/web/src/components/agent-live/SingleAgentLiveCard.tsx
+++ b/web/src/components/agent-live/SingleAgentLiveCard.tsx
@@ -19,6 +19,7 @@ import { useEffect, useMemo, useRef, useState, type KeyboardEvent } from 'react'
 
 import type { LiveRun } from './live-run-store';
 import { formatDuration } from './time-format';
+import { ToolChip, buildToolChips } from './tool-chips';
 
 import type { TimelineItem } from '@/api/kernel-types';
 import { redactObject } from '@/lib/redact';
@@ -67,10 +68,22 @@ export function SingleAgentLiveCard({ run, agentName = 'rara', onOpenTranscript,
     setShowLatest(!atBottom);
   };
 
+  const isRunning = run.status === 'running';
   const elapsed = (run.endedAt ?? nowTick) - run.startedAt;
-  const headerLabel = `${agentName} is working`;
+  const headerLabel = isRunning
+    ? `${agentName} is working`
+    : run.status === 'failed'
+      ? `${agentName} encountered an error`
+      : run.status === 'cancelled'
+        ? `${agentName} was interrupted`
+        : `${agentName} finished`;
   const redactedItems = useMemo(() => run.items.map(redactItem), [run.items]);
-  const chips = useMemo(() => buildToolChips(redactedItems), [redactedItems]);
+  // Newest chip first (hermes pattern) while running; chronological order is
+  // nicer once the turn settles so the viewer can read the recap top-down.
+  const chips = useMemo(() => {
+    const built = buildToolChips(redactedItems);
+    return isRunning ? built.slice().reverse() : built;
+  }, [redactedItems, isRunning]);
 
   const onHeaderKey = (ev: KeyboardEvent<HTMLDivElement>) => {
     if (ev.key === 'Enter' || ev.key === ' ') {
@@ -91,13 +104,10 @@ export function SingleAgentLiveCard({ run, agentName = 'rara', onOpenTranscript,
         className="flex cursor-pointer items-center gap-2 px-3 py-2 hover:bg-accent/40"
       >
         <Bot className="h-4 w-4 shrink-0 text-muted-foreground" />
-        <span
-          className="flex h-2 w-2 shrink-0 animate-pulse rounded-full bg-emerald-500"
-          aria-hidden
-        />
+        <RunStatusDot status={run.status} />
         <span className="min-w-0 flex-1 truncate text-sm font-medium text-foreground">
           {headerLabel}
-          {run.currentStage && (
+          {isRunning && run.currentStage && (
             <span className="ml-2 font-normal text-muted-foreground">
               · {stageLabel(run.currentStage)}
             </span>
@@ -121,19 +131,21 @@ export function SingleAgentLiveCard({ run, agentName = 'rara', onOpenTranscript,
         >
           <Maximize2 className="h-3.5 w-3.5" />
         </button>
-        <button
-          type="button"
-          disabled={!onStop}
-          onClick={(e) => {
-            e.stopPropagation();
-            onStop?.();
-          }}
-          className="inline-flex h-7 w-7 items-center justify-center rounded-md text-muted-foreground transition hover:bg-accent hover:text-foreground disabled:cursor-not-allowed disabled:opacity-40"
-          aria-label="Stop task"
-          title={onStop ? 'Stop' : 'Cancel not yet wired'}
-        >
-          <Square className="h-3.5 w-3.5" />
-        </button>
+        {isRunning && (
+          <button
+            type="button"
+            disabled={!onStop}
+            onClick={(e) => {
+              e.stopPropagation();
+              onStop?.();
+            }}
+            className="inline-flex h-7 w-7 items-center justify-center rounded-md text-muted-foreground transition hover:bg-accent hover:text-foreground disabled:cursor-not-allowed disabled:opacity-40"
+            aria-label="Stop task"
+            title={onStop ? 'Stop' : 'Cancel not yet wired'}
+          >
+            <Square className="h-3.5 w-3.5" />
+          </button>
+        )}
         <ChevronDown
           className={cn(
             'h-4 w-4 shrink-0 text-muted-foreground transition-transform',
@@ -152,11 +164,15 @@ export function SingleAgentLiveCard({ run, agentName = 'rara', onOpenTranscript,
           >
             {redactedItems.length === 0 ? (
               <div className="flex items-center gap-2 px-4 py-3 text-xs text-muted-foreground">
-                <span
-                  className="inline-block h-1.5 w-1.5 shrink-0 animate-pulse rounded-full bg-emerald-500"
-                  aria-hidden
-                />
-                <span className="truncate">{stageLabel(run.currentStage)}</span>
+                {isRunning && (
+                  <span
+                    className="inline-block h-1.5 w-1.5 shrink-0 animate-pulse rounded-full bg-emerald-500"
+                    aria-hidden
+                  />
+                )}
+                <span className="truncate">
+                  {isRunning ? stageLabel(run.currentStage) : 'No tool calls in this run'}
+                </span>
               </div>
             ) : (
               <div className="flex flex-col gap-1 px-3 py-2">
@@ -195,133 +211,32 @@ function redactItem(item: TimelineItem): TimelineItem {
   return item;
 }
 
-interface ToolChipModel {
-  /** Source `tool_use` seq — used as React key. */
-  seq: number;
-  tool: string;
-  /** Derived short preview from the (redacted) input. Empty if nothing useful. */
-  preview: string;
-  status: 'running' | 'completed' | 'errored';
-  /** Short error text when `status === 'errored'`. Replaces the preview in the UI. */
-  errorText?: string;
-}
-
 /**
- * Fold timeline items into one chip per `tool_use`, pairing each use with the
- * nearest following `tool_result` / `error` that shares the same `tool` name.
- *
- * Pairing note: `TimelineItem` deliberately does not expose the backend
- * `tool_call_id` (see `live-run-store.ts` WeakMap comment), so pairing is a
- * best-effort name-order heuristic. If the same tool is invoked twice before
- * the first result lands, chips briefly share state — acceptable for a live
- * indicator.
- *
- * Newest chip first (hermes pattern) so the most recent activity sits at the
- * top of the compact panel.
+ * Leading indicator dot in the header. Pulses while running; shows a
+ * solid success/error/cancelled marker once the run terminates so the
+ * card remains visually distinguishable after `done`/`error`.
  */
-function buildToolChips(items: readonly TimelineItem[]): ToolChipModel[] {
-  const chips: ToolChipModel[] = [];
-  for (let i = 0; i < items.length; i++) {
-    const use = items[i];
-    if (!use || use.kind !== 'tool_use' || !use.tool) continue;
-    const toolName = use.tool;
-    // Default to running when no pairing follow-up is found; a tool_use
-    // without a matching tool_result/error is still in-flight from the UI's
-    // perspective even if streaming has technically stopped.
-    let status: ToolChipModel['status'] = 'running';
-    let errorText: string | undefined;
-    for (let j = i + 1; j < items.length; j++) {
-      const follow = items[j];
-      if (!follow) continue;
-      if (follow.kind === 'tool_result' && follow.tool === toolName) {
-        status = follow.success === false ? 'errored' : 'completed';
-        if (status === 'errored' && follow.output) errorText = clip(follow.output);
-        break;
-      }
-      if (follow.kind === 'error') {
-        status = 'errored';
-        errorText = clip(follow.content ?? '');
-        break;
-      }
-    }
-    const chip: ToolChipModel = {
-      seq: use.seq,
-      tool: toolName,
-      preview: derivePreview(use.input),
-      status,
-    };
-    if (errorText !== undefined) chip.errorText = errorText;
-    chips.push(chip);
-  }
-  return chips.reverse();
-}
-
-/** Keys to try in priority order when deriving a short preview from tool input. */
-const PREVIEW_KEYS = [
-  'query',
-  'file_path',
-  'path',
-  'pattern',
-  'description',
-  'command',
-  'prompt',
-  'skill',
-] as const;
-
-function derivePreview(input: Record<string, unknown> | undefined): string {
-  if (!input) return '';
-  for (const key of PREVIEW_KEYS) {
-    const v = input[key];
-    if (typeof v === 'string' && v.length > 0) {
-      const shaped = key === 'file_path' || key === 'path' ? shortenPath(v) : v;
-      return clip(shaped);
-    }
-  }
-  for (const v of Object.values(input)) {
-    if (typeof v === 'string' && v.length > 0) return clip(v);
-  }
-  return '';
-}
-
-/** Clip long strings to ~110 chars with a trailing ellipsis. */
-function clip(s: string): string {
-  const limit = 110;
-  const flat = s.replace(/\s+/g, ' ').trim();
-  return flat.length > limit ? flat.slice(0, limit) + '…' : flat;
-}
-
-/** Render long paths as `…/<last-two-segments>` to keep chips one-line. */
-function shortenPath(p: string): string {
-  const parts = p.split('/').filter(Boolean);
-  if (parts.length <= 2) return p;
-  return '…/' + parts.slice(-2).join('/');
-}
-
-function ToolChip({ chip }: { chip: ToolChipModel }) {
-  const body = chip.status === 'errored' && chip.errorText ? chip.errorText : chip.preview;
-  return (
-    <div className="flex items-center gap-2 rounded-sm bg-muted/40 px-2 py-1 text-[11px]">
-      <StatusIcon status={chip.status} />
-      <span className="shrink-0 font-mono text-foreground">{chip.tool}</span>
-      {body && <span className="min-w-0 flex-1 truncate text-muted-foreground">{body}</span>}
-    </div>
-  );
-}
-
-function StatusIcon({ status }: { status: ToolChipModel['status'] }) {
+function RunStatusDot({ status }: { status: LiveRun['status'] }) {
   if (status === 'running') {
     return (
       <span
-        role="status"
-        aria-label="running"
-        className="inline-block h-3 w-3 shrink-0 animate-spin rounded-full border border-muted-foreground/30 border-t-muted-foreground"
+        className="flex h-2 w-2 shrink-0 animate-pulse rounded-full bg-emerald-500"
+        aria-hidden
       />
     );
   }
   if (status === 'completed') {
     return <CheckCircle2 aria-label="completed" className="h-3 w-3 shrink-0 text-emerald-500" />;
   }
-  return <AlertCircle aria-label="errored" className="h-3 w-3 shrink-0 text-destructive" />;
+  if (status === 'failed') {
+    return <AlertCircle aria-label="failed" className="h-3 w-3 shrink-0 text-destructive" />;
+  }
+  return (
+    <span
+      className="flex h-2 w-2 shrink-0 rounded-full bg-muted-foreground/50"
+      aria-label="cancelled"
+    />
+  );
 }
 
 /**

--- a/web/src/components/agent-live/__tests__/live-run-store.test.ts
+++ b/web/src/components/agent-live/__tests__/live-run-store.test.ts
@@ -77,7 +77,7 @@ describe('LiveRunStore', () => {
     expect(run.toolCalls).toBe(1);
   });
 
-  it('moves an active run into history on done and clears active slot', () => {
+  it('keeps a completed run pinned in the active slot after done', () => {
     const store = new LiveRunStore();
     const sk = 's3';
     store.publish(sk, startEvent);
@@ -85,20 +85,31 @@ describe('LiveRunStore', () => {
     store.publish(sk, toolEnd('a', 'done'));
     store.publish(sk, { type: 'done' } satisfies PublicWebEvent);
     const slice = store.snapshot(sk);
-    expect(slice.active).toBeNull();
+    expect(slice.active?.status).toBe('completed');
+    expect(slice.history).toHaveLength(0);
+  });
+
+  it('retires the completed run to history when the next stream starts', () => {
+    const store = new LiveRunStore();
+    const sk = 's3b';
+    store.publish(sk, startEvent);
+    store.publish(sk, { type: 'done' } satisfies PublicWebEvent);
+    store.publish(sk, startEvent);
+    const slice = store.snapshot(sk);
+    expect(slice.active?.status).toBe('running');
     expect(slice.history).toHaveLength(1);
     expect(slice.history[0]?.status).toBe('completed');
   });
 
-  it('marks a stream_closed without done as cancelled', () => {
+  it('marks a stream_closed without done as cancelled and keeps it visible', () => {
     const store = new LiveRunStore();
     const sk = 's4';
     store.publish(sk, startEvent);
     store.publish(sk, toolStart('a', 'Grep'));
     store.publish(sk, closeEvent);
     const slice = store.snapshot(sk);
-    expect(slice.active).toBeNull();
-    expect(slice.history[0]?.status).toBe('cancelled');
+    expect(slice.active?.status).toBe('cancelled');
+    expect(slice.history).toHaveLength(0);
   });
 
   it('tracks the latest progress.stage on the active run', () => {

--- a/web/src/components/agent-live/live-run-store.ts
+++ b/web/src/components/agent-live/live-run-store.ts
@@ -201,10 +201,18 @@ export function reduce(
   const type = event.type;
 
   if (type === '__stream_started') {
-    // Retire any run that was left dangling (e.g. WS reconnect) before
-    // opening a new active run. `cancelled` rather than `completed` so
-    // history UI reads accurately.
-    const retired = slice.active ? finalize(slice.active, 'cancelled', 'Stream restarted') : null;
+    // Retire the previous active run before opening a new one. If the run
+    // already terminated (`completed` / `failed`), keep its recorded
+    // status; only dangling `running` runs flip to `cancelled`. The
+    // reducer keeps terminal runs in the `active` slot until the next
+    // stream starts so the UI can render a persistent "last completed"
+    // card instead of an abrupt unmount on `done`.
+    const prev = slice.active;
+    const retired = prev
+      ? prev.status === 'running'
+        ? finalize(prev, 'cancelled', 'Stream restarted')
+        : prev
+      : null;
     const history = retired ? [retired, ...slice.history] : slice.history;
     const active: LiveRun = {
       runId: nextRunId(sessionKey),
@@ -222,13 +230,17 @@ export function reduce(
 
   if (type === '__stream_closed') {
     if (!slice.active) return slice;
-    // Close the run if no terminal `done`/`error` has arrived yet — the
-    // WebSocket hung up mid-flight, treat as cancelled.
+    // Already terminal (done/error arrived before close) — nothing to do;
+    // the card stays pinned in the active slot until the next run.
     if (slice.active.status !== 'running') {
-      return { active: null, history: [slice.active, ...slice.history] };
+      return slice;
     }
-    const retired = finalize(slice.active, 'cancelled', 'Stream closed');
-    return { active: null, history: [retired, ...slice.history] };
+    // WebSocket hung up mid-flight — mark cancelled but keep visible so
+    // the viewer can inspect what ran before the drop.
+    return {
+      ...slice,
+      active: finalize(slice.active, 'cancelled', 'Stream closed'),
+    };
   }
 
   // All remaining events need an active run.
@@ -237,13 +249,17 @@ export function reduce(
 
   switch (type) {
     case 'done': {
-      const retired = finalize(run, 'completed', null);
-      return { active: null, history: [retired, ...slice.history] };
+      // Keep the run in the active slot so the card persists as a
+      // "last completed" summary until the next stream starts. History
+      // still gets populated when a new run replaces this one.
+      return { ...slice, active: finalize(run, 'completed', null) };
     }
     case 'error': {
       const message = readString(event, 'message') ?? 'Unknown error';
-      const retired = finalize({ ...run, error: message }, 'failed', message);
-      return { active: null, history: [retired, ...slice.history] };
+      return {
+        ...slice,
+        active: finalize({ ...run, error: message }, 'failed', message),
+      };
     }
     case 'reasoning_delta': {
       const text = readString(event, 'text') ?? '';

--- a/web/src/components/agent-live/tool-chips.tsx
+++ b/web/src/components/agent-live/tool-chips.tsx
@@ -1,0 +1,241 @@
+/*
+ * Copyright 2025 Rararulab
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Shared tool-chip model and presentation used by both the live
+ * `SingleAgentLiveCard` and the historical `TurnToolcallCard`.
+ *
+ * A "chip" folds a `tool_use` timeline item together with its paired
+ * `tool_result` (or error) into one compact row showing the tool name,
+ * a short preview of the input, and a status icon.
+ */
+
+import { AlertCircle, CheckCircle2, ChevronRight } from 'lucide-react';
+import { useState } from 'react';
+
+import type { TimelineItem } from '@/api/kernel-types';
+import { cn } from '@/lib/utils';
+
+const DETAIL_MAX_CHARS = 4000;
+
+/** Status of a single folded tool chip. */
+export type ToolChipStatus = 'running' | 'completed' | 'errored';
+
+/** Data backing a single folded tool chip. */
+export interface ToolChipModel {
+  /** Source `tool_use` seq — used as React key. */
+  seq: number;
+  tool: string;
+  /** Derived short preview from the (redacted) input. Empty if nothing useful. */
+  preview: string;
+  status: ToolChipStatus;
+  /** Short error text when `status === 'errored'`. Replaces the preview in the UI. */
+  errorText?: string;
+  /** Raw tool input kept for expandable detail views. */
+  input?: Record<string, unknown> | undefined;
+  /** Raw paired output (preview text) kept for expandable detail views. */
+  output?: string | undefined;
+}
+
+/**
+ * Fold timeline items into one chip per `tool_use`, pairing each use with the
+ * nearest following `tool_result` / `error` that shares the same `tool` name.
+ *
+ * Pairing note: `TimelineItem` deliberately does not expose the backend
+ * `tool_call_id` (see `live-run-store.ts` WeakMap comment), so pairing is a
+ * best-effort name-order heuristic. If the same tool is invoked twice before
+ * the first result lands, chips briefly share state — acceptable for a live
+ * indicator.
+ */
+export function buildToolChips(items: readonly TimelineItem[]): ToolChipModel[] {
+  const chips: ToolChipModel[] = [];
+  for (let i = 0; i < items.length; i++) {
+    const use = items[i];
+    if (!use || use.kind !== 'tool_use' || !use.tool) continue;
+    const toolName = use.tool;
+    let status: ToolChipStatus = 'running';
+    let errorText: string | undefined;
+    let output: string | undefined;
+    for (let j = i + 1; j < items.length; j++) {
+      const follow = items[j];
+      if (!follow) continue;
+      if (follow.kind === 'tool_result' && follow.tool === toolName) {
+        status = follow.success === false ? 'errored' : 'completed';
+        if (follow.output) output = follow.output;
+        if (status === 'errored' && follow.output) errorText = clip(follow.output);
+        break;
+      }
+      if (follow.kind === 'error') {
+        status = 'errored';
+        errorText = clip(follow.content ?? '');
+        break;
+      }
+    }
+    const chip: ToolChipModel = {
+      seq: use.seq,
+      tool: toolName,
+      preview: derivePreview(use.input),
+      status,
+      input: use.input,
+    };
+    if (errorText !== undefined) chip.errorText = errorText;
+    if (output !== undefined) chip.output = output;
+    chips.push(chip);
+  }
+  return chips;
+}
+
+/** Keys to try in priority order when deriving a short preview from tool input. */
+const PREVIEW_KEYS = [
+  'query',
+  'file_path',
+  'path',
+  'pattern',
+  'description',
+  'command',
+  'prompt',
+  'skill',
+] as const;
+
+function derivePreview(input: Record<string, unknown> | undefined): string {
+  if (!input) return '';
+  for (const key of PREVIEW_KEYS) {
+    const v = input[key];
+    if (typeof v === 'string' && v.length > 0) {
+      const shaped = key === 'file_path' || key === 'path' ? shortenPath(v) : v;
+      return clip(shaped);
+    }
+  }
+  for (const v of Object.values(input)) {
+    if (typeof v === 'string' && v.length > 0) return clip(v);
+  }
+  return '';
+}
+
+/** Clip long strings to ~110 chars with a trailing ellipsis. */
+function clip(s: string): string {
+  const limit = 110;
+  const flat = s.replace(/\s+/g, ' ').trim();
+  return flat.length > limit ? flat.slice(0, limit) + '…' : flat;
+}
+
+/** Render long paths as `…/<last-two-segments>` to keep chips one-line. */
+function shortenPath(p: string): string {
+  const parts = p.split('/').filter(Boolean);
+  if (parts.length <= 2) return p;
+  return '…/' + parts.slice(-2).join('/');
+}
+
+export interface ToolChipProps {
+  chip: ToolChipModel;
+  /** When true, the chip is a button that expands an input/output detail pane. */
+  expandable?: boolean;
+}
+
+/**
+ * Compact one-line chip: status icon · tool name · preview (or error text).
+ *
+ * When `expandable` is set, clicking the chip toggles a muted detail panel
+ * showing the full tool input JSON and (when available) the paired output.
+ */
+export function ToolChip({ chip, expandable = false }: ToolChipProps) {
+  const [expanded, setExpanded] = useState(false);
+  const body = chip.status === 'errored' && chip.errorText ? chip.errorText : chip.preview;
+  const hasDetail =
+    (!!chip.input && Object.keys(chip.input).length > 0) || !!(chip.output && chip.output.length);
+  const canExpand = expandable && hasDetail;
+
+  const row = (
+    <div
+      className={cn(
+        'flex items-center gap-2 rounded-sm bg-muted/40 px-2 py-1 text-[11px]',
+        canExpand && 'cursor-pointer hover:bg-muted/60',
+      )}
+    >
+      {canExpand && (
+        <ChevronRight
+          className={cn(
+            'h-3 w-3 shrink-0 text-muted-foreground/50 transition-transform',
+            expanded && 'rotate-90',
+          )}
+          aria-hidden
+        />
+      )}
+      <StatusIcon status={chip.status} />
+      <span className="shrink-0 font-mono text-foreground">{chip.tool}</span>
+      {body && <span className="min-w-0 flex-1 truncate text-muted-foreground">{body}</span>}
+    </div>
+  );
+
+  if (!canExpand) {
+    return row;
+  }
+
+  return (
+    <div>
+      <button
+        type="button"
+        onClick={() => setExpanded((v) => !v)}
+        className="block w-full text-left"
+        aria-expanded={expanded}
+      >
+        {row}
+      </button>
+      <div
+        className={cn(
+          'grid transition-[grid-template-rows] duration-200 ease-out',
+          expanded ? 'grid-rows-[1fr]' : 'grid-rows-[0fr]',
+        )}
+      >
+        <div className="overflow-hidden">
+          <div className="mt-1 rounded border bg-muted/40">
+            {chip.input && Object.keys(chip.input).length > 0 && (
+              <pre className="max-h-60 overflow-auto whitespace-pre-wrap break-all p-3 text-[11px] text-muted-foreground">
+                {JSON.stringify(chip.input, null, 2)}
+              </pre>
+            )}
+            {chip.output && chip.output.length > 0 && (
+              <pre className="max-h-60 overflow-auto whitespace-pre-wrap break-all border-t p-3 text-[11px] text-muted-foreground">
+                {truncate(chip.output)}
+              </pre>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function StatusIcon({ status }: { status: ToolChipStatus }) {
+  if (status === 'running') {
+    return (
+      <span
+        role="status"
+        aria-label="running"
+        className="inline-block h-3 w-3 shrink-0 animate-spin rounded-full border border-muted-foreground/30 border-t-muted-foreground"
+      />
+    );
+  }
+  if (status === 'completed') {
+    return <CheckCircle2 aria-label="completed" className="h-3 w-3 shrink-0 text-emerald-500" />;
+  }
+  return <AlertCircle aria-label="errored" className="h-3 w-3 shrink-0 text-destructive" />;
+}
+
+function truncate(s: string): string {
+  if (s.length <= DETAIL_MAX_CHARS) return s;
+  return s.slice(0, DETAIL_MAX_CHARS) + '\n... (truncated)';
+}

--- a/web/src/components/kernel/SessionDetail.tsx
+++ b/web/src/components/kernel/SessionDetail.tsx
@@ -15,12 +15,14 @@
  */
 
 import { Zap } from 'lucide-react';
-import { Fragment, useCallback, useRef, useState } from 'react';
+import { Fragment, useCallback, useMemo, useRef, useState } from 'react';
 
 import { SessionHeader } from './SessionHeader';
 import { TimelineBar } from './TimelineBar';
 import { TimelineRow } from './TimelineRow';
+import { TurnToolcallCard, isToolcallItem } from './TurnToolcallCard';
 
+import type { TimelineItem } from '@/api/kernel-types';
 import { Skeleton } from '@/components/ui/skeleton';
 import { useSessionTimeline } from '@/hooks/use-session-timeline';
 
@@ -45,6 +47,11 @@ export interface SessionDetailProps {
  *
  * Consumes `useSessionTimeline` and renders the full execution trace.
  * Wrapped by `KernelTop` — selected session is passed from the list.
+ *
+ * Rendering strategy: non-tool timeline items (`thinking`, `agent`,
+ * `plan_card`, ...) map to a `TimelineRow`; consecutive tool-call items
+ * from the same turn collapse into a single `TurnToolcallCard` so the
+ * compact chip view replaces the verbose per-call rows.
  */
 export function SessionDetail({ session, autoRefresh }: SessionDetailProps) {
   const timeline = useSessionTimeline(session.agent_id, session.state, autoRefresh);
@@ -55,6 +62,11 @@ export function SessionDetail({ session, autoRefresh }: SessionDetailProps) {
     setSelectedIdx(idx);
     rowRefs.current.get(idx)?.scrollIntoView({ behavior: 'smooth', block: 'center' });
   }, []);
+
+  const groups = useMemo(
+    () => groupTimeline(timeline.items, timeline.historicalItems.length),
+    [timeline.items, timeline.historicalItems.length],
+  );
 
   return (
     <div className="flex h-full flex-col">
@@ -99,26 +111,37 @@ export function SessionDetail({ session, autoRefresh }: SessionDetailProps) {
           </div>
         ) : (
           <div className="divide-y">
-            {timeline.items.map((item, idx) => {
-              const prev = timeline.items[idx - 1];
-              const turnChanged = idx > 0 && (!prev || prev.turn !== item.turn);
-              const isLive = idx >= timeline.historicalItems.length;
-              const rowKey = `${isLive ? 'l' : 'h'}-${item.turn}-${item.seq}-${idx}`;
+            {groups.map((group) => {
+              if (group.kind === 'toolcall') {
+                return (
+                  <Fragment key={group.key}>
+                    {group.turnHeader && (
+                      <div className="bg-muted/40 px-4 py-1 text-[10px] uppercase tracking-wider text-muted-foreground">
+                        Turn #{group.turn + 1}
+                      </div>
+                    )}
+                    <TurnToolcallCard items={group.items} turn={group.turn} isLive={group.isLive} />
+                  </Fragment>
+                );
+              }
+              const { item, absoluteIdx, turnHeader } = group;
               return (
-                <Fragment key={rowKey}>
-                  {turnChanged && (
+                <Fragment key={group.key}>
+                  {turnHeader && (
                     <div className="bg-muted/40 px-4 py-1 text-[10px] uppercase tracking-wider text-muted-foreground">
                       Turn #{item.turn + 1}
                     </div>
                   )}
                   <TimelineRow
                     ref={(el) => {
-                      if (el) rowRefs.current.set(idx, el);
-                      else rowRefs.current.delete(idx);
+                      if (el) rowRefs.current.set(absoluteIdx, el);
+                      else rowRefs.current.delete(absoluteIdx);
                     }}
                     item={item}
-                    isSelected={selectedIdx === idx}
-                    onClick={() => setSelectedIdx((prev) => (prev === idx ? null : idx))}
+                    isSelected={selectedIdx === absoluteIdx}
+                    onClick={() =>
+                      setSelectedIdx((prev) => (prev === absoluteIdx ? null : absoluteIdx))
+                    }
                   />
                 </Fragment>
               );
@@ -128,4 +151,79 @@ export function SessionDetail({ session, autoRefresh }: SessionDetailProps) {
       </div>
     </div>
   );
+}
+
+/** Rendered slot in the event list — either a single row or a toolcall card. */
+type TimelineGroup =
+  | {
+      kind: 'row';
+      key: string;
+      item: TimelineItem;
+      absoluteIdx: number;
+      turnHeader: boolean;
+    }
+  | {
+      kind: 'toolcall';
+      key: string;
+      turn: number;
+      items: TimelineItem[];
+      isLive: boolean;
+      turnHeader: boolean;
+    };
+
+/**
+ * Split a flat `TimelineItem[]` into renderable groups. Consecutive
+ * tool-call items (see {@link isToolcallItem}) sharing the same `turn`
+ * collapse into one `toolcall` group; everything else becomes a `row`
+ * group. The first item of a new turn carries a `turnHeader` flag so
+ * the caller can render the divider consistently.
+ */
+function groupTimeline(items: TimelineItem[], historicalCount: number): TimelineGroup[] {
+  const groups: TimelineGroup[] = [];
+  let prevTurn: number | null = null;
+  let i = 0;
+  while (i < items.length) {
+    const item = items[i];
+    if (!item) {
+      i++;
+      continue;
+    }
+    const turnHeader = prevTurn !== null && prevTurn !== item.turn;
+    if (isToolcallItem(item)) {
+      // Greedy fold all consecutive tool-call items of the same turn.
+      const bundle: TimelineItem[] = [];
+      const firstSeq = item.seq;
+      const turn = item.turn;
+      let liveInGroup = false;
+      while (i < items.length) {
+        const cur = items[i];
+        if (!cur || cur.turn !== turn || !isToolcallItem(cur)) break;
+        if (i >= historicalCount) liveInGroup = true;
+        bundle.push(cur);
+        i++;
+      }
+      groups.push({
+        kind: 'toolcall',
+        key: `tc-${turn}-${firstSeq}`,
+        turn,
+        items: bundle,
+        isLive: liveInGroup,
+        turnHeader,
+      });
+      prevTurn = turn;
+      continue;
+    }
+    const absoluteIdx = i;
+    const isLive = absoluteIdx >= historicalCount;
+    groups.push({
+      kind: 'row',
+      key: `${isLive ? 'l' : 'h'}-${item.turn}-${item.seq}-${absoluteIdx}`,
+      item,
+      absoluteIdx,
+      turnHeader,
+    });
+    prevTurn = item.turn;
+    i++;
+  }
+  return groups;
 }

--- a/web/src/components/kernel/TurnToolcallCard.tsx
+++ b/web/src/components/kernel/TurnToolcallCard.tsx
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2025 Rararulab
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ChevronDown, Wrench } from 'lucide-react';
+import { useState } from 'react';
+
+import type { TimelineItem } from '@/api/kernel-types';
+import { ToolChip, buildToolChips } from '@/components/agent-live/tool-chips';
+import { cn } from '@/lib/utils';
+
+export interface TurnToolcallCardProps {
+  /** Tool-related items (`tool_use` / `tool_result` / bare `error`) for one turn. */
+  items: TimelineItem[];
+  /** 0-based turn index — used only for the React key by the parent. */
+  turn: number;
+  /** True when any `tool_use` in `items` is still streaming. */
+  isLive?: boolean;
+}
+
+/**
+ * Collapsed per-turn summary of every tool call made within a single
+ * agent turn. Replaces the previous inline `tool_use` / `tool_result`
+ * rows in `SessionDetail` — the same information in a denser form, with
+ * click-to-expand JSON payloads.
+ */
+export function TurnToolcallCard({ items, isLive = false }: TurnToolcallCardProps) {
+  const [expanded, setExpanded] = useState(true);
+  const chips = buildToolChips(items);
+  if (chips.length === 0) return null;
+
+  const completed = chips.filter((c) => c.status === 'completed').length;
+  const errored = chips.filter((c) => c.status === 'errored').length;
+  const running = chips.filter((c) => c.status === 'running').length;
+
+  return (
+    <section className="px-4 py-2">
+      <button
+        type="button"
+        onClick={() => setExpanded((v) => !v)}
+        aria-expanded={expanded}
+        className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left transition hover:bg-accent/40"
+      >
+        <Wrench className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+        <span className="text-xs font-medium text-foreground">
+          {chips.length} tool call{chips.length === 1 ? '' : 's'}
+        </span>
+        <span className="flex-1 truncate text-[11px] text-muted-foreground">
+          {running > 0 && <span className="mr-2">{running} running</span>}
+          {completed > 0 && <span className="mr-2 text-emerald-600">{completed} ok</span>}
+          {errored > 0 && <span className="mr-2 text-destructive">{errored} errored</span>}
+        </span>
+        {isLive && (
+          <span
+            className="h-1.5 w-1.5 shrink-0 animate-pulse rounded-full bg-emerald-500"
+            aria-hidden
+          />
+        )}
+        <ChevronDown
+          className={cn(
+            'h-3.5 w-3.5 shrink-0 text-muted-foreground transition-transform',
+            expanded && 'rotate-180',
+          )}
+          aria-hidden
+        />
+      </button>
+
+      {expanded && (
+        <div className="mt-1.5 flex flex-col gap-1 pl-6">
+          {chips.map((chip) => (
+            <ToolChip key={`c-${chip.seq}`} chip={chip} expandable />
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}
+
+/** Whether a timeline item belongs to the per-turn tool-call card. */
+export function isToolcallItem(item: TimelineItem): boolean {
+  if (item.kind === 'tool_use' || item.kind === 'tool_result') return true;
+  // Bare `error` rows that were emitted from a tool-call end carry a `tool`
+  // name — fold them into the card so the chip shows the error text.
+  // Turn-level errors (no `tool`) stay inline as a regular error row.
+  if (item.kind === 'error' && item.tool) return true;
+  return false;
+}

--- a/web/src/pages/AGENT.md
+++ b/web/src/pages/AGENT.md
@@ -12,9 +12,13 @@ React page-level components that mount pi-web-ui's Lit web components
   flagged as the final one of its turn.
 - `pi-chat-messages.ts` — pure conversion from rara's `ChatMessageData` shape
   (see `@/api/types`) into pi-agent-core `Message` objects. Owns
-  `assistantSeqByRef` (a `WeakMap<AssistantMessage, number>`) and the
-  `finalAssistantIndices` helper that computes which assistant per turn is the
-  "final" one.
+  `assistantSeqByRef` (a `WeakMap<AssistantMessage, number>`),
+  `toolResultByCallId` (a `Map<string, ToolResultMessage>` populated as a
+  side-channel so tool results are NOT emitted as standalone bubbles — see
+  #1718), `messagesForArtifactReconstruction` (re-weaves those results back
+  in for `ArtifactsPanel.reconstructFromMessages`), and the
+  `finalAssistantIndices` helper that computes which assistant per turn is
+  the "final" one.
 - `pi-chat-messages.test.ts` — unit tests for the conversion + final-assistant
   gating logic.
 - Other pages (`Agents.tsx`, `Skills.tsx`, `McpServers.tsx`, etc.) follow the
@@ -69,6 +73,11 @@ AssistantMessage[]  ──────────────►   pi-web-ui re
   buttons gate.
 - Do NOT clone or spread (`{ ...msg }`) the `AssistantMessage` between
   registration and the renderer — WeakMap keys are by identity, not by value.
+- Do NOT re-introduce standalone `ToolResultMessage` entries in
+  `toAgentMessages`' output list. Pi-web-ui's `<message-list>` renders one
+  DOM row per message object; under rara's avatar CSS that means one bare
+  avatar per tool result. Keep results in `toolResultByCallId` and let the
+  custom assistant renderer inline them via `toolResultsById` (#1718).
 - Do NOT move the `assistantSeqByRef` declaration to a barrel/re-export file
   without keeping the canonical instance in `pi-chat-messages.ts`; re-exports
   are fine, redeclarations are not.

--- a/web/src/pages/PiChat.tsx
+++ b/web/src/pages/PiChat.tsx
@@ -39,7 +39,12 @@ import { useEffect, useRef, useCallback, useState } from 'react';
 // object is executed server-side; the renderer is what matters here.
 void extractDocumentTool;
 
-import { assistantSeqByRef, toAgentMessages } from './pi-chat-messages';
+import {
+  assistantSeqByRef,
+  messagesForArtifactReconstruction,
+  toAgentMessages,
+  toolResultByCallId,
+} from './pi-chat-messages';
 
 import { RaraStorageBackend } from '@/adapters/rara-storage';
 import { createRaraStreamFn } from '@/adapters/rara-stream';
@@ -201,11 +206,18 @@ function registerCascadeAssistantRenderer(agentResolver: () => Agent | null): vo
     render(message) {
       const seq = assistantSeqByRef.get(message);
       const showButtons = seq !== undefined;
-      // Rebuild the toolResult lookup from current agent state. Cheap
-      // (a single linear scan) and avoids stale-closure bugs because the
-      // resolver always hits the live agent ref.
+      // Rebuild the toolResult lookup. Historical messages live in
+      // `toolResultByCallId` because `toAgentMessages` no longer emits
+      // standalone tool-result bubbles (#1718). Live streaming frames
+      // still land in `agent.state.messages` as `toolResult` entries
+      // (pi-agent-core's post-stream loop pushes them after the relay
+      // tool resolves), so we merge both sources here — streaming
+      // wins on key collision so a fresher result from the current
+      // turn can override a stale persisted one.
       const agent = agentResolver();
-      const resultByCallId = new Map<string, import('@mariozechner/pi-ai').ToolResultMessage>();
+      const resultByCallId = new Map<string, import('@mariozechner/pi-ai').ToolResultMessage>(
+        toolResultByCallId,
+      );
       if (agent) {
         for (const m of agent.state.messages) {
           if (m.role === 'toolResult') {
@@ -524,7 +536,9 @@ export default function PiChat() {
       }
       // Rebuild the artifacts panel from the same message list so switching
       // back to a session restores every previously-created artifact.
-      await chatPanelRef.current?.artifactsPanel?.reconstructFromMessages(agentMsgs);
+      await chatPanelRef.current?.artifactsPanel?.reconstructFromMessages(
+        messagesForArtifactReconstruction(agentMsgs),
+      );
     } catch {
       /* session may have no messages yet */
     }
@@ -551,7 +565,9 @@ export default function PiChat() {
       );
       const agentMsgs = toAgentMessages(msgs);
       agent.replaceMessages(agentMsgs);
-      await chatPanelRef.current?.artifactsPanel?.reconstructFromMessages(agentMsgs);
+      await chatPanelRef.current?.artifactsPanel?.reconstructFromMessages(
+        messagesForArtifactReconstruction(agentMsgs),
+      );
       chatPanelRef.current?.agentInterface?.requestUpdate();
     } catch {
       /* ignore */

--- a/web/src/pages/__tests__/pi-chat-messages.test.ts
+++ b/web/src/pages/__tests__/pi-chat-messages.test.ts
@@ -17,7 +17,13 @@
 import type { AssistantMessage } from '@mariozechner/pi-ai';
 import { describe, expect, it } from 'vitest';
 
-import { assistantSeqByRef, finalAssistantIndices, toAgentMessages } from '../pi-chat-messages';
+import {
+  assistantSeqByRef,
+  finalAssistantIndices,
+  messagesForArtifactReconstruction,
+  toAgentMessages,
+  toolResultByCallId,
+} from '../pi-chat-messages';
 
 import type { ChatMessageData, ChatToolCallData } from '@/api/types';
 
@@ -158,5 +164,58 @@ describe('toAgentMessages — trace button registration (#1672)', () => {
     const [a] = assistants(out);
     expect(isRegistered(a)).toBe(true);
     expect(assistantSeqByRef.get(expectAssistant(a))).toBe(2);
+  });
+});
+
+describe('toAgentMessages — tool-result side-channel (#1718)', () => {
+  it('does NOT emit standalone ToolResultMessage entries into the display list', () => {
+    const out = toAgentMessages([
+      user(1),
+      assistantToolCall(2),
+      toolResult(3, 2),
+      assistantText(4),
+    ]);
+    expect(out.some((m) => m.role === 'toolResult')).toBe(false);
+  });
+
+  it('populates toolResultByCallId so the assistant renderer can pair results to calls', () => {
+    toAgentMessages([user(1), assistantToolCall(2), toolResult(3, 2), assistantText(4)]);
+    const tr = toolResultByCallId.get('tc-2');
+    expect(tr).toBeDefined();
+    expect(tr?.toolName).toBe('do_thing');
+    expect(tr?.isError).toBe(false);
+  });
+
+  it('marks kernel-style failure JSON results as errors', () => {
+    const errorResult: ChatMessageData = {
+      seq: 3,
+      role: 'tool_result',
+      content: '{"error": "boom"}',
+      tool_call_id: 'tc-2',
+      tool_name: 'do_thing',
+      created_at: ISO,
+    };
+    toAgentMessages([user(1), assistantToolCall(2), errorResult]);
+    expect(toolResultByCallId.get('tc-2')?.isError).toBe(true);
+  });
+
+  it('clears stale side-channel entries across conversions', () => {
+    toAgentMessages([user(1), assistantToolCall(2), toolResult(3, 2)]);
+    expect(toolResultByCallId.has('tc-2')).toBe(true);
+    toAgentMessages([user(1), assistantText(2)]);
+    expect(toolResultByCallId.has('tc-2')).toBe(false);
+  });
+
+  it('messagesForArtifactReconstruction re-weaves tool results after their paired assistant', () => {
+    const out = toAgentMessages([
+      user(1),
+      assistantToolCall(2),
+      toolResult(3, 2),
+      assistantText(4),
+    ]);
+    const woven = messagesForArtifactReconstruction(out);
+    const roles = woven.map((m) => m.role);
+    // Expect: user, assistant(toolCall), toolResult, assistant(text)
+    expect(roles).toEqual(['user', 'assistant', 'toolResult', 'assistant']);
   });
 });

--- a/web/src/pages/pi-chat-messages.ts
+++ b/web/src/pages/pi-chat-messages.ts
@@ -104,6 +104,28 @@ function parseAssistantContent(raw: string): (TextContent | ThinkingContent)[] {
 export const assistantSeqByRef = new WeakMap<AgentMessage, number>();
 
 /**
+ * Module-level side-channel from `tool_call_id` → the persisted
+ * {@link ToolResultMessage} for that call. Populated by
+ * {@link toAgentMessages} instead of pushing standalone tool-result
+ * bubbles into the message list — pi-web-ui's `<message-list>` assigns
+ * one DOM row (and, via rara's CSS, one avatar) per message object,
+ * so emitting a tool result as its own entry surfaced every result as
+ * a bare avatar+bubble under the assistant's reply (#1718).
+ *
+ * The custom assistant renderer in `PiChat.tsx` reads this map to
+ * build the `toolResultsById` lookup that pi-web-ui's
+ * `<assistant-message>` needs to inline the result under its paired
+ * `<tool-message>`. The same map is also consumed by
+ * {@link messagesForArtifactReconstruction} so pi-web-ui's
+ * `ArtifactsPanel.reconstructFromMessages` (which walks tool-result
+ * messages to replay artifact operations) keeps working.
+ *
+ * Cleared at the start of every {@link toAgentMessages} call so a
+ * session switch does not leak results from the previous session.
+ */
+export const toolResultByCallId = new Map<string, ToolResultMessage>();
+
+/**
  * For each turn (a contiguous run of non-user messages bounded by the
  * next user message or the end of the list), return the index in `msgs`
  * of the last `assistant`-role message in that turn. Indices not in the
@@ -147,6 +169,9 @@ export function toAgentMessages(msgs: ChatMessageData[]): AgentMessage[] {
   // Track the last assistant message so "tool" role messages can attach ToolCall items.
   let lastAssistant: AssistantMessage | null = null;
   const finals = finalAssistantIndices(msgs);
+  // Reset the side-channel: subsequent loads must not see stale entries
+  // from a previous session.
+  toolResultByCallId.clear();
 
   for (let i = 0; i < msgs.length; i++) {
     const m = msgs[i];
@@ -249,12 +274,24 @@ export function toAgentMessages(msgs: ChatMessageData[]): AgentMessage[] {
         lastAssistant.content.push(toolCall);
       }
     } else if (m.role === 'tool_result') {
-      // Tool result — emit as a separate ToolResultMessage. Preserve the
-      // backend's failure markers so ArtifactsPanel.reconstructFromMessages
-      // (which only replays successful ops) skips failed calls on reload.
-      // The kernel serializes failures in two shapes: a bare string starting
-      // with "Error:" (pi-mono convention) and JSON objects with an `error`
-      // key (produced by the anyhow -> ToolOutput path).
+      // Tool result — DO NOT push as a standalone AgentMessage; that
+      // made pi-web-ui's `<message-list>` render each result as its own
+      // DOM row with its own avatar under rara's CSS, creating a
+      // bare-bubble chain under the assistant reply (#1718). Instead
+      // stash the result in `toolResultByCallId` for:
+      //   1. `PiChat.tsx`'s custom assistant renderer, which builds the
+      //      `toolResultsById` map that `<assistant-message>` uses to
+      //      inline the result under its paired `<tool-message>`; and
+      //   2. `ArtifactsPanel.reconstructFromMessages`, via
+      //      {@link messagesForArtifactReconstruction} — artifacts
+      //      replay walks tool-result messages to reconstruct state.
+      //
+      // Preserve the backend's failure markers so the artifacts panel
+      // (which only replays successful ops) skips failed calls on
+      // reload. The kernel serializes failures in two shapes: a bare
+      // string starting with "Error:" (pi-mono convention) and JSON
+      // objects with an `error` key (produced by the anyhow ->
+      // ToolOutput path).
       if (m.tool_call_id && m.tool_name) {
         const text =
           typeof m.content === 'string'
@@ -271,9 +308,49 @@ export function toAgentMessages(msgs: ChatMessageData[]): AgentMessage[] {
           isError: isToolFailure(text),
           timestamp: ts,
         };
-        result.push(toolResult as AgentMessage);
+        toolResultByCallId.set(m.tool_call_id, toolResult);
       }
     }
   }
   return result;
+}
+
+/**
+ * Return the message list for display plus a parallel list augmented
+ * with the suppressed tool-result bubbles, suitable for pi-web-ui's
+ * `ArtifactsPanel.reconstructFromMessages` which pairs assistant
+ * tool-calls with their `toolResult` responses to replay artifact
+ * operations.
+ *
+ * The augmented list inserts each `ToolResultMessage` directly after
+ * the assistant message that contains its matching `ToolCall`, so
+ * reconstruction sees call/result pairs in the same relative order as
+ * the backend persisted them. Results whose calls are not found (e.g.
+ * a persisted tool result without its paired assistant tool-call on
+ * this page) are appended at the end so nothing is silently dropped.
+ *
+ * Reads from {@link toolResultByCallId}, so this MUST be called after
+ * {@link toAgentMessages} for the same message list — the side-channel
+ * map is cleared on every `toAgentMessages` call.
+ */
+export function messagesForArtifactReconstruction(displayMessages: AgentMessage[]): AgentMessage[] {
+  if (toolResultByCallId.size === 0) return displayMessages;
+  const augmented: AgentMessage[] = [];
+  const emitted = new Set<string>();
+  for (const msg of displayMessages) {
+    augmented.push(msg);
+    if (msg.role !== 'assistant') continue;
+    for (const part of msg.content) {
+      if (part.type !== 'toolCall') continue;
+      const tr = toolResultByCallId.get(part.id);
+      if (tr && !emitted.has(part.id)) {
+        augmented.push(tr as AgentMessage);
+        emitted.add(part.id);
+      }
+    }
+  }
+  for (const [id, tr] of toolResultByCallId) {
+    if (!emitted.has(id)) augmented.push(tr as AgentMessage);
+  }
+  return augmented;
 }

--- a/web/src/tools/rara-tool-renderers.ts
+++ b/web/src/tools/rara-tool-renderers.ts
@@ -23,7 +23,7 @@
  * module-level `Map`, so late registration would miss the first render.
  */
 
-import { BashRenderer, registerToolRenderer } from '@mariozechner/pi-web-ui';
+import { registerToolRenderer } from '@mariozechner/pi-web-ui';
 
 import { CompactToolRenderer } from './CompactToolRenderer';
 
@@ -31,11 +31,15 @@ import { CompactToolRenderer } from './CompactToolRenderer';
  * Tool names declared by the rara backend (see `crates/app/src/tools/`).
  * Everything in this list gets the compact single-line renderer.
  *
- * Four tools keep pi-mono's specialised renderers and are intentionally
+ * `bash` is included here (not given pi-mono's `BashRenderer`) so every
+ * rara tool call has a uniform compact layout — a single-line summary
+ * plus a `<details>` block for the full command/IO. The specialised
+ * terminal card carried too much visual weight in long chat transcripts
+ * (#1718); users can still expand the row to see the entire command
+ * and output verbatim.
+ *
+ * Three tools keep pi-mono's specialised renderers and are intentionally
  * absent:
- * - `bash`            — pi-mono's `BashRenderer` shows a live terminal
- *                       block, which fits a single command better than
- *                       a truncated one-liner.
  * - `artifacts`       — `ArtifactsToolRenderer` renders the artifact
  *                       card UX; JSON wouldn't help.
  * - `javascript_repl` — pi-mono-registered; no rara-side equivalent.
@@ -49,6 +53,7 @@ import { CompactToolRenderer } from './CompactToolRenderer';
 const RARA_COMPACT_TOOLS = [
   'acp-delegate',
   'ask-user',
+  'bash',
   'create-directory',
   'create-skill',
   'debug_trace',
@@ -96,8 +101,6 @@ const RARA_COMPACT_TOOLS = [
 ];
 
 export function registerRaraToolRenderers(): void {
-  registerToolRenderer('bash', new BashRenderer());
-
   for (const name of RARA_COMPACT_TOOLS) {
     registerToolRenderer(name, new CompactToolRenderer(name));
   }


### PR DESCRIPTION
## Summary

- Extracted `buildToolChips` + `ToolChip` into a shared module (`components/agent-live/tool-chips.tsx`) reused by both the live `SingleAgentLiveCard` and a new historical `TurnToolcallCard`.
- `SessionDetail` now groups consecutive `tool_use` / `tool_result` (plus tool-bound `error`) items from the same turn into one collapsible `TurnToolcallCard`; non-tool items (`thinking`, `agent`, `plan_card`, etc.) still render as `TimelineRow`.
- Live-run-store keeps terminal runs pinned in the `active` slot until the next `__stream_started` retires them to history, so the live card no longer vanishes on `done` / `error`. The header dot flips to a solid success / error / cancelled marker and the stop button hides once the run settles.

Turn boundary signal: the existing `TimelineItem.turn` (0-based turn index) on historical items plus `liveTurnIdx` on live items — no schema changes required.

## Type of change

| Type | Label |
|------|-------|
| Refactor | `refactor` |

## Component

`ui`

## Closes

Closes #1718

## Test plan

- [x] `npm run build` passes
- [x] `npm run lint` passes
- [x] `npm run test` passes (72 tests, includes updated `live-run-store` reducer expectations)
- [x] `npm run format:check` passes