### PR TITLE
feat(telemetry): export OTLP traces to self-hosted Langfuse (#1855)

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -131,6 +131,29 @@ agents:
     max_output_chars: 50
 
 # ---------------------------------------------------------------------------
+# Telemetry — OTLP traces export (optional)
+# ---------------------------------------------------------------------------
+#
+# Two independent paths are supported:
+#
+# 1. `telemetry.otlp_endpoint` / `otlp_protocol` — the legacy generic OTLP
+#    sink (Alloy / Tempo). Set `otlp_endpoint` to a non-empty URL to enable.
+#
+# 2. `telemetry.otlp` — the self-hosted Langfuse traces exporter (HTTP only).
+#    Disabled by default; set `enabled: true` and provide a `traces_endpoint`
+#    plus auth header to push spans to a running Langfuse instance.
+#
+# Example (commented out — opt in by uncommenting and setting `enabled: true`):
+#
+# telemetry:
+#   otlp:
+#     enabled: false
+#     traces_endpoint: "http://10.0.0.183:3000/api/public/otel/v1/traces"
+#     deployment_environment: "dev"
+#     headers:
+#       authorization: "Basic <base64(public_key:secret_key)>"
+
+# ---------------------------------------------------------------------------
 # Optional integrations — remove or leave commented out if unused
 # ---------------------------------------------------------------------------
 

--- a/crates/app/src/lib.rs
+++ b/crates/app/src/lib.rs
@@ -209,6 +209,30 @@ pub struct TelemetryConfig {
     /// Export protocol: `"http"` or `"grpc"`.
     #[serde(default)]
     pub otlp_protocol: Option<String>,
+    /// Self-hosted Langfuse / OTLP HTTP traces exporter (opt-in).
+    ///
+    /// When `enabled`, the application configures an OTLP/HTTP traces
+    /// exporter pointing at `traces_endpoint` with the provided `headers`
+    /// (typically `authorization: "Basic <base64(public:secret)>"` for
+    /// Langfuse). Disabled by default.
+    #[serde(default)]
+    pub otlp:          Option<OtlpConfig>,
+}
+
+/// OTLP/HTTP traces exporter config (Langfuse-compatible).
+#[derive(Debug, Clone, bon::Builder, Serialize, Deserialize)]
+pub struct OtlpConfig {
+    /// Whether the exporter is active. `false` skips construction entirely.
+    pub enabled:                Option<bool>,
+    /// OTLP/HTTP traces ingest URL — full path including
+    /// `/v1/traces` (or Langfuse's `/api/public/otel/v1/traces`).
+    pub traces_endpoint:        Option<String>,
+    /// HTTP headers attached to every export request.
+    #[serde(default)]
+    pub headers:                std::collections::HashMap<String, String>,
+    /// Deployment environment label (e.g. `dev`, `staging`, `prod`)
+    /// emitted as `deployment.environment.name` resource attribute.
+    pub deployment_environment: Option<String>,
 }
 
 fn default_database_config() -> DatabaseConfig { DatabaseConfig::builder().build() }
@@ -1334,5 +1358,76 @@ mita:
 
         let config = AppConfig::load_from_paths(&global, &local).expect("load config");
         assert_eq!(config.http.bind_address, "127.0.0.1:35555");
+    }
+
+    #[test]
+    fn telemetry_otlp_defaults_to_disabled() {
+        let cfg: AppConfig = serde_yaml::from_str(BASE_YAML).expect("base yaml");
+        assert!(
+            cfg.telemetry.otlp.is_none(),
+            "no `telemetry.otlp` block should leave it unset"
+        );
+        assert!(cfg.telemetry.otlp_endpoint.is_none());
+    }
+
+    #[test]
+    fn telemetry_otlp_parses_full_block() {
+        let yaml = format!(
+            r#"{BASE_YAML}
+telemetry:
+  otlp:
+    enabled: true
+    traces_endpoint: "http://10.0.0.183:3000/api/public/otel/v1/traces"
+    deployment_environment: "dev"
+    headers:
+      authorization: "Basic ZGVtbw=="
+"#
+        );
+        let cfg: AppConfig = serde_yaml::from_str(&yaml).expect("yaml");
+        let otlp = cfg.telemetry.otlp.expect("otlp block");
+        assert_eq!(otlp.enabled, Some(true));
+        assert_eq!(
+            otlp.traces_endpoint.as_deref(),
+            Some("http://10.0.0.183:3000/api/public/otel/v1/traces")
+        );
+        assert_eq!(otlp.deployment_environment.as_deref(), Some("dev"));
+        assert_eq!(
+            otlp.headers.get("authorization").map(String::as_str),
+            Some("Basic ZGVtbw==")
+        );
+    }
+
+    #[test]
+    fn telemetry_otlp_disabled_block_parses() {
+        let yaml = format!(
+            r#"{BASE_YAML}
+telemetry:
+  otlp:
+    enabled: false
+    traces_endpoint: "http://example.invalid/v1/traces"
+"#
+        );
+        let cfg: AppConfig = serde_yaml::from_str(&yaml).expect("yaml");
+        let otlp = cfg.telemetry.otlp.expect("otlp block");
+        assert_eq!(otlp.enabled, Some(false));
+        assert!(otlp.headers.is_empty());
+    }
+
+    #[test]
+    fn telemetry_otlp_missing_endpoint_parses_but_runtime_rejects() {
+        // Endpoint is `Option<String>` so deserialization succeeds; the
+        // bootstrap path in `rara-cli` is responsible for rejecting an
+        // enabled-without-endpoint config at startup.
+        let yaml = format!(
+            r#"{BASE_YAML}
+telemetry:
+  otlp:
+    enabled: true
+"#
+        );
+        let cfg: AppConfig = serde_yaml::from_str(&yaml).expect("yaml");
+        let otlp = cfg.telemetry.otlp.expect("otlp block");
+        assert_eq!(otlp.enabled, Some(true));
+        assert!(otlp.traces_endpoint.is_none());
     }
 }

