### PR TITLE
fix(backend-admin): add CORS layer to admin HTTP surface (#1734)

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -12,6 +12,13 @@
 
 http:
   bind_address: "127.0.0.1:25555"
+  # Browser origins permitted to call `/api/v1/*`. At least one entry is
+  # required — the server refuses to boot with an empty list. Add every host
+  # the Vite dev server is reachable from (localhost plus any LAN IPs used to
+  # open the UI from other devices).
+  cors_allowed_origins:
+    - "http://localhost:5173"
+    - "http://10.0.0.183:5173"
 
 grpc:
   bind_address: "127.0.0.1:50051"

--- a/crates/app/src/lib.rs
+++ b/crates/app/src/lib.rs
@@ -728,6 +728,7 @@ pub async fn start_with_options(
         &rara.skill_registry,
         &rara.mcp_manager,
         auth_state,
+        &config.http.cors_allowed_origins,
     );
 
     let dock_store_path = rara_paths::data_dir().join("dock");

--- a/crates/extensions/backend-admin/AGENT.md
+++ b/crates/extensions/backend-admin/AGENT.md
@@ -30,6 +30,7 @@ Unified HTTP admin routes for all backend subsystems — settings management, mo
 - `SettingsSvc` is the single source of truth for runtime-mutable settings (LLM keys, Telegram tokens, etc.).
 - Settings changes are broadcast via `tokio::sync::watch` — subscribers get notified of all changes.
 - Admin routes should not bypass `SettingsSvc` to read/write settings directly in the KV store.
+- CORS (`CorsLayer`) MUST wrap OUTSIDE `auth_layer` in `state.rs` so browser preflight `OPTIONS` (which carries no `Authorization` header) bypasses the bearer-token check. Allowed origins come from `http.cors_allowed_origins` in YAML — never hardcode them in Rust.
 
 ## What NOT To Do
 

--- a/crates/extensions/backend-admin/Cargo.toml
+++ b/crates/extensions/backend-admin/Cargo.toml
@@ -38,6 +38,7 @@ strum = { workspace = true }
 strum_macros = { workspace = true }
 tokio = { workspace = true, features = ["sync", "fs", "rt"] }
 tokio-util = { workspace = true }
+tower-http = { workspace = true, features = ["cors"] }
 tracing = { workspace = true }
 tracing-opentelemetry = "0.32.0"
 utoipa = { workspace = true }

--- a/crates/extensions/backend-admin/src/state.rs
+++ b/crates/extensions/backend-admin/src/state.rs
@@ -19,7 +19,9 @@
 
 use std::sync::Arc;
 
+use axum::http::{HeaderValue, Method, header};
 use snafu::Whatever;
+use tower_http::cors::CorsLayer;
 use tracing::info;
 
 use crate::data_feeds::DataFeedRouterState;
@@ -81,6 +83,7 @@ impl BackendState {
         skill_registry: &rara_skills::registry::InMemoryRegistry,
         mcp_manager: &rara_mcp::manager::mgr::McpManager,
         auth_state: crate::auth::AuthState,
+        cors_allowed_origins: &[String],
     ) -> (axum::Router, utoipa::openapi::OpenApi) {
         let mut api = Self::api_doc();
 
@@ -135,6 +138,15 @@ impl BackendState {
             crate::auth::auth_layer,
         ));
 
+        // CORS layer wraps OUTSIDE auth_layer so browser preflight (`OPTIONS`
+        // without an `Authorization` header) is answered by tower-http
+        // instead of being rejected with 401 by the auth middleware.
+        //
+        // Origins are drawn from YAML config — no hardcoded defaults and no
+        // silent fallback: an empty or invalid list is a hard configuration
+        // error caught at boot rather than at first browser request.
+        let router = router.layer(build_cors_layer(cors_allowed_origins));
+
         (router, api)
     }
 
@@ -157,6 +169,41 @@ impl BackendState {
         struct ApiDoc;
         ApiDoc::openapi()
     }
