### PR TITLE
refactor(model): rename feed_events table to data_feed_events (#1720)

### DIFF
--- a/crates/app/src/feed_store.rs
+++ b/crates/app/src/feed_store.rs
@@ -14,9 +14,11 @@
 
 //! SQLite-backed [`FeedStore`] implementation.
 //!
-//! Persists [`FeedEvent`]s to the `feed_events` table and tracks per-subscriber
-//! read cursors in `feed_read_cursors`. Both tables are created by the
-//! `20260414125453_feed_events` migration.
+//! Persists [`FeedEvent`]s to the `data_feed_events` table and tracks
+//! per-subscriber read cursors in `feed_read_cursors`. The events table is
+//! created by the `20260414125453_feed_events` migration and renamed to
+//! `data_feed_events` by
+//! `20260424074904_rename_feed_events_to_data_feed_events`.
 
 use async_trait::async_trait;
 use jiff::Timestamp;
@@ -30,8 +32,8 @@ use tracing::instrument;
 
 /// SQLite-backed feed event store.
 ///
-/// Implements [`FeedStore`] using the `feed_events` and `feed_read_cursors`
-/// tables. All operations use the shared connection pool.
+/// Implements [`FeedStore`] using the `data_feed_events` and
+/// `feed_read_cursors` tables. All operations use the shared connection pool.
 pub struct SqliteFeedStore {
     pool: SqlitePool,
 }
@@ -54,7 +56,7 @@ impl FeedStore for SqliteFeedStore {
 
         // INSERT OR IGNORE for idempotency on event.id.
         sqlx::query(
-            "INSERT OR IGNORE INTO feed_events (id, source_name, event_type, tags, payload, \
+            "INSERT OR IGNORE INTO data_feed_events (id, source_name, event_type, tags, payload, \
              received_at) VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
         )
         .bind(&id)
@@ -65,7 +67,7 @@ impl FeedStore for SqliteFeedStore {
         .bind(&received_at)
         .execute(&self.pool)
         .await
-        .whatever_context("feed_events insert failed")?;
+        .whatever_context("data_feed_events insert failed")?;
 
         Ok(())
     }
@@ -73,7 +75,7 @@ impl FeedStore for SqliteFeedStore {
     #[instrument(skip_all)]
     async fn query(&self, filter: FeedFilter) -> rara_kernel::Result<Vec<FeedEvent>> {
         let mut sql = String::from(
-            "SELECT id, source_name, event_type, tags, payload, received_at FROM feed_events \
+            "SELECT id, source_name, event_type, tags, payload, received_at FROM data_feed_events \
              WHERE 1=1",
         );
         let mut binds: Vec<String> = Vec::new();
@@ -101,7 +103,7 @@ impl FeedStore for SqliteFeedStore {
         let rows: Vec<FeedEventRow> = query
             .fetch_all(&self.pool)
             .await
-            .whatever_context("feed_events query failed")?;
+            .whatever_context("data_feed_events query failed")?;
 
         let mut events: Vec<FeedEvent> = Vec::with_capacity(rows.len());
         for row in rows {
@@ -127,11 +129,11 @@ impl FeedStore for SqliteFeedStore {
         let event_id = up_to.to_string();
 
         let source: Option<(String,)> =
-            sqlx::query_as("SELECT source_name FROM feed_events WHERE id = ?1")
+            sqlx::query_as("SELECT source_name FROM data_feed_events WHERE id = ?1")
                 .bind(&event_id)
                 .fetch_optional(&self.pool)
                 .await
-                .whatever_context("feed_events lookup failed")?;
+                .whatever_context("data_feed_events lookup failed")?;
 
         let source_name = source.map(|s| s.0).unwrap_or_else(|| "unknown".to_owned());
 
@@ -156,9 +158,9 @@ impl FeedStore for SqliteFeedStore {
         let sub_id = subscriber.to_string();
 
         let count: (i64,) = sqlx::query_as(
-            "SELECT COUNT(*) FROM feed_events e WHERE NOT EXISTS (SELECT 1 FROM feed_read_cursors \
-             c WHERE c.subscriber_id = ?1 AND c.source_name = e.source_name AND c.last_read_id >= \
-             e.id)",
+            "SELECT COUNT(*) FROM data_feed_events e WHERE NOT EXISTS (SELECT 1 FROM \
+             feed_read_cursors c WHERE c.subscriber_id = ?1 AND c.source_name = e.source_name AND \
+             c.last_read_id >= e.id)",
         )
         .bind(&sub_id)
         .fetch_one(&self.pool)

--- a/crates/app/src/lib.rs
+++ b/crates/app/src/lib.rs
@@ -566,7 +566,7 @@ pub async fn start_with_options(
     let (_kernel_arc, kernel_handle) = kernel.start(cancellation_token.clone());
 
     // Spawn the feed dispatch task — consumes events from all transports,
-    // persists them to the feed_events table, and routes matching events
+    // persists them to the data_feed_events table, and routes matching events
     // to subscribing sessions via SubscriptionRegistry.
     {
         let store = feed_store.clone();

--- a/crates/extensions/backend-admin/src/data_feeds/service.rs
+++ b/crates/extensions/backend-admin/src/data_feeds/service.rs
@@ -14,7 +14,7 @@
 
 //! Persistence layer for data feed CRUD and event queries.
 //!
-//! [`DataFeedSvc`] operates directly on the `data_feeds` and `feed_events`
+//! [`DataFeedSvc`] operates directly on the `data_feeds` and `data_feed_events`
 //! SQLite tables. It does not depend on [`DataFeedRegistry`] — the registry
 //! manages in-memory runtime state while this service manages persistence.
 //!
@@ -30,7 +30,7 @@ use tracing::instrument;
 /// Service for data feed persistence operations.
 ///
 /// Holds a SQLite connection pool and provides CRUD on the `data_feeds`
-/// table plus paginated queries on the `feed_events` table.
+/// table plus paginated queries on the `data_feed_events` table.
 #[derive(Clone)]
 pub struct DataFeedSvc {
     pool: SqlitePool,
@@ -202,14 +202,15 @@ impl DataFeedSvc {
         // Count total matching events for pagination metadata.
         let total: (i64,) = if let Some(ref ts) = since {
             sqlx::query_as(
-                "SELECT COUNT(*) FROM feed_events WHERE source_name = ?1 AND received_at >= ?2",
+                "SELECT COUNT(*) FROM data_feed_events WHERE source_name = ?1 AND received_at >= \
+                 ?2",
             )
             .bind(source_name)
             .bind(ts.to_string())
             .fetch_one(&self.pool)
             .await?
         } else {
-            sqlx::query_as("SELECT COUNT(*) FROM feed_events WHERE source_name = ?1")
+            sqlx::query_as("SELECT COUNT(*) FROM data_feed_events WHERE source_name = ?1")
                 .bind(source_name)
                 .fetch_one(&self.pool)
                 .await?
@@ -217,9 +218,9 @@ impl DataFeedSvc {
 
         let rows: Vec<EventRow> = if let Some(ref ts) = since {
             sqlx::query_as(
-                "SELECT id, source_name, event_type, tags, payload, received_at FROM feed_events \
-                 WHERE source_name = ?1 AND received_at >= ?2 ORDER BY received_at DESC LIMIT ?3 \
-                 OFFSET ?4",
+                "SELECT id, source_name, event_type, tags, payload, received_at FROM \
+                 data_feed_events WHERE source_name = ?1 AND received_at >= ?2 ORDER BY \
+                 received_at DESC LIMIT ?3 OFFSET ?4",
             )
             .bind(source_name)
             .bind(ts.to_string())
@@ -229,8 +230,9 @@ impl DataFeedSvc {
             .await?
         } else {
             sqlx::query_as(
-                "SELECT id, source_name, event_type, tags, payload, received_at FROM feed_events \
-                 WHERE source_name = ?1 ORDER BY received_at DESC LIMIT ?2 OFFSET ?3",
+                "SELECT id, source_name, event_type, tags, payload, received_at FROM \
+                 data_feed_events WHERE source_name = ?1 ORDER BY received_at DESC LIMIT ?2 \
+                 OFFSET ?3",
             )
             .bind(source_name)
             .bind(limit)
@@ -261,7 +263,7 @@ impl DataFeedSvc {
         event_id: &str,
     ) -> anyhow::Result<Option<FeedEvent>> {
         let row: Option<EventRow> = sqlx::query_as(
-            "SELECT id, source_name, event_type, tags, payload, received_at FROM feed_events \
+            "SELECT id, source_name, event_type, tags, payload, received_at FROM data_feed_events \
              WHERE id = ?1 AND source_name = ?2",
         )
         .bind(event_id)

--- a/crates/rara-model/migrations/20260424074904_rename_feed_events_to_data_feed_events.down.sql
+++ b/crates/rara-model/migrations/20260424074904_rename_feed_events_to_data_feed_events.down.sql
@@ -1,0 +1,4 @@
+-- Inverse of the rename: restore the original feed_events table and index names.
+ALTER INDEX idx_data_feed_events_received RENAME TO idx_feed_events_received;
+ALTER INDEX idx_data_feed_events_source RENAME TO idx_feed_events_source;
+ALTER TABLE data_feed_events RENAME TO feed_events;

--- a/crates/rara-model/migrations/20260424074904_rename_feed_events_to_data_feed_events.down.sql
+++ b/crates/rara-model/migrations/20260424074904_rename_feed_events_to_data_feed_events.down.sql
@@ -1,4 +1,9 @@
 -- Inverse of the rename: restore the original feed_events table and index names.
-ALTER INDEX idx_data_feed_events_received RENAME TO idx_feed_events_received;
-ALTER INDEX idx_data_feed_events_source RENAME TO idx_feed_events_source;
+-- SQLite has no ALTER INDEX; use DROP + CREATE instead.
+DROP INDEX idx_data_feed_events_source;
+DROP INDEX idx_data_feed_events_received;
+
 ALTER TABLE data_feed_events RENAME TO feed_events;
+
+CREATE INDEX idx_feed_events_source ON feed_events(source_name);
+CREATE INDEX idx_feed_events_received ON feed_events(received_at);

--- a/crates/rara-model/migrations/20260424074904_rename_feed_events_to_data_feed_events.up.sql
+++ b/crates/rara-model/migrations/20260424074904_rename_feed_events_to_data_feed_events.up.sql
@@ -1,0 +1,7 @@
+-- Rename feed_events table to data_feed_events for naming consistency with
+-- the data_feeds config table. Both tables belong to the data-feed subsystem.
+ALTER TABLE feed_events RENAME TO data_feed_events;
+
+-- Rename associated indexes so their names reflect the new table name.
+ALTER INDEX idx_feed_events_source RENAME TO idx_data_feed_events_source;
+ALTER INDEX idx_feed_events_received RENAME TO idx_data_feed_events_received;

--- a/crates/rara-model/migrations/20260424074904_rename_feed_events_to_data_feed_events.up.sql
+++ b/crates/rara-model/migrations/20260424074904_rename_feed_events_to_data_feed_events.up.sql
@@ -1,7 +1,10 @@
 -- Rename feed_events table to data_feed_events for naming consistency with
--- the data_feeds config table. Both tables belong to the data-feed subsystem.
+-- the data_feeds config table. SQLite: ALTER TABLE RENAME is supported;
+-- indexes must be DROP + CREATE because SQLite has no ALTER INDEX.
 ALTER TABLE feed_events RENAME TO data_feed_events;
 
--- Rename associated indexes so their names reflect the new table name.
-ALTER INDEX idx_feed_events_source RENAME TO idx_data_feed_events_source;
-ALTER INDEX idx_feed_events_received RENAME TO idx_data_feed_events_received;
+DROP INDEX idx_feed_events_source;
+DROP INDEX idx_feed_events_received;
+
+CREATE INDEX idx_data_feed_events_source ON data_feed_events(source_name);
+CREATE INDEX idx_data_feed_events_received ON data_feed_events(received_at);


### PR DESCRIPTION
## Summary

Rename the `feed_events` DB table to `data_feed_events` so the naming matches the `data_feeds` config table — both now share the `data_feed_` prefix, making it obvious they belong to the same subsystem.

- New forward-only migration `20260424074904_rename_feed_events_to_data_feed_events` uses a SQLite-compatible approach: `ALTER TABLE feed_events RENAME TO data_feed_events`, then `DROP INDEX` for the two old indexes (`idx_feed_events_source`, `idx_feed_events_received`) and `CREATE INDEX` for the renamed equivalents. SQLite does not support `ALTER INDEX RENAME`, so drop+recreate is the correct path.
- The `ALTER TABLE RENAME` preserves existing rows in place (no data copy), so the 1700+ live rows survive the migration.
- Updated every SQL literal in `crates/app/src/feed_store.rs` and `crates/extensions/backend-admin/src/data_feeds/service.rs`, plus one inline comment in `crates/app/src/lib.rs`. No schema/column changes.

## Type of change

| Type | Label |
|------|-------|
| Refactor | `refactor` |

## Component

`backend`

## Closes

Closes #1720

## Test plan

- [x] `cargo check -p rara-app -p rara-backend-admin` passes
- [x] `just clippy` passes
- [x] `cargo +nightly fmt --all --check` passes
- [x] `prek run --all-files` passes