### PR TITLE
fix(web): buffer task-completion replies when no WS listener attached (#1804)

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -131,6 +131,32 @@ agents:
     max_output_chars: 50
 
 # ---------------------------------------------------------------------------
+# Web channel adapter (optional)
+# ---------------------------------------------------------------------------
+#
+# `reply_buffer` is a per-session in-memory ring of "important" outbound
+# events (final `message`, `error`, `background_task_done`, `progress`).
+# When a long-running background task completes while the user has
+# closed the browser tab, the WS broadcast has zero receivers and the
+# event would otherwise be silently dropped. The buffer keeps the last
+# `capacity` events per session for `ttl`, so a reconnecting tab drains
+# them before live tail starts. Streaming token deltas are NOT buffered.
+#
+# Trade-off: buffer is keyed per session, not per receiver — a tab that
+# disconnects + reconnects within `ttl` will see events it already saw
+# delivered a second time. The frontend can dedupe by payload if
+# necessary.
+#
+# Omit the block entirely to disable buffering (legacy pre-#1804
+# behaviour).
+
+web:
+  reply_buffer:
+    capacity: 64
+    ttl: 10m
+    sweep_interval: 1m
+
+# ---------------------------------------------------------------------------
 # Optional integrations — remove or leave commented out if unused
 # ---------------------------------------------------------------------------
 

--- a/crates/app/src/lib.rs
+++ b/crates/app/src/lib.rs
@@ -496,16 +496,7 @@ pub async fn start_with_options(
         .and_then(|w| w.reply_buffer.clone())
         .map(|cfg| {
             let buffer = rara_channels::web_reply_buffer::ReplyBuffer::new(cfg);
-            let (sweeper_tx, sweeper_rx) = tokio::sync::watch::channel(false);
-            // Bridge the workspace cancellation token to the sweeper's
-            // dedicated watch handle so shutdown propagates through the
-            // same signal that stops every other long-running task.
-            let token = cancellation_token.clone();
-            tokio::spawn(async move {
-                token.cancelled().await;
-                let _ = sweeper_tx.send(true);
-            });
-            Arc::clone(&buffer).spawn_sweeper(sweeper_rx);
+            Arc::clone(&buffer).spawn_sweeper(cancellation_token.clone());
             buffer
         });
 

--- a/crates/app/src/lib.rs
+++ b/crates/app/src/lib.rs
@@ -93,6 +93,15 @@ pub struct AppConfig {
     /// WeChat iLink Bot configuration (seeded to settings store at startup).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub wechat:                 Option<flatten::WechatConfig>,
+    /// Web channel adapter configuration.
+    ///
+    /// When present, a per-session reply buffer is wired into the
+    /// [`WebAdapter`](rara_channels::web::WebAdapter) so that
+    /// task-completion replies survive moments where no WS / SSE
+    /// listener is attached (issue #1804). When absent, buffering is
+    /// disabled and behaviour matches pre-#1804.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub web:                    Option<WebConfig>,
     /// Composio credentials (seeded to settings store at startup).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub composio:               Option<flatten::ComposioConfig>,
@@ -138,6 +147,16 @@ pub struct AppConfig {
     /// rara falls back to `http-fetch` for web access.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub browser:                Option<rara_browser::BrowserConfig>,
+}
+
+/// Web channel adapter configuration (YAML `web:` block).
+#[derive(Debug, Clone, bon::Builder, Serialize, Deserialize)]
+pub struct WebConfig {
+    /// Per-session ring buffer for important outbound events
+    /// (`Message`, `Error`, `BackgroundTaskDone`, `Progress`). When
+    /// the YAML key is absent, no buffering is performed.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reply_buffer: Option<rara_channels::web_reply_buffer::ReplyBufferConfig>,
 }
 
 /// Configuration for the Mita background proactive agent.
@@ -463,12 +482,40 @@ pub async fn start_with_options(
     .await
     .whatever_context("Failed to initialize BackendState")?;
 
+    // Created here (rather than below near `kernel.start`) so the web
+    // reply-buffer sweeper task started a few lines down can listen on
+    // the same shutdown signal as every other long-running task.
+    let cancellation_token = CancellationToken::new();
+
+    // Build the optional reply buffer and spawn its TTL sweeper. When
+    // `web.reply_buffer` is absent, buffering is disabled. The sweeper
+    // runs until the process-wide `cancellation_token` fires.
+    let reply_buffer = config
+        .web
+        .as_ref()
+        .and_then(|w| w.reply_buffer.clone())
+        .map(|cfg| {
+            let buffer = rara_channels::web_reply_buffer::ReplyBuffer::new(cfg);
+            let (sweeper_tx, sweeper_rx) = tokio::sync::watch::channel(false);
+            // Bridge the workspace cancellation token to the sweeper's
+            // dedicated watch handle so shutdown propagates through the
+            // same signal that stops every other long-running task.
+            let token = cancellation_token.clone();
+            tokio::spawn(async move {
+                token.cancelled().await;
+                let _ = sweeper_tx.send(true);
+            });
+            Arc::clone(&buffer).spawn_sweeper(sweeper_rx);
+            buffer
+        });
+
     let web_adapter = Arc::new(
         rara_channels::web::WebAdapter::new(
             config.owner_token.clone(),
             config.owner_user_id.clone(),
         )
-        .with_stt_service(stt_service.clone()),
+        .with_stt_service(stt_service.clone())
+        .with_reply_buffer(reply_buffer),
     );
     let web_router = web_adapter.router();
 
@@ -575,8 +622,6 @@ pub async fn start_with_options(
         .skill_prompt_provider(skill_prompt_provider)
         .scheduler_dir(rara_paths::workspace_dir().join("scheduler"))
         .build();
-
-    let cancellation_token = CancellationToken::new();
 
     // Supervisor restarts whisper-server on crash, stops on app shutdown.
     let _whisper_supervisor =

--- a/crates/channels/Cargo.toml
+++ b/crates/channels/Cargo.toml
@@ -17,6 +17,7 @@ governor = "0.10"
 humantime-serde = "1"
 image = { workspace = true }
 jiff = { workspace = true }
+parking_lot = { workspace = true }
 rand = { workspace = true }
 rara-dock = { workspace = true }
 rara-domain-shared = { workspace = true }
@@ -48,12 +49,14 @@ uuid = { workspace = true }
 
 [dev-dependencies]
 base64 = { workspace = true }
+futures = { workspace = true }
 rara-kernel = { workspace = true }
 rara-paths = { workspace = true }
 rara-stt = { workspace = true }
 serde_json = { workspace = true }
 tempfile = { workspace = true }
 tokio = { workspace = true, features = ["full", "test-util"] }
+tokio-tungstenite = "0.29"
 wiremock = "0.6"
 
 [lints]

--- a/crates/channels/Cargo.toml
+++ b/crates/channels/Cargo.toml
@@ -9,10 +9,12 @@ anyhow = { workspace = true }
 async-trait = { workspace = true }
 axum = { workspace = true, features = ["ws"] }
 base64 = { workspace = true }
+bon = { workspace = true }
 chrono = { workspace = true }
 dashmap = "6"
 futures = { workspace = true }
 governor = "0.10"
+humantime-serde = "1"
 image = { workspace = true }
 jiff = { workspace = true }
 rand = { workspace = true }

--- a/crates/channels/src/lib.rs
+++ b/crates/channels/src/lib.rs
@@ -27,6 +27,7 @@
 pub mod telegram;
 pub mod terminal;
 pub mod web;
+pub mod web_reply_buffer;
 pub mod wechat;
 
 /// Tool display formatting helpers.

--- a/crates/channels/src/web.rs
+++ b/crates/channels/src/web.rs
@@ -657,13 +657,20 @@ impl WebAdapter {
     /// `receiver_count`. Trade-off: a tab that read an event live will
     /// see it again if it disconnects + reconnects within the TTL window.
     /// See `web_reply_buffer.rs` module docs.
-    async fn publish_adapter_event(
+    fn publish_adapter_event(
         buses: &DashMap<SessionKey, broadcast::Sender<WebEvent>>,
         reply_buffer: Option<&Arc<ReplyBuffer>>,
         session_key: &SessionKey,
         event: WebEvent,
     ) {
         let event_kind: &'static str = (&event).into();
+        // Only clone the event when it actually needs buffering — keeps
+        // streaming hot paths (TextDelta / ReasoningDelta / …) at zero
+        // extra allocations.
+        let buffer_target = match reply_buffer {
+            Some(buf) if ReplyBuffer::should_buffer(&event) => Some(buf),
+            _ => None,
+        };
         if let Some(tx) = buses.get(session_key) {
             let receiver_count = tx.receiver_count();
             tracing::debug!(
@@ -672,7 +679,16 @@ impl WebAdapter {
                 event_kind,
                 "web publish_adapter_event"
             );
-            if tx.send(event.clone()).is_err() {
+            let send_result = match buffer_target {
+                Some(buf) => {
+                    let for_buf = event.clone();
+                    let r = tx.send(event);
+                    buf.append(session_key, for_buf);
+                    r
+                }
+                None => tx.send(event),
+            };
+            if send_result.is_err() {
                 tracing::warn!(
                     session_key = %session_key,
                     event_kind,
@@ -685,12 +701,9 @@ impl WebAdapter {
                 event_kind,
                 "web publish_adapter_event: no bus yet"
             );
-        }
-
-        if let Some(buf) = reply_buffer
-            && ReplyBuffer::should_buffer(&event)
-        {
-            buf.append(session_key, event).await;
+            if let Some(buf) = buffer_target {
+                buf.append(session_key, event);
+            }
         }
     }
 }
@@ -738,8 +751,7 @@ async fn approval_listener(
                             reply_buffer.as_ref(),
                             &req.session_key,
                             event,
-                        )
-                        .await;
+                        );
                     }
                     Err(tokio::sync::broadcast::error::RecvError::Closed) => return,
                     Err(tokio::sync::broadcast::error::RecvError::Lagged(n)) => {
@@ -765,8 +777,7 @@ async fn approval_listener(
                             reply_buffer.as_ref(),
                             &session_key,
                             event,
-                        )
-                        .await;
+                        );
                     }
                     Err(tokio::sync::broadcast::error::RecvError::Closed) => return,
                     Err(tokio::sync::broadcast::error::RecvError::Lagged(n)) => {
@@ -1083,7 +1094,7 @@ async fn handle_ws(socket: WebSocket, params: SessionQuery, state: WebAdapterSta
     // socket sees buffered events first in publish order. The buffer is
     // not removed on drain — see `web_reply_buffer` module docs for why.
     if let Some(ref buf) = state.reply_buffer {
-        let backlog = buf.snapshot(&session_key).await;
+        let backlog = buf.snapshot(&session_key);
         if !backlog.is_empty() {
             debug!(
                 session_key = %session_key_str,
@@ -1230,8 +1241,7 @@ async fn handle_ws(socket: WebSocket, params: SessionQuery, state: WebAdapterSta
                         WebEvent::Error {
                             message: "adapter not started".to_owned(),
                         },
-                    )
-                    .await;
+                    );
                     continue;
                 };
 
@@ -1240,8 +1250,7 @@ async fn handle_ws(socket: WebSocket, params: SessionQuery, state: WebAdapterSta
                     reply_buffer.as_ref(),
                     &session_key,
                     WebEvent::Typing,
-                )
-                .await;
+                );
 
                 // When no channel binding exists yet (first message),
                 // resolve() returns session_key = None. Patch it with the
@@ -1260,8 +1269,7 @@ async fn handle_ws(socket: WebSocket, params: SessionQuery, state: WebAdapterSta
                                 WebEvent::Error {
                                     message: e.to_string(),
                                 },
-                            )
-                            .await;
+                            );
                         }
                         // No per-message forwarder spawn needed — the
                         // per-WS stream_forwarder above is already
@@ -1277,8 +1285,7 @@ async fn handle_ws(socket: WebSocket, params: SessionQuery, state: WebAdapterSta
                             WebEvent::Error {
                                 message: e.to_string(),
                             },
-                        )
-                        .await;
+                        );
                     }
                 }
             }
@@ -1335,7 +1342,7 @@ async fn sse_handler(
 
     // Drain any buffered "important" events before live tail starts.
     if let Some(ref buf) = state.reply_buffer {
-        let backlog = buf.snapshot(&session_key).await;
+        let backlog = buf.snapshot(&session_key);
         if !backlog.is_empty() {
             debug!(
                 session_key = %params.session_key,
@@ -1519,8 +1526,7 @@ async fn send_message_handler(
                 state.reply_buffer.as_ref(),
                 &session_key,
                 WebEvent::Typing,
-            )
-            .await;
+            );
             match sink.ingest(raw).await {
                 Ok(()) => {
                     // No forwarder to spawn — each WS/SSE is permanently
@@ -1602,8 +1608,7 @@ impl ChannelAdapter for WebAdapter {
             self.reply_buffer.as_ref(),
             &session_key,
             event,
-        )
-        .await;
+        );
         Ok(())
     }
 
@@ -1654,8 +1659,7 @@ impl ChannelAdapter for WebAdapter {
             self.reply_buffer.as_ref(),
             &key,
             WebEvent::Typing,
-        )
-        .await;
+        );
         Ok(())
     }
 
@@ -1670,8 +1674,7 @@ impl ChannelAdapter for WebAdapter {
             WebEvent::Phase {
                 phase: phase.to_string(),
             },
-        )
-        .await;
+        );
         Ok(())
     }
 }

--- a/crates/channels/src/web.rs
+++ b/crates/channels/src/web.rs
@@ -82,6 +82,8 @@ use serde::{Deserialize, Serialize};
 use tokio::sync::{RwLock, broadcast, mpsc, watch};
 use tracing::{debug, error, info, warn};
 
+use crate::web_reply_buffer::ReplyBuffer;
+
 // ---------------------------------------------------------------------------
 // Constants
 // ---------------------------------------------------------------------------
@@ -507,6 +509,13 @@ pub struct WebAdapter {
     shutdown_rx:       watch::Receiver<bool>,
     /// Optional STT service for transcribing voice messages to text.
     stt_service:       Option<rara_stt::SttService>,
+    /// Per-session ring buffer for "important" `WebEvent`s. When set,
+    /// adapter publishes that match
+    /// [`ReplyBuffer::should_buffer`] are appended so that a later
+    /// WS / SSE reconnect can drain them and recover task-completion
+    /// replies that fired while no listener was attached (issue #1804).
+    /// When `None`, buffering is disabled and behaviour matches pre-#1804.
+    reply_buffer:      Option<Arc<ReplyBuffer>>,
 }
 
 impl WebAdapter {
@@ -529,6 +538,7 @@ impl WebAdapter {
             shutdown_tx,
             shutdown_rx,
             stt_service: None,
+            reply_buffer: None,
         }
     }
 
@@ -536,6 +546,15 @@ impl WebAdapter {
     #[must_use]
     pub fn with_stt_service(mut self, stt: Option<rara_stt::SttService>) -> Self {
         self.stt_service = stt;
+        self
+    }
+
+    /// Attach a per-session [`ReplyBuffer`] so that "important" outbound
+    /// events survive periods when no WS / SSE listener is attached.
+    /// Pass `None` to disable buffering (legacy behaviour).
+    #[must_use]
+    pub fn with_reply_buffer(mut self, buffer: Option<Arc<ReplyBuffer>>) -> Self {
+        self.reply_buffer = buffer;
         self
     }
 
@@ -555,6 +574,7 @@ impl WebAdapter {
             owner_user_id:     self.owner_user_id.clone(),
             shutdown_rx:       self.shutdown_rx.clone(),
             stt_service:       self.stt_service.clone(),
+            reply_buffer:      self.reply_buffer.clone(),
         };
 
         Router::new()
@@ -602,6 +622,14 @@ impl WebAdapter {
         Ok(())
     }
 
+    /// Test-only: subscribe to the per-session adapter event bus,
+    /// creating it lazily if needed. Mirrors what the WS / SSE
+    /// handlers do at connect time.
+    #[doc(hidden)]
+    pub fn subscribe_for_test(&self, session_key: &SessionKey) -> broadcast::Receiver<WebEvent> {
+        Self::get_or_create_adapter_bus(&self.adapter_events, *session_key).subscribe()
+    }
+
     /// Get or create the per-session adapter-event broadcast sender.
     ///
     /// Kept deliberately minimal — the heavy fan-out path (kernel stream
@@ -619,29 +647,50 @@ impl WebAdapter {
     }
 
     /// Publish an adapter-local event to all WS/SSE tasks subscribed to
-    /// `session_key`. Silently drops if no bus exists (no consumers yet).
-    fn publish_adapter_event(
+    /// `session_key`, and optionally append it to the per-session
+    /// [`ReplyBuffer`] when [`ReplyBuffer::should_buffer`] returns `true`.
+    ///
+    /// The broadcast send always runs first so a connected receiver sees
+    /// the event with no extra latency; the buffer append happens after,
+    /// gated by `should_buffer` to avoid hoarding streaming token deltas.
+    /// Buffering is unconditional on the publish side: it does not check
+    /// `receiver_count`. Trade-off: a tab that read an event live will
+    /// see it again if it disconnects + reconnects within the TTL window.
+    /// See `web_reply_buffer.rs` module docs.
+    async fn publish_adapter_event(
         buses: &DashMap<SessionKey, broadcast::Sender<WebEvent>>,
+        reply_buffer: Option<&Arc<ReplyBuffer>>,
         session_key: &SessionKey,
         event: WebEvent,
     ) {
-        let Some(tx) = buses.get(session_key) else {
-            return;
-        };
         let event_kind: &'static str = (&event).into();
-        let receiver_count = tx.receiver_count();
-        tracing::debug!(
-            session_key = %session_key,
-            receiver_count,
-            event_kind,
-            "web publish_adapter_event"
-        );
-        if tx.send(event).is_err() {
-            tracing::warn!(
+        if let Some(tx) = buses.get(session_key) {
+            let receiver_count = tx.receiver_count();
+            tracing::debug!(
+                session_key = %session_key,
+                receiver_count,
+                event_kind,
+                "web publish_adapter_event"
+            );
+            if tx.send(event.clone()).is_err() {
+                tracing::warn!(
+                    session_key = %session_key,
+                    event_kind,
+                    "web publish: no active receivers"
+                );
+            }
+        } else {
+            tracing::debug!(
                 session_key = %session_key,
                 event_kind,
-                "web publish: no active receivers"
+                "web publish_adapter_event: no bus yet"
             );
+        }
+
+        if let Some(buf) = reply_buffer
+            && ReplyBuffer::should_buffer(&event)
+        {
+            buf.append(session_key, event).await;
         }
     }
 }
@@ -661,6 +710,7 @@ async fn approval_listener(
     mut request_rx: tokio::sync::broadcast::Receiver<ApprovalRequest>,
     mut resolution_rx: tokio::sync::broadcast::Receiver<ApprovalResponse>,
     adapter_events: Arc<DashMap<SessionKey, broadcast::Sender<WebEvent>>>,
+    reply_buffer: Option<Arc<ReplyBuffer>>,
     mut shutdown_rx: watch::Receiver<bool>,
 ) {
     let session_by_request: Arc<DashMap<uuid::Uuid, SessionKey>> = Arc::new(DashMap::new());
@@ -683,7 +733,13 @@ async fn approval_listener(
                             requested_at: req.requested_at.to_string(),
                             timeout_secs: req.timeout_secs,
                         };
-                        WebAdapter::publish_adapter_event(&adapter_events, &req.session_key, event);
+                        WebAdapter::publish_adapter_event(
+                            &adapter_events,
+                            reply_buffer.as_ref(),
+                            &req.session_key,
+                            event,
+                        )
+                        .await;
                     }
                     Err(tokio::sync::broadcast::error::RecvError::Closed) => return,
                     Err(tokio::sync::broadcast::error::RecvError::Lagged(n)) => {
@@ -704,7 +760,13 @@ async fn approval_listener(
                             id: resp.request_id.to_string(),
                             decision,
                         };
-                        WebAdapter::publish_adapter_event(&adapter_events, &session_key, event);
+                        WebAdapter::publish_adapter_event(
+                            &adapter_events,
+                            reply_buffer.as_ref(),
+                            &session_key,
+                            event,
+                        )
+                        .await;
                     }
                     Err(tokio::sync::broadcast::error::RecvError::Closed) => return,
                     Err(tokio::sync::broadcast::error::RecvError::Lagged(n)) => {
@@ -753,6 +815,8 @@ struct WebAdapterState {
     owner_user_id:     String,
     shutdown_rx:       watch::Receiver<bool>,
     stt_service:       Option<rara_stt::SttService>,
+    /// Optional per-session ring buffer; see [`WebAdapter::reply_buffer`].
+    reply_buffer:      Option<Arc<ReplyBuffer>>,
 }
 
 // ---------------------------------------------------------------------------
@@ -1014,6 +1078,26 @@ async fn handle_ws(socket: WebSocket, params: SessionQuery, state: WebAdapterSta
     let adapter_bus = WebAdapter::get_or_create_adapter_bus(&state.adapter_events, session_key);
     let mut adapter_rx = adapter_bus.subscribe();
 
+    // Drain any "important" events buffered during a no-listener window
+    // BEFORE the live forwarder starts pushing into the same mpsc, so the
+    // socket sees buffered events first in publish order. The buffer is
+    // not removed on drain — see `web_reply_buffer` module docs for why.
+    if let Some(ref buf) = state.reply_buffer {
+        let backlog = buf.snapshot(&session_key).await;
+        if !backlog.is_empty() {
+            debug!(
+                session_key = %session_key_str,
+                count = backlog.len(),
+                "draining web reply buffer to new WS"
+            );
+            for ev in backlog {
+                if ws_event_tx.send(ev).is_err() {
+                    break;
+                }
+            }
+        }
+    }
+
     // Forwarder: adapter bus → per-WS mpsc.
     let adapter_forwarder = {
         let ws_event_tx = ws_event_tx.clone();
@@ -1116,6 +1200,7 @@ async fn handle_ws(socket: WebSocket, params: SessionQuery, state: WebAdapterSta
         let session_key_str = session_key_str.clone();
         let user_id = state.owner_user_id.clone();
         let stt_service = state.stt_service.clone();
+        let reply_buffer = state.reply_buffer.clone();
         tokio::spawn(async move {
             while let Some(Ok(msg)) = ws_rx.next().await {
                 let text = match msg {
@@ -1140,15 +1225,23 @@ async fn handle_ws(socket: WebSocket, params: SessionQuery, state: WebAdapterSta
                     warn!(session_key = %session_key_str, "sink not set");
                     WebAdapter::publish_adapter_event(
                         &adapter_events,
+                        reply_buffer.as_ref(),
                         &session_key,
                         WebEvent::Error {
                             message: "adapter not started".to_owned(),
                         },
-                    );
+                    )
+                    .await;
                     continue;
                 };
 
-                WebAdapter::publish_adapter_event(&adapter_events, &session_key, WebEvent::Typing);
+                WebAdapter::publish_adapter_event(
+                    &adapter_events,
+                    reply_buffer.as_ref(),
+                    &session_key,
+                    WebEvent::Typing,
+                )
+                .await;
 
                 // When no channel binding exists yet (first message),
                 // resolve() returns session_key = None. Patch it with the
@@ -1162,11 +1255,13 @@ async fn handle_ws(socket: WebSocket, params: SessionQuery, state: WebAdapterSta
                             error!(session_key = %session_key_str, error = %e, "submit_message failed");
                             WebAdapter::publish_adapter_event(
                                 &adapter_events,
+                                reply_buffer.as_ref(),
                                 &session_key,
                                 WebEvent::Error {
                                     message: e.to_string(),
                                 },
-                            );
+                            )
+                            .await;
                         }
                         // No per-message forwarder spawn needed — the
                         // per-WS stream_forwarder above is already
@@ -1177,11 +1272,13 @@ async fn handle_ws(socket: WebSocket, params: SessionQuery, state: WebAdapterSta
                         error!(session_key = %session_key_str, error = %e, "resolve failed");
                         WebAdapter::publish_adapter_event(
                             &adapter_events,
+                            reply_buffer.as_ref(),
                             &session_key,
                             WebEvent::Error {
                                 message: e.to_string(),
                             },
-                        );
+                        )
+                        .await;
                     }
                 }
             }
@@ -1235,6 +1332,24 @@ async fn sse_handler(
 
     let adapter_bus = WebAdapter::get_or_create_adapter_bus(&state.adapter_events, session_key);
     let mut adapter_rx = adapter_bus.subscribe();
+
+    // Drain any buffered "important" events before live tail starts.
+    if let Some(ref buf) = state.reply_buffer {
+        let backlog = buf.snapshot(&session_key).await;
+        if !backlog.is_empty() {
+            debug!(
+                session_key = %params.session_key,
+                count = backlog.len(),
+                "draining web reply buffer to new SSE"
+            );
+            for ev in backlog {
+                if ev_tx.send(ev).is_err() {
+                    break;
+                }
+            }
+        }
+    }
+
     {
         let ev_tx = ev_tx.clone();
         let skey = params.session_key.clone();
@@ -1401,9 +1516,11 @@ async fn send_message_handler(
         Some(sink) => {
             WebAdapter::publish_adapter_event(
                 &state.adapter_events,
+                state.reply_buffer.as_ref(),
                 &session_key,
                 WebEvent::Typing,
-            );
+            )
+            .await;
             match sink.ingest(raw).await {
                 Ok(()) => {
                     // No forwarder to spawn — each WS/SSE is permanently
@@ -1480,7 +1597,13 @@ impl ChannelAdapter for WebAdapter {
         };
 
         let event = platform_outbound_to_web_event(msg);
-        WebAdapter::publish_adapter_event(&self.adapter_events, &session_key, event);
+        WebAdapter::publish_adapter_event(
+            &self.adapter_events,
+            self.reply_buffer.as_ref(),
+            &session_key,
+            event,
+        )
+        .await;
         Ok(())
     }
 
@@ -1502,6 +1625,7 @@ impl ChannelAdapter for WebAdapter {
                 request_rx,
                 resolution_rx,
                 events,
+                self.reply_buffer.clone(),
                 shutdown_rx,
             ));
         }
@@ -1525,7 +1649,13 @@ impl ChannelAdapter for WebAdapter {
         let Ok(key) = SessionKey::try_from_raw(session_key) else {
             return Ok(());
         };
-        WebAdapter::publish_adapter_event(&self.adapter_events, &key, WebEvent::Typing);
+        WebAdapter::publish_adapter_event(
+            &self.adapter_events,
+            self.reply_buffer.as_ref(),
+            &key,
+            WebEvent::Typing,
+        )
+        .await;
         Ok(())
     }
 
@@ -1535,11 +1665,13 @@ impl ChannelAdapter for WebAdapter {
         };
         WebAdapter::publish_adapter_event(
             &self.adapter_events,
+            self.reply_buffer.as_ref(),
             &key,
             WebEvent::Phase {
                 phase: phase.to_string(),
             },
-        );
+        )
+        .await;
         Ok(())
     }
 }

--- a/crates/channels/src/web_reply_buffer.rs
+++ b/crates/channels/src/web_reply_buffer.rs
@@ -1,0 +1,352 @@
+// Copyright 2025 Rararulab
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Per-session ring buffer for "important" `WebEvent`s so that task-completion
+//! replies survive periods where no WS / SSE listener is attached.
+//!
+//! # Why this exists
+//!
+//! `WebAdapter` publishes outbound replies through a `tokio::broadcast`
+//! channel. When a long-running background task finishes while the user has
+//! closed their browser tab, `broadcast::Sender::send` returns `Err` because
+//! `receiver_count == 0`, and the `Reply` envelope is silently dropped. When
+//! the user reconnects, the kernel has no record of "you owe this socket a
+//! reply" — task output is lost forever (see issue #1804).
+//!
+//! # What is buffered
+//!
+//! Only events whose loss is user-visible:
+//!
+//! - [`WebEvent::Message`]      — final agent reply (the original #1804 case)
+//! - [`WebEvent::Error`]        — surfaced error notifications
+//! - [`WebEvent::BackgroundTaskDone`] — terminal status of a bg task
+//! - [`WebEvent::Progress`]     — terminal stage signals
+//!
+//! Streaming deltas (`TextDelta`, `ReasoningDelta`, `ToolCall*`, …) are
+//! intentionally **not** buffered: replaying a partial token stream after the
+//! fact has no useful semantics for the UI.
+//!
+//! # Replay semantics & trade-off
+//!
+//! On connect the WS / SSE handler drains the buffer into the new socket
+//! before forwarding live events. The buffer is **not** removed on drain —
+//! a session may have multiple concurrent tabs, and a brand-new tab opening
+//! mid-turn should still see the catch-up history. The cost is that an
+//! already-connected tab which read an event live will see it *again* if it
+//! reconnects (e.g. WS drop + retry inside the TTL window). Callers that
+//! cannot tolerate duplicate `WebEvent::Message` rows must dedupe by
+//! payload — there is no per-event sequence number on the wire today.
+//!
+//! Bounded capacity (oldest event is dropped on overflow) and a TTL sweep
+//! task keep memory bounded; both are configured from YAML — no defaults
+//! are hard-coded in Rust.
+
+use std::{
+    collections::VecDeque,
+    sync::Arc,
+    time::{Duration, Instant},
+};
+
+use dashmap::DashMap;
+use rara_kernel::session::SessionKey;
+use serde::{Deserialize, Serialize};
+use tokio::sync::{Mutex, watch};
+
+use crate::web::WebEvent;
+
+/// Configuration for the per-session reply buffer.
+///
+/// Both fields are sourced from the YAML config file
+/// (`web.reply_buffer.*`) — see `config.example.yaml`.
+#[derive(Debug, Clone, bon::Builder, Serialize, Deserialize)]
+pub struct ReplyBufferConfig {
+    /// Maximum number of "important" events retained per session.
+    /// On overflow, the oldest event is evicted (FIFO).
+    pub capacity:       usize,
+    /// How long after the last write a session's buffer is kept
+    /// before the sweeper drops it.
+    #[serde(
+        deserialize_with = "humantime_serde::deserialize",
+        serialize_with = "humantime_serde::serialize"
+    )]
+    pub ttl:            Duration,
+    /// Sweeper tick interval. The sweeper runs every `sweep_interval` and
+    /// removes any session whose buffer hasn't been written to within
+    /// the last `ttl`.
+    #[serde(
+        deserialize_with = "humantime_serde::deserialize",
+        serialize_with = "humantime_serde::serialize"
+    )]
+    pub sweep_interval: Duration,
+}
+
+/// One session's bounded ring of important events plus a last-write
+/// timestamp used by the TTL sweeper.
+struct SessionBuffer {
+    events:     VecDeque<WebEvent>,
+    last_write: Instant,
+}
+
+/// Per-session reply buffer registry. Shared across all WS / SSE
+/// handlers and the `ChannelAdapter::send` path.
+pub struct ReplyBuffer {
+    sessions: DashMap<SessionKey, Arc<Mutex<SessionBuffer>>>,
+    config:   ReplyBufferConfig,
+}
+
+impl ReplyBuffer {
+    /// Construct a new empty buffer with the given configuration.
+    pub fn new(config: ReplyBufferConfig) -> Arc<Self> {
+        Arc::new(Self {
+            sessions: DashMap::new(),
+            config,
+        })
+    }
+
+    /// Decide whether an event must survive a "no listeners" publish.
+    ///
+    /// Streaming chunks intentionally fall through to `false` — replaying
+    /// a partial token stream after the fact has no useful UX.
+    pub fn should_buffer(event: &WebEvent) -> bool {
+        matches!(
+            event,
+            WebEvent::Message { .. }
+                | WebEvent::Error { .. }
+                | WebEvent::BackgroundTaskDone { .. }
+                | WebEvent::Progress { .. }
+        )
+    }
+
+    /// Append an event to the session's ring, evicting the oldest entry
+    /// when capacity is exceeded.
+    pub async fn append(&self, session_key: &SessionKey, event: WebEvent) {
+        let entry = self
+            .sessions
+            .entry(session_key.clone())
+            .or_insert_with(|| {
+                Arc::new(Mutex::new(SessionBuffer {
+                    events:     VecDeque::with_capacity(self.config.capacity.min(64)),
+                    last_write: Instant::now(),
+                }))
+            })
+            .clone();
+        let mut guard = entry.lock().await;
+        if guard.events.len() == self.config.capacity {
+            guard.events.pop_front();
+        }
+        guard.events.push_back(event);
+        guard.last_write = Instant::now();
+    }
+
+    /// Snapshot of currently buffered events for `session_key`, in
+    /// publish order (oldest first). Returns an empty vec if the
+    /// session has no buffer.
+    ///
+    /// The buffer is **not** drained — see module-level docs for why.
+    pub async fn snapshot(&self, session_key: &SessionKey) -> Vec<WebEvent> {
+        let Some(entry) = self.sessions.get(session_key).map(|e| e.clone()) else {
+            return Vec::new();
+        };
+        entry.lock().await.events.iter().cloned().collect()
+    }
+
+    /// Number of buffered events for `session_key` — exposed for tests
+    /// and metrics.
+    #[doc(hidden)]
+    pub async fn len(&self, session_key: &SessionKey) -> usize {
+        match self.sessions.get(session_key).map(|e| e.clone()) {
+            Some(entry) => entry.lock().await.events.len(),
+            None => 0,
+        }
+    }
+
+    /// Number of currently tracked sessions — exposed for tests / metrics.
+    #[doc(hidden)]
+    pub fn session_count(&self) -> usize { self.sessions.len() }
+
+    /// Spawn the TTL sweeper. Returns immediately; the sweeper runs in
+    /// the background until `shutdown_rx` flips to `true`.
+    pub fn spawn_sweeper(self: Arc<Self>, mut shutdown_rx: watch::Receiver<bool>) {
+        let interval = self.config.sweep_interval;
+        let ttl = self.config.ttl;
+        tokio::spawn(async move {
+            let mut ticker = tokio::time::interval(interval);
+            ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+            loop {
+                tokio::select! {
+                    _ = shutdown_rx.changed() => return,
+                    _ = ticker.tick() => {
+                        self.sweep_expired(ttl).await;
+                    }
+                }
+            }
+        });
+    }
+
+    /// Remove sessions whose `last_write` is older than `ttl`. Pulled out
+    /// for direct unit testing.
+    #[doc(hidden)]
+    pub async fn sweep_expired(&self, ttl: Duration) {
+        let now = Instant::now();
+        let mut victims: Vec<SessionKey> = Vec::new();
+        for entry in &self.sessions {
+            let buf = entry.value().clone();
+            let guard = buf.lock().await;
+            if now.duration_since(guard.last_write) > ttl {
+                victims.push(entry.key().clone());
+            }
+        }
+        for k in victims {
+            self.sessions.remove(&k);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use rara_kernel::{io::BackgroundTaskStatus, session::SessionKey};
+
+    use super::{ReplyBuffer, ReplyBufferConfig, WebEvent};
+
+    fn config(capacity: usize) -> ReplyBufferConfig {
+        ReplyBufferConfig::builder()
+            .capacity(capacity)
+            .ttl(Duration::from_mins(1))
+            .sweep_interval(Duration::from_secs(10))
+            .build()
+    }
+
+    fn session() -> SessionKey { SessionKey::new() }
+
+    #[test]
+    fn streaming_events_are_not_buffered() {
+        assert!(!ReplyBuffer::should_buffer(&WebEvent::TextDelta {
+            text: "x".to_owned(),
+        }));
+        assert!(!ReplyBuffer::should_buffer(&WebEvent::ReasoningDelta {
+            text: "x".to_owned(),
+        }));
+        assert!(!ReplyBuffer::should_buffer(&WebEvent::ToolCallStart {
+            name:      "t".to_owned(),
+            id:        "id".to_owned(),
+            arguments: serde_json::json!({}),
+        }));
+    }
+
+    #[test]
+    fn important_events_are_buffered() {
+        assert!(ReplyBuffer::should_buffer(&WebEvent::Message {
+            content: "hi".to_owned(),
+        }));
+        assert!(ReplyBuffer::should_buffer(&WebEvent::Error {
+            message: "bad".to_owned(),
+        }));
+        assert!(ReplyBuffer::should_buffer(&WebEvent::BackgroundTaskDone {
+            task_id: "t".to_owned(),
+            status:  BackgroundTaskStatus::Completed,
+        }));
+        assert!(ReplyBuffer::should_buffer(&WebEvent::Progress {
+            stage: "done".to_owned(),
+        }));
+    }
+
+    #[tokio::test]
+    async fn append_then_snapshot_returns_events_in_order() {
+        let buf = ReplyBuffer::new(config(8));
+        let s = session();
+        buf.append(
+            &s,
+            WebEvent::Message {
+                content: "first".to_owned(),
+            },
+        )
+        .await;
+        buf.append(
+            &s,
+            WebEvent::Message {
+                content: "second".to_owned(),
+            },
+        )
+        .await;
+
+        let snap = buf.snapshot(&s).await;
+        assert_eq!(snap.len(), 2);
+        match (&snap[0], &snap[1]) {
+            (WebEvent::Message { content: a }, WebEvent::Message { content: b }) => {
+                assert_eq!(a, "first");
+                assert_eq!(b, "second");
+            }
+            other => panic!("unexpected: {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn snapshot_does_not_drain() {
+        let buf = ReplyBuffer::new(config(8));
+        let s = session();
+        buf.append(
+            &s,
+            WebEvent::Message {
+                content: "x".to_owned(),
+            },
+        )
+        .await;
+        assert_eq!(buf.snapshot(&s).await.len(), 1);
+        assert_eq!(buf.snapshot(&s).await.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn capacity_overflow_evicts_oldest() {
+        let buf = ReplyBuffer::new(config(2));
+        let s = session();
+        for i in 0..3 {
+            buf.append(
+                &s,
+                WebEvent::Message {
+                    content: format!("m{i}"),
+                },
+            )
+            .await;
+        }
+        let snap = buf.snapshot(&s).await;
+        assert_eq!(snap.len(), 2);
+        match (&snap[0], &snap[1]) {
+            (WebEvent::Message { content: a }, WebEvent::Message { content: b }) => {
+                assert_eq!(a, "m1");
+                assert_eq!(b, "m2");
+            }
+            other => panic!("unexpected: {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn sweep_expired_drops_idle_sessions() {
+        let buf = ReplyBuffer::new(config(4));
+        let s = session();
+        buf.append(
+            &s,
+            WebEvent::Message {
+                content: "x".to_owned(),
+            },
+        )
+        .await;
+        assert_eq!(buf.session_count(), 1);
+
+        // ttl=0 makes every entry immediately eligible.
+        buf.sweep_expired(Duration::from_nanos(0)).await;
+        assert_eq!(buf.session_count(), 0);
+    }
+}

--- a/crates/channels/src/web_reply_buffer.rs
+++ b/crates/channels/src/web_reply_buffer.rs
@@ -59,9 +59,10 @@ use std::{
 };
 
 use dashmap::DashMap;
+use parking_lot::Mutex;
 use rara_kernel::session::SessionKey;
 use serde::{Deserialize, Serialize};
-use tokio::sync::{Mutex, watch};
+use tokio_util::sync::CancellationToken;
 
 use crate::web::WebEvent;
 
@@ -130,18 +131,18 @@ impl ReplyBuffer {
 
     /// Append an event to the session's ring, evicting the oldest entry
     /// when capacity is exceeded.
-    pub async fn append(&self, session_key: &SessionKey, event: WebEvent) {
+    pub fn append(&self, session_key: &SessionKey, event: WebEvent) {
         let entry = self
             .sessions
             .entry(session_key.clone())
             .or_insert_with(|| {
                 Arc::new(Mutex::new(SessionBuffer {
-                    events:     VecDeque::with_capacity(self.config.capacity.min(64)),
+                    events:     VecDeque::with_capacity(self.config.capacity),
                     last_write: Instant::now(),
                 }))
             })
             .clone();
-        let mut guard = entry.lock().await;
+        let mut guard = entry.lock();
         if guard.events.len() == self.config.capacity {
             guard.events.pop_front();
         }
@@ -154,21 +155,11 @@ impl ReplyBuffer {
     /// session has no buffer.
     ///
     /// The buffer is **not** drained — see module-level docs for why.
-    pub async fn snapshot(&self, session_key: &SessionKey) -> Vec<WebEvent> {
+    pub fn snapshot(&self, session_key: &SessionKey) -> Vec<WebEvent> {
         let Some(entry) = self.sessions.get(session_key).map(|e| e.clone()) else {
             return Vec::new();
         };
-        entry.lock().await.events.iter().cloned().collect()
-    }
-
-    /// Number of buffered events for `session_key` — exposed for tests
-    /// and metrics.
-    #[doc(hidden)]
-    pub async fn len(&self, session_key: &SessionKey) -> usize {
-        match self.sessions.get(session_key).map(|e| e.clone()) {
-            Some(entry) => entry.lock().await.events.len(),
-            None => 0,
-        }
+        entry.lock().events.iter().cloned().collect()
     }
 
     /// Number of currently tracked sessions — exposed for tests / metrics.
@@ -176,8 +167,8 @@ impl ReplyBuffer {
     pub fn session_count(&self) -> usize { self.sessions.len() }
 
     /// Spawn the TTL sweeper. Returns immediately; the sweeper runs in
-    /// the background until `shutdown_rx` flips to `true`.
-    pub fn spawn_sweeper(self: Arc<Self>, mut shutdown_rx: watch::Receiver<bool>) {
+    /// the background until `cancel` fires.
+    pub fn spawn_sweeper(self: Arc<Self>, cancel: CancellationToken) {
         let interval = self.config.sweep_interval;
         let ttl = self.config.ttl;
         tokio::spawn(async move {
@@ -185,9 +176,9 @@ impl ReplyBuffer {
             ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
             loop {
                 tokio::select! {
-                    _ = shutdown_rx.changed() => return,
+                    _ = cancel.cancelled() => return,
                     _ = ticker.tick() => {
-                        self.sweep_expired(ttl).await;
+                        self.sweep_expired(ttl);
                     }
                 }
             }
@@ -197,16 +188,16 @@ impl ReplyBuffer {
     /// Remove sessions whose `last_write` is older than `ttl`. Pulled out
     /// for direct unit testing.
     #[doc(hidden)]
-    pub async fn sweep_expired(&self, ttl: Duration) {
+    pub fn sweep_expired(&self, ttl: Duration) {
         let now = Instant::now();
-        let mut victims: Vec<SessionKey> = Vec::new();
-        for entry in &self.sessions {
-            let buf = entry.value().clone();
-            let guard = buf.lock().await;
-            if now.duration_since(guard.last_write) > ttl {
-                victims.push(entry.key().clone());
-            }
-        }
+        let victims: Vec<SessionKey> = self
+            .sessions
+            .iter()
+            .filter_map(|entry| {
+                let guard = entry.value().lock();
+                (now.duration_since(guard.last_write) > ttl).then(|| entry.key().clone())
+            })
+            .collect();
         for k in victims {
             self.sessions.remove(&k);
         }
@@ -263,8 +254,8 @@ mod tests {
         }));
     }
 
-    #[tokio::test]
-    async fn append_then_snapshot_returns_events_in_order() {
+    #[test]
+    fn append_then_snapshot_returns_events_in_order() {
         let buf = ReplyBuffer::new(config(8));
         let s = session();
         buf.append(
@@ -272,17 +263,15 @@ mod tests {
             WebEvent::Message {
                 content: "first".to_owned(),
             },
-        )
-        .await;
+        );
         buf.append(
             &s,
             WebEvent::Message {
                 content: "second".to_owned(),
             },
-        )
-        .await;
+        );
 
-        let snap = buf.snapshot(&s).await;
+        let snap = buf.snapshot(&s);
         assert_eq!(snap.len(), 2);
         match (&snap[0], &snap[1]) {
             (WebEvent::Message { content: a }, WebEvent::Message { content: b }) => {
@@ -293,8 +282,8 @@ mod tests {
         }
     }
 
-    #[tokio::test]
-    async fn snapshot_does_not_drain() {
+    #[test]
+    fn snapshot_does_not_drain() {
         let buf = ReplyBuffer::new(config(8));
         let s = session();
         buf.append(
@@ -302,14 +291,13 @@ mod tests {
             WebEvent::Message {
                 content: "x".to_owned(),
             },
-        )
-        .await;
-        assert_eq!(buf.snapshot(&s).await.len(), 1);
-        assert_eq!(buf.snapshot(&s).await.len(), 1);
+        );
+        assert_eq!(buf.snapshot(&s).len(), 1);
+        assert_eq!(buf.snapshot(&s).len(), 1);
     }
 
-    #[tokio::test]
-    async fn capacity_overflow_evicts_oldest() {
+    #[test]
+    fn capacity_overflow_evicts_oldest() {
         let buf = ReplyBuffer::new(config(2));
         let s = session();
         for i in 0..3 {
@@ -318,10 +306,9 @@ mod tests {
                 WebEvent::Message {
                     content: format!("m{i}"),
                 },
-            )
-            .await;
+            );
         }
-        let snap = buf.snapshot(&s).await;
+        let snap = buf.snapshot(&s);
         assert_eq!(snap.len(), 2);
         match (&snap[0], &snap[1]) {
             (WebEvent::Message { content: a }, WebEvent::Message { content: b }) => {
@@ -332,8 +319,8 @@ mod tests {
         }
     }
 
-    #[tokio::test]
-    async fn sweep_expired_drops_idle_sessions() {
+    #[test]
+    fn sweep_expired_drops_idle_sessions() {
         let buf = ReplyBuffer::new(config(4));
         let s = session();
         buf.append(
@@ -341,12 +328,11 @@ mod tests {
             WebEvent::Message {
                 content: "x".to_owned(),
             },
-        )
-        .await;
+        );
         assert_eq!(buf.session_count(), 1);
 
         // ttl=0 makes every entry immediately eligible.
-        buf.sweep_expired(Duration::from_nanos(0)).await;
+        buf.sweep_expired(Duration::from_nanos(0));
         assert_eq!(buf.session_count(), 0);
     }
 }

--- a/crates/channels/tests/web_buffer_e2e.rs
+++ b/crates/channels/tests/web_buffer_e2e.rs
@@ -17,19 +17,17 @@
 //!
 //! Two scenarios:
 //!
-//! - **Happy-path egress routing** — exercises the same code path that
-//!   `IOSubsystem` invokes for a turn reply: build a `Web` endpoint with a real
+//! - **Happy-path egress routing** — covers the egress-sink contract for an
+//!   already-routed Web `Reply`: build a `Web` endpoint with a real
 //!   `connection_id`, call `WebAdapter::send` with a `PlatformOutbound::Reply`,
-//!   and assert a live subscriber sees a matching `WebEvent::Message`. This
-//!   closes the test-coverage gap from review of #1796/#1801, where the routing
-//!   fix landed without a regression test against the egress sink.
+//!   and assert a live subscriber sees a matching `WebEvent::Message`.
 //! - **Listener-loss recovery** — same `WebAdapter::send` invocation, but the
 //!   subscriber is dropped before publish. A fresh subscriber then drains the
 //!   reply buffer and observes the missed event.
 //!
 //! These tests do not boot a kernel; they drive `ChannelAdapter::send`
-//! directly because the buffering bug lives in the adapter, not in
-//! origin-endpoint resolution (which #1796/#1801 already cover).
+//! directly because the buffering bug lives in the adapter sink, not in
+//! origin-endpoint resolution.
 
 use std::{sync::Arc, time::Duration};
 
@@ -104,7 +102,7 @@ async fn happy_path_reply_reaches_subscribed_listener() {
 
     // The buffer must also have captured the reply so a hypothetical
     // reconnecting tab could replay it.
-    let buffered = buffer.snapshot(&session_key).await;
+    let buffered = buffer.snapshot(&session_key);
     assert_eq!(buffered.len(), 1, "buffer should retain the reply");
 }
 
@@ -138,7 +136,7 @@ async fn listener_loss_is_recovered_via_buffer_snapshot() {
     // The broadcast had zero receivers at publish time, so a
     // pre-#1804 build would have lost the reply forever. With the
     // buffer, a reconnecting tab drains the snapshot.
-    let backlog = buffer.snapshot(&session_key).await;
+    let backlog = buffer.snapshot(&session_key);
     assert_eq!(backlog.len(), 1, "exactly one buffered event");
     match &backlog[0] {
         WebEvent::Message { content } => assert_eq!(content, "while-you-were-away"),
@@ -147,7 +145,7 @@ async fn listener_loss_is_recovered_via_buffer_snapshot() {
 }
 
 #[tokio::test]
-async fn buffer_disabled_when_no_config() {
+async fn send_without_buffer_does_not_panic() {
     // Adapter built without a buffer behaves exactly like pre-#1804:
     // a publish with no listeners drops the event silently.
     let adapter = WebAdapter::new("tok".to_owned(), "user".to_owned());

--- a/crates/channels/tests/web_buffer_e2e.rs
+++ b/crates/channels/tests/web_buffer_e2e.rs
@@ -1,0 +1,173 @@
+// Copyright 2025 Rararulab
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! End-to-end coverage for the per-session reply buffer wired into
+//! `WebAdapter` (issue #1804).
+//!
+//! Two scenarios:
+//!
+//! - **Happy-path egress routing** — exercises the same code path that
+//!   `IOSubsystem` invokes for a turn reply: build a `Web` endpoint with a real
+//!   `connection_id`, call `WebAdapter::send` with a `PlatformOutbound::Reply`,
+//!   and assert a live subscriber sees a matching `WebEvent::Message`. This
+//!   closes the test-coverage gap from review of #1796/#1801, where the routing
+//!   fix landed without a regression test against the egress sink.
+//! - **Listener-loss recovery** — same `WebAdapter::send` invocation, but the
+//!   subscriber is dropped before publish. A fresh subscriber then drains the
+//!   reply buffer and observes the missed event.
+//!
+//! These tests do not boot a kernel; they drive `ChannelAdapter::send`
+//! directly because the buffering bug lives in the adapter, not in
+//! origin-endpoint resolution (which #1796/#1801 already cover).
+
+use std::{sync::Arc, time::Duration};
+
+use rara_channels::{
+    web::{WebAdapter, WebEvent},
+    web_reply_buffer::{ReplyBuffer, ReplyBufferConfig},
+};
+use rara_kernel::{
+    channel::{adapter::ChannelAdapter, types::ChannelType},
+    io::{Endpoint, EndpointAddress, PlatformOutbound},
+    session::SessionKey,
+};
+
+fn buffer_config() -> ReplyBufferConfig {
+    ReplyBufferConfig::builder()
+        .capacity(32)
+        .ttl(Duration::from_mins(1))
+        .sweep_interval(Duration::from_secs(30))
+        .build()
+}
+
+fn web_endpoint(session_key: &SessionKey) -> Endpoint {
+    Endpoint {
+        channel_type: ChannelType::Web,
+        address:      EndpointAddress::Web {
+            connection_id: session_key.to_string(),
+        },
+    }
+}
+
+/// Simulates a connected WS / SSE session by lazily creating the
+/// per-session broadcast bus and returning a fresh subscription on
+/// it — mirroring what the real WS handler does at connect time.
+fn subscribe(
+    adapter: &WebAdapter,
+    session_key: &SessionKey,
+) -> tokio::sync::broadcast::Receiver<WebEvent> {
+    adapter.subscribe_for_test(session_key)
+}
+
+#[tokio::test]
+async fn happy_path_reply_reaches_subscribed_listener() {
+    let buffer = ReplyBuffer::new(buffer_config());
+    let adapter = WebAdapter::new("tok".to_owned(), "user".to_owned())
+        .with_reply_buffer(Some(Arc::clone(&buffer)));
+
+    let session_key = SessionKey::new();
+    let mut rx = subscribe(&adapter, &session_key);
+
+    let endpoint = web_endpoint(&session_key);
+    adapter
+        .send(
+            &endpoint,
+            PlatformOutbound::Reply {
+                content:       "task complete".to_owned(),
+                attachments:   Vec::new(),
+                reply_context: None,
+            },
+        )
+        .await
+        .expect("egress send");
+
+    let event = tokio::time::timeout(Duration::from_secs(2), rx.recv())
+        .await
+        .expect("listener received event before timeout")
+        .expect("broadcast not closed");
+
+    match event {
+        WebEvent::Message { content } => assert_eq!(content, "task complete"),
+        other => panic!("expected WebEvent::Message, got {other:?}"),
+    }
+
+    // The buffer must also have captured the reply so a hypothetical
+    // reconnecting tab could replay it.
+    let buffered = buffer.snapshot(&session_key).await;
+    assert_eq!(buffered.len(), 1, "buffer should retain the reply");
+}
+
+#[tokio::test]
+async fn listener_loss_is_recovered_via_buffer_snapshot() {
+    let buffer = ReplyBuffer::new(buffer_config());
+    let adapter = WebAdapter::new("tok".to_owned(), "user".to_owned())
+        .with_reply_buffer(Some(Arc::clone(&buffer)));
+
+    let session_key = SessionKey::new();
+
+    // First "tab" subscribes, then closes before the reply arrives.
+    {
+        let _rx = subscribe(&adapter, &session_key);
+        // _rx is dropped at end of scope, dropping the only listener.
+    }
+
+    let endpoint = web_endpoint(&session_key);
+    adapter
+        .send(
+            &endpoint,
+            PlatformOutbound::Reply {
+                content:       "while-you-were-away".to_owned(),
+                attachments:   Vec::new(),
+                reply_context: None,
+            },
+        )
+        .await
+        .expect("egress send while no listener");
+
+    // The broadcast had zero receivers at publish time, so a
+    // pre-#1804 build would have lost the reply forever. With the
+    // buffer, a reconnecting tab drains the snapshot.
+    let backlog = buffer.snapshot(&session_key).await;
+    assert_eq!(backlog.len(), 1, "exactly one buffered event");
+    match &backlog[0] {
+        WebEvent::Message { content } => assert_eq!(content, "while-you-were-away"),
+        other => panic!("expected WebEvent::Message, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn buffer_disabled_when_no_config() {
+    // Adapter built without a buffer behaves exactly like pre-#1804:
+    // a publish with no listeners drops the event silently.
+    let adapter = WebAdapter::new("tok".to_owned(), "user".to_owned());
+
+    let session_key = SessionKey::new();
+    let endpoint = web_endpoint(&session_key);
+
+    // No subscriber → no bus → publish is a noop, but it must not panic.
+    adapter
+        .send(
+            &endpoint,
+            PlatformOutbound::Reply {
+                content:       "lost".to_owned(),
+                attachments:   Vec::new(),
+                reply_context: None,
+            },
+        )
+        .await
+        .expect("egress send without buffer");
+
+    // We can't read what's missing, but we can prove the disable path
+    // by asserting the adapter accepted the call without a panic.
+}

--- a/crates/channels/tests/web_ws_drain.rs
+++ b/crates/channels/tests/web_ws_drain.rs
@@ -1,0 +1,199 @@
+// Copyright 2025 Rararulab
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Integration test for the WS handler's "subscribe → drain backlog →
+//! forwarder" sequencing invariant (issue #1804).
+//!
+//! Boots a real `axum` server backed by `WebAdapter::router()`, connects a
+//! `tokio_tungstenite` client over a TCP loopback, and asserts:
+//!
+//! 1. An event published while no listener is attached lands in the per-session
+//!    `ReplyBuffer`.
+//! 2. On WS connect the client receives the buffered backlog **before** any
+//!    live event published after the upgrade.
+//!
+//! This is the race-free guarantee the WS handler must uphold: the snapshot
+//! drain runs against the *already-subscribed* adapter bus, so a publish that
+//! arrives between subscribe and drain is captured by the broadcast forwarder
+//! (and dedupable later) — but never lost.
+
+use std::{sync::Arc, time::Duration};
+
+use futures::{SinkExt, StreamExt};
+use rara_channels::{
+    web::{WebAdapter, WebEvent},
+    web_reply_buffer::{ReplyBuffer, ReplyBufferConfig},
+};
+use rara_kernel::{
+    channel::{adapter::ChannelAdapter, types::ChannelType},
+    io::{Endpoint, EndpointAddress, PlatformOutbound},
+    session::SessionKey,
+};
+use tokio_tungstenite::tungstenite::Message;
+
+const OWNER_TOKEN: &str = "test-owner-token";
+const OWNER_USER_ID: &str = "test-user";
+
+fn buffer_config() -> ReplyBufferConfig {
+    ReplyBufferConfig::builder()
+        .capacity(32)
+        .ttl(Duration::from_mins(1))
+        .sweep_interval(Duration::from_secs(30))
+        .build()
+}
+
+fn web_endpoint(session_key: &SessionKey) -> Endpoint {
+    Endpoint {
+        channel_type: ChannelType::Web,
+        address:      EndpointAddress::Web {
+            connection_id: session_key.to_string(),
+        },
+    }
+}
+
+/// Read the next `WebEvent` from the WS stream, ignoring transport-level
+/// frames (Ping / Pong / Close).
+async fn next_event<S>(stream: &mut S) -> WebEvent
+where
+    S: StreamExt<Item = Result<Message, tokio_tungstenite::tungstenite::Error>> + Unpin,
+{
+    loop {
+        let frame = tokio::time::timeout(Duration::from_secs(5), stream.next())
+            .await
+            .expect("ws frame within timeout")
+            .expect("stream not closed")
+            .expect("ws frame ok");
+        match frame {
+            Message::Text(t) => {
+                return serde_json::from_str(t.as_str()).expect("WebEvent JSON");
+            }
+            Message::Binary(_) | Message::Ping(_) | Message::Pong(_) => continue,
+            Message::Close(_) => panic!("server closed unexpectedly"),
+            Message::Frame(_) => continue,
+        }
+    }
+}
+
+#[tokio::test]
+async fn ws_drains_backlog_before_live_events() {
+    let buffer = ReplyBuffer::new(buffer_config());
+    let adapter = Arc::new(
+        WebAdapter::new(OWNER_TOKEN.to_owned(), OWNER_USER_ID.to_owned())
+            .with_reply_buffer(Some(Arc::clone(&buffer))),
+    );
+
+    // Mount the adapter under /chat to mirror production wiring.
+    let app = axum::Router::new().nest("/chat", adapter.router());
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind loopback");
+    let addr = listener.local_addr().expect("local_addr");
+    let server = tokio::spawn(async move {
+        axum::serve(listener, app).await.expect("axum serve");
+    });
+
+    let session_key = SessionKey::new();
+    let endpoint = web_endpoint(&session_key);
+
+    // Step 1: publish a buffered event while no WS listener is attached.
+    // This lands in the ReplyBuffer (the no-listeners branch in
+    // `publish_adapter_event`).
+    adapter
+        .send(
+            &endpoint,
+            PlatformOutbound::Reply {
+                content:       "buffered-while-away".to_owned(),
+                attachments:   Vec::new(),
+                reply_context: None,
+            },
+        )
+        .await
+        .expect("egress send #1");
+
+    // Sanity: buffer captured the event.
+    assert_eq!(buffer.snapshot(&session_key).len(), 1);
+
+    // Step 2: connect a real WS client.
+    let url = format!(
+        "ws://{addr}/chat/ws?session_key={key}&token={tok}",
+        key = session_key,
+        tok = OWNER_TOKEN
+    );
+    let (mut ws, _resp) = tokio_tungstenite::connect_async(&url)
+        .await
+        .expect("ws connect");
+
+    // Step 3: the very first frame must be the buffered "while-away" reply,
+    // not anything that follows. This proves drain happens before live
+    // forwarding.
+    let first = next_event(&mut ws).await;
+    match first {
+        WebEvent::Message { content } => {
+            assert_eq!(content, "buffered-while-away", "drain must fire first");
+        }
+        other => panic!("expected backlog Message first, got {other:?}"),
+    }
+
+    // Step 4: now publish a live event. It must arrive via the broadcast
+    // forwarder.
+    adapter
+        .send(
+            &endpoint,
+            PlatformOutbound::Reply {
+                content:       "live-after-connect".to_owned(),
+                attachments:   Vec::new(),
+                reply_context: None,
+            },
+        )
+        .await
+        .expect("egress send #2");
+
+    let second = next_event(&mut ws).await;
+    match second {
+        WebEvent::Message { content } => assert_eq!(content, "live-after-connect"),
+        other => panic!("expected live Message second, got {other:?}"),
+    }
+
+    // Tidy up: client closes, server task is aborted at scope end.
+    ws.send(Message::Close(None)).await.ok();
+    drop(ws);
+    server.abort();
+}
+
+#[tokio::test]
+async fn ws_rejects_invalid_owner_token() {
+    let adapter = Arc::new(WebAdapter::new(
+        OWNER_TOKEN.to_owned(),
+        OWNER_USER_ID.to_owned(),
+    ));
+    let app = axum::Router::new().nest("/chat", adapter.router());
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind loopback");
+    let addr = listener.local_addr().expect("local_addr");
+    let server = tokio::spawn(async move {
+        axum::serve(listener, app).await.expect("axum serve");
+    });
+
+    let session_key = SessionKey::new();
+    let url = format!(
+        "ws://{addr}/chat/ws?session_key={key}&token=wrong",
+        key = session_key,
+    );
+    let result = tokio_tungstenite::connect_async(&url).await;
+    assert!(result.is_err(), "wrong token must reject the upgrade");
+
+    server.abort();
+}


### PR DESCRIPTION
## Summary

Part of #1793. PR #1796 + #1801 fixed origin-endpoint routing so a
background-task reply is correctly addressed at `Web{connection_id}`.
This PR closes the second half: even with correct routing, the
`WebAdapter` publishes via `tokio::broadcast` and silently drops
events when `receiver_count == 0`. A user who closed their tab while
a long task was running never saw the completion reply.

The fix adds a per-session bounded ring buffer wired into
`WebAdapter::publish_adapter_event`. Important events
(`Message` / `Error` / `BackgroundTaskDone` / `Progress`) are
appended to the buffer on every publish; on WS / SSE connect the
handler drains the buffer before live tail starts, so a reconnecting
tab sees what it missed. Streaming token deltas are intentionally
**not** buffered.

Configuration lives in `web.reply_buffer.{capacity, ttl, sweep_interval}`
in YAML; omitting the block disables buffering and matches pre-#1804
behaviour.

### Design trade-off

The buffer is keyed by `SessionKey`, not receiver. A tab that drops
and reconnects within `ttl` will see events it already processed a
second time. The frontend can dedupe by payload if necessary.
Alternatives — per-receiver tracking, persistent storage — were
rejected as overkill for the bounded in-memory broadcast loss this
fixes.

### Review follow-up (commit `5559239d`)

- `SessionBuffer` switched to `parking_lot::Mutex`; `append` /
  `snapshot` / `sweep_expired` collapsed back to sync.
  `publish_adapter_event` becomes sync and clones the event only when
  it actually needs buffering — streaming hot paths allocate no extra
  copies.
- `spawn_sweeper` accepts `CancellationToken` directly; the watch
  bridge in `app/lib.rs` is removed.
- New `crates/channels/tests/web_ws_drain.rs` boots a real `axum`
  server + `tokio_tungstenite` client over loopback TCP and asserts
  the "drain backlog before live forwarder" invariant from
  `ws_handler`.

## Type of change

| Type | Label |
|------|-------|
| Bug fix | `bug` |

## Component

`core`

## Closes

Closes #1804

## Test plan

- [x] `cargo test --workspace` — all suites pass, no regressions
- [x] `cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings` — clean
- [x] `cargo +nightly fmt --all -- --check` — clean
- [x] `RUSTDOCFLAGS=-D warnings cargo +nightly doc --workspace --no-deps --document-private-items` — clean
- [x] `prek run --all-files` — all hooks pass
- [x] `web_buffer_e2e` covers the egress-sink contract for an already-routed Web Reply plus the listener-loss reproducer for #1804
- [x] `web_ws_drain` covers the WS handler subscribe-then-drain race-free invariant via a real axum + tungstenite loopback round-trip