### PR TITLE
fix(channels): push live approval events to web UI (#1745)

### DIFF
--- a/crates/channels/src/web.rs
+++ b/crates/channels/src/web.rs
@@ -75,6 +75,7 @@ use rara_kernel::{
         EgressError, Endpoint, EndpointAddress, EndpointRegistry, InteractionType,
         PlatformOutbound, RawPlatformMessage, ReplyContext, StreamEvent, StreamHub,
     },
+    security::{ApprovalRequest, ApprovalResponse},
     session::SessionKey,
 };
 use serde::{Deserialize, Serialize};
@@ -210,6 +211,23 @@ pub enum WebEvent {
         /// Base64-encoded payload (standard alphabet, with padding).
         data_base64:  String,
     },
+    /// A new approval request has been submitted for this session. The
+    /// browser should refresh its pending-approval view (e.g. invalidate
+    /// the `kernel-approvals` query) so the user sees the request without
+    /// waiting for the next poll.
+    ApprovalRequested {
+        id:           String,
+        tool_name:    String,
+        summary:      String,
+        risk_level:   String,
+        requested_at: String,
+        timeout_secs: u64,
+    },
+    /// A previously-pending approval has been resolved (approved, denied,
+    /// or timed out) — possibly by another surface such as Telegram. The
+    /// browser should refresh its pending-approval view to drop the
+    /// cleared entry.
+    ApprovalResolved { id: String, decision: String },
     /// Stream completed (no more deltas).
     Done,
 }
@@ -605,6 +623,95 @@ impl WebAdapter {
                 "web publish: no active receivers"
             );
         }
+    }
+}
+
+/// Listen for approval lifecycle events and fan them out to the originating
+/// session's adapter bus.
+///
+/// Maps `ApprovalRequest` → [`WebEvent::ApprovalRequested`] keyed by
+/// `session_key`. Resolutions carry only `request_id`, so the listener
+/// maintains a short-lived `request_id → session_key` map populated from
+/// the request stream and drained on resolution. Entries that never fire
+/// (lost due to broadcast lag) leak until the adapter stops — bounded by
+/// the per-agent pending limit enforced by `ApprovalManager`, so the map
+/// never grows unboundedly in practice.
+#[tracing::instrument(skip_all, name = "web.approval_listener")]
+async fn approval_listener(
+    mut request_rx: tokio::sync::broadcast::Receiver<ApprovalRequest>,
+    mut resolution_rx: tokio::sync::broadcast::Receiver<ApprovalResponse>,
+    adapter_events: Arc<DashMap<SessionKey, broadcast::Sender<WebEvent>>>,
+    mut shutdown_rx: watch::Receiver<bool>,
+) {
+    let session_by_request: Arc<DashMap<uuid::Uuid, SessionKey>> = Arc::new(DashMap::new());
+
+    loop {
+        tokio::select! {
+            _ = shutdown_rx.changed() => {
+                info!("web approval listener: shutting down");
+                return;
+            }
+            result = request_rx.recv() => {
+                match result {
+                    Ok(req) => {
+                        session_by_request.insert(req.id, req.session_key.clone());
+                        let event = WebEvent::ApprovalRequested {
+                            id:           req.id.to_string(),
+                            tool_name:    req.tool_name.clone(),
+                            summary:      req.summary.clone(),
+                            risk_level:   risk_level_str(req.risk_level).to_owned(),
+                            requested_at: req.requested_at.to_string(),
+                            timeout_secs: req.timeout_secs,
+                        };
+                        WebAdapter::publish_adapter_event(&adapter_events, &req.session_key, event);
+                    }
+                    Err(tokio::sync::broadcast::error::RecvError::Closed) => return,
+                    Err(tokio::sync::broadcast::error::RecvError::Lagged(n)) => {
+                        warn!(skipped = n, "web approval listener: request stream lagged");
+                    }
+                }
+            }
+            result = resolution_rx.recv() => {
+                match result {
+                    Ok(resp) => {
+                        let Some((_, session_key)) = session_by_request.remove(&resp.request_id) else {
+                            // Request originated before this listener was
+                            // subscribed, or the session already went away.
+                            continue;
+                        };
+                        let decision = decision_str(resp.decision).to_owned();
+                        let event = WebEvent::ApprovalResolved {
+                            id: resp.request_id.to_string(),
+                            decision,
+                        };
+                        WebAdapter::publish_adapter_event(&adapter_events, &session_key, event);
+                    }
+                    Err(tokio::sync::broadcast::error::RecvError::Closed) => return,
+                    Err(tokio::sync::broadcast::error::RecvError::Lagged(n)) => {
+                        warn!(skipped = n, "web approval listener: resolution stream lagged");
+                    }
+                }
+            }
+        }
+    }
+}
+
+fn risk_level_str(level: rara_kernel::security::RiskLevel) -> &'static str {
+    use rara_kernel::security::RiskLevel;
+    match level {
+        RiskLevel::Low => "low",
+        RiskLevel::Medium => "medium",
+        RiskLevel::High => "high",
+        RiskLevel::Critical => "critical",
+    }
+}
+
+fn decision_str(decision: rara_kernel::security::ApprovalDecision) -> &'static str {
+    use rara_kernel::security::ApprovalDecision;
+    match decision {
+        ApprovalDecision::Approved => "approved",
+        ApprovalDecision::Denied => "denied",
+        ApprovalDecision::TimedOut => "timed_out",
     }
 }
 
