### PR TITLE
feat(kernel,channels,web): push session events for non-user tape mutations (#1849)

### DIFF
--- a/crates/channels/src/lib.rs
+++ b/crates/channels/src/lib.rs
@@ -28,6 +28,7 @@ pub mod telegram;
 pub mod terminal;
 pub mod web;
 pub mod web_reply_buffer;
+pub mod web_session_events;
 pub mod wechat;
 
 /// Tool display formatting helpers.

--- a/crates/channels/src/web.rs
+++ b/crates/channels/src/web.rs
@@ -577,12 +577,24 @@ impl WebAdapter {
             reply_buffer:      self.reply_buffer.clone(),
         };
 
+        let events_state = crate::web_session_events::SessionEventsState {
+            owner_token: self.owner_token.clone(),
+            handle:      Arc::clone(&self.sink),
+        };
+        let events_router = Router::new()
+            .route(
+                "/events/{session_key}",
+                get(crate::web_session_events::events_ws_handler),
+            )
+            .with_state(events_state);
+
         Router::new()
             .route("/ws", get(ws_handler))
             .route("/events", get(sse_handler))
             .route("/messages", post(send_message_handler))
             .route("/signals/{session_id}/interrupt", post(interrupt_handler))
             .with_state(state)
+            .merge(events_router)
     }
 
     /// Test-only entry point that mirrors the inbound code path exercised by

