### PR TITLE
feat(backend-admin): subscription management (#1736)

### DIFF
--- a/crates/extensions/backend-admin/AGENT.md
+++ b/crates/extensions/backend-admin/AGENT.md
@@ -14,6 +14,7 @@ Unified HTTP admin routes for all backend subsystems — settings management, mo
 - `src/agents/` — Agent manifest listing and management routes.
 - `src/mcp/` — MCP server management routes (list, add, remove, reconnect).
 - `src/skills/` — Skills registry HTTP routes.
+- `src/subscriptions/` — Tag-based notification subscription management. Thin HTTP facade over the kernel `SubscriptionRegistry`; DELETE is admin-gated with an audit log.
 - `src/state.rs` — `BackendState` that holds shared references to all backend services.
 - `src/system_routes.rs` — System-level routes (version, health).
 - `src/lib.rs` — Crate root, re-exports all modules.

--- a/crates/extensions/backend-admin/src/auth.rs
+++ b/crates/extensions/backend-admin/src/auth.rs
@@ -67,6 +67,18 @@ impl AuthState {
             security: handle.security().clone(),
         }
     }
+
+    /// Test-only constructor that accepts an already-built [`SecurityRef`]
+    /// directly, bypassing [`KernelHandle`]. Lets sibling modules wire
+    /// integration tests without spinning up a full kernel.
+    #[cfg(test)]
+    pub(crate) fn for_tests(owner_token: &str, owner_user_id: &str, security: SecurityRef) -> Self {
+        Self {
+            owner_token: Arc::from(owner_token),
+            owner_user_id: owner_user_id.to_owned(),
+            security,
+        }
+    }
 }
 
 /// Axum middleware enforcing `Authorization: Bearer <owner_token>`.

--- a/crates/extensions/backend-admin/src/state.rs
+++ b/crates/extensions/backend-admin/src/state.rs
@@ -118,6 +118,15 @@ impl BackendState {
             self.feed_router_state.clone(),
         ));
 
+        // Subscription management routes — wrap the kernel's subscription
+        // registry with a REST surface so operators can create the
+        // subscriptions that drive ProactiveTurn / SilentAppend fan-out.
+        router = router.merge(crate::subscriptions::subscription_routes(
+            crate::subscriptions::SubscriptionRouterState {
+                registry: kernel_handle.subscription_registry().clone(),
+            },
+        ));
+
         // Wrap every admin route with the bearer-auth middleware. Handlers
         // pull `Extension<Principal<Resolved>>` out of request extensions for
         // authorization checks; the middleware itself enforces the token.

--- a/crates/extensions/backend-admin/src/subscriptions/mod.rs
+++ b/crates/extensions/backend-admin/src/subscriptions/mod.rs
@@ -12,20 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! # rara-backend-admin
+//! Admin HTTP surface for the kernel `SubscriptionRegistry`.
 //!
-//! Unified HTTP admin routes for all backend subsystems: settings,
-//! models, MCP servers, skills, data feeds, and domain routes (chat).
+//! Tag-based notification subscriptions already exist inside the kernel,
+//! but have no out-of-band management channel — without a REST surface
+//! the feed dispatch loop (`crates/app/src/lib.rs`) finds nothing to match
+//! and no `ProactiveTurn` ever fires. This module wraps the registry with
+//! a thin HTTP facade so operators can create / list / update / delete
+//! subscriptions at runtime.
 
-pub mod agents;
-pub mod auth;
-pub mod chat;
-pub mod data_feeds;
-pub mod kernel;
-pub mod mcp;
-pub mod scheduler;
-pub mod settings;
-pub mod skills;
-pub mod state;
-pub mod subscriptions;
-pub mod system_routes;
+mod router;
+
+pub use router::{SubscriptionRouterState, subscription_routes};

