### PR TITLE
fix(web): stop poisoning React Query onlineManager from health probe (#1819)

### DIFF
--- a/web/src/components/ServerStatusProvider.tsx
+++ b/web/src/components/ServerStatusProvider.tsx
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import { onlineManager } from '@tanstack/react-query';
 import { useEffect, useMemo, useState } from 'react';
 import type { ReactNode } from 'react';
 
@@ -36,13 +35,10 @@ export function ServerStatusProvider({ children }: { children: ReactNode }) {
       try {
         const res = await fetch(resolveUrl('/api/v1/health'), { signal: controller.signal });
         if (cancelled) return;
-        const online = res.ok;
-        setIsOnline(online);
-        onlineManager.setOnline(online);
+        setIsOnline(res.ok);
       } catch {
         if (cancelled) return;
         setIsOnline(false);
-        onlineManager.setOnline(false);
       } finally {
         clearTimeout(timer);
         if (!cancelled) {


### PR DESCRIPTION
## Summary

`ServerStatusProvider` was calling `onlineManager.setOnline(false)` whenever the backend `/api/v1/health` probe failed or timed out. `onlineManager` is React Query's *browser-online* signal — flipping it to false pauses every `useQuery` hook globally. The fallout: Skills, Agents, MCP, and Settings sub-cards rendered blank with no requests in the Network tab, and the Connection pill's own healthQuery was paused so it stuck on "Connecting…". Sessions still worked because they go through WebSockets, not React Query.

The fix: backend reachability ≠ browser online status. Drop the `onlineManager` calls (and the now-unused import). Local `isOnline` state and the `useServerStatus` context value still update, so banners / disabled-feature affordances keep working — they just no longer poison the global query pool.

## Type of change

| Type | Label |
|------|-------|
| Bug fix | `bug` |

## Component

`ui`

## Closes

Closes #1819

## Test plan

- [x] `npm run build` passes in `web/`
- [x] `grep -r onlineManager web/src` returns no other references