### PR TITLE
fix(web): settings — drop empty General + enrich Appearance/Connection (#1790)

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -38,7 +38,8 @@ const STORAGE_KEY = 'rara_backend_url';
 const queryClient = new QueryClient();
 
 const SETTINGS_PAGES: readonly SettingsPage[] = [
-  'general',
+  'appearance',
+  'connection',
   'providers',
   'agents',
   'skills',

--- a/web/src/components/settings/SettingsModal.tsx
+++ b/web/src/components/settings/SettingsModal.tsx
@@ -87,7 +87,7 @@ export default function SettingsModal({ open, onClose, section }: SettingsModalP
           <X className="h-4 w-4" />
         </button>
         <div className="min-h-0 flex-1 overflow-hidden">
-          <SettingsPanel key={section ?? 'general'} initialSection={section} />
+          <SettingsPanel key={section ?? 'connection'} initialSection={section} />
         </div>
       </div>
     </div>

--- a/web/src/components/settings/SettingsPanel.tsx
+++ b/web/src/components/settings/SettingsPanel.tsx
@@ -24,6 +24,8 @@ import {
   EyeOff,
   Mail,
   MessageSquare,
+  Monitor,
+  Moon,
   Plus,
   Save,
   Settings2,
@@ -135,6 +137,18 @@ const THEME_OPTIONS: Array<{ key: Theme; label: string; icon: ReactNode; descrip
     label: 'Light',
     icon: <Sun className="h-4 w-4" />,
     description: 'Bright workspace',
+  },
+  {
+    key: 'dark',
+    label: 'Dark',
+    icon: <Moon className="h-4 w-4" />,
+    description: 'Dim, easy on eyes',
+  },
+  {
+    key: 'system',
+    label: 'System',
+    icon: <Monitor className="h-4 w-4" />,
+    description: 'Match OS setting',
   },
 ];
 
@@ -837,50 +851,37 @@ export default function SettingsPanel({
                   </div>
                 </CardHeader>
                 <CardContent>
-                  <div className="mb-3 flex items-center justify-between gap-3">
-                    <div className="space-y-1">
-                      <p className="font-medium">Theme</p>
-                      <p className="text-xs text-muted-foreground">
-                        Choose how the UI looks across all pages.
-                      </p>
-                    </div>
-                    <Badge variant="secondary" className="capitalize">
-                      {theme}
-                    </Badge>
+                  <div className="mb-3 space-y-1">
+                    <p className="font-medium">Theme</p>
+                    <p className="text-xs text-muted-foreground">
+                      Choose how the UI looks across all pages.
+                    </p>
                   </div>
-                  <div className="grid gap-2 md:grid-cols-3">
-                    {THEME_OPTIONS.map((option) => (
-                      <button
-                        key={option.key}
-                        type="button"
-                        onClick={() => setTheme(option.key)}
-                        className={cn(
-                          'group rounded-xl border p-3 text-left transition-all',
-                          theme === option.key
-                            ? 'border-primary/30 bg-primary/8 shadow-sm ring-1 ring-primary/10'
-                            : 'hover:bg-accent/40',
-                        )}
-                      >
-                        <div className="flex items-center gap-2">
-                          <span
-                            className={cn(
-                              'inline-flex h-8 w-8 items-center justify-center rounded-lg border',
-                              theme === option.key
-                                ? 'border-primary/20 bg-primary/10 text-primary'
-                                : 'border-border/70 bg-background/70 text-muted-foreground',
-                            )}
-                          >
-                            {option.icon}
-                          </span>
-                          <div className="min-w-0">
-                            <p className="text-sm font-medium">{option.label}</p>
-                            <p className="truncate text-xs text-muted-foreground">
-                              {option.description}
-                            </p>
+                  <div className="grid grid-cols-3 gap-3">
+                    {THEME_OPTIONS.map((option) => {
+                      const isActive = theme === option.key;
+                      return (
+                        <button
+                          key={option.key}
+                          type="button"
+                          onClick={() => setTheme(option.key)}
+                          className={cn(
+                            'flex flex-col items-start gap-1.5 rounded-card border px-3 py-3 text-left transition-colors',
+                            isActive
+                              ? 'border-brand bg-muted'
+                              : 'border-border/60 hover:bg-muted/40',
+                          )}
+                        >
+                          <div className="flex items-center gap-2">
+                            <span className="text-muted-foreground">{option.icon}</span>
+                            <span className="text-sm font-medium">{option.label}</span>
                           </div>
-                        </div>
-                      </button>
-                    ))}
+                          <span className="text-xs text-muted-foreground">
+                            {option.description}
+                          </span>
+                        </button>
+                      );
+                    })}
                   </div>
                 </CardContent>
               </Card>

--- a/web/src/components/settings/SettingsPanel.tsx
+++ b/web/src/components/settings/SettingsPanel.tsx
@@ -75,7 +75,6 @@ import Skills from '@/pages/Skills';
 
 /** Admin settings section identifiers. Exported so the floating modal can deep-link into a specific tab. */
 export type SettingsPage =
-  | 'general'
   | 'appearance'
   | 'connection'
   | 'providers'
@@ -581,7 +580,6 @@ function AddProviderButton({
 }
 
 const SETTINGS_PAGES: readonly SettingsPage[] = [
-  'general',
   'appearance',
   'connection',
   'providers',
@@ -620,7 +618,7 @@ export default function SettingsPanel({
   const { theme, setTheme } = useTheme();
   const queryClient = useQueryClient();
   const [activeCategory, setActiveCategory] = useState<SettingsPage>(() =>
-    initialSection && SETTINGS_PAGES.includes(initialSection) ? initialSection : 'general',
+    initialSection && SETTINGS_PAGES.includes(initialSection) ? initialSection : 'connection',
   );
   const [toast, setToast] = useState<ToastState>(null);
 
@@ -735,7 +733,6 @@ export default function SettingsPanel({
     {
       label: 'Workspace',
       items: [
-        { id: 'general', label: 'General', icon: <Settings2 className="h-4 w-4" /> },
         { id: 'appearance', label: 'Appearance', icon: <Palette className="h-4 w-4" /> },
         { id: 'connection', label: 'Connection', icon: <Wifi className="h-4 w-4" /> },
       ],
@@ -823,45 +820,6 @@ export default function SettingsPanel({
             </div>
           )}
 
-          {/* ── General (documentation) ── */}
-          {activeCategory === 'general' && (
-            <>
-              {/* Documentation */}
-              <Card className="app-surface border-border/60">
-                <CardHeader>
-                  <div className="flex items-start gap-3">
-                    <BookOpen className="mt-0.5 h-5 w-5 text-muted-foreground" />
-                    <div>
-                      <CardTitle className="text-base">Documentation</CardTitle>
-                      <CardDescription>Project guides and backend API reference</CardDescription>
-                    </div>
-                  </div>
-                </CardHeader>
-                <CardContent>
-                  <div className="grid gap-2 lg:grid-cols-2">
-                    <a
-                      href="/book/"
-                      target="_blank"
-                      rel="noreferrer"
-                      className="group rounded-xl border bg-card p-4 transition-colors hover:bg-accent/30"
-                    >
-                      <div className="flex items-start justify-between gap-3">
-                        <div className="flex items-center gap-3">
-                          <BookOpen className="h-4 w-4 text-muted-foreground" />
-                          <div>
-                            <p className="font-medium">Guides</p>
-                            <p className="text-xs text-muted-foreground">mdBook</p>
-                          </div>
-                        </div>
-                        <ExternalLink className="h-4 w-4 text-muted-foreground transition-transform group-hover:translate-x-0.5" />
-                      </div>
-                    </a>
-                  </div>
-                </CardContent>
-              </Card>
-            </>
-          )}
-
           {/* ── Connection ── */}
           {activeCategory === 'connection' && <ConnectionCard />}
 
@@ -924,6 +882,36 @@ export default function SettingsPanel({
                       </button>
                     ))}
                   </div>
+                </CardContent>
+              </Card>
+
+              {/* Documentation — subdued footer card with project links. */}
+              <Card className="app-surface border-border/60">
+                <CardHeader className="pb-3">
+                  <div className="flex items-start gap-3">
+                    <BookOpen className="mt-0.5 h-5 w-5 text-muted-foreground" />
+                    <div>
+                      <CardTitle className="text-base">Documentation</CardTitle>
+                      <CardDescription>Project guides and backend API reference</CardDescription>
+                    </div>
+                  </div>
+                </CardHeader>
+                <CardContent>
+                  <a
+                    href="/book/"
+                    target="_blank"
+                    rel="noreferrer"
+                    className="group flex items-center justify-between rounded-card border border-border/60 bg-card px-3 py-2.5 transition-colors hover:bg-muted/40"
+                  >
+                    <div className="flex items-center gap-2.5">
+                      <BookOpen className="h-4 w-4 text-muted-foreground" />
+                      <div>
+                        <p className="text-sm font-medium">Guides</p>
+                        <p className="text-xs text-muted-foreground">mdBook</p>
+                      </div>
+                    </div>
+                    <ExternalLink className="h-4 w-4 text-muted-foreground transition-transform group-hover:translate-x-0.5" />
+                  </a>
                 </CardContent>
               </Card>
             </>

--- a/web/src/components/settings/SettingsPanel.tsx
+++ b/web/src/components/settings/SettingsPanel.tsx
@@ -43,7 +43,7 @@ import type { ReactNode } from 'react';
 import { useEffect, useState } from 'react';
 
 import { settingsApi } from '@/api/client';
-import { getBackendUrl, setBackendUrl } from '@/api/client';
+import { getBackendUrl, resolveUrl, setBackendUrl } from '@/api/client';
 import type { SettingsMap } from '@/api/types';
 import DataFeedsPanel from '@/components/DataFeedsPanel';
 import { Badge } from '@/components/ui/badge';
@@ -67,7 +67,6 @@ import {
   SelectValue,
 } from '@/components/ui/select';
 import { Skeleton } from '@/components/ui/skeleton';
-import { useServerStatus } from '@/hooks/use-server-status';
 import { useTheme, type Theme } from '@/hooks/use-theme';
 import { cn } from '@/lib/utils';
 import Agents from '@/pages/Agents';
@@ -408,34 +407,94 @@ function KvGroup({
   );
 }
 
-/** Backend URL configuration card for the General settings tab. */
-function ConnectionCard() {
-  const { isOnline } = useServerStatus();
-  const [url, setUrl] = useState(() => getBackendUrl());
-  const [saving, setSaving] = useState(false);
-  const [result, setResult] = useState<{ kind: 'success' | 'error'; message: string } | null>(null);
+/** Health probe result: backend version + measured round-trip latency + capture timestamp. */
+interface HealthProbe {
+  version: string;
+  status: string;
+  latencyMs: number;
+  fetchedAt: number;
+}
 
-  async function saveAndReconnect() {
-    setSaving(true);
-    setResult(null);
-    try {
-      const res = await fetch(`${url}/api/v1/settings`, {
+/** Format epoch-millis as a relative "Ns ago" string, falling back to minutes/hours. */
+function formatRelative(fromMs: number, nowMs: number): string {
+  const deltaSec = Math.max(0, Math.floor((nowMs - fromMs) / 1000));
+  if (deltaSec < 60) return `${deltaSec}s ago`;
+  const min = Math.floor(deltaSec / 60);
+  if (min < 60) return `${min}m ago`;
+  const hr = Math.floor(min / 60);
+  return `${hr}h ago`;
+}
+
+/** Backend URL configuration card with live version/latency/heartbeat metrics. */
+function ConnectionCard() {
+  const queryClient = useQueryClient();
+  const savedUrl = getBackendUrl();
+  const [url, setUrl] = useState(savedUrl);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  // Tick state forces re-render every second so "Last heartbeat" stays fresh
+  // without having to refetch the health endpoint.
+  const [, setNowTick] = useState(0);
+
+  useEffect(() => {
+    const id = setInterval(() => setNowTick((t) => t + 1), 1000);
+    return () => clearInterval(id);
+  }, []);
+
+  const healthQuery = useQuery<HealthProbe>({
+    queryKey: ['health-probe'],
+    queryFn: async () => {
+      const start = performance.now();
+      const res = await fetch(resolveUrl('/api/v1/health'), {
         signal: AbortSignal.timeout(5000),
       });
-      if (res.ok) {
+      if (!res.ok) throw new Error(`Health check failed: ${res.status}`);
+      const body = (await res.json()) as { version?: string; status?: string };
+      return {
+        version: body.version ?? 'unknown',
+        status: body.status ?? 'unknown',
+        latencyMs: Math.round(performance.now() - start),
+        fetchedAt: Date.now(),
+      };
+    },
+    refetchInterval: 5000,
+    retry: false,
+  });
+
+  const isDirty = url.trim() !== savedUrl.trim();
+
+  // Status pill: explicit error after first attempt, "Connecting…" before any attempt completes.
+  const pill: { label: string; variant: 'secondary' | 'destructive' | 'outline' } =
+    healthQuery.isError
+      ? { label: 'Disconnected', variant: 'destructive' }
+      : healthQuery.data
+        ? { label: 'Connected', variant: 'secondary' }
+        : { label: 'Connecting…', variant: 'outline' };
+
+  async function reconnect() {
+    setSaving(true);
+    setError(null);
+    try {
+      if (isDirty) {
+        // Probe the new URL before persisting so we don't trap the user with a bad backend.
+        const res = await fetch(`${url}/api/v1/health`, {
+          signal: AbortSignal.timeout(5000),
+        });
+        if (!res.ok) throw new Error(`Server returned ${res.status}`);
         setBackendUrl(url); // persists + reloads
-      } else {
-        setResult({ kind: 'error', message: `Server returned ${res.status}` });
+        return;
       }
+      await queryClient.invalidateQueries({ queryKey: ['health-probe'] });
     } catch (e) {
-      setResult({
-        kind: 'error',
-        message: `Cannot connect: ${e instanceof Error ? e.message : String(e)}`,
-      });
+      setError(`Cannot connect: ${e instanceof Error ? e.message : String(e)}`);
     } finally {
       setSaving(false);
     }
   }
+
+  const lastHeartbeatAgo = healthQuery.data
+    ? formatRelative(healthQuery.data.fetchedAt, Date.now())
+    : null;
 
   return (
     <Card className="app-surface border-border/60">
@@ -446,8 +505,8 @@ function ConnectionCard() {
             <CardTitle className="text-base">Connection</CardTitle>
             <CardDescription>Backend server URL</CardDescription>
           </div>
-          <Badge variant={isOnline ? 'secondary' : 'destructive'} className="capitalize">
-            {isOnline ? 'Connected' : 'Disconnected'}
+          <Badge variant={pill.variant} className="capitalize">
+            {pill.label}
           </Badge>
         </div>
       </CardHeader>
@@ -457,29 +516,38 @@ function ConnectionCard() {
             value={url}
             onChange={(e) => {
               setUrl(e.target.value);
-              setResult(null);
+              setError(null);
             }}
             placeholder="http://localhost:25555"
             className="h-9 font-mono text-sm"
             onKeyDown={(e) => {
-              if (e.key === 'Enter' && !saving) void saveAndReconnect();
+              if (e.key === 'Enter' && !saving) void reconnect();
             }}
           />
-          <Button onClick={saveAndReconnect} disabled={saving || !url.trim()} size="sm">
+          <Button onClick={reconnect} disabled={saving || !url.trim()} size="sm">
             <Save className="mr-1.5 h-3.5 w-3.5" />
-            {saving ? 'Testing...' : 'Save & Reconnect'}
+            {saving ? 'Testing...' : isDirty ? 'Save & Reconnect' : 'Reconnect'}
           </Button>
         </div>
-        {result && (
-          <p
-            className={cn(
-              'text-sm',
-              result.kind === 'success' ? 'text-green-600' : 'text-destructive',
-            )}
-          >
-            {result.message}
-          </p>
-        )}
+
+        <div className="flex flex-wrap gap-x-6 gap-y-2 border-t pt-3 text-xs">
+          <div className="flex items-baseline gap-2">
+            <span className="text-muted-foreground">Version</span>
+            <span className="font-mono">{healthQuery.data?.version ?? '—'}</span>
+          </div>
+          <div className="flex items-baseline gap-2">
+            <span className="text-muted-foreground">Latency</span>
+            <span className="font-mono">
+              {healthQuery.data ? `${healthQuery.data.latencyMs} ms` : '—'}
+            </span>
+          </div>
+          <div className="flex items-baseline gap-2">
+            <span className="text-muted-foreground">Last heartbeat</span>
+            <span className="font-mono">{lastHeartbeatAgo ?? '—'}</span>
+          </div>
+        </div>
+
+        {error && <p className="text-sm text-destructive">{error}</p>}
       </CardContent>
     </Card>
   );


### PR DESCRIPTION
## Summary
PR2 (#1773) split Settings into grouped tabs but left General empty (only Documentation) and Appearance/Connection visually thin. This PR:

- Removes the General tab; Documentation card moves to bottom of Appearance.
- Appearance theme selector now renders 3 cards (Light / Dark / System), active one highlighted with border-brand + bg-muted.
- Connection card adds backend version + latency + last heartbeat row, refreshed every 5s. Reconnect button replaces Save & Reconnect when URL is unchanged.

## Type of change
| Type | Label |
|------|-------|
| Bug fix | bug |

## Component
ui

## Closes
Closes #1790

## Test plan
- [x] npm run typecheck
- [x] npm run lint
- [x] npm run build
- [x] Manually verified Appearance shows 3 themes + Connection shows version/latency/heartbeat