### PR TITLE
fix(web): hide inline tool-call cards during streaming (#1839)

### DIFF
--- a/web/src/index.css
+++ b/web/src/index.css
@@ -384,6 +384,21 @@
 }
 
 /*
+ * Hide pi-web-ui's inline tool-call cards while a turn is streaming.
+ * `StreamingMessageContainer.js` hardcodes `hideToolCalls=false`, so the
+ * heavy `BashRenderer` / etc. cards stack under the assistant bubble during
+ * streaming and then collapse into our compact `renderTurnChipCard` chips
+ * once the turn settles — visually jarring and redundant since the
+ * `AgentLiveCard` above already summarises in-flight tool activity.
+ *
+ * Only the streaming variant is suppressed; the historical messageRenderer
+ * already passes `hideToolCalls=true`, so this is a no-op there.
+ */
+.rara-chat streaming-message-container tool-message {
+  display: none;
+}
+
+/*
  * Pi-web-ui left-aligns user messages (`class="flex justify-start"`
  * on the bubble's parent). Flip to the right side — the standard
  * chat convention of "my messages on the right". `:has()` gives us a


### PR DESCRIPTION
## Summary

`StreamingMessageContainer` renders pi-web-ui's inline tool-call cards (heavy "Running command..." `BashRenderer` blocks etc.) while a turn streams, duplicating what `AgentLiveCard` already summarises above the bubble. Once the turn settles, our compact `renderTurnChipCard` chips take over — the visual jump from heavy cards to small chips is jarring.

Suppress the streaming variant with a scoped CSS rule (`streaming-message-container tool-message { display: none }`). The historical `messageRenderer` already passes `hideToolCalls=true`, so this only affects the in-flight view; the live card remains the single source of truth for running state.

## Type of change

| Type | Label |
|------|-------|
| Bug fix | `bug` |

## Component

`ui`

## Closes

Closes #1839

## Test plan

- [x] Streaming turn now leaves the assistant bubble clean (live card alone shows running state)
- [x] Completed turns still render the compact chip card
- [x] No change to historical messages