### PR TITLE
fix(web): session search returns no results due to cmdk client-side filter (#1795)

### DIFF
--- a/web/src/components/SessionSearchDialog.tsx
+++ b/web/src/components/SessionSearchDialog.tsx
@@ -150,7 +150,12 @@ export function SessionSearchDialog({
   const showRecents = trimmed.length === 0;
 
   return (
-    <CommandDialog open={open} onOpenChange={onOpenChange}>
+    // `shouldFilter={false}` — results come pre-filtered from the backend
+    // search API. cmdk's default fuzzy filter scores composite values like
+    // `${session_key}:${seq}:${title}:${snippet}` poorly (especially for
+    // CJK queries against snippets containing `<mark>` tags), so leaving it
+    // on hides genuine hits. See issue #1795.
+    <CommandDialog open={open} onOpenChange={onOpenChange} shouldFilter={false}>
       <CommandInput placeholder="搜索会话 (Cmd+K)…" value={query} onValueChange={setQuery} />
       <CommandList>
         {showRecents ? (

--- a/web/src/components/__tests__/SessionSearchDialog.test.tsx
+++ b/web/src/components/__tests__/SessionSearchDialog.test.tsx
@@ -125,6 +125,40 @@ describe('SessionSearchDialog', () => {
     expect(mark?.textContent).toBe('world');
   });
 
+  it('renders backend hits for Chinese queries (no client-side filter)', async () => {
+    // Regression for #1795: cmdk's default `shouldFilter` was scoring the
+    // composite `value` (uuid + seq + Chinese title + <mark> snippet) at 0
+    // and hiding real hits. The dialog must trust the backend's results.
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    searchSessionsMock.mockResolvedValue([
+      hitFixture({
+        session_key: 'cn-1',
+        session_title: '预算讨论',
+        snippet: '本月<mark>预算</mark>',
+      }),
+    ]);
+    const { SessionSearchDialog } = await import('../SessionSearchDialog');
+
+    render(
+      <SessionSearchDialog open onOpenChange={vi.fn()} onSelect={vi.fn()} recentSessions={[]} />,
+    );
+
+    const input = await screen.findByPlaceholderText(/搜索会话/);
+    act(() => {
+      fireEvent.change(input, { target: { value: '预算' } });
+    });
+
+    await act(async () => {
+      vi.advanceTimersByTime(260);
+    });
+
+    expect(searchSessionsMock).toHaveBeenCalledWith('预算', 20);
+    await waitFor(() => expect(screen.getByText('预算讨论')).toBeInTheDocument());
+    const mark = document.body.querySelector('mark');
+    expect(mark?.textContent).toBe('预算');
+    vi.useRealTimers();
+  });
+
   it('calls onSelect + onOpenChange(false) when a result is picked', async () => {
     searchSessionsMock.mockResolvedValue([hitFixture({ session_key: 'picked' })]);
     const onSelect = vi.fn();

--- a/web/src/components/ui/command.tsx
+++ b/web/src/components/ui/command.tsx
@@ -42,16 +42,19 @@ const Command = React.forwardRef<
 ));
 Command.displayName = CommandPrimitive.displayName;
 
-/** Dialog container that hosts the command palette UI. */
-function CommandDialog({
-  children,
-  open,
-  onOpenChange,
-}: {
-  children: React.ReactNode;
+/**
+ * Dialog container that hosts the command palette UI.
+ *
+ * Forwards extra `Command` props (e.g. `shouldFilter`, `filter`, `value`)
+ * so callers can opt out of cmdk's built-in client-side filtering when
+ * the result list is already filtered upstream (e.g. server-side search).
+ */
+type CommandDialogProps = {
   open: boolean;
   onOpenChange: (value: boolean) => void;
-}) {
+} & Omit<React.ComponentProps<typeof Command>, 'open' | 'onOpenChange'>;
+
+function CommandDialog({ children, open, onOpenChange, ...commandProps }: CommandDialogProps) {
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="overflow-hidden p-0 shadow-lg sm:max-w-[640px]">
@@ -60,7 +63,10 @@ function CommandDialog({
             itself is the label for sighted users. */}
         <DialogTitle className="sr-only">Command palette</DialogTitle>
         <DialogDescription className="sr-only">Search your sessions and messages</DialogDescription>
-        <Command className="[&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground [&_[cmdk-group]]:px-2 [&_[cmdk-input-wrapper]_svg]:h-5 [&_[cmdk-input-wrapper]_svg]:w-5 [&_[cmdk-input]]:h-12 [&_[cmdk-item]]:px-2 [&_[cmdk-item]]:py-3 [&_[cmdk-item]_svg]:h-5 [&_[cmdk-item]_svg]:w-5">
+        <Command
+          className="[&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground [&_[cmdk-group]]:px-2 [&_[cmdk-input-wrapper]_svg]:h-5 [&_[cmdk-input-wrapper]_svg]:w-5 [&_[cmdk-input]]:h-12 [&_[cmdk-item]]:px-2 [&_[cmdk-item]]:py-3 [&_[cmdk-item]_svg]:h-5 [&_[cmdk-item]_svg]:w-5"
+          {...commandProps}
+        >
           {children}
         </Command>
       </DialogContent>


### PR DESCRIPTION
## Summary

Cmd+K 会话搜索 (`SessionSearchDialog`) 之前在搜聊天内容（尤其中文 query）时常常显示"没有匹配的会话"，即便后端 `/api/sessions/search` 返回了命中。

根因：组件用了 cmdk 的 `CommandDialog`，但没设置 `shouldFilter={false}`。cmdk 默认会用 command-score 在客户端再做一次模糊过滤。每个 hit 的 `value` 是 `${session_key}:${seq}:${session_title}:${snippet}` —— 长 uuid 前缀 + `<mark>` 标签 + 中文文本对 command-score 几乎拿不到正分，命中被前端二次过滤掉。

修复：
- `web/src/components/ui/command.tsx`：让 `CommandDialog` 透传 `Command` 的 props（`shouldFilter` / `filter` / `value` 等）。
- `web/src/components/SessionSearchDialog.tsx`：传 `shouldFilter={false}`，注释说明结果已由后端过滤。
- 加 vitest 回归用例：中文 query (`'预算'`) → 后端命中（中文标题 + `<mark>` 中文 snippet）应当渲染出来。

## Type of change

| Type | Label |
|------|-------|
| Bug fix | `bug` |

## Component

`ui`

## Closes

Closes #1795

## Test plan

- [x] `bunx vitest run SessionSearchDialog` — 5/5 通过（含新增的中文 query 回归用例）
- [x] `bun run build` 通过
- [x] pre-commit web lint-staged 通过