### PR TITLE
fix(web): pretty-print json tool responses (#1837)

### DIFF
--- a/web/src/components/agent-live/__tests__/tool-chips.test.ts
+++ b/web/src/components/agent-live/__tests__/tool-chips.test.ts
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2025 Rararulab
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { formatMaybeJson } from '../tool-chips';
+
+describe('formatMaybeJson', () => {
+  it('pretty-prints JSON objects with 2-space indent', () => {
+    const compact = '{"a":1,"b":[2,3]}';
+    expect(formatMaybeJson(compact)).toBe('{\n  "a": 1,\n  "b": [\n    2,\n    3\n  ]\n}');
+  });
+
+  it('pretty-prints JSON arrays', () => {
+    expect(formatMaybeJson('[1,2,3]')).toBe('[\n  1,\n  2,\n  3\n]');
+  });
+
+  it('passes Markdown through unchanged', () => {
+    const md = '# Heading\n\n- bullet\n- bullet\n';
+    expect(formatMaybeJson(md)).toBe(md);
+  });
+
+  it('passes plain text through unchanged', () => {
+    expect(formatMaybeJson('hello world')).toBe('hello world');
+  });
+
+  it('passes malformed JSON through unchanged', () => {
+    const broken = '{"a": 1,';
+    expect(formatMaybeJson(broken)).toBe(broken);
+  });
+});

--- a/web/src/components/agent-live/tool-chips.tsx
+++ b/web/src/components/agent-live/tool-chips.tsx
@@ -209,7 +209,7 @@ export function ToolChip({ chip, expandable = false }: ToolChipProps) {
             )}
             {chip.output && chip.output.length > 0 && (
               <pre className="max-h-60 overflow-auto whitespace-pre-wrap break-all border-t p-3 text-[11px] text-muted-foreground">
-                {truncate(chip.output)}
+                {truncate(formatMaybeJson(chip.output))}
               </pre>
             )}
           </div>
@@ -238,4 +238,19 @@ function StatusIcon({ status }: { status: ToolChipStatus }) {
 function truncate(s: string): string {
   if (s.length <= DETAIL_MAX_CHARS) return s;
   return s.slice(0, DETAIL_MAX_CHARS) + '\n... (truncated)';
+}
+
+/**
+ * Pretty-print tool output when it's a JSON document, leave it untouched
+ * otherwise. Tool outputs arrive as opaque strings — most kernel tools return
+ * a JSON payload, but some return Markdown / plain text we must not reformat.
+ */
+export function formatMaybeJson(s: string): string {
+  const trimmed = s.trim();
+  if (!trimmed.startsWith('{') && !trimmed.startsWith('[')) return s;
+  try {
+    return JSON.stringify(JSON.parse(trimmed), null, 2);
+  } catch {
+    return s;
+  }
 }


### PR DESCRIPTION
## Summary

Tool **input** in the chat tool-call detail panel was rendered with `JSON.stringify(..., null, 2)` (pretty), but the paired **output** was passed through verbatim — JSON payloads showed up as one unindented line. This adds a `formatMaybeJson` helper that detects JSON-shaped output and pretty-prints it with 2-space indent; Markdown / plain text passes through unchanged.

## Type of change

| Type | Label |
|------|-------|
| Bug fix | `bug` |

## Component

`ui`

## Closes

Closes #1837

## Test plan

- [x] New unit tests for `formatMaybeJson` (5 cases: object, array, markdown, plain text, malformed JSON)
- [x] `bun run build` passes in `web/`
- [x] Local visual check (request + response panes both formatted)