--- a/crates/cmd/src/main.rs
+++ b/crates/cmd/src/main.rs
@@ -66,7 +66,34 @@ impl ServerArgs {
         std::fs::create_dir_all(logs_dir).expect("failed to create logs directory");
         let logs_dir_str = logs_dir.to_string_lossy().into_owned();
 
-        let logging_opts = if let Some(ref endpoint) = config
+        // Pinned OpenTelemetry semantic-convention schema URL for the OTLP
+        // traces exporter. Pinning the version lets backends (Langfuse,
+        // Tempo, etc.) interpret span attributes against a known semconv
+        // release rather than a moving target.
+        const OTEL_SCHEMA_URL: &str = "https://opentelemetry.io/schemas/1.40.0";
+
+        let langfuse_otlp = config
+            .telemetry
+            .otlp
+            .as_ref()
+            .filter(|o| o.enabled.unwrap_or(false));
+
+        let logging_opts = if let Some(otlp) = langfuse_otlp {
+            use common_telemetry::logging::{LoggingOptions, OtlpExportProtocol};
+            let Some(endpoint) = otlp.traces_endpoint.clone() else {
+                whatever!("telemetry.otlp.enabled = true requires telemetry.otlp.traces_endpoint");
+            };
+            LoggingOptions {
+                dir: logs_dir_str,
+                enable_otlp_tracing: true,
+                otlp_endpoint: Some(endpoint),
+                otlp_export_protocol: Some(OtlpExportProtocol::Http),
+                otlp_headers: otlp.headers.clone(),
+                otlp_schema_url: Some(OTEL_SCHEMA_URL.to_string()),
+                otlp_deployment_environment: otlp.deployment_environment.clone(),
+                ..Default::default()
+            }
+        } else if let Some(ref endpoint) = config
             .telemetry
             .otlp_endpoint
             .as_deref()
@@ -82,6 +109,7 @@ impl ServerArgs {
                 enable_otlp_tracing: true,
                 otlp_endpoint: Some(endpoint.to_string()),
                 otlp_export_protocol: protocol,
+                otlp_schema_url: Some(OTEL_SCHEMA_URL.to_string()),
                 ..Default::default()
             }
         } else if std::env::var("KUBERNETES_SERVICE_HOST").is_ok() {
@@ -93,6 +121,7 @@ impl ServerArgs {
                 enable_otlp_tracing: true,
                 otlp_endpoint: Some("http://rara-infra-alloy:4318/v1/traces".to_string()),
                 otlp_export_protocol: Some(OtlpExportProtocol::Http),
+                otlp_schema_url: Some(OTEL_SCHEMA_URL.to_string()),
                 log_format: common_telemetry::logging::LogFormat::Json,
                 ..Default::default()
             }

--- a/crates/common/telemetry/src/logging.rs
+++ b/crates/common/telemetry/src/logging.rs
@@ -205,6 +205,21 @@ pub struct LoggingOptions {
     #[serde(skip_serializing_if = "HashMap::is_empty")]
     #[default(_code = "HashMap::new()")]
     pub otlp_headers: HashMap<String, String>,
+
+    /// OpenTelemetry semantic-convention schema URL pinned on the tracer
+    /// provider's resource.
+    ///
+    /// Pinning a schema URL lets backends (e.g. Langfuse) interpret span
+    /// attributes against a known semconv version. When `None`, the resource
+    /// is built without a schema URL.
+    pub otlp_schema_url: Option<String>,
+
+    /// Deployment environment label (e.g. `dev`, `staging`, `prod`).
+    ///
+    /// When set, the value is attached to the OTel resource as
+    /// `deployment.environment.name` so traces from different environments
+    /// can be filtered downstream.
+    pub otlp_deployment_environment: Option<String>,
 }
 
 /// OpenTelemetry Protocol (OTLP) export transport protocols.
@@ -619,17 +634,31 @@ pub fn init_global_logging(
                     Sampler::ParentBased,
                 );
 
-            let otel_resource = opentelemetry_sdk::Resource::builder_empty()
-                .with_attributes([
-                    KeyValue::new(resource::SERVICE_NAME, app_name.to_string()),
-                    KeyValue::new(
-                        resource::SERVICE_INSTANCE_ID,
-                        node_id.unwrap_or("none".to_string()),
-                    ),
-                    KeyValue::new(resource::SERVICE_VERSION, env!("CARGO_PKG_VERSION")),
-                    KeyValue::new(resource::PROCESS_PID, std::process::id().to_string()),
-                ])
-                .build();
+            let mut resource_attrs = vec![
+                KeyValue::new(resource::SERVICE_NAME, app_name.to_string()),
+                KeyValue::new(
+                    resource::SERVICE_INSTANCE_ID,
+                    node_id.unwrap_or("none".to_string()),
+                ),
+                KeyValue::new(resource::SERVICE_VERSION, env!("CARGO_PKG_VERSION")),
+                KeyValue::new(resource::PROCESS_PID, std::process::id().to_string()),
+            ];
+            if let Some(env) = opts.otlp_deployment_environment.as_deref() {
+                resource_attrs.push(KeyValue::new(
+                    resource::DEPLOYMENT_ENVIRONMENT_NAME,
+                    env.to_string(),
+                ));
+            }
+            // Pin the semconv schema URL on the resource (when configured) so
+            // downstream backends like Langfuse can interpret span attributes
+            // against a known version.
+            let resource_builder = opentelemetry_sdk::Resource::builder_empty();
+            let otel_resource = match opts.otlp_schema_url.as_deref() {
+                Some(schema_url) => resource_builder
+                    .with_schema_url(resource_attrs, schema_url.to_string())
+                    .build(),
+                None => resource_builder.with_attributes(resource_attrs).build(),
+            };
 
             let provider = opentelemetry_sdk::trace::SdkTracerProvider::builder()
                 .with_batch_exporter(build_otlp_exporter(opts))


### PR DESCRIPTION
## Summary

Wire a YAML-driven OTLP/HTTP traces exporter for self-hosted Langfuse (and any compatible OTLP backend) into the existing `common-telemetry` pipeline. Off by default — opt-in via `telemetry.otlp.enabled = true`.

- Pins OpenTelemetry semconv schema URL `https://opentelemetry.io/schemas/1.40.0` on the tracer provider's resource so backends can interpret attributes against a known version.
- Resource attributes set: `service.name`, `service.version`, `service.instance.id`, `process.pid`, and (when configured) `deployment.environment.name`.
- Auth headers (e.g. `Authorization: Basic <base64>`) flow through unchanged from YAML to the OTLP HTTP exporter.
- Legacy `telemetry.otlp_endpoint` / `otlp_protocol` (Alloy / Tempo) path is preserved.

YAML schema:

```yaml
telemetry:
  otlp:
    enabled: true
    traces_endpoint: "http://10.0.0.183:3000/api/public/otel/v1/traces"
    deployment_environment: "dev"
    headers:
      authorization: "Basic <base64(public_key:secret_key)>"
```

This PR ships the export capability only; the user must run their own Langfuse instance before turning it on. Span attribute changes (OTel GenAI / OpenInference) are tracked under #1856; Pyroscope under #1857.

## Type of change

| Type | Label |
|------|-------|
| New feature | `enhancement` |

## Component

`core`

## Closes

Closes #1855

## Test plan

- [x] `cargo check --workspace --all-targets`
- [x] `cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings`
- [x] `cargo +nightly fmt --all -- --check`
- [x] `RUSTDOCFLAGS=-D warnings cargo +nightly doc --workspace --no-deps --document-private-items`
- [x] New unit tests for config parsing (enabled / disabled / missing-endpoint / full-block)
- [x] Pre-commit hooks pass