### PR TITLE
chore(ci): split clippy/test back, add mold linker (#1765)

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -23,8 +23,8 @@ permissions:
   contents: read
 
 jobs:
-  clippy-test:
-    name: Clippy & Test
+  clippy:
+    name: Clippy
     runs-on: arc-runner-set
     steps:
       - name: Checkout code
@@ -37,6 +37,9 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends libsqlite3-dev libpq-dev
 
+      - name: Setup mold linker
+        uses: rui314/setup-mold@9c9c13bf4c3f1adef0cc596abc155580bcb04444 # v1
+
       - name: Rust cache
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
@@ -45,6 +48,29 @@ jobs:
 
       - name: Run clippy
         run: cargo clippy --workspace --all-targets --no-deps -- -D warnings
+
+  test:
+    name: Test
+    runs-on: arc-runner-set
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
+        with:
+          persist-credentials: false
+
+      - name: Install diesel system libraries
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends libsqlite3-dev libpq-dev
+
+      - name: Setup mold linker
+        uses: rui314/setup-mold@9c9c13bf4c3f1adef0cc596abc155580bcb04444 # v1
+
+      - name: Rust cache
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          shared-key: rust-ci
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Run tests
         run: cargo nextest run --workspace
@@ -57,6 +83,9 @@ jobs:
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
         with:
           persist-credentials: false
+
+      - name: Setup mold linker
+        uses: rui314/setup-mold@9c9c13bf4c3f1adef0cc596abc155580bcb04444 # v1
 
       - name: Rust cache
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
@@ -72,19 +101,22 @@ jobs:
   rust-success:
     name: Rust Success
     runs-on: arc-runner-set
-    needs: [clippy-test, docs]
+    needs: [clippy, test, docs]
     if: always()
     steps:
       - name: Check all Rust jobs status
         env:
-          CLIPPY_TEST_RESULT: ${{ needs.clippy-test.result }}
+          CLIPPY_RESULT: ${{ needs.clippy.result }}
+          TEST_RESULT: ${{ needs.test.result }}
           DOCS_RESULT: ${{ needs.docs.result }}
         run: |
-          if [[ "$CLIPPY_TEST_RESULT" != "success" || \
+          if [[ "$CLIPPY_RESULT" != "success" || \
+                "$TEST_RESULT" != "success" || \
                 "$DOCS_RESULT" != "success" ]]; then
             echo "One or more Rust jobs failed"
-            echo "  clippy-test: $CLIPPY_TEST_RESULT"
-            echo "  docs:        $DOCS_RESULT"
+            echo "  clippy: $CLIPPY_RESULT"
+            echo "  test:   $TEST_RESULT"
+            echo "  docs:   $DOCS_RESULT"
             exit 1
           fi
           echo "All Rust jobs passed successfully"

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Install diesel system libraries
         run: |
           sudo apt-get update
-          sudo apt-get install -y --no-install-recommends libsqlite3-dev libpq-dev
+          sudo apt-get install -y --no-install-recommends libsqlite3-dev libpq-dev wget
 
       - name: Setup mold linker
         uses: rui314/setup-mold@9c9c13bf4c3f1adef0cc596abc155580bcb04444 # v1
@@ -61,7 +61,7 @@ jobs:
       - name: Install diesel system libraries
         run: |
           sudo apt-get update
-          sudo apt-get install -y --no-install-recommends libsqlite3-dev libpq-dev
+          sudo apt-get install -y --no-install-recommends libsqlite3-dev libpq-dev wget
 
       - name: Setup mold linker
         uses: rui314/setup-mold@9c9c13bf4c3f1adef0cc596abc155580bcb04444 # v1
@@ -83,6 +83,11 @@ jobs:
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
         with:
           persist-credentials: false
+
+      - name: Install wget for mold installer
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends wget
 
       - name: Setup mold linker
         uses: rui314/setup-mold@9c9c13bf4c3f1adef0cc596abc155580bcb04444 # v1

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -14,6 +14,9 @@ env:
   CARGO_INCREMENTAL: false
   CARGO_NET_RETRY: 10
   RUSTUP_MAX_RETRIES: 10
+  # Disable the runner image's preset sccache wrapper — no backend is configured,
+  # so `rustc -vV` probes (notably `cargo +nightly doc`) time out trying to start a server.
+  RUSTC_WRAPPER: ""
 
 defaults:
   run:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -47,7 +47,11 @@ jobs:
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           shared-key: rust-ci
-          save-if: ${{ github.ref == 'refs/heads/main' }}
+          # Save on all branches: main runs get cancelled by concurrency
+          # before reaching the save step, so main-only save-if leaves the
+          # cache permanently empty. All branches share `shared-key: rust-ci`,
+          # so concurrent saves overwrite rather than accumulate.
+          save-if: true
 
       - name: Run clippy
         run: cargo clippy --workspace --all-targets --no-deps -- -D warnings
@@ -73,7 +77,11 @@ jobs:
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           shared-key: rust-ci
-          save-if: ${{ github.ref == 'refs/heads/main' }}
+          # Save on all branches: main runs get cancelled by concurrency
+          # before reaching the save step, so main-only save-if leaves the
+          # cache permanently empty. All branches share `shared-key: rust-ci`,
+          # so concurrent saves overwrite rather than accumulate.
+          save-if: true
 
       - name: Run tests
         run: cargo nextest run --workspace
@@ -99,7 +107,11 @@ jobs:
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           shared-key: rust-ci
-          save-if: ${{ github.ref == 'refs/heads/main' }}
+          # Save on all branches: main runs get cancelled by concurrency
+          # before reaching the save step, so main-only save-if leaves the
+          # cache permanently empty. All branches share `shared-key: rust-ci`,
+          # so concurrent saves overwrite rather than accumulate.
+          save-if: true
 
       - name: Generate documentation
         run: cargo +nightly doc --workspace --no-deps --document-private-items


### PR DESCRIPTION
## Summary

Follow-up to #1755/#1756. Reverses the clippy+test job merge (contrary to the 8/8 OSS Rust CI consensus) and adopts the two remaining ruff/uv patterns:

- Split `clippy-test` back into separate `clippy` and `test` jobs so failures are isolated and the two run in parallel. Shared `rust-cache` (`shared-key: rust-ci`) keeps the repeat-compile cost negligible.
- Add `rui314/setup-mold@v1` linker step (pinned SHA `9c9c13bf4c3f1adef0cc596abc155580bcb04444`) to all three Rust jobs (`clippy`, `test`, `docs`) for faster link times on cold and incremental builds.
- Update `rust-success` aggregator to depend on `[clippy, test, docs]` and report each status line.

Doctest was intentionally not added — deferred per reviewer preference.

## Type of change

| Type | Label |
|------|-------|
| Chore / CI | `chore` |

## Component

`ci`

## Closes

Closes #1765

## Test plan

- [x] YAML parses (`python3 -c 'import yaml; yaml.safe_load(...)'`)
- [x] Three parallel Rust jobs visible in CI
- [x] mold step runs before rust-cache in all Rust jobs
- [x] `rust-success` gates on `clippy` + `test` + `docs`