### PR TITLE
refactor(kernel): clean up scheduler review nits (#1729)

### DIFF
--- a/crates/app/src/lib.rs
+++ b/crates/app/src/lib.rs
@@ -517,27 +517,27 @@ pub async fn start_with_options(
         })
     };
 
-    let mut kernel = rara_kernel::kernel::Kernel::new(
-        kernel_config,
-        rara.driver_registry.clone(),
-        rara.tool_registry.clone(),
-        rara.agent_registry.clone(),
-        rara.session_index.clone(),
-        rara.tape_service.clone(),
-        settings_provider.clone(),
-        Arc::new(rara_kernel::security::SecuritySubsystem::new(
+    let mut kernel = rara_kernel::kernel::Kernel::builder()
+        .config(kernel_config)
+        .driver_registry(rara.driver_registry.clone())
+        .tool_registry(rara.tool_registry.clone())
+        .agent_registry(rara.agent_registry.clone())
+        .session_index(rara.session_index.clone())
+        .tape_service(rara.tape_service.clone())
+        .settings(settings_provider.clone())
+        .security(Arc::new(rara_kernel::security::SecuritySubsystem::new(
             rara.user_store.clone(),
             Arc::new(rara_kernel::security::ApprovalManager::new(
                 rara_kernel::security::ApprovalPolicy::default(),
             )),
-        )),
-        io,
-        rara.knowledge_service.clone(),
-        mcp_tool_provider,
-        trace_service,
-        skill_prompt_provider,
-        rara_paths::workspace_dir().join("scheduler"),
-    );
+        )))
+        .io(io)
+        .knowledge(rara.knowledge_service.clone())
+        .maybe_dynamic_tool_provider(mcp_tool_provider)
+        .trace_service(trace_service)
+        .skill_prompt_provider(skill_prompt_provider)
+        .scheduler_dir(rara_paths::workspace_dir().join("scheduler"))
+        .build();
 
     let cancellation_token = CancellationToken::new();
 

