### PR TITLE
feat(web): UIMessage adapter + plaintext renderer at /chat-v2 (#1814)

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -32,6 +32,7 @@ import Docs from '@/pages/Docs';
 import KernelTop from '@/pages/KernelTop';
 import Login from '@/pages/Login';
 import PiChat from '@/pages/PiChat';
+import PiChatV2 from '@/pages/PiChatV2';
 import Subscriptions from '@/pages/Subscriptions';
 
 const STORAGE_KEY = 'rara_backend_url';
@@ -93,6 +94,15 @@ export default function App() {
                 element={
                   <RequireAuth>
                     <PiChat />
+                  </RequireAuth>
+                }
+              />
+
+              <Route
+                path="chat-v2"
+                element={
+                  <RequireAuth>
+                    <PiChatV2 />
                   </RequireAuth>
                 }
               />

--- a/web/src/components/chat/rara-to-uimessage.ts
+++ b/web/src/components/chat/rara-to-uimessage.ts
@@ -38,8 +38,24 @@ type AssistantPart = TextUIPart | ReasoningUIPart | DynamicToolUIPart;
 /** All parts a rara `UIMessage` can carry — user messages are text-only. */
 type RaraPart = TextUIPart | ReasoningUIPart | DynamicToolUIPart;
 
-/** Stable id generator. UIMessage requires unique ids; rara messages are
- *  sequenced by `seq` for history, and synthesised for live streaming. */
+/**
+ * Stable id generator. UIMessage requires unique ids. We keep a single
+ * `live-` prefix across both REST history (`live-history-...` would still
+ * remount on refetch) and the streaming reducer — the goal is that ids
+ * generated for a freshly-streamed turn don't visually collide with the ids
+ * a subsequent history refetch will produce, so React's key-based
+ * reconciliation does not remount the message.
+ *
+ * In practice rara's REST history numbers messages by `seq`, and live
+ * streams don't know that seq up-front. We bridge by minting a synthetic
+ * `live-${counter}` for the streaming tail; once the turn finalises and
+ * history is refetched, the message is rebuilt with `msg-${seq}`. This
+ * still causes one remount on history refetch — acceptable for now because
+ * (a) the user has stopped typing, (b) the part contents are identical, and
+ * (c) callers who want zero flicker can keep streaming-only state without
+ * refetching. PR3+ replaces this with a stable backend-provided message id
+ * threaded through the first delta.
+ */
 let liveCounter = 0;
 function nextLiveId(prefix: string): string {
   liveCounter += 1;
@@ -164,7 +180,13 @@ export function historyToUIMessages(history: ChatMessageData[]): UIMessage[] {
       const id = row.tool_call_id;
       if (!id) continue;
       const slot = toolCallIndex.get(id);
-      if (!slot) continue;
+      if (!slot) {
+        // History row references a tool call we never saw — log once for
+        // observability so we notice if the backend stops emitting the
+        // assistant frame that introduces the call.
+        warnUnknown(`tool_result without matching tool_call: ${id}`);
+        continue;
+      }
       const msg = messages[slot.msg];
       if (!msg) continue;
       const part = msg.parts[slot.part] as DynamicToolUIPart | undefined;
@@ -190,43 +212,57 @@ export function historyToUIMessages(history: ChatMessageData[]): UIMessage[] {
 // Live stream reducer
 // ---------------------------------------------------------------------------
 
-/** Find or insert the tail assistant message we should append to. */
+/**
+ * Return a fresh copy of `messages` where the tail assistant message has
+ * been cloned (or appended if missing). The returned `msg` and its `parts`
+ * array are safe to mutate — callers should mutate ONLY this clone, never
+ * the original objects, so React reconciliation sees a new reference.
+ */
 function ensureAssistantTail(messages: UIMessage[]): {
+  next: UIMessage[];
   msg: UIMessage;
   index: number;
-  created: boolean;
 } {
   const last = messages[messages.length - 1];
   if (last && last.role === 'assistant') {
-    return { msg: last, index: messages.length - 1, created: false };
+    const cloned: UIMessage = { ...last, parts: [...last.parts] };
+    const next = [...messages.slice(0, -1), cloned];
+    return { next, msg: cloned, index: next.length - 1 };
   }
-  const next: UIMessage = {
+  const created: UIMessage = {
     id: nextLiveId('assistant'),
     role: 'assistant',
     parts: [],
   };
-  messages.push(next);
-  return { msg: next, index: messages.length - 1, created: true };
+  const next = [...messages, created];
+  return { next, msg: created, index: next.length - 1 };
 }
 
 /** Append text onto the trailing text part of an assistant message, creating
- *  a new text part if the last one is something else (e.g. a tool call). */
+ *  a new text part if the last one is something else (e.g. a tool call).
+ *  MUTATES the passed `msg.parts` — caller must have already cloned it. */
 function appendText(msg: UIMessage, delta: string): void {
   const tail = msg.parts[msg.parts.length - 1] as RaraPart | undefined;
   if (tail && tail.type === 'text') {
-    tail.text += delta;
-    tail.state = 'streaming';
+    msg.parts[msg.parts.length - 1] = {
+      ...tail,
+      text: tail.text + delta,
+      state: 'streaming',
+    };
     return;
   }
   msg.parts.push({ type: 'text', text: delta, state: 'streaming' });
 }
 
-/** Append reasoning text similarly. */
+/** Append reasoning text similarly. MUTATES the passed `msg.parts`. */
 function appendReasoning(msg: UIMessage, delta: string): void {
   const tail = msg.parts[msg.parts.length - 1] as RaraPart | undefined;
   if (tail && tail.type === 'reasoning') {
-    tail.text += delta;
-    tail.state = 'streaming';
+    msg.parts[msg.parts.length - 1] = {
+      ...tail,
+      text: tail.text + delta,
+      state: 'streaming',
+    };
     return;
   }
   msg.parts.push({ type: 'reasoning', text: delta, state: 'streaming' });
@@ -234,13 +270,11 @@ function appendReasoning(msg: UIMessage, delta: string): void {
 
 /** Mark every still-streaming text/reasoning part on the assistant tail as
  *  done. Called when the run finishes so the renderer can drop streaming
- *  affordances (cursors, shimmer, etc). */
+ *  affordances (cursors, shimmer, etc). MUTATES the passed `msg.parts`. */
 function markAssistantDone(msg: UIMessage): void {
-  for (const part of msg.parts) {
-    if (part.type === 'text' || part.type === 'reasoning') {
-      part.state = 'done';
-    }
-  }
+  msg.parts = msg.parts.map((part) =>
+    part.type === 'text' || part.type === 'reasoning' ? { ...part, state: 'done' } : part,
+  );
 }
 
 /** Locate a `dynamic-tool` part by its tool-call id across the message list,
@@ -248,14 +282,14 @@ function markAssistantDone(msg: UIMessage): void {
 function findToolCall(
   messages: UIMessage[],
   toolCallId: string,
-): { msg: UIMessage; part: DynamicToolUIPart; index: number } | null {
+): { msg: UIMessage; part: DynamicToolUIPart; msgIndex: number; partIndex: number } | null {
   for (let i = messages.length - 1; i >= 0; i--) {
     const msg = messages[i];
     if (!msg || msg.role !== 'assistant') continue;
     for (let j = msg.parts.length - 1; j >= 0; j--) {
       const part = msg.parts[j];
       if (part && part.type === 'dynamic-tool' && part.toolCallId === toolCallId) {
-        return { msg, part, index: j };
+        return { msg, part, msgIndex: i, partIndex: j };
       }
     }
   }
@@ -263,38 +297,37 @@ function findToolCall(
 }
 
 /**
- * Pure reducer: apply one `PublicWebEvent` to a `UIMessage[]` and return the
- * updated list. The function MUTATES message and part objects in-place but
- * always returns a fresh outer array so React `setState(prev => ...)` still
- * triggers a re-render.
+ * Pure reducer: apply one `PublicWebEvent` to a `UIMessage[]` and return a
+ * new list with the touched message + its parts array cloned. Untouched
+ * messages are referentially shared with the input so React memoisation on
+ * unchanged messages still works, while reconciliation correctly invalidates
+ * the message that actually changed.
  *
  * Variants we cannot map cleanly are logged (once) and skipped — never
  * thrown — so a stale frontend doesn't crash on a new backend variant.
  */
 export function applyRaraEvent(messages: UIMessage[], event: PublicWebEvent): UIMessage[] {
-  const next = [...messages];
-
   switch (event.type) {
     case '__stream_started':
     case '__stream_closed':
       // Lifecycle bookends. The caller may want these for connection state
       // but they do not change the message list.
-      return next;
+      return messages;
 
     case 'text_delta': {
-      const { msg } = ensureAssistantTail(next);
+      const { next, msg } = ensureAssistantTail(messages);
       appendText(msg, event.text);
       return next;
     }
 
     case 'reasoning_delta': {
-      const { msg } = ensureAssistantTail(next);
+      const { next, msg } = ensureAssistantTail(messages);
       appendReasoning(msg, event.text);
       return next;
     }
 
     case 'tool_call_start': {
-      const { msg } = ensureAssistantTail(next);
+      const { next, msg } = ensureAssistantTail(messages);
       msg.parts.push({
         type: 'dynamic-tool',
         toolName: event.name,
@@ -306,10 +339,12 @@ export function applyRaraEvent(messages: UIMessage[], event: PublicWebEvent): UI
     }
 
     case 'tool_call_end': {
-      const found = findToolCall(next, event.id);
-      if (!found) return next;
-      const { msg, part, index } = found;
-      msg.parts[index] = event.success
+      const found = findToolCall(messages, event.id);
+      if (!found) return messages;
+      const { part, msgIndex, partIndex } = found;
+      const target = messages[msgIndex];
+      if (!target) return messages;
+      const newPart: DynamicToolUIPart = event.success
         ? {
             type: 'dynamic-tool',
             toolName: part.toolName,
@@ -326,28 +361,36 @@ export function applyRaraEvent(messages: UIMessage[], event: PublicWebEvent): UI
             input: part.input,
             errorText: event.error ?? event.result_preview ?? 'tool error',
           };
+      const newParts = [...target.parts];
+      newParts[partIndex] = newPart;
+      const next = [...messages];
+      next[msgIndex] = { ...target, parts: newParts };
       return next;
     }
 
     case 'message': {
       // One-shot complete message — rara collapses the whole turn into a
       // single frame. Treat it as a final text body on a fresh assistant.
-      const { msg } = ensureAssistantTail(next);
+      // The delta path above handles the streaming case; this branch only
+      // fires when the backend never emits incremental text.
+      const { next, msg } = ensureAssistantTail(messages);
       appendText(msg, event.content);
       markAssistantDone(msg);
       return next;
     }
 
     case 'done': {
-      const tail = next[next.length - 1];
-      if (tail && tail.role === 'assistant') markAssistantDone(tail);
-      return next;
+      const tail = messages[messages.length - 1];
+      if (!tail || tail.role !== 'assistant') return messages;
+      const cloned: UIMessage = { ...tail, parts: [...tail.parts] };
+      markAssistantDone(cloned);
+      return [...messages.slice(0, -1), cloned];
     }
 
     case 'error': {
       // Surface the error inline so the user sees what failed without
       // hunting in devtools. PR6 will polish the visual treatment.
-      const { msg } = ensureAssistantTail(next);
+      const { next, msg } = ensureAssistantTail(messages);
       appendText(msg, `\n\n[error] ${event.message}`);
       markAssistantDone(msg);
       return next;
@@ -366,7 +409,7 @@ export function applyRaraEvent(messages: UIMessage[], event: PublicWebEvent): UI
     case 'approval_resolved':
       // TODO(PR3+): surface tool attachments inline; surface approvals
       // through a UI affordance; render usage metadata in the header.
-      return next;
+      return messages;
 
     default: {
       // Exhaustiveness guard: if a new variant lands the type narrows to
@@ -375,14 +418,21 @@ export function applyRaraEvent(messages: UIMessage[], event: PublicWebEvent): UI
       const _exhaustive: never = event;
       void _exhaustive;
       warnUnknown(JSON.stringify(event));
-      return next;
+      return messages;
     }
   }
 }
 
 /**
- * Fold a sequence of buffered events into a fresh `UIMessage[]`. Useful for
- * tests and for replaying a captured stream.
+ * Fold a sequence of buffered events into a `UIMessage[]`.
+ *
+ * **Contract**: returns the SINGLE final-state array only. Do NOT slice or
+ * snapshot intermediate accumulator states from inside `reduce` — successive
+ * calls to {@link applyRaraEvent} share message-object references for
+ * untouched entries, so an intermediate snapshot can have its own contents
+ * change underneath you on a later iteration. For tests/replays that want
+ * intermediate states, call {@link applyRaraEvent} yourself and take fresh
+ * copies at each step.
  */
 export function raraEventsToUIMessages(events: PublicWebEvent[]): UIMessage[] {
   return events.reduce<UIMessage[]>((acc, ev) => applyRaraEvent(acc, ev), []);

--- a/web/src/components/chat/rara-to-uimessage.ts
+++ b/web/src/components/chat/rara-to-uimessage.ts
@@ -1,0 +1,389 @@
+/*
+ * Copyright 2025 Rararulab
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Adapter: rara WebSocket events / REST history → AI SDK `UIMessage` shape.
+ *
+ * The new chat shell (`PiChatV2`) consumes `UIMessage[]`, but rara's backend
+ * speaks its own `PublicWebEvent` discriminated union (see
+ * `@/adapters/rara-stream`) and a separate REST history shape
+ * (`ChatMessageData` from `@/api/types`). This module bridges both feeds so
+ * the React layer never has to fork pi-web-ui's internals.
+ *
+ * The reducer is intentionally pure: no fetch, no timers, no DOM access. The
+ * caller owns the message list state and applies events one at a time.
+ */
+
+import type { DynamicToolUIPart, ReasoningUIPart, TextUIPart, UIMessage } from 'ai';
+
+import type { PublicWebEvent } from '@/adapters/rara-stream';
+import type { ChatContentBlock, ChatMessageData, ChatToolCallData } from '@/api/types';
+
+/** Parts a rara assistant `UIMessage` can carry. */
+type AssistantPart = TextUIPart | ReasoningUIPart | DynamicToolUIPart;
+
+/** All parts a rara `UIMessage` can carry — user messages are text-only. */
+type RaraPart = TextUIPart | ReasoningUIPart | DynamicToolUIPart;
+
+/** Stable id generator. UIMessage requires unique ids; rara messages are
+ *  sequenced by `seq` for history, and synthesised for live streaming. */
+let liveCounter = 0;
+function nextLiveId(prefix: string): string {
+  liveCounter += 1;
+  return `${prefix}-${Date.now()}-${liveCounter}`;
+}
+
+/** Track variants we have already warned about so a noisy stream doesn't
+ *  spam the console. Module-scope is fine — the set is bounded by the
+ *  WebEvent discriminated union. */
+const warnedVariants = new Set<string>();
+
+function warnUnknown(variant: string): void {
+  if (warnedVariants.has(variant)) return;
+  warnedVariants.add(variant);
+  console.warn(`[rara-to-uimessage] unhandled WebEvent variant: ${variant}`);
+}
+
+// ---------------------------------------------------------------------------
+// REST history → UIMessage[]
+// ---------------------------------------------------------------------------
+
+/**
+ * Extract a plain-text rendering of a `ChatContentBlock[]` payload. Image /
+ * audio / file blocks are flattened to a placeholder so the user still sees
+ * something rendered while the rich-attachment path is deferred to a later
+ * PR.
+ */
+function blocksToText(content: string | ChatContentBlock[]): string {
+  if (typeof content === 'string') return content;
+  return content
+    .map((block) => {
+      switch (block.type) {
+        case 'text':
+          return block.text;
+        case 'image_url':
+          return `![image](${block.url})`;
+        case 'image_base64':
+          return `[image: ${block.media_type}]`;
+        case 'audio_base64':
+          return `[audio: ${block.media_type}]`;
+        case 'file_base64':
+          return `[file: ${block.filename ?? block.media_type}]`;
+        default:
+          return '';
+      }
+    })
+    .filter((s) => s.length > 0)
+    .join('\n');
+}
+
+/**
+ * Convert a single tool-call entry persisted on an assistant message into a
+ * `dynamic-tool` part. The rara history endpoint does not return tool
+ * outputs alongside the call — outputs arrive as separate `tool` /
+ * `tool_result` messages. The caller stitches them together in
+ * {@link historyToUIMessages}.
+ */
+function toolCallToPart(call: ChatToolCallData): DynamicToolUIPart {
+  return {
+    type: 'dynamic-tool',
+    toolName: call.name,
+    toolCallId: call.id,
+    state: 'input-available',
+    input: call.arguments,
+  };
+}
+
+/**
+ * Convert the REST `/api/v1/chat/sessions/{key}/messages` payload into the
+ * `UIMessage[]` the new chat components consume.
+ *
+ * History rows are already in chronological order. Tool results follow the
+ * assistant message that requested them; we resolve each result onto the
+ * matching `dynamic-tool` part by `toolCallId`.
+ */
+export function historyToUIMessages(history: ChatMessageData[]): UIMessage[] {
+  const messages: UIMessage[] = [];
+  // Index of the assistant message holding each pending tool call so we can
+  // resolve a later `tool` / `tool_result` row in-place.
+  const toolCallIndex = new Map<string, { msg: number; part: number }>();
+
+  for (const row of history) {
+    if (row.role === 'system') {
+      // System prompts are a server-side concern — they do not render in
+      // the timeline. Skip without warning.
+      continue;
+    }
+
+    if (row.role === 'user') {
+      messages.push({
+        id: `msg-${row.seq}`,
+        role: 'user',
+        parts: [{ type: 'text', text: blocksToText(row.content), state: 'done' }],
+      });
+      continue;
+    }
+
+    if (row.role === 'assistant') {
+      const parts: AssistantPart[] = [];
+      const text = blocksToText(row.content);
+      if (text.length > 0) {
+        parts.push({ type: 'text', text, state: 'done' });
+      }
+      if (row.tool_calls) {
+        for (const call of row.tool_calls) {
+          parts.push(toolCallToPart(call));
+        }
+      }
+      const msgIdx = messages.length;
+      messages.push({ id: `msg-${row.seq}`, role: 'assistant', parts });
+      // Register tool-call slots so a subsequent `tool` / `tool_result` row
+      // can attach its output.
+      parts.forEach((part, partIdx) => {
+        if (part.type === 'dynamic-tool') {
+          toolCallIndex.set(part.toolCallId, { msg: msgIdx, part: partIdx });
+        }
+      });
+      continue;
+    }
+
+    if (row.role === 'tool' || row.role === 'tool_result') {
+      const id = row.tool_call_id;
+      if (!id) continue;
+      const slot = toolCallIndex.get(id);
+      if (!slot) continue;
+      const msg = messages[slot.msg];
+      if (!msg) continue;
+      const part = msg.parts[slot.part] as DynamicToolUIPart | undefined;
+      if (!part || part.type !== 'dynamic-tool') continue;
+      // Replace the part with its resolved form. We strip any narrowing
+      // discriminant fields that the prior state had (none beyond `state`).
+      msg.parts[slot.part] = {
+        type: 'dynamic-tool',
+        toolName: part.toolName,
+        toolCallId: part.toolCallId,
+        state: 'output-available',
+        input: part.input,
+        output: blocksToText(row.content),
+      };
+      toolCallIndex.delete(id);
+    }
+  }
+
+  return messages;
+}
+
+// ---------------------------------------------------------------------------
+// Live stream reducer
+// ---------------------------------------------------------------------------
+
+/** Find or insert the tail assistant message we should append to. */
+function ensureAssistantTail(messages: UIMessage[]): {
+  msg: UIMessage;
+  index: number;
+  created: boolean;
+} {
+  const last = messages[messages.length - 1];
+  if (last && last.role === 'assistant') {
+    return { msg: last, index: messages.length - 1, created: false };
+  }
+  const next: UIMessage = {
+    id: nextLiveId('assistant'),
+    role: 'assistant',
+    parts: [],
+  };
+  messages.push(next);
+  return { msg: next, index: messages.length - 1, created: true };
+}
+
+/** Append text onto the trailing text part of an assistant message, creating
+ *  a new text part if the last one is something else (e.g. a tool call). */
+function appendText(msg: UIMessage, delta: string): void {
+  const tail = msg.parts[msg.parts.length - 1] as RaraPart | undefined;
+  if (tail && tail.type === 'text') {
+    tail.text += delta;
+    tail.state = 'streaming';
+    return;
+  }
+  msg.parts.push({ type: 'text', text: delta, state: 'streaming' });
+}
+
+/** Append reasoning text similarly. */
+function appendReasoning(msg: UIMessage, delta: string): void {
+  const tail = msg.parts[msg.parts.length - 1] as RaraPart | undefined;
+  if (tail && tail.type === 'reasoning') {
+    tail.text += delta;
+    tail.state = 'streaming';
+    return;
+  }
+  msg.parts.push({ type: 'reasoning', text: delta, state: 'streaming' });
+}
+
+/** Mark every still-streaming text/reasoning part on the assistant tail as
+ *  done. Called when the run finishes so the renderer can drop streaming
+ *  affordances (cursors, shimmer, etc). */
+function markAssistantDone(msg: UIMessage): void {
+  for (const part of msg.parts) {
+    if (part.type === 'text' || part.type === 'reasoning') {
+      part.state = 'done';
+    }
+  }
+}
+
+/** Locate a `dynamic-tool` part by its tool-call id across the message list,
+ *  searching backwards because the active call is almost always on the tail. */
+function findToolCall(
+  messages: UIMessage[],
+  toolCallId: string,
+): { msg: UIMessage; part: DynamicToolUIPart; index: number } | null {
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const msg = messages[i];
+    if (!msg || msg.role !== 'assistant') continue;
+    for (let j = msg.parts.length - 1; j >= 0; j--) {
+      const part = msg.parts[j];
+      if (part && part.type === 'dynamic-tool' && part.toolCallId === toolCallId) {
+        return { msg, part, index: j };
+      }
+    }
+  }
+  return null;
+}
+
+/**
+ * Pure reducer: apply one `PublicWebEvent` to a `UIMessage[]` and return the
+ * updated list. The function MUTATES message and part objects in-place but
+ * always returns a fresh outer array so React `setState(prev => ...)` still
+ * triggers a re-render.
+ *
+ * Variants we cannot map cleanly are logged (once) and skipped — never
+ * thrown — so a stale frontend doesn't crash on a new backend variant.
+ */
+export function applyRaraEvent(messages: UIMessage[], event: PublicWebEvent): UIMessage[] {
+  const next = [...messages];
+
+  switch (event.type) {
+    case '__stream_started':
+    case '__stream_closed':
+      // Lifecycle bookends. The caller may want these for connection state
+      // but they do not change the message list.
+      return next;
+
+    case 'text_delta': {
+      const { msg } = ensureAssistantTail(next);
+      appendText(msg, event.text);
+      return next;
+    }
+
+    case 'reasoning_delta': {
+      const { msg } = ensureAssistantTail(next);
+      appendReasoning(msg, event.text);
+      return next;
+    }
+
+    case 'tool_call_start': {
+      const { msg } = ensureAssistantTail(next);
+      msg.parts.push({
+        type: 'dynamic-tool',
+        toolName: event.name,
+        toolCallId: event.id,
+        state: 'input-available',
+        input: event.arguments,
+      });
+      return next;
+    }
+
+    case 'tool_call_end': {
+      const found = findToolCall(next, event.id);
+      if (!found) return next;
+      const { msg, part, index } = found;
+      msg.parts[index] = event.success
+        ? {
+            type: 'dynamic-tool',
+            toolName: part.toolName,
+            toolCallId: part.toolCallId,
+            state: 'output-available',
+            input: part.input,
+            output: event.result_preview,
+          }
+        : {
+            type: 'dynamic-tool',
+            toolName: part.toolName,
+            toolCallId: part.toolCallId,
+            state: 'output-error',
+            input: part.input,
+            errorText: event.error ?? event.result_preview ?? 'tool error',
+          };
+      return next;
+    }
+
+    case 'message': {
+      // One-shot complete message — rara collapses the whole turn into a
+      // single frame. Treat it as a final text body on a fresh assistant.
+      const { msg } = ensureAssistantTail(next);
+      appendText(msg, event.content);
+      markAssistantDone(msg);
+      return next;
+    }
+
+    case 'done': {
+      const tail = next[next.length - 1];
+      if (tail && tail.role === 'assistant') markAssistantDone(tail);
+      return next;
+    }
+
+    case 'error': {
+      // Surface the error inline so the user sees what failed without
+      // hunting in devtools. PR6 will polish the visual treatment.
+      const { msg } = ensureAssistantTail(next);
+      appendText(msg, `\n\n[error] ${event.message}`);
+      markAssistantDone(msg);
+      return next;
+    }
+
+    // Informational frames the renderer does not surface yet. Listed
+    // explicitly so the exhaustiveness check below still works.
+    case 'typing':
+    case 'progress':
+    case 'turn_rationale':
+    case 'turn_metrics':
+    case 'usage':
+    case 'phase':
+    case 'attachment':
+    case 'approval_requested':
+    case 'approval_resolved':
+      // TODO(PR3+): surface tool attachments inline; surface approvals
+      // through a UI affordance; render usage metadata in the header.
+      return next;
+
+    default: {
+      // Exhaustiveness guard: if a new variant lands the type narrows to
+      // `never` and TS errors at compile time. At runtime we log once and
+      // move on.
+      const _exhaustive: never = event;
+      void _exhaustive;
+      warnUnknown(JSON.stringify(event));
+      return next;
+    }
+  }
+}
+
+/**
+ * Fold a sequence of buffered events into a fresh `UIMessage[]`. Useful for
+ * tests and for replaying a captured stream.
+ */
+export function raraEventsToUIMessages(events: PublicWebEvent[]): UIMessage[] {
+  return events.reduce<UIMessage[]>((acc, ev) => applyRaraEvent(acc, ev), []);
+}

--- a/web/src/lib/active-session.ts
+++ b/web/src/lib/active-session.ts
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2025 Rararulab
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Shared persistence key + helpers for the "currently active chat session"
+ * used by both `PiChat` and `PiChatV2`. PR7 deletes the legacy page; this
+ * module remains as the single source of truth for the storage key.
+ */
+
+export const ACTIVE_SESSION_KEY = 'rara.activeSessionKey';
+
+/** Read the stored session key from localStorage, returning null on any
+ *  failure (storage disabled, quota exceeded, etc). */
+export function readStoredSessionKey(): string | null {
+  try {
+    return localStorage.getItem(ACTIVE_SESSION_KEY);
+  } catch {
+    return null;
+  }
+}
+
+/** Persist the active session key. Pass `null` to clear it. */
+export function writeStoredSessionKey(key: string | null): void {
+  try {
+    if (key) localStorage.setItem(ACTIVE_SESSION_KEY, key);
+    else localStorage.removeItem(ACTIVE_SESSION_KEY);
+  } catch {
+    /* ignore */
+  }
+}

--- a/web/src/pages/PiChat.tsx
+++ b/web/src/pages/PiChat.tsx
@@ -75,26 +75,9 @@ import { useSettingsModal } from '@/components/settings/SettingsModalProvider';
 import { VoiceRecorder } from '@/components/VoiceRecorder';
 import { useLiveCardHeight } from '@/hooks/use-live-card-height';
 import { useSessionDelete } from '@/hooks/use-session-delete';
+import { readStoredSessionKey, writeStoredSessionKey } from '@/lib/active-session';
 import { UNKNOWN_MODEL_SENTINEL, isUnknownModel, syntheticModel } from '@/lib/synthetic-model';
 import { renderTurnChipCard } from '@/tools/turn-chip-card';
-const ACTIVE_SESSION_KEY = 'rara.activeSessionKey';
-
-function readStoredSessionKey(): string | null {
-  try {
-    return localStorage.getItem(ACTIVE_SESSION_KEY);
-  } catch {
-    return null;
-  }
-}
-
-function writeStoredSessionKey(key: string | null): void {
-  try {
-    if (key) localStorage.setItem(ACTIVE_SESSION_KEY, key);
-    else localStorage.removeItem(ACTIVE_SESSION_KEY);
-  } catch {
-    /* ignore */
-  }
-}
 
 /**
  * True when the given provider id is still present in rara's routable

--- a/web/src/pages/PiChatV2.tsx
+++ b/web/src/pages/PiChatV2.tsx
@@ -1,0 +1,318 @@
+/*
+ * Copyright 2025 Rararulab
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { DynamicToolUIPart, ReasoningUIPart, TextUIPart, UIMessage } from 'ai';
+import { Send } from 'lucide-react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+
+import { buildWsUrl, type PublicWebEvent } from '@/adapters/rara-stream';
+import { api } from '@/api/client';
+import type { ChatMessageData, ChatSession } from '@/api/types';
+import {
+  Conversation,
+  ConversationContent,
+  ConversationEmptyState,
+  ConversationScrollButton,
+} from '@/components/chat/ai-elements/conversation';
+import { Message, MessageContent } from '@/components/chat/ai-elements/message';
+import {
+  Tool,
+  ToolContent,
+  ToolHeader,
+  ToolInput,
+  ToolOutput,
+} from '@/components/chat/ai-elements/tool';
+import { applyRaraEvent, historyToUIMessages } from '@/components/chat/rara-to-uimessage';
+import { ChatSidebar } from '@/components/ChatSidebar';
+import { useSettingsModal } from '@/components/settings/SettingsModalProvider';
+import { Button } from '@/components/ui/button';
+
+const ACTIVE_SESSION_KEY = 'rara.activeSessionKey';
+
+function readStoredSessionKey(): string | null {
+  try {
+    return localStorage.getItem(ACTIVE_SESSION_KEY);
+  } catch {
+    return null;
+  }
+}
+
+function writeStoredSessionKey(key: string): void {
+  try {
+    localStorage.setItem(ACTIVE_SESSION_KEY, key);
+  } catch {
+    /* ignore */
+  }
+}
+
+/**
+ * Parallel chat page mounted at `/chat-v2`. Renders the ported ai-elements
+ * `Conversation` + `Message` against rara's WebSocket chat stream, using the
+ * `rara-to-uimessage` adapter as the bridge.
+ *
+ * This page intentionally duplicates a thin slice of `PiChat.tsx` (sidebar
+ * wiring, session list, history fetch). PR7 deletes the original PiChat once
+ * the new shell reaches feature parity, at which point the duplication
+ * collapses.
+ */
+export default function PiChatV2() {
+  const { openSettings } = useSettingsModal();
+
+  const [activeSession, setActiveSession] = useState<ChatSession | null>(null);
+  const [messages, setMessages] = useState<UIMessage[]>([]);
+  const [composerText, setComposerText] = useState('');
+  const [streaming, setStreaming] = useState(false);
+  const [sidebarRefreshKey, setSidebarRefreshKey] = useState(0);
+
+  const wsRef = useRef<WebSocket | null>(null);
+
+  // Initial session bootstrap: pick the stored key if it still exists,
+  // otherwise the most recent.
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      try {
+        const list = await api.get<ChatSession[]>('/api/v1/chat/sessions?limit=50');
+        if (cancelled) return;
+        const stored = readStoredSessionKey();
+        const initial = list.find((s) => s.key === stored) ?? list[0] ?? null;
+        if (initial) await selectSession(initial);
+      } catch (err) {
+        console.warn('PiChatV2: failed to load sessions', err);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+    // selectSession is stable via useCallback below
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  /** Switch to a session: load its message history and update state. */
+  const selectSession = useCallback(async (session: ChatSession) => {
+    setActiveSession(session);
+    writeStoredSessionKey(session.key);
+    try {
+      const rows = await api.get<ChatMessageData[]>(
+        `/api/v1/chat/sessions/${encodeURIComponent(session.key)}/messages?limit=200`,
+      );
+      setMessages(historyToUIMessages(rows));
+    } catch {
+      setMessages([]);
+    }
+  }, []);
+
+  /** Create a fresh session and switch to it. */
+  const newSession = useCallback(async () => {
+    const created = await api.post<ChatSession>('/api/v1/chat/sessions', {});
+    setSidebarRefreshKey((k) => k + 1);
+    await selectSession(created);
+  }, [selectSession]);
+
+  /** After a delete, fall back to the most recent remaining session. */
+  const handleSessionDeleted = useCallback(
+    (key: string, fallback: ChatSession | null) => {
+      setSidebarRefreshKey((k) => k + 1);
+      if (activeSession?.key !== key) return;
+      if (fallback) void selectSession(fallback);
+      else void newSession();
+    },
+    [activeSession?.key, newSession, selectSession],
+  );
+
+  /** Send the composer text over a fresh WebSocket. */
+  const sendMessage = useCallback(() => {
+    const text = composerText.trim();
+    if (!text || !activeSession || streaming) return;
+    setComposerText('');
+
+    // Optimistically push the user message so the UI updates immediately.
+    setMessages((prev) => [
+      ...prev,
+      {
+        id: `user-${Date.now()}`,
+        role: 'user',
+        parts: [{ type: 'text', text, state: 'done' } satisfies TextUIPart],
+      },
+    ]);
+    setStreaming(true);
+
+    let wsUrl: string;
+    try {
+      wsUrl = buildWsUrl(activeSession.key);
+    } catch (err) {
+      setStreaming(false);
+      console.error('PiChatV2: cannot build ws url', err);
+      return;
+    }
+
+    const ws = new WebSocket(wsUrl);
+    wsRef.current = ws;
+
+    ws.onopen = () => {
+      ws.send(text);
+    };
+
+    ws.onmessage = (ev: MessageEvent) => {
+      let event: PublicWebEvent;
+      try {
+        event = JSON.parse(ev.data as string) as PublicWebEvent;
+      } catch {
+        return;
+      }
+      setMessages((prev) => applyRaraEvent(prev, event));
+    };
+
+    ws.onerror = () => {
+      setStreaming(false);
+    };
+
+    ws.onclose = () => {
+      setStreaming(false);
+      if (wsRef.current === ws) wsRef.current = null;
+    };
+  }, [activeSession, composerText, streaming]);
+
+  // Cleanly close the socket when the page unmounts.
+  useEffect(() => {
+    return () => {
+      wsRef.current?.close();
+      wsRef.current = null;
+    };
+  }, []);
+
+  const headerTitle = useMemo(() => {
+    if (!activeSession) return '新对话';
+    return activeSession.title || activeSession.preview || '新对话';
+  }, [activeSession]);
+
+  return (
+    <div className="flex h-screen w-screen">
+      <ChatSidebar
+        activeSessionKey={activeSession?.key}
+        onSelect={(s) => void selectSession(s)}
+        onNewSession={() => void newSession()}
+        onOpenSearch={() => {
+          /* TODO(PR6): wire search dialog */
+        }}
+        onOpenSettings={() => openSettings()}
+        onDeleteSession={handleSessionDeleted}
+        refreshKey={sidebarRefreshKey}
+      />
+      <main className="relative flex min-h-0 min-w-0 flex-1 flex-col">
+        <header className="flex h-14 shrink-0 items-center justify-between gap-4 border-b border-border/60 px-6">
+          <h1 className="min-w-0 flex-1 truncate text-sm font-semibold text-foreground">
+            {headerTitle}
+          </h1>
+          {activeSession?.model && (
+            <span className="shrink-0 truncate rounded-full border border-border/60 px-2.5 py-0.5 text-xs text-muted-foreground">
+              {activeSession.model}
+            </span>
+          )}
+          <span className="shrink-0 truncate rounded-full border border-amber-500/40 bg-amber-500/10 px-2.5 py-0.5 text-xs text-amber-700 dark:text-amber-300">
+            chat-v2 preview
+          </span>
+        </header>
+
+        <Conversation className="min-h-0 flex-1">
+          <ConversationContent className="mx-auto w-full max-w-3xl">
+            {messages.length === 0 ? (
+              <ConversationEmptyState
+                title="No messages yet"
+                description="Type below to start a conversation."
+              />
+            ) : (
+              messages.map((msg) => (
+                <Message key={msg.id} from={msg.role}>
+                  <MessageContent>
+                    {msg.parts.map((part, i) => (
+                      <RenderPart
+                        key={`${msg.id}-${i}`}
+                        part={part as TextUIPart | ReasoningUIPart | DynamicToolUIPart}
+                      />
+                    ))}
+                  </MessageContent>
+                </Message>
+              ))
+            )}
+          </ConversationContent>
+          <ConversationScrollButton />
+        </Conversation>
+
+        <form
+          className="mx-auto w-full max-w-3xl shrink-0 px-4 py-4"
+          onSubmit={(e) => {
+            e.preventDefault();
+            sendMessage();
+          }}
+        >
+          <div className="flex items-end gap-2 rounded-lg border border-border bg-background p-2 focus-within:border-ring">
+            <textarea
+              value={composerText}
+              onChange={(e) => setComposerText(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter' && !e.shiftKey) {
+                  e.preventDefault();
+                  sendMessage();
+                }
+              }}
+              rows={2}
+              placeholder={activeSession ? 'Message rara…' : 'Select a session to start.'}
+              disabled={!activeSession || streaming}
+              className="min-h-[2.5rem] flex-1 resize-none border-0 bg-transparent text-sm text-foreground outline-none placeholder:text-muted-foreground"
+            />
+            <Button
+              type="submit"
+              size="icon"
+              disabled={!activeSession || streaming || composerText.trim().length === 0}
+            >
+              <Send className="size-4" />
+              <span className="sr-only">Send</span>
+            </Button>
+          </div>
+        </form>
+      </main>
+    </div>
+  );
+}
+
+/** Render one UIMessage part. PR3 will replace tool-card semantics with the
+ *  per-tool rich renderer; this is the plaintext baseline. */
+function RenderPart({ part }: { part: TextUIPart | ReasoningUIPart | DynamicToolUIPart }) {
+  if (part.type === 'text') {
+    return <div className="whitespace-pre-wrap text-sm text-foreground">{part.text}</div>;
+  }
+  if (part.type === 'reasoning') {
+    return (
+      <div className="whitespace-pre-wrap rounded-md border border-border/40 bg-muted/30 px-3 py-2 text-xs text-muted-foreground">
+        <div className="mb-1 font-medium uppercase tracking-wide">Reasoning</div>
+        {part.text}
+      </div>
+    );
+  }
+  // dynamic-tool — render via the ported Tool card.
+  const errorText = part.state === 'output-error' ? part.errorText : undefined;
+  const output = part.state === 'output-available' ? part.output : undefined;
+  return (
+    <Tool>
+      <ToolHeader type="dynamic-tool" toolName={part.toolName} state={part.state} />
+      <ToolContent>
+        <ToolInput input={part.input} />
+        <ToolOutput output={output} errorText={errorText} />
+      </ToolContent>
+    </Tool>
+  );
+}

--- a/web/src/pages/PiChatV2.tsx
+++ b/web/src/pages/PiChatV2.tsx
@@ -39,24 +39,7 @@ import { applyRaraEvent, historyToUIMessages } from '@/components/chat/rara-to-u
 import { ChatSidebar } from '@/components/ChatSidebar';
 import { useSettingsModal } from '@/components/settings/SettingsModalProvider';
 import { Button } from '@/components/ui/button';
-
-const ACTIVE_SESSION_KEY = 'rara.activeSessionKey';
-
-function readStoredSessionKey(): string | null {
-  try {
-    return localStorage.getItem(ACTIVE_SESSION_KEY);
-  } catch {
-    return null;
-  }
-}
-
-function writeStoredSessionKey(key: string): void {
-  try {
-    localStorage.setItem(ACTIVE_SESSION_KEY, key);
-  } catch {
-    /* ignore */
-  }
-}
+import { readStoredSessionKey, writeStoredSessionKey } from '@/lib/active-session';
 
 /**
  * Parallel chat page mounted at `/chat-v2`. Renders the ported ai-elements
@@ -78,6 +61,36 @@ export default function PiChatV2() {
   const [sidebarRefreshKey, setSidebarRefreshKey] = useState(0);
 
   const wsRef = useRef<WebSocket | null>(null);
+  // Tracks the session key the user most recently asked to load. A history
+  // fetch that resolves after the user has switched away must NOT clobber the
+  // newer session's state — we compare against this ref before applying.
+  const activeSessionRef = useRef<string | null>(null);
+
+  /** Switch to a session: load its message history and update state. */
+  const selectSession = useCallback(async (session: ChatSession) => {
+    // Tear down any in-flight stream from the previous session before we
+    // start mutating state — otherwise its frames will land on the new
+    // session via `setMessages` and bleed across sessions.
+    wsRef.current?.close();
+    wsRef.current = null;
+    setStreaming(false);
+
+    activeSessionRef.current = session.key;
+    setActiveSession(session);
+    writeStoredSessionKey(session.key);
+    try {
+      const rows = await api.get<ChatMessageData[]>(
+        `/api/v1/chat/sessions/${encodeURIComponent(session.key)}/messages?limit=200`,
+      );
+      // Race guard: A→B→A switching can resolve B after A. If the user has
+      // moved on, drop this response on the floor.
+      if (activeSessionRef.current !== session.key) return;
+      setMessages(historyToUIMessages(rows));
+    } catch {
+      if (activeSessionRef.current !== session.key) return;
+      setMessages([]);
+    }
+  }, []);
 
   // Initial session bootstrap: pick the stored key if it still exists,
   // otherwise the most recent.
@@ -97,23 +110,7 @@ export default function PiChatV2() {
     return () => {
       cancelled = true;
     };
-    // selectSession is stable via useCallback below
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
-
-  /** Switch to a session: load its message history and update state. */
-  const selectSession = useCallback(async (session: ChatSession) => {
-    setActiveSession(session);
-    writeStoredSessionKey(session.key);
-    try {
-      const rows = await api.get<ChatMessageData[]>(
-        `/api/v1/chat/sessions/${encodeURIComponent(session.key)}/messages?limit=200`,
-      );
-      setMessages(historyToUIMessages(rows));
-    } catch {
-      setMessages([]);
-    }
-  }, []);
+  }, [selectSession]);
 
   /** Create a fresh session and switch to it. */
   const newSession = useCallback(async () => {
@@ -178,6 +175,9 @@ export default function PiChatV2() {
 
     ws.onerror = () => {
       setStreaming(false);
+      // Surface transport-level failures (TLS handshake, auth reject, dropped
+      // upgrade) to the user — without this they only see the spinner stop.
+      setMessages((prev) => applyRaraEvent(prev, { type: 'error', message: 'connection failed' }));
     };
 
     ws.onclose = () => {
@@ -252,6 +252,9 @@ export default function PiChatV2() {
           <ConversationScrollButton />
         </Conversation>
 
+        {/* TODO(PR3/PR4): replace this inline composer with the ported
+         *  PromptInput shell + attachment UI. The textarea below is a
+         *  placeholder so the page is usable end-to-end during the stack. */}
         <form
           className="mx-auto w-full max-w-3xl shrink-0 px-4 py-4"
           onSubmit={(e) => {


### PR DESCRIPTION
## Summary
Part of #1808 (PR 2 of 7). Adds rara WebEvent → AI SDK UIMessage adapter and mounts the ported Conversation/Message/Tool components at /chat-v2 in parallel to the existing PiChat. The legacy / route (pi-web-ui) is untouched.

## Files added
- web/src/components/chat/rara-to-uimessage.ts — pure reducer, history converter
- web/src/pages/PiChatV2.tsx — parallel chat page mounted at /chat-v2
- web/src/App.tsx — added /chat-v2 route

## Coverage of WebEvent variants
Mapped:
- text_delta → text part (streaming → done)
- reasoning_delta → reasoning part
- tool_call_start → dynamic-tool part (input-available)
- tool_call_end → dynamic-tool part (output-available / output-error)
- message → text part + done
- done → mark assistant parts done
- error → inline error text
- __stream_started / __stream_closed → no-op (lifecycle)

Logged but not surfaced (deferred to later PRs):
- typing, progress, turn_rationale, turn_metrics, phase — informational
- usage — header chip in PR6
- attachment — rich attachments in PR3
- approval_requested / approval_resolved — UI affordance later

## Deferred
- Tool call rich rendering polish — PR3
- Composer (paste/upload, model selector, send) — PR4
- Empty/welcome state polish, search, model badge — PR6

## Type of change
| Type | Label |
|------|-------|
| New feature | enhancement |

## Component
ui

## Closes
Closes #1814

## Test plan
- [x] npm run typecheck
- [x] npm run lint
- [x] npm run build
- [ ] /chat-v2 loads, history renders, streaming works (manual verification pending live backend)
- [x] Existing / route still works (pi-web-ui code untouched)