### PR TITLE
feat(sandbox): stage boxlite runtime (#1699)

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -94,6 +94,14 @@ jobs:
       - name: Run tests
         run: cargo nextest run --workspace
 
+      # Smoke-test the boxlite staging code path. With BOXLITE_DEPS_STUB=1
+      # the build produces no real runtime files, so this is a dry-run
+      # (`--check`) that just exercises the path/permission logic. Real
+      # staging is run by developers locally on macOS — see
+      # docs/guides/boxlite-runtime.md and tracking issue #1842.
+      - name: Smoke-test boxlite setup (dry-run)
+        run: cargo run -p rara-cli -- setup boxlite --check
+
   docs:
     name: Documentation
     runs-on: arc-runner-set

--- a/crates/cmd/Cargo.toml
+++ b/crates/cmd/Cargo.toml
@@ -30,6 +30,7 @@ chrono.workspace = true
 clap = { workspace = true }
 common-telemetry.workspace = true
 crossterm.workspace = true
+dirs.workspace = true
 eventsource-stream.workspace = true
 futures.workspace = true
 indexmap.workspace = true

--- a/crates/cmd/src/setup/AGENT.md
+++ b/crates/cmd/src/setup/AGENT.md
@@ -1,11 +1,12 @@
 # setup — Agent Guidelines
 
 ## Purpose
-Interactive CLI wizard for configuring rara — database, LLM, Telegram, STT, and users. Also provides `rara setup whisper` for automated whisper.cpp installation.
+Interactive CLI wizard for configuring rara — database, LLM, Telegram, STT, and users. Also provides standalone subcommands: `rara setup whisper` (whisper.cpp install) and `rara setup boxlite` (sandbox runtime staging).
 
 ## Architecture
-- `mod.rs` — `SetupCmd` with optional `SetupSub` subcommands (currently: `Whisper`). Orchestrates the full wizard flow.
+- `mod.rs` — `SetupCmd` with optional `SetupSub` subcommands (`Whisper`, `Boxlite`). Orchestrates the full wizard flow.
 - `whisper_install.rs` — Automated whisper.cpp pipeline: detect existing binary → clone/build from source → download GGML model → start server → verify health + transcription → shutdown. Entry point: `ensure_whisper()`.
+- `boxlite.rs` — Stages boxlite microVM runtime files (built by `cargo build -p rara-sandbox`) into the platform user-data dir so `rara-sandbox` can find them at runtime. Entry point: `run_boxlite_setup(check_only)`. See `docs/guides/boxlite-runtime.md` for the user-facing flow.
 - `stt.rs` — STT config section for the full wizard (`setup_stt`) and standalone whisper entry point (`run_whisper_setup`).
 - `writer.rs` — Config assembly and YAML serialization. `assemble_config()` merges all sections.
 - `prompt.rs` — Interactive CLI helpers (ask, confirm, ask_choice, print_step/ok/err).

--- a/crates/cmd/src/setup/boxlite.rs
+++ b/crates/cmd/src/setup/boxlite.rs
@@ -1,0 +1,271 @@
+// Copyright 2025 Rararulab
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Stage boxlite's runtime artifacts into a stable user-data directory so
+//! `rara-sandbox` can find them at runtime without each user manually
+//! copying files out of cargo's `target/` tree.
+//!
+//! See `docs/guides/boxlite-runtime.md` for the user-facing flow.
+
+use std::{
+    fs,
+    path::{Path, PathBuf},
+    time::SystemTime,
+};
+
+use snafu::{ResultExt, Whatever};
+use tracing::instrument;
+
+use super::prompt;
+
+/// Boxlite version pinned by `crates/rara-sandbox/Cargo.toml`. Bump
+/// lockstep with the `tag = "vX.Y.Z"` git dependency there — boxlite stages
+/// per-version, so a stale value silently writes to the wrong directory.
+///
+/// This is a mechanism constant (matches the dependency, not user
+/// preference), not a YAML knob.
+const BOXLITE_VERSION: &str = "v0.8.2";
+
+/// Files that boxlite's runtime expects to find in its staging directory
+/// before the first VM will start. Names mirror
+/// `crates/rara-sandbox/AGENT.md` footgun #3.
+const RUNTIME_FILES: &[&str] = &[
+    "boxlite-guest",
+    "boxlite-shim",
+    "mke2fs",
+    "debugfs",
+    #[cfg(target_os = "macos")]
+    "libkrunfw.dylib",
+    #[cfg(target_os = "linux")]
+    "libkrunfw.so",
+];
+
+/// Files that should be marked executable on unix.
+const EXECUTABLE_FILES: &[&str] = &["boxlite-guest", "boxlite-shim", "mke2fs", "debugfs"];
+
+/// Stamp file boxlite's own embedded-runtime extractor checks to short-
+/// circuit re-extraction. We write the same stamp so eager staging is a
+/// drop-in replacement for the lazy first-call path.
+const COMPLETE_STAMP: &str = ".complete";
+
+/// Outcome of a boxlite staging run, surfaced to the caller for logging /
+/// CI assertions.
+pub enum StageOutcome {
+    /// Files were copied into place (or already present and valid).
+    Staged {
+        /// Destination directory containing the staged runtime.
+        dest: PathBuf,
+    },
+    /// Build artifacts were not found. This is the expected state in CI
+    /// when `BOXLITE_DEPS_STUB=1` was used at build time, or when the user
+    /// has not yet run `cargo build -p rara-sandbox`.
+    NoArtifacts,
+    /// `--check` was requested; the discovered source is reported but
+    /// nothing was copied.
+    CheckOnly {
+        /// Build directory that would be the staging source.
+        source: Option<PathBuf>,
+        /// Destination directory that would receive the files.
+        dest:   PathBuf,
+    },
+}
+
+/// Stage boxlite's runtime artifacts from cargo's build directory into the
+/// platform user-data dir.
+///
+/// `check_only` skips the copy step — useful for CI smoke tests that want
+/// to exercise the code path without depending on a real boxlite build.
+#[instrument(skip_all, fields(check_only))]
+pub async fn run_boxlite_setup(check_only: bool) -> Result<StageOutcome, Whatever> {
+    prompt::print_step("Boxlite Runtime Staging");
+
+    let dest = staged_runtime_dir()?;
+    println!("  destination: {}", dest.display());
+
+    let source = locate_build_runtime().whatever_context("failed to scan target/ for boxlite")?;
+
+    if check_only {
+        match &source {
+            Some(src) => prompt::print_ok(&format!("would stage from {}", src.display())),
+            None => println!(
+                "  no boxlite build artifacts found (run `cargo build -p rara-sandbox` first, or \
+                 BOXLITE_DEPS_STUB was set)"
+            ),
+        }
+        return Ok(StageOutcome::CheckOnly { source, dest });
+    }
+
+    let Some(source) = source else {
+        prompt::print_err(
+            "no boxlite build artifacts found under target/. Either build rara-sandbox without \
+             BOXLITE_DEPS_STUB, or skip staging on this platform.",
+        );
+        return Ok(StageOutcome::NoArtifacts);
+    };
+
+    if dest.join(COMPLETE_STAMP).is_file() {
+        prompt::print_ok(&format!("already staged at {}", dest.display()));
+        return Ok(StageOutcome::Staged { dest });
+    }
+
+    stage_runtime(&source, &dest)
+        .whatever_context(format!("failed to stage runtime to {}", dest.display()))?;
+
+    prompt::print_ok(&format!(
+        "staged {} files at {}",
+        RUNTIME_FILES.len(),
+        dest.display()
+    ));
+    Ok(StageOutcome::Staged { dest })
+}
+
+/// Resolve the destination staging directory.
+///
+/// Mirrors boxlite's release-mode embedded-runtime path so that boxlite's
+/// own extractor sees our `.complete` stamp and skips redundant work
+/// (`crates/rara-sandbox/AGENT.md` footgun #3).
+fn staged_runtime_dir() -> Result<PathBuf, Whatever> {
+    let Some(base) = dirs::data_local_dir() else {
+        snafu::whatever!("could not determine platform data-local directory");
+    };
+    Ok(base.join("boxlite").join("runtimes").join(BOXLITE_VERSION))
+}
+
+/// Find the newest `target/*/build/boxlite-*/out/runtime` directory that
+/// holds the expected runtime files.
+///
+/// The cargo build hash is unstable across feature sets, so we glob and
+/// pick the newest match rather than reproducing cargo's hashing.
+fn locate_build_runtime() -> std::io::Result<Option<PathBuf>> {
+    let target_dir = workspace_target_dir();
+    if !target_dir.is_dir() {
+        return Ok(None);
+    }
+
+    // Profile subdirs to scan. `release` first so production builds win
+    // ties when both a debug and release build exist.
+    let candidates = ["release", "debug"]
+        .iter()
+        .map(|profile| target_dir.join(profile).join("build"))
+        .filter(|p| p.is_dir())
+        .flat_map(|build_dir| collect_boxlite_runtimes(&build_dir))
+        .flatten();
+
+    let newest = candidates
+        .filter(|p| has_required_files(p))
+        .max_by_key(|p| {
+            fs::metadata(p)
+                .and_then(|m| m.modified())
+                .unwrap_or(SystemTime::UNIX_EPOCH)
+        });
+
+    Ok(newest)
+}
+
+/// Yield every `boxlite-*/out/runtime` directory inside a
+/// `target/<profile>/build/`.
+fn collect_boxlite_runtimes(build_dir: &Path) -> std::io::Result<Vec<PathBuf>> {
+    let mut out = Vec::new();
+    for entry in fs::read_dir(build_dir)? {
+        let entry = entry?;
+        let name = entry.file_name();
+        let Some(name) = name.to_str() else { continue };
+        if !name.starts_with("boxlite-") {
+            continue;
+        }
+        let runtime = entry.path().join("out").join("runtime");
+        if runtime.is_dir() {
+            out.push(runtime);
+        }
+    }
+    Ok(out)
+}
+
+/// True if every required runtime file is present in `dir`.
+fn has_required_files(dir: &Path) -> bool {
+    RUNTIME_FILES.iter().all(|name| dir.join(name).is_file())
+}
+
+/// Walk `target/`. We deliberately ignore `CARGO_TARGET_DIR` —
+/// `whisper_install.rs` doesn't read it either, and adding a divergent
+/// fallback here would surprise users who have a custom target dir.
+fn workspace_target_dir() -> PathBuf {
+    // The setup binary is invoked from the workspace root via `just` or
+    // `cargo run`; both leave cwd at the workspace root.
+    PathBuf::from("target")
+}
+
+/// Copy required files from `source` to `dest`, set unix permissions to
+/// match boxlite's expectations, then write a `.complete` stamp.
+///
+/// Writing the stamp last preserves the "atomic enough" guarantee boxlite
+/// itself relies on — partial copies leave no stamp, so a re-run will
+/// retry instead of silently using a half-staged dir.
+fn stage_runtime(source: &Path, dest: &Path) -> std::io::Result<()> {
+    fs::create_dir_all(dest)?;
+
+    for name in RUNTIME_FILES {
+        let src = source.join(name);
+        let dst = dest.join(name);
+        // Remove first to avoid `text file busy` if a previous boxlite
+        // process still has it open via mmap.
+        if dst.exists() {
+            fs::remove_file(&dst)?;
+        }
+        fs::copy(&src, &dst)?;
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mode = if EXECUTABLE_FILES.contains(name) {
+                0o755
+            } else {
+                0o644
+            };
+            fs::set_permissions(&dst, fs::Permissions::from_mode(mode))?;
+        }
+    }
+
+    fs::write(dest.join(COMPLETE_STAMP), BOXLITE_VERSION)?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs::File;
+
+    use tempfile::tempdir;
+
+    use super::*;
+
+    #[test]
+    fn version_matches_sandbox_dep() {
+        // Sanity: every staged dir is keyed by this version. If the
+        // sandbox crate bumps boxlite, this constant must move with it.
+        let cargo_toml = include_str!("../../../rara-sandbox/Cargo.toml");
+        assert!(
+            cargo_toml.contains(&format!("tag = \"{BOXLITE_VERSION}\"")),
+            "BOXLITE_VERSION must match the git tag pinned in rara-sandbox/Cargo.toml"
+        );
+    }
+
+    #[test]
+    fn has_required_files_detects_missing() {
+        let dir = tempdir().unwrap();
+        assert!(!has_required_files(dir.path()));
+        for name in RUNTIME_FILES {
+            File::create(dir.path().join(name)).unwrap();
+        }
+        assert!(has_required_files(dir.path()));
+    }
+}

