### PR TITLE
feat(kernel): synthetic trigger inherits origin endpoint for background task completion (#1794)

### DIFF
--- a/crates/kernel/src/io.rs
+++ b/crates/kernel/src/io.rs
@@ -163,6 +163,15 @@ pub struct InboundMessage {
     /// `None` on ingress when no channel binding exists (first message).
     /// Always `Some` after the kernel runs session resolution.
     session_key: Option<SessionKey>,
+
+    /// Explicit origin endpoint override.
+    ///
+    /// Set on synthetic messages (e.g. background-task completion triggers)
+    /// so that downstream reply routing can reach the channel that
+    /// originally triggered the work, even when the synthetic message's
+    /// `source.channel_type` is `Internal`. When `Some`, it takes priority
+    /// over the derivation performed by [`Self::origin_endpoint`].
+    origin_endpoint_override: Option<Endpoint>,
 }
 
 impl InboundMessage {
@@ -193,6 +202,7 @@ impl InboundMessage {
             timestamp,
             metadata,
             session_key,
+            origin_endpoint_override: None,
         }
     }
 
@@ -256,7 +266,20 @@ impl InboundMessage {
             reply_context: None,
             timestamp: jiff::Timestamp::now(),
             metadata: HashMap::new(),
+            origin_endpoint_override: None,
         }
+    }
+
+    /// Attach an explicit origin endpoint to this message.
+    ///
+    /// Used for synthetic re-entry messages (e.g. background-task
+    /// completion triggers) so that the agent's reply inherits the
+    /// routing target of the original user-facing message, even though
+    /// the synthetic message itself has `ChannelType::Internal`.
+    #[must_use]
+    pub fn with_origin_endpoint(mut self, endpoint: Option<Endpoint>) -> Self {
+        self.origin_endpoint_override = endpoint;
+        self
     }
 
     /// Build the originating endpoint for session-scoped reply routing.
