### PR TITLE
fix(web): make reply buffer always-on, remove YAML config knob (#1831)

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -131,32 +131,6 @@ agents:
     max_output_chars: 50
 
 # ---------------------------------------------------------------------------
-# Web channel adapter (optional)
-# ---------------------------------------------------------------------------
-#
-# `reply_buffer` is a per-session in-memory ring of "important" outbound
-# events (final `message`, `error`, `background_task_done`, `progress`).
-# When a long-running background task completes while the user has
-# closed the browser tab, the WS broadcast has zero receivers and the
-# event would otherwise be silently dropped. The buffer keeps the last
-# `capacity` events per session for `ttl`, so a reconnecting tab drains
-# them before live tail starts. Streaming token deltas are NOT buffered.
-#
-# Trade-off: buffer is keyed per session, not per receiver — a tab that
-# disconnects + reconnects within `ttl` will see events it already saw
-# delivered a second time. The frontend can dedupe by payload if
-# necessary.
-#
-# Omit the block entirely to disable buffering (legacy pre-#1804
-# behaviour).
-
-web:
-  reply_buffer:
-    capacity: 64
-    ttl: 10m
-    sweep_interval: 1m
-
-# ---------------------------------------------------------------------------
 # Optional integrations — remove or leave commented out if unused
 # ---------------------------------------------------------------------------
 

--- a/crates/app/src/lib.rs
+++ b/crates/app/src/lib.rs
@@ -93,15 +93,6 @@ pub struct AppConfig {
     /// WeChat iLink Bot configuration (seeded to settings store at startup).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub wechat:                 Option<flatten::WechatConfig>,
-    /// Web channel adapter configuration.
-    ///
-    /// When present, a per-session reply buffer is wired into the
-    /// [`WebAdapter`](rara_channels::web::WebAdapter) so that
-    /// task-completion replies survive moments where no WS / SSE
-    /// listener is attached (issue #1804). When absent, buffering is
-    /// disabled and behaviour matches pre-#1804.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub web:                    Option<WebConfig>,
     /// Composio credentials (seeded to settings store at startup).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub composio:               Option<flatten::ComposioConfig>,
@@ -147,16 +138,6 @@ pub struct AppConfig {
     /// rara falls back to `http-fetch` for web access.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub browser:                Option<rara_browser::BrowserConfig>,
-}
-
-/// Web channel adapter configuration (YAML `web:` block).
-#[derive(Debug, Clone, bon::Builder, Serialize, Deserialize)]
-pub struct WebConfig {
-    /// Per-session ring buffer for important outbound events
-    /// (`Message`, `Error`, `BackgroundTaskDone`, `Progress`). When
-    /// the YAML key is absent, no buffering is performed.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub reply_buffer: Option<rara_channels::web_reply_buffer::ReplyBufferConfig>,
 }
 
 /// Configuration for the Mita background proactive agent.
@@ -487,18 +468,11 @@ pub async fn start_with_options(
     // the same shutdown signal as every other long-running task.
     let cancellation_token = CancellationToken::new();
 
-    // Build the optional reply buffer and spawn its TTL sweeper. When
-    // `web.reply_buffer` is absent, buffering is disabled. The sweeper
-    // runs until the process-wide `cancellation_token` fires.
-    let reply_buffer = config
-        .web
-        .as_ref()
-        .and_then(|w| w.reply_buffer.clone())
-        .map(|cfg| {
-            let buffer = rara_channels::web_reply_buffer::ReplyBuffer::new(cfg);
-            Arc::clone(&buffer).spawn_sweeper(cancellation_token.clone());
-            buffer
-        });
+    // The web reply buffer is always wired in production — see
+    // `web_reply_buffer` module docs for why this is a mechanism, not
+    // a YAML knob. The sweeper runs until `cancellation_token` fires.
+    let reply_buffer = rara_channels::web_reply_buffer::ReplyBuffer::new();
+    Arc::clone(&reply_buffer).spawn_sweeper(cancellation_token.clone());
 
     let web_adapter = Arc::new(
         rara_channels::web::WebAdapter::new(

--- a/crates/channels/Cargo.toml
+++ b/crates/channels/Cargo.toml
@@ -9,12 +9,10 @@ anyhow = { workspace = true }
 async-trait = { workspace = true }
 axum = { workspace = true, features = ["ws"] }
 base64 = { workspace = true }
-bon = { workspace = true }
 chrono = { workspace = true }
 dashmap = "6"
 futures = { workspace = true }
 governor = "0.10"
-humantime-serde = "1"
 image = { workspace = true }
 jiff = { workspace = true }
 parking_lot = { workspace = true }

--- a/crates/channels/src/web.rs
+++ b/crates/channels/src/web.rs
@@ -509,13 +509,13 @@ pub struct WebAdapter {
     shutdown_rx:       watch::Receiver<bool>,
     /// Optional STT service for transcribing voice messages to text.
     stt_service:       Option<rara_stt::SttService>,
-    /// Per-session ring buffer for "important" `WebEvent`s. When set,
-    /// adapter publishes that match
-    /// [`ReplyBuffer::should_buffer`] are appended so that a later
-    /// WS / SSE reconnect can drain them and recover task-completion
-    /// replies that fired while no listener was attached (issue #1804).
-    /// When `None`, buffering is disabled and behaviour matches pre-#1804.
-    reply_buffer:      Option<Arc<ReplyBuffer>>,
+    /// Per-session ring buffer for "important" `WebEvent`s. Adapter
+    /// publishes matching [`ReplyBuffer::should_buffer`] are appended so
+    /// that a later WS / SSE reconnect can drain them and recover
+    /// task-completion replies that fired while no listener was attached
+    /// (issue #1804). The buffer is always wired in production — see the
+    /// `web_reply_buffer` module for why this is a mechanism, not a knob.
+    reply_buffer:      Arc<ReplyBuffer>,
 }
 
 impl WebAdapter {
@@ -538,7 +538,7 @@ impl WebAdapter {
             shutdown_tx,
             shutdown_rx,
             stt_service: None,
-            reply_buffer: None,
+            reply_buffer: ReplyBuffer::new(),
         }
     }
 
@@ -549,11 +549,11 @@ impl WebAdapter {
         self
     }
 
-    /// Attach a per-session [`ReplyBuffer`] so that "important" outbound
-    /// events survive periods when no WS / SSE listener is attached.
-    /// Pass `None` to disable buffering (legacy behaviour).
+    /// Override the default per-session [`ReplyBuffer`]. Production code
+    /// uses the buffer constructed by [`WebAdapter::new`] and only needs
+    /// this hook in tests that want to inspect the buffer directly.
     #[must_use]
-    pub fn with_reply_buffer(mut self, buffer: Option<Arc<ReplyBuffer>>) -> Self {
+    pub fn with_reply_buffer(mut self, buffer: Arc<ReplyBuffer>) -> Self {
         self.reply_buffer = buffer;
         self
     }
@@ -647,8 +647,8 @@ impl WebAdapter {
     }
 
     /// Publish an adapter-local event to all WS/SSE tasks subscribed to
-    /// `session_key`, and optionally append it to the per-session
-    /// [`ReplyBuffer`] when [`ReplyBuffer::should_buffer`] returns `true`.
+    /// `session_key`, and append it to the per-session [`ReplyBuffer`]
+    /// when [`ReplyBuffer::should_buffer`] returns `true`.
     ///
     /// The broadcast send always runs first so a connected receiver sees
     /// the event with no extra latency; the buffer append happens after,
@@ -659,7 +659,7 @@ impl WebAdapter {
     /// See `web_reply_buffer.rs` module docs.
     fn publish_adapter_event(
         buses: &DashMap<SessionKey, broadcast::Sender<WebEvent>>,
-        reply_buffer: Option<&Arc<ReplyBuffer>>,
+        reply_buffer: &Arc<ReplyBuffer>,
         session_key: &SessionKey,
         event: WebEvent,
     ) {
@@ -667,10 +667,7 @@ impl WebAdapter {
         // Only clone the event when it actually needs buffering — keeps
         // streaming hot paths (TextDelta / ReasoningDelta / …) at zero
         // extra allocations.
-        let buffer_target = match reply_buffer {
-            Some(buf) if ReplyBuffer::should_buffer(&event) => Some(buf),
-            _ => None,
-        };
+        let needs_buffer = ReplyBuffer::should_buffer(&event);
         if let Some(tx) = buses.get(session_key) {
             let receiver_count = tx.receiver_count();
             tracing::debug!(
@@ -679,14 +676,13 @@ impl WebAdapter {
                 event_kind,
                 "web publish_adapter_event"
             );
-            let send_result = match buffer_target {
-                Some(buf) => {
-                    let for_buf = event.clone();
-                    let r = tx.send(event);
-                    buf.append(session_key, for_buf);
-                    r
-                }
-                None => tx.send(event),
+            let send_result = if needs_buffer {
+                let for_buf = event.clone();
+                let r = tx.send(event);
+                reply_buffer.append(session_key, for_buf);
+                r
+            } else {
+                tx.send(event)
             };
             if send_result.is_err() {
                 tracing::warn!(
@@ -701,8 +697,8 @@ impl WebAdapter {
                 event_kind,
                 "web publish_adapter_event: no bus yet"
             );
-            if let Some(buf) = buffer_target {
-                buf.append(session_key, event);
+            if needs_buffer {
+                reply_buffer.append(session_key, event);
             }
         }
     }
@@ -723,7 +719,7 @@ async fn approval_listener(
     mut request_rx: tokio::sync::broadcast::Receiver<ApprovalRequest>,
     mut resolution_rx: tokio::sync::broadcast::Receiver<ApprovalResponse>,
     adapter_events: Arc<DashMap<SessionKey, broadcast::Sender<WebEvent>>>,
-    reply_buffer: Option<Arc<ReplyBuffer>>,
+    reply_buffer: Arc<ReplyBuffer>,
     mut shutdown_rx: watch::Receiver<bool>,
 ) {
     let session_by_request: Arc<DashMap<uuid::Uuid, SessionKey>> = Arc::new(DashMap::new());
@@ -748,7 +744,7 @@ async fn approval_listener(
                         };
                         WebAdapter::publish_adapter_event(
                             &adapter_events,
-                            reply_buffer.as_ref(),
+                            &reply_buffer,
                             &req.session_key,
                             event,
                         );
@@ -774,7 +770,7 @@ async fn approval_listener(
                         };
                         WebAdapter::publish_adapter_event(
                             &adapter_events,
-                            reply_buffer.as_ref(),
+                            &reply_buffer,
                             &session_key,
                             event,
                         );
@@ -826,8 +822,8 @@ struct WebAdapterState {
     owner_user_id:     String,
     shutdown_rx:       watch::Receiver<bool>,
     stt_service:       Option<rara_stt::SttService>,
-    /// Optional per-session ring buffer; see [`WebAdapter::reply_buffer`].
-    reply_buffer:      Option<Arc<ReplyBuffer>>,
+    /// Always-on per-session ring buffer; see [`WebAdapter::reply_buffer`].
+    reply_buffer:      Arc<ReplyBuffer>,
 }
 
 // ---------------------------------------------------------------------------
@@ -1093,18 +1089,16 @@ async fn handle_ws(socket: WebSocket, params: SessionQuery, state: WebAdapterSta
     // BEFORE the live forwarder starts pushing into the same mpsc, so the
     // socket sees buffered events first in publish order. The buffer is
     // not removed on drain — see `web_reply_buffer` module docs for why.
-    if let Some(ref buf) = state.reply_buffer {
-        let backlog = buf.snapshot(&session_key);
-        if !backlog.is_empty() {
-            debug!(
-                session_key = %session_key_str,
-                count = backlog.len(),
-                "draining web reply buffer to new WS"
-            );
-            for ev in backlog {
-                if ws_event_tx.send(ev).is_err() {
-                    break;
-                }
+    let backlog = state.reply_buffer.snapshot(&session_key);
+    if !backlog.is_empty() {
+        debug!(
+            session_key = %session_key_str,
+            count = backlog.len(),
+            "draining web reply buffer to new WS"
+        );
+        for ev in backlog {
+            if ws_event_tx.send(ev).is_err() {
+                break;
             }
         }
     }
@@ -1236,7 +1230,7 @@ async fn handle_ws(socket: WebSocket, params: SessionQuery, state: WebAdapterSta
                     warn!(session_key = %session_key_str, "sink not set");
                     WebAdapter::publish_adapter_event(
                         &adapter_events,
-                        reply_buffer.as_ref(),
+                        &reply_buffer,
                         &session_key,
                         WebEvent::Error {
                             message: "adapter not started".to_owned(),
@@ -1247,7 +1241,7 @@ async fn handle_ws(socket: WebSocket, params: SessionQuery, state: WebAdapterSta
 
                 WebAdapter::publish_adapter_event(
                     &adapter_events,
-                    reply_buffer.as_ref(),
+                    &reply_buffer,
                     &session_key,
                     WebEvent::Typing,
                 );
@@ -1264,7 +1258,7 @@ async fn handle_ws(socket: WebSocket, params: SessionQuery, state: WebAdapterSta
                             error!(session_key = %session_key_str, error = %e, "submit_message failed");
                             WebAdapter::publish_adapter_event(
                                 &adapter_events,
-                                reply_buffer.as_ref(),
+                                &reply_buffer,
                                 &session_key,
                                 WebEvent::Error {
                                     message: e.to_string(),
@@ -1280,7 +1274,7 @@ async fn handle_ws(socket: WebSocket, params: SessionQuery, state: WebAdapterSta
                         error!(session_key = %session_key_str, error = %e, "resolve failed");
                         WebAdapter::publish_adapter_event(
                             &adapter_events,
-                            reply_buffer.as_ref(),
+                            &reply_buffer,
                             &session_key,
                             WebEvent::Error {
                                 message: e.to_string(),
@@ -1341,18 +1335,16 @@ async fn sse_handler(
     let mut adapter_rx = adapter_bus.subscribe();
 
     // Drain any buffered "important" events before live tail starts.
-    if let Some(ref buf) = state.reply_buffer {
-        let backlog = buf.snapshot(&session_key);
-        if !backlog.is_empty() {
-            debug!(
-                session_key = %params.session_key,
-                count = backlog.len(),
-                "draining web reply buffer to new SSE"
-            );
-            for ev in backlog {
-                if ev_tx.send(ev).is_err() {
-                    break;
-                }
+    let backlog = state.reply_buffer.snapshot(&session_key);
+    if !backlog.is_empty() {
+        debug!(
+            session_key = %params.session_key,
+            count = backlog.len(),
+            "draining web reply buffer to new SSE"
+        );
+        for ev in backlog {
+            if ev_tx.send(ev).is_err() {
+                break;
             }
         }
     }
@@ -1523,7 +1515,7 @@ async fn send_message_handler(
         Some(sink) => {
             WebAdapter::publish_adapter_event(
                 &state.adapter_events,
-                state.reply_buffer.as_ref(),
+                &state.reply_buffer,
                 &session_key,
                 WebEvent::Typing,
             );
@@ -1605,7 +1597,7 @@ impl ChannelAdapter for WebAdapter {
         let event = platform_outbound_to_web_event(msg);
         WebAdapter::publish_adapter_event(
             &self.adapter_events,
-            self.reply_buffer.as_ref(),
+            &self.reply_buffer,
             &session_key,
             event,
         );
@@ -1656,7 +1648,7 @@ impl ChannelAdapter for WebAdapter {
         };
         WebAdapter::publish_adapter_event(
             &self.adapter_events,
-            self.reply_buffer.as_ref(),
+            &self.reply_buffer,
             &key,
             WebEvent::Typing,
         );
@@ -1669,7 +1661,7 @@ impl ChannelAdapter for WebAdapter {
         };
         WebAdapter::publish_adapter_event(
             &self.adapter_events,
-            self.reply_buffer.as_ref(),
+            &self.reply_buffer,
             &key,
             WebEvent::Phase {
                 phase: phase.to_string(),

--- a/crates/channels/src/web_reply_buffer.rs
+++ b/crates/channels/src/web_reply_buffer.rs
@@ -1,56 +1,11 @@
-// Copyright 2025 Rararulab
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//      http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-
-//! Per-session ring buffer for "important" `WebEvent`s so that task-completion
-//! replies survive periods where no WS / SSE listener is attached.
+//! Always-on per-session reply buffer for the Web channel.
 //!
-//! # Why this exists
-//!
-//! `WebAdapter` publishes outbound replies through a `tokio::broadcast`
-//! channel. When a long-running background task finishes while the user has
-//! closed their browser tab, `broadcast::Sender::send` returns `Err` because
-//! `receiver_count == 0`, and the `Reply` envelope is silently dropped. When
-//! the user reconnects, the kernel has no record of "you owe this socket a
-//! reply" — task output is lost forever (see issue #1804).
-//!
-//! # What is buffered
-//!
-//! Only events whose loss is user-visible:
-//!
-//! - [`WebEvent::Message`]      — final agent reply (the original #1804 case)
-//! - [`WebEvent::Error`]        — surfaced error notifications
-//! - [`WebEvent::BackgroundTaskDone`] — terminal status of a bg task
-//! - [`WebEvent::Progress`]     — terminal stage signals
-//!
-//! Streaming deltas (`TextDelta`, `ReasoningDelta`, `ToolCall*`, …) are
-//! intentionally **not** buffered: replaying a partial token stream after the
-//! fact has no useful semantics for the UI.
-//!
-//! # Replay semantics & trade-off
-//!
-//! On connect the WS / SSE handler drains the buffer into the new socket
-//! before forwarding live events. The buffer is **not** removed on drain —
-//! a session may have multiple concurrent tabs, and a brand-new tab opening
-//! mid-turn should still see the catch-up history. The cost is that an
-//! already-connected tab which read an event live will see it *again* if it
-//! reconnects (e.g. WS drop + retry inside the TTL window). Callers that
-//! cannot tolerate duplicate `WebEvent::Message` rows must dedupe by
-//! payload — there is no per-event sequence number on the wire today.
-//!
-//! Bounded capacity (oldest event is dropped on overflow) and a TTL sweep
-//! task keep memory bounded; both are configured from YAML — no defaults
-//! are hard-coded in Rust.
+//! The buffer is a structural correctness fix, not a tunable feature: when a
+//! long-running task completes while the user has closed their tab, the
+//! WS broadcast has zero receivers and the event would otherwise be silently
+//! dropped (issue #1804). Capacity, TTL, and sweeper interval are mechanism
+//! parameters that live as `const` next to the code, **not** deployment
+//! configuration — there is no YAML knob to disable buffering.
 
 use std::{
     collections::VecDeque,
@@ -61,36 +16,20 @@ use std::{
 use dashmap::DashMap;
 use parking_lot::Mutex;
 use rara_kernel::session::SessionKey;
-use serde::{Deserialize, Serialize};
 use tokio_util::sync::CancellationToken;
 
 use crate::web::WebEvent;
 
-/// Configuration for the per-session reply buffer.
-///
-/// Both fields are sourced from the YAML config file
-/// (`web.reply_buffer.*`) — see `config.example.yaml`.
-#[derive(Debug, Clone, bon::Builder, Serialize, Deserialize)]
-pub struct ReplyBufferConfig {
-    /// Maximum number of "important" events retained per session.
-    /// On overflow, the oldest event is evicted (FIFO).
-    pub capacity:       usize,
-    /// How long after the last write a session's buffer is kept
-    /// before the sweeper drops it.
-    #[serde(
-        deserialize_with = "humantime_serde::deserialize",
-        serialize_with = "humantime_serde::serialize"
-    )]
-    pub ttl:            Duration,
-    /// Sweeper tick interval. The sweeper runs every `sweep_interval` and
-    /// removes any session whose buffer hasn't been written to within
-    /// the last `ttl`.
-    #[serde(
-        deserialize_with = "humantime_serde::deserialize",
-        serialize_with = "humantime_serde::serialize"
-    )]
-    pub sweep_interval: Duration,
-}
+/// Maximum number of "important" events retained per session before FIFO
+/// eviction.
+const REPLY_BUFFER_CAPACITY: usize = 64;
+
+/// How long after the last write a session's buffer is kept before the
+/// sweeper drops it.
+const REPLY_BUFFER_TTL: Duration = Duration::from_mins(10);
+
+/// How often the sweeper checks for expired sessions.
+const REPLY_BUFFER_SWEEP_INTERVAL: Duration = Duration::from_mins(1);
 
 /// One session's bounded ring of important events plus a last-write
 /// timestamp used by the TTL sweeper.
@@ -103,15 +42,13 @@ struct SessionBuffer {
 /// handlers and the `ChannelAdapter::send` path.
 pub struct ReplyBuffer {
     sessions: DashMap<SessionKey, Arc<Mutex<SessionBuffer>>>,
-    config:   ReplyBufferConfig,
 }
 
 impl ReplyBuffer {
-    /// Construct a new empty buffer with the given configuration.
-    pub fn new(config: ReplyBufferConfig) -> Arc<Self> {
+    /// Construct a new empty buffer.
+    pub fn new() -> Arc<Self> {
         Arc::new(Self {
             sessions: DashMap::new(),
-            config,
         })
     }
 
@@ -137,13 +74,13 @@ impl ReplyBuffer {
             .entry(session_key.clone())
             .or_insert_with(|| {
                 Arc::new(Mutex::new(SessionBuffer {
-                    events:     VecDeque::with_capacity(self.config.capacity),
+                    events:     VecDeque::with_capacity(REPLY_BUFFER_CAPACITY),
                     last_write: Instant::now(),
                 }))
             })
             .clone();
         let mut guard = entry.lock();
-        if guard.events.len() == self.config.capacity {
+        if guard.events.len() == REPLY_BUFFER_CAPACITY {
             guard.events.pop_front();
         }
         guard.events.push_back(event);
@@ -169,16 +106,14 @@ impl ReplyBuffer {
     /// Spawn the TTL sweeper. Returns immediately; the sweeper runs in
     /// the background until `cancel` fires.
     pub fn spawn_sweeper(self: Arc<Self>, cancel: CancellationToken) {
-        let interval = self.config.sweep_interval;
-        let ttl = self.config.ttl;
         tokio::spawn(async move {
-            let mut ticker = tokio::time::interval(interval);
+            let mut ticker = tokio::time::interval(REPLY_BUFFER_SWEEP_INTERVAL);
             ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
             loop {
                 tokio::select! {
                     _ = cancel.cancelled() => return,
                     _ = ticker.tick() => {
-                        self.sweep_expired(ttl);
+                        self.sweep_expired(REPLY_BUFFER_TTL);
                     }
                 }
             }
@@ -210,15 +145,7 @@ mod tests {
 
     use rara_kernel::{io::BackgroundTaskStatus, session::SessionKey};
 
-    use super::{ReplyBuffer, ReplyBufferConfig, WebEvent};
-
-    fn config(capacity: usize) -> ReplyBufferConfig {
-        ReplyBufferConfig::builder()
-            .capacity(capacity)
-            .ttl(Duration::from_mins(1))
-            .sweep_interval(Duration::from_secs(10))
-            .build()
-    }
+    use super::{REPLY_BUFFER_CAPACITY, ReplyBuffer, WebEvent};
 
     fn session() -> SessionKey { SessionKey::new() }
 
@@ -256,7 +183,7 @@ mod tests {
 
     #[test]
     fn append_then_snapshot_returns_events_in_order() {
-        let buf = ReplyBuffer::new(config(8));
+        let buf = ReplyBuffer::new();
         let s = session();
         buf.append(
             &s,
@@ -284,7 +211,7 @@ mod tests {
 
     #[test]
     fn snapshot_does_not_drain() {
-        let buf = ReplyBuffer::new(config(8));
+        let buf = ReplyBuffer::new();
         let s = session();
         buf.append(
             &s,
@@ -298,9 +225,9 @@ mod tests {
 
     #[test]
     fn capacity_overflow_evicts_oldest() {
-        let buf = ReplyBuffer::new(config(2));
+        let buf = ReplyBuffer::new();
         let s = session();
-        for i in 0..3 {
+        for i in 0..=REPLY_BUFFER_CAPACITY {
             buf.append(
                 &s,
                 WebEvent::Message {
@@ -309,19 +236,17 @@ mod tests {
             );
         }
         let snap = buf.snapshot(&s);
-        assert_eq!(snap.len(), 2);
-        match (&snap[0], &snap[1]) {
-            (WebEvent::Message { content: a }, WebEvent::Message { content: b }) => {
-                assert_eq!(a, "m1");
-                assert_eq!(b, "m2");
-            }
+        assert_eq!(snap.len(), REPLY_BUFFER_CAPACITY);
+        // Oldest ("m0") should have been evicted; first remaining is "m1".
+        match &snap[0] {
+            WebEvent::Message { content } => assert_eq!(content, "m1"),
             other => panic!("unexpected: {other:?}"),
         }
     }
 
     #[test]
     fn sweep_expired_drops_idle_sessions() {
-        let buf = ReplyBuffer::new(config(4));
+        let buf = ReplyBuffer::new();
         let s = session();
         buf.append(
             &s,
@@ -331,7 +256,6 @@ mod tests {
         );
         assert_eq!(buf.session_count(), 1);
 
-        // ttl=0 makes every entry immediately eligible.
         buf.sweep_expired(Duration::from_nanos(0));
         assert_eq!(buf.session_count(), 0);
     }

--- a/crates/channels/tests/web_buffer_e2e.rs
+++ b/crates/channels/tests/web_buffer_e2e.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! End-to-end coverage for the per-session reply buffer wired into
+//! End-to-end coverage for the always-on per-session reply buffer wired into
 //! `WebAdapter` (issue #1804).
 //!
 //! Two scenarios:
@@ -33,21 +33,13 @@ use std::{sync::Arc, time::Duration};
 
 use rara_channels::{
     web::{WebAdapter, WebEvent},
-    web_reply_buffer::{ReplyBuffer, ReplyBufferConfig},
+    web_reply_buffer::ReplyBuffer,
 };
 use rara_kernel::{
     channel::{adapter::ChannelAdapter, types::ChannelType},
     io::{Endpoint, EndpointAddress, PlatformOutbound},
     session::SessionKey,
 };
-
-fn buffer_config() -> ReplyBufferConfig {
-    ReplyBufferConfig::builder()
-        .capacity(32)
-        .ttl(Duration::from_mins(1))
-        .sweep_interval(Duration::from_secs(30))
-        .build()
-}
 
 fn web_endpoint(session_key: &SessionKey) -> Endpoint {
     Endpoint {
@@ -70,9 +62,9 @@ fn subscribe(
 
 #[tokio::test]
 async fn happy_path_reply_reaches_subscribed_listener() {
-    let buffer = ReplyBuffer::new(buffer_config());
-    let adapter = WebAdapter::new("tok".to_owned(), "user".to_owned())
-        .with_reply_buffer(Some(Arc::clone(&buffer)));
+    let buffer = ReplyBuffer::new();
+    let adapter =
+        WebAdapter::new("tok".to_owned(), "user".to_owned()).with_reply_buffer(Arc::clone(&buffer));
 
     let session_key = SessionKey::new();
     let mut rx = subscribe(&adapter, &session_key);
@@ -108,9 +100,9 @@ async fn happy_path_reply_reaches_subscribed_listener() {
 
 #[tokio::test]
 async fn listener_loss_is_recovered_via_buffer_snapshot() {
-    let buffer = ReplyBuffer::new(buffer_config());
-    let adapter = WebAdapter::new("tok".to_owned(), "user".to_owned())
-        .with_reply_buffer(Some(Arc::clone(&buffer)));
+    let buffer = ReplyBuffer::new();
+    let adapter =
+        WebAdapter::new("tok".to_owned(), "user".to_owned()).with_reply_buffer(Arc::clone(&buffer));
 
     let session_key = SessionKey::new();
 
@@ -142,30 +134,4 @@ async fn listener_loss_is_recovered_via_buffer_snapshot() {
         WebEvent::Message { content } => assert_eq!(content, "while-you-were-away"),
         other => panic!("expected WebEvent::Message, got {other:?}"),
     }
-}
-
-#[tokio::test]
-async fn send_without_buffer_does_not_panic() {
-    // Adapter built without a buffer behaves exactly like pre-#1804:
-    // a publish with no listeners drops the event silently.
-    let adapter = WebAdapter::new("tok".to_owned(), "user".to_owned());
-
-    let session_key = SessionKey::new();
-    let endpoint = web_endpoint(&session_key);
-
-    // No subscriber → no bus → publish is a noop, but it must not panic.
-    adapter
-        .send(
-            &endpoint,
-            PlatformOutbound::Reply {
-                content:       "lost".to_owned(),
-                attachments:   Vec::new(),
-                reply_context: None,
-            },
-        )
-        .await
-        .expect("egress send without buffer");
-
-    // We can't read what's missing, but we can prove the disable path
-    // by asserting the adapter accepted the call without a panic.
 }

--- a/crates/channels/tests/web_ws_drain.rs
+++ b/crates/channels/tests/web_ws_drain.rs
@@ -33,7 +33,7 @@ use std::{sync::Arc, time::Duration};
 use futures::{SinkExt, StreamExt};
 use rara_channels::{
     web::{WebAdapter, WebEvent},
-    web_reply_buffer::{ReplyBuffer, ReplyBufferConfig},
+    web_reply_buffer::ReplyBuffer,
 };
 use rara_kernel::{
     channel::{adapter::ChannelAdapter, types::ChannelType},
@@ -44,14 +44,6 @@ use tokio_tungstenite::tungstenite::Message;
 
 const OWNER_TOKEN: &str = "test-owner-token";
 const OWNER_USER_ID: &str = "test-user";
-
-fn buffer_config() -> ReplyBufferConfig {
-    ReplyBufferConfig::builder()
-        .capacity(32)
-        .ttl(Duration::from_mins(1))
-        .sweep_interval(Duration::from_secs(30))
-        .build()
-}
 
 fn web_endpoint(session_key: &SessionKey) -> Endpoint {
     Endpoint {
@@ -87,10 +79,10 @@ where
 
 #[tokio::test]
 async fn ws_drains_backlog_before_live_events() {
-    let buffer = ReplyBuffer::new(buffer_config());
+    let buffer = ReplyBuffer::new();
     let adapter = Arc::new(
         WebAdapter::new(OWNER_TOKEN.to_owned(), OWNER_USER_ID.to_owned())
-            .with_reply_buffer(Some(Arc::clone(&buffer))),
+            .with_reply_buffer(Arc::clone(&buffer)),
     );
 
     // Mount the adapter under /chat to mirror production wiring.


### PR DESCRIPTION
## Summary

The web reply buffer is a structural correctness fix for #1804 (broadcast send sees zero receivers when a long task completes after the user closes their tab → reply lost), not a tunable feature. Making it YAML opt-in in #1817 was a footgun: the default config silently kept the bug.

This PR:

- Drops `WebConfig` and `ReplyBufferConfig` entirely. Capacity (64), TTL (10m), and sweeper interval (1m) are mechanism `const`s next to `ReplyBuffer`, not deployment config.
- `WebAdapter::reply_buffer` is `Arc<ReplyBuffer>` (no `Option`); `ReplyBuffer::new()` takes no arguments; the buffer is wired unconditionally in `rara-app` startup.
- Removes the `web.reply_buffer.*` block from `config.example.yaml` and the `humantime-serde` dep from `rara-channels`.
- Removes the `send_without_buffer_does_not_panic` test (no-buffer code path no longer exists).

The "no hardcoded defaults in Rust" guideline applies to environment config (DB URLs, ports, secrets), not mechanism parameters with a single sane value.

## Type of change

| Type | Label |
|------|-------|
| Bug fix | `bug` |

## Component

`core`

## Closes

Closes #1831

## Test plan

- [x] `cargo check --workspace --all-targets` passes
- [x] `cargo test --workspace` passes
- [x] `cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings` clean
- [x] `cargo +nightly fmt --all -- --check` clean
- [x] `RUSTDOCFLAGS="-D warnings" cargo +nightly doc --workspace --no-deps --document-private-items` clean
- [x] `prek run --all-files` all green