+}
+
+/// Build a [`CorsLayer`] allow-listing the given origins for the admin HTTP
+/// surface.
+///
+/// Panics when the allow-list is empty or contains an origin that is not a
+/// valid HTTP header value. CORS misconfiguration is a boot-time error: the
+/// frontend cannot reach the admin API without it, and silent fallback would
+/// delay the failure to first browser request.
+fn build_cors_layer(allowed_origins: &[String]) -> CorsLayer {
+    assert!(
+        !allowed_origins.is_empty(),
+        "http.cors_allowed_origins must list at least one origin — see config.example.yaml",
+    );
+
+    let origins: Vec<HeaderValue> = allowed_origins
+        .iter()
+        .map(|origin| {
+            HeaderValue::from_str(origin).unwrap_or_else(|err| {
+                panic!("invalid http.cors_allowed_origins entry {origin:?}: {err}")
+            })
+        })
+        .collect();
+
+    CorsLayer::new()
+        .allow_origin(origins)
+        .allow_methods([
+            Method::GET,
+            Method::POST,
+            Method::PUT,
+            Method::PATCH,
+            Method::DELETE,
+            Method::OPTIONS,
+        ])
+        .allow_headers([header::AUTHORIZATION, header::CONTENT_TYPE])
 }
 
 fn merge_openapi_router(

--- a/crates/server/src/http.rs
+++ b/crates/server/src/http.rs
@@ -33,11 +33,7 @@ use smart_default::SmartDefault;
 use snafu::ResultExt;
 use tokio::sync::oneshot;
 use tokio_util::sync::CancellationToken;
-use tower_http::{
-    cors::{Any, CorsLayer},
-    timeout::TimeoutLayer,
-    trace::TraceLayer,
-};
+use tower_http::{timeout::TimeoutLayer, trace::TraceLayer};
 use tracing::{Span, info};
 
 use super::ServiceHandler;
@@ -87,21 +83,26 @@ async fn observe_http_metrics(request: Request, next: Next) -> Response {
 pub struct RestServerConfig {
     /// The address to bind the REST server
     #[default = "127.0.0.1:25555"]
-    pub bind_address:    String,
+    pub bind_address:         String,
     /// Maximum HTTP request body size
     #[default(_code = "DEFAULT_MAX_HTTP_BODY_SIZE")]
-    pub max_body_size:   ReadableSize,
-    /// Whether to enable CORS
-    #[default = true]
-    pub enable_cors:     bool,
+    pub max_body_size:        ReadableSize,
     /// Request timeout in seconds
     #[default(DEFAULT_REQUEST_TIMEOUT_SECS)]
-    pub request_timeout: u64,
+    pub request_timeout:      u64,
     /// Port for the web frontend dev server (optional).
     ///
     /// When set, the app spawns `bun run dev` in `web/`. Vite uses its
     /// own port (default 5173); this field gates whether to start it.
-    pub web_port:        Option<u16>,
+    pub web_port:             Option<u16>,
+    /// Explicit CORS allow-list for the admin HTTP surface.
+    ///
+    /// Each entry is an origin string (scheme + host + port) permitted to
+    /// call `/api/v1/*` from a browser, e.g. `http://localhost:5173`. An
+    /// empty list is a hard boot-time error — no hardcoded default, no
+    /// silent fallback (see `docs/guides/anti-patterns.md`).
+    #[serde(default)]
+    pub cors_allowed_origins: Vec<String>,
 }
 
 /// Starts the REST server and returns a handle for managing its lifecycle.
@@ -182,14 +183,9 @@ where
             DefaultBodyLimit::max(config.max_body_size.as_bytes() as usize)
         });
 
-    // Add CORS if enabled
-    if config.enable_cors {
-        let cors = CorsLayer::new()
-            .allow_origin(Any)
-            .allow_methods(Any)
-            .allow_headers(Any);
-        api_router = api_router.layer(cors);
-    }
+    // CORS is now owned by each domain router (see `rara_backend_admin::state`)
+    // so the allow-list can be configured per surface and preflight (OPTIONS)
+    // responses bypass downstream auth middleware.
 
     // Build the final router: merge API routes, add /health and fallback,
     // then apply TraceLayer as the outermost layer so it observes every

--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -123,9 +123,9 @@ just consul-keys   # list current keys
 |-----|---------|---------|-------------|
 | `bind_address` | `RARA__HTTP__BIND_ADDRESS` | `127.0.0.1:25555` | HTTP listen address |
 | `max_body_size` | `RARA__HTTP__MAX_BODY_SIZE` | `100MB` | Max request body |
-| `enable_cors` | `RARA__HTTP__ENABLE_CORS` | `true` | CORS headers |
 | `request_timeout` | `RARA__HTTP__REQUEST_TIMEOUT` | `60` | Timeout in seconds |
 | `web_port` | `RARA__HTTP__WEB_PORT` | *(none)* | Static frontend server port (spawns `npx serve` or `python3 http.server` for `web/dist/`) |
+| `cors_allowed_origins` | `RARA__HTTP__CORS_ALLOWED_ORIGINS` | *(required)* | Allow-list of browser origins for `/api/v1/*` (e.g. `["http://localhost:5173"]`) — empty list is a boot-time error |
 
 #### gRPC Server (`grpc.*`)
 


### PR DESCRIPTION
## Summary

Browser clients (Vite dev server on `:5173`) could not call the admin API on `:25555`. Two problems stacked:

1. The admin HTTP surface no longer installed any CORS layer (the old blanket `Any`/`Any`/`Any` layer in `rara-server::http` produced 401s on preflight once bearer auth landed in #1710).
2. The bearer-auth middleware rejected `OPTIONS` preflight with 401 because browsers do not attach `Authorization` to preflight.

Fix:

- Install `tower-http::CorsLayer` inside `BackendState::routes()`, wrapping OUTSIDE the auth layer so preflight bypasses the bearer check.
- Allow-list sourced from a new `http.cors_allowed_origins` YAML key — no hardcoded defaults, no silent fallback (empty or invalid origins panic at boot per `docs/guides/anti-patterns.md`).
- Remove the obsolete `enable_cors` + blanket `Any`/`Any`/`Any` CORS layer from `rara-server::http`; ownership is now per-router.
- `Cargo.toml`: enable `cors` feature on `tower-http` for `rara-backend-admin`.
- Docs + `config.example.yaml` updated; `AGENT.md` records the invariant.

## Type of change

| Type | Label |
|------|-------|
| Bug fix | `bug` |

## Component

`backend`

## Closes

Closes #1734

## Test plan

- [x] `cargo check --all --all-targets` passes
- [x] `cargo clippy --workspace --all-targets --no-deps` clean
- [x] `cargo +nightly fmt --all -- --check` clean
- [x] `RUSTDOCFLAGS="-D warnings" cargo +nightly doc --workspace --no-deps --document-private-items` clean
- [ ] Local `curl -X OPTIONS` preflight check: skipped — server boot requires full config + DB seed; verifying via CI + manual user login after merge