@@ -264,7 +287,15 @@ impl InboundMessage {
     /// Returns `Some(Endpoint)` for channel types that support multiple
     /// chat destinations per user (e.g. Telegram private vs group chats).
     /// Returns `None` for internal/synthetic messages.
+    ///
+    /// When an explicit override has been set via
+    /// [`Self::with_origin_endpoint`], the override takes priority over
+    /// the derivation from `source` — this is how synthetic trigger
+    /// messages inherit the triggering turn's routing target.
     pub fn origin_endpoint(&self) -> Option<Endpoint> {
+        if let Some(ref ep) = self.origin_endpoint_override {
+            return Some(ep.clone());
+        }
         match self.source.channel_type {
             ChannelType::Telegram => {
                 let chat_id = self.source.platform_chat_id.as_ref()?.parse::<i64>().ok()?;
@@ -2899,5 +2930,52 @@ mod inbound_message_tests {
         assert_eq!(blocks.len(), 2);
         assert!(matches!(blocks[0], ContentBlock::Text { .. }));
         assert!(matches!(blocks[1], ContentBlock::ImageUrl { .. }));
+    }
+
+    #[test]
+    fn synthetic_without_override_has_no_origin_endpoint() {
+        let msg = InboundMessage::synthetic(
+            "hello".to_string(),
+            UserId("system".to_string()),
+            SessionKey::new(),
+        );
+        // Synthetic messages are ChannelType::Internal, which does not
+        // derive an endpoint from `source`.
+        assert!(msg.origin_endpoint().is_none());
+    }
+
+    #[test]
+    fn synthetic_with_origin_override_propagates_to_reply_envelope() {
+        // Background-task completion wiring: the synthetic trigger must
+        // carry the originating turn's endpoint so the reply envelope
+        // routes back to the same channel (Web, CLI, Telegram, ...).
+        let origin = Endpoint {
+            channel_type: ChannelType::Web,
+            address:      EndpointAddress::Web {
+                connection_id: "conn-1794".to_string(),
+            },
+        };
+        let session_key = SessionKey::new();
+        let msg = InboundMessage::synthetic(
+            "[Background Task completed]".to_string(),
+            UserId("system".to_string()),
+            session_key,
+        )
+        .with_origin_endpoint(Some(origin.clone()));
+
+        assert_eq!(msg.origin_endpoint(), Some(origin.clone()));
+
+        // The kernel constructs reply envelopes via
+        // `with_origin(msg.origin_endpoint())`. Confirm the override flows
+        // end-to-end into the envelope.
+        let envelope = OutboundEnvelope::reply(
+            msg.id.clone(),
+            msg.user.clone(),
+            session_key,
+            crate::channel::types::MessageContent::Text("done".to_string()),
+            vec![],
+        )
+        .with_origin(msg.origin_endpoint());
+        assert_eq!(envelope.origin_endpoint, Some(origin));
     }
 }

--- a/crates/kernel/src/kernel.rs
+++ b/crates/kernel/src/kernel.rs
@@ -1138,17 +1138,21 @@ impl Kernel {
         let is_background = self.handle().is_background_task(parent_id, child_id);
 
         if is_background {
-            // Capture trigger_message_id before removing from active list.
-            let trigger_message_id = self
+            // Capture trigger metadata before removing from active list so
+            // the synthetic completion message inherits the originating
+            // turn's routing context.
+            let (trigger_message_id, trigger_origin_endpoint) = self
                 .handle()
                 .process_table()
                 .with(&parent_id, |p| {
                     p.background_tasks
                         .iter()
                         .find(|t| t.child_key == child_id)
-                        .map(|t| t.trigger_message_id.clone())
+                        .map(|t| (t.trigger_message_id.clone(), t.origin_endpoint.clone()))
                 })
-                .flatten();
+                .flatten()
+                .map(|(id, ep)| (Some(id), ep))
+                .unwrap_or((None, None));
 
             // Remove from active list.
             self.handle().remove_background_task(parent_id, child_id);
@@ -1205,7 +1209,8 @@ impl Kernel {
             );
 
             let system_user = crate::identity::UserId("system".to_string());
-            let mut msg = crate::io::InboundMessage::synthetic(directive, system_user, parent_id);
+            let mut msg = crate::io::InboundMessage::synthetic(directive, system_user, parent_id)
+                .with_origin_endpoint(trigger_origin_endpoint);
             msg.metadata.insert(
                 "background_task_done".to_string(),
                 serde_json::json!(child_id.to_string()),

--- a/crates/kernel/src/session/mod.rs
+++ b/crates/kernel/src/session/mod.rs
@@ -378,6 +378,12 @@ pub struct BackgroundTaskEntry {
     pub created_at:         jiff::Timestamp,
     /// The inbound message that triggered the spawn.
     pub trigger_message_id: crate::io::MessageId,
+    /// Origin endpoint of the triggering turn, propagated onto the
+    /// synthetic completion trigger so the parent's reply lands in the
+    /// channel that originally asked for the background work (Web, CLI,
+    /// Telegram, ...). `None` when the trigger itself had no origin
+    /// (e.g. spawned from another synthetic source).
+    pub origin_endpoint:    Option<crate::io::Endpoint>,
 }
 
 /// A running session instance in the session table.

--- a/crates/kernel/src/tool/background_common.rs
+++ b/crates/kernel/src/tool/background_common.rs
@@ -76,6 +76,7 @@ pub(crate) async fn spawn_and_register_background(
             description: manifest.description.clone(),
             created_at: jiff::Timestamp::now(),
             trigger_message_id: context.rara_message_id.clone(),
+            origin_endpoint: context.origin_endpoint.clone(),
         },
     );
 


### PR DESCRIPTION
## Summary

Part of #1793. Fix the core routing bug that prevents Web clients from receiving replies when a background (`task`/`spawn-background`) child agent finishes.

When a child completes, `handle_process_cleanup` synthesizes a trigger message back to the parent agent. Previously that synthetic message had no `origin_endpoint`, so the reply envelope had none either. Egress then fell back to `list_channel_bindings_by_session`, which only contains persistent bindings — Telegram/WeChat had them, Web's per-connection endpoints did not, so Web clients silently lost the reply.

This change:

- Adds `origin_endpoint: Option<Endpoint>` to `BackgroundTaskEntry`, populated from `ToolContext::origin_endpoint` at registration time.
- Adds an explicit `origin_endpoint_override` field on `InboundMessage` plus a `with_origin_endpoint(...)` builder method. `origin_endpoint()` now prefers the override over the `source`-derived value.
- In `handle_process_cleanup`, captures the entry's stored origin alongside `trigger_message_id` and attaches it to the synthetic completion message.

The reply path (`start_llm_turn` → `with_origin(msg.origin_endpoint())`) already plumbs the message's `origin_endpoint` into the outbound envelope, so the override flows end-to-end without further changes.

Out of scope (deliberate, deferred to the next PR in the stack):

- Making `origin_endpoint()` / `derive_endpoint()` return a Web endpoint at ingress.
- Changes to `web.rs` egress, `WebEvent`, or the frontend.

## Type of change

| Type | Label |
|------|-------|
| New feature | `enhancement` |

## Component

`core`

## Closes

Closes #1794

## Test plan

- [x] New unit test `synthetic_with_origin_override_propagates_to_reply_envelope` covers the synthetic-msg → reply-envelope wiring with a Web endpoint.
- [x] New unit test `synthetic_without_override_has_no_origin_endpoint` documents the existing default.
- [x] `cargo test -p rara-kernel --lib` passes (552 passed).
- [x] `prek run --all-files` passes.