--- a/crates/channels/src/web_session_events.rs
+++ b/crates/channels/src/web_session_events.rs
@@ -1,0 +1,214 @@
+// Copyright 2025 Rararulab
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Session-events WebSocket — server-pushed notification stream that
+//! survives across user turns.
+//!
+//! The chat WebSocket in [`crate::web`] is per-`streamFn` call: it opens
+//! when the user submits a turn and closes when the kernel emits `done`.
+//! That leaves the UI deaf to tape mutations that arrive outside a user
+//! turn, e.g. when a background task completes and the kernel injects a
+//! synthetic re-entry that produces an assistant summary (#1849).
+//!
+//! This module exposes a separate, lighter WS endpoint mounted at
+//! `/events/{session_key}` (under the same auth as the chat WS) which
+//! forwards [`KernelNotification::TapeAppended`] frames for the matching
+//! session. The frame payload is intentionally minimal — the frontend
+//! treats it as a refetch trigger rather than a data source.
+
+use axum::{
+    extract::{
+        Path, Query, State, WebSocketUpgrade,
+        ws::{Message, WebSocket},
+    },
+    response::Response,
+};
+use futures::{SinkExt, StreamExt};
+use rara_kernel::{
+    handle::KernelHandle,
+    notification::{KernelNotification, NotificationFilter},
+    session::SessionKey,
+};
+use serde::{Deserialize, Serialize};
+use tokio::sync::{broadcast, mpsc};
+use tracing::{debug, info, warn};
+
+/// Query parameters for the session events WS endpoint.
+#[derive(Debug, Deserialize)]
+pub struct EventsQuery {
+    /// Owner token fallback when the client cannot set
+    /// `Authorization: Bearer <token>`.
+    #[serde(default)]
+    pub token: Option<String>,
+}
+
+/// Frames sent over the session events WebSocket.
+///
+/// Stable, additive contract: the client matches on `type` and ignores
+/// unknown variants.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum SessionEventFrame {
+    /// Sent immediately on connect for liveness — frontend uses it to
+    /// confirm the socket is established before arming reconnect logic.
+    Hello,
+    /// A new entry was appended to the session's tape. Clients refetch
+    /// messages on receipt.
+    TapeAppended {
+        entry_id:  u64,
+        role:      Option<String>,
+        timestamp: String,
+    },
+}
+
+/// State required by the session-events WS handler.
+///
+/// A trait object so the handler does not depend on `WebAdapter`'s
+/// concrete state struct (which has many other fields irrelevant here).
+#[derive(Clone)]
+pub struct SessionEventsState {
+    pub owner_token: String,
+    /// Shared kernel handle, populated by `WebAdapter::start`.
+    pub handle:      std::sync::Arc<tokio::sync::RwLock<Option<KernelHandle>>>,
+}
+
+/// Axum handler for `GET /events/{session_key}`.
+pub async fn events_ws_handler(
+    ws: WebSocketUpgrade,
+    Path(session_key): Path<String>,
+    Query(query): Query<EventsQuery>,
+    headers: axum::http::HeaderMap,
+    State(state): State<SessionEventsState>,
+) -> Response {
+    let header_token = bearer_token_from_headers(&headers);
+    let query_token = query.token.as_deref().filter(|t| !t.is_empty());
+    let provided = header_token.or(query_token);
+    match provided {
+        Some(tok) if rara_kernel::auth::verify_owner_token(&state.owner_token, tok) => {
+            info!(%session_key, "session-events WS auth via owner token");
+        }
+        Some(_) => {
+            warn!(%session_key, "invalid owner token on session-events WS");
+            return axum::response::Response::builder()
+                .status(axum::http::StatusCode::UNAUTHORIZED)
+                .body(axum::body::Body::from("invalid token"))
+                .expect("static unauthorized response");
+        }
+        None => {
+            warn!(%session_key, "missing owner token on session-events WS");
+            return axum::response::Response::builder()
+                .status(axum::http::StatusCode::UNAUTHORIZED)
+                .body(axum::body::Body::from("missing token"))
+                .expect("static unauthorized response");
+        }
+    }
+
+    let key = match SessionKey::try_from_raw(&session_key) {
+        Ok(k) => k,
+        Err(e) => {
+            warn!(%session_key, error = %e, "invalid session key on session-events WS");
+            return axum::response::Response::builder()
+                .status(axum::http::StatusCode::BAD_REQUEST)
+                .body(axum::body::Body::from("invalid session key"))
+                .expect("static bad request response");
+        }
+    };
+
+    ws.on_upgrade(move |socket| handle_events_ws(socket, key, state))
+}
+
+async fn handle_events_ws(socket: WebSocket, key: SessionKey, state: SessionEventsState) {
+    let handle = {
+        let guard = state.handle.read().await;
+        match guard.as_ref() {
+            Some(h) => h.clone(),
+            None => {
+                warn!(session_key = %key, "kernel handle not yet attached, closing WS");
+                return;
+            }
+        }
+    };
+
+    let mut subscription = handle
+        .notification_bus()
+        .subscribe(NotificationFilter::default())
+        .await;
+
+    let (mut ws_tx, _ws_rx) = socket.split();
+    let (out_tx, mut out_rx) = mpsc::unbounded_channel::<SessionEventFrame>();
+
+    // Send the initial `hello` so the client knows the socket is live.
+    if out_tx.send(SessionEventFrame::Hello).is_err() {
+        return;
+    }
+
+    // Forwarder: kernel notification bus → per-WS mpsc, filtered by session.
+    let forwarder = {
+        let target = key.clone();
+        let out_tx = out_tx.clone();
+        tokio::spawn(async move {
+            loop {
+                match subscription.recv().await {
+                    Ok(KernelNotification::TapeAppended {
+                        session_key,
+                        entry_id,
+                        role,
+                        timestamp,
+                    }) if session_key == target => {
+                        let frame = SessionEventFrame::TapeAppended {
+                            entry_id,
+                            role,
+                            timestamp: timestamp.to_string(),
+                        };
+                        if out_tx.send(frame).is_err() {
+                            break;
+                        }
+                    }
+                    Ok(_) => {} // other event types ignored
+                    Err(broadcast::error::RecvError::Lagged(n)) => {
+                        warn!(session_key = %target, skipped = n, "session-events bus lagged");
+                    }
+                    Err(broadcast::error::RecvError::Closed) => break,
+                }
+            }
+        })
+    };
+
+    drop(out_tx);
+
+    while let Some(frame) = out_rx.recv().await {
+        let json = match serde_json::to_string(&frame) {
+            Ok(j) => j,
+            Err(e) => {
+                warn!(error = %e, "serialize session event frame");
+                continue;
+            }
+        };
+        if ws_tx.send(Message::Text(json.into())).await.is_err() {
+            debug!(session_key = %key, "session-events WS send failed, closing");
+            break;
+        }
+    }
+
+    forwarder.abort();
+}
+
+fn bearer_token_from_headers(headers: &axum::http::HeaderMap) -> Option<&str> {
+    headers
+        .get(axum::http::header::AUTHORIZATION)
+        .and_then(|h| h.to_str().ok())
+        .and_then(|h| h.strip_prefix("Bearer "))
+        .map(str::trim)
+        .filter(|t| !t.is_empty())
+}

