### PR TITLE
feat(tool): expose run_code via boxlite (#1700)

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -131,6 +131,21 @@ agents:
     max_output_chars: 50
 
 # ---------------------------------------------------------------------------
+# Sandboxed code execution (`run_code` tool — optional)
+# ---------------------------------------------------------------------------
+#
+# When this block is present the `run_code` tool can spin up a per-session
+# boxlite microVM using the configured rootfs image. Omit the block to
+# disable code execution: the tool stays registered but every call returns
+# a clear "sandbox not configured" error so the LLM can react.
+#
+# Pre-flight: `rara setup boxlite` must have staged the runtime files (see
+# docs/guides/boxlite-runtime.md).
+
+# sandbox:
+#   default_rootfs_image: "alpine:latest"
+
+# ---------------------------------------------------------------------------
 # Optional integrations — remove or leave commented out if unused
 # ---------------------------------------------------------------------------
 

--- a/crates/app/AGENT.md
+++ b/crates/app/AGENT.md
@@ -38,6 +38,7 @@ Application orchestration crate that wires all subsystems together, boots the ke
 - Migrations run from `crates/rara-model/migrations/` via `diesel_migrations::embed_migrations!` — never modify applied migrations.
 - `KernelHandle` is injected into `DispatchRaraTool` and `ListSessionsTool` after kernel start via `RwLock` slots — these tools will panic if invoked before wiring completes.
 - Mita-exclusive tools: `dispatch-rara`, `list-sessions`, `read-tape`, `write-user-note`, `distill-user-notes`, `update-soul-state`, `evolve-soul`, `update-session-title`, `write-skill-draft`. These are declared in Mita's manifest (`rara-agents`) and must not be added to Rara's tool set.
+- `run_code` (sandboxed code execution) is wired to a per-session boxlite microVM. The first call in a session creates the VM, subsequent calls reuse it, and `SandboxCleanupHook` (registered in `start_with_options`) destroys it via `LifecycleHook::on_session_end` when the kernel removes the session. The default rootfs image is required via the YAML `sandbox.default_rootfs_image` key — there is no Rust fallback. Threat model: hardware-isolated execution (Hypervisor.framework on macOS, KVM on Linux). Network egress is currently UNRESTRICTED inside the VM and there are no resource limits beyond boxlite's own defaults — both are documented as out-of-scope for #1700 and #1696.
 
 ## What NOT To Do
 

--- a/crates/app/Cargo.toml
+++ b/crates/app/Cargo.toml
@@ -48,6 +48,8 @@ rara-keyring-store.workspace = true
 rara-mcp.workspace = true
 rara-paths = { workspace = true }
 rara-pg-credential-store.workspace = true
+rara-sandbox = { workspace = true }
+dashmap = "6"
 rara-server = { workspace = true }
 rara-sessions.workspace = true
 rara-stt = { workspace = true }

--- a/crates/app/src/boot.rs
+++ b/crates/app/src/boot.rs
@@ -100,6 +100,8 @@ pub(crate) async fn boot(
     users: &[UserConfig],
     owner_user_id: &str,
     browser_manager: Option<rara_browser::BrowserManagerRef>,
+    sandbox_config: Option<crate::SandboxToolConfig>,
+    sandbox_map: crate::tools::SandboxMap,
 ) -> Result<BootResult, Whatever> {
     // -- credential store --------------------------------------------------
     let credential_store: rara_keyring_store::KeyringStoreRef = Arc::new(
@@ -231,6 +233,8 @@ pub(crate) async fn boot(
             user_question_manager: user_question_manager.clone(),
             fff_picker,
             fff_query_tracker,
+            sandbox_config,
+            sandbox_map,
         },
     );
 

--- a/crates/app/src/lib.rs
+++ b/crates/app/src/lib.rs
@@ -20,7 +20,7 @@ pub mod gateway;
 // `crate::tool::AgentTool` in derived impls.
 pub(crate) use rara_kernel::tool;
 mod feed_store;
-mod tools;
+pub mod tools;
 mod web_server;
 
 use std::{
@@ -138,6 +138,29 @@ pub struct AppConfig {
     /// rara falls back to `http-fetch` for web access.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub browser:                Option<rara_browser::BrowserConfig>,
+    /// Sandboxed code execution (optional).
+    ///
+    /// When present, the `run_code` tool is registered and uses the configured
+    /// rootfs image to spin up a per-session boxlite microVM. When absent,
+    /// `run_code` is still registered but every invocation returns a clear
+    /// "sandbox not configured" error so the LLM can react and the user can
+    /// fix their YAML — no hardcoded image fallback (per
+    /// `docs/guides/anti-patterns.md`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub sandbox:                Option<SandboxToolConfig>,
+}
+
+/// Configuration for the `run_code` sandbox tool.
+///
+/// The default rootfs image MUST live in YAML — there is no Rust fallback.
+/// See `crates/app/src/tools/run_code.rs` and `crates/rara-sandbox/AGENT.md`
+/// for the rationale.
+#[derive(Debug, Clone, bon::Builder, Serialize, Deserialize)]
+pub struct SandboxToolConfig {
+    /// OCI image reference passed to boxlite (e.g. `"alpine:latest"`,
+    /// `"python:3.12-slim"`). The image must already be resolvable by the
+    /// host's boxlite image store.
+    pub default_rootfs_image: String,
 }
 
 /// Configuration for the Mita background proactive agent.
@@ -383,12 +406,19 @@ pub async fn start_with_options(
             None
         };
 
+    // Shared per-session sandbox map — the `run_code` tool inserts entries,
+    // and the `SandboxCleanupHook` registered below removes them when the
+    // owning session ends.
+    let sandbox_map: crate::tools::SandboxMap = std::sync::Arc::new(dashmap::DashMap::new());
+
     let rara = crate::boot::boot(
         diesel_pools.clone(),
         settings_provider.clone(),
         &config.users,
         &config.owner_user_id,
         browser_manager,
+        config.sandbox.clone(),
+        sandbox_map.clone(),
     )
     .await
     .whatever_context("Failed to boot kernel dependencies")?;
@@ -601,11 +631,13 @@ pub async fn start_with_options(
         });
     }
 
-    // Register lifecycle hooks for the closed learning loop.
+    // Register lifecycle hooks for the closed learning loop and per-session
+    // resource cleanup.
     kernel.set_lifecycle_hooks(rara_kernel::lifecycle::LifecycleHookRegistry::with_hooks(
         vec![
             std::sync::Arc::new(rara_kernel::lifecycle::SkillNudgeHook),
             std::sync::Arc::new(rara_kernel::lifecycle::MemoryNudgeHook::new(10)),
+            std::sync::Arc::new(crate::tools::SandboxCleanupHook::new(sandbox_map.clone())),
         ],
     ));
 

--- a/crates/app/src/tools/mod.rs
+++ b/crates/app/src/tools/mod.rs
@@ -50,6 +50,7 @@ mod mita_write_user_note;
 mod multi_edit;
 mod notify;
 mod read_file;
+pub mod run_code;
 mod send_email;
 mod send_file;
 mod session_info;
@@ -95,6 +96,8 @@ use mita_write_skill_draft::WriteSkillDraftTool;
 use mita_write_user_note::MitaWriteUserNoteTool;
 use multi_edit::MultiEditTool;
 use read_file::ReadFileTool;
+use run_code::RunCodeTool;
+pub use run_code::{SandboxCleanupHook, SandboxMap};
 use send_email::SendEmailTool;
 use send_file::SendFileTool;
 use session_info::SessionInfoTool;
@@ -152,6 +155,10 @@ pub struct ToolDeps {
     pub fff_picker:             fff_search::SharedPicker,
     /// Shared fff query tracker state (initialized at boot).
     pub fff_query_tracker:      fff_search::SharedQueryTracker,
+    /// Sandbox tool config from YAML; `None` disables `run_code`.
+    pub sandbox_config:         Option<crate::SandboxToolConfig>,
+    /// Shared per-session sandbox map; the cleanup hook holds a clone.
+    pub sandbox_map:            SandboxMap,
 }
 
 /// Result of tool registration, carrying handles needed for post-init wiring.
@@ -184,6 +191,10 @@ pub fn register_all(registry: &mut ToolRegistry, deps: ToolDeps) -> ToolRegistra
     // `rara_kernel::guard::path_scope::{FILE_PATH_TOOLS, PATH_TOOLS}`.
     let tools: Vec<AgentToolRef> = vec![
         Arc::new(BashTool::new()),
+        Arc::new(RunCodeTool::new(
+            deps.sandbox_config.clone(),
+            deps.sandbox_map.clone(),
+        )),
         Arc::new(ReadFileTool::new()),
         Arc::new(WriteFileTool::new()),
         Arc::new(EditFileTool::new()),

--- a/crates/app/src/tools/run_code.rs
+++ b/crates/app/src/tools/run_code.rs
@@ -109,10 +109,6 @@ impl RunCodeTool {
         &self,
         session_key: SessionKey,
     ) -> anyhow::Result<Arc<Mutex<Sandbox>>> {
-        if let Some(existing) = self.sandboxes.get(&session_key) {
-            return Ok(Arc::clone(existing.value()));
-        }
-
         let cfg = self.config.as_ref().ok_or_else(|| {
             anyhow::anyhow!(
                 "run_code is unavailable: `sandbox.default_rootfs_image` is not set in \
@@ -120,8 +116,9 @@ impl RunCodeTool {
             )
         })?;
 
-        // Use entry() to avoid the create-twice race: if another task
-        // raced us, only one Sandbox::create call wins.
+        // entry() closes the create-twice race: if two first-calls hit
+        // the same shard concurrently, only one reaches Vacant and runs
+        // Sandbox::create.
         let entry = self.sandboxes.entry(session_key);
         let arc = match entry {
             dashmap::mapref::entry::Entry::Occupied(o) => Arc::clone(o.get()),
@@ -200,7 +197,13 @@ impl ToolExecute for RunCodeTool {
             }
         }
 
-        let exit_code = outcome.execution.wait().await.ok().map(|s| s.code());
+        let exit_code = match outcome.execution.wait().await {
+            Ok(status) => Some(status.code()),
+            Err(e) => {
+                tracing::warn!(error = %e, "sandbox exec wait failed; reporting None");
+                None
+            }
+        };
 
         Ok(RunCodeResult {
             exit_code,
@@ -239,17 +242,18 @@ impl LifecycleHook for SandboxCleanupHook {
         // is preferable to blocking subsequent session teardown.
         tokio::spawn(async move {
             // `destroy` consumes `self`; pull the inner Sandbox out of
-            // the Arc<Mutex<…>>. If another task is still mid-exec, we
-            // bail out: the kernel's signal pipeline has already
-            // cancelled the turn, but the Sandbox would be leaked
-            // anyway since `destroy` cannot run on a borrowed handle.
+            // the Arc<Mutex<…>>. If another task is still mid-exec we
+            // cannot reclaim ownership — the kernel signal pipeline has
+            // already cancelled the turn but the in-flight clone is
+            // still live, so the VM gets leaked until process exit.
+            // Tracked in #1866.
             let inner = match Arc::try_unwrap(sandbox) {
                 Ok(mutex) => mutex.into_inner(),
                 Err(arc) => {
                     tracing::warn!(
                         session_key = %session_key,
                         strong_count = Arc::strong_count(&arc),
-                        "sandbox still in use at session end; leaking VM until process exit"
+                        "sandbox still in use at session end; leaking VM until process exit (see #1866)"
                     );
                     return;
                 }

--- a/crates/app/src/tools/run_code.rs
+++ b/crates/app/src/tools/run_code.rs
@@ -1,0 +1,297 @@
+// Copyright 2025 Rararulab
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Sandboxed code execution tool, backed by `rara-sandbox` (boxlite).
+//!
+//! The first invocation in a [`SessionKey`] creates a microVM (rootfs image
+//! taken from YAML config) and stashes it in a session-keyed map. Subsequent
+//! invocations in the same session reuse the same VM — boxlite cold start is
+//! ~60 ms but installing dependencies on every call would be wasteful, so
+//! the sandbox is held until the session ends. Cleanup is driven by the
+//! `LifecycleHook::on_session_end` hook installed at startup
+//! (see [`SandboxCleanupHook`]).
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use dashmap::DashMap;
+use futures::StreamExt;
+use rara_kernel::{
+    io::{StreamEvent, StreamHandle},
+    lifecycle::{LifecycleHook, SessionEndContext},
+    session::SessionKey,
+    tool::{ToolContext, ToolExecute},
+};
+use rara_sandbox::{ExecRequest, Sandbox, SandboxConfig};
+use rara_tool_macro::ToolDef;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use tokio::sync::Mutex;
+
+use crate::SandboxToolConfig;
+
+/// Per-session sandbox lookup table.
+///
+/// Wrapped in `Arc` so the tool and the cleanup hook share a single map.
+pub type SandboxMap = Arc<DashMap<SessionKey, Arc<Mutex<Sandbox>>>>;
+
+/// Input parameters for the `run_code` tool.
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct RunCodeParams {
+    /// Executable to invoke inside the sandbox (e.g. `"sh"`, `"python"`).
+    command: String,
+    /// Arguments to pass, in order. Empty vec means no args.
+    #[serde(default)]
+    args:    Vec<String>,
+}
+
+/// Typed result returned by `run_code`.
+#[derive(Debug, Clone, Serialize)]
+pub struct RunCodeResult {
+    /// Process exit code reported by boxlite. `None` if the sandbox never
+    /// reported one (e.g. transport error).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub exit_code: Option<i32>,
+    /// Combined stdout captured during execution.
+    pub stdout:    String,
+    /// Combined stderr captured during execution. Empty when the sandbox
+    /// declined to materialise a stderr stream.
+    pub stderr:    String,
+}
+
+/// Sandboxed code execution tool.
+///
+/// Tier is `Deferred` — most agent turns do not need code execution, and
+/// the rootfs image carries non-trivial cost (microVM cold start + image
+/// pull on first use), so we keep it out of the always-on tool set.
+#[derive(ToolDef)]
+#[tool(
+    name = "run_code",
+    description = "Execute a command inside a hardware-isolated sandbox (boxlite microVM). Reuses \
+                   one VM per session; the VM is destroyed when the session ends. Use this for \
+                   running LLM-generated code that should not touch the host.",
+    tier = "deferred",
+    destructive
+)]
+pub struct RunCodeTool {
+    /// Sandbox creation parameters resolved from YAML at startup.
+    /// `None` means the operator did not configure `sandbox:` in
+    /// `config.yaml` — in that case every call returns an error.
+    config:    Option<SandboxToolConfig>,
+    /// Shared per-session sandbox handles. Cloned into
+    /// [`SandboxCleanupHook`] so session-end cleanup hits the same map.
+    sandboxes: SandboxMap,
+}
+
+impl RunCodeTool {
+    /// Create a new tool wired to the given config and shared sandbox map.
+    pub fn new(config: Option<SandboxToolConfig>, sandboxes: SandboxMap) -> Self {
+        Self { config, sandboxes }
+    }
+
+    /// Look up an existing sandbox for `session_key`, creating one on the
+    /// first call. Concurrent invocations within the same session
+    /// serialize on the per-session mutex returned here.
+    /// Public for the integration test in `tests/run_code_session.rs`.
+    /// Not part of the agent-callable surface.
+    pub async fn sandbox_for_session(
+        &self,
+        session_key: SessionKey,
+    ) -> anyhow::Result<Arc<Mutex<Sandbox>>> {
+        if let Some(existing) = self.sandboxes.get(&session_key) {
+            return Ok(Arc::clone(existing.value()));
+        }
+
+        let cfg = self.config.as_ref().ok_or_else(|| {
+            anyhow::anyhow!(
+                "run_code is unavailable: `sandbox.default_rootfs_image` is not set in \
+                 config.yaml. Add a `sandbox:` block (see config.example.yaml) and restart."
+            )
+        })?;
+
+        // Use entry() to avoid the create-twice race: if another task
+        // raced us, only one Sandbox::create call wins.
+        let entry = self.sandboxes.entry(session_key);
+        let arc = match entry {
+            dashmap::mapref::entry::Entry::Occupied(o) => Arc::clone(o.get()),
+            dashmap::mapref::entry::Entry::Vacant(v) => {
+                let sandbox = Sandbox::create(
+                    SandboxConfig::builder()
+                        .rootfs_image(cfg.default_rootfs_image.clone())
+                        .build(),
+                )
+                .await
+                .map_err(|e| anyhow::anyhow!("failed to create sandbox: {e}"))?;
+                let arc = Arc::new(Mutex::new(sandbox));
+                v.insert(Arc::clone(&arc));
+                arc
+            }
+        };
+        Ok(arc)
+    }
+}
+
+#[async_trait]
+impl ToolExecute for RunCodeTool {
+    type Output = RunCodeResult;
+    type Params = RunCodeParams;
+
+    #[tracing::instrument(skip_all, fields(command = %params.command))]
+    async fn run(
+        &self,
+        params: RunCodeParams,
+        context: &ToolContext,
+    ) -> anyhow::Result<RunCodeResult> {
+        let sandbox = self.sandbox_for_session(context.session_key).await?;
+        let request = ExecRequest::builder()
+            .command(params.command)
+            .args(params.args)
+            .build();
+
+        // Hold the per-session lock for the whole exec — boxlite's `LiteBox`
+        // is not assumed `Sync` (see `rara-sandbox/AGENT.md`), so concurrent
+        // calls within the same session must serialize.
+        let guard = sandbox.lock().await;
+        let mut outcome = guard
+            .exec(request)
+            .await
+            .map_err(|e| anyhow::anyhow!("sandbox exec failed: {e}"))?;
+
+        // Build streaming context up front so each stdout chunk can be
+        // forwarded to the agent UI as it arrives.
+        let stream_ctx: Option<(StreamHandle, String)> = context
+            .stream_handle
+            .as_ref()
+            .zip(context.tool_call_id.as_ref())
+            .map(|(h, id)| (h.clone(), id.clone()));
+
+        let mut stdout = String::new();
+        while let Some(line) = outcome.stdout.next().await {
+            if let Some((ref handle, ref tool_call_id)) = stream_ctx {
+                handle.emit(StreamEvent::ToolOutput {
+                    tool_call_id: tool_call_id.clone(),
+                    chunk:        line.clone(),
+                });
+            }
+            stdout.push_str(&line);
+            if !line.ends_with('\n') {
+                stdout.push('\n');
+            }
+        }
+
+        let mut stderr = String::new();
+        if let Some(mut s) = outcome.stderr {
+            while let Some(line) = s.next().await {
+                stderr.push_str(&line);
+                if !line.ends_with('\n') {
+                    stderr.push('\n');
+                }
+            }
+        }
+
+        let exit_code = outcome.execution.wait().await.ok().map(|s| s.code());
+
+        Ok(RunCodeResult {
+            exit_code,
+            stdout,
+            stderr,
+        })
+    }
+}
+
+/// Lifecycle hook that destroys per-session sandboxes when their owning
+/// session ends.
+///
+/// Holds the same [`SandboxMap`] as the tool itself; the kernel fires
+/// `on_session_end` from `cleanup_process` (see `crates/kernel/src/kernel.rs`).
+pub struct SandboxCleanupHook {
+    sandboxes: SandboxMap,
+}
+
+impl SandboxCleanupHook {
+    /// Build a hook that watches the given shared map.
+    pub fn new(sandboxes: SandboxMap) -> Self { Self { sandboxes } }
+}
+
+#[async_trait]
+impl LifecycleHook for SandboxCleanupHook {
+    fn name(&self) -> &str { "sandbox-cleanup" }
+
+    async fn on_session_end(&self, ctx: &SessionEndContext) {
+        let Some((_, sandbox)) = self.sandboxes.remove(&ctx.session_key) else {
+            return;
+        };
+        let session_key = ctx.session_key;
+        // The lifecycle pipeline times each hook out at 5s. `Sandbox::destroy`
+        // can take longer (boxlite tears down the VM), so spawn it
+        // detached — the map entry is already removed, and a leaked box
+        // is preferable to blocking subsequent session teardown.
+        tokio::spawn(async move {
+            // `destroy` consumes `self`; pull the inner Sandbox out of
+            // the Arc<Mutex<…>>. If another task is still mid-exec, we
+            // bail out: the kernel's signal pipeline has already
+            // cancelled the turn, but the Sandbox would be leaked
+            // anyway since `destroy` cannot run on a borrowed handle.
+            let inner = match Arc::try_unwrap(sandbox) {
+                Ok(mutex) => mutex.into_inner(),
+                Err(arc) => {
+                    tracing::warn!(
+                        session_key = %session_key,
+                        strong_count = Arc::strong_count(&arc),
+                        "sandbox still in use at session end; leaking VM until process exit"
+                    );
+                    return;
+                }
+            };
+            if let Err(e) = inner.destroy().await {
+                tracing::warn!(error = %e, "failed to destroy sandbox on session end");
+            }
+        });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn run_code_params_parses_minimal() {
+        let v = serde_json::json!({"command": "echo"});
+        let p: RunCodeParams = serde_json::from_value(v).expect("parse");
+        assert_eq!(p.command, "echo");
+        assert!(p.args.is_empty());
+    }
+
+    #[test]
+    fn run_code_params_parses_with_args() {
+        let v = serde_json::json!({"command": "sh", "args": ["-c", "echo hi"]});
+        let p: RunCodeParams = serde_json::from_value(v).expect("parse");
+        assert_eq!(p.command, "sh");
+        assert_eq!(p.args, vec!["-c", "echo hi"]);
+    }
+
+    #[test]
+    fn run_code_schema_advertises_required_command() {
+        let schema = schemars::schema_for!(RunCodeParams);
+        let value = serde_json::to_value(&schema).expect("serialize");
+        let required = value
+            .get("required")
+            .and_then(|r| r.as_array())
+            .expect("required array");
+        assert!(
+            required.iter().any(|v| v.as_str() == Some("command")),
+            "command must be required, got: {required:?}"
+        );
+    }
+}

--- a/crates/app/tests/run_code_session.rs
+++ b/crates/app/tests/run_code_session.rs
@@ -1,0 +1,59 @@
+// Integration test for the session-scoped lifecycle of the `run_code` tool.
+//
+// Marked `#[ignore]` for the same reason as
+// `crates/rara-sandbox/tests/alpine_echo.rs`: it requires `rara setup boxlite`
+// to have staged runtime files plus a warm OCI image cache. CI runs with
+// `BOXLITE_DEPS_STUB=1` and would always fail this test.
+
+use std::sync::Arc;
+
+use dashmap::DashMap;
+use rara_app::{
+    SandboxToolConfig,
+    tools::run_code::{RunCodeTool, SandboxCleanupHook, SandboxMap},
+};
+use rara_kernel::{
+    lifecycle::{LifecycleHook, SessionEndContext},
+    session::SessionKey,
+};
+
+#[tokio::test]
+#[ignore = "requires boxlite runtime files (issue #1699) and a local OCI image cache"]
+async fn run_code_reuses_sandbox_across_calls_and_destroys_on_session_end() {
+    let cfg = SandboxToolConfig::builder()
+        .default_rootfs_image("alpine:latest".to_owned())
+        .build();
+    let map: SandboxMap = Arc::new(DashMap::new());
+    let tool = RunCodeTool::new(Some(cfg), map.clone());
+    let session = SessionKey::default();
+
+    // First call: must create the sandbox.
+    let first = tool
+        .sandbox_for_session(session)
+        .await
+        .expect("sandbox creation should succeed");
+    assert_eq!(map.len(), 1, "first call must populate the map");
+
+    // Second call: must reuse the same Arc (pointer equality).
+    let second = tool
+        .sandbox_for_session(session)
+        .await
+        .expect("second lookup should succeed");
+    assert!(
+        Arc::ptr_eq(&first, &second),
+        "subsequent calls must reuse the existing sandbox"
+    );
+
+    // Drop our locally held Arcs so try_unwrap inside the hook succeeds.
+    drop(first);
+    drop(second);
+
+    // Hook fires destroy in a spawned task; map entry is removed synchronously.
+    let hook = SandboxCleanupHook::new(map.clone());
+    hook.on_session_end(&SessionEndContext {
+        session_key:   session,
+        manifest_name: "test".to_owned(),
+    })
+    .await;
+    assert_eq!(map.len(), 0, "session-end hook must remove the entry");
+}

--- a/crates/kernel/AGENT.md
+++ b/crates/kernel/AGENT.md
@@ -429,3 +429,12 @@ Each kernel turn calls `StreamHub::open(session)` which gets-or-creates a `broad
 - Wire-shape choice at the backend admin layer: **200 + `triggered` discriminator**, not 409. Two outcomes are both success (fresh vs. deduped); the frontend doesn't need to decode a status code just to tell them apart, and there's no global toast infrastructure that would benefit from a dedicated error channel.
 - `Syscall::ListAllJobs` is an admin-only surface. The kernel does not authenticate it; the backend HTTP route is the auth boundary. Do NOT repurpose this variant for session-scoped tool calls — use `Syscall::ListJobs` there so future tightening of `ListAllJobs` permissions cannot regress tool UX.
 - `JobResultStore::read_latest` intentionally walks results newest-first and skips malformed entries, so a single corrupt tail object does not hide the rest of the history from the admin UI. Keep the fall-through behaviour when extending the store.
+
+---
+
+## Lifecycle Hooks — `lifecycle.rs`
+
+- `LifecycleHook::on_session_end` fires from `Kernel::cleanup_process` immediately after the session is removed from the process table. Use it for releasing per-session resources owned outside the kernel — the canonical example is `crates/app/src/tools/run_code.rs` destroying its boxlite microVM.
+- The hook runs in the `cleanup_process` task and is bounded to 5 s by `LifecycleHookRegistry::fire_session_end`. Long teardown (e.g. `Sandbox::destroy`) must be spawned as a detached `tokio::task` so it does not stall subsequent session cleanup.
+- Do NOT attempt to mutate the process table from inside `on_session_end` — the entry has already been removed, and the hook is invoked from the kernel's own cleanup path. Treat the context as read-only metadata.
+- `SessionEndContext` only carries `session_key` + `manifest_name`. If a future hook needs more state, add it to the context struct rather than smuggling it through global maps; the goal is for hooks to be stateless except for whatever shared handle they were registered with.

--- a/crates/kernel/AGENT.md
+++ b/crates/kernel/AGENT.md
@@ -435,6 +435,6 @@ Each kernel turn calls `StreamHub::open(session)` which gets-or-creates a `broad
 ## Lifecycle Hooks — `lifecycle.rs`
 
 - `LifecycleHook::on_session_end` fires from `Kernel::cleanup_process` immediately after the session is removed from the process table. Use it for releasing per-session resources owned outside the kernel — the canonical example is `crates/app/src/tools/run_code.rs` destroying its boxlite microVM.
-- The hook runs in the `cleanup_process` task and is bounded to 5 s by `LifecycleHookRegistry::fire_session_end`. Long teardown (e.g. `Sandbox::destroy`) must be spawned as a detached `tokio::task` so it does not stall subsequent session cleanup.
+- The hook *invocation* (the `await` inside `LifecycleHookRegistry::fire_session_end`) is bounded to 5 s; spawned detached `tokio::task`s are unbounded by design. Long teardown (e.g. `Sandbox::destroy`) must therefore be spawned detached so it does not stall subsequent session cleanup, while still running to completion or process exit.
 - Do NOT attempt to mutate the process table from inside `on_session_end` — the entry has already been removed, and the hook is invoked from the kernel's own cleanup path. Treat the context as read-only metadata.
 - `SessionEndContext` only carries `session_key` + `manifest_name`. If a future hook needs more state, add it to the context struct rather than smuggling it through global maps; the goal is for hooks to be stateless except for whatever shared handle they were registered with.

--- a/crates/kernel/src/kernel.rs
+++ b/crates/kernel/src/kernel.rs
@@ -1259,6 +1259,15 @@ impl Kernel {
             let state = rt.state();
             let parent_id = rt.parent_id;
 
+            // Notify lifecycle hooks so consumers (e.g. the `run_code` tool)
+            // can release per-session resources (sandbox VMs, etc.).
+            self.lifecycle_hooks
+                .fire_session_end(&crate::lifecycle::SessionEndContext {
+                    session_key,
+                    manifest_name: manifest_name.clone(),
+                })
+                .await;
+
             // Clear in-flight ledger entry for scheduled job agents and
             // deliver the result to the origin session that created the job.
             if manifest_name == "scheduled_job" {

--- a/crates/kernel/src/lifecycle.rs
+++ b/crates/kernel/src/lifecycle.rs
@@ -73,6 +73,15 @@ pub struct FoldContext {
     pub entries_count: usize,
 }
 
+/// Context for session-end hooks.
+#[derive(Debug, Clone)]
+pub struct SessionEndContext {
+    /// The session that just terminated.
+    pub session_key:   SessionKey,
+    /// Manifest name of the agent that owned the session.
+    pub manifest_name: String,
+}
+
 /// Context for delegation (child agent) hooks.
 #[derive(Debug, Clone)]
 pub struct DelegationResult {
@@ -126,6 +135,14 @@ pub trait LifecycleHook: Send + Sync + 'static {
 
     /// Called when a delegated child agent finishes.
     async fn delegation_done(&self, _result: &DelegationResult) {}
+
+    /// Called when a session terminates and is being removed from the
+    /// process table.
+    ///
+    /// Use this to release per-session resources owned outside the kernel
+    /// (e.g. a sandbox VM held by the `run_code` tool). Hooks must not
+    /// block — long teardown should be spawned as a background task.
+    async fn on_session_end(&self, _ctx: &SessionEndContext) {}
 }
 
 /// Shared reference to a lifecycle hook.
@@ -209,6 +226,18 @@ impl LifecycleHookRegistry {
             .await
             {
                 tracing::warn!(hook = hook.name(), "post_fold hook timed out: {e}");
+            }
+        }
+    }
+
+    /// Fire `on_session_end` on all registered hooks.
+    pub async fn fire_session_end(&self, ctx: &SessionEndContext) {
+        for hook in self.hooks.iter() {
+            if let Err(e) =
+                tokio::time::timeout(std::time::Duration::from_secs(5), hook.on_session_end(ctx))
+                    .await
+            {
+                tracing::warn!(hook = hook.name(), "on_session_end hook timed out: {e}");
             }
         }
     }

--- a/crates/rara-sandbox/AGENT.md
+++ b/crates/rara-sandbox/AGENT.md
@@ -85,11 +85,13 @@ Public surface (intentionally minimal, see #1697/#1698):
 - `bon`, `futures`, `serde`, `snafu`, `tokio`, `tracing` — standard
   workspace deps.
 
-**Downstream (crates that will depend on this one):**
+**Downstream (crates that depend on this one):**
 
-- `rara-kernel` tool subsystem — wiring happens in issue #1700. Not this
-  issue. Do not add a `rara-kernel` integration here; `rara-kernel` will
-  import `rara-sandbox` and build a `Tool` impl on top.
+- `rara-app` — `crates/app/src/tools/run_code.rs` exposes the `run_code`
+  agent-callable tool; sandboxes are stored per-session in a `DashMap`
+  shared with `SandboxCleanupHook`. The hook destroys the VM via the
+  kernel's `LifecycleHook::on_session_end` (added in #1700) so each
+  session pays the boxlite cold-start cost at most once.
 
 ## Boxlite Footguns (from the v0.8.2 spike)
 


### PR DESCRIPTION
## Summary

Step 3 (final) of #1696. Surfaces sandboxed code execution as the
LLM-callable `run_code` tool with per-session sandbox reuse.

- New `run_code` tool (deferred tier, destructive) under
  `crates/app/src/tools/run_code.rs`. First invocation in a session
  creates a boxlite microVM from the configured rootfs image;
  subsequent calls reuse it.
- New YAML key `sandbox.default_rootfs_image` — no Rust fallback;
  unset means the tool returns a clear \"not configured\" error.
- New kernel hook `LifecycleHook::on_session_end`, fired from
  `Kernel::cleanup_process`. `SandboxCleanupHook` registered in
  `start_with_options` calls `Sandbox::destroy` on session teardown.
- Stdout streams through the existing `StreamHandle` /
  `StreamEvent::ToolOutput` path, mirroring `bash.rs`.
- AGENT.md updated for `rara-kernel`, `rara-app`, and `rara-sandbox`
  (downstream pointer now references the real wiring site).
- Integration test `crates/app/tests/run_code_session.rs` exercises
  the session-scoped lifecycle end-to-end; gated `#[ignore]` for
  the same reason as `crates/rara-sandbox/tests/alpine_echo.rs`.

## Type of change

| Type | Label |
|------|-------|
| New feature | `enhancement` |

## Component

`core`

## Closes

Closes #1700

## Test plan

- [x] `cargo +nightly fmt --all -- --check` passes
- [x] `cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings` passes
- [x] `RUSTDOCFLAGS=\"-D warnings\" cargo +nightly doc --workspace --no-deps --document-private-items` passes
- [x] `cargo test -p rara-app run_code` passes (3 unit tests + 1 ignored integration test)
- [x] `cargo test -p rara-kernel lifecycle` passes (4 tests)
- [ ] End-to-end test with real boxlite — requires `rara setup boxlite` (blocked by env, not regressed by this PR)