### PR TITLE
fix(kernel,channels): emit TextClear on laziness nudge to clear stale stream text (#1852)

### DIFF
--- a/crates/channels/src/web.rs
+++ b/crates/channels/src/web.rs
@@ -114,6 +114,11 @@ pub enum WebEvent {
     TextDelta { text: String },
     /// Incremental reasoning/thinking text.
     ReasoningDelta { text: String },
+    /// Discard any in-flight assistant text the client has rendered for the
+    /// current turn. Emitted by the kernel before a tool-call batch and
+    /// before the anti-laziness nudge restarts the iteration, so the next
+    /// `TextDelta` stream is not appended on top of abandoned narration.
+    TextClear,
     /// A tool call has started.
     ToolCallStart {
         name:      String,
@@ -270,7 +275,8 @@ fn platform_outbound_to_web_event(msg: PlatformOutbound) -> WebEvent {
 fn stream_event_to_web_event(event: StreamEvent) -> Option<WebEvent> {
     match event {
         StreamEvent::TextDelta { text } => Some(WebEvent::TextDelta { text }),
-        StreamEvent::ReasoningDelta { .. } | StreamEvent::TextClear => None,
+        StreamEvent::ReasoningDelta { .. } => None,
+        StreamEvent::TextClear => Some(WebEvent::TextClear),
         StreamEvent::TurnRationale { text } => Some(WebEvent::TurnRationale { text }),
         StreamEvent::ToolCallStart {
             name,

--- a/crates/kernel/src/agent/mod.rs
+++ b/crates/kernel/src/agent/mod.rs
@@ -1896,7 +1896,7 @@ pub(crate) async fn run_agent_loop(
                     iteration,
                     ack_nudge_count,
                     ?kind,
-                    text_preview = %accumulated_text.chars().take(80).collect::<String>(),
+                    text_preview = ?accumulated_text.chars().take(80).collect::<String>(),
                     "laziness detected, nudging model to take action"
                 );
                 // Persist intermediate assistant text to tape so the model
@@ -1929,6 +1929,10 @@ pub(crate) async fn run_agent_loop(
                         None,
                     )
                     .await;
+                // Why: signal the frontend to discard the abandoned ack text
+                // before the next iteration's TextDelta events arrive, so
+                // the new turn's stream is not appended on top of stale text.
+                stream_handle.emit(StreamEvent::TextClear);
                 continue;
             }
         }


### PR DESCRIPTION
## Summary

When the agent loop's anti-laziness detector fires, it appends the partial assistant text plus the nudge to the tape and `continue`s — but never signals the frontend to discard the abandoned text. The next iteration's `TextDelta` events get appended on top of the stale ack, producing a Frankenstein assistant message in the web UI.

This PR ships three targeted fixes on the same control flow:

- `crates/kernel/src/agent/mod.rs` — emit `StreamEvent::TextClear` in the laziness branch right before the `continue`, mirroring the existing tool-call path at line 1676.
- `crates/channels/src/web.rs` — add a `TextClear` variant to `WebEvent` and route `StreamEvent::TextClear` to it. Previously the adapter filtered `TextClear` to `None`, so the frontend's `case 'text_clear'` handler was dead code even on the tool-call path. The variant serialises as `{"type":"text_clear"}`, matching the existing frontend handler at `web/src/hooks/use-session-timeline.ts:240`.
- Diag log fix: switch the laziness `text_preview` field from `%` (Display) to `?` (Debug) so newlines and `<think>` blocks render visibly in logs.

No frontend code changes — the existing `case 'text_clear'` handler is now finally reachable.

## Type of change

| Type | Label |
|------|-------|
| Bug fix | `bug` |

## Component

`core` (kernel agent loop + web channel adapter)

## Closes

Closes #1852

## Test plan

- [x] `cargo check --all --all-targets`
- [x] `cargo +nightly fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings`
- [x] `RUSTDOCFLAGS="-D warnings" cargo +nightly doc --workspace --no-deps --document-private-items`
- [x] `cargo test --workspace` — all green
- [x] `prek run --all-files` — all hooks pass
- [x] `bun run build` — frontend builds clean (TS already references `text_clear`)