### PR TITLE
fix(web): auto-dismiss live card after turn completes (#1848)

### DIFF
--- a/web/src/components/agent-live/SingleAgentLiveCard.tsx
+++ b/web/src/components/agent-live/SingleAgentLiveCard.tsx
@@ -17,7 +17,7 @@
 import { AlertCircle, Bot, CheckCircle2, ChevronDown, Maximize2, Square } from 'lucide-react';
 import { useEffect, useMemo, useRef, useState, type KeyboardEvent } from 'react';
 
-import type { LiveRun } from './live-run-store';
+import { AUTO_DISMISS_MS, type LiveRun } from './live-run-store';
 import { formatDuration } from './time-format';
 import { ToolChip, buildToolChips } from './tool-chips';
 
@@ -32,6 +32,12 @@ interface Props {
   onStop?: () => void;
 }
 
+// Window of the auto-dismiss interval reserved for the fade-out
+// animation. The store retires the run at AUTO_DISMISS_MS; we begin
+// fading the card opacity FADE_OUT_MS earlier so the unmount lines up
+// with opacity reaching zero.
+const FADE_OUT_MS = 300;
+
 /** Folded header + collapsible timeline for a single active run. */
 export function SingleAgentLiveCard({ run, agentName = 'rara', onOpenTranscript, onStop }: Props) {
   const [expanded, setExpanded] = useState(true);
@@ -39,6 +45,24 @@ export function SingleAgentLiveCard({ run, agentName = 'rara', onOpenTranscript,
   const scrollerRef = useRef<HTMLDivElement>(null);
   const [stickToBottom, setStickToBottom] = useState(true);
   const [showLatest, setShowLatest] = useState(false);
+  const [fading, setFading] = useState(false);
+
+  // Trigger the fade-out shortly before the store retires the run. Reset
+  // when a new run takes the active slot (different runId) or when the
+  // run flips back to running (defensive — should not happen today).
+  useEffect(() => {
+    if (run.status === 'running') {
+      setFading(false);
+      return;
+    }
+    const elapsedSinceEnd = run.endedAt ? Date.now() - run.endedAt : 0;
+    const fadeAt = Math.max(0, AUTO_DISMISS_MS - FADE_OUT_MS - elapsedSinceEnd);
+    const id = window.setTimeout(() => setFading(true), fadeAt);
+    return () => {
+      window.clearTimeout(id);
+      setFading(false);
+    };
+  }, [run.runId, run.status, run.endedAt]);
 
   // 1 Hz tick while the run is live so the elapsed chip updates.
   useEffect(() => {
@@ -93,7 +117,12 @@ export function SingleAgentLiveCard({ run, agentName = 'rara', onOpenTranscript,
   };
 
   return (
-    <section className="overflow-hidden rounded-lg border border-border/50 bg-card/60 backdrop-blur-sm">
+    <section
+      className={cn(
+        'overflow-hidden rounded-lg border border-border/50 bg-card/60 backdrop-blur-sm transition-opacity duration-300 ease-out',
+        fading && 'opacity-0',
+      )}
+    >
       <div
         role="button"
         tabIndex={0}

--- a/web/src/components/agent-live/__tests__/live-run-store.test.ts
+++ b/web/src/components/agent-live/__tests__/live-run-store.test.ts
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-import { describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { LiveRunStore, mergeBySourceSeq, timelineKey } from '../live-run-store';
+import { AUTO_DISMISS_MS, LiveRunStore, mergeBySourceSeq, timelineKey } from '../live-run-store';
 
 import type { PublicWebEvent } from '@/adapters/rara-stream';
 import type { TimelineItem } from '@/api/kernel-types';
@@ -126,6 +126,85 @@ describe('LiveRunStore', () => {
     expect(store.snapshot(sk).active?.currentStage).toBe(
       'Waiting for LLM response (iteration 2)...',
     );
+  });
+});
+
+describe('LiveRunStore auto-dismiss', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('retires a completed run to history after AUTO_DISMISS_MS', () => {
+    const store = new LiveRunStore();
+    const sk = 'auto1';
+    store.publish(sk, startEvent);
+    store.publish(sk, { type: 'done' } satisfies PublicWebEvent);
+    expect(store.snapshot(sk).active?.status).toBe('completed');
+
+    vi.advanceTimersByTime(AUTO_DISMISS_MS - 1);
+    expect(store.snapshot(sk).active?.status).toBe('completed');
+
+    vi.advanceTimersByTime(1);
+    const slice = store.snapshot(sk);
+    expect(slice.active).toBeNull();
+    expect(slice.history).toHaveLength(1);
+    expect(slice.history[0]?.status).toBe('completed');
+  });
+
+  it('retires a failed run after the same delay', () => {
+    const store = new LiveRunStore();
+    const sk = 'auto2';
+    store.publish(sk, startEvent);
+    store.publish(sk, { type: 'error', message: 'boom' } satisfies PublicWebEvent);
+    expect(store.snapshot(sk).active?.status).toBe('failed');
+
+    vi.advanceTimersByTime(AUTO_DISMISS_MS);
+    const slice = store.snapshot(sk);
+    expect(slice.active).toBeNull();
+    expect(slice.history[0]?.status).toBe('failed');
+  });
+
+  it('cancels the dismiss timer when a new stream starts', () => {
+    const store = new LiveRunStore();
+    const sk = 'auto3';
+    store.publish(sk, startEvent);
+    store.publish(sk, { type: 'done' } satisfies PublicWebEvent);
+    vi.advanceTimersByTime(AUTO_DISMISS_MS - 100);
+    // New stream lands before the timer fires — it should retire the
+    // completed run via the existing __stream_started path and not
+    // double-retire when the timer would have fired.
+    store.publish(sk, startEvent);
+    expect(store.snapshot(sk).active?.status).toBe('running');
+    expect(store.snapshot(sk).history).toHaveLength(1);
+
+    vi.advanceTimersByTime(1_000);
+    // Active is still the running run; history did not gain a duplicate.
+    expect(store.snapshot(sk).active?.status).toBe('running');
+    expect(store.snapshot(sk).history).toHaveLength(1);
+  });
+
+  it('does not arm a timer while the run is still running', () => {
+    const store = new LiveRunStore();
+    const sk = 'auto4';
+    store.publish(sk, startEvent);
+    store.publish(sk, toolStart('a', 'Grep'));
+    vi.advanceTimersByTime(AUTO_DISMISS_MS * 2);
+    expect(store.snapshot(sk).active?.status).toBe('running');
+  });
+
+  it('reset clears any pending dismiss timer', () => {
+    const store = new LiveRunStore();
+    const sk = 'auto5';
+    store.publish(sk, startEvent);
+    store.publish(sk, { type: 'done' } satisfies PublicWebEvent);
+    store.reset(sk);
+    // Even after the dismiss window, no spurious mutation occurs.
+    vi.advanceTimersByTime(AUTO_DISMISS_MS);
+    expect(store.snapshot(sk).active).toBeNull();
+    expect(store.snapshot(sk).history).toHaveLength(0);
   });
 });
 

--- a/web/src/components/agent-live/live-run-store.ts
+++ b/web/src/components/agent-live/live-run-store.ts
@@ -103,6 +103,13 @@ export function timelineKey(source: string, seq: number): string {
 }
 
 /**
+ * Delay between a run reaching a terminal state and the live card
+ * being auto-retired to history. Lives at module scope so tests and
+ * the SingleAgentLiveCard fade-out can read the same value.
+ */
+export const AUTO_DISMISS_MS = 5_000;
+
+/**
  * Factory for a per-store run-id generator. Counter lives inside each
  * store instance so parallel test stores don't share global state (and
  * neither does the production singleton leak into tests that construct
@@ -135,6 +142,10 @@ export class LiveRunStore {
   private readonly slices = new Map<string, SessionSlice>();
   private readonly listeners = new Map<string, Set<Listener>>();
   private readonly nextRunId = makeRunIdFactory();
+  // Pending auto-dismiss timers, keyed by sessionKey. A timer is armed
+  // when a publish transitions the active run from `running` to a
+  // terminal state and is cleared on retire / reset / new stream start.
+  private readonly dismissTimers = new Map<string, ReturnType<typeof setTimeout>>();
 
   /** Read the current immutable slice for a session. */
   snapshot(sessionKey: string): SessionSlice {
@@ -160,13 +171,69 @@ export class LiveRunStore {
     const next = reduce(current, sessionKey, event, this.nextRunId);
     if (next === current) return;
     this.slices.set(sessionKey, next);
+    this.scheduleAutoDismiss(sessionKey, current.active, next.active);
     this.emit(sessionKey);
   }
 
   /** Clear a session's state — called on session switch / unmount. */
   reset(sessionKey: string): void {
+    this.cancelAutoDismiss(sessionKey);
     if (!this.slices.has(sessionKey)) return;
     this.slices.delete(sessionKey);
+    this.emit(sessionKey);
+  }
+
+  /**
+   * Arm or cancel the auto-dismiss timer for a session based on the
+   * active-run transition produced by the latest publish. The timer is
+   * an effect, not a reducer concern — keeping it here preserves the
+   * reducer's purity while still guaranteeing exactly one pending
+   * timer per session.
+   */
+  private scheduleAutoDismiss(
+    sessionKey: string,
+    prev: LiveRun | null,
+    next: LiveRun | null,
+  ): void {
+    // If the active run is gone (retired) or is running again, drop any
+    // pending dismissal — there is nothing terminal to clear.
+    if (!next || next.status === 'running') {
+      this.cancelAutoDismiss(sessionKey);
+      return;
+    }
+    // Already terminal across both snapshots and same run — keep the
+    // existing timer running rather than restarting it on every event.
+    if (prev && prev.runId === next.runId && prev.status === next.status) {
+      return;
+    }
+    this.cancelAutoDismiss(sessionKey);
+    const timer = setTimeout(() => {
+      this.dismissTimers.delete(sessionKey);
+      this.dismissActive(sessionKey, next.runId);
+    }, AUTO_DISMISS_MS);
+    this.dismissTimers.set(sessionKey, timer);
+  }
+
+  private cancelAutoDismiss(sessionKey: string): void {
+    const timer = this.dismissTimers.get(sessionKey);
+    if (timer === undefined) return;
+    clearTimeout(timer);
+    this.dismissTimers.delete(sessionKey);
+  }
+
+  /**
+   * Retire the active run to history — invoked by the auto-dismiss
+   * timer. Guarded by `runId` so a stale timer racing against a new
+   * stream cannot evict a freshly-started run.
+   */
+  private dismissActive(sessionKey: string, runId: string): void {
+    const slice = this.slices.get(sessionKey);
+    if (!slice || !slice.active || slice.active.runId !== runId) return;
+    const next: SessionSlice = {
+      active: null,
+      history: [slice.active, ...slice.history],
+    };
+    this.slices.set(sessionKey, next);
     this.emit(sessionKey);
   }
 


### PR DESCRIPTION
## Summary

The live agent card kept the just-finished run pinned in the active slot until the next stream started, so any turn without a follow-up left the card stuck on screen indefinitely.

`LiveRunStore` now arms a 5s auto-dismiss timer when the active run transitions to a terminal status (`completed` / `failed` / `cancelled`). When it fires the run is retired to history. A new `__stream_started` before the timer fires cancels it. The reducer stays pure — the timer lives in the `LiveRunStore` class. `SingleAgentLiveCard` fades out via a tailwind opacity transition just before the store retires the run, so the dismissal is not abrupt.

## Type of change

| Type | Label |
|------|-------|
| Bug fix | `bug` |

## Component

`ui`

## Closes

Closes #1848

## Test plan

- [x] `bun run test --run` passes (added 5 new auto-dismiss cases with `vi.useFakeTimers()`)
- [x] `bun run build` succeeds
- [x] Pre-existing tests still pass (the "keeps a completed run pinned" snapshot test verifies the synchronous post-`done` state)