### PR TITLE
fix(store,kernel): root-cause SQLite writer contention causing silent trace loss (#1843)

### DIFF
--- a/crates/app/src/boot.rs
+++ b/crates/app/src/boot.rs
@@ -95,7 +95,7 @@ pub struct PlatformBindingConfig {
 /// `browser_manager` is optional — pass `Some` when Lightpanda started
 /// successfully; browser tools are registered into the tool registry when set.
 pub(crate) async fn boot(
-    diesel_pool: yunara_store::diesel_pool::DieselSqlitePool,
+    diesel_pools: yunara_store::diesel_pool::DieselSqlitePools,
     settings_provider: Arc<dyn rara_domain_shared::settings::SettingsProvider>,
     users: &[UserConfig],
     owner_user_id: &str,
@@ -103,7 +103,7 @@ pub(crate) async fn boot(
 ) -> Result<BootResult, Whatever> {
     // -- credential store --------------------------------------------------
     let credential_store: rara_keyring_store::KeyringStoreRef = Arc::new(
-        rara_pg_credential_store::PgKeyringStore::new(diesel_pool.clone()),
+        rara_pg_credential_store::PgKeyringStore::new(diesel_pools.clone()),
     );
 
     // -- LLM driver registry -----------------------------------------------
@@ -147,7 +147,7 @@ pub(crate) async fn boot(
         rara_kernel::memory::FileTapeStore::new(rara_paths::memory_dir(), &workspace_path)
             .await
             .whatever_context("Failed to initialize FileTapeStore")?,
-        diesel_pool.clone(),
+        diesel_pools.clone(),
     );
     info!("TapeService initialized (FTS5 enabled)");
 
@@ -159,7 +159,7 @@ pub(crate) async fn boot(
     // -- skills registry ---------------------------------------------------
 
     let skill_registry = rara_skills::registry::InMemoryRegistry::new();
-    rara_skills::cache::spawn_background_sync(diesel_pool.clone(), skill_registry.clone());
+    rara_skills::cache::spawn_background_sync(diesel_pools.clone(), skill_registry.clone());
     info!("skill registry initialized with background sync");
 
     // -- marketplace service -----------------------------------------------
@@ -316,7 +316,7 @@ pub(crate) async fn boot(
     // -- knowledge layer ------------------------------------------------------
 
     let knowledge_service =
-        init_knowledge_service(diesel_pool.clone(), settings_provider.as_ref(), embedder)
+        init_knowledge_service(diesel_pools.clone(), settings_provider.as_ref(), embedder)
             .await
             .whatever_context("Failed to initialize knowledge layer")?;
 
@@ -912,7 +912,7 @@ impl rara_composio::ComposioAuthProvider for SettingsComposioAuthProvider {
 /// Initialize the knowledge layer — all configuration read from settings,
 /// reuses the application's shared SQLite pool.
 async fn init_knowledge_service(
-    pool: yunara_store::diesel_pool::DieselSqlitePool,
+    pools: yunara_store::diesel_pool::DieselSqlitePools,
     settings: &dyn rara_domain_shared::settings::SettingsProvider,
     embedder: rara_kernel::llm::LlmEmbedderRef,
 ) -> anyhow::Result<rara_kernel::memory::knowledge::KnowledgeServiceRef> {
@@ -956,7 +956,7 @@ async fn init_knowledge_service(
 
     info!("knowledge layer initialized");
     Ok(Arc::new(KnowledgeService {
-        pool,
+        pools,
         embedding_svc,
         config,
     }))

--- a/crates/app/src/feed_store.rs
+++ b/crates/app/src/feed_store.rs
@@ -25,19 +25,19 @@ use rara_kernel::data_feed::{FeedEvent, FeedEventId, FeedFilter, FeedStore};
 use rara_model::schema::data_feed_events;
 use snafu::ResultExt;
 use tracing::instrument;
-use yunara_store::diesel_pool::DieselSqlitePool;
+use yunara_store::diesel_pool::DieselSqlitePools;
 
 /// SQLite-backed feed event store.
 ///
-/// Implements [`FeedStore`] using the `data_feed_events` table. All operations
-/// go through the shared diesel-async pool.
+/// Implements [`FeedStore`] using the `data_feed_events` table. Reads use
+/// the reader pool; appends use the single-writer pool.
 pub struct SqliteFeedStore {
-    pool: DieselSqlitePool,
+    pools: DieselSqlitePools,
 }
 
 impl SqliteFeedStore {
-    /// Create a new store backed by the given connection pool.
-    pub fn new(pool: DieselSqlitePool) -> Self { Self { pool } }
+    /// Create a new store backed by the given pool bundle.
+    pub fn new(pools: DieselSqlitePools) -> Self { Self { pools } }
 }
 
 #[async_trait]
@@ -52,7 +52,8 @@ impl FeedStore for SqliteFeedStore {
         let received_at = event.received_at.to_string();
 
         let mut conn = self
-            .pool
+            .pools
+            .writer
             .get()
             .await
             .whatever_context("data_feed_events pool acquire failed")?;
@@ -78,7 +79,8 @@ impl FeedStore for SqliteFeedStore {
     #[instrument(skip_all)]
     async fn query(&self, filter: FeedFilter) -> rara_kernel::Result<Vec<FeedEvent>> {
         let mut conn = self
-            .pool
+            .pools
+            .reader
             .get()
             .await
             .whatever_context("data_feed_events pool acquire failed")?;

--- a/crates/app/src/lib.rs
+++ b/crates/app/src/lib.rs
@@ -342,10 +342,10 @@ pub async fn start_with_options(
     let db_store = init_infra(&config)
         .await
         .whatever_context("Failed to initialize infrastructure services")?;
-    let diesel_pool = db_store.pool().clone();
+    let diesel_pools = db_store.pools().clone();
 
     let settings_svc =
-        rara_backend_admin::settings::SettingsSvc::load(db_store.kv_store(), diesel_pool.clone())
+        rara_backend_admin::settings::SettingsSvc::load(db_store.kv_store(), diesel_pools.clone())
             .await
             .whatever_context("Failed to initialize runtime settings")?;
 
@@ -384,7 +384,7 @@ pub async fn start_with_options(
         };
 
     let rara = crate::boot::boot(
-        diesel_pool.clone(),
+        diesel_pools.clone(),
         settings_provider.clone(),
         &config.users,
         &config.owner_user_id,
@@ -400,9 +400,10 @@ pub async fn start_with_options(
     let (feed_event_tx, mut feed_event_rx) =
         tokio::sync::mpsc::channel::<rara_kernel::data_feed::FeedEvent>(256);
     let feed_registry = Arc::new(rara_kernel::data_feed::DataFeedRegistry::new(feed_event_tx));
-    let feed_store: rara_kernel::data_feed::FeedStoreRef =
-        Arc::new(crate::feed_store::SqliteFeedStore::new(diesel_pool.clone()));
-    let feed_svc = rara_backend_admin::data_feeds::DataFeedSvc::new(diesel_pool.clone());
+    let feed_store: rara_kernel::data_feed::FeedStoreRef = Arc::new(
+        crate::feed_store::SqliteFeedStore::new(diesel_pools.clone()),
+    );
+    let feed_svc = rara_backend_admin::data_feeds::DataFeedSvc::new(diesel_pools.clone());
 
     // Install the status reporter so runtime transitions (running / idle /
     // error + last_error) persist back to the `data_feeds` table.
@@ -449,7 +450,7 @@ pub async fn start_with_options(
     // turn end) and the backend session service (which reads them for
     // the web "📊 详情" button). Create it once here so both sides see
     // the same underlying pool.
-    let trace_service = rara_kernel::trace::TraceService::new(diesel_pool.clone());
+    let trace_service = rara_kernel::trace::TraceService::new(diesel_pools.clone());
 
     let backend = rara_backend_admin::state::BackendState::init(
         rara.session_index.clone(),

--- a/crates/cmd/src/debug.rs
+++ b/crates/cmd/src/debug.rs
@@ -34,7 +34,7 @@ use rara_kernel::{
     trace::{ExecutionTrace, TraceService},
 };
 use snafu::{ResultExt, Whatever};
-use yunara_store::diesel_pool::{DieselPoolConfig, DieselSqlitePool, build_sqlite_pool};
+use yunara_store::diesel_pool::{DieselPoolConfig, DieselSqlitePools, build_sqlite_pools};
 
 #[derive(Debug, Clone, Args)]
 #[command(about = "Inspect a message by its rara_message_id")]
@@ -98,10 +98,10 @@ impl DebugCmd {
 
 /// Open the rara SQLite database in read-only mode. The CLI must not run
 /// migrations or hold a write lock — the running daemon may be active.
-async fn open_db() -> Result<DieselSqlitePool, yunara_store::error::Error> {
+async fn open_db() -> Result<DieselSqlitePools, yunara_store::error::Error> {
     let db_path = rara_paths::database_dir().join("rara.db");
     let url = format!("sqlite:{}?mode=ro", db_path.display());
-    build_sqlite_pool(
+    build_sqlite_pools(
         &DieselPoolConfig::builder()
             .database_url(url)
             .max_connections(1)

--- a/crates/common/yunara-store/AGENT.md
+++ b/crates/common/yunara-store/AGENT.md
@@ -9,21 +9,22 @@ used for runtime settings and miscellaneous persisted state.
 
 ### Key modules
 
-- `src/diesel_pool.rs` — `DieselSqlitePool` plus `build_sqlite_pool`. The sqlite pool sets `WAL`, `busy_timeout=5000`, `foreign_keys=ON` pragmas once per physical connection via the manager's `custom_setup` hook.
-- `src/config.rs` — `DatabaseConfig` with `bon::Builder`; `open(database_url)` wraps `build_sqlite_pool` and returns a `DBStore`.
-- `src/db.rs` — `DBStore` wraps `DieselSqlitePool`; provides `pool()` and `kv_store()`.
+- `src/diesel_pool.rs` — `DieselSqlitePool` (single bb8 pool), `DieselSqlitePools` (reader + writer bundle), and `build_sqlite_pools`. The reader pool is sized by `DieselPoolConfig::max_connections`; the writer pool is hard-pinned to `max_size=1` because SQLite serialises writers at the file level (#1843). Both pools set `WAL`, `busy_timeout=5000`, `foreign_keys=ON` pragmas once per physical connection via `custom_setup`, and run a best-effort `ROLLBACK` on every checkout via a `bb8::CustomizeConnection` to scrub leaked transactions.
+- `src/config.rs` — `DatabaseConfig` with `bon::Builder`; `open(database_url)` wraps `build_sqlite_pools` and returns a `DBStore`.
+- `src/db.rs` — `DBStore` wraps `DieselSqlitePools`; exposes `reader()` (concurrent SELECTs) and `writer()` (single-writer mutations) plus `kv_store()`.
 - `src/kv.rs` — `KVStore` backed by the `kv_table` SQLite table (JSON values). Full diesel DSL; `batch_set` runs inside a transaction.
 - `src/error.rs` — `snafu` error enum covering pool, diesel, and codec failures.
 
 ### Public API
 
-- `DatabaseConfig`, `DBStore`, `KVStore`, `DieselSqlitePool`.
+- `DatabaseConfig`, `DBStore`, `KVStore`, `DieselSqlitePool`, `DieselSqlitePools`.
 
 ## Critical Invariants
 
 - No hardcoded database URLs — caller supplies the URL to `DatabaseConfig::open()`.
 - The `kv_table` schema is owned by `rara-model/migrations` and must exist before `KVStore` is used.
 - Pragmas are applied on physical-connection establishment, not on every checkout — `bb8` recycles the same connection without re-setup.
+- All mutations (`INSERT`/`UPDATE`/`DELETE`/`transaction`) MUST run on the writer pool. Pure SELECTs run on the reader pool. Routing a write to the reader pool re-introduces the contention #1843 was opened to fix.
 
 ## What NOT To Do
 

--- a/crates/common/yunara-store/src/config.rs
+++ b/crates/common/yunara-store/src/config.rs
@@ -14,7 +14,7 @@
 
 use crate::{
     db::DBStore,
-    diesel_pool::{DieselPoolConfig, build_sqlite_pool},
+    diesel_pool::{DieselPoolConfig, build_sqlite_pools},
     error::Result,
 };
 
@@ -25,7 +25,7 @@ use crate::{
 /// the consuming binary via `diesel_migrations::embed_migrations!`.
 #[derive(Debug, Clone, bon::Builder, serde::Serialize, serde::Deserialize)]
 pub struct DatabaseConfig {
-    /// Maximum number of connections in the pool.
+    /// Maximum number of connections in the reader pool.
     #[serde(default = "default_max_connections")]
     #[builder(default = 5, getter)]
     pub max_connections: u32,
@@ -36,10 +36,10 @@ fn default_max_connections() -> u32 { 5 }
 impl DatabaseConfig {
     /// Open a SQLite database at the given URL.
     ///
-    /// Builds a diesel-async bb8 pool and applies the `WAL` / `busy_timeout`
-    /// / `foreign_keys` pragmas once per physical connection via the pool's
-    /// `custom_setup` hook. The caller is responsible for running
-    /// migrations afterwards.
+    /// Builds a paired diesel-async bb8 reader/writer pool and applies the
+    /// `WAL` / `busy_timeout` / `foreign_keys` pragmas once per physical
+    /// connection via the pool's `custom_setup` hook. The caller is
+    /// responsible for running migrations afterwards.
     #[tracing::instrument(
         level = "trace",
         skip(self),
@@ -47,7 +47,7 @@ impl DatabaseConfig {
         err
     )]
     pub async fn open(&self, database_url: &str) -> Result<DBStore> {
-        let pool = build_sqlite_pool(
+        let pools = build_sqlite_pools(
             &DieselPoolConfig::builder()
                 .database_url(database_url.to_owned())
                 .max_connections(self.max_connections)
@@ -57,6 +57,6 @@ impl DatabaseConfig {
 
         tracing::info!("SQLite database initialized: {database_url}");
 
-        Ok(DBStore::new(pool))
+        Ok(DBStore::new(pools))
     }
 }

--- a/crates/common/yunara-store/src/db.rs
+++ b/crates/common/yunara-store/src/db.rs
@@ -12,25 +12,34 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::{diesel_pool::DieselSqlitePool, kv::KVStore};
+use crate::{
+    diesel_pool::{DieselSqlitePool, DieselSqlitePools},
+    kv::KVStore,
+};
 
-/// Database store that owns the shared diesel-async SQLite pool.
+/// Database store that owns the shared diesel-async SQLite pools.
 #[derive(Clone)]
 pub struct DBStore {
-    pool: DieselSqlitePool,
+    pools: DieselSqlitePools,
 }
 
 impl DBStore {
-    /// Wrap an existing diesel-async SQLite pool.
-    pub fn new(pool: DieselSqlitePool) -> Self { Self { pool } }
+    /// Wrap an existing reader/writer pool bundle.
+    pub fn new(pools: DieselSqlitePools) -> Self { Self { pools } }
 
     /// Get a KV store instance.
-    pub fn kv_store(&self) -> KVStore { KVStore::new(self.pool.clone()) }
+    pub fn kv_store(&self) -> KVStore { KVStore::new(self.pools.clone()) }
 
-    /// Get the underlying diesel-async SQLite pool.
-    pub fn pool(&self) -> &DieselSqlitePool { &self.pool }
+    /// Get the underlying reader/writer pool bundle.
+    pub fn pools(&self) -> &DieselSqlitePools { &self.pools }
+
+    /// Reader pool — concurrent SELECTs.
+    pub fn reader(&self) -> &DieselSqlitePool { &self.pools.reader }
+
+    /// Writer pool — single-writer mutations.
+    pub fn writer(&self) -> &DieselSqlitePool { &self.pools.writer }
 }
 
-impl From<DBStore> for DieselSqlitePool {
-    fn from(store: DBStore) -> Self { store.pool }
+impl From<DBStore> for DieselSqlitePools {
+    fn from(store: DBStore) -> Self { store.pools }
 }

--- a/crates/common/yunara-store/src/diesel_pool.rs
+++ b/crates/common/yunara-store/src/diesel_pool.rs
@@ -17,6 +17,23 @@
 //! Introduced as part of the sqlx → diesel migration (#1702). SQLite uses
 //! [`SyncConnectionWrapper`] because SQLite itself is single-threaded and has
 //! no native async driver.
+//!
+//! ## Reader / writer split (#1843)
+//!
+//! SQLite serialises writers at the file level — even with WAL, a second
+//! writer racing the first gets `SQLITE_BUSY`. To make that contention
+//! explicit and bounded, we run two pools:
+//!
+//! - **reader**: `max_connections` connections, used for `SELECT`-only paths.
+//! - **writer**: a single connection (`max_size = 1`), used for everything that
+//!   can mutate the database (insert/update/delete, `transaction`, FTS updates,
+//!   migrations).
+//!
+//! Holding writers to a single bb8 slot pushes the queueing into the
+//! application layer where it shows up as latency rather than as opaque
+//! `database is locked` errors deep in driver code.
+
+use std::time::Duration;
 
 use diesel::SqliteConnection;
 use diesel_async::{
@@ -36,30 +53,64 @@ pub type DieselSqliteConnection = SyncConnectionWrapper<SqliteConnection>;
 /// bb8-managed diesel-async pool for SQLite.
 pub type DieselSqlitePool = ::bb8::Pool<AsyncDieselConnectionManager<DieselSqliteConnection>>;
 
+/// Reader + writer pool bundle (see module docs for the rationale).
+#[derive(Clone)]
+pub struct DieselSqlitePools {
+    /// Concurrent SELECT-only pool, sized by
+    /// `DieselPoolConfig::max_connections`.
+    pub reader: DieselSqlitePool,
+    /// Single-writer pool — only one mutation runs at a time.
+    pub writer: DieselSqlitePool,
+}
+
+impl std::fmt::Debug for DieselSqlitePools {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("DieselSqlitePools").finish_non_exhaustive()
+    }
+}
+
 /// Pool sizing and connection parameters for the diesel-async pools.
 ///
 /// Defaults are deliberately absent — this struct is populated from the YAML
 /// config (per the no-hardcoded-defaults invariant) by the caller and handed
-/// to [`build_sqlite_pool`].
+/// to [`build_sqlite_pools`].
 #[derive(Debug, Clone, bon::Builder, serde::Serialize, serde::Deserialize)]
 pub struct DieselPoolConfig {
     /// Database URL (`sqlite://…`).
     pub database_url:    String,
-    /// Maximum number of pooled connections.
+    /// Maximum number of pooled reader connections.
     pub max_connections: u32,
-    /// Minimum idle connections to keep warm (`None` means unset).
+    /// Minimum idle connections to keep warm in the reader pool (`None` means
+    /// unset).
     #[serde(default)]
     pub min_idle:        Option<u32>,
 }
 
-/// Build a bb8 pool of diesel-async SQLite connections.
+/// Build a paired reader + writer pool of diesel-async SQLite connections.
 ///
 /// Each newly-established connection has `PRAGMA journal_mode=WAL`,
 /// `PRAGMA busy_timeout=5000`, and `PRAGMA foreign_keys=ON` applied via the
 /// manager's `custom_setup` hook so pragmas are set exactly once per
-/// physical connection rather than on every checkout.
+/// physical connection rather than on every checkout. A
+/// [`bb8::CustomizeConnection`] hook then runs a best-effort `ROLLBACK` on
+/// every checkout so a connection leaked with an open transaction (from an
+/// upstream bug) is scrubbed before the next user gets it.
+///
+/// The writer pool is hard-pinned to `max_size = 1` regardless of config —
+/// SQLite serialises writers at the file level, so additional writer
+/// connections only translate into `SQLITE_BUSY` retries.
 #[tracing::instrument(level = "trace", skip(config), fields(url = %config.database_url), err)]
-pub async fn build_sqlite_pool(config: &DieselPoolConfig) -> Result<DieselSqlitePool> {
+pub async fn build_sqlite_pools(config: &DieselPoolConfig) -> Result<DieselSqlitePools> {
+    let reader = build_pool(config, config.max_connections, config.min_idle).await?;
+    let writer = build_pool(config, 1, Some(1)).await?;
+    Ok(DieselSqlitePools { reader, writer })
+}
+
+async fn build_pool(
+    config: &DieselPoolConfig,
+    max_size: u32,
+    min_idle: Option<u32>,
+) -> Result<DieselSqlitePool> {
     let mut manager_config = ManagerConfig::<DieselSqliteConnection>::default();
     manager_config.custom_setup = Box::new(|url| {
         let url = url.to_owned();
@@ -79,11 +130,49 @@ pub async fn build_sqlite_pool(config: &DieselPoolConfig) -> Result<DieselSqlite
         config.database_url.clone(),
         manager_config,
     );
-    let mut builder = ::bb8::Pool::builder().max_size(config.max_connections);
-    if let Some(min_idle) = config.min_idle {
+    let mut builder = ::bb8::Pool::builder()
+        .max_size(max_size)
+        .connection_customizer(Box::new(SqliteConnectionCustomizer));
+    if let Some(min_idle) = min_idle {
         builder = builder.min_idle(Some(min_idle));
     }
+    // Cap how long a writer caller will block waiting for the single slot.
+    // The default is 30s, which is long enough that callers (e.g. trace
+    // save) that ought to retry fail closed instead.
+    builder = builder.connection_timeout(Duration::from_secs(30));
     builder.build(manager).await.context(BuildDieselPoolSnafu)
+}
+
+/// Per-checkout connection scrubber.
+///
+/// `on_acquire` runs every time a connection is checked out. We issue a
+/// best-effort `ROLLBACK` (idempotent — if no transaction is open SQLite
+/// returns an error which we ignore) so that a connection leaked mid-tx
+/// does not poison the next user with `cannot start a transaction within a
+/// transaction`.
+#[derive(Debug)]
+struct SqliteConnectionCustomizer;
+
+impl bb8::CustomizeConnection<DieselSqliteConnection, diesel_async::pooled_connection::PoolError>
+    for SqliteConnectionCustomizer
+{
+    fn on_acquire<'a>(
+        &'a self,
+        conn: &'a mut DieselSqliteConnection,
+    ) -> std::pin::Pin<
+        Box<
+            dyn std::future::Future<
+                    Output = std::result::Result<(), diesel_async::pooled_connection::PoolError>,
+                > + Send
+                + 'a,
+        >,
+    > {
+        Box::pin(async move {
+            // Best-effort: if no tx is open this errors and we discard it.
+            let _ = diesel::sql_query("ROLLBACK").execute(conn).await;
+            Ok(())
+        })
+    }
 }
 
 /// SQLite pragmas applied to every newly-established connection. Order

--- a/crates/common/yunara-store/src/kv.rs
+++ b/crates/common/yunara-store/src/kv.rs
@@ -24,28 +24,29 @@ use tracing::info;
 use uuid::Uuid;
 
 use crate::{
-    diesel_pool::DieselSqlitePool,
+    diesel_pool::DieselSqlitePools,
     error::{CodecSnafu, DieselPoolRunSnafu, DieselSnafu, Result},
 };
 
 /// Key-value store backed by SQLite via diesel-async.
 ///
-/// All values are serialized to JSON before storage.
+/// All values are serialized to JSON before storage. Reads use the reader
+/// pool; writes go through the single-writer pool.
 #[derive(Clone)]
 pub struct KVStore {
-    pool: DieselSqlitePool,
+    pools: DieselSqlitePools,
 }
 
 impl KVStore {
-    /// Create a new KV store from a diesel-async SQLite pool.
-    pub(crate) fn new(pool: DieselSqlitePool) -> Self { Self { pool } }
+    /// Create a new KV store from a diesel-async SQLite pool bundle.
+    pub(crate) fn new(pools: DieselSqlitePools) -> Self { Self { pools } }
 
     /// Set a key-value pair.
     ///
     /// The value will be serialized to JSON before storage.
     pub async fn set<T: Serialize>(&self, key: &str, value: &T) -> Result<()> {
         let value_json = serde_json::to_string(value).context(CodecSnafu)?;
-        let mut conn = self.pool.get().await.context(DieselPoolRunSnafu)?;
+        let mut conn = self.pools.writer.get().await.context(DieselPoolRunSnafu)?;
 
         diesel::insert_into(kv_table::table)
             .values((kv_table::key.eq(key), kv_table::value.eq(&value_json)))
@@ -65,7 +66,7 @@ impl KVStore {
     pub async fn get<T: DeserializeOwned>(&self, key: &str) -> Result<Option<T>> {
         use diesel::OptionalExtension;
 
-        let mut conn = self.pool.get().await.context(DieselPoolRunSnafu)?;
+        let mut conn = self.pools.reader.get().await.context(DieselPoolRunSnafu)?;
         let row: Option<Option<String>> = kv_table::table
             .filter(kv_table::key.eq(key))
             .select(kv_table::value)
@@ -85,7 +86,7 @@ impl KVStore {
 
     /// Remove a key-value pair.
     pub async fn remove(&self, key: &str) -> Result<()> {
-        let mut conn = self.pool.get().await.context(DieselPoolRunSnafu)?;
+        let mut conn = self.pools.writer.get().await.context(DieselPoolRunSnafu)?;
         diesel::delete(kv_table::table.filter(kv_table::key.eq(key)))
             .execute(&mut *conn)
             .await
@@ -113,7 +114,7 @@ impl KVStore {
             return Ok(());
         }
 
-        let mut conn = self.pool.get().await.context(DieselPoolRunSnafu)?;
+        let mut conn = self.pools.writer.get().await.context(DieselPoolRunSnafu)?;
         use diesel_async::AsyncConnection;
         conn.transaction::<_, diesel::result::Error, _>(|tx| {
             async move {
@@ -149,7 +150,7 @@ impl KVStore {
             return Ok(HashMap::new());
         }
 
-        let mut conn = self.pool.get().await.context(DieselPoolRunSnafu)?;
+        let mut conn = self.pools.reader.get().await.context(DieselPoolRunSnafu)?;
         let rows: Vec<(String, Option<String>)> = kv_table::table
             .filter(kv_table::key.eq_any(&keys))
             .select((kv_table::key, kv_table::value))

--- a/crates/common/yunara-store/src/lib.rs
+++ b/crates/common/yunara-store/src/lib.rs
@@ -22,7 +22,7 @@ pub use config::DatabaseConfig;
 pub use db::DBStore;
 pub use diesel_pool::{
     DieselPoolConfig, DieselPoolInitError, DieselPoolRunError, DieselSqliteConnection,
-    DieselSqlitePool, build_sqlite_pool,
+    DieselSqlitePool, DieselSqlitePools, build_sqlite_pools,
 };
 pub use error::{Error, Result};
 pub use kv::KVStore;

--- a/crates/extensions/backend-admin/src/chat/service.rs
+++ b/crates/extensions/backend-admin/src/chat/service.rs
@@ -1339,7 +1339,7 @@ mod search_sessions_tests {
     async fn build_service_with_fts(
         dir: &std::path::Path,
     ) -> (SessionService, Arc<InMemorySessionIndex>) {
-        let pool = rara_kernel::testing::build_memory_diesel_pool().await;
+        let pool = rara_kernel::testing::build_memory_diesel_pools().await;
 
         let store = FileTapeStore::new(dir, dir).await.unwrap();
         let tape_service = TapeService::with_fts(store, pool.clone());

--- a/crates/extensions/backend-admin/src/data_feeds/router.rs
+++ b/crates/extensions/backend-admin/src/data_feeds/router.rs
@@ -524,7 +524,7 @@ mod tests {
         error::Result as KernelResult,
         identity::{KernelUser, Permission, Role, UserStore},
         security::{ApprovalManager, ApprovalPolicy, SecuritySubsystem},
-        testing::build_memory_diesel_pool,
+        testing::build_memory_diesel_pools,
     };
     use tower::ServiceExt;
 
@@ -573,8 +573,8 @@ mod tests {
     /// diesel pool. The non-admin Principal guard runs before any DB query,
     /// so the pool is never hit on the 403 path these tests exercise.
     async fn app_with_user(user: KernelUser) -> Router {
-        let pool = build_memory_diesel_pool().await;
-        let svc = DataFeedSvc::new(pool);
+        let pools = build_memory_diesel_pools().await;
+        let svc = DataFeedSvc::new(pools);
         let (event_tx, _event_rx) = tokio::sync::mpsc::channel(16);
         let registry = Arc::new(DataFeedRegistry::new(event_tx));
         let state = DataFeedRouterState { svc, registry };

--- a/crates/extensions/backend-admin/src/data_feeds/service.rs
+++ b/crates/extensions/backend-admin/src/data_feeds/service.rs
@@ -29,29 +29,29 @@ use rara_kernel::data_feed::{
 use rara_model::schema::{data_feed_events, data_feeds};
 use snafu::ResultExt;
 use tracing::instrument;
-use yunara_store::diesel_pool::DieselSqlitePool;
+use yunara_store::diesel_pool::DieselSqlitePools;
 
 use super::error::{DataFeedSvcError, EncodeJsonSnafu, PoolAcquireSnafu, QuerySnafu, Result};
 
 /// Service for data feed persistence operations.
 ///
-/// Holds a diesel-async SQLite pool and provides CRUD on the `data_feeds`
-/// table plus paginated queries on the `data_feed_events` table.
+/// Holds the diesel-async SQLite pool bundle and provides CRUD on the
+/// `data_feeds` table plus paginated queries on the `data_feed_events` table.
 #[derive(Clone)]
 pub struct DataFeedSvc {
-    pool: DieselSqlitePool,
+    pools: DieselSqlitePools,
 }
 
 impl DataFeedSvc {
-    /// Create a new service backed by the given pool.
-    pub fn new(pool: DieselSqlitePool) -> Self { Self { pool } }
+    /// Create a new service backed by the given pool bundle.
+    pub fn new(pools: DieselSqlitePools) -> Self { Self { pools } }
 
     // -- Feed config CRUD ---------------------------------------------------
 
     /// List all registered data feed configurations.
     #[instrument(skip_all)]
     pub async fn list_feeds(&self) -> Result<Vec<DataFeedConfig>> {
-        let mut conn = self.pool.get().await.context(PoolAcquireSnafu)?;
+        let mut conn = self.pools.reader.get().await.context(PoolAcquireSnafu)?;
         let rows: Vec<FeedRow> = data_feeds::table
             .select(FeedRow::as_select())
             .order(data_feeds::created_at.desc())
@@ -67,7 +67,7 @@ impl DataFeedSvc {
     pub async fn get_feed(&self, id: &str) -> Result<Option<DataFeedConfig>> {
         use diesel::OptionalExtension;
 
-        let mut conn = self.pool.get().await.context(PoolAcquireSnafu)?;
+        let mut conn = self.pools.reader.get().await.context(PoolAcquireSnafu)?;
         let row: Option<FeedRow> = data_feeds::table
             .filter(data_feeds::id.eq(id))
             .select(FeedRow::as_select())
@@ -91,7 +91,7 @@ impl DataFeedSvc {
             .transpose()
             .context(EncodeJsonSnafu)?;
 
-        let mut conn = self.pool.get().await.context(PoolAcquireSnafu)?;
+        let mut conn = self.pools.writer.get().await.context(PoolAcquireSnafu)?;
         diesel::insert_into(data_feeds::table)
             .values((
                 data_feeds::id.eq(&config.id),
@@ -128,7 +128,7 @@ impl DataFeedSvc {
             .context(EncodeJsonSnafu)?;
         let now = Timestamp::now().to_string();
 
-        let mut conn = self.pool.get().await.context(PoolAcquireSnafu)?;
+        let mut conn = self.pools.writer.get().await.context(PoolAcquireSnafu)?;
         let affected = diesel::update(data_feeds::table.filter(data_feeds::id.eq(&config.id)))
             .set((
                 data_feeds::name.eq(&config.name),
@@ -151,7 +151,7 @@ impl DataFeedSvc {
     /// Delete a feed by ID. Returns `true` if a row was deleted.
     #[instrument(skip(self))]
     pub async fn delete_feed(&self, id: &str) -> Result<bool> {
-        let mut conn = self.pool.get().await.context(PoolAcquireSnafu)?;
+        let mut conn = self.pools.writer.get().await.context(PoolAcquireSnafu)?;
         let affected = diesel::delete(data_feeds::table.filter(data_feeds::id.eq(id)))
             .execute(&mut *conn)
             .await
@@ -175,7 +175,7 @@ impl DataFeedSvc {
         last_error: Option<String>,
     ) -> Result<bool> {
         let now = Timestamp::now().to_string();
-        let mut conn = self.pool.get().await.context(PoolAcquireSnafu)?;
+        let mut conn = self.pools.writer.get().await.context(PoolAcquireSnafu)?;
         let affected = diesel::update(data_feeds::table.filter(data_feeds::name.eq(name)))
             .set((
                 data_feeds::status.eq(status.to_string()),
@@ -194,7 +194,7 @@ impl DataFeedSvc {
         use diesel::{dsl::sql, sql_types::Integer};
 
         let now = Timestamp::now().to_string();
-        let mut conn = self.pool.get().await.context(PoolAcquireSnafu)?;
+        let mut conn = self.pools.writer.get().await.context(PoolAcquireSnafu)?;
         // `NOT enabled` on a stored integer column has no clean DSL — we use
         // the sanctioned `sql::<Integer>` fragment per
         // docs/guides/db-diesel-migration.md.
@@ -220,7 +220,7 @@ impl DataFeedSvc {
         limit: i64,
         offset: i64,
     ) -> Result<EventPage> {
-        let mut conn = self.pool.get().await.context(PoolAcquireSnafu)?;
+        let mut conn = self.pools.reader.get().await.context(PoolAcquireSnafu)?;
 
         // Count total matching events for pagination metadata.
         let mut count_q = data_feed_events::table
@@ -269,7 +269,7 @@ impl DataFeedSvc {
     pub async fn get_event(&self, source_name: &str, event_id: &str) -> Result<Option<FeedEvent>> {
         use diesel::OptionalExtension;
 
-        let mut conn = self.pool.get().await.context(PoolAcquireSnafu)?;
+        let mut conn = self.pools.reader.get().await.context(PoolAcquireSnafu)?;
         let row: Option<EventRow> = data_feed_events::table
             .filter(data_feed_events::id.eq(event_id))
             .filter(data_feed_events::source_name.eq(source_name))

--- a/crates/extensions/backend-admin/src/settings/service.rs
+++ b/crates/extensions/backend-admin/src/settings/service.rs
@@ -24,7 +24,7 @@ use diesel_async::RunQueryDsl;
 use rara_model::schema::kv_table;
 use snafu::Whatever;
 use tokio::sync::watch;
-use yunara_store::{KVStore, diesel_pool::DieselSqlitePool};
+use yunara_store::{KVStore, diesel_pool::DieselSqlitePools};
 
 /// Internal prefix applied to all settings keys in the KV store.
 const PREFIX: &str = "settings.";
@@ -35,18 +35,18 @@ const PREFIX: &str = "settings.";
 /// [`SettingsProvider`](rara_domain_shared::settings::SettingsProvider).
 #[derive(Clone)]
 pub struct SettingsSvc {
-    kv:   KVStore,
-    pool: DieselSqlitePool,
-    tx:   Arc<watch::Sender<()>>,
+    kv:    KVStore,
+    pools: DieselSqlitePools,
+    tx:    Arc<watch::Sender<()>>,
 }
 
 impl SettingsSvc {
     /// Load settings from the flat KV store.
-    pub async fn load(kv: KVStore, pool: DieselSqlitePool) -> Result<Self, Whatever> {
+    pub async fn load(kv: KVStore, pools: DieselSqlitePools) -> Result<Self, Whatever> {
         let (tx, _rx) = watch::channel(());
         Ok(Self {
             kv,
-            pool,
+            pools,
             tx: Arc::new(tx),
         })
     }
@@ -85,7 +85,7 @@ impl rara_domain_shared::settings::SettingsProvider for SettingsSvc {
     async fn list(&self) -> HashMap<String, String> {
         // Query all rows with the settings prefix.
         let pattern = format!("{PREFIX}%");
-        let mut conn = match self.pool.get().await {
+        let mut conn = match self.pools.reader.get().await {
             Ok(c) => c,
             Err(_) => return HashMap::new(),
         };

--- a/crates/integrations/pg-credential-store/src/lib.rs
+++ b/crates/integrations/pg-credential-store/src/lib.rs
@@ -30,7 +30,7 @@ use diesel_async::RunQueryDsl;
 use rara_keyring_store::{KeyringStore, PgSnafu, PoolSnafu, Result};
 use rara_model::schema::credential_store;
 use snafu::ResultExt;
-use yunara_store::diesel_pool::DieselSqlitePool;
+use yunara_store::diesel_pool::DieselSqlitePools;
 
 /// Row projection for the `credential_store` table.
 #[derive(Queryable, Selectable)]
@@ -42,7 +42,7 @@ struct CredentialRow {
 
 #[derive(Clone)]
 pub struct PgKeyringStore {
-    pool: DieselSqlitePool,
+    pools: DieselSqlitePools,
 }
 
 impl Debug for PgKeyringStore {
@@ -52,14 +52,14 @@ impl Debug for PgKeyringStore {
 }
 
 impl PgKeyringStore {
-    pub fn new(pool: DieselSqlitePool) -> Self { Self { pool } }
+    pub fn new(pools: DieselSqlitePools) -> Self { Self { pools } }
 }
 
 #[async_trait]
 impl KeyringStore for PgKeyringStore {
     #[tracing::instrument(skip(self), level = "debug")]
     async fn load(&self, service: &str, account: &str) -> Result<Option<String>> {
-        let mut conn = self.pool.get().await.context(PoolSnafu)?;
+        let mut conn = self.pools.reader.get().await.context(PoolSnafu)?;
         let row: Option<CredentialRow> = credential_store::table
             .filter(credential_store::service.eq(service))
             .filter(credential_store::account.eq(account))
@@ -73,7 +73,7 @@ impl KeyringStore for PgKeyringStore {
 
     #[tracing::instrument(skip(self, value), fields(value_len = value.len()), level = "debug")]
     async fn save(&self, service: &str, account: &str, value: &str) -> Result<()> {
-        let mut conn = self.pool.get().await.context(PoolSnafu)?;
+        let mut conn = self.pools.writer.get().await.context(PoolSnafu)?;
         // SQLite's `datetime('now')` is emitted via `sql::<Text>` — diesel has
         // no cross-backend DSL helper for the sqlite-specific `datetime()`
         // form. Per docs/guides/db-diesel-migration.md, narrow literal-SQL
@@ -100,7 +100,7 @@ impl KeyringStore for PgKeyringStore {
 
     #[tracing::instrument(skip(self), level = "debug")]
     async fn delete(&self, service: &str, account: &str) -> Result<bool> {
-        let mut conn = self.pool.get().await.context(PoolSnafu)?;
+        let mut conn = self.pools.writer.get().await.context(PoolSnafu)?;
         let affected = diesel::delete(
             credential_store::table
                 .filter(credential_store::service.eq(service))

--- a/crates/kernel/src/kernel.rs
+++ b/crates/kernel/src/kernel.rs
@@ -2700,7 +2700,40 @@ impl Kernel {
                 // alive at this point (we emit `TraceReady` through it just
                 // below), so ownership cannot be transferred out.
                 let trace = trace_builder.finalize(msg_id.to_string());
-                match trace_service.save(&session_key.to_string(), &trace).await {
+                // Single SQLite writer + WAL still surfaces transient
+                // `database is locked` when the busy_timeout window is
+                // exhausted under heavy contention (concurrent FTS index +
+                // knowledge insert + trace save). Retry the save with
+                // exponential backoff before giving up — silent loss of
+                // execution traces is what #1843 was opened to fix.
+                let save_result = {
+                    let backoffs = [
+                        std::time::Duration::from_millis(100),
+                        std::time::Duration::from_millis(500),
+                        std::time::Duration::from_secs(2),
+                    ];
+                    let mut attempt: Result<String, crate::error::KernelError> =
+                        trace_service.save(&session_key.to_string(), &trace).await;
+                    for delay in backoffs {
+                        match &attempt {
+                            Ok(_) => break,
+                            Err(e) if is_database_locked(e) => {
+                                tracing::debug!(
+                                    session_key = %session_key,
+                                    delay_ms = delay.as_millis() as u64,
+                                    "trace save hit SQLITE_BUSY — retrying",
+                                );
+                                tokio::time::sleep(delay).await;
+                                attempt = trace_service
+                                    .save(&session_key.to_string(), &trace)
+                                    .await;
+                            }
+                            Err(_) => break,
+                        }
+                    }
+                    attempt
+                };
+                match save_result {
                     Ok(trace_id) => {
                         stream_handle
                             .emit(crate::io::StreamEvent::TraceReady { trace_id });
@@ -3136,7 +3169,7 @@ impl Kernel {
                     &entries,
                     &user_id,
                     &tape_name,
-                    &knowledge.pool,
+                    &knowledge.pools,
                     &knowledge.embedding_svc,
                     &resolved,
                     knowledge.config.similarity_threshold,
@@ -3608,6 +3641,25 @@ fn acquire_parent_child_permit(
         .map_err(|_| KernelError::SpawnLimitReached {
             message: format!("parent session {parent_id} reached its child concurrency limit"),
         })
+}
+
+/// Walk a `KernelError`'s source chain looking for a SQLite "database is
+/// locked" string. We can't match on `diesel::result::Error::DatabaseError`
+/// directly because the error has already been wrapped in `KernelError`
+/// by the time it surfaces here, so a string match against the chain is
+/// the only stable option.
+fn is_database_locked(err: &KernelError) -> bool {
+    let mut current: Option<&dyn std::error::Error> = Some(err);
+    while let Some(e) = current {
+        if e.to_string()
+            .to_ascii_lowercase()
+            .contains("database is locked")
+        {
+            return true;
+        }
+        current = e.source();
+    }
+    false
 }
 
 #[cfg(test)]

--- a/crates/kernel/src/memory/fts/mod.rs
+++ b/crates/kernel/src/memory/fts/mod.rs
@@ -10,15 +10,15 @@
 mod repo;
 mod tokenizer;
 
-use diesel_async::RunQueryDsl;
+use diesel_async::{AsyncConnection, RunQueryDsl, scoped_futures::ScopedFutureExt};
 use serde_json::Value;
 use snafu::ResultExt;
 pub(crate) use tokenizer::warmup as warmup_tokenizer;
 use tracing::{debug, warn};
-use yunara_store::diesel_pool::DieselSqlitePool;
+use yunara_store::diesel_pool::DieselSqlitePools;
 
 use super::{TapEntry, TapEntryKind};
-use crate::error::{DieselPoolSnafu, Result};
+use crate::error::{DieselPoolSnafu, DieselSnafu, Result};
 
 /// A hit returned by [`TapeFts::search`].
 #[derive(Debug, Clone)]
@@ -38,15 +38,15 @@ pub(crate) struct FtsHit {
 /// search when FTS returns an error.
 #[derive(Debug, Clone)]
 pub(crate) struct TapeFts {
-    pool: DieselSqlitePool,
+    pools: DieselSqlitePools,
 }
 
 impl TapeFts {
-    /// Create a new FTS handle using the shared pool.
+    /// Create a new FTS handle using the shared pool bundle.
     ///
-    /// The pool must already have the `tape_fts` virtual table (created by
-    /// the `tape_fts_init` migration).
-    pub(crate) fn new(pool: DieselSqlitePool) -> Self { Self { pool } }
+    /// The database must already have the `tape_fts` virtual table (created
+    /// by the `tape_fts_init` migration).
+    pub(crate) fn new(pools: DieselSqlitePools) -> Self { Self { pools } }
 
     /// Index a batch of tape entries into FTS5.
     ///
@@ -58,7 +58,7 @@ impl TapeFts {
         session_key: &str,
         entries: &[TapEntry],
     ) -> Result<usize> {
-        let mut conn = self.pool.get().await.context(DieselPoolSnafu)?;
+        let mut conn = self.pools.writer.get().await.context(DieselPoolSnafu)?;
         let hwm = repo::get_hwm(&mut conn, tape_name).await.unwrap_or(0) as u64;
 
         let new_entries: Vec<_> = entries.iter().filter(|e| e.id > hwm).collect();
@@ -95,31 +95,59 @@ impl TapeFts {
             message: format!("fts segment task join failed: {e}"),
         })?;
 
-        // Emit inserts + HWM update as a single atomic FTS update. Diesel's
-        // `sql_query` approach keeps us flexible even though the virtual
-        // table is outside the DSL.
-        diesel::sql_query("BEGIN")
-            .execute(&mut *conn)
+        // Emit inserts + HWM update as a single atomic FTS update via
+        // diesel-async's `transaction` so any error inside automatically
+        // rolls back. The previous manual `BEGIN`/`COMMIT` pair leaked the
+        // open transaction back to the pool whenever an inner step
+        // returned `Err`, which produced "cannot start a transaction
+        // within a transaction" on the next checkout (#1843).
+        let count = conn
+            .transaction::<_, diesel::result::Error, _>(|conn| {
+                let tape_name = tape_name.to_owned();
+                let session_key = session_key.to_owned();
+                let segmented = segmented.clone();
+                async move {
+                    use diesel::{
+                        ExpressionMethods,
+                        sql_types::{BigInt, Text},
+                        upsert::excluded,
+                    };
+                    use rara_model::schema::tape_fts_meta;
+
+                    let mut count = 0usize;
+                    for (entry_id, kind_str, content) in &segmented {
+                        diesel::sql_query(
+                            "INSERT INTO tape_fts (content, tape_name, entry_kind, entry_id, \
+                             session_key) VALUES (?, ?, ?, ?, ?)",
+                        )
+                        .bind::<Text, _>(content)
+                        .bind::<Text, _>(&tape_name)
+                        .bind::<Text, _>(kind_str)
+                        .bind::<BigInt, _>(*entry_id as i64)
+                        .bind::<Text, _>(&session_key)
+                        .execute(&mut *conn)
+                        .await?;
+                        count += 1;
+                    }
+                    diesel::insert_into(tape_fts_meta::table)
+                        .values((
+                            tape_fts_meta::tape_name.eq(&tape_name),
+                            tape_fts_meta::last_indexed_id.eq(max_id as i32),
+                        ))
+                        .on_conflict(tape_fts_meta::tape_name)
+                        .do_update()
+                        .set(
+                            tape_fts_meta::last_indexed_id
+                                .eq(excluded(tape_fts_meta::last_indexed_id)),
+                        )
+                        .execute(conn)
+                        .await?;
+                    Ok(count)
+                }
+                .scope_boxed()
+            })
             .await
-            .context(crate::error::DieselSnafu)?;
-        let mut count = 0usize;
-        for (entry_id, kind_str, content) in &segmented {
-            repo::insert(
-                &mut conn,
-                content,
-                tape_name,
-                kind_str,
-                *entry_id as i64,
-                session_key,
-            )
-            .await?;
-            count += 1;
-        }
-        repo::upsert_hwm(&mut conn, tape_name, max_id as i64).await?;
-        diesel::sql_query("COMMIT")
-            .execute(&mut *conn)
-            .await
-            .context(crate::error::DieselSnafu)?;
+            .context(DieselSnafu)?;
 
         debug!(tape_name, count, max_id, "FTS indexed entries");
         Ok(count)
@@ -140,7 +168,7 @@ impl TapeFts {
             return Ok(Vec::new());
         }
 
-        let mut conn = self.pool.get().await.context(DieselPoolSnafu)?;
+        let mut conn = self.pools.reader.get().await.context(DieselPoolSnafu)?;
         let rows = repo::search(&mut conn, &fts_query, tape_filter, limit as i64).await?;
 
         Ok(rows
@@ -155,13 +183,13 @@ impl TapeFts {
 
     /// Return the high-water mark (last indexed entry ID) for a tape.
     pub(crate) async fn last_indexed_id(&self, tape_name: &str) -> Result<u64> {
-        let mut conn = self.pool.get().await.context(DieselPoolSnafu)?;
+        let mut conn = self.pools.reader.get().await.context(DieselPoolSnafu)?;
         Ok(repo::get_hwm(&mut conn, tape_name).await? as u64)
     }
 
     /// Remove all FTS entries for a tape (used on reset/archive/delete).
     pub(crate) async fn remove_tape(&self, tape_name: &str) -> Result<()> {
-        let mut conn = self.pool.get().await.context(DieselPoolSnafu)?;
+        let mut conn = self.pools.writer.get().await.context(DieselPoolSnafu)?;
         repo::delete_by_tape(&mut conn, tape_name).await?;
         debug!(tape_name, "FTS entries removed");
         Ok(())
@@ -169,7 +197,7 @@ impl TapeFts {
 
     /// Delete all FTS data (full reset).
     pub(crate) async fn clear_all(&self) -> Result<()> {
-        let mut conn = self.pool.get().await.context(DieselPoolSnafu)?;
+        let mut conn = self.pools.writer.get().await.context(DieselPoolSnafu)?;
         repo::delete_all(&mut conn).await?;
         warn!("FTS index cleared — will rebuild on next access");
         Ok(())
@@ -359,7 +387,7 @@ mod tests {
     }
 
     /// Helper: create an in-memory pool with the FTS schema.
-    async fn test_pool() -> DieselSqlitePool { crate::testing::build_memory_diesel_pool().await }
+    async fn test_pool() -> DieselSqlitePools { crate::testing::build_memory_diesel_pools().await }
 
     #[tokio::test]
     async fn roundtrip_index_and_search() {

--- a/crates/kernel/src/memory/knowledge/extractor.rs
+++ b/crates/kernel/src/memory/knowledge/extractor.rs
@@ -23,7 +23,7 @@
 use serde::{Deserialize, Serialize};
 use snafu::prelude::*;
 use tracing::{info, warn};
-use yunara_store::diesel_pool::DieselSqlitePool;
+use yunara_store::diesel_pool::DieselSqlitePools;
 
 use super::{
     categories,
@@ -87,7 +87,7 @@ pub async fn extract_knowledge(
     entries: &[TapEntry],
     username: &str,
     tape_name: &str,
-    pool: &DieselSqlitePool,
+    pools: &DieselSqlitePools,
     embedding_svc: &EmbeddingService,
     agent: &ResolvedAgent,
     similarity_threshold: f32,
@@ -148,7 +148,7 @@ pub async fn extract_knowledge(
             embedding:       Some(blob),
         };
 
-        let row_id = items::insert_item(pool, &new_item)
+        let row_id = items::insert_item(&pools.writer, &new_item)
             .await
             .context(DatabaseSnafu)?;
         embedding_svc
@@ -168,7 +168,7 @@ pub async fn extract_knowledge(
     }
 
     // Step 5: Update category files.
-    update_category_files(driver, extractor_model, username, pool).await?;
+    update_category_files(driver, extractor_model, username, pools).await?;
 
     info!(username, new_count, "knowledge extraction complete");
     Ok(new_count)
@@ -250,9 +250,9 @@ async fn update_category_files(
     driver: &dyn LlmDriver,
     model: &str,
     username: &str,
-    pool: &DieselSqlitePool,
+    pools: &DieselSqlitePools,
 ) -> Result<()> {
-    let all_items = items::list_items_by_username(pool, username)
+    let all_items = items::list_items_by_username(&pools.reader, username)
         .await
         .context(DatabaseSnafu)?;
     if all_items.is_empty() {

--- a/crates/kernel/src/memory/knowledge/service.rs
+++ b/crates/kernel/src/memory/knowledge/service.rs
@@ -16,7 +16,7 @@
 
 use std::sync::Arc;
 
-use yunara_store::diesel_pool::DieselSqlitePool;
+use yunara_store::diesel_pool::DieselSqlitePools;
 
 use super::{EmbeddingService, KnowledgeConfig};
 
@@ -29,7 +29,7 @@ use super::{EmbeddingService, KnowledgeConfig};
 /// keyed by the `knowledge_extractor` manifest, so a single atomic snapshot
 /// reaches `extract_knowledge`. See #1636 / #1638.
 pub struct KnowledgeService {
-    pub pool:          DieselSqlitePool,
+    pub pools:         DieselSqlitePools,
     pub embedding_svc: Arc<EmbeddingService>,
     pub config:        KnowledgeConfig,
 }

--- a/crates/kernel/src/memory/knowledge/tool.rs
+++ b/crates/kernel/src/memory/knowledge/tool.rs
@@ -26,7 +26,7 @@ use rara_tool_macro::ToolDef;
 use schemars::JsonSchema;
 use serde::Deserialize;
 use serde_json::{Value, json};
-use yunara_store::diesel_pool::DieselSqlitePool;
+use yunara_store::diesel_pool::DieselSqlitePools;
 
 use super::{categories, embedding::EmbeddingService, items};
 use crate::tool::{ToolContext, ToolExecute};
@@ -40,16 +40,16 @@ use crate::tool::{ToolContext, ToolExecute};
     tier = "deferred"
 )]
 pub struct MemoryTool {
-    pool:          DieselSqlitePool,
+    pools:         DieselSqlitePools,
     embedding_svc: Arc<EmbeddingService>,
 }
 
 impl MemoryTool {
-    /// Create a new `MemoryTool` with the given database pool and embedding
+    /// Create a new `MemoryTool` with the given pool bundle and embedding
     /// service.
-    pub fn new(pool: DieselSqlitePool, embedding_svc: Arc<EmbeddingService>) -> Self {
+    pub fn new(pools: DieselSqlitePools, embedding_svc: Arc<EmbeddingService>) -> Self {
         Self {
-            pool,
+            pools,
             embedding_svc,
         }
     }
@@ -109,7 +109,7 @@ impl MemoryTool {
 
         // Fetch matching items from SQLite.
         let ids: Vec<i64> = results.iter().map(|(key, _)| *key as i64).collect();
-        let mut matched_items = items::get_items_by_ids(&self.pool, &ids).await?;
+        let mut matched_items = items::get_items_by_ids(&self.pools.reader, &ids).await?;
 
         // Filter by username.
         matched_items.retain(|item| item.username == username);

--- a/crates/kernel/src/memory/service.rs
+++ b/crates/kernel/src/memory/service.rs
@@ -118,14 +118,14 @@ impl TapeService {
     /// Create a service with FTS5 full-text search support.
     pub fn with_fts(
         store: FileTapeStore,
-        pool: yunara_store::diesel_pool::DieselSqlitePool,
+        pools: yunara_store::diesel_pool::DieselSqlitePools,
     ) -> Self {
         // Preload the jieba dictionary off the hot path. `warmup` is
         // idempotent — repeated `with_fts` calls do not leak threads.
         super::fts::warmup_tokenizer();
         Self {
             store,
-            fts: Some(super::fts::TapeFts::new(pool)),
+            fts: Some(super::fts::TapeFts::new(pools)),
         }
     }
 
@@ -1989,9 +1989,9 @@ mod tests {
 
     /// Create a [`TapeService`] with FTS enabled via an in-memory SQLite pool.
     async fn temp_tape_service_with_fts(dir: &Path) -> TapeService {
-        let pool = crate::testing::build_memory_diesel_pool().await;
+        let pools = crate::testing::build_memory_diesel_pools().await;
         let store = super::super::FileTapeStore::new(dir, dir).await.unwrap();
-        TapeService::with_fts(store, pool)
+        TapeService::with_fts(store, pools)
     }
 
     #[tokio::test]

--- a/crates/kernel/src/testing.rs
+++ b/crates/kernel/src/testing.rs
@@ -26,7 +26,7 @@ use std::{
 
 use async_trait::async_trait;
 use tokio_util::sync::CancellationToken;
-use yunara_store::diesel_pool::{DieselPoolConfig, DieselSqlitePool, build_sqlite_pool};
+use yunara_store::diesel_pool::{DieselPoolConfig, DieselSqlitePools, build_sqlite_pools};
 
 use crate::{
     agent::{AgentManifest, AgentRegistry, AgentRole, ManifestLoader},
@@ -51,10 +51,10 @@ use crate::{
 /// see the same database — shared in-memory SQLite across connections
 /// requires URI filename tricks we don't need here. A temp file is deleted
 /// when the pool drops in practice (OS cleanup on test process exit).
-pub async fn build_memory_diesel_pool() -> DieselSqlitePool {
+pub async fn build_memory_diesel_pools() -> DieselSqlitePools {
     use diesel_async::RunQueryDsl as _;
     let db_path = std::env::temp_dir().join(format!("rara-test-{}.sqlite", uuid::Uuid::new_v4()));
-    let pool = build_sqlite_pool(
+    let pools = build_sqlite_pools(
         &DieselPoolConfig::builder()
             .database_url(db_path.to_string_lossy().into_owned())
             .max_connections(1)
@@ -62,7 +62,7 @@ pub async fn build_memory_diesel_pool() -> DieselSqlitePool {
     )
     .await
     .expect("in-memory diesel pool");
-    let mut conn = pool.get().await.expect("pool conn");
+    let mut conn = pools.writer.get().await.expect("pool conn");
     for ddl in MEMORY_TEST_SCHEMA {
         diesel::sql_query(*ddl)
             .execute(&mut *conn)
@@ -70,7 +70,7 @@ pub async fn build_memory_diesel_pool() -> DieselSqlitePool {
             .expect("bootstrap schema");
     }
     drop(conn);
-    pool
+    pools
 }
 
 /// DDL the in-memory test pool installs on boot. Mirrors the production
@@ -209,7 +209,7 @@ impl crate::io::IdentityResolver for StubIdentityResolver {
 /// Build a minimal knowledge service backed by in-memory SQLite and a noop
 /// embedder.
 async fn stub_knowledge_service() -> crate::memory::knowledge::KnowledgeServiceRef {
-    let pool = build_memory_diesel_pool().await;
+    let pool = build_memory_diesel_pools().await;
 
     let config = crate::memory::knowledge::KnowledgeConfig::builder()
         .embedding_dimensions(64_usize)
@@ -230,7 +230,7 @@ async fn stub_knowledge_service() -> crate::memory::knowledge::KnowledgeServiceR
     .expect("noop embedding service");
 
     Arc::new(crate::memory::knowledge::KnowledgeService {
-        pool,
+        pools: pool,
         embedding_svc: Arc::new(embedding_svc),
         config,
     })
@@ -434,7 +434,7 @@ impl TestKernelBuilder {
         let knowledge = stub_knowledge_service().await;
 
         // Trace service (in-memory diesel SQLite)
-        let trace_pool = build_memory_diesel_pool().await;
+        let trace_pool = build_memory_diesel_pools().await;
         let trace_service = crate::trace::TraceService::new(trace_pool);
 
         // Skills prompt (empty)

--- a/crates/kernel/src/trace/mod.rs
+++ b/crates/kernel/src/trace/mod.rs
@@ -40,7 +40,7 @@ use diesel::{
 use diesel_async::RunQueryDsl;
 use rara_model::schema::execution_traces;
 use snafu::ResultExt;
-use yunara_store::diesel_pool::DieselSqlitePool;
+use yunara_store::diesel_pool::DieselSqlitePools;
 
 use crate::error::{DieselPoolSnafu, DieselSnafu, JsonSnafu, Result};
 
@@ -115,14 +115,14 @@ struct TraceSessionAndDataRow {
 /// Traces older than 30 days are automatically cleaned up every 100 saves.
 #[derive(Debug, Clone)]
 pub struct TraceService {
-    pool:       DieselSqlitePool,
+    pools:      DieselSqlitePools,
     save_count: Arc<AtomicU32>,
 }
 
 impl TraceService {
-    pub fn new(pool: DieselSqlitePool) -> Self {
+    pub fn new(pools: DieselSqlitePools) -> Self {
         Self {
-            pool,
+            pools,
             save_count: Arc::new(AtomicU32::new(0)),
         }
     }
@@ -133,7 +133,7 @@ impl TraceService {
         let id = ulid::Ulid::new().to_string();
         let trace_data = serde_json::to_string(trace).context(JsonSnafu)?;
 
-        let mut conn = self.pool.get().await.context(DieselPoolSnafu)?;
+        let mut conn = self.pools.writer.get().await.context(DieselPoolSnafu)?;
         diesel::insert_into(execution_traces::table)
             .values((
                 execution_traces::id.eq(&id),
@@ -146,10 +146,10 @@ impl TraceService {
 
         // Periodically clean up old traces.
         if self.save_count.fetch_add(1, Ordering::Relaxed) % CLEANUP_INTERVAL == 0 {
-            let pool = self.pool.clone();
+            let writer = self.pools.writer.clone();
             tokio::spawn(async move {
                 let cutoff = format!("-{TRACE_RETENTION_DAYS} days");
-                let mut conn = match pool.get().await {
+                let mut conn = match writer.get().await {
                     Ok(c) => c,
                     Err(e) => {
                         tracing::warn!(error = %e, "failed to acquire diesel conn for trace cleanup");
@@ -181,7 +181,7 @@ impl TraceService {
     pub async fn get(&self, id: &str) -> Result<Option<ExecutionTrace>> {
         use diesel::OptionalExtension;
 
-        let mut conn = self.pool.get().await.context(DieselPoolSnafu)?;
+        let mut conn = self.pools.reader.get().await.context(DieselPoolSnafu)?;
         let row: Option<TraceDataRow> = execution_traces::table
             .filter(execution_traces::id.eq(id))
             .select(TraceDataRow::as_select())
@@ -204,7 +204,7 @@ impl TraceService {
     pub async fn get_session_id(&self, id: &str) -> Result<Option<String>> {
         use diesel::OptionalExtension;
 
-        let mut conn = self.pool.get().await.context(DieselPoolSnafu)?;
+        let mut conn = self.pools.reader.get().await.context(DieselPoolSnafu)?;
         let row: Option<TraceSessionRow> = execution_traces::table
             .filter(execution_traces::id.eq(id))
             .select(TraceSessionRow::as_select())
@@ -229,7 +229,7 @@ impl TraceService {
     ) -> Result<Option<(String, ExecutionTrace)>> {
         use diesel::OptionalExtension;
 
-        let mut conn = self.pool.get().await.context(DieselPoolSnafu)?;
+        let mut conn = self.pools.reader.get().await.context(DieselPoolSnafu)?;
 
         // `json_extract(trace_data, '$.rara_message_id') = ?` has no DSL
         // analogue — diesel lacks a cross-backend JSON1 helper. Emit the
@@ -261,7 +261,7 @@ impl TraceService {
     /// removed.
     #[tracing::instrument(skip_all)]
     pub async fn cleanup(&self, retention_days: u32) -> Result<u64> {
-        let mut conn = self.pool.get().await.context(DieselPoolSnafu)?;
+        let mut conn = self.pools.writer.get().await.context(DieselPoolSnafu)?;
         let cutoff = format!("-{retention_days} days");
         let cutoff_expr = diesel::dsl::sql::<Text>("datetime('now', ")
             .bind::<Text, _>(cutoff)

--- a/crates/skills/src/cache.rs
+++ b/crates/skills/src/cache.rs
@@ -27,7 +27,7 @@ use diesel::{
 use diesel_async::RunQueryDsl;
 use rara_model::schema::skill_cache;
 use snafu::ResultExt;
-use yunara_store::diesel_pool::DieselSqlitePool;
+use yunara_store::diesel_pool::DieselSqlitePools;
 
 use crate::{
     error::{DieselPoolSnafu, DieselSnafu, InvalidInputSnafu, Result},
@@ -62,7 +62,7 @@ pub(crate) struct SkillCacheRow {
 
 /// SQLite-backed skill cache (backing store, not a SkillRegistry).
 pub struct SqliteSkillCache {
-    pool: DieselSqlitePool,
+    pools: DieselSqlitePools,
 }
 
 /// Cached skill with hash for change detection.
@@ -73,11 +73,11 @@ pub struct CachedSkill {
 }
 
 impl SqliteSkillCache {
-    pub fn new(pool: DieselSqlitePool) -> Self { Self { pool } }
+    pub fn new(pools: DieselSqlitePools) -> Self { Self { pools } }
 
     /// Load all cached skill metadata from the database.
     pub async fn load_all(&self) -> Result<HashMap<String, CachedSkill>> {
-        let mut conn = self.pool.get().await.context(DieselPoolSnafu)?;
+        let mut conn = self.pools.reader.get().await.context(DieselPoolSnafu)?;
         let rows: Vec<SkillCacheRow> = skill_cache::table
             .select(SkillCacheRow::as_select())
             .order(skill_cache::name.asc())
@@ -117,7 +117,7 @@ impl SqliteSkillCache {
         // docs/guides/db-diesel-migration.md.
         let now_expr = diesel::dsl::sql::<Text>("datetime('now')");
 
-        let mut conn = self.pool.get().await.context(DieselPoolSnafu)?;
+        let mut conn = self.pools.writer.get().await.context(DieselPoolSnafu)?;
         diesel::insert_into(skill_cache::table)
             .values((
                 skill_cache::name.eq(&meta.name),
@@ -157,7 +157,7 @@ impl SqliteSkillCache {
 
     /// Remove a skill from the cache by name.
     pub async fn remove(&self, name: &str) -> Result<()> {
-        let mut conn = self.pool.get().await.context(DieselPoolSnafu)?;
+        let mut conn = self.pools.writer.get().await.context(DieselPoolSnafu)?;
         diesel::delete(skill_cache::table.filter(skill_cache::name.eq(name)))
             .execute(&mut *conn)
             .await
@@ -167,7 +167,7 @@ impl SqliteSkillCache {
 
     /// Remove all skills from the cache.
     pub async fn clear(&self) -> Result<()> {
-        let mut conn = self.pool.get().await.context(DieselPoolSnafu)?;
+        let mut conn = self.pools.writer.get().await.context(DieselPoolSnafu)?;
         diesel::delete(skill_cache::table)
             .execute(&mut *conn)
             .await
@@ -184,7 +184,10 @@ impl SqliteSkillCache {
 /// 1. **Phase 1** — load cached metadata from DB → fill registry (fast).
 /// 2. **Phase 2** — FS scan + SHA-256 hash comparison → upsert changed skills.
 /// 3. **Phase 3** — garbage-collect stale cache entries no longer on disk.
-pub fn spawn_background_sync(pool: DieselSqlitePool, registry: crate::registry::InMemoryRegistry) {
+pub fn spawn_background_sync(
+    pools: DieselSqlitePools,
+    registry: crate::registry::InMemoryRegistry,
+) {
     use std::collections::HashSet;
 
     use tracing::{info, warn};
@@ -192,7 +195,7 @@ pub fn spawn_background_sync(pool: DieselSqlitePool, registry: crate::registry::
     use crate::discover::{FsSkillDiscoverer, SkillDiscoverer};
 
     tokio::spawn(async move {
-        let cache = SqliteSkillCache::new(pool);
+        let cache = SqliteSkillCache::new(pools);
         let discoverer = FsSkillDiscoverer::new(FsSkillDiscoverer::default_paths());
 
         // Phase 1: load from SQLite cache (fast startup)

--- a/docs/guides/debug.md
+++ b/docs/guides/debug.md
@@ -85,13 +85,16 @@ Before restarting, **confirm with the user** — other people may be using the i
 
 ## Database & config on the remote
 
-- Config: `/Users/rara/.config/rara/config.yaml` (read-only from your side — propose YAML changes as a PR against `config.example.yaml`)
-- DB: `/Users/rara/.config/rara/rara.db` (SQLite)
+Paths are resolved via `rara_paths` — on macOS that means `dirs::config_dir()`
++ `dirs::data_local_dir()`, which both land under `Library/Application Support`.
+
+- Config: `/Users/rara/Library/Application Support/rara/config.yaml` (read-only from your side — propose YAML changes as a PR against `config.example.yaml`)
+- DB: `/Users/rara/Library/Application Support/rara/db/rara.db` (SQLite, with `-wal` / `-shm` siblings while open)
 
 Inspect DB without copying it off:
 
 ```bash
-ssh local-rara 'sqlite3 /Users/rara/.config/rara/rara.db "<query>"'
+ssh local-rara 'sqlite3 "/Users/rara/Library/Application Support/rara/db/rara.db" "<query>"'
 ```
 
 Do NOT run migrations or schema-mutating SQL on the remote manually — migrations live in `crates/rara-model/migrations/` and apply on boot.


### PR DESCRIPTION
## Summary

Five fixes that together eliminate the silent execution-trace loss observed under concurrent FTS index + knowledge insert + trace save (#1843).

- **A.** `TapeFts::index_entries` now wraps inserts + HWM update in `conn.transaction(|c| ...)` instead of manual `BEGIN`/`COMMIT`, so any inner error rolls back automatically and the connection is never returned to the pool with an open tx.
- **B.** `yunara-store` now exposes `DieselSqlitePools { reader, writer }`. Reader is sized by `DieselPoolConfig::max_connections`; writer is hard-pinned to `max_size=1`. All mutating call-sites (FTS, trace, skills cache, knowledge, kv batch_set, settings, data_feeds, pg-credential-store, feed_store) now use `pools.writer`; SELECT-only paths use `pools.reader`. SQLite writer queueing is now explicit and bounded in the application instead of surfacing as opaque `SQLITE_BUSY`.
- **C.** A `bb8::CustomizeConnection` impl runs a best-effort `ROLLBACK` on every `on_acquire` so a leaked transaction (from any future bug) cannot poison the next user.
- **D.** Trace save in `kernel.rs` now retries on `database is locked` (100ms → 500ms → 2s) before falling through to `warn!`, so transient `SQLITE_BUSY` no longer drops traces.
- **E.** `docs/guides/debug.md` DB + config paths corrected to match the actual `rara_paths` resolution on macOS (`/Users/rara/Library/Application Support/rara/...`).

## Type of change

| Type | Label |
|------|-------|
| Bug fix | `bug` |

## Component

`core`

## Closes

Closes #1843

## Test plan

- [x] `cargo check --all --all-targets` passes
- [x] `cargo +nightly fmt --all -- --check` passes
- [x] `cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings` passes
- [x] `RUSTDOCFLAGS=-D warnings cargo +nightly doc --workspace --no-deps --document-private-items` passes
- [x] `cargo test --workspace` passes (1097 tests, 14 ignored)
- [x] `prek run --all-files` passes