@@ -1340,6 +1447,25 @@ impl ChannelAdapter for WebAdapter {
     async fn start(&self, handle: KernelHandle) -> Result<(), KernelError> {
         *self.stream_hub.write().await = Some(handle.stream_hub().clone());
         *self.endpoint_registry.write().await = Some(handle.endpoint_registry().clone());
+
+        // Subscribe to approval events and fan them out to the originating
+        // session's adapter bus so the browser learns about
+        // requests/resolutions without polling. Mirrors the Telegram
+        // adapter's `approval_listener` (see
+        // `crates/channels/src/telegram/adapter.rs`).
+        {
+            let request_rx = handle.security().approval().subscribe_requests();
+            let resolution_rx = handle.security().approval().subscribe_resolutions();
+            let events = Arc::clone(&self.adapter_events);
+            let shutdown_rx = self.shutdown_rx.clone();
+            tokio::spawn(approval_listener(
+                request_rx,
+                resolution_rx,
+                events,
+                shutdown_rx,
+            ));
+        }
+
         let mut guard = self.sink.write().await;
         *guard = Some(handle);
         info!("WebAdapter started");
@@ -1533,6 +1659,34 @@ mod tests {
         let json = serde_json::to_value(&event).expect("serialize");
         assert_eq!(json["type"], "error");
         assert_eq!(json["message"], "model rejected reasoning=minimal");
+    }
+
+    #[test]
+    fn approval_requested_serializes_as_snake_case_tagged_frame() {
+        let event = WebEvent::ApprovalRequested {
+            id:           "11111111-1111-1111-1111-111111111111".to_owned(),
+            tool_name:    "bash".to_owned(),
+            summary:      "rm -rf /tmp/x".to_owned(),
+            risk_level:   "critical".to_owned(),
+            requested_at: "2025-01-01T00:00:00Z".to_owned(),
+            timeout_secs: 120,
+        };
+        let json = serde_json::to_value(&event).expect("serialize");
+        assert_eq!(json["type"], "approval_requested");
+        assert_eq!(json["tool_name"], "bash");
+        assert_eq!(json["risk_level"], "critical");
+        assert_eq!(json["timeout_secs"], 120);
+    }
+
+    #[test]
+    fn approval_resolved_serializes_as_snake_case_tagged_frame() {
+        let event = WebEvent::ApprovalResolved {
+            id:       "22222222-2222-2222-2222-222222222222".to_owned(),
+            decision: "approved".to_owned(),
+        };
+        let json = serde_json::to_value(&event).expect("serialize");
+        assert_eq!(json["type"], "approval_resolved");
+        assert_eq!(json["decision"], "approved");
     }
 
     #[test]

--- a/crates/kernel/src/security.rs
+++ b/crates/kernel/src/security.rs
@@ -166,22 +166,30 @@ struct PendingRequest {
 /// blocks on a oneshot channel until a human resolves it (via `resolve()`)
 /// or the request times out.
 pub struct ApprovalManager {
-    pending:    DashMap<Uuid, PendingRequest>,
-    expired:    DashMap<Uuid, Timestamp>,
-    policy:     RwLock<ApprovalPolicy>,
+    pending:     DashMap<Uuid, PendingRequest>,
+    expired:     DashMap<Uuid, Timestamp>,
+    policy:      RwLock<ApprovalPolicy>,
     /// Broadcast channel for notifying external listeners (e.g. Telegram
     /// adapter) when a new approval request is submitted.
-    request_tx: tokio::sync::broadcast::Sender<ApprovalRequest>,
+    request_tx:  tokio::sync::broadcast::Sender<ApprovalRequest>,
+    /// Broadcast channel for notifying external listeners when a pending
+    /// approval is resolved. Channel adapters use this to push live
+    /// "approval resolved" events to their clients (e.g. to clear a
+    /// pending badge in the web UI) regardless of which surface actually
+    /// resolved the request.
+    resolved_tx: tokio::sync::broadcast::Sender<ApprovalResponse>,
 }
 
 impl ApprovalManager {
     pub fn new(policy: ApprovalPolicy) -> Self {
         let (request_tx, _) = tokio::sync::broadcast::channel(16);
+        let (resolved_tx, _) = tokio::sync::broadcast::channel(16);
         Self {
             pending: DashMap::new(),
             expired: DashMap::new(),
             policy: RwLock::new(policy),
             request_tx,
+            resolved_tx,
         }
     }
 
@@ -189,6 +197,13 @@ impl ApprovalManager {
     /// use this to send interactive approval prompts to users.
     pub fn subscribe_requests(&self) -> tokio::sync::broadcast::Receiver<ApprovalRequest> {
         self.request_tx.subscribe()
+    }
+
+    /// Subscribe to approval resolutions. Channel adapters use this to push
+    /// a "request resolved" notification to clients so stale pending UI can
+    /// be cleared no matter which surface approved/denied the request.
+    pub fn subscribe_resolutions(&self) -> tokio::sync::broadcast::Receiver<ApprovalResponse> {
+        self.resolved_tx.subscribe()
     }
 
     /// Check if a tool requires approval based on current policy.
@@ -250,8 +265,18 @@ impl ApprovalManager {
                 decision
             }
             _ => {
-                self.expired.insert(id, Timestamp::now());
+                let now = Timestamp::now();
+                self.expired.insert(id, now);
                 self.pending.remove(&id);
+                // Broadcast the timeout as a resolution so live clients
+                // clear the pending entry without waiting for their next
+                // poll of the approvals endpoint.
+                let _ = self.resolved_tx.send(ApprovalResponse {
+                    request_id: id,
+                    decision:   ApprovalDecision::TimedOut,
+                    decided_at: now,
+                    decided_by: None,
+                });
                 warn!(request_id = %id, "approval request timed out");
                 ApprovalDecision::TimedOut
             }
@@ -275,6 +300,10 @@ impl ApprovalManager {
                     decided_by,
                 };
                 let _ = pending.sender.send(decision);
+                // Notify external listeners (web UI, future surfaces) that
+                // this request is no longer pending so they can clear any
+                // cached "pending" state.
+                let _ = self.resolved_tx.send(response.clone());
                 info!(request_id = %request_id, ?decision, "approval resolved");
                 Ok(response)
             }

--- a/web/src/adapters/rara-stream.ts
+++ b/web/src/adapters/rara-stream.ts
@@ -90,7 +90,17 @@ type WebEvent =
       mime_type: string;
       filename: string | null;
       data_base64: string;
-    };
+    }
+  | {
+      type: 'approval_requested';
+      id: string;
+      tool_name: string;
+      summary: string;
+      risk_level: string;
+      requested_at: string;
+      timeout_secs: number;
+    }
+  | { type: 'approval_resolved'; id: string; decision: string };
 
 // ---------------------------------------------------------------------------
 // Session key — provided via callback at stream time

--- a/web/src/pages/PiChat.tsx
+++ b/web/src/pages/PiChat.tsx
@@ -31,6 +31,7 @@ import {
   // pi-mono can render server-triggered document-extraction tool calls.
   extractDocumentTool,
 } from '@mariozechner/pi-web-ui';
+import { useQueryClient } from '@tanstack/react-query';
 import { html } from 'lit';
 import { useEffect, useRef, useCallback, useState } from 'react';
 
@@ -294,6 +295,12 @@ function registerCascadeAssistantRenderer(agentResolver: () => Agent | null): vo
  * wiring it up to rara's storage backend and WebSocket stream function.
  */
 export default function PiChat() {
+  const queryClient = useQueryClient();
+  // Stashed in a ref so the long-lived `useEffect([])` init block can call
+  // `invalidateQueries` without triggering exhaustive-deps or re-running.
+  // The `QueryClient` instance is stable for the app's lifetime.
+  const queryClientRef = useRef(queryClient);
+  queryClientRef.current = queryClient;
   const containerRef = useRef<HTMLDivElement>(null);
   // Live-card scroll-padding wiring: `liveCardEl` measures the rendered
   // card; `mainEl` receives the `--rara-live-card-h` CSS variable that
@@ -779,8 +786,17 @@ export default function PiChat() {
             },
             // Feed the agent-live store with every WS frame so the card
             // can render in parallel to pi-chat-panel without opening a
-            // second WebSocket (see #1615).
-            (sessionKey, event) => liveRunStore.publish(sessionKey, event),
+            // second WebSocket (see #1615). Also listen for approval
+            // lifecycle events pushed by the backend (see #1745) and
+            // invalidate the `kernel-approvals` query so the admin
+            // drawer refreshes immediately instead of waiting for the
+            // next 5s poll.
+            (sessionKey, event) => {
+              liveRunStore.publish(sessionKey, event);
+              if (event.type === 'approval_requested' || event.type === 'approval_resolved') {
+                void queryClientRef.current.invalidateQueries({ queryKey: ['kernel-approvals'] });
+              }
+            },
           ),
           convertToLlm: defaultConvertToLlm,
           sessionId: initialSession.key,


### PR DESCRIPTION
## Summary

`ApprovalManager` already broadcasts new approval requests for external listeners, but only the Telegram adapter subscribed — the browser silently waited on its 5s poll to notice new pending approvals. This wires the web adapter into the same broadcast and adds a companion resolution broadcast so clients can clear stale "pending" state no matter which surface resolves the request.

- `ApprovalManager` now exposes `subscribe_resolutions()` in addition to `subscribe_requests()`; `resolve()` and the timeout branch both fan out an `ApprovalResponse`.
- `WebAdapter::start()` spawns `approval_listener`, which mirrors the Telegram pattern (`tokio::select!` on the two broadcast receivers + shutdown watch) and publishes `WebEvent::ApprovalRequested` / `WebEvent::ApprovalResolved` to the originating session's adapter bus.
- Frontend: extends the `WebEvent` discriminated union in `rara-stream.ts` and, in `PiChat`, invalidates the `['kernel-approvals']` react-query on approval events. The `ApprovalsDrawer` on `KernelTop` now refreshes live instead of on the 5s tick.

## Type of change

| Type | Label |
|------|-------|
| Bug fix | `bug` |

## Component

`backend` + `ui`

## Closes

Closes #1745

## Test plan

- [x] `cargo check -p rara-channels -p rara-kernel`
- [x] `cargo clippy -p rara-channels --all-targets -- -D warnings`
- [x] `cargo +nightly fmt --all`
- [x] `cargo test -p rara-channels --lib web::` — includes two new serde round-trip tests for the new variants
- [x] `cd web && npm run build`
- [x] `prek run --all-files`