### PR TITLE
ci(rust): install libsqlite3-dev and libpq-dev for diesel link step (#1757)

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -68,6 +68,11 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Install diesel system libraries
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends libsqlite3-dev libpq-dev
+
       - name: Start sccache
         run: sccache --start-server || true
 


### PR DESCRIPTION
## Summary

The `Rust / Test` job was failing on PR #1750 with `rust-lld: unable to find library -lsqlite3` / `-lpq`. diesel 2.3 links against the OS sqlite/libpq at test-binary link time; the sqlx-era CI didn't need either (bundled sqlite, no Rust pg usage in tests).

Add `libsqlite3-dev` + `libpq-dev` to the Test job's apt install step. Clippy/Doc don't link, so they don't need the libs.

## Type of change

| Type | Label |
|------|-------|
| Chore | `chore` |

## Component

`ci`

## Closes

Closes #1757

## Test plan

- [ ] Rust / Test job passes after this lands