### PR TITLE
feat(web): RequireAuth route guard (#1722)

### DIFF
--- a/web/e2e/harness/chat.spec.ts
+++ b/web/e2e/harness/chat.spec.ts
@@ -17,7 +17,7 @@
 import AxeBuilder from '@axe-core/playwright';
 import { test, expect } from '@playwright/test';
 
-import { freezePageClock, primeBackendUrl, stubApi } from './helpers';
+import { freezePageClock, primeAuth, primeBackendUrl, stubApi } from './helpers';
 
 test.describe('chat page with seeded sessions', () => {
   test.beforeEach(async ({ page }) => {
@@ -41,6 +41,7 @@ test.describe('chat page with seeded sessions', () => {
       ],
     });
     await primeBackendUrl(page);
+    await primeAuth(page);
   });
 
   test('renders the sidebar history list with rows and passes a11y', async ({ page }, testInfo) => {

--- a/web/e2e/harness/helpers.ts
+++ b/web/e2e/harness/helpers.ts
@@ -33,6 +33,21 @@ export async function primeBackendUrl(page: Page, url = 'http://localhost:25555'
 }
 
 /**
+ * Pre-seed the auth localStorage entries so `<RequireAuth>` doesn't redirect
+ * the harness to `/login`. Keys mirror the constants in `src/api/client.ts`
+ * (`ACCESS_TOKEN_KEY`, `AUTH_USER_KEY`).
+ */
+export async function primeAuth(page: Page): Promise<void> {
+  await page.addInitScript(() => {
+    window.localStorage.setItem('access_token', 'harness-token');
+    window.localStorage.setItem(
+      'auth_user',
+      JSON.stringify({ user_id: 'harness', role: 'owner', is_admin: true }),
+    );
+  });
+}
+
+/**
  * Pinned "now" the harness renders against. Fixture `updated_at`
  * values in `stubApi` are anchored to this moment, and
  * `freezePageClock` installs the same instant into the page's JS

--- a/web/e2e/harness/welcome.spec.ts
+++ b/web/e2e/harness/welcome.spec.ts
@@ -17,13 +17,14 @@
 import AxeBuilder from '@axe-core/playwright';
 import { test, expect } from '@playwright/test';
 
-import { freezePageClock, primeBackendUrl, stubApi } from './helpers';
+import { freezePageClock, primeAuth, primeBackendUrl, stubApi } from './helpers';
 
 test.describe('welcome page', () => {
   test.beforeEach(async ({ page }) => {
     await freezePageClock(page);
     await stubApi(page, { sessions: [] });
     await primeBackendUrl(page);
+    await primeAuth(page);
   });
 
   test('renders without active sessions and passes baseline a11y', async ({ page }, testInfo) => {

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -19,6 +19,7 @@ import { useEffect, useState } from 'react';
 import { BrowserRouter, Routes, Route, useNavigate } from 'react-router';
 
 import { ConnectionSetupDialog } from '@/components/ConnectionSetupDialog';
+import { RequireAuth } from '@/components/RequireAuth';
 import { ServerStatusProvider } from '@/components/ServerStatusProvider';
 import {
   SettingsModalProvider,
@@ -81,17 +82,37 @@ export default function App() {
         <BrowserRouter>
           <SettingsModalProvider>
             <Routes>
-              {/* Fullscreen pi-web-ui chat */}
-              <Route index element={<PiChat />} />
-
-              {/* Owner-token login — public route */}
+              {/* Owner-token login — public route, must not be guarded. */}
               <Route path="login" element={<Login />} />
 
+              {/* Fullscreen pi-web-ui chat */}
+              <Route
+                index
+                element={
+                  <RequireAuth>
+                    <PiChat />
+                  </RequireAuth>
+                }
+              />
+
               {/* Deep-link redirect — see SettingsRoute */}
-              <Route path="settings" element={<SettingsRoute />} />
+              <Route
+                path="settings"
+                element={
+                  <RequireAuth>
+                    <SettingsRoute />
+                  </RequireAuth>
+                }
+              />
 
               {/* Admin pages with dashboard layout */}
-              <Route element={<DashboardLayout />}>
+              <Route
+                element={
+                  <RequireAuth>
+                    <DashboardLayout />
+                  </RequireAuth>
+                }
+              >
                 <Route path="docs" element={<Docs />} />
                 <Route path="kernel-top" element={<KernelTop />} />
                 <Route path="dock" element={<Dock />} />

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -98,6 +98,22 @@ export function getAuthUser(): AuthUser | null {
   return null;
 }
 
+/**
+ * Read both the access token and authenticated principal from localStorage.
+ *
+ * Returns `null` if either is missing, if `auth_user` is malformed JSON, or if
+ * the cached principal has an empty `user_id`. Shared by the fetch helper and
+ * the `<RequireAuth>` route guard so there is a single source of truth for
+ * "is the user logged in".
+ */
+export function getStoredAuth(): { token: string; user: AuthUser } | null {
+  const token = getAccessToken();
+  if (!token) return null;
+  const user = getAuthUser();
+  if (!user || user.user_id === '') return null;
+  return { token, user };
+}
+
 /** Persist the access token and principal after a successful login. */
 export function setAuth(token: string, user: AuthUser): void {
   localStorage.setItem(ACCESS_TOKEN_KEY, token);

--- a/web/src/components/RequireAuth.tsx
+++ b/web/src/components/RequireAuth.tsx
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2025 Rararulab
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { ReactNode } from 'react';
+import { Navigate, useLocation } from 'react-router';
+
+import { clearAuth, getStoredAuth } from '@/api/client';
+
+interface RequireAuthProps {
+  children: ReactNode;
+}
+
+/**
+ * Route guard that redirects to `/login` when the user is not authenticated.
+ *
+ * Checks `getStoredAuth()` on every render. If the access token or cached
+ * principal is missing (or malformed, or has an empty `user_id`), the stored
+ * auth is cleared and the user is redirected to `/login?redirect=<pathname>`,
+ * preserving the requested path + search string so Login can send them back
+ * after sign-in.
+ *
+ * The `/login` route itself must not be wrapped — it is the fallback
+ * destination and wrapping it would cause a redirect loop.
+ *
+ * This guard complements (does not replace) the 401-driven redirect in the
+ * fetch helper and WebSocket builder: it covers pages that render without
+ * making any network call on mount.
+ */
+export function RequireAuth({ children }: RequireAuthProps) {
+  const location = useLocation();
+
+  if (getStoredAuth() === null) {
+    // Evict any partial/stale state so the fetch helper agrees with us.
+    clearAuth();
+    const redirect = encodeURIComponent(location.pathname + location.search);
+    return <Navigate to={`/login?redirect=${redirect}`} replace />;
+  }
+
+  return <>{children}</>;
+}


### PR DESCRIPTION
## Summary

Part of #1710 admin-auth epic. Follow-up to summary PR #1721 review: 6b chose not to add a route guard and relied on fetch/WS 401 redirect, which leaves pages that make no on-mount API call blank for unauthenticated users.

- Add `<RequireAuth>` in `web/src/components/RequireAuth.tsx` that checks `getStoredAuth()` on every render and `<Navigate replace to="/login?redirect=<path>">` when logged out; the `/login` route itself stays public to avoid a redirect loop.
- Extract `getStoredAuth()` in `api/client.ts` as the single source of truth for "is the user logged in". Treats missing token, missing principal, malformed `auth_user` JSON, and empty `user_id` all as logged out. Uses the existing `ACCESS_TOKEN_KEY`/`AUTH_USER_KEY` constants and `clearAuth()` helper.
- Wrap every protected route in `App.tsx` (`index`, `settings`, and the `DashboardLayout` group).

No role-based gating, no token refresh — follow-up concerns per summary PR body.

## Type of change

| Type | Label |
|------|-------|
| New feature | `enhancement` |

## Component

`ui`

## Closes

Closes #1722

## Test plan

- [x] `cd web && npm run typecheck` passes
- [x] `cd web && npm run lint` passes
- [x] `cd web && npm run build` passes