--- a/crates/extensions/backend-admin/src/subscriptions/router.rs
+++ b/crates/extensions/backend-admin/src/subscriptions/router.rs
@@ -1,0 +1,506 @@
+// Copyright 2025 Rararulab
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Subscription REST API.
+//!
+//! | Method | Path                                    | Description                      |
+//! |--------|-----------------------------------------|----------------------------------|
+//! | GET    | `/api/v1/subscriptions`                 | list subscriptions (`?owner=`)   |
+//! | POST   | `/api/v1/subscriptions`                 | create subscription              |
+//! | PATCH  | `/api/v1/subscriptions/{id}`            | update tags / on_receive         |
+//! | DELETE | `/api/v1/subscriptions/{id}`            | unsubscribe (admin + audit)      |
+//!
+//! The `subscriber` session key on create is supplied by the caller — the
+//! admin UI lets an operator bind a subscription to any existing session
+//! (typically their own) so matching `FeedEvent`s fan out to that session.
+
+use axum::{
+    Extension, Json, Router,
+    extract::{Path, Query, State},
+    http::StatusCode,
+    routing::{get, patch},
+};
+use rara_kernel::{
+    identity::{Principal, Resolved, UserId},
+    notification::{NotifyAction, Subscription, SubscriptionRegistryRef},
+    session::SessionKey,
+};
+use serde::{Deserialize, Serialize};
+use tracing::info;
+use uuid::Uuid;
+
+use crate::kernel::problem::ProblemDetails;
+
+/// Shared state for subscription routes.
+///
+/// Wraps the kernel's in-memory registry so the HTTP handlers can persist
+/// new subscriptions without owning their own store — the JSON file
+/// backing the registry remains the single source of truth.
+#[derive(Clone)]
+pub struct SubscriptionRouterState {
+    /// Kernel subscription registry (shared Arc).
+    pub registry: SubscriptionRegistryRef,
+}
+
+/// Build the `/api/v1/subscriptions/...` router.
+pub fn subscription_routes(state: SubscriptionRouterState) -> Router {
+    Router::new()
+        .route(
+            "/api/v1/subscriptions",
+            get(list_subscriptions).post(create_subscription),
+        )
+        .route(
+            "/api/v1/subscriptions/{id}",
+            patch(update_subscription).delete(delete_subscription),
+        )
+        .with_state(state)
+}
+
+// ---------------------------------------------------------------------------
+// DTOs
+// ---------------------------------------------------------------------------
+
+/// Wire representation of a [`Subscription`] — mirrors the kernel struct
+/// but stringifies the session key for JSON ergonomics.
+#[derive(Debug, Serialize)]
+struct SubscriptionDto {
+    id:         Uuid,
+    subscriber: String,
+    owner:      String,
+    match_tags: Vec<String>,
+    on_receive: NotifyAction,
+}
+
+impl From<Subscription> for SubscriptionDto {
+    fn from(sub: Subscription) -> Self {
+        Self {
+            id:         sub.id,
+            subscriber: sub.subscriber.to_string(),
+            owner:      sub.owner.0,
+            match_tags: sub.match_tags,
+            on_receive: sub.on_receive,
+        }
+    }
+}
+
+/// `GET /api/v1/subscriptions?owner=<user>` — optional owner filter.
+#[derive(Debug, Deserialize)]
+struct ListQuery {
+    owner: Option<String>,
+}
+
+/// Body of `POST /api/v1/subscriptions`.
+#[derive(Debug, Deserialize)]
+struct CreateSubscriptionRequest {
+    /// Session key (UUID) that will receive matching notifications.
+    subscriber: String,
+    /// Owner user ID — defaults to the authenticated caller when omitted.
+    owner:      Option<String>,
+    match_tags: Vec<String>,
+    on_receive: NotifyAction,
+}
+
+/// Body of `PATCH /api/v1/subscriptions/{id}`.
+#[derive(Debug, Deserialize)]
+struct UpdateSubscriptionRequest {
+    match_tags: Option<Vec<String>>,
+    on_receive: Option<NotifyAction>,
+}
+
+// ---------------------------------------------------------------------------
+// Handlers
+// ---------------------------------------------------------------------------
+
+/// `GET /api/v1/subscriptions` — list subscriptions (optionally filtered).
+async fn list_subscriptions(
+    State(state): State<SubscriptionRouterState>,
+    Query(params): Query<ListQuery>,
+) -> Json<Vec<SubscriptionDto>> {
+    let owner = params.owner.map(UserId);
+    let subs = state.registry.list_all(owner.as_ref()).await;
+    Json(subs.into_iter().map(SubscriptionDto::from).collect())
+}
+
+/// `POST /api/v1/subscriptions` — register a new subscription.
+async fn create_subscription(
+    State(state): State<SubscriptionRouterState>,
+    Extension(principal): Extension<Principal<Resolved>>,
+    Json(body): Json<CreateSubscriptionRequest>,
+) -> Result<(StatusCode, Json<SubscriptionDto>), ProblemDetails> {
+    if body.match_tags.is_empty() {
+        return Err(ProblemDetails::bad_request(
+            "match_tags must contain at least one tag",
+        ));
+    }
+
+    let subscriber = SessionKey::try_from_raw(&body.subscriber)
+        .map_err(|e| ProblemDetails::bad_request(format!("invalid subscriber session key: {e}")))?;
+
+    // Default the owner to the authenticated caller. An explicit owner is
+    // accepted to support operator workflows (e.g. creating a subscription
+    // on behalf of another user), but it is still audited below.
+    let owner = body
+        .owner
+        .map(UserId)
+        .unwrap_or_else(|| principal.user_id.clone());
+
+    let id = state
+        .registry
+        .subscribe(
+            subscriber,
+            owner.clone(),
+            body.match_tags.clone(),
+            body.on_receive,
+        )
+        .await;
+
+    info!(
+        actor = %principal.user_id,
+        subscription_id = %id,
+        owner = %owner,
+        tags = ?body.match_tags,
+        action = ?body.on_receive,
+        "create_subscription"
+    );
+
+    let created = Subscription {
+        id,
+        subscriber,
+        owner,
+        match_tags: body.match_tags,
+        on_receive: body.on_receive,
+    };
+    Ok((StatusCode::CREATED, Json(SubscriptionDto::from(created))))
+}
+
+/// `PATCH /api/v1/subscriptions/{id}` — update tags and/or action.
+async fn update_subscription(
+    State(state): State<SubscriptionRouterState>,
+    Extension(principal): Extension<Principal<Resolved>>,
+    Path(id): Path<Uuid>,
+    Json(body): Json<UpdateSubscriptionRequest>,
+) -> Result<Json<SubscriptionDto>, ProblemDetails> {
+    if body.match_tags.is_none() && body.on_receive.is_none() {
+        return Err(ProblemDetails::bad_request(
+            "at least one of match_tags or on_receive must be provided",
+        ));
+    }
+
+    if let Some(ref tags) = body.match_tags {
+        if tags.is_empty() {
+            return Err(ProblemDetails::bad_request(
+                "match_tags must contain at least one tag",
+            ));
+        }
+    }
+
+    let updated = state
+        .registry
+        .update(id, body.match_tags, body.on_receive)
+        .await
+        .ok_or_else(|| {
+            ProblemDetails::not_found(
+                "Subscription Not Found",
+                format!("no subscription with id: {id}"),
+            )
+        })?;
+
+    info!(
+        actor = %principal.user_id,
+        subscription_id = %id,
+        "update_subscription"
+    );
+
+    Ok(Json(SubscriptionDto::from(updated)))
+}
+
+/// `DELETE /api/v1/subscriptions/{id}` — admin-only unsubscribe with audit.
+async fn delete_subscription(
+    State(state): State<SubscriptionRouterState>,
+    Extension(principal): Extension<Principal<Resolved>>,
+    Path(id): Path<Uuid>,
+) -> Result<StatusCode, ProblemDetails> {
+    if !principal.is_admin() {
+        return Err(ProblemDetails::forbidden(
+            "deleting subscriptions requires admin role",
+        ));
+    }
+
+    info!(
+        actor = %principal.user_id,
+        subscription_id = %id,
+        "delete_subscription"
+    );
+
+    match state.registry.admin_unsubscribe(id).await {
+        Some(_) => Ok(StatusCode::NO_CONTENT),
+        None => Err(ProblemDetails::not_found(
+            "Subscription Not Found",
+            format!("no subscription with id: {id}"),
+        )),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use async_trait::async_trait;
+    use axum::{
+        Router,
+        body::{Body, to_bytes},
+        http::{Request, StatusCode},
+        middleware,
+    };
+    use rara_kernel::{
+        error::Result as KernelResult,
+        identity::{KernelUser, Permission, Role, UserStore},
+        notification::SubscriptionRegistry,
+        security::{ApprovalManager, ApprovalPolicy, SecuritySubsystem},
+        session::SessionKey,
+    };
+    use tempfile::TempDir;
+    use tower::ServiceExt;
+
+    use super::*;
+    use crate::auth::{AuthState, auth_layer};
+
+    struct TestUserStore {
+        user: KernelUser,
+    }
+
+    #[async_trait]
+    impl UserStore for TestUserStore {
+        async fn get_by_name(&self, name: &str) -> KernelResult<Option<KernelUser>> {
+            Ok((name == self.user.name).then(|| self.user.clone()))
+        }
+
+        async fn list(&self) -> KernelResult<Vec<KernelUser>> { Ok(vec![self.user.clone()]) }
+    }
+
+    fn user_of(role: Role) -> KernelUser {
+        KernelUser {
+            name: match role {
+                Role::Admin | Role::Root => "admin".into(),
+                Role::User => "alice".into(),
+            },
+            role,
+            permissions: match role {
+                Role::Admin | Role::Root => vec![Permission::All],
+                // Non-admin callers still need Spawn to resolve through the
+                // security subsystem — matches production user seeding.
+                Role::User => vec![Permission::Spawn],
+            },
+            enabled: true,
+        }
+    }
+
+    fn auth_state_direct(user: KernelUser) -> AuthState {
+        let name = user.name.clone();
+        let store: Arc<dyn UserStore> = Arc::new(TestUserStore { user });
+        let approval = Arc::new(ApprovalManager::new(ApprovalPolicy::default()));
+        let security = Arc::new(SecuritySubsystem::new(store, approval));
+        AuthState::for_tests("s3cret", &name, security)
+    }
+
+    fn test_registry() -> (SubscriptionRegistryRef, TempDir) {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("subscriptions.json");
+        (Arc::new(SubscriptionRegistry::load(path)), tmp)
+    }
+
+    fn app(user: KernelUser) -> (Router, SubscriptionRegistryRef, TempDir) {
+        let (registry, tmp) = test_registry();
+        let state = SubscriptionRouterState {
+            registry: registry.clone(),
+        };
+        let auth = auth_state_direct(user);
+        let router =
+            subscription_routes(state).layer(middleware::from_fn_with_state(auth, auth_layer));
+        (router, registry, tmp)
+    }
+
+    async fn body_bytes(res: axum::response::Response) -> Vec<u8> {
+        to_bytes(res.into_body(), 64 * 1024).await.unwrap().to_vec()
+    }
+
+    #[tokio::test]
+    async fn rejects_missing_auth() {
+        let (app, _reg, _tmp) = app(user_of(Role::Admin));
+        let res = app
+            .oneshot(
+                Request::builder()
+                    .uri("/api/v1/subscriptions")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(res.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn create_list_and_admin_delete_round_trip() {
+        let (app, registry, _tmp) = app(user_of(Role::Admin));
+        let session = SessionKey::new();
+
+        let body = serde_json::json!({
+            "subscriber": session.to_string(),
+            "match_tags": ["news.aapl"],
+            "on_receive": "proactive_turn",
+        });
+        let res = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/v1/subscriptions")
+                    .header("Authorization", "Bearer s3cret")
+                    .header("Content-Type", "application/json")
+                    .body(Body::from(body.to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(res.status(), StatusCode::CREATED);
+        let created: serde_json::Value = serde_json::from_slice(&body_bytes(res).await).unwrap();
+        let id = created["id"].as_str().unwrap().to_owned();
+        assert_eq!(created["match_tags"][0], "news.aapl");
+        assert_eq!(created["on_receive"], "proactive_turn");
+
+        // Registry reflects the new subscription.
+        assert_eq!(registry.list_all(None).await.len(), 1);
+
+        // List endpoint returns it.
+        let res = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri("/api/v1/subscriptions")
+                    .header("Authorization", "Bearer s3cret")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(res.status(), StatusCode::OK);
+        let listed: serde_json::Value = serde_json::from_slice(&body_bytes(res).await).unwrap();
+        assert_eq!(listed.as_array().unwrap().len(), 1);
+
+        // Admin can delete.
+        let res = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("DELETE")
+                    .uri(format!("/api/v1/subscriptions/{id}"))
+                    .header("Authorization", "Bearer s3cret")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(res.status(), StatusCode::NO_CONTENT);
+        assert!(registry.list_all(None).await.is_empty());
+    }
+
+    #[tokio::test]
+    async fn non_admin_cannot_delete() {
+        let (app, registry, _tmp) = app(user_of(Role::User));
+        // Seed a subscription directly via the registry.
+        let id = registry
+            .subscribe(
+                SessionKey::new(),
+                UserId("alice".into()),
+                vec!["x".into()],
+                NotifyAction::SilentAppend,
+            )
+            .await;
+
+        let res = app
+            .oneshot(
+                Request::builder()
+                    .method("DELETE")
+                    .uri(format!("/api/v1/subscriptions/{id}"))
+                    .header("Authorization", "Bearer s3cret")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(res.status(), StatusCode::FORBIDDEN);
+        assert_eq!(registry.list_all(None).await.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn patch_updates_tags_and_action() {
+        let (app, registry, _tmp) = app(user_of(Role::Admin));
+        let id = registry
+            .subscribe(
+                SessionKey::new(),
+                UserId("admin".into()),
+                vec!["old".into()],
+                NotifyAction::SilentAppend,
+            )
+            .await;
+
+        let body = serde_json::json!({
+            "match_tags": ["new", "news.aapl"],
+            "on_receive": "proactive_turn",
+        });
+        let res = app
+            .oneshot(
+                Request::builder()
+                    .method("PATCH")
+                    .uri(format!("/api/v1/subscriptions/{id}"))
+                    .header("Authorization", "Bearer s3cret")
+                    .header("Content-Type", "application/json")
+                    .body(Body::from(body.to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(res.status(), StatusCode::OK);
+        let updated: serde_json::Value = serde_json::from_slice(&body_bytes(res).await).unwrap();
+        assert_eq!(updated["match_tags"][1], "news.aapl");
+        assert_eq!(updated["on_receive"], "proactive_turn");
+    }
+
+    #[tokio::test]
+    async fn create_rejects_empty_tags() {
+        let (app, _reg, _tmp) = app(user_of(Role::Admin));
+        let body = serde_json::json!({
+            "subscriber": SessionKey::new().to_string(),
+            "match_tags": [],
+            "on_receive": "silent_append",
+        });
+        let res = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/v1/subscriptions")
+                    .header("Authorization", "Bearer s3cret")
+                    .header("Content-Type", "application/json")
+                    .body(Body::from(body.to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(res.status(), StatusCode::BAD_REQUEST);
+    }
+}

--- a/crates/kernel/src/notification/subscription.rs
+++ b/crates/kernel/src/notification/subscription.rs
@@ -333,6 +333,61 @@ impl SubscriptionRegistry {
         result
     }
 
+    /// Return all subscriptions, optionally filtered by owner.
+    ///
+    /// Used by admin APIs that need to enumerate the full registry.
+    pub async fn list_all(&self, owner: Option<&UserId>) -> Vec<Subscription> {
+        let inner = self.inner.read().await;
+        inner
+            .subs
+            .values()
+            .filter(|sub| owner.is_none_or(|o| &sub.owner == o))
+            .cloned()
+            .collect()
+    }
+
+    /// Remove a subscription by ID without an ownership check.
+    ///
+    /// Intended for admin/operator code paths that audit the caller's
+    /// role externally (e.g. `is_admin()` in the HTTP handler). Returns
+    /// the removed subscription when it existed, `None` otherwise.
+    pub async fn admin_unsubscribe(&self, subscription_id: Uuid) -> Option<Subscription> {
+        let mut inner = self.inner.write().await;
+        let removed = inner.remove(subscription_id);
+        if removed.is_some() {
+            inner.persist();
+        }
+        removed
+    }
+
+    /// Replace a subscription's match tags and/or action. Returns the
+    /// updated subscription if it existed.
+    ///
+    /// `None` arguments preserve the existing field — this is a partial
+    /// update suitable for HTTP PATCH semantics.
+    pub async fn update(
+        &self,
+        subscription_id: Uuid,
+        match_tags: Option<Vec<String>>,
+        on_receive: Option<NotifyAction>,
+    ) -> Option<Subscription> {
+        let mut inner = self.inner.write().await;
+        let existing = inner.subs.get(&subscription_id)?.clone();
+        let new_sub = Subscription {
+            id:         existing.id,
+            subscriber: existing.subscriber,
+            owner:      existing.owner,
+            match_tags: match_tags.unwrap_or(existing.match_tags),
+            on_receive: on_receive.unwrap_or(existing.on_receive),
+        };
+        // remove() also clears the tag indices, then insert() rebuilds them
+        // for the new tag set.
+        inner.remove(subscription_id);
+        inner.insert(new_sub.clone());
+        inner.persist();
+        Some(new_sub)
+    }
+
     /// Remove all subscriptions for a given session (cleanup on session end).
     pub async fn remove_session(&self, session_key: &SessionKey) {
         let mut inner = self.inner.write().await;

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -32,6 +32,7 @@ import Docs from '@/pages/Docs';
 import KernelTop from '@/pages/KernelTop';
 import Login from '@/pages/Login';
 import PiChat from '@/pages/PiChat';
+import Subscriptions from '@/pages/Subscriptions';
 
 const STORAGE_KEY = 'rara_backend_url';
 const queryClient = new QueryClient();
@@ -116,6 +117,7 @@ export default function App() {
                 <Route path="docs" element={<Docs />} />
                 <Route path="kernel-top" element={<KernelTop />} />
                 <Route path="dock" element={<Dock />} />
+                <Route path="subscriptions" element={<Subscriptions />} />
               </Route>
             </Routes>
           </SettingsModalProvider>

--- a/web/src/layouts/DashboardLayout.tsx
+++ b/web/src/layouts/DashboardLayout.tsx
@@ -15,7 +15,7 @@
  */
 
 import { useQuery } from '@tanstack/react-query';
-import { Activity, LayoutDashboard, Settings } from 'lucide-react';
+import { Activity, Bell, LayoutDashboard, Settings } from 'lucide-react';
 import { useState } from 'react';
 import { Outlet, useLocation, useNavigate } from 'react-router';
 
@@ -143,6 +143,15 @@ export default function DashboardLayout() {
           >
             <LayoutDashboard className="h-3.5 w-3.5" />
             Dock
+          </Button>
+          <Button
+            variant="ghost"
+            size="sm"
+            className="h-7 gap-1.5 text-xs text-muted-foreground hover:text-foreground"
+            onClick={() => navigate('/subscriptions')}
+          >
+            <Bell className="h-3.5 w-3.5" />
+            Subscriptions
           </Button>
           <Button
             variant="ghost"

--- a/web/src/pages/Subscriptions.tsx
+++ b/web/src/pages/Subscriptions.tsx
@@ -1,0 +1,437 @@
+/*
+ * Copyright 2025 Rararulab
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { Plus, Trash2, X } from 'lucide-react';
+import { useMemo, useState } from 'react';
+
+import { api } from '@/api/client';
+import type { ChatSession } from '@/api/types';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Card } from '@/components/ui/card';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+
+// ---------------------------------------------------------------------------
+// Types — mirrors the Rust `SubscriptionDto`
+// ---------------------------------------------------------------------------
+
+type NotifyAction = 'proactive_turn' | 'silent_append';
+
+interface SubscriptionDto {
+  id: string;
+  subscriber: string;
+  owner: string;
+  match_tags: string[];
+  on_receive: NotifyAction;
+}
+
+interface CreateBody {
+  subscriber: string;
+  owner?: string;
+  match_tags: string[];
+  on_receive: NotifyAction;
+}
+
+// ---------------------------------------------------------------------------
+// Page
+// ---------------------------------------------------------------------------
+
+/**
+ * Subscriptions — admin UI for the kernel notification registry.
+ *
+ * Operators create subscriptions that bind a chat session to a set of data
+ * feed tags. When a matching `FeedEvent` fires, the kernel dispatches a
+ * `ProactiveTurn` or appends silently depending on the chosen action.
+ */
+export default function Subscriptions() {
+  const queryClient = useQueryClient();
+  const [createOpen, setCreateOpen] = useState(false);
+  const [pendingDelete, setPendingDelete] = useState<SubscriptionDto | null>(null);
+
+  const subsQuery = useQuery({
+    queryKey: ['subscriptions'],
+    queryFn: () => api.get<SubscriptionDto[]>('/api/v1/subscriptions'),
+  });
+
+  const sessionsQuery = useQuery({
+    queryKey: ['chat-sessions-brief'],
+    queryFn: () => api.get<ChatSession[]>('/api/v1/chat/sessions?limit=100&offset=0'),
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: (id: string) => api.del<void>(`/api/v1/subscriptions/${id}`),
+    onSettled: () => queryClient.invalidateQueries({ queryKey: ['subscriptions'] }),
+  });
+
+  const sessionLabel = useMemo(() => {
+    const index = new Map<string, string>();
+    for (const s of sessionsQuery.data ?? []) {
+      index.set(s.key, s.title ?? s.key.slice(0, 8));
+    }
+    return (key: string) => index.get(key) ?? key.slice(0, 8);
+  }, [sessionsQuery.data]);
+
+  const subs = subsQuery.data ?? [];
+
+  return (
+    <div className="flex h-full flex-col gap-4">
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-xl font-semibold">Subscriptions</h1>
+          <p className="text-sm text-muted-foreground">
+            Bind a chat session to data feed tags — matching events trigger a proactive turn or get
+            silently appended to the conversation.
+          </p>
+        </div>
+        <Button onClick={() => setCreateOpen(true)} className="gap-1.5">
+          <Plus className="h-4 w-4" />
+          New subscription
+        </Button>
+      </div>
+
+      {/* Table */}
+      <Card className="flex-1 min-h-0 overflow-auto p-0">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Tags</TableHead>
+              <TableHead className="w-[160px]">Action</TableHead>
+              <TableHead className="w-[200px]">Subscriber session</TableHead>
+              <TableHead className="w-[140px]">Owner</TableHead>
+              <TableHead className="w-[60px]" />
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {subsQuery.isLoading && (
+              <TableRow>
+                <TableCell colSpan={5} className="text-center text-sm text-muted-foreground">
+                  Loading…
+                </TableCell>
+              </TableRow>
+            )}
+            {!subsQuery.isLoading && subs.length === 0 && (
+              <TableRow>
+                <TableCell colSpan={5} className="text-center text-sm text-muted-foreground">
+                  No subscriptions yet — click “New subscription” to create one.
+                </TableCell>
+              </TableRow>
+            )}
+            {subs.map((sub) => (
+              <TableRow key={sub.id}>
+                <TableCell>
+                  <div className="flex flex-wrap gap-1">
+                    {sub.match_tags.map((tag) => (
+                      <Badge key={tag} variant="secondary">
+                        {tag}
+                      </Badge>
+                    ))}
+                  </div>
+                </TableCell>
+                <TableCell>
+                  <Badge variant={sub.on_receive === 'proactive_turn' ? 'default' : 'outline'}>
+                    {sub.on_receive}
+                  </Badge>
+                </TableCell>
+                <TableCell>
+                  <span className="font-mono text-xs" title={sub.subscriber}>
+                    {sessionLabel(sub.subscriber)}
+                  </span>
+                </TableCell>
+                <TableCell className="text-sm">{sub.owner}</TableCell>
+                <TableCell>
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    className="h-7 w-7 text-muted-foreground hover:text-destructive"
+                    onClick={() => setPendingDelete(sub)}
+                  >
+                    <Trash2 className="h-3.5 w-3.5" />
+                  </Button>
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </Card>
+
+      {/* Create dialog */}
+      <CreateSubscriptionDialog
+        open={createOpen}
+        onOpenChange={setCreateOpen}
+        sessions={sessionsQuery.data ?? []}
+        onCreated={() => queryClient.invalidateQueries({ queryKey: ['subscriptions'] })}
+      />
+
+      {/* Delete confirm */}
+      <AlertDialog
+        open={pendingDelete !== null}
+        onOpenChange={(open) => !open && setPendingDelete(null)}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Delete this subscription?</AlertDialogTitle>
+            <AlertDialogDescription>
+              Matching feed events will stop being dispatched to the bound session. This action is
+              audited and requires admin role on the backend.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={() => {
+                if (pendingDelete) {
+                  deleteMutation.mutate(pendingDelete.id);
+                  setPendingDelete(null);
+                }
+              }}
+            >
+              Delete
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Create dialog
+// ---------------------------------------------------------------------------
+
+interface CreateDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  sessions: ChatSession[];
+  onCreated: () => void;
+}
+
+function CreateSubscriptionDialog({ open, onOpenChange, sessions, onCreated }: CreateDialogProps) {
+  const [subscriber, setSubscriber] = useState<string>('');
+  const [tagsInput, setTagsInput] = useState<string>('');
+  const [tags, setTags] = useState<string[]>([]);
+  const [action, setAction] = useState<NotifyAction>('proactive_turn');
+  const [error, setError] = useState<string | null>(null);
+
+  const createMutation = useMutation({
+    mutationFn: (body: CreateBody) => api.post<SubscriptionDto>('/api/v1/subscriptions', body),
+    onSuccess: () => {
+      onCreated();
+      reset();
+      onOpenChange(false);
+    },
+    onError: (err: Error) => setError(err.message),
+  });
+
+  function reset() {
+    setSubscriber('');
+    setTagsInput('');
+    setTags([]);
+    setAction('proactive_turn');
+    setError(null);
+  }
+
+  function commitTagInput() {
+    const trimmed = tagsInput.trim();
+    if (!trimmed) return;
+    if (!tags.includes(trimmed)) {
+      setTags([...tags, trimmed]);
+    }
+    setTagsInput('');
+  }
+
+  function submit() {
+    setError(null);
+    if (!subscriber) {
+      setError('Select a subscriber session');
+      return;
+    }
+    const allTags = tagsInput.trim() ? [...tags, tagsInput.trim()] : tags;
+    if (allTags.length === 0) {
+      setError('At least one tag is required');
+      return;
+    }
+    createMutation.mutate({
+      subscriber,
+      match_tags: allTags,
+      on_receive: action,
+    });
+  }
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(nextOpen) => {
+        if (!nextOpen) reset();
+        onOpenChange(nextOpen);
+      }}
+    >
+      <DialogContent className="sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle>New subscription</DialogTitle>
+          <DialogDescription>
+            Route feed events that carry any of the selected tags to the chosen session.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4 py-2">
+          {/* Subscriber session */}
+          <div className="space-y-2">
+            <Label htmlFor="subscriber">Subscriber session</Label>
+            <Select value={subscriber} onValueChange={setSubscriber}>
+              <SelectTrigger id="subscriber">
+                <SelectValue placeholder="Select a session…" />
+              </SelectTrigger>
+              <SelectContent>
+                {sessions.length === 0 && (
+                  <SelectItem value="__none" disabled>
+                    No sessions available
+                  </SelectItem>
+                )}
+                {sessions.map((s) => (
+                  <SelectItem key={s.key} value={s.key}>
+                    {s.title ?? s.key.slice(0, 8)}
+                    <span className="ml-2 font-mono text-xs text-muted-foreground">
+                      {s.key.slice(0, 8)}
+                    </span>
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          {/* Tags */}
+          <div className="space-y-2">
+            <Label htmlFor="tags">Match tags</Label>
+            <div className="flex flex-wrap gap-1 rounded-md border border-input bg-background p-2">
+              {tags.map((tag) => (
+                <Badge key={tag} variant="secondary" className="gap-1 pr-1">
+                  {tag}
+                  <button
+                    type="button"
+                    onClick={() => setTags(tags.filter((t) => t !== tag))}
+                    className="rounded-sm hover:bg-muted-foreground/20"
+                  >
+                    <X className="h-3 w-3" />
+                  </button>
+                </Badge>
+              ))}
+              <Input
+                id="tags"
+                value={tagsInput}
+                onChange={(e) => setTagsInput(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter' || e.key === ',') {
+                    e.preventDefault();
+                    commitTagInput();
+                  } else if (e.key === 'Backspace' && !tagsInput && tags.length > 0) {
+                    setTags(tags.slice(0, -1));
+                  }
+                }}
+                onBlur={commitTagInput}
+                placeholder="e.g. news.aapl (press Enter)"
+                className="flex-1 min-w-[120px] border-0 bg-transparent p-0 shadow-none focus-visible:ring-0"
+              />
+            </div>
+            <p className="text-xs text-muted-foreground">
+              Press Enter or comma to add a tag. A feed event whose tag list intersects any of these
+              will fire the subscription.
+            </p>
+          </div>
+
+          {/* Action */}
+          <div className="space-y-2">
+            <Label>On receive</Label>
+            <div className="flex gap-4 text-sm">
+              <label className="flex items-center gap-2">
+                <input
+                  type="radio"
+                  name="on_receive"
+                  value="proactive_turn"
+                  checked={action === 'proactive_turn'}
+                  onChange={() => setAction('proactive_turn')}
+                />
+                <span>
+                  <span className="font-medium">proactive_turn</span> — kick the agent into a new
+                  turn
+                </span>
+              </label>
+              <label className="flex items-center gap-2">
+                <input
+                  type="radio"
+                  name="on_receive"
+                  value="silent_append"
+                  checked={action === 'silent_append'}
+                  onChange={() => setAction('silent_append')}
+                />
+                <span>
+                  <span className="font-medium">silent_append</span> — append to tape without
+                  replying
+                </span>
+              </label>
+            </div>
+          </div>
+
+          {error && <p className="text-sm text-destructive">{error}</p>}
+        </div>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)}>
+            Cancel
+          </Button>
+          <Button onClick={submit} disabled={createMutation.isPending}>
+            {createMutation.isPending ? 'Creating…' : 'Create'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}


### PR DESCRIPTION
## Summary

Admin REST API + web UI to manage the kernel's tag-based notification subscriptions, so operators can actually wire `FeedEvent` fan-out to chat sessions (`ProactiveTurn` / `SilentAppend`).

- `GET/POST /api/v1/subscriptions` and `PATCH/DELETE /api/v1/subscriptions/{id}` on the admin surface
- DELETE is admin-gated with audit log, matching the `data_feeds::delete_feed` pattern
- New `/subscriptions` admin page (list + create dialog with tag multi-input + action radio + delete confirm)
- Added nav button in the dashboard top bar

## Type of change

| Type | Label |
|------|-------|
| New feature | `enhancement` |

## Component

`backend`

## Closes

Closes #1736

## Test plan

- [x] `cargo check --workspace --all-targets` passes
- [x] `cargo clippy -p rara-backend-admin -p rara-kernel --all-targets --no-deps` clean
- [x] `cargo test -p rara-backend-admin --lib subscriptions::` (5/5 passing — missing auth, round-trip, non-admin denied, patch, empty-tags rejection)
- [x] `cd web && npm run build` passes
- [ ] Local end-to-end: login, visit `/subscriptions`, create and delete