### PR TITLE
fix(web): probe public /api/v1/health in ConnectionSetupDialog (#1799)

### DIFF
--- a/web/src/components/ConnectionSetupDialog.tsx
+++ b/web/src/components/ConnectionSetupDialog.tsx
@@ -42,7 +42,7 @@ export function ConnectionSetupDialog({ open, onConnect }: ConnectionSetupDialog
     setTesting(true);
     setError(null);
     try {
-      const res = await fetch(`${url}/api/v1/settings`, {
+      const res = await fetch(`${url}/api/v1/health`, {
         signal: AbortSignal.timeout(5000),
       });
       if (res.ok) {


### PR DESCRIPTION
## Summary

`ConnectionSetupDialog` was probing `/api/v1/settings` to verify backend reachability, but that endpoint sits behind `auth_layer`. On a fresh browser or private window the setup dialog opens **before** the user can reach `/login`, so the probe always returns 401 and the user is permanently locked out of the app — they never get a chance to enter their owner token.

Switch the probe to `/api/v1/health`, which is the public reachability endpoint and matches what `SettingsPanel`'s newer `ConnectionCard` already uses.

## Type of change

| Type | Label |
|------|-------|
| Bug fix | `bug` |

## Component

`ui`

## Closes

Closes #1799

## Test plan

- [x] `bun run build` passes in `web/`
- [x] Verified in private window: dialog now connects on a public health probe; user can proceed to `/login`