### PR TITLE
refactor(data-feed): snafu errors + admin gating (#1739)

### DIFF
--- a/crates/app/src/feed_store.rs
+++ b/crates/app/src/feed_store.rs
@@ -14,30 +14,23 @@
 
 //! SQLite-backed [`FeedStore`] implementation.
 //!
-//! Persists [`FeedEvent`]s to the `data_feed_events` table and tracks
-//! per-subscriber read cursors in `feed_read_cursors`. Both tables are
+//! Persists [`FeedEvent`]s to the `data_feed_events` table. The table is
 //! created by the init migration baseline.
 
 use async_trait::async_trait;
-use diesel::{
-    ExpressionMethods, QueryDsl, Queryable, Selectable, SelectableHelper, upsert::excluded,
-};
+use diesel::{ExpressionMethods, QueryDsl, Queryable, Selectable, SelectableHelper};
 use diesel_async::RunQueryDsl;
 use jiff::Timestamp;
-use rara_kernel::{
-    data_feed::{FeedEvent, FeedEventId, FeedFilter, FeedStore},
-    session::SessionKey,
-};
-use rara_model::schema::{data_feed_events, feed_read_cursors};
+use rara_kernel::data_feed::{FeedEvent, FeedEventId, FeedFilter, FeedStore};
+use rara_model::schema::data_feed_events;
 use snafu::ResultExt;
 use tracing::instrument;
 use yunara_store::diesel_pool::DieselSqlitePool;
 
 /// SQLite-backed feed event store.
 ///
-/// Implements [`FeedStore`] using the `data_feed_events` and
-/// `feed_read_cursors` tables. All operations go through the shared
-/// diesel-async pool.
+/// Implements [`FeedStore`] using the `data_feed_events` table. All operations
+/// go through the shared diesel-async pool.
 pub struct SqliteFeedStore {
     pool: DieselSqlitePool,
 }
@@ -121,92 +114,6 @@ impl FeedStore for SqliteFeedStore {
         }
 
         Ok(events)
-    }
-
-    #[instrument(skip_all, fields(subscriber = %subscriber))]
-    async fn mark_read(
-        &self,
-        subscriber: &SessionKey,
-        up_to: FeedEventId,
-    ) -> rara_kernel::Result<()> {
-        use diesel::OptionalExtension;
-
-        let sub_id = subscriber.to_string();
-        let event_id = up_to.to_string();
-
-        let mut conn = self
-            .pool
-            .get()
-            .await
-            .whatever_context("feed_read_cursors pool acquire failed")?;
-
-        let source_name: String = data_feed_events::table
-            .filter(data_feed_events::id.eq(&event_id))
-            .select(data_feed_events::source_name)
-            .first::<String>(&mut *conn)
-            .await
-            .optional()
-            .whatever_context("data_feed_events lookup failed")?
-            .unwrap_or_else(|| "unknown".to_owned());
-
-        let now = Timestamp::now().to_string();
-
-        diesel::insert_into(feed_read_cursors::table)
-            .values((
-                feed_read_cursors::subscriber_id.eq(&sub_id),
-                feed_read_cursors::source_name.eq(&source_name),
-                feed_read_cursors::last_read_id.eq(&event_id),
-                feed_read_cursors::updated_at.eq(&now),
-            ))
-            .on_conflict((
-                feed_read_cursors::subscriber_id,
-                feed_read_cursors::source_name,
-            ))
-            .do_update()
-            .set((
-                feed_read_cursors::last_read_id.eq(excluded(feed_read_cursors::last_read_id)),
-                feed_read_cursors::updated_at.eq(excluded(feed_read_cursors::updated_at)),
-            ))
-            .execute(&mut *conn)
-            .await
-            .whatever_context("feed_read_cursors upsert failed")?;
-
-        Ok(())
-    }
-
-    #[instrument(skip_all, fields(subscriber = %subscriber))]
-    async fn unread_count(&self, subscriber: &SessionKey) -> rara_kernel::Result<usize> {
-        use diesel::sql_types::BigInt;
-
-        let sub_id = subscriber.to_string();
-
-        let mut conn = self
-            .pool
-            .get()
-            .await
-            .whatever_context("data_feed_events pool acquire failed")?;
-
-        // Correlated NOT EXISTS subquery — no clean DSL translation without
-        // a relationship definition, so we keep this one-shot raw-SQL count
-        // embedded as a narrow `sql_query` escape hatch per
-        // docs/guides/db-diesel-migration.md.
-        #[derive(diesel::QueryableByName)]
-        struct CountRow {
-            #[diesel(sql_type = BigInt)]
-            n: i64,
-        }
-
-        let row: CountRow = diesel::sql_query(
-            "SELECT COUNT(*) AS n FROM data_feed_events e WHERE NOT EXISTS (SELECT 1 FROM \
-             feed_read_cursors c WHERE c.subscriber_id = ?1 AND c.source_name = e.source_name AND \
-             c.last_read_id >= e.id)",
-        )
-        .bind::<diesel::sql_types::Text, _>(&sub_id)
-        .get_result(&mut *conn)
-        .await
-        .whatever_context("unread_count query failed")?;
-
-        Ok(row.n as usize)
     }
 }
 