--- a/crates/kernel/src/handle.rs
+++ b/crates/kernel/src/handle.rs
@@ -114,6 +114,10 @@ pub struct KernelHandle {
     feed_store:            Option<crate::data_feed::FeedStoreRef>,
     /// Tag-based subscription registry for routing notifications to sessions.
     subscription_registry: crate::notification::SubscriptionRegistryRef,
+    /// Kernel event bus exposed for adapters that need to subscribe to
+    /// session-scoped events such as
+    /// [`crate::notification::KernelNotification::TapeAppended`].
+    notification_bus:      crate::notification::NotificationBusRef,
 }
 
 impl KernelHandle {
@@ -139,6 +143,7 @@ impl KernelHandle {
         feed_registry: Option<Arc<crate::data_feed::DataFeedRegistry>>,
         feed_store: Option<crate::data_feed::FeedStoreRef>,
         subscription_registry: crate::notification::SubscriptionRegistryRef,
+        notification_bus: crate::notification::NotificationBusRef,
     ) -> Self {
         Self {
             event_queue,
@@ -160,7 +165,13 @@ impl KernelHandle {
             feed_registry,
             feed_store,
             subscription_registry,
+            notification_bus,
         }
+    }
+
+    /// Access the kernel notification bus.
+    pub fn notification_bus(&self) -> &crate::notification::NotificationBusRef {
+        &self.notification_bus
     }
 
     // -- Mutation methods (flow through event queue) -------------------------

--- a/crates/kernel/src/kernel.rs
+++ b/crates/kernel/src/kernel.rs
@@ -255,6 +255,12 @@ impl Kernel {
         scheduler_dir: std::path::PathBuf,
     ) -> Self {
         let event_bus: NotificationBusRef = Arc::new(BroadcastNotificationBus::default());
+        // Plumb the notification bus into the tape service so message
+        // appends publish `TapeAppended` events. This is the single point
+        // where every tape mutation is observable, regardless of whether
+        // the writer is a user turn, a synthetic re-entry, or a future
+        // scheduled task.
+        let tape_service = tape_service.with_notifications(event_bus.clone());
         // Clamp default_tool_timeout so it never exceeds the global wave timeout.
         let mut config = config;
         if config.default_tool_timeout >= config.tool_execution_timeout {
@@ -416,6 +422,7 @@ impl Kernel {
             self.feed_registry.clone(),
             self.feed_store.clone(),
             Arc::clone(self.syscall.subscription_registry()),
+            Arc::clone(self.syscall.event_bus()),
         )
     }
 

--- a/crates/kernel/src/memory/service.rs
+++ b/crates/kernel/src/memory/service.rs
@@ -29,7 +29,10 @@ use super::{
     AnchorNode, AnchorSummary, AnchorTree, FileTapeStore, ForkEdge, HandoffState, SessionBranch,
     TapEntry, TapEntryKind, TapResult, get_fork_metadata,
 };
-use crate::session::{SessionIndex, SessionKey};
+use crate::{
+    notification::{KernelNotification, NotificationBusRef},
+    session::{SessionIndex, SessionKey},
+};
 
 thread_local! {
     /// Per-thread current tape context used while executing fork closures.
@@ -105,15 +108,37 @@ pub fn current_tape() -> String {
 /// workflows (anchors, fork/merge, search, LLM context building). It is **not**
 /// bound to a specific tape — every method accepts a `tape_name` parameter so a
 /// single instance can serve all sessions.
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct TapeService {
-    store: FileTapeStore,
-    fts:   Option<super::fts::TapeFts>,
+    store:        FileTapeStore,
+    fts:          Option<super::fts::TapeFts>,
+    /// Optional notification bus for publishing tape mutation events.
+    ///
+    /// Wired in by `Kernel::new` after the bus is constructed, so external
+    /// adapters can react to writes that happen outside a live user turn
+    /// (background-task summaries, scheduled re-entries).
+    notification: Option<NotificationBusRef>,
+}
+
+impl std::fmt::Debug for TapeService {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("TapeService")
+            .field("store", &self.store)
+            .field("fts", &self.fts.is_some())
+            .field("notification", &self.notification.is_some())
+            .finish()
+    }
 }
 
 impl TapeService {
     /// Create a service backed by the given store.
-    pub fn new(store: FileTapeStore) -> Self { Self { store, fts: None } }
+    pub fn new(store: FileTapeStore) -> Self {
+        Self {
+            store,
+            fts: None,
+            notification: None,
+        }
+    }
 
     /// Create a service with FTS5 full-text search support.
     pub fn with_fts(
@@ -126,7 +151,16 @@ impl TapeService {
         Self {
             store,
             fts: Some(super::fts::TapeFts::new(pools)),
+            notification: None,
         }
+    }
+
+    /// Attach a notification bus so message appends publish
+    /// [`KernelNotification::TapeAppended`].
+    #[must_use]
+    pub fn with_notifications(mut self, bus: NotificationBusRef) -> Self {
+        self.notification = Some(bus);
+        self
     }
 
     /// Access the underlying [`FileTapeStore`] for low-level operations such as
@@ -266,6 +300,27 @@ impl TapeService {
                 .await
             {
                 tracing::warn!(%e, tape_name, "FTS index failed on append");
+            }
+        }
+
+        // Publish a tape-appended notification so adapters can refresh.
+        // Best-effort: errors come from a parsed tape_name that does not
+        // resolve to a SessionKey (user tape, internal tape) — those tapes
+        // are not user-facing chat sessions and are intentionally skipped.
+        if let Some(bus) = &self.notification {
+            if let Ok(session_key) = SessionKey::try_from_raw(tape_name) {
+                let role = entry
+                    .payload
+                    .get("role")
+                    .and_then(|v| v.as_str())
+                    .map(str::to_owned);
+                bus.publish(KernelNotification::TapeAppended {
+                    session_key,
+                    entry_id: entry.id,
+                    role,
+                    timestamp: entry.timestamp,
+                })
+                .await;
             }
         }
 
@@ -1389,6 +1444,46 @@ mod tests {
     async fn temp_tape_service(dir: &Path) -> TapeService {
         let store = super::super::FileTapeStore::new(dir, dir).await.unwrap();
         TapeService::new(store)
+    }
+
+    #[tokio::test]
+    async fn append_message_publishes_tape_appended() {
+        use crate::notification::{
+            BroadcastNotificationBus, KernelNotification, NotificationFilter,
+        };
+
+        let tmp = tempfile::tempdir().unwrap();
+        let bus: NotificationBusRef = Arc::new(BroadcastNotificationBus::default());
+        let svc = temp_tape_service(tmp.path())
+            .await
+            .with_notifications(bus.clone());
+
+        let key = SessionKey::new();
+        let key_raw = key.to_string();
+        let mut rx = bus.subscribe(NotificationFilter::default()).await;
+
+        svc.append_message(
+            &key_raw,
+            json!({"role": "assistant", "content": "hi"}),
+            None,
+        )
+        .await
+        .unwrap();
+
+        // The bus capacity is 256; one publish should arrive without lag.
+        let event = tokio::time::timeout(std::time::Duration::from_secs(1), rx.recv())
+            .await
+            .expect("publish timed out")
+            .expect("publish failed");
+        match event {
+            KernelNotification::TapeAppended {
+                session_key, role, ..
+            } => {
+                assert_eq!(session_key, key);
+                assert_eq!(role.as_deref(), Some("assistant"));
+            }
+            other => panic!("unexpected notification: {other:?}"),
+        }
     }
 
     #[tokio::test]

--- a/crates/kernel/src/notification/bus.rs
+++ b/crates/kernel/src/notification/bus.rs
@@ -61,6 +61,21 @@ pub enum KernelNotification {
         reason:    String,
         timestamp: Timestamp,
     },
+    /// A new entry was appended to a session's tape.
+    ///
+    /// Emitted by [`crate::memory::TapeService::append_message`] so external
+    /// adapters (e.g. the web events WS) can refresh their view when the
+    /// kernel writes to a tape outside the live-streaming user turn — for
+    /// example a background-task summary or a scheduled re-entry.
+    ///
+    /// `role` is best-effort, extracted from the message payload when
+    /// present; it is `None` for non-message tape kinds.
+    TapeAppended {
+        session_key: SessionKey,
+        entry_id:    u64,
+        role:        Option<String>,
+        timestamp:   Timestamp,
+    },
 }
 
 /// Filter for subscribing to specific events.

--- a/web/src/hooks/__tests__/use-session-events.test.tsx
+++ b/web/src/hooks/__tests__/use-session-events.test.tsx
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2025 Rararulab
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { useSessionEvents } from '../use-session-events';
+
+vi.mock('@/api/client', () => ({
+  getAccessToken: () => 'test-token',
+}));
+
+interface MockWebSocket {
+  url: string;
+  onopen: ((ev: Event) => void) | null;
+  onmessage: ((ev: MessageEvent) => void) | null;
+  onerror: ((ev: Event) => void) | null;
+  onclose: ((ev: CloseEvent) => void) | null;
+  close: () => void;
+}
+
+let lastSocket: MockWebSocket | null = null;
+
+class FakeWebSocket implements MockWebSocket {
+  url: string;
+  onopen: ((ev: Event) => void) | null = null;
+  onmessage: ((ev: MessageEvent) => void) | null = null;
+  onerror: ((ev: Event) => void) | null = null;
+  onclose: ((ev: CloseEvent) => void) | null = null;
+  closed = false;
+
+  constructor(url: string) {
+    this.url = url;
+    // eslint-disable-next-line @typescript-eslint/no-this-alias
+    lastSocket = this;
+  }
+
+  close() {
+    this.closed = true;
+  }
+}
+
+describe('useSessionEvents', () => {
+  beforeEach(() => {
+    lastSocket = null;
+    Object.defineProperty(globalThis, 'WebSocket', {
+      writable: true,
+      configurable: true,
+      value: FakeWebSocket,
+    });
+    Object.defineProperty(globalThis, 'window', {
+      writable: true,
+      configurable: true,
+      value: {
+        location: { host: 'localhost:5173', protocol: 'http:' },
+      },
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('opens a WebSocket scoped to the session key', () => {
+    const onTapeAppended = vi.fn();
+    renderHook(() => useSessionEvents({ sessionKey: 'sess-abc', onTapeAppended }));
+    expect(lastSocket).not.toBeNull();
+    expect(lastSocket!.url).toContain('/api/v1/kernel/chat/events/sess-abc');
+    expect(lastSocket!.url).toContain('token=test-token');
+  });
+
+  it('invokes onTapeAppended when a tape_appended frame arrives', () => {
+    const onTapeAppended = vi.fn();
+    renderHook(() => useSessionEvents({ sessionKey: 'sess-abc', onTapeAppended }));
+    const sock = lastSocket!;
+
+    sock.onmessage?.(
+      new MessageEvent('message', {
+        data: JSON.stringify({
+          type: 'tape_appended',
+          entry_id: 42,
+          role: 'assistant',
+          timestamp: '2026-01-01T00:00:00Z',
+        }),
+      }),
+    );
+
+    expect(onTapeAppended).toHaveBeenCalledWith({
+      entry_id: 42,
+      role: 'assistant',
+      timestamp: '2026-01-01T00:00:00Z',
+    });
+  });
+
+  it('ignores hello frames and unknown types', () => {
+    const onTapeAppended = vi.fn();
+    renderHook(() => useSessionEvents({ sessionKey: 'sess-abc', onTapeAppended }));
+    const sock = lastSocket!;
+
+    sock.onmessage?.(new MessageEvent('message', { data: JSON.stringify({ type: 'hello' }) }));
+    sock.onmessage?.(new MessageEvent('message', { data: JSON.stringify({ type: 'unknown' }) }));
+    sock.onmessage?.(new MessageEvent('message', { data: 'not-json' }));
+
+    expect(onTapeAppended).not.toHaveBeenCalled();
+  });
+
+  it('does not open a socket when sessionKey is null', () => {
+    const onTapeAppended = vi.fn();
+    renderHook(() => useSessionEvents({ sessionKey: null, onTapeAppended }));
+    expect(lastSocket).toBeNull();
+  });
+});

--- a/web/src/hooks/use-session-events.ts
+++ b/web/src/hooks/use-session-events.ts
@@ -1,0 +1,136 @@
+/*
+ * Copyright 2025 Rararulab
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useEffect, useRef } from 'react';
+
+import { getAccessToken } from '@/api/client';
+
+/**
+ * Frame contract mirrored from `rara-channels::web_session_events::SessionEventFrame`.
+ * Stable additive: clients ignore unknown `type` values.
+ */
+export type SessionEventFrame =
+  | { type: 'hello' }
+  | {
+      type: 'tape_appended';
+      entry_id: number;
+      role: string | null;
+      timestamp: string;
+    };
+
+export interface UseSessionEventsOptions {
+  /** Active session key. When `null`, the hook closes any open WS. */
+  sessionKey: string | null;
+  /** Called for each `tape_appended` frame; the caller decides how to refresh state. */
+  onTapeAppended: (event: { entry_id: number; role: string | null; timestamp: string }) => void;
+}
+
+const INITIAL_BACKOFF_MS = 1_000;
+const MAX_BACKOFF_MS = 30_000;
+
+/**
+ * Maintain a persistent WebSocket subscription to the kernel's session
+ * event bus so the UI sees tape mutations that arrive outside a live
+ * user turn (background-task summaries, scheduled re-entries, …).
+ *
+ * Reconnects with capped exponential backoff. Lifecycle is tied to
+ * `sessionKey`: switching sessions closes the old socket and opens a
+ * new one; setting `sessionKey` to `null` closes the socket cleanly.
+ */
+export function useSessionEvents({ sessionKey, onTapeAppended }: UseSessionEventsOptions): void {
+  // Stable ref so the effect does not re-subscribe when callers pass a
+  // fresh closure each render. Updated inside an effect to satisfy the
+  // "no ref writes during render" lint.
+  const onTapeAppendedRef = useRef(onTapeAppended);
+  useEffect(() => {
+    onTapeAppendedRef.current = onTapeAppended;
+  }, [onTapeAppended]);
+
+  useEffect(() => {
+    if (!sessionKey) return;
+
+    let backoff = INITIAL_BACKOFF_MS;
+    let cancelled = false;
+    let ws: WebSocket | null = null;
+    let retryTimer: ReturnType<typeof setTimeout> | null = null;
+
+    const connect = () => {
+      if (cancelled) return;
+      const token = getAccessToken();
+      if (!token) return;
+
+      const host = window.location.host;
+      const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
+      const url = `${protocol}//${host}/api/v1/kernel/chat/events/${encodeURIComponent(
+        sessionKey,
+      )}?token=${encodeURIComponent(token)}`;
+
+      ws = new WebSocket(url);
+
+      ws.onopen = () => {
+        backoff = INITIAL_BACKOFF_MS;
+      };
+
+      ws.onmessage = (ev) => {
+        let frame: SessionEventFrame;
+        try {
+          frame = JSON.parse(ev.data) as SessionEventFrame;
+        } catch {
+          return;
+        }
+        if (frame.type === 'tape_appended') {
+          onTapeAppendedRef.current({
+            entry_id: frame.entry_id,
+            role: frame.role,
+            timestamp: frame.timestamp,
+          });
+        }
+      };
+
+      ws.onerror = () => {
+        // Let `onclose` drive reconnect — `onerror` always precedes it.
+      };
+
+      ws.onclose = () => {
+        ws = null;
+        if (cancelled) return;
+        const delay = backoff;
+        backoff = Math.min(backoff * 2, MAX_BACKOFF_MS);
+        retryTimer = setTimeout(connect, delay);
+      };
+    };
+
+    connect();
+
+    return () => {
+      cancelled = true;
+      if (retryTimer) clearTimeout(retryTimer);
+      if (ws) {
+        // Detach handlers so an in-flight close does not schedule a retry
+        // after the effect has unmounted.
+        ws.onopen = null;
+        ws.onmessage = null;
+        ws.onerror = null;
+        ws.onclose = null;
+        try {
+          ws.close();
+        } catch {
+          /* ignore */
+        }
+      }
+    };
+  }, [sessionKey]);
+}

--- a/web/src/pages/PiChat.tsx
+++ b/web/src/pages/PiChat.tsx
@@ -76,6 +76,7 @@ import { useSettingsModal } from '@/components/settings/SettingsModalProvider';
 import { VoiceRecorder } from '@/components/VoiceRecorder';
 import { useLiveCardHeight } from '@/hooks/use-live-card-height';
 import { useSessionDelete } from '@/hooks/use-session-delete';
+import { useSessionEvents } from '@/hooks/use-session-events';
 import { UNKNOWN_MODEL_SENTINEL, isUnknownModel, syntheticModel } from '@/lib/synthetic-model';
 import { renderTurnChipCard } from '@/tools/turn-chip-card';
 const ACTIVE_SESSION_KEY = 'rara.activeSessionKey';
@@ -617,6 +618,19 @@ export default function PiChat() {
     activeSessionKey: activeSession?.key,
     switchSession,
     newSession,
+  });
+
+  // Subscribe to server-pushed session events so tape mutations that
+  // arrive outside a live streamFn turn — background-task summaries,
+  // future scheduled re-entries — refresh the chat without a manual
+  // refresh. The reload is a full snapshot fetch; mid-stream the
+  // assistant message has not been persisted yet so a concurrent reload
+  // is a no-op replay (#1849).
+  useSessionEvents({
+    sessionKey: activeSession?.key ?? null,
+    onTapeAppended: () => {
+      void reloadMessages();
+    },
   });
 
   /**


### PR DESCRIPTION
## Summary

Background-task summaries (and future scheduled re-entries) write assistant messages into the session tape after the per-`streamFn` chat WebSocket has already closed, so the chat UI never learned about them without a manual refresh.

- `KernelNotification::TapeAppended` is published from `TapeService::append_message`; the tape service is the single chokepoint for every tape mutation, so this covers user turns, synthetic re-entries, and future scheduled tasks uniformly.
- `WebAdapter` exposes a small persistent WS at `GET /events/{session_key}` (mounted under the existing chat router, so the public path is `/api/v1/kernel/chat/events/{session_key}`). It filters the kernel notification bus by session and forwards `tape_appended` frames. Auth reuses the chat WS owner-token mechanism (Authorization header or `?token=` fallback).
- The new `useSessionEvents` hook subscribes for the lifetime of the active session, reconnects with capped exponential backoff, and triggers `reloadMessages` on each event so the chat snaps to the latest tape without a refresh. It is wired in next to the existing `liveRunStore` subscription in `PiChat.tsx` but is independent of `liveRunStore` (different lifecycle).

## Type of change

| Type | Label |
|------|-------|
| New feature | `enhancement` |

## Component

`core` + `ui`

## Closes

Closes #1849

## Test plan

- [x] `cargo check --workspace --all-targets` passes
- [x] `cargo +nightly fmt --all -- --check` passes
- [x] `cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings` passes
- [x] `RUSTDOCFLAGS=-D warnings cargo +nightly doc --workspace --no-deps --document-private-items` passes
- [x] `cd web && bun run build` passes
- [x] `cd web && bun run test --run` passes (97 tests)
- [x] New backend test: `append_message_publishes_tape_appended` verifies the publish path
- [x] New frontend test: 4 cases for `useSessionEvents` (open, dispatch, ignore unknown, null skip)