### PR TITLE
fix(store): remove unused diesel postgres linkage (#1759)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -160,9 +160,9 @@ croner = "3"
 crossbeam-queue = "0.3"
 crossterm = "0.28"
 derive_more = { version = "2.0", features = ["full"] }
-diesel = { version = "2.3", features = ["sqlite", "postgres", "chrono", "uuid", "serde_json", "r2d2", "returning_clauses_for_sqlite_3_35"] }
-diesel-async = { version = "0.8", features = ["sqlite", "postgres", "bb8"] }
-diesel_migrations = { version = "2.3", features = ["sqlite", "postgres"] }
+diesel = { version = "2.3", features = ["sqlite", "chrono", "uuid", "serde_json", "r2d2", "returning_clauses_for_sqlite_3_35"] }
+diesel-async = { version = "0.8", features = ["sqlite", "bb8"] }
+diesel_migrations = { version = "2.3", features = ["sqlite"] }
 dirs = "^6"
 eventsource-stream = "0.2"
 futures = "^0.3"

--- a/crates/common/yunara-store/AGENT.md
+++ b/crates/common/yunara-store/AGENT.md
@@ -9,7 +9,7 @@ used for runtime settings and miscellaneous persisted state.
 
 ### Key modules
 
-- `src/diesel_pool.rs` — `DieselSqlitePool` / `DieselPgPool` aliases plus `build_sqlite_pool` / `build_pg_pool`. The sqlite pool sets `WAL`, `busy_timeout=5000`, `foreign_keys=ON` pragmas once per physical connection via the manager's `custom_setup` hook.
+- `src/diesel_pool.rs` — `DieselSqlitePool` plus `build_sqlite_pool`. The sqlite pool sets `WAL`, `busy_timeout=5000`, `foreign_keys=ON` pragmas once per physical connection via the manager's `custom_setup` hook.
 - `src/config.rs` — `DatabaseConfig` with `bon::Builder`; `open(database_url)` wraps `build_sqlite_pool` and returns a `DBStore`.
 - `src/db.rs` — `DBStore` wraps `DieselSqlitePool`; provides `pool()` and `kv_store()`.
 - `src/kv.rs` — `KVStore` backed by the `kv_table` SQLite table (JSON values). Full diesel DSL; `batch_set` runs inside a transaction.
@@ -17,7 +17,7 @@ used for runtime settings and miscellaneous persisted state.
 
 ### Public API
 
-- `DatabaseConfig`, `DBStore`, `KVStore`, `DieselSqlitePool`, `DieselPgPool`.
+- `DatabaseConfig`, `DBStore`, `KVStore`, `DieselSqlitePool`.
 
 ## Critical Invariants
 

--- a/crates/common/yunara-store/README.md
+++ b/crates/common/yunara-store/README.md
@@ -1,8 +1,7 @@
 # yunara-store
 
-Shared diesel-async + bb8 SQLite/Postgres connection pool and a JSON
+Shared diesel-async + bb8 SQLite connection pool and a JSON
 key-value store backed by the `kv_table` schema owned by `rara-model`.
 
-Provides `DBStore` / `DieselSqlitePool` / `DieselPgPool` for database
-connections and `KVStore` / `KVStoreExt` for application identifiers and
-runtime settings.
+Provides `DBStore` / `DieselSqlitePool` for database connections and
+`KVStore` / `KVStoreExt` for application identifiers and runtime settings.

--- a/crates/common/yunara-store/src/diesel_pool.rs
+++ b/crates/common/yunara-store/src/diesel_pool.rs
@@ -16,11 +16,11 @@
 //!
 //! Introduced as part of the sqlx → diesel migration (#1702). SQLite uses
 //! [`SyncConnectionWrapper`] because SQLite itself is single-threaded and has
-//! no native async driver. Postgres uses the native [`AsyncPgConnection`].
+//! no native async driver.
 
 use diesel::SqliteConnection;
 use diesel_async::{
-    AsyncConnection, AsyncPgConnection, RunQueryDsl,
+    AsyncConnection, RunQueryDsl,
     pooled_connection::{AsyncDieselConnectionManager, ManagerConfig},
     sync_connection_wrapper::SyncConnectionWrapper,
 };
@@ -36,20 +36,14 @@ pub type DieselSqliteConnection = SyncConnectionWrapper<SqliteConnection>;
 /// bb8-managed diesel-async pool for SQLite.
 pub type DieselSqlitePool = ::bb8::Pool<AsyncDieselConnectionManager<DieselSqliteConnection>>;
 
-/// Postgres diesel-async connection.
-pub type DieselPgConnection = AsyncPgConnection;
-
-/// bb8-managed diesel-async pool for Postgres.
-pub type DieselPgPool = ::bb8::Pool<AsyncDieselConnectionManager<DieselPgConnection>>;
-
 /// Pool sizing and connection parameters for the diesel-async pools.
 ///
 /// Defaults are deliberately absent — this struct is populated from the YAML
 /// config (per the no-hardcoded-defaults invariant) by the caller and handed
-/// to [`build_sqlite_pool`] / [`build_pg_pool`].
+/// to [`build_sqlite_pool`].
 #[derive(Debug, Clone, bon::Builder, serde::Serialize, serde::Deserialize)]
 pub struct DieselPoolConfig {
-    /// Database URL (`sqlite://…` or `postgres://…`).
+    /// Database URL (`sqlite://…`).
     pub database_url:    String,
     /// Maximum number of pooled connections.
     pub max_connections: u32,
@@ -85,18 +79,6 @@ pub async fn build_sqlite_pool(config: &DieselPoolConfig) -> Result<DieselSqlite
         config.database_url.clone(),
         manager_config,
     );
-    let mut builder = ::bb8::Pool::builder().max_size(config.max_connections);
-    if let Some(min_idle) = config.min_idle {
-        builder = builder.min_idle(Some(min_idle));
-    }
-    builder.build(manager).await.context(BuildDieselPoolSnafu)
-}
-
-/// Build a bb8 pool of diesel-async Postgres connections.
-#[tracing::instrument(level = "trace", skip(config), fields(url = %config.database_url), err)]
-pub async fn build_pg_pool(config: &DieselPoolConfig) -> Result<DieselPgPool> {
-    let manager =
-        AsyncDieselConnectionManager::<DieselPgConnection>::new(config.database_url.clone());
     let mut builder = ::bb8::Pool::builder().max_size(config.max_connections);
     if let Some(min_idle) = config.min_idle {
         builder = builder.min_idle(Some(min_idle));

--- a/crates/common/yunara-store/src/lib.rs
+++ b/crates/common/yunara-store/src/lib.rs
@@ -21,8 +21,8 @@ pub mod kv;
 pub use config::DatabaseConfig;
 pub use db::DBStore;
 pub use diesel_pool::{
-    DieselPgConnection, DieselPgPool, DieselPoolConfig, DieselPoolInitError, DieselPoolRunError,
-    DieselSqliteConnection, DieselSqlitePool, build_pg_pool, build_sqlite_pool,
+    DieselPoolConfig, DieselPoolInitError, DieselPoolRunError, DieselSqliteConnection,
+    DieselSqlitePool, build_sqlite_pool,
 };
 pub use error::{Error, Result};
 pub use kv::KVStore;


### PR DESCRIPTION
## Summary

Remove the unused Diesel/Postgres linkage from the SQLite startup path so `rara server` no longer drags in `libpq` on machines that only need SQLite.

## Type of change

| Type | Label |
|------|-------|
| Bug fix | `bug` |

## Component

`backend`

## Closes

Closes #1759

## Test plan

- [x] `cargo check -p yunara-store -p rara-cli`
- [x] pre-commit hooks passed during `git commit`
- [x] Confirmed `build_pg_pool` had no runtime call sites before removal