### PR TITLE
refactor(web): group turn into single bubble (#1727)

### DIFF
--- a/web/src/index.css
+++ b/web/src/index.css
@@ -354,6 +354,28 @@
 }
 
 /*
+ * Per-turn bubble grouping (#1727). pi-agent-core emits one AssistantMessage
+ * per agentic-loop iteration (LLM → tool → LLM → tool → final text), and
+ * pi-web-ui's MessageList renders one DOM row per message. Without this
+ * rule the transcript shows the same avatar repeated 2-5 times stacked under
+ * a single user question, which reads as fragmented replies.
+ *
+ * The React layer tags every non-first assistant frame of a turn with
+ * `rara-assistant-continuation` (see `registerCascadeAssistantRenderer` in
+ * `PiChat.tsx`). We suppress the `::before` avatar on those frames and
+ * negate the parent's `gap-3` (0.75rem) so consecutive frames merge into
+ * what visually reads as a single bubble column stacked under the first
+ * avatar. Turn boundaries — a new user message, or the end of the list —
+ * restore the avatar on the next assistant frame naturally.
+ */
+.rara-chat .rara-assistant-continuation assistant-message::before {
+  content: none;
+}
+.rara-chat .rara-assistant-continuation {
+  margin-top: -0.75rem;
+}
+
+/*
  * Pi-web-ui left-aligns user messages (`class="flex justify-start"`
  * on the bubble's parent). Flip to the right side — the standard
  * chat convention of "my messages on the right". `:has()` gives us a

--- a/web/src/pages/PiChat.tsx
+++ b/web/src/pages/PiChat.tsx
@@ -41,6 +41,7 @@ void extractDocumentTool;
 
 import {
   assistantSeqByRef,
+  isFirstAssistantOfTurn,
   messagesForArtifactReconstruction,
   toAgentMessages,
   toolResultByCallId,
@@ -237,8 +238,18 @@ function registerCascadeAssistantRenderer(agentResolver: () => Agent | null): vo
           }),
         );
       };
+      // Per-turn bubble grouping (#1727): pi-agent-core pushes one
+      // `AssistantMessage` per agentic-loop iteration, so a single user
+      // turn often produces 2-5 assistant frames. We tag everything after
+      // the first frame of each turn as a "continuation" — the avatar and
+      // top-of-bubble chrome are suppressed via CSS so the turn reads as
+      // one bubble stacked under a single avatar.
+      const isFirstOfTurn = agent ? isFirstAssistantOfTurn(message, agent.state.messages) : true;
+      const wrapperClass = isFirstOfTurn
+        ? 'rara-assistant-with-trace'
+        : 'rara-assistant-with-trace rara-assistant-continuation';
       return html`
-        <div class="rara-assistant-with-trace">
+        <div class=${wrapperClass}>
           <assistant-message
             .message=${message}
             .tools=${agent?.state.tools ?? []}

--- a/web/src/pages/__tests__/pi-chat-messages.test.ts
+++ b/web/src/pages/__tests__/pi-chat-messages.test.ts
@@ -20,6 +20,7 @@ import { describe, expect, it } from 'vitest';
 import {
   assistantSeqByRef,
   finalAssistantIndices,
+  isFirstAssistantOfTurn,
   messagesForArtifactReconstruction,
   toAgentMessages,
   toolResultByCallId,
@@ -217,5 +218,42 @@ describe('toAgentMessages — tool-result side-channel (#1718)', () => {
     const roles = woven.map((m) => m.role);
     // Expect: user, assistant(toolCall), toolResult, assistant(text)
     expect(roles).toEqual(['user', 'assistant', 'toolResult', 'assistant']);
+  });
+});
+
+describe('isFirstAssistantOfTurn (#1727)', () => {
+  it('flags the sole assistant after a user as first-of-turn', () => {
+    const out = toAgentMessages([user(1), assistantText(2)]);
+    const [a] = assistants(out);
+    expect(isFirstAssistantOfTurn(expectAssistant(a), out)).toBe(true);
+  });
+
+  it('flags the first assistant of a multi-iteration turn, not the later ones', () => {
+    const out = toAgentMessages([user(1), assistantToolCall(2), assistantText(3)]);
+    const [first, second] = assistants(out);
+    expect(isFirstAssistantOfTurn(expectAssistant(first), out)).toBe(true);
+    expect(isFirstAssistantOfTurn(expectAssistant(second), out)).toBe(false);
+  });
+
+  it('treats intervening toolResult frames as transparent to turn position', () => {
+    const out = messagesForArtifactReconstruction(
+      toAgentMessages([user(1), assistantToolCall(2), toolResult(3, 2), assistantText(4)]),
+    );
+    const [first, second] = assistants(out);
+    expect(isFirstAssistantOfTurn(expectAssistant(first), out)).toBe(true);
+    expect(isFirstAssistantOfTurn(expectAssistant(second), out)).toBe(false);
+  });
+
+  it('restores first-of-turn after a new user message', () => {
+    const out = toAgentMessages([
+      user(1),
+      assistantToolCall(2),
+      assistantText(3),
+      user(4),
+      assistantText(5),
+    ]);
+    const [, second, third] = assistants(out);
+    expect(isFirstAssistantOfTurn(expectAssistant(second), out)).toBe(false);
+    expect(isFirstAssistantOfTurn(expectAssistant(third), out)).toBe(true);
   });
 });

--- a/web/src/pages/__tests__/pi-chat-messages.test.ts
+++ b/web/src/pages/__tests__/pi-chat-messages.test.ts
@@ -244,6 +244,30 @@ describe('isFirstAssistantOfTurn (#1727)', () => {
     expect(isFirstAssistantOfTurn(expectAssistant(second), out)).toBe(false);
   });
 
+  it('treats an empty-thinking assistant frame as transparent so the next visible assistant owns the avatar', () => {
+    const emptyThinking: AssistantMessage = {
+      role: 'assistant',
+      content: [{ type: 'thinking', thinking: '' }],
+      usage: {
+        input: 0,
+        output: 0,
+        cacheRead: 0,
+        cacheWrite: 0,
+        totalTokens: 0,
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+      },
+      stopReason: 'stop',
+      api: 'anthropic',
+      provider: 'anthropic',
+      model: 'claude-3-5-sonnet',
+      timestamp: Date.parse(ISO),
+    };
+    const visible = expectAssistant(assistants(toAgentMessages([user(1), assistantText(2)]))[0]);
+    const list = [...toAgentMessages([user(1)]), emptyThinking, visible];
+    expect(isFirstAssistantOfTurn(emptyThinking, list)).toBe(false);
+    expect(isFirstAssistantOfTurn(visible, list)).toBe(true);
+  });
+
   it('restores first-of-turn after a new user message', () => {
     const out = toAgentMessages([
       user(1),

--- a/web/src/pages/pi-chat-messages.ts
+++ b/web/src/pages/pi-chat-messages.ts
@@ -149,17 +149,38 @@ export const toolResultByCallId = new Map<string, ToolResultMessage>();
  * appends.
  */
 export function isFirstAssistantOfTurn(msg: AgentMessage, all: readonly AgentMessage[]): boolean {
+  // pi-agent-core emits per-iteration `AssistantMessage` frames that can
+  // carry only an empty thinking-block; pi-web-ui's `:has()` avatar rules
+  // do not match those, so they paint no avatar. Treating them as the
+  // turn's first frame would anchor the avatar to an invisible row and
+  // strip it from the real content. Skip them in both the self check and
+  // the backward walk so the avatar lands on the first visible frame.
+  if (msg.role === 'assistant' && !hasVisibleContent(msg)) return false;
   const idx = all.indexOf(msg);
   if (idx < 0) return true;
   for (let j = idx - 1; j >= 0; j--) {
     const prev = all[j];
     if (!prev) continue;
     if (prev.role === 'toolResult') continue;
-    if (prev.role === 'assistant') return false;
+    if (prev.role === 'assistant') {
+      if (!hasVisibleContent(prev)) continue;
+      return false;
+    }
     // user / user-with-attachments / anything else is a turn boundary.
     return true;
   }
   return true;
+}
+
+function hasVisibleContent(msg: AssistantMessage): boolean {
+  const content = msg.content;
+  if (!Array.isArray(content)) return false;
+  return content.some((part) => {
+    if (part.type === 'text') return part.text.trim().length > 0;
+    if (part.type === 'thinking') return part.thinking.trim().length > 0;
+    if (part.type === 'toolCall') return true;
+    return false;
+  });
 }
 
 /**

--- a/web/src/pages/pi-chat-messages.ts
+++ b/web/src/pages/pi-chat-messages.ts
@@ -126,6 +126,43 @@ export const assistantSeqByRef = new WeakMap<AgentMessage, number>();
 export const toolResultByCallId = new Map<string, ToolResultMessage>();
 
 /**
+ * True when `msg` is the **first** assistant message of its turn inside
+ * the provided live `AgentMessage[]` — i.e. the closest preceding
+ * non-tool-result / non-assistant message is either absent (list head)
+ * or a user/user-with-attachments message.
+ *
+ * The avatar + top-of-bubble chrome is painted only for this frame; every
+ * subsequent assistant message in the same turn renders as a "continuation"
+ * (no avatar, collapsed top margin) so the whole turn reads as one bubble
+ * (#1727). Works uniformly for persisted history (emitted by
+ * {@link toAgentMessages}) and live streaming (pi-agent-core pushes each
+ * agentic-loop iteration as its own `AssistantMessage` into
+ * `agent.state.messages`).
+ *
+ * `toolResult` frames — pi-agent-core appends them post-stream for live
+ * turns — are transparent to the turn boundary: they neither open nor
+ * close a turn. Only user messages do.
+ *
+ * `O(n)` on the message list; called at render time per assistant row.
+ * For pi-web-ui's typical 200-message ceiling this is trivially cheap and
+ * avoids maintaining a parallel cache that could desync from streaming
+ * appends.
+ */
+export function isFirstAssistantOfTurn(msg: AgentMessage, all: readonly AgentMessage[]): boolean {
+  const idx = all.indexOf(msg);
+  if (idx < 0) return true;
+  for (let j = idx - 1; j >= 0; j--) {
+    const prev = all[j];
+    if (!prev) continue;
+    if (prev.role === 'toolResult') continue;
+    if (prev.role === 'assistant') return false;
+    // user / user-with-attachments / anything else is a turn boundary.
+    return true;
+  }
+  return true;
+}
+
+/**
  * For each turn (a contiguous run of non-user messages bounded by the
  * next user message or the end of the list), return the index in `msgs`
  * of the last `assistant`-role message in that turn. Indices not in the


### PR DESCRIPTION
## Summary

- Group one user-question → one assistant bubble. pi-agent-core pushes one `AssistantMessage` per agentic-loop iteration; pi-web-ui renders one DOM row per message; without grouping, a single turn shows 2-5 avatars stacked under one user prompt.
- Add `isFirstAssistantOfTurn(msg, all)` helper that walks the live message list to detect the first assistant frame following a user boundary (toolResult frames are transparent). Works for both persisted history and live streaming since pi-web-ui reads `agent.state.messages` directly.
- Tag every non-first assistant frame with `rara-assistant-continuation` in the custom Lit renderer; new CSS rules suppress the `::before` avatar and negate the parent's `gap-3` on those wrappers so the turn reads as one bubble column under a single avatar. Trace buttons (`📊 详情` / `🔍 Cascade`) still only land on the final assistant, unchanged from #1672.

## Type of change

| Type | Label |
|------|-------|
| Refactor | `refactor` |

## Component

`ui`

## Closes

Closes #1727

## Test plan

- [x] `npm run test` passes (21 tests in `pi-chat-messages.test.ts`, 4 new for `isFirstAssistantOfTurn`)
- [x] `npm run lint` passes
- [x] `npm run build` passes
- [ ] Manual: reload a long session with multi-iteration turns; verify only the first frame of each turn shows an avatar, the turn reads as one column, and trace buttons still appear once per turn