### PR TITLE
fix(just): migrate-reset targets wrong DB path (#1761)

### DIFF
--- a/justfile
+++ b/justfile
@@ -301,8 +301,8 @@ migrate-reset:
     else
         DB_DIR="${XDG_DATA_HOME:-$HOME/.local/share}/rara"
     fi
-    echo "🧹 Removing $DB_DIR/rara.db* ..."
-    rm -f "$DB_DIR/rara.db" "$DB_DIR/rara.db-wal" "$DB_DIR/rara.db-shm"
+    echo "🧹 Removing $DB_DIR/db/rara.db* ..."
+    rm -f "$DB_DIR/db/rara.db" "$DB_DIR/db/rara.db-wal" "$DB_DIR/db/rara.db-shm"
     echo "✅ Next rara start-up will re-run every diesel migration from scratch."
 
 [doc("reset rara data directory (drops database, agentfs, etc.)")]


### PR DESCRIPTION
## Summary

The `migrate-reset` recipe in `justfile` was removing `$DB_DIR/rara.db*`, but the real DB location (and the `nuke` target) is `$DB_DIR/db/rara.db*` — an extra `/db/` segment. As a result `just migrate-reset` silently did nothing on both macOS (`~/Library/Application Support/rara/db/*`) and Linux (`${XDG_DATA_HOME:-$HOME/.local/share}/rara/db/*`).

This fixes the `rm -f` invocation and the user-facing echo to point at the correct path. The `nuke` target is untouched (it already used the correct layout).

## Type of change

| Type | Label |
|------|-------|
| Bug fix | `bug` |

## Component

`core`

## Closes

Closes #1761

## Test plan

- [x] `just --show migrate-reset` prints the corrected path
- [x] Path matches the layout used by the `nuke` target in the same file