### PR TITLE
fix(web): align turn chip card under message bubble, not avatar (#1784)

### DIFF
--- a/web/src/pages/PiChat.tsx
+++ b/web/src/pages/PiChat.tsx
@@ -285,7 +285,7 @@ function registerCascadeAssistantRenderer(agentResolver: () => Agent | null): vo
             .toolResultsById=${resultByCallId}
             .hideToolCalls=${true}
           ></assistant-message>
-          ${chipCard ?? ''}
+          ${chipCard ? html`<div class="pl-[2.75rem]">${chipCard}</div>` : ''}
           ${showButtons
             ? html`
                 <div class="mt-1 flex justify-start gap-1 pl-[2.75rem]">


### PR DESCRIPTION
## Summary

Inset the per-turn tool-call chip card with `pl-[2.75rem]` so it aligns under the assistant message bubble instead of starting at the avatar's left edge. Matches the existing indent of the `详情` / `Cascade` action row.

## Type of change

| Type | Label |
|------|-------|
| Bug fix | `bug` |

## Component

`ui`

## Closes

Closes #1784

## Test plan

- [x] Tested locally