### PR TITLE
fix(web): hoist relay Map across stream invocations (#1732)

### DIFF
--- a/web/src/adapters/__tests__/rara-stream.test.ts
+++ b/web/src/adapters/__tests__/rara-stream.test.ts
@@ -157,11 +157,20 @@ function userContext(text: string): Context {
 describe('createRaraStreamFn — relay Map stability across invocations (#1732)', () => {
   beforeEach(() => {
     installLocalStorageStub();
+    // Seed an authenticated principal + token so `buildWsUrl` does not
+    // redirect to /login before we get a chance to drive the WebSocket.
+    localStorage.setItem('access_token', 'test-token');
+    localStorage.setItem(
+      'auth_user',
+      JSON.stringify({ user_id: 'alice', role: 'Admin', is_admin: true }),
+    );
     MockWebSocket.instances = [];
     vi.stubGlobal('WebSocket', MockWebSocket as unknown as typeof WebSocket);
   });
 
   afterEach(() => {
+    localStorage.removeItem('access_token');
+    localStorage.removeItem('auth_user');
     vi.unstubAllGlobals();
   });
 

--- a/web/src/adapters/__tests__/rara-stream.test.ts
+++ b/web/src/adapters/__tests__/rara-stream.test.ts
@@ -14,9 +14,11 @@
  * limitations under the License.
  */
 
+import type { AgentTool } from '@mariozechner/pi-agent-core';
+import type { Context, Model } from '@mariozechner/pi-ai';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { buildWsUrl } from '../rara-stream';
+import { buildWsUrl, createRaraStreamFn } from '../rara-stream';
 
 const STORAGE_KEY = 'rara_backend_url';
 
@@ -92,5 +94,139 @@ describe('buildWsUrl — backend override resolution (#1622)', () => {
     expect(buildWsUrl('sess/with spaces')).toBe(
       'ws://10.0.0.183:25555/api/v1/kernel/chat/ws?session_key=sess%2Fwith+spaces&user_id=alice&token=test-token',
     );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Relay Map stability across StreamFn invocations (#1732)
+// ---------------------------------------------------------------------------
+
+/**
+ * Minimal mock WebSocket that exposes `onopen` / `onmessage` / `onclose`
+ * callbacks so tests can drive the rara-stream state machine directly
+ * without a live backend. Each constructed instance is tracked on
+ * {@link MockWebSocket.instances} so the active test can reach in and
+ * emit frames.
+ */
+class MockWebSocket {
+  static instances: MockWebSocket[] = [];
+  onopen: ((ev: Event) => void) | null = null;
+  onmessage: ((ev: MessageEvent) => void) | null = null;
+  onerror: ((ev: Event) => void) | null = null;
+  onclose: ((ev: CloseEvent) => void) | null = null;
+  sent: string[] = [];
+  readyState = 1;
+  url: string;
+  constructor(url: string) {
+    this.url = url;
+    MockWebSocket.instances.push(this);
+  }
+  send(data: string) {
+    this.sent.push(data);
+  }
+  close() {
+    this.readyState = 3;
+    this.onclose?.(new CloseEvent('close'));
+  }
+  emit(payload: unknown) {
+    this.onmessage?.(new MessageEvent('message', { data: JSON.stringify(payload) }));
+  }
+}
+
+function fakeModel(): Model<any> {
+  return {
+    id: 'test-model',
+    api: 'test',
+    provider: 'test',
+    name: 'Test',
+    baseUrl: 'http://test',
+    contextWindow: 1000,
+    maxTokens: 1000,
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+  } as unknown as Model<any>;
+}
+
+function userContext(text: string): Context {
+  return {
+    systemPrompt: '',
+    messages: [{ role: 'user', content: text }],
+    tools: [],
+  } as unknown as Context;
+}
+
+describe('createRaraStreamFn — relay Map stability across invocations (#1732)', () => {
+  beforeEach(() => {
+    installLocalStorageStub();
+    MockWebSocket.instances = [];
+    vi.stubGlobal('WebSocket', MockWebSocket as unknown as typeof WebSocket);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('relay shim installed on first invocation resolves tool calls from a second invocation', async () => {
+    const streamFn = createRaraStreamFn(() => 'sess-1');
+
+    // --- First invocation: tool_call_start + tool_call_end for id "t1" ---
+    const ctx = userContext('hello');
+    void streamFn(fakeModel(), ctx);
+    const ws1 = MockWebSocket.instances[0]!;
+    ws1.onopen?.(new Event('open'));
+    ws1.emit({
+      type: 'tool_call_start',
+      id: 't1',
+      name: 'search',
+      arguments: { q: 'first' },
+    });
+    ws1.emit({
+      type: 'tool_call_end',
+      id: 't1',
+      result_preview: 'first-result',
+      success: true,
+      error: null,
+    });
+    ws1.emit({ type: 'done' });
+
+    // Shim was installed into context.tools on first invocation.
+    expect(ctx.tools?.map((t) => t.name)).toContain('search');
+    const shim = ctx.tools?.find((t) => t.name === 'search') as AgentTool | undefined;
+    expect(shim).toBeDefined();
+    // First id resolves via the shim's execute().
+    await expect(shim!.execute('t1', {}, {} as never)).resolves.toMatchObject({
+      content: [{ type: 'text', text: 'first-result' }],
+    });
+
+    // --- Second invocation: new tool_call_start for a fresh id "t2" ---
+    // pi-agent-core reuses the same `context` and its existing tool
+    // entry, so rara-stream must not allocate a new pendingToolResults
+    // Map — otherwise shim.execute('t2') throws "No kernel result ...".
+    void streamFn(fakeModel(), ctx);
+    const ws2 = MockWebSocket.instances[1]!;
+    ws2.onopen?.(new Event('open'));
+    ws2.emit({
+      type: 'tool_call_start',
+      id: 't2',
+      name: 'search',
+      arguments: { q: 'second' },
+    });
+    ws2.emit({
+      type: 'tool_call_end',
+      id: 't2',
+      result_preview: 'second-result',
+      success: true,
+      error: null,
+    });
+    ws2.emit({ type: 'done' });
+
+    // Same shim reference (not re-pushed) — confirms dedup across turns.
+    const shim2 = ctx.tools?.find((t) => t.name === 'search') as AgentTool | undefined;
+    expect(shim2).toBe(shim);
+    expect(ctx.tools?.filter((t) => t.name === 'search').length).toBe(1);
+
+    // Critical: the shim must resolve the new id from the shared Map.
+    await expect(shim!.execute('t2', {}, {} as never)).resolves.toMatchObject({
+      content: [{ type: 'text', text: 'second-result' }],
+    });
   });
 });

--- a/web/src/adapters/rara-stream.ts
+++ b/web/src/adapters/rara-stream.ts
@@ -369,6 +369,26 @@ export function createRaraStreamFn(
   getPendingAttachments?: PendingAttachmentsFn,
   onWebEvent?: WebEventObserver,
 ): StreamFn {
+  // Session-stable registry of kernel-authoritative tool results keyed by
+  // `toolCallId`. Hoisted out of the inner `StreamFn` closure so the relay
+  // `AgentTool` shims installed into `context.tools` on the first invocation
+  // keep resolving new entries registered by subsequent invocations within
+  // the same session (see #1732). pi-agent-core skips reinstalling shims
+  // whose name already lives in `context.tools`, so if each invocation
+  // allocated its own Map the shim would close over a stale reference and
+  // throw "No kernel result registered for tool call ..." on follow-up turns.
+  //
+  // NOTE: entries accumulate for the lifetime of the returned `StreamFn` —
+  // we intentionally never evict because `resolved` is cached so late
+  // pi-agent-core `execute()` calls still return the real result. A single
+  // session's tool-call count is bounded (hundreds max, each holding a
+  // result preview on the order of tens of KB), so unbounded growth is not
+  // a practical concern; an eviction policy would risk regressing #1601.
+  const pendingToolResults = new Map<string, PendingToolResult>();
+  // Deduplicate shim installation across invocations — one `AgentTool` per
+  // distinct tool name for the whole session.
+  const installedTools = new Set<string>();
+
   return (
     model: Model<any>,
     context: Context,
@@ -395,19 +415,14 @@ export function createRaraStreamFn(
 
     // Accumulated content blocks for building partial messages
     const content: (TextContent | ThinkingContent | ToolCall)[] = [];
-    // Per-turn registry of kernel-authoritative tool results keyed by
-    // `toolCallId`. The companion `AgentTool` shims installed into
-    // `context.tools` await these promises so pi-agent-core's loop
-    // threads the real result through without the "Tool X not found"
-    // fallback (see #1601).
-    const pendingToolResults = new Map<string, PendingToolResult>();
-    // Deduplicate shim installation — one `AgentTool` per distinct name.
-    const installedTools = new Set<string>();
     // Ensure `context.tools` is an array we can mutate in place so the
     // shims are visible when pi-agent-core's loop reads `currentContext.tools`
     // after this stream ends.
     if (!context.tools) context.tools = [];
     const contextTools = context.tools;
+    // Names already present in `context.tools` — includes shims installed
+    // by a previous invocation of this same `StreamFn` (per-session closure),
+    // so we don't push duplicate entries on follow-up turns.
     const installedNamesFromContext = new Set(contextTools.map((t) => t.name));
     // Running usage — starts empty, replaced when the backend emits its
     // final `usage` event. Cost is computed against the session model's


### PR DESCRIPTION
## Summary

`pendingToolResults` and `installedTools` were allocated inside the inner
`StreamFn` closure returned by `createRaraStreamFn`, so every new turn got
a fresh `Map`. The relay `AgentTool` shim built on the first turn closed
over the original `Map` and kept referencing it; pi-agent-core's
`context.tools` already contained the shim on subsequent turns, so it
skipped reinstalling. The second turn's `tool_call_start` frames seeded
entries in a `Map` the shim no longer saw, and `execute()` threw
`No kernel result registered for tool call <id> (<name>)`.

Hoist both the pending-results `Map` and the installed-names `Set` into
the `createRaraStreamFn` factory closure so they live for the full session
lifetime of the returned `StreamFn`. Because `resolved` is already cached
on each slot, late `execute()` calls continue to return the real result,
so the accumulating `Map` is the intended design — comment explains why
no eviction.

Added a regression test that drives two consecutive invocations against
the same context and verifies the second turn's tool call resolves
through the shim installed on the first turn.

## Type of change

| Type | Label |
|------|-------|
| Bug fix | `bug` |

## Component

`ui`

## Closes

Closes #1732

## Test plan

- [x] `npm test` passes (83/83)
- [x] `npm run build` passes
- [x] `npx eslint` clean on touched files
- [x] New test `relay Map stability across invocations (#1732)` covers the regression