### PR TITLE
fix(web): force hide streaming tool-call cards over inline style (#1846)

### DIFF
--- a/web/src/index.css
+++ b/web/src/index.css
@@ -391,11 +391,15 @@
  * once the turn settles — visually jarring and redundant since the
  * `AgentLiveCard` above already summarises in-flight tool activity.
  *
+ * `!important` is required because pi-web-ui's `<tool-message>` sets
+ * `this.style.display = "block"` in `connectedCallback`, and inline styles
+ * beat any class-selector rule no matter how specific.
+ *
  * Only the streaming variant is suppressed; the historical messageRenderer
  * already passes `hideToolCalls=true`, so this is a no-op there.
  */
 .rara-chat streaming-message-container tool-message {
-  display: none;
+  display: none !important;
 }
 
 /*


### PR DESCRIPTION
## Summary

Follow-up to #1841. The previous rule `.rara-chat streaming-message-container tool-message { display: none }` did not actually hide the cards because pi-web-ui's `<tool-message>` element sets `this.style.display = "block"` in `connectedCallback` (`Messages.js:220`), and inline styles trump class-selector rules regardless of specificity.

Add `!important` so the streaming-only hide actually applies. Heavy "Tool Call" / "Running command..." cards now stay hidden during streaming; the AgentLiveCard remains the single source of truth for in-flight state.

## Type of change

| Type | Label |
|------|-------|
| Bug fix | `bug` |

## Component

`ui`

## Closes

Closes #1846

## Test plan

- [x] Streaming turn no longer shows stacked tool-call cards (verified the inline-style root cause via pi-web-ui source)
- [x] Historical messages unaffected (rule is scoped to `streaming-message-container`)