--- a/crates/extensions/backend-admin/src/data_feeds/error.rs
+++ b/crates/extensions/backend-admin/src/data_feeds/error.rs
@@ -1,0 +1,66 @@
+// Copyright 2025 Rararulab
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Error types for the data-feed domain service.
+//!
+//! [`DataFeedSvcError`] is a domain-layer snafu enum. The service layer does
+//! not sit at an application boundary (that is the HTTP router), so per
+//! `docs/guides/rust-style.md` it must not expose `anyhow::Error`. Router
+//! handlers map each variant to an RFC 9457 [`ProblemDetails`] response via
+//! the conversions in this module.
+//!
+//! [`ProblemDetails`]: crate::kernel::problem::ProblemDetails
+
+use diesel_async::pooled_connection::PoolError as DieselConnPoolError;
+use snafu::Snafu;
+use yunara_store::diesel_pool::DieselPoolRunError;
+
+use crate::kernel::problem::ProblemDetails;
+
+/// Result alias for the data-feed service.
+pub type Result<T> = std::result::Result<T, DataFeedSvcError>;
+
+/// Errors that can occur during data-feed persistence operations.
+#[derive(Debug, Snafu)]
+#[snafu(visibility(pub))]
+pub enum DataFeedSvcError {
+    /// Failed to acquire a connection from the diesel-async pool.
+    #[snafu(display("data_feeds pool acquire failed: {source}"))]
+    PoolAcquire {
+        source: DieselPoolRunError<DieselConnPoolError>,
+    },
+
+    /// A diesel query against the data-feed tables failed.
+    #[snafu(display("data_feeds query failed: {source}"))]
+    Query { source: diesel::result::Error },
+
+    /// Failed to serialise a feed-config field (tags / transport / auth) to
+    /// JSON before persistence.
+    #[snafu(display("failed to encode feed config field as JSON: {source}"))]
+    EncodeJson { source: serde_json::Error },
+
+    /// Failed to deserialise a persisted feed-config / event row back into
+    /// domain types (JSON columns, enum strings, or timestamps).
+    #[snafu(display("failed to decode persisted feed data: {message}"))]
+    DecodeRow { message: String },
+}
+
+/// Map a service error to a `ProblemDetails` HTTP response.
+///
+/// All variants currently collapse to 500 Internal Server Error — the
+/// service does not distinguish not-found at this layer (the router
+/// performs a follow-up `get_feed` check and returns 404 itself).
+impl From<DataFeedSvcError> for ProblemDetails {
+    fn from(err: DataFeedSvcError) -> Self { ProblemDetails::internal(err.to_string()) }
+}

--- a/crates/extensions/backend-admin/src/data_feeds/mod.rs
+++ b/crates/extensions/backend-admin/src/data_feeds/mod.rs
@@ -19,10 +19,12 @@
 //! and the in-memory
 //! [`DataFeedRegistry`](rara_kernel::data_feed::DataFeedRegistry).
 
+pub mod error;
 pub mod reporter;
 pub mod router;
 pub mod service;
 
+pub use error::{DataFeedSvcError, Result as DataFeedResult};
 pub use reporter::SvcStatusReporter;
 pub use router::{DataFeedRouterState, data_feed_routes, start_feed_task};
 pub use service::DataFeedSvc;