--- a/crates/cmd/src/setup/boxlite.rs
+++ b/crates/cmd/src/setup/boxlite.rs
@@ -114,7 +114,7 @@ pub async fn run_boxlite_setup(check_only: bool) -> Result<StageOutcome, Whateve
         return Ok(StageOutcome::NoArtifacts);
     };
 
-    if dest.join(COMPLETE_STAMP).is_file() {
+    if dest.join(COMPLETE_STAMP).is_file() && has_required_files(&dest) {
         prompt::print_ok(&format!("already staged at {}", dest.display()));
         return Ok(StageOutcome::Staged { dest });
     }
@@ -197,13 +197,15 @@ fn has_required_files(dir: &Path) -> bool {
     RUNTIME_FILES.iter().all(|name| dir.join(name).is_file())
 }
 
-/// Walk `target/`. We deliberately ignore `CARGO_TARGET_DIR` —
-/// `whisper_install.rs` doesn't read it either, and adding a divergent
-/// fallback here would surprise users who have a custom target dir.
+/// Resolve the workspace target directory, honoring `CARGO_TARGET_DIR`
+/// for users who keep build artefacts outside the repo (common on shared
+/// CI runners and dev setups). Falls back to `./target` when unset; the
+/// setup binary is invoked from the workspace root via `just` or
+/// `cargo run`, so the relative path resolves correctly.
 fn workspace_target_dir() -> PathBuf {
-    // The setup binary is invoked from the workspace root via `just` or
-    // `cargo run`; both leave cwd at the workspace root.
-    PathBuf::from("target")
+    std::env::var_os("CARGO_TARGET_DIR")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PathBuf::from("target"))
 }
 
 /// Copy required files from `source` to `dest`, set unix permissions to

