### PR TITLE
feat(web): design tokens + sidebar/login rework (#1768)

### DIFF
--- a/web/src/components/ChatSidebar.tsx
+++ b/web/src/components/ChatSidebar.tsx
@@ -14,15 +14,7 @@
  * limitations under the License.
  */
 
-import {
-  PanelLeftClose,
-  PanelLeft,
-  Plus,
-  Search,
-  Settings,
-  Trash2,
-  MessageSquare,
-} from 'lucide-react';
+import { PanelLeftClose, PanelLeft, Plus, Search, Settings, Trash2 } from 'lucide-react';
 import { useEffect, useState } from 'react';
 
 import { SidebarRunHistory } from './SidebarRunHistory';
@@ -149,7 +141,9 @@ export function ChatSidebar({
         )}
       >
         {!collapsed && (
-          <span className="text-sm font-semibold tracking-[0.15em] text-foreground/90">RARA</span>
+          <span className="text-[20px] font-semibold leading-none tracking-tight text-foreground">
+            rara
+          </span>
         )}
         <button
           type="button"
@@ -172,14 +166,12 @@ export function ChatSidebar({
           type="button"
           onClick={onNewSession}
           className={cn(
-            'flex h-9 items-center rounded-md text-sm font-medium transition-colors cursor-pointer',
-            collapsed
-              ? 'w-9 justify-center text-muted-foreground hover:bg-secondary/60 hover:text-foreground'
-              : 'w-full gap-2 px-3 text-foreground bg-secondary/40 hover:bg-secondary/70',
+            'flex h-9 items-center rounded-md text-sm font-medium text-foreground transition-colors cursor-pointer hover:bg-secondary/60',
+            collapsed ? 'w-9 justify-center' : 'w-full gap-2 px-3',
           )}
           title="新建会话"
         >
-          <Plus className="h-4 w-4 shrink-0" />
+          <Plus className="h-4 w-4 shrink-0 text-brand" />
           {!collapsed && <span className="truncate">新建会话</span>}
         </button>
         <button
@@ -211,8 +203,7 @@ export function ChatSidebar({
       {/* History list */}
       {!collapsed && (
         <>
-          <div className="mt-2 flex shrink-0 items-center gap-2 px-4 py-2 text-[11px] font-medium uppercase tracking-wider text-muted-foreground/80">
-            <MessageSquare className="h-3 w-3" />
+          <div className="mb-1 mt-4 shrink-0 px-4 text-[11px] font-medium uppercase tracking-wider text-muted-foreground/70">
             历史会话
           </div>
           <div className="min-h-0 flex-1 overflow-y-auto">
@@ -225,10 +216,10 @@ export function ChatSidebar({
                 <div
                   key={s.key}
                   className={cn(
-                    'group mx-2 flex items-start gap-2 rounded-md text-sm transition-colors',
+                    'group mx-2 flex items-start gap-2 rounded-md border-l-2 text-sm transition-colors',
                     s.key === activeSessionKey
-                      ? 'bg-secondary/70 text-foreground'
-                      : 'text-foreground/80 hover:bg-secondary/50 hover:text-foreground',
+                      ? 'border-brand bg-secondary/70 text-foreground'
+                      : 'border-transparent text-foreground/80 hover:bg-secondary/50 hover:text-foreground',
                   )}
                 >
                   <button

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -70,6 +70,23 @@
   --font-mono:
     'Geist Mono', ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono',
     'Courier New', monospace;
+
+  /*
+   * Brand accent — warm coral/orange in the HeroUI admin family. Intentionally
+   * separate from `--color-primary` so admin surfaces (rose) and accent marks
+   * (coral) can coexist on the same page without fighting. Use `bg-brand`,
+   * `text-brand`, `border-brand` in markup.
+   */
+  --color-brand: oklch(0.72 0.18 35);
+  --color-brand-foreground: oklch(0.99 0 0);
+
+  /* Radius scale — cards stay compact (0.75rem) to match hero admin. */
+  --radius-card: 0.75rem;
+  --radius-pill: 9999px;
+
+  /* Shadow scale — very light by default, slightly lifted on hover. */
+  --shadow-card: 0 1px 2px 0 rgb(0 0 0 / 0.04);
+  --shadow-hover: 0 4px 12px 0 rgb(0 0 0 / 0.06);
 }
 
 /*

--- a/web/src/pages/Login.tsx
+++ b/web/src/pages/Login.tsx
@@ -80,14 +80,17 @@ export default function Login() {
   }
 
   return (
-    <div className="flex min-h-screen items-center justify-center bg-background p-6">
+    <div className="flex min-h-screen flex-col items-center justify-center gap-6 bg-background p-6">
+      <div className="text-[24px] font-semibold leading-none tracking-tight text-foreground">
+        rara
+      </div>
       <form
         onSubmit={handleSubmit}
-        className="w-full max-w-sm space-y-5 rounded-2xl border border-border/70 bg-background/70 p-6 shadow-sm"
+        className="w-full max-w-sm space-y-5 rounded-card border border-border/60 bg-background/70 p-6 shadow-[var(--shadow-card)]"
       >
         <header className="space-y-1">
-          <h1 className="text-xl font-semibold">Sign in to rara</h1>
-          <p className="text-sm text-muted-foreground">Paste your owner token to continue.</p>
+          <h1 className="text-[18px] font-semibold leading-tight">Sign in to rara</h1>
+          <p className="text-[13px] text-muted-foreground">Paste your owner token to continue.</p>
         </header>
 
         <div className="space-y-2">
@@ -110,7 +113,11 @@ export default function Login() {
           </p>
         )}
 
-        <Button type="submit" className="w-full" disabled={submitting}>
+        <Button
+          type="submit"
+          className="w-full bg-brand text-brand-foreground hover:bg-brand/90"
+          disabled={submitting}
+        >
           {submitting ? 'Signing in…' : 'Sign in'}
         </Button>
       </form>


### PR DESCRIPTION
## Summary
Part of #1766 (stacked PR 1 of 3). Establishes a HeroUI-style token layer (warm coral `--color-brand`, `--radius-card`/`--radius-pill`, light `--shadow-card`/`--shadow-hover`) and applies it to the two surfaces outside the existing `.rara-admin` rose scope: chat sidebar and login page.

- Sidebar: `RARA` uppercase block → lowercase `rara` Geist lockup (20px/600). Three action rows flattened (no secondary background on 新建会话); the `+` icon picks up `text-brand` to mark the primary action. 历史会话 label drops its redundant icon prefix and shifts to hero-admin nav spacing. Active session row gets a `border-l-2 border-brand` accent bar.
- Login: adds a centred lowercase `rara` lockup above the card, tightens heading/tagline sizing, switches the submit button to `bg-brand`.
- Geist fonts already load via `index.html`; no new npm deps.

## Type of change
| Type | Label |
|------|-------|
| New feature | `enhancement` |

## Component
`ui`

## Closes
Closes #1768

## Test plan
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run build`
- [x] `npm run test` (83 passed, ChatSidebar tests green)