--- a/crates/extensions/backend-admin/src/data_feeds/router.rs
+++ b/crates/extensions/backend-admin/src/data_feeds/router.rs
@@ -154,8 +154,22 @@ async fn list_feeds(
 /// `POST /api/v1/data-feeds` — create a new feed, sync registry, start task.
 async fn create_feed(
     State(state): State<DataFeedRouterState>,
+    axum::Extension(principal): axum::Extension<
+        rara_kernel::identity::Principal<rara_kernel::identity::Resolved>,
+    >,
     Json(body): Json<CreateFeedRequest>,
 ) -> Result<(StatusCode, Json<DataFeedConfig>), ProblemDetails> {
+    if !principal.is_admin() {
+        return Err(ProblemDetails::forbidden(
+            "creating data feeds requires admin role",
+        ));
+    }
+    info!(
+        actor = %principal.user_id,
+        name = %body.name,
+        "create_feed"
+    );
+
     let auth = body
         .auth
         .map(serde_json::from_value)
@@ -210,9 +224,23 @@ async fn get_feed(
 /// keep their current values.
 async fn update_feed(
     State(state): State<DataFeedRouterState>,
+    axum::Extension(principal): axum::Extension<
+        rara_kernel::identity::Principal<rara_kernel::identity::Resolved>,
+    >,
     Path(id): Path<String>,
     Json(body): Json<UpdateFeedRequest>,
 ) -> Result<Json<DataFeedConfig>, ProblemDetails> {
+    if !principal.is_admin() {
+        return Err(ProblemDetails::forbidden(
+            "updating data feeds requires admin role",
+        ));
+    }
+    info!(
+        actor = %principal.user_id,
+        feed_id = %id,
+        "update_feed"
+    );
+
     let existing = state.svc.get_feed(&id).await?.ok_or_else(|| {
         ProblemDetails::not_found("Feed Not Found", format!("no feed with id: {id}"))
     })?;
@@ -310,8 +338,22 @@ async fn delete_feed(
 /// needed).
 async fn toggle_feed(
     State(state): State<DataFeedRouterState>,
+    axum::Extension(principal): axum::Extension<
+        rara_kernel::identity::Principal<rara_kernel::identity::Resolved>,
+    >,
     Path(id): Path<String>,
 ) -> Result<Json<DataFeedConfig>, ProblemDetails> {
+    if !principal.is_admin() {
+        return Err(ProblemDetails::forbidden(
+            "toggling data feeds requires admin role",
+        ));
+    }
+    info!(
+        actor = %principal.user_id,
+        feed_id = %id,
+        "toggle_feed"
+    );
+
     let toggled = state.svc.toggle_feed(&id).await?;
 
     if !toggled {
@@ -465,5 +507,138 @@ pub fn start_feed_task(config: &DataFeedConfig, registry: &Arc<DataFeedRegistry>
                 "websocket feed type not yet implemented, skipping task start"
             );
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use async_trait::async_trait;
+    use axum::{
+        Router,
+        body::Body,
+        http::{Request, StatusCode},
+        middleware,
+    };
+    use rara_kernel::{
+        data_feed::DataFeedRegistry,
+        error::Result as KernelResult,
+        identity::{KernelUser, Permission, Role, UserStore},
+        security::{ApprovalManager, ApprovalPolicy, SecuritySubsystem},
+        testing::build_memory_diesel_pool,
+    };
+    use tower::ServiceExt;
+
+    use super::*;
+    use crate::auth::{AuthState, auth_layer};
+
+    struct TestUserStore {
+        user: KernelUser,
+    }
+
+    #[async_trait]
+    impl UserStore for TestUserStore {
+        async fn get_by_name(&self, name: &str) -> KernelResult<Option<KernelUser>> {
+            Ok((name == self.user.name).then(|| self.user.clone()))
+        }
+
+        async fn list(&self) -> KernelResult<Vec<KernelUser>> { Ok(vec![self.user.clone()]) }
+    }
+
+    fn user_of(role: Role) -> KernelUser {
+        KernelUser {
+            name: match role {
+                Role::Admin | Role::Root => "admin".into(),
+                Role::User => "alice".into(),
+            },
+            role,
+            permissions: match role {
+                Role::Admin | Role::Root => vec![Permission::All],
+                // Non-admin callers still need Spawn to resolve through the
+                // security subsystem — matches production user seeding.
+                Role::User => vec![Permission::Spawn],
+            },
+            enabled: true,
+        }
+    }
+
+    fn auth_state_direct(user: KernelUser) -> AuthState {
+        let name = user.name.clone();
+        let store: Arc<dyn UserStore> = Arc::new(TestUserStore { user });
+        let approval = Arc::new(ApprovalManager::new(ApprovalPolicy::default()));
+        let security = Arc::new(SecuritySubsystem::new(store, approval));
+        AuthState::for_tests("s3cret", &name, security)
+    }
+
+    /// Build a router whose handlers use a real (but empty / schema-less)
+    /// diesel pool. The non-admin Principal guard runs before any DB query,
+    /// so the pool is never hit on the 403 path these tests exercise.
+    async fn app_with_user(user: KernelUser) -> Router {
+        let pool = build_memory_diesel_pool().await;
+        let svc = DataFeedSvc::new(pool);
+        let (event_tx, _event_rx) = tokio::sync::mpsc::channel(16);
+        let registry = Arc::new(DataFeedRegistry::new(event_tx));
+        let state = DataFeedRouterState { svc, registry };
+        let auth = auth_state_direct(user);
+        data_feed_routes(state).layer(middleware::from_fn_with_state(auth, auth_layer))
+    }
+
+    #[tokio::test]
+    async fn non_admin_cannot_create_feed() {
+        let app = app_with_user(user_of(Role::User)).await;
+        let body = serde_json::json!({
+            "name": "x",
+            "feed_type": "polling",
+            "tags": [],
+            "transport": {},
+        });
+        let res = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/v1/data-feeds")
+                    .header("Authorization", "Bearer s3cret")
+                    .header("Content-Type", "application/json")
+                    .body(Body::from(body.to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(res.status(), StatusCode::FORBIDDEN);
+    }
+
+    #[tokio::test]
+    async fn non_admin_cannot_update_feed() {
+        let app = app_with_user(user_of(Role::User)).await;
+        let body = serde_json::json!({ "name": "new" });
+        let res = app
+            .oneshot(
+                Request::builder()
+                    .method("PUT")
+                    .uri("/api/v1/data-feeds/some-id")
+                    .header("Authorization", "Bearer s3cret")
+                    .header("Content-Type", "application/json")
+                    .body(Body::from(body.to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(res.status(), StatusCode::FORBIDDEN);
+    }
+
+    #[tokio::test]
+    async fn non_admin_cannot_toggle_feed() {
+        let app = app_with_user(user_of(Role::User)).await;
+        let res = app
+            .oneshot(
+                Request::builder()
+                    .method("PUT")
+                    .uri("/api/v1/data-feeds/some-id/toggle")
+                    .header("Authorization", "Bearer s3cret")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(res.status(), StatusCode::FORBIDDEN);
     }
 }

--- a/crates/extensions/backend-admin/src/data_feeds/router.rs
+++ b/crates/extensions/backend-admin/src/data_feeds/router.rs
@@ -147,11 +147,7 @@ struct EventListResponse {
 async fn list_feeds(
     State(state): State<DataFeedRouterState>,
 ) -> Result<Json<Vec<DataFeedConfig>>, ProblemDetails> {
-    let feeds = state
-        .svc
-        .list_feeds()
-        .await
-        .map_err(|e| ProblemDetails::internal(e.to_string()))?;
+    let feeds = state.svc.list_feeds().await?;
     Ok(Json(feeds))
 }
 
@@ -181,11 +177,7 @@ async fn create_feed(
         .build();
 
     // 1. Persist to database.
-    state
-        .svc
-        .create_feed(&config)
-        .await
-        .map_err(|e| ProblemDetails::internal(e.to_string()))?;
+    state.svc.create_feed(&config).await?;
 
     // 2. Sync to in-memory registry.
     if let Err(e) = state.registry.register(config.clone()) {
@@ -206,14 +198,9 @@ async fn get_feed(
     State(state): State<DataFeedRouterState>,
     Path(id): Path<String>,
 ) -> Result<Json<DataFeedConfig>, ProblemDetails> {
-    let feed = state
-        .svc
-        .get_feed(&id)
-        .await
-        .map_err(|e| ProblemDetails::internal(e.to_string()))?
-        .ok_or_else(|| {
-            ProblemDetails::not_found("Feed Not Found", format!("no feed with id: {id}"))
-        })?;
+    let feed = state.svc.get_feed(&id).await?.ok_or_else(|| {
+        ProblemDetails::not_found("Feed Not Found", format!("no feed with id: {id}"))
+    })?;
     Ok(Json(feed))
 }
 
@@ -226,14 +213,9 @@ async fn update_feed(
     Path(id): Path<String>,
     Json(body): Json<UpdateFeedRequest>,
 ) -> Result<Json<DataFeedConfig>, ProblemDetails> {
-    let existing = state
-        .svc
-        .get_feed(&id)
-        .await
-        .map_err(|e| ProblemDetails::internal(e.to_string()))?
-        .ok_or_else(|| {
-            ProblemDetails::not_found("Feed Not Found", format!("no feed with id: {id}"))
-        })?;
+    let existing = state.svc.get_feed(&id).await?.ok_or_else(|| {
+        ProblemDetails::not_found("Feed Not Found", format!("no feed with id: {id}"))
+    })?;
 
     // Merge: supplied field wins, otherwise keep existing.
     let new_name = body.name.unwrap_or(existing.name.clone());
@@ -265,11 +247,7 @@ async fn update_feed(
         .build();
 
     // 1. Persist to database.
-    state
-        .svc
-        .update_feed(&updated)
-        .await
-        .map_err(|e| ProblemDetails::internal(e.to_string()))?;
+    state.svc.update_feed(&updated).await?;
 
     // 2. Sync registry: remove old entry (cancels running task), re-register.
     let _ = state.registry.remove(&existing.name);
@@ -316,11 +294,7 @@ async fn delete_feed(
     }
 
     // 2. Delete from database.
-    let deleted = state
-        .svc
-        .delete_feed(&id)
-        .await
-        .map_err(|e| ProblemDetails::internal(e.to_string()))?;
+    let deleted = state.svc.delete_feed(&id).await?;
 
     if deleted {
         Ok(StatusCode::NO_CONTENT)
@@ -338,11 +312,7 @@ async fn toggle_feed(
     State(state): State<DataFeedRouterState>,
     Path(id): Path<String>,
 ) -> Result<Json<DataFeedConfig>, ProblemDetails> {
-    let toggled = state
-        .svc
-        .toggle_feed(&id)
-        .await
-        .map_err(|e| ProblemDetails::internal(e.to_string()))?;
+    let toggled = state.svc.toggle_feed(&id).await?;
 
     if !toggled {
         return Err(ProblemDetails::not_found(
@@ -352,14 +322,9 @@ async fn toggle_feed(
     }
 
     // Fetch updated config.
-    let feed = state
-        .svc
-        .get_feed(&id)
-        .await
-        .map_err(|e| ProblemDetails::internal(e.to_string()))?
-        .ok_or_else(|| {
-            ProblemDetails::not_found("Feed Not Found", format!("no feed with id: {id}"))
-        })?;
+    let feed = state.svc.get_feed(&id).await?.ok_or_else(|| {
+        ProblemDetails::not_found("Feed Not Found", format!("no feed with id: {id}"))
+    })?;
 
     // Sync registry: remove (cancels running task), re-register with new state.
     let _ = state.registry.remove(&feed.name);
@@ -392,14 +357,9 @@ async fn query_events(
     Path(id): Path<String>,
     Query(params): Query<EventQueryParams>,
 ) -> Result<Json<EventListResponse>, ProblemDetails> {
-    let feed = state
-        .svc
-        .get_feed(&id)
-        .await
-        .map_err(|e| ProblemDetails::internal(e.to_string()))?
-        .ok_or_else(|| {
-            ProblemDetails::not_found("Feed Not Found", format!("no feed with id: {id}"))
-        })?;
+    let feed = state.svc.get_feed(&id).await?.ok_or_else(|| {
+        ProblemDetails::not_found("Feed Not Found", format!("no feed with id: {id}"))
+    })?;
 
     let since = params
         .since
@@ -414,8 +374,7 @@ async fn query_events(
     let page = state
         .svc
         .query_events(&feed.name, since, limit, offset)
-        .await
-        .map_err(|e| ProblemDetails::internal(e.to_string()))?;
+        .await?;
 
     Ok(Json(EventListResponse {
         events:   page.events,
@@ -429,20 +388,14 @@ async fn get_event(
     State(state): State<DataFeedRouterState>,
     Path((id, event_id)): Path<(String, String)>,
 ) -> Result<Json<rara_kernel::data_feed::FeedEvent>, ProblemDetails> {
-    let feed = state
-        .svc
-        .get_feed(&id)
-        .await
-        .map_err(|e| ProblemDetails::internal(e.to_string()))?
-        .ok_or_else(|| {
-            ProblemDetails::not_found("Feed Not Found", format!("no feed with id: {id}"))
-        })?;
+    let feed = state.svc.get_feed(&id).await?.ok_or_else(|| {
+        ProblemDetails::not_found("Feed Not Found", format!("no feed with id: {id}"))
+    })?;
 
     let event = state
         .svc
         .get_event(&feed.name, &event_id)
-        .await
-        .map_err(|e| ProblemDetails::internal(e.to_string()))?
+        .await?
         .ok_or_else(|| {
             ProblemDetails::not_found("Event Not Found", format!("no event with id: {event_id}"))
         })?;

--- a/crates/extensions/backend-admin/src/data_feeds/service.rs
+++ b/crates/extensions/backend-admin/src/data_feeds/service.rs
@@ -27,8 +27,11 @@ use rara_kernel::data_feed::{
     AuthConfig, DataFeedConfig, FeedEvent, FeedEventId, FeedStatus, FeedType,
 };
 use rara_model::schema::{data_feed_events, data_feeds};
+use snafu::ResultExt;
 use tracing::instrument;
 use yunara_store::diesel_pool::DieselSqlitePool;
+
+use super::error::{DataFeedSvcError, EncodeJsonSnafu, PoolAcquireSnafu, QuerySnafu, Result};
 
 /// Service for data feed persistence operations.
 ///
@@ -47,45 +50,48 @@ impl DataFeedSvc {
 
     /// List all registered data feed configurations.
     #[instrument(skip_all)]
-    pub async fn list_feeds(&self) -> anyhow::Result<Vec<DataFeedConfig>> {
-        let mut conn = self.pool.get().await?;
+    pub async fn list_feeds(&self) -> Result<Vec<DataFeedConfig>> {
+        let mut conn = self.pool.get().await.context(PoolAcquireSnafu)?;
         let rows: Vec<FeedRow> = data_feeds::table
             .select(FeedRow::as_select())
             .order(data_feeds::created_at.desc())
             .load(&mut *conn)
-            .await?;
+            .await
+            .context(QuerySnafu)?;
 
         rows.into_iter().map(FeedRow::into_config).collect()
     }
 
     /// Get a single feed by ID.
     #[instrument(skip(self))]
-    pub async fn get_feed(&self, id: &str) -> anyhow::Result<Option<DataFeedConfig>> {
+    pub async fn get_feed(&self, id: &str) -> Result<Option<DataFeedConfig>> {
         use diesel::OptionalExtension;
 
-        let mut conn = self.pool.get().await?;
+        let mut conn = self.pool.get().await.context(PoolAcquireSnafu)?;
         let row: Option<FeedRow> = data_feeds::table
             .filter(data_feeds::id.eq(id))
             .select(FeedRow::as_select())
             .first(&mut *conn)
             .await
-            .optional()?;
+            .optional()
+            .context(QuerySnafu)?;
 
         row.map(FeedRow::into_config).transpose()
     }
 
     /// Insert a new feed configuration.
     #[instrument(skip_all)]
-    pub async fn create_feed(&self, config: &DataFeedConfig) -> anyhow::Result<()> {
-        let tags_json = serde_json::to_string(&config.tags)?;
-        let transport_json = serde_json::to_string(&config.transport)?;
+    pub async fn create_feed(&self, config: &DataFeedConfig) -> Result<()> {
+        let tags_json = serde_json::to_string(&config.tags).context(EncodeJsonSnafu)?;
+        let transport_json = serde_json::to_string(&config.transport).context(EncodeJsonSnafu)?;
         let auth_json = config
             .auth
             .as_ref()
             .map(serde_json::to_string)
-            .transpose()?;
+            .transpose()
+            .context(EncodeJsonSnafu)?;
 
-        let mut conn = self.pool.get().await?;
+        let mut conn = self.pool.get().await.context(PoolAcquireSnafu)?;
         diesel::insert_into(data_feeds::table)
             .values((
                 data_feeds::id.eq(&config.id),
@@ -101,7 +107,8 @@ impl DataFeedSvc {
                 data_feeds::updated_at.eq(config.updated_at.to_string()),
             ))
             .execute(&mut *conn)
-            .await?;
+            .await
+            .context(QuerySnafu)?;
 
         Ok(())
     }
@@ -110,17 +117,18 @@ impl DataFeedSvc {
     ///
     /// Returns `true` if a row was updated.
     #[instrument(skip_all)]
-    pub async fn update_feed(&self, config: &DataFeedConfig) -> anyhow::Result<bool> {
-        let tags_json = serde_json::to_string(&config.tags)?;
-        let transport_json = serde_json::to_string(&config.transport)?;
+    pub async fn update_feed(&self, config: &DataFeedConfig) -> Result<bool> {
+        let tags_json = serde_json::to_string(&config.tags).context(EncodeJsonSnafu)?;
+        let transport_json = serde_json::to_string(&config.transport).context(EncodeJsonSnafu)?;
         let auth_json = config
             .auth
             .as_ref()
             .map(serde_json::to_string)
-            .transpose()?;
+            .transpose()
+            .context(EncodeJsonSnafu)?;
         let now = Timestamp::now().to_string();
 
-        let mut conn = self.pool.get().await?;
+        let mut conn = self.pool.get().await.context(PoolAcquireSnafu)?;
         let affected = diesel::update(data_feeds::table.filter(data_feeds::id.eq(&config.id)))
             .set((
                 data_feeds::name.eq(&config.name),
@@ -134,18 +142,20 @@ impl DataFeedSvc {
                 data_feeds::updated_at.eq(&now),
             ))
             .execute(&mut *conn)
-            .await?;
+            .await
+            .context(QuerySnafu)?;
 
         Ok(affected > 0)
     }
 
     /// Delete a feed by ID. Returns `true` if a row was deleted.
     #[instrument(skip(self))]
-    pub async fn delete_feed(&self, id: &str) -> anyhow::Result<bool> {
-        let mut conn = self.pool.get().await?;
+    pub async fn delete_feed(&self, id: &str) -> Result<bool> {
+        let mut conn = self.pool.get().await.context(PoolAcquireSnafu)?;
         let affected = diesel::delete(data_feeds::table.filter(data_feeds::id.eq(id)))
             .execute(&mut *conn)
-            .await?;
+            .await
+            .context(QuerySnafu)?;
         Ok(affected > 0)
     }
 
@@ -163,9 +173,9 @@ impl DataFeedSvc {
         name: &str,
         status: FeedStatus,
         last_error: Option<String>,
-    ) -> anyhow::Result<bool> {
+    ) -> Result<bool> {
         let now = Timestamp::now().to_string();
-        let mut conn = self.pool.get().await?;
+        let mut conn = self.pool.get().await.context(PoolAcquireSnafu)?;
         let affected = diesel::update(data_feeds::table.filter(data_feeds::name.eq(name)))
             .set((
                 data_feeds::status.eq(status.to_string()),
@@ -173,17 +183,18 @@ impl DataFeedSvc {
                 data_feeds::updated_at.eq(&now),
             ))
             .execute(&mut *conn)
-            .await?;
+            .await
+            .context(QuerySnafu)?;
         Ok(affected > 0)
     }
 
     /// Toggle the enabled flag for a feed. Returns `true` if updated.
     #[instrument(skip(self))]
-    pub async fn toggle_feed(&self, id: &str) -> anyhow::Result<bool> {
+    pub async fn toggle_feed(&self, id: &str) -> Result<bool> {
         use diesel::{dsl::sql, sql_types::Integer};
 
         let now = Timestamp::now().to_string();
-        let mut conn = self.pool.get().await?;
+        let mut conn = self.pool.get().await.context(PoolAcquireSnafu)?;
         // `NOT enabled` on a stored integer column has no clean DSL — we use
         // the sanctioned `sql::<Integer>` fragment per
         // docs/guides/db-diesel-migration.md.
@@ -193,7 +204,8 @@ impl DataFeedSvc {
                 data_feeds::updated_at.eq(&now),
             ))
             .execute(&mut *conn)
-            .await?;
+            .await
+            .context(QuerySnafu)?;
         Ok(affected > 0)
     }
 
@@ -207,8 +219,8 @@ impl DataFeedSvc {
         since: Option<Timestamp>,
         limit: i64,
         offset: i64,
-    ) -> anyhow::Result<EventPage> {
-        let mut conn = self.pool.get().await?;
+    ) -> Result<EventPage> {
+        let mut conn = self.pool.get().await.context(PoolAcquireSnafu)?;
 
         // Count total matching events for pagination metadata.
         let mut count_q = data_feed_events::table
@@ -217,7 +229,11 @@ impl DataFeedSvc {
         if let Some(ref ts) = since {
             count_q = count_q.filter(data_feed_events::received_at.ge(ts.to_string()));
         }
-        let total: i64 = count_q.count().get_result(&mut *conn).await?;
+        let total: i64 = count_q
+            .count()
+            .get_result(&mut *conn)
+            .await
+            .context(QuerySnafu)?;
 
         let mut rows_q = data_feed_events::table
             .filter(data_feed_events::source_name.eq(source_name))
@@ -231,12 +247,13 @@ impl DataFeedSvc {
             .limit(limit)
             .offset(offset)
             .load(&mut *conn)
-            .await?;
+            .await
+            .context(QuerySnafu)?;
 
         let events: Vec<FeedEvent> = rows
             .into_iter()
             .map(EventRow::into_event)
-            .collect::<anyhow::Result<Vec<_>>>()?;
+            .collect::<Result<Vec<_>>>()?;
 
         let has_more = (offset + limit) < total;
 
@@ -249,21 +266,18 @@ impl DataFeedSvc {
 
     /// Get a single event by ID within a feed.
     #[instrument(skip(self))]
-    pub async fn get_event(
-        &self,
-        source_name: &str,
-        event_id: &str,
-    ) -> anyhow::Result<Option<FeedEvent>> {
+    pub async fn get_event(&self, source_name: &str, event_id: &str) -> Result<Option<FeedEvent>> {
         use diesel::OptionalExtension;
 
-        let mut conn = self.pool.get().await?;
+        let mut conn = self.pool.get().await.context(PoolAcquireSnafu)?;
         let row: Option<EventRow> = data_feed_events::table
             .filter(data_feed_events::id.eq(event_id))
             .filter(data_feed_events::source_name.eq(source_name))
             .select(EventRow::as_select())
             .first(&mut *conn)
             .await
-            .optional()?;
+            .optional()
+            .context(QuerySnafu)?;
 
         row.map(EventRow::into_event).transpose()
     }
@@ -302,16 +316,30 @@ struct FeedRow {
 }
 
 impl FeedRow {
-    fn into_config(self) -> anyhow::Result<DataFeedConfig> {
-        let feed_type: FeedType =
-            serde_json::from_value(serde_json::Value::String(self.feed_type))?;
-        let status: FeedStatus = serde_json::from_value(serde_json::Value::String(self.status))?;
-        let tags: Vec<String> = serde_json::from_str(&self.tags)?;
-        let transport: serde_json::Value = serde_json::from_str(&self.transport)?;
-        let auth: Option<AuthConfig> =
-            self.auth.as_deref().map(serde_json::from_str).transpose()?;
-        let created_at: Timestamp = self.created_at.parse()?;
-        let updated_at: Timestamp = self.updated_at.parse()?;
+    fn into_config(self) -> Result<DataFeedConfig> {
+        let decode = |msg: String| DataFeedSvcError::DecodeRow { message: msg };
+        let feed_type: FeedType = serde_json::from_value(serde_json::Value::String(self.feed_type))
+            .map_err(|e| decode(format!("feed_type: {e}")))?;
+        let status: FeedStatus = serde_json::from_value(serde_json::Value::String(self.status))
+            .map_err(|e| decode(format!("status: {e}")))?;
+        let tags: Vec<String> =
+            serde_json::from_str(&self.tags).map_err(|e| decode(format!("tags: {e}")))?;
+        let transport: serde_json::Value =
+            serde_json::from_str(&self.transport).map_err(|e| decode(format!("transport: {e}")))?;
+        let auth: Option<AuthConfig> = self
+            .auth
+            .as_deref()
+            .map(serde_json::from_str)
+            .transpose()
+            .map_err(|e| decode(format!("auth: {e}")))?;
+        let created_at: Timestamp = self
+            .created_at
+            .parse()
+            .map_err(|e| decode(format!("created_at: {e}")))?;
+        let updated_at: Timestamp = self
+            .updated_at
+            .parse()
+            .map_err(|e| decode(format!("updated_at: {e}")))?;
 
         Ok(DataFeedConfig::builder()
             .id(self.id)
@@ -342,12 +370,18 @@ struct EventRow {
 }
 
 impl EventRow {
-    fn into_event(self) -> anyhow::Result<FeedEvent> {
+    fn into_event(self) -> Result<FeedEvent> {
+        let decode = |msg: String| DataFeedSvcError::DecodeRow { message: msg };
         let id = FeedEventId::try_from_raw(&self.id)
-            .map_err(|e| anyhow::anyhow!("invalid event id: {e}"))?;
-        let tags: Vec<String> = serde_json::from_str(&self.tags)?;
-        let payload: serde_json::Value = serde_json::from_str(&self.payload)?;
-        let received_at: Timestamp = self.received_at.parse()?;
+            .map_err(|e| decode(format!("invalid event id: {e}")))?;
+        let tags: Vec<String> =
+            serde_json::from_str(&self.tags).map_err(|e| decode(format!("tags: {e}")))?;
+        let payload: serde_json::Value =
+            serde_json::from_str(&self.payload).map_err(|e| decode(format!("payload: {e}")))?;
+        let received_at: Timestamp = self
+            .received_at
+            .parse()
+            .map_err(|e| decode(format!("received_at: {e}")))?;
 
         Ok(FeedEvent::builder()
             .id(id)

--- a/crates/kernel/src/data_feed/store.rs
+++ b/crates/kernel/src/data_feed/store.rs
@@ -17,16 +17,14 @@
 use async_trait::async_trait;
 use jiff::Timestamp;
 
-use super::event::{FeedEvent, FeedEventId};
-use crate::session::SessionKey;
+use super::event::FeedEvent;
 
 /// Persistent store for external feed events.
 ///
-/// Implementations handle event persistence, filtered queries, and
-/// per-subscriber read-cursor tracking. The kernel owns one shared `FeedStore`
-/// instance; transport layers call [`append`](Self::append) on ingestion and
-/// agent sessions call [`query`](Self::query) /
-/// [`unread_count`](Self::unread_count) to consume events.
+/// Implementations handle event persistence and filtered queries. The kernel
+/// owns one shared `FeedStore` instance; transport layers call
+/// [`append`](Self::append) on ingestion and agent sessions call
+/// [`query`](Self::query) to consume events.
 #[async_trait]
 pub trait FeedStore: Send + Sync {
     /// Persist a new event.
@@ -37,15 +35,6 @@ pub trait FeedStore: Send + Sync {
 
     /// Query events matching `filter`, returned in chronological order.
     async fn query(&self, filter: FeedFilter) -> crate::Result<Vec<FeedEvent>>;
-
-    /// Mark all events up to (and including) `up_to` as read for `subscriber`.
-    ///
-    /// The read cursor is per-subscriber, per-source so that multiple agent
-    /// sessions can independently track their consumption progress.
-    async fn mark_read(&self, subscriber: &SessionKey, up_to: FeedEventId) -> crate::Result<()>;
-
-    /// Return the number of unread events for `subscriber` across all sources.
-    async fn unread_count(&self, subscriber: &SessionKey) -> crate::Result<usize>;
 }
 
 /// Filter criteria for [`FeedStore::query`].

--- a/crates/rara-model/migrations/2026-04-24-165308-0000_datafeed_drop_feed_read_cursors/down.sql
+++ b/crates/rara-model/migrations/2026-04-24-165308-0000_datafeed_drop_feed_read_cursors/down.sql
@@ -1,0 +1,9 @@
+-- Recreate the feed_read_cursors table with the exact schema from the
+-- init migration baseline (crates/rara-model/migrations/20260304000000_init/up.sql).
+CREATE TABLE feed_read_cursors (
+    subscriber_id TEXT NOT NULL,
+    source_name   TEXT NOT NULL,
+    last_read_id  TEXT NOT NULL,
+    updated_at    TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+    PRIMARY KEY (subscriber_id, source_name)
+);

--- a/crates/rara-model/migrations/2026-04-24-165308-0000_datafeed_drop_feed_read_cursors/up.sql
+++ b/crates/rara-model/migrations/2026-04-24-165308-0000_datafeed_drop_feed_read_cursors/up.sql
@@ -1,0 +1,4 @@
+-- Drop the feed_read_cursors table. The FeedStore::mark_read and
+-- FeedStore::unread_count methods that backed this table were hollow
+-- (zero callers) and have been removed; see issue #1739.
+DROP TABLE feed_read_cursors;

--- a/crates/rara-model/src/schema.rs
+++ b/crates/rara-model/src/schema.rs
@@ -94,15 +94,6 @@ diesel::table! {
 }
 
 diesel::table! {
-    feed_read_cursors (subscriber_id, source_name) {
-        subscriber_id -> Text,
-        source_name -> Text,
-        last_read_id -> Text,
-        updated_at -> Text,
-    }
-}
-
-diesel::table! {
     kernel_audit_events (id) {
         id -> Text,
         timestamp -> Text,
@@ -196,7 +187,6 @@ diesel::allow_tables_to_appear_in_same_query!(
     data_feed_events,
     data_feeds,
     execution_traces,
-    feed_read_cursors,
     kernel_audit_events,
     kernel_outbox,
     kernel_users,


### PR DESCRIPTION
## Summary

Finishes PR3 of the data-feed refactor tracked in #1739.

- Drop the unused `feed_read_cursors` table (migration in an earlier commit).
- Remove hollow `mark_read` / `unread_count` from the kernel `FeedStore` trait.
- Convert the backend-admin data-feed service from `anyhow::Result` to a dedicated `DataFeedSvcError` snafu enum; router handlers rely on `From<DataFeedSvcError> for ProblemDetails` to drop per-call `map_err` boilerplate.
- Gate `create_feed` / `update_feed` / `toggle_feed` on `Principal::is_admin()`; emit audit logs matching `delete_feed`.
- Add three tokio tests asserting 403 on non-admin callers for create/update/toggle.

## Type of change

| Type | Label |
|------|-------|
| Refactor | `refactor` |

## Component

`core`

## Closes

Closes #1739

## Test plan

- [x] `cargo check --all --all-targets`
- [x] `cargo clippy --workspace --all-targets --all-features --no-deps`
- [x] `cargo +nightly fmt --all -- --check`
- [x] `cargo test -p rara-backend-admin -p rara-kernel -p rara-app` (724 passed, 7 ignored)