### PR TITLE
fix(server): apply CORS layer to all public routes including health (#1832)

### DIFF
--- a/crates/app/src/lib.rs
+++ b/crates/app/src/lib.rs
@@ -809,6 +809,10 @@ pub async fn start_with_options(
     let webhook_router =
         (rara_kernel::data_feed::webhook::webhook_routes(webhook_state))(axum::Router::new());
 
+    // CORS wraps the outermost composed router so every public surface
+    // (health, dock, webhook, kernel chat, admin) shares one allow-list.
+    // See `rara_backend_admin::state::build_cors_layer` for the rationale.
+    let cors_origins = config.http.cors_allowed_origins.clone();
     let routes_fn: Box<dyn Fn(axum::Router) -> axum::Router + Send + Sync> =
         Box::new(move |router| {
             health_routes(router)
@@ -816,6 +820,7 @@ pub async fn start_with_options(
                 .merge(dock_routes.clone())
                 .merge(webhook_router.clone())
                 .nest("/api/v1/kernel/chat", web_router.clone())
+                .layer(rara_backend_admin::state::build_cors_layer(&cors_origins))
         });
 
     info!("Application initialized successfully");

--- a/crates/extensions/backend-admin/AGENT.md
+++ b/crates/extensions/backend-admin/AGENT.md
@@ -30,7 +30,7 @@ Unified HTTP admin routes for all backend subsystems — settings management, mo
 - `SettingsSvc` is the single source of truth for runtime-mutable settings (LLM keys, Telegram tokens, etc.).
 - Settings changes are broadcast via `tokio::sync::watch` — subscribers get notified of all changes.
 - Admin routes should not bypass `SettingsSvc` to read/write settings directly in the KV store.
-- CORS (`CorsLayer`) MUST wrap OUTSIDE `auth_layer` in `state.rs` so browser preflight `OPTIONS` (which carries no `Authorization` header) bypasses the bearer-token check. Allowed origins come from `http.cors_allowed_origins` in YAML — never hardcode them in Rust.
+- CORS (`CorsLayer`) is built here via `state::build_cors_layer` (`pub`) but applied by `rara-app` to the outermost composed router — NOT inside `BackendState::routes`. This way every public route (health, dock, webhook, kernel chat, admin) shares one allow-list and browser preflight `OPTIONS` (no `Authorization` header) is answered before any auth middleware can 401 it. Allowed origins come from `http.cors_allowed_origins` in YAML — never hardcode them in Rust.
 
 ## What NOT To Do
 

--- a/crates/extensions/backend-admin/src/state.rs
+++ b/crates/extensions/backend-admin/src/state.rs
@@ -83,7 +83,7 @@ impl BackendState {
         skill_registry: &rara_skills::registry::InMemoryRegistry,
         mcp_manager: &rara_mcp::manager::mgr::McpManager,
         auth_state: crate::auth::AuthState,
-        cors_allowed_origins: &[String],
+        _cors_allowed_origins: &[String],
     ) -> (axum::Router, utoipa::openapi::OpenApi) {
         let mut api = Self::api_doc();
 
@@ -138,14 +138,11 @@ impl BackendState {
             crate::auth::auth_layer,
         ));
 
-        // CORS layer wraps OUTSIDE auth_layer so browser preflight (`OPTIONS`
-        // without an `Authorization` header) is answered by tower-http
-        // instead of being rejected with 401 by the auth middleware.
-        //
-        // Origins are drawn from YAML config — no hardcoded defaults and no
-        // silent fallback: an empty or invalid list is a hard configuration
-        // error caught at boot rather than at first browser request.
-        let router = router.layer(build_cors_layer(cors_allowed_origins));
+        // NOTE: the CORS layer is intentionally NOT applied here. CORS is a
+        // cross-cutting concern for every public route (health, dock, webhook,
+        // kernel chat), not just admin. It is applied by `rara-app` to the
+        // outermost composed router via [`build_cors_layer`] so the same
+        // origin allow-list governs all browser-facing endpoints.
 
         (router, api)
     }
@@ -171,14 +168,20 @@ impl BackendState {
     }
 }
 
-/// Build a [`CorsLayer`] allow-listing the given origins for the admin HTTP
-/// surface.
+/// Build a [`CorsLayer`] allow-listing the given origins for every public
+/// HTTP route.
+///
+/// Applied by `rara-app` to the outermost composed router so that health,
+/// dock, webhook, kernel chat, and admin endpoints share one consistent
+/// origin allow-list. Browser preflight (`OPTIONS` without an
+/// `Authorization` header) is answered here, before any auth middleware can
+/// reject it with 401.
 ///
 /// Panics when the allow-list is empty or contains an origin that is not a
 /// valid HTTP header value. CORS misconfiguration is a boot-time error: the
-/// frontend cannot reach the admin API without it, and silent fallback would
-/// delay the failure to first browser request.
-fn build_cors_layer(allowed_origins: &[String]) -> CorsLayer {
+/// frontend cannot reach the API without it, and silent fallback would delay
+/// the failure to first browser request.
+pub fn build_cors_layer(allowed_origins: &[String]) -> CorsLayer {
     assert!(
         !allowed_origins.is_empty(),
         "http.cors_allowed_origins must list at least one origin — see config.example.yaml",


### PR DESCRIPTION
## Summary

`GET /api/v1/health` (and `/api/health`, dock, webhook, kernel chat) responded 200 cross-origin without `Access-Control-Allow-Origin`, so browsers blocked the response and the frontend `ServerStatusProvider` thought the backend was offline forever — Connection pill in Settings stayed red even when the backend was healthy.

The CORS layer was attached inside `BackendState::routes` (admin routes only). Health/dock/webhook/kernel chat all bypassed it. Fix:

- Make `rara_backend_admin::state::build_cors_layer` `pub` and update its docs to reflect the new outer-router scope.
- Remove the per-admin-router `.layer(build_cors_layer(...))` call (param kept as `_` for caller compatibility).
- In `rara-app`, wrap the outermost composed router (`health + domain + dock + webhook + nested kernel chat`) with the CORS layer so every public surface shares one allow-list.
- Update `crates/extensions/backend-admin/AGENT.md` invariant to reflect the new wiring.

## Type of change

| Type | Label |
|------|-------|
| Bug fix | `bug` |

## Component

`backend`, `ui`

## Closes

Closes #1832

## Test plan

- [x] `cargo check --all --all-targets`
- [x] `cargo +nightly fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings`
- [x] `cargo test -p rara-backend-admin` (61 passed)
- [ ] Manual: `curl -i http://10.0.0.183:25555/api/v1/health -H 'Origin: http://10.0.0.183:5173'` shows `access-control-allow-origin` after deploy