--- a/crates/kernel/src/handle.rs
+++ b/crates/kernel/src/handle.rs
@@ -432,11 +432,13 @@ impl KernelHandle {
     /// Seed a pre-built [`crate::schedule::JobEntry`] onto the wheel, bypassing
     /// the `RegisterJob` syscall path.
     ///
-    /// Crate-private by design: test helpers in [`crate::testing`] wrap this
-    /// so the capability isn't reachable from every downstream crate. The
-    /// syscall path remains the only way production callers register jobs,
-    /// because it is the only path that supplies a real session principal.
-    pub(crate) fn seed_job(&self, entry: crate::schedule::JobEntry) {
+    /// The deliberately-ugly name signals to humans (including future in-crate
+    /// test files) that this is a test-harness hatch, not a general API: the
+    /// syscall path is the only supported way to register jobs in production
+    /// because it supplies a real session principal. The sole legitimate caller
+    /// is [`crate::testing::TestKernel::seed_job`], which wraps this so
+    /// downstream crates cannot reach it at all.
+    pub(crate) fn __seed_job_unsafe_test_harness(&self, entry: crate::schedule::JobEntry) {
         let mut wheel = self.job_wheel.lock();
         wheel.add(entry);
         wheel.persist();

--- a/crates/kernel/src/kernel.rs
+++ b/crates/kernel/src/kernel.rs
@@ -228,11 +228,16 @@ pub struct Kernel {
     feed_store:            Option<crate::data_feed::FeedStoreRef>,
 }
 
+#[bon::bon]
 impl Kernel {
     /// Construct a kernel from core infrastructure dependencies.
     ///
     /// Registries are loaded separately via `load_*` methods before `start()`.
-    #[allow(clippy::too_many_arguments)]
+    /// Callers use the generated builder: `Kernel::builder().config(...). ...
+    /// .scheduler_dir(...).build()`. The builder rejects incomplete
+    /// construction at compile time, making future argument additions safe —
+    /// positional `new(...)` would silently drift on any added parameter.
+    #[builder(start_fn = builder, finish_fn = build)]
     pub fn new(
         config: KernelConfig,
         driver_registry: DriverRegistryRef,

--- a/crates/kernel/src/syscall.rs
+++ b/crates/kernel/src/syscall.rs
@@ -559,10 +559,10 @@ impl SyscallDispatcher {
                                 Ok(crate::event::TriggerJobReply::Fired(job))
                             }
                             Err(e) => {
-                                let wheel_ref = self.job_wheel.clone();
                                 let cancel_id = job.id;
+                                let wheel = self.job_wheel.clone();
                                 let cancelled = tokio::task::spawn_blocking(move || {
-                                    wheel_ref.lock().cancel_in_flight(&cancel_id)
+                                    wheel.lock().cancel_in_flight(&cancel_id)
                                 })
                                 .await
                                 .unwrap_or(false);

--- a/crates/kernel/src/testing.rs
+++ b/crates/kernel/src/testing.rs
@@ -401,22 +401,21 @@ impl TestKernelBuilder {
         // see each other's seeded jobs (observed as flaky
         // `list_on_empty_kernel_is_empty`).
         let scheduler_dir = self.tmp_dir.join("scheduler");
-        let kernel = Kernel::new(
-            self.config,
-            driver_registry,
-            tool_registry,
-            agent_registry,
-            session_index,
-            tape_service,
-            settings,
-            security,
-            io,
-            knowledge,
-            None, // no dynamic tool provider
-            trace_service,
-            skill_prompt_provider,
-            scheduler_dir,
-        );
+        let kernel = Kernel::builder()
+            .config(self.config)
+            .driver_registry(driver_registry)
+            .tool_registry(tool_registry)
+            .agent_registry(agent_registry)
+            .session_index(session_index)
+            .tape_service(tape_service)
+            .settings(settings)
+            .security(security)
+            .io(io)
+            .knowledge(knowledge)
+            .trace_service(trace_service)
+            .skill_prompt_provider(skill_prompt_provider)
+            .scheduler_dir(scheduler_dir)
+            .build();
 
         let cancel_token = CancellationToken::new();
         let (_kernel_arc, handle) = kernel.start(cancel_token.clone());

--- a/crates/kernel/src/testing.rs
+++ b/crates/kernel/src/testing.rs
@@ -449,9 +449,11 @@ impl TestKernel {
     /// The syscall path requires a real session principal in the process
     /// table, which integration tests typically don't set up. This helper is
     /// the only public surface for wheel-seeding; the underlying
-    /// `KernelHandle::seed_job` is crate-private so downstream code can't
-    /// reach it from production.
-    pub fn seed_job(&self, entry: crate::schedule::JobEntry) { self.handle.seed_job(entry); }
+    /// `KernelHandle::__seed_job_unsafe_test_harness` is crate-private and
+    /// deliberately named to warn off in-crate callers.
+    pub fn seed_job(&self, entry: crate::schedule::JobEntry) {
+        self.handle.__seed_job_unsafe_test_harness(entry);
+    }
 }
 
 /// Convenience helper: build a [`CompletionResponse`] with text content.


### PR DESCRIPTION
## Summary

Three follow-up nits from the third-round code review on the scheduler epic (#1686):

- Rename \`KernelHandle::seed_job\` to \`__seed_job_unsafe_test_harness\` so future in-crate tests cannot bypass \`TestKernelBuilder::seed_job\` via the suggestive short name.
- Drop the redundant \`wheel_ref\` shadow in the \`Syscall::TriggerJob\` rollback branch — inline clone into a differently-named local so the two handles are clearly independent.
- Migrate \`Kernel::new\` to \`bon::Builder\` via \`#[bon::bon]\` + \`#[builder(start_fn = builder, finish_fn = build)]\`; remove \`#[allow(clippy::too_many_arguments)]\` and update both call sites (production \`rara-app\` and \`TestKernelBuilder::build\`).

## Type of change

| Type | Label |
|------|-------|
| Refactor | \`refactor\` |

## Component

\`core\`

## Closes

Closes #1729

## Test plan

- [x] \`cargo check --workspace --all-targets\`
- [x] \`cargo test -p rara-kernel\`
- [x] \`cargo test -p rara-backend-admin\`
- [x] \`cargo test -p rara-app\`
- [x] \`cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings\`
- [x] \`prek run --all-files\`