### PR TITLE
feat(web): home empty state + hierarchy (#1789)

### DIFF
--- a/web/src/components/ChatSidebar.tsx
+++ b/web/src/components/ChatSidebar.tsx
@@ -129,7 +129,7 @@ export function ChatSidebar({
   return (
     <aside
       className={cn(
-        'flex h-screen shrink-0 flex-col border-r border-border/50 bg-background/40 backdrop-blur-md transition-[width] duration-200 ease-out',
+        'flex h-screen shrink-0 flex-col border-r border-border bg-canvas transition-[width] duration-200 ease-out',
         collapsed ? 'w-14' : 'w-64',
       )}
     >

--- a/web/src/components/ChatSidebar.tsx
+++ b/web/src/components/ChatSidebar.tsx
@@ -203,7 +203,7 @@ export function ChatSidebar({
       {/* History list */}
       {!collapsed && (
         <>
-          <div className="mb-1 mt-4 shrink-0 px-4 text-[11px] font-medium uppercase tracking-wider text-muted-foreground/70">
+          <div className="mb-1 mt-4 shrink-0 px-4 text-[11px] font-medium uppercase tracking-wider text-muted-foreground">
             历史会话
           </div>
           <div className="min-h-0 flex-1 overflow-y-auto">
@@ -230,7 +230,7 @@ export function ChatSidebar({
                     <div className="truncate text-[13px] leading-tight">
                       {stripForPreview(s.title || s.preview || '新对话')}
                     </div>
-                    <div className="mt-0.5 truncate text-[11px] text-muted-foreground/80">
+                    <div className="mt-0.5 truncate text-[11px] text-muted-foreground">
                       {formatRelativeDate(s.updated_at)}
                     </div>
                   </button>

--- a/web/src/components/ChatWelcome.tsx
+++ b/web/src/components/ChatWelcome.tsx
@@ -1,0 +1,153 @@
+/*
+ * Copyright 2025 Rararulab
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+import { ArrowUpRight, Lightbulb, ListChecks, MessageSquare, Sparkles } from 'lucide-react';
+import { useEffect, useState } from 'react';
+
+import { api } from '@/api/client';
+import type { ChatSession } from '@/api/types';
+
+interface StarterPrompt {
+  icon: typeof Sparkles;
+  label: string;
+  prompt: string;
+}
+
+// Curated starter prompts. Kept short; first line is the visible label,
+// `prompt` is what gets dropped into the composer on click. Style mirrors
+// ChatGPT/Claude empty states — concrete verbs, not marketing copy.
+const STARTERS: StarterPrompt[] = [
+  {
+    icon: Sparkles,
+    label: '帮我写一段',
+    prompt: '帮我写一段关于 ',
+  },
+  {
+    icon: Lightbulb,
+    label: '解释一个概念',
+    prompt: '请用通俗的语言解释 ',
+  },
+  {
+    icon: ListChecks,
+    label: '拆解任务',
+    prompt: '帮我把这个目标拆成可执行的步骤：',
+  },
+  {
+    icon: MessageSquare,
+    label: '继续讨论',
+    prompt: '我想继续讨论 ',
+  },
+];
+
+interface ChatWelcomeProps {
+  /** Open an existing session from the recent peek. */
+  onSelectSession: (session: ChatSession) => void;
+}
+
+/**
+ * Home empty-state panel. Rendered above pi-web-ui's empty message column
+ * when the active session has no messages. Layout mirrors ChatGPT/Claude:
+ * a calm greeting, four starter cards, and a peek at recent sessions —
+ * no giant wordmark, no floating composer (the composer stays anchored
+ * at the bottom of `<main>` in both empty and populated states).
+ */
+export function ChatWelcome({ onSelectSession }: ChatWelcomeProps) {
+  const [recents, setRecents] = useState<ChatSession[]>([]);
+
+  useEffect(() => {
+    let alive = true;
+    api
+      .get<ChatSession[]>('/api/v1/chat/sessions?limit=4&offset=0')
+      .then((list) => {
+        if (alive) setRecents(list.filter((s) => s.message_count > 0));
+      })
+      .catch(() => {
+        if (alive) setRecents([]);
+      });
+    return () => {
+      alive = false;
+    };
+  }, []);
+
+  // Prefill pi-web-ui's composer textarea. Pi-web-ui's editor reacts to
+  // native `input` events to track the buffer, so dispatching one after
+  // assignment keeps internal state in sync. We don't auto-send — the
+  // user finishes the thought and presses Enter.
+  const handleStarter = (prompt: string) => {
+    const ta = document.querySelector<HTMLTextAreaElement>('textarea');
+    if (!ta) return;
+    ta.value = prompt;
+    ta.dispatchEvent(new Event('input', { bubbles: true }));
+    ta.focus();
+    // Drop the caret at the end so the user can keep typing.
+    const len = ta.value.length;
+    ta.setSelectionRange(len, len);
+  };
+
+  return (
+    <div className="pointer-events-auto mx-auto flex w-full max-w-3xl flex-col gap-8 px-6 pb-32 pt-16 sm:pt-24">
+      <header className="flex flex-col gap-2">
+        <h1 className="text-h1 text-foreground">你好，欢迎回来</h1>
+        <p className="text-body-lg text-muted-foreground">今天想做点什么？</p>
+      </header>
+
+      <section className="flex flex-col gap-3">
+        <h2 className="text-section-label text-muted-foreground">起步提示</h2>
+        <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
+          {STARTERS.map(({ icon: Icon, label, prompt }) => (
+            <button
+              key={label}
+              type="button"
+              onClick={() => handleStarter(prompt)}
+              className="group flex items-center gap-3 rounded-xl border border-border/60 bg-background/60 px-4 py-3 text-left text-sm text-foreground transition-colors hover:border-border hover:bg-secondary/40"
+            >
+              <Icon className="h-4 w-4 shrink-0 text-muted-foreground transition-colors group-hover:text-foreground" />
+              <span className="flex-1 truncate">{label}</span>
+              <ArrowUpRight className="h-3.5 w-3.5 shrink-0 text-muted-foreground/0 transition-opacity group-hover:text-muted-foreground group-hover:opacity-100" />
+            </button>
+          ))}
+        </div>
+      </section>
+
+      {recents.length > 0 && (
+        <section className="flex flex-col gap-3">
+          <h2 className="text-section-label text-muted-foreground">最近会话</h2>
+          <ul className="flex flex-col">
+            {recents.map((s) => (
+              <li key={s.key}>
+                <button
+                  type="button"
+                  onClick={() => onSelectSession(s)}
+                  className="group flex w-full items-center gap-3 rounded-md px-2 py-2 text-left transition-colors hover:bg-secondary/40"
+                >
+                  <span className="flex-1 truncate text-sm text-foreground">
+                    {s.title || s.preview || '新对话'}
+                  </span>
+                  <span className="shrink-0 text-xs text-muted-foreground">
+                    {formatRelative(s.updated_at)}
+                  </span>
+                </button>
+              </li>
+            ))}
+          </ul>
+        </section>
+      )}
+    </div>
+  );
+}
+
+function formatRelative(iso: string): string {
+  const diff = Date.now() - new Date(iso).getTime();
+  const days = Math.floor(diff / 86_400_000);
+  if (days === 0) return '今天';
+  if (days === 1) return '昨天';
+  if (days < 7) return `${days} 天前`;
+  return new Date(iso).toLocaleDateString();
+}

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -110,6 +110,14 @@
    * as the tool-call glass bubble so the page reads as one palette.
    */
   --canvas: oklch(0.96 0.005 250);
+
+  /*
+   * Darken pi-web-ui's stock `--muted-foreground` (oklch 55.6%) to clear
+   * WCAG AA 4.5:1 against the cooler `--canvas`. Pi's value barely
+   * passes against pure white (4.57:1) — the canvas is darker, so 11px
+   * timestamps and meta copy fall under without this override.
+   */
+  --muted-foreground: oklch(45% 0 0);
 }
 
 .dark {

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -130,7 +130,7 @@
   --secondary: #f0dee0;
   --secondary-foreground: #3d2b2e;
   --muted: #f0dee0;
-  --muted-foreground: #8c7478;
+  --muted-foreground: #6b5256;
   --accent: #f0dee0;
   --accent-foreground: #3d2b2e;
   --destructive: #d46a6a;

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -226,36 +226,19 @@
     font-family: var(--font-mono);
   }
   /*
-   * Chat-shell atmosphere: one very faint info-blue glow in the top-left
-   * corner, painted on top of the canvas. Ties the page to the same cool
-   * palette the user-message glass bubble uses, stops the chat from
-   * reading as "bare white sheet" without pulling focus from content.
+   * Chat-shell background — neutral, matches the restraint ChatGPT and
+   * Claude.ai use. The canvas already provides a slight off-white tint
+   * (see `--canvas` above); we just clear any prior gradient on
+   * `.rara-chat` so the page reads as a single calm sheet. Atmosphere
+   * for the chat now comes from the bubbles and avatar ring, not from
+   * page-level color washes.
    */
   .rara-chat {
-    background-image:
-      radial-gradient(
-        ellipse 70% 50% at 0% 0%,
-        color-mix(in oklab, oklch(0.62 0.18 250) 22%, transparent) 0%,
-        transparent 65%
-      ),
-      radial-gradient(
-        ellipse 60% 45% at 100% 100%,
-        color-mix(in oklab, oklch(0.72 0.14 340) 20%, transparent) 0%,
-        transparent 60%
-      );
+    background-image: none;
+    background-color: var(--color-background);
   }
   .dark .rara-chat {
-    background-image:
-      radial-gradient(
-        ellipse 70% 50% at 0% 0%,
-        color-mix(in oklab, oklch(0.62 0.18 250) 22%, transparent) 0%,
-        transparent 65%
-      ),
-      radial-gradient(
-        ellipse 60% 45% at 100% 100%,
-        color-mix(in oklab, oklch(0.55 0.14 340) 20%, transparent) 0%,
-        transparent 60%
-      );
+    background-color: var(--color-background);
   }
 
   /* Rara admin gradient background — only on admin pages */
@@ -420,26 +403,12 @@
 }
 
 /*
- * Welcome-state composer lift. When the session is empty we float the
- * composer (pi-web-ui's last flex-col child) up to sit near the middle
- * of the viewport, together with the RARA wordmark positioned just
- * above it. The floating voice button piggybacks on the same translate
- * so it keeps its alignment with the paperclip inside the composer.
- * Transition is long enough to read as an intentional shift when the
- * first message flips us out of welcome mode.
+ * Composer position is identical between empty (Home) and populated
+ * (Session) states — anchored to the bottom of `<main>` by pi-web-ui's
+ * own flex layout. The Home empty-state panel (`ChatWelcome`) renders
+ * in the scroll area above instead of lifting the composer, matching
+ * ChatGPT/Claude.ai. No translate needed.
  */
-.rara-chat[data-welcome='true'] agent-interface .flex-col.bg-background > *:last-child,
-.rara-chat[data-welcome='true'] .voice-float {
-  /* Lifts the composer centre close to viewport centre. Natural bottom
-     is ~8-10rem from the edge (padding + composer body), so ~40vh up
-     lands the centre near 50vh with some headroom for the wordmark. */
-  transform: translateY(-40vh);
-  transition: transform 420ms cubic-bezier(0.22, 0.61, 0.36, 1);
-}
-.rara-chat agent-interface .flex-col.bg-background > *:last-child,
-.rara-chat .voice-float {
-  transition: transform 420ms cubic-bezier(0.22, 0.61, 0.36, 1);
-}
 
 /*
  * Cap the composer width and centre it so a wide viewport doesn't
@@ -518,6 +487,12 @@
  */
 .rara-chat agent-interface .overflow-y-auto > .max-w-3xl {
   padding-bottom: var(--rara-live-card-h, 0);
+  /* Tighten pi-web-ui's default `p-4` (16px) on the inline axis — a
+     little less air around bubbles reads closer to ChatGPT/Claude
+     density. Vertical padding is left to pi-web-ui so its content
+     observer keeps scroll math correct. */
+  padding-left: 0.5rem;
+  padding-right: 0.5rem;
 }
 .rara-chat agent-interface .overflow-y-auto {
   scroll-padding-bottom: var(--rara-live-card-h, 0);
@@ -565,6 +540,29 @@
 }
 
 @layer components {
+  /*
+   * Typography scale (#1789). Three load-bearing classes so visual
+   * hierarchy doesn't rely on whitespace alone:
+   *   `.text-h1`            — page-level greeting / hero header
+   *   `.text-h2`            — sub-header inside a page
+   *   `.text-section-label` — uppercase tag above a list/grid section
+   *   `.text-body-lg`       — slightly relaxed body for hero subtitles
+   * Plain `text-sm` / `text-xs` continue to carry body and meta copy;
+   * the scale is intentionally narrow — three new classes, not eight.
+   */
+  .text-h1 {
+    @apply text-3xl font-semibold leading-tight tracking-tight sm:text-4xl;
+  }
+  .text-h2 {
+    @apply text-xl font-semibold leading-tight tracking-tight;
+  }
+  .text-section-label {
+    @apply text-[11px] font-medium uppercase tracking-wider;
+  }
+  .text-body-lg {
+    @apply text-base leading-relaxed;
+  }
+
   .app-surface {
     background: color-mix(in oklab, var(--color-card) 92%, transparent);
     backdrop-filter: blur(14px);

--- a/web/src/pages/PiChat.tsx
+++ b/web/src/pages/PiChat.tsx
@@ -63,6 +63,7 @@ import { AlmaCaret } from '@/components/AlmaCaret';
 import { CascadeModal } from '@/components/chat/CascadeModal';
 import { ExecutionTraceModal } from '@/components/chat/ExecutionTraceModal';
 import { ChatSidebar } from '@/components/ChatSidebar';
+import { ChatWelcome } from '@/components/ChatWelcome';
 import { RaraModelDialog } from '@/components/RaraModelDialog';
 import { SessionSearchDialog } from '@/components/SessionSearchDialog';
 import { useSettingsModal } from '@/components/settings/SettingsModalProvider';
@@ -1019,22 +1020,15 @@ export default function PiChat() {
           </div>
         )}
         {/*
-          Welcome overlay — rendered above pi-web-ui's empty message list
-          when the active session has no messages. Pointer-events-none so
-          clicks pass through to the composer below; flipped off the
-          moment the user commits their first message (onBeforeSend).
+          Home empty-state — greeting + starter prompts + recent sessions
+          peek, rendered above pi-web-ui's empty message column. Sits in
+          a scroll-friendly absolute layer so it doesn't displace the
+          composer (composer stays anchored at the bottom of `<main>`,
+          identical to the populated session layout).
         */}
         {showWelcome && !isInitializing && (
-          <div className="pointer-events-none absolute inset-x-0 bottom-[calc(40vh+8rem)] z-10 flex justify-center px-6">
-            <div className="flex flex-col items-center gap-3">
-              <div
-                className="text-[32px] font-semibold leading-none tracking-tight text-foreground"
-                style={{ fontFamily: 'var(--font-sans)' }}
-              >
-                rara
-              </div>
-              <p className="text-sm text-muted-foreground">How can I help today?</p>
-            </div>
+          <div className="pointer-events-none absolute inset-0 z-10 overflow-y-auto">
+            <ChatWelcome onSelectSession={(s) => void switchSession(s)} />
           </div>
         )}
         {/*


### PR DESCRIPTION
## Summary

Visual refresh for the web frontend's Home empty state and shared chat chrome, modeled on ChatGPT / Claude.ai restraint:

- New `ChatWelcome` component: greeting (H1), four starter prompt cards that prefill the composer, and a peek at the four most recent sessions. Replaces the giant `RARA` wordmark + floating composer.
- Composer is now anchored to the bottom of `<main>` in both empty and populated states (no `data-welcome` translate); Home → Session no longer relayouts.
- Drop the `.rara-chat` radial gradient; chat shell uses the neutral system background (`--color-background`) ChatGPT / Claude use.
- Add a narrow typography scale (`.text-h1`, `.text-h2`, `.text-section-label`, `.text-body-lg`) so hierarchy carries weight beyond whitespace.
- Stronger sidebar separator (`border-r border-border` on canvas) + slightly tighter message-column inline padding.
- No new UI deps; reuses `lucide-react` icons already in the bundle.

## Type of change

| Type | Label |
|------|-------|
| Enhancement | `enhancement` |

## Component

`ui`

## Closes

Closes #1789

## Test plan

- [x] `bun run lint` passes
- [x] `bun run build` passes
- [ ] Manual visual check against `chatgpt.com` / `claude.ai` empty state
- [ ] Verify Home → Session has no composer relayout

🤖 Generated with [Claude Code](https://claude.com/claude-code)