### PR TITLE
fix(web): forward send-file attachments to browser via stream event (#1731)

### DIFF
--- a/crates/app/src/tools/send_file.rs
+++ b/crates/app/src/tools/send_file.rs
@@ -23,10 +23,10 @@ use std::path::Path;
 
 use async_trait::async_trait;
 use rara_kernel::{
-    channel::types::MessageContent,
+    channel::types::{ChannelType, MessageContent},
     event::KernelEventEnvelope,
     identity::UserId,
-    io::{Attachment, OutboundEnvelope},
+    io::{Attachment, OutboundEnvelope, StreamEvent},
     tool::{ToolContext, ToolExecute},
 };
 use rara_tool_macro::ToolDef;
@@ -108,6 +108,29 @@ impl ToolExecute for SendFileTool {
             .and_then(|n| n.to_str())
             .map(|s| s.to_string());
 
+        // Web sessions don't receive the OutboundEnvelope via the standard
+        // adapter fanout (see `binding_to_endpoint` in kernel/src/io.rs —
+        // Web returns `None` because chat_id == session_key). Emit the
+        // bytes on the stream instead so the browser can render the file
+        // inline next to the send-file tool call. Other channels already
+        // render the attachment through their own adapter and would
+        // double-render if they observed this event, so we scope it to
+        // Web origins.
+        let is_web_origin = matches!(
+            context.origin_endpoint.as_ref().map(|e| e.channel_type),
+            Some(ChannelType::Web)
+        );
+        if is_web_origin {
+            if let Some(handle) = context.stream_handle.as_ref() {
+                handle.emit(StreamEvent::Attachment {
+                    tool_call_id: context.tool_call_id.clone(),
+                    mime_type:    mime_type.to_string(),
+                    filename:     filename.clone(),
+                    data:         data.clone(),
+                });
+            }
+        }
+
         let attachment = Attachment {
             data,
             mime_type: mime_type.to_string(),
@@ -178,7 +201,143 @@ fn mime_from_extension(ext: &str) -> &'static str {
 
 #[cfg(test)]
 mod tests {
+    use std::io::Write as _;
+
+    use rara_kernel::{
+        channel::types::ChannelType,
+        io::{Endpoint, EndpointAddress, MessageId, StreamHub},
+        queue::{ShardedEventQueue, ShardedEventQueueConfig},
+        session::SessionKey,
+    };
+
     use super::*;
+
+    fn build_queue() -> rara_kernel::queue::ShardedQueueRef {
+        std::sync::Arc::new(ShardedEventQueue::new(ShardedEventQueueConfig {
+            num_shards:      0,
+            shard_capacity:  1,
+            global_capacity: 16,
+        }))
+    }
+
+    fn build_context(
+        origin: Option<Endpoint>,
+        stream_handle: Option<rara_kernel::io::StreamHandle>,
+    ) -> ToolContext {
+        ToolContext {
+            user_id: "test-user".into(),
+            session_key: SessionKey::new(),
+            origin_endpoint: origin,
+            origin_user_id: None,
+            event_queue: build_queue(),
+            rara_message_id: MessageId::new(),
+            context_window_tokens: 0,
+            tool_registry: None,
+            stream_handle,
+            tool_call_id: Some("call-123".into()),
+        }
+    }
+
+    fn web_endpoint() -> Endpoint {
+        Endpoint {
+            channel_type: ChannelType::Web,
+            address:      EndpointAddress::Web {
+                connection_id: "conn-1".into(),
+            },
+        }
+    }
+
+    fn telegram_endpoint() -> Endpoint {
+        Endpoint {
+            channel_type: ChannelType::Telegram,
+            address:      EndpointAddress::Telegram {
+                chat_id:   42,
+                thread_id: None,
+            },
+        }
+    }
+
+    fn write_temp_png() -> tempfile::NamedTempFile {
+        // A minimal PNG-ish payload — SendFileTool only inspects the extension
+        // for MIME detection, not the byte signature.
+        let mut f = tempfile::Builder::new()
+            .suffix(".png")
+            .tempfile()
+            .expect("tempfile");
+        f.write_all(b"\x89PNG\r\n\x1a\nFAKEDATA").expect("write");
+        f
+    }
+
+    #[tokio::test]
+    async fn attachment_stream_event_emitted_for_web_origin() {
+        use rara_kernel::io::StreamEvent;
+
+        let hub = StreamHub::new(16);
+        let session = SessionKey::new();
+        let handle = hub.open(session);
+        // Subscribe to the per-stream broadcast directly. The session-level
+        // bus is fed by an async bridge task whose scheduling cannot be
+        // observed from a synchronous `try_recv` right after `emit()`.
+        let streams = hub.subscribe_session(&session);
+        assert_eq!(streams.len(), 1, "open() should have created one stream");
+        let (_id, mut rx) = streams.into_iter().next().expect("one stream");
+
+        let ctx = build_context(Some(web_endpoint()), Some(handle));
+        let file = write_temp_png();
+        let params = SendFileParams {
+            file_path: file.path().to_string_lossy().into_owned(),
+            caption:   Some("hi".into()),
+        };
+        SendFileTool.run(params, &ctx).await.expect("send-file ok");
+
+        let mut saw_attachment = false;
+        while let Ok(ev) = rx.try_recv() {
+            if let StreamEvent::Attachment {
+                tool_call_id,
+                mime_type,
+                filename,
+                data,
+            } = ev
+            {
+                assert_eq!(tool_call_id.as_deref(), Some("call-123"));
+                assert_eq!(mime_type, "image/png");
+                assert!(filename.is_some());
+                assert!(!data.is_empty());
+                saw_attachment = true;
+                break;
+            }
+        }
+        assert!(
+            saw_attachment,
+            "expected StreamEvent::Attachment for web origin"
+        );
+    }
+
+    #[tokio::test]
+    async fn attachment_stream_event_suppressed_for_telegram_origin() {
+        use rara_kernel::io::StreamEvent;
+
+        let hub = StreamHub::new(16);
+        let session = SessionKey::new();
+        let handle = hub.open(session);
+        let streams = hub.subscribe_session(&session);
+        let (_id, mut rx) = streams.into_iter().next().expect("one stream");
+
+        let ctx = build_context(Some(telegram_endpoint()), Some(handle));
+        let file = write_temp_png();
+        let params = SendFileParams {
+            file_path: file.path().to_string_lossy().into_owned(),
+            caption:   None,
+        };
+        SendFileTool.run(params, &ctx).await.expect("send-file ok");
+
+        while let Ok(ev) = rx.try_recv() {
+            assert!(
+                !matches!(ev, StreamEvent::Attachment { .. }),
+                "Telegram origin must not emit StreamEvent::Attachment"
+            );
+        }
+    }
 
     #[test]
     fn mime_images_detected() {

--- a/crates/channels/src/web.rs
+++ b/crates/channels/src/web.rs
@@ -194,6 +194,22 @@ pub enum WebEvent {
     /// (e.g. trace detail modal) can embed the ID without an extra
     /// round-trip; the current web UI ignores unknown events gracefully.
     TraceReady { trace_id: String },
+    /// Binary attachment (image, document, etc.) produced by a tool.
+    ///
+    /// Bytes are transported as standard (non URL-safe) base64 so the
+    /// browser can reconstruct a blob or data URL and render the file
+    /// inline alongside the matching tool call.
+    Attachment {
+        /// LLM-assigned tool call id, when the attachment was emitted from
+        /// within a tool invocation.
+        tool_call_id: Option<String>,
+        /// IANA media type of the attachment bytes.
+        mime_type:    String,
+        /// Optional original filename.
+        filename:     Option<String>,
+        /// Base64-encoded payload (standard alphabet, with padding).
+        data_base64:  String,
+    },
     /// Stream completed (no more deltas).
     Done,
 }
@@ -368,6 +384,20 @@ fn stream_event_to_web_event(event: StreamEvent) -> Option<WebEvent> {
         StreamEvent::LoopBreakerTriggered { .. } => None, // informational only
         StreamEvent::ToolOutput { .. } => None,    // live preview, not persisted
         StreamEvent::TraceReady { trace_id } => Some(WebEvent::TraceReady { trace_id }),
+        StreamEvent::Attachment {
+            tool_call_id,
+            mime_type,
+            filename,
+            data,
+        } => {
+            use base64::{Engine as _, engine::general_purpose::STANDARD};
+            Some(WebEvent::Attachment {
+                tool_call_id,
+                mime_type,
+                filename,
+                data_base64: STANDARD.encode(&data),
+            })
+        }
         // Terminal marker from StreamHub::close — surface as per-turn Done.
         // The session-level bus itself stays open across turns.
         StreamEvent::StreamClosed { .. } => Some(WebEvent::Done),

--- a/crates/cmd/src/chat/mod.rs
+++ b/crates/cmd/src/chat/mod.rs
@@ -1039,6 +1039,9 @@ fn stream_event_to_cli_event(event: StreamEvent) -> Option<CliEvent> {
         StreamEvent::TraceReady { trace_id } => CliEvent::Progress {
             text: format!("Trace saved: {trace_id}"),
         },
+        // CLI chat has no inline attachment rendering surface today — skip
+        // the binary payload rather than crash the exhaustive match.
+        StreamEvent::Attachment { .. } => return None,
         // The CLI forwarder observes stream closure via RecvError::Closed
         // and emits its own Done — returning None here prevents a duplicate
         // Done from the explicit terminal marker (see fn doc comment).

--- a/crates/kernel/src/io.rs
+++ b/crates/kernel/src/io.rs
@@ -1037,6 +1037,30 @@ pub enum StreamEvent {
         /// [`TraceService::save`](crate::trace::TraceService::save).
         trace_id: String,
     },
+    /// A binary attachment (image, document, etc.) produced by a tool
+    /// and intended for in-stream rendering by the receiving client.
+    ///
+    /// Emitted alongside an outbound envelope when the delivery target is a
+    /// channel that does not receive the envelope through the standard
+    /// adapter fanout (currently the Web UI, whose bindings are
+    /// self-referential and skipped by
+    /// [`binding_to_endpoint`](crate::io::IOSubsystem)). Channel adapters
+    /// that already deliver the envelope via `ChannelAdapter::send` (e.g.
+    /// Telegram) ignore this event to avoid double-rendering.
+    Attachment {
+        /// LLM-assigned tool call id this attachment belongs to, when the
+        /// attachment is emitted from within a tool invocation. `None` for
+        /// ambient replies (reserved for future use).
+        tool_call_id: Option<String>,
+        /// IANA media type of the attachment bytes (e.g. `image/png`).
+        mime_type:    String,
+        /// Optional human-readable filename, typically the original file
+        /// basename.
+        filename:     Option<String>,
+        /// Raw attachment bytes. Client transports are expected to
+        /// re-encode (e.g. base64 for JSON frames).
+        data:         Vec<u8>,
+    },
     /// Terminal marker emitted by [`StreamHub::close`] immediately before the
     /// per-stream broadcast sender is dropped.
     ///

--- a/crates/kernel/src/trace/builder.rs
+++ b/crates/kernel/src/trace/builder.rs
@@ -269,6 +269,7 @@ impl TraceBuilder {
             | StreamEvent::ToolCallLimitResolved { .. }
             | StreamEvent::LoopBreakerTriggered { .. }
             | StreamEvent::TraceReady { .. }
+            | StreamEvent::Attachment { .. }
             | StreamEvent::StreamClosed { .. } => {}
         }
     }

--- a/web/src/adapters/rara-stream.ts
+++ b/web/src/adapters/rara-stream.ts
@@ -83,7 +83,14 @@ type WebEvent =
       cost: number;
       model: string;
     }
-  | { type: 'phase'; phase: string };
+  | { type: 'phase'; phase: string }
+  | {
+      type: 'attachment';
+      tool_call_id: string | null;
+      mime_type: string;
+      filename: string | null;
+      data_base64: string;
+    };
 
 // ---------------------------------------------------------------------------
 // Session key — provided via callback at stream time
@@ -385,6 +392,21 @@ export function createRaraStreamFn(
   // result preview on the order of tens of KB), so unbounded growth is not
   // a practical concern; an eviction policy would risk regressing #1601.
   const pendingToolResults = new Map<string, PendingToolResult>();
+  // Attachments emitted by a tool (currently send-file) before its
+  // `tool_call_end` frame. Keyed by the tool call id so the matching
+  // end handler can append image/file blocks onto the resolved tool
+  // result instead of dropping the binary payload (see #1731). Hoisted
+  // to the same outer scope as `pendingToolResults` for the same
+  // reason: the relay shims survive across stream re-invocations, and
+  // attachment frames may straddle invocation boundaries.
+  const pendingAttachments = new Map<
+    string,
+    {
+      mime_type: string;
+      filename: string | null;
+      data_base64: string;
+    }[]
+  >();
   // Deduplicate shim installation across invocations — one `AgentTool` per
   // distinct tool name for the whole session.
   const installedTools = new Set<string>();
@@ -604,8 +626,35 @@ export function createRaraStreamFn(
             const slot = pendingToolResults.get(event.id);
             if (slot) {
               const text = event.error ?? event.result_preview;
+              const content: AgentToolResult<unknown>['content'] = [{ type: 'text', text }];
+              // Append any buffered attachments for this tool call. Images
+              // flow into pi-ai as `image` content blocks (rendered inline
+              // by CompactToolRenderer); non-image files surface as a
+              // text-block download link carrying the base64 data URL so
+              // the user can still retrieve them without a second trip to
+              // the backend.
+              const atts = pendingAttachments.get(event.id);
+              if (atts) {
+                for (const att of atts) {
+                  if (att.mime_type.startsWith('image/')) {
+                    content.push({
+                      type: 'image',
+                      data: att.data_base64,
+                      mimeType: att.mime_type,
+                    });
+                  } else {
+                    const label = att.filename ?? 'attachment';
+                    const href = `data:${att.mime_type};base64,${att.data_base64}`;
+                    content.push({
+                      type: 'text',
+                      text: `[${label}](${href})`,
+                    });
+                  }
+                }
+                pendingAttachments.delete(event.id);
+              }
               const result: AgentToolResult<unknown> = {
-                content: [{ type: 'text', text }],
+                content,
                 details: {},
               };
               slot.resolved = result;
@@ -664,6 +713,19 @@ export function createRaraStreamFn(
             };
             next.cost = calculateCost(model, next);
             currentUsage = next;
+            break;
+          }
+
+          case 'attachment': {
+            if (event.tool_call_id) {
+              const arr = pendingAttachments.get(event.tool_call_id) ?? [];
+              arr.push({
+                mime_type: event.mime_type,
+                filename: event.filename,
+                data_base64: event.data_base64,
+              });
+              pendingAttachments.set(event.tool_call_id, arr);
+            }
             break;
           }
 


### PR DESCRIPTION
## Summary

Web sessions lost file bytes sent via `SendFileTool` because `binding_to_endpoint` intentionally returns `None` for `ChannelType::Web` (Web is self-referential and flows through `StreamHub`, not adapter fanout). The browser only saw a truncated `ToolCallEnd` preview and never received the actual bytes.

This PR adds a new `StreamEvent::Attachment` variant carrying `tool_call_id`, mime type, filename, and raw bytes. `SendFileTool` emits it on the session stream only when the origin endpoint is Web — Telegram and other adapters keep rendering attachments via their own delivery path to avoid double-render. The web channel maps the event to `WebEvent::Attachment` with base64-encoded bytes; the frontend buffers attachments by tool call id and splices them into the matching tool result as pi-ai image content blocks (rendered inline by `CompactToolRenderer`) or as download links for non-image MIME types.

## Type of change

| Type | Label |
|------|-------|
| Bug fix | `bug` |

## Component

`core`

## Closes

Closes #1731

## Test plan

- [x] `cargo check --all --all-targets` passes
- [x] `cargo +nightly fmt --all -- --check` passes
- [x] `cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings` passes
- [x] `RUSTDOCFLAGS="-D warnings" cargo +nightly doc --workspace --no-deps --document-private-items` passes
- [x] `cd web && npm run build` passes
- [x] `cd web && npm test` — all 82 tests pass
- [ ] Manual: send a file via `SendFileTool` from a Web session → verify inline image rendering / download link