--- a/crates/cmd/src/setup/mod.rs
+++ b/crates/cmd/src/setup/mod.rs
@@ -14,6 +14,7 @@
 
 //! Interactive configuration wizard for rara.
 
+mod boxlite;
 mod db;
 mod llm;
 mod prompt;
@@ -40,6 +41,12 @@ pub struct SetupCmd {
 enum SetupSub {
     /// Configure whisper speech-to-text (STT) settings only.
     Whisper,
+    /// Stage boxlite microVM runtime artifacts into the user data directory.
+    Boxlite {
+        /// Print the source/destination plan without copying any files.
+        #[arg(long)]
+        check: bool,
+    },
 }
 
 impl SetupCmd {
@@ -47,6 +54,10 @@ impl SetupCmd {
     pub async fn run(self) -> Result<(), Whatever> {
         match self.sub {
             Some(SetupSub::Whisper) => return stt::run_whisper_setup().await,
+            Some(SetupSub::Boxlite { check }) => {
+                boxlite::run_boxlite_setup(check).await?;
+                return Ok(());
+            }
             None => {}
         }
 

--- a/crates/rara-sandbox/AGENT.md
+++ b/crates/rara-sandbox/AGENT.md
@@ -119,8 +119,13 @@ person if they aren't written down.
    - `boxlite-shim`
    - `debugfs`
 
-   On macOS the directory is:
-   `~/Library/Application Support/boxlite/runtimes/v0.8.2/`.
-   Copy the artefacts from a boxlite release build into this path
-   before running the integration test. Automating this is tracked in
-   issue #1699.
+   Staging is automated via `rara setup boxlite` (see
+   `docs/guides/boxlite-runtime.md`). The destination is:
+   - macOS: `~/Library/Application Support/boxlite/runtimes/v0.8.2/`
+   - Linux: `$XDG_DATA_HOME/boxlite/runtimes/v0.8.2/`
+     (fallback `~/.local/share/boxlite/runtimes/v0.8.2/`)
+
+   Run `cargo build -p rara-sandbox` once (without `BOXLITE_DEPS_STUB`)
+   so boxlite's build.rs downloads the platform tarball, then run
+   `rara setup boxlite` to copy the files into place. The version
+   segment must match the `tag = "v…"` in this crate's `Cargo.toml`.

--- a/crates/rara-sandbox/tests/alpine_echo.rs
+++ b/crates/rara-sandbox/tests/alpine_echo.rs
@@ -1,15 +1,15 @@
 //! End-to-end round-trip: create -> exec `echo` -> destroy.
 //!
-//! This test is `#[ignore]`d because it requires the boxlite runtime files
-//! (`boxlite-guest`, `libkrunfw.dylib`, `mke2fs`, `boxlite-shim`, `debugfs`)
-//! to be staged under the platform-specific runtime directory, and a local
-//! OCI image store that can resolve `alpine:latest`. Runtime-file staging
-//! is tracked in issue #1699; until that lands, CI cannot run this test
-//! from a fresh checkout.
+//! This test is `#[ignore]`d because it requires (a) a real boxlite build
+//! (no `BOXLITE_DEPS_STUB`) and (b) a local OCI image store that can
+//! resolve `alpine:latest`. CI today builds with the stub for runner
+//! provisioning reasons (#1842), so the test cannot run there.
 //!
-//! Run locally with:
+//! Run locally on macOS:
 //!
 //! ```bash
+//! cargo build -p rara-sandbox            # boxlite build.rs downloads runtime
+//! cargo run -p rara-cli -- setup boxlite # stage files into user-data dir
 //! cargo test -p rara-sandbox -- --ignored alpine_echo_roundtrip
 //! ```
 

--- a/docs/guides/boxlite-runtime.md
+++ b/docs/guides/boxlite-runtime.md
@@ -1,0 +1,60 @@
+# Boxlite Runtime Staging
+
+`rara-sandbox` wraps boxlite (a microVM library) for hardware-isolated code
+execution. Boxlite needs five runtime files (`boxlite-guest`,
+`boxlite-shim`, `mke2fs`, `debugfs`, and `libkrunfw.dylib`/`.so`) to be
+present at a stable user-data path before the first VM will start.
+
+`rara setup boxlite` copies those files out of cargo's build directory
+into that path. Run it once per machine, after the first
+`cargo build -p rara-sandbox`.
+
+## When to run
+
+- **First-time setup** on a developer machine that will use sandboxed
+  code execution.
+- **After bumping the boxlite tag** in `crates/rara-sandbox/Cargo.toml` —
+  the destination directory is keyed by version, so a new tag means a new
+  empty directory.
+- **After `cargo clean`** wipes the build artefacts; re-run
+  `cargo build -p rara-sandbox` first, then re-stage.
+
+## Usage
+
+```bash
+# Build rara-sandbox so boxlite's build.rs downloads the platform tarball
+# into target/<profile>/build/boxlite-<hash>/out/runtime/.
+cargo build -p rara-sandbox
+
+# Copy the runtime files into the platform user-data directory.
+cargo run -p rara-cli -- setup boxlite
+
+# Dry-run: print where the files would come from / go to, without copying.
+cargo run -p rara-cli -- setup boxlite --check
+```
+
+## Staging paths
+
+| Platform | Destination |
+|----------|-------------|
+| macOS    | `~/Library/Application Support/boxlite/runtimes/<version>/` |
+| Linux    | `$XDG_DATA_HOME/boxlite/runtimes/<version>/` (fallback `~/.local/share/boxlite/runtimes/<version>/`) |
+
+These match boxlite's own embedded-runtime fallback paths, so the eager
+stamp file (`.complete`) lets boxlite's lazy extractor short-circuit on
+the first VM boot.
+
+## Idempotence
+
+Re-running `rara setup boxlite` on an already-staged directory is a
+no-op — the `.complete` stamp written at the end of staging is checked
+first and reported as "already staged".
+
+## CI
+
+CI builds `rara-sandbox` with `BOXLITE_DEPS_STUB="1"` to avoid pulling
+the full native build chain (meson, ninja, patchelf) onto every runner.
+That means CI never actually has runtime files to stage, so
+`rara setup boxlite --check` in CI exercises only the code path; it
+prints "no boxlite build artifacts found" and exits cleanly. Removing
+the stub is tracked in #1842.

--- a/justfile
+++ b/justfile
@@ -236,6 +236,19 @@ example-hello:
     @echo "🏃 Running hello-world example..."
     cargo run --example hello-world
 
+[doc("stage boxlite microVM runtime files into the user-data dir (see docs/guides/boxlite-runtime.md)")]
+[group("🛠️  Setup")]
+setup-boxlite:
+    @echo "📦 Building rara-sandbox so boxlite extracts the runtime tarball..."
+    cargo build -p rara-sandbox
+    @echo "📦 Staging boxlite runtime files..."
+    cargo run -p rara-cli -- setup boxlite
+
+[doc("dry-run boxlite runtime staging (no copy) — used by CI smoke")]
+[group("🛠️  Setup")]
+setup-boxlite-check:
+    cargo run -p rara-cli -- setup boxlite --check
+
 
 [doc("start frontend dev server (proxies /api to localhost:25555)")]
 [group("🔧 Development")]


### PR DESCRIPTION
## Summary

Step 2 of the boxlite epic #1696. Adds `rara setup boxlite` — a
new subcommand under the existing setup dispatcher — that stages
boxlite's runtime files (`boxlite-guest`, `boxlite-shim`, `mke2fs`,
`debugfs`, `libkrunfw.{dylib,so}`) from cargo's
`target/<profile>/build/boxlite-<hash>/out/runtime/` into the
platform user-data path that boxlite's own embedded-runtime
extractor falls back to (macOS: `~/Library/Application Support/boxlite/runtimes/v0.8.2/`,
Linux: `$XDG_DATA_HOME/boxlite/runtimes/v0.8.2/`).

`--check` runs a no-copy dry-run; wired into CI as a smoke step so
the code path is exercised on every run (even though `BOXLITE_DEPS_STUB=1`
leaves the build dir empty there).

## Type of change

| Type | Label |
|------|-------|
| New feature | `enhancement` |

## Component

`core`

## Closes

Closes #1699

## Design notes

- **Not a `build.rs`** — build-time IO is fragile and runs on every cargo build.
- **Not an xtask** — rara has no xtask infrastructure today; the setup-subcommand pattern already exists (whisper).
- **Version pinning** — `BOXLITE_VERSION` is a Rust const matched against `crates/rara-sandbox/Cargo.toml`'s git tag via a unit test, so a sandbox crate bump cannot silently desync.
- **Idempotent** — re-running on a staged dir is a no-op (`.complete` stamp check).
- **`BOXLITE_DEPS_STUB`** — kept on in CI per #1842; this PR does NOT change that. The `--check` smoke just exercises the path/permission logic.

## Test plan

- [x] `cargo +nightly fmt --all -- --check`
- [x] `cargo check --all --all-targets`
- [x] `cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings`
- [x] `RUSTDOCFLAGS=-D warnings cargo +nightly doc --workspace --no-deps --document-private-items`
- [x] `cargo test --no-run -p rara-sandbox`
- [x] `cargo test -p rara-cli setup::boxlite` — 2/2 unit tests pass
- [x] `cargo run -p rara-cli -- setup boxlite --check` — dry-run prints expected output and exits 0
- [ ] Real end-to-end staging on macOS without the stub — not run in this iteration; the integration test in `crates/rara-sandbox/tests/alpine_echo.rs` is still `#[ignore]`d and depends on a real boxlite build + a warm OCI image cache for `alpine:latest`.