### PR TITLE
feat(telemetry): integrate Pyroscope continuous profiling (#1857)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -194,6 +194,8 @@ opendal = { version = "0.52", features = ["services-fs", "services-memory"] }
 parking_lot = "0.12"
 prost = "^0.14"
 protobuf = "^3.7"
+pyroscope = "0.5"
+pyroscope_pprofrs = "0.2"
 rand = "0.10"
 rapidfuzz = "0.5"
 ratatui = { version = "0.29", features = ["crossterm"] }

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -146,10 +146,10 @@ agents:
 #   default_rootfs_image: "alpine:latest"
 
 # ---------------------------------------------------------------------------
-# Telemetry — OTLP traces export (optional)
+# Telemetry — optional OTLP traces and Pyroscope continuous profiling
 # ---------------------------------------------------------------------------
 #
-# Two independent paths are supported:
+# Two independent OTLP paths are supported:
 #
 # 1. `telemetry.otlp_endpoint` / `otlp_protocol` — the legacy generic OTLP
 #    sink (Alloy / Tempo). Set `otlp_endpoint` to a non-empty URL to enable.
@@ -158,15 +158,35 @@ agents:
 #    Disabled by default; set `enabled: true` and provide a `traces_endpoint`
 #    plus auth header to push spans to a running Langfuse instance.
 #
-# Example (commented out — opt in by uncommenting and setting `enabled: true`):
+# `pyroscope` enables continuous CPU profiling via the Grafana Pyroscope agent
+# (pprof-rs backend). Omit the whole `pyroscope:` section to disable — that is
+# the zero-overhead default. When present, every field is required.
+#
+# Tags attached to profiles are process-level only (env, host, build_commit).
+# Per-request labels (session_id, skill_name, user_id, …) MUST NOT be added —
+# they explode label cardinality on the Pyroscope server.
+#
+# Limitation: pprof-rs samples OS-thread CPU only. It does NOT capture async
+# `.await` stalls or tokio mutex contention; use tokio-console for those
+# (separate feature flag, future chore).
+#
+# Example (commented out — opt in by uncommenting):
 #
 # telemetry:
+#   otlp_endpoint: "http://alloy:4318/v1/traces"
+#   otlp_protocol: "http"
+#   env: "prod"
 #   otlp:
 #     enabled: false
 #     traces_endpoint: "http://10.0.0.183:3000/api/public/otel/v1/traces"
 #     deployment_environment: "dev"
 #     headers:
 #       authorization: "Basic <base64(public_key:secret_key)>"
+#   pyroscope:
+#     enabled: false  # default off — flip to true to ship profiles
+#     endpoint: "http://10.0.0.183:4040"
+#     application_name: "rara"
+#     sample_rate: 100  # Hz
 
 # ---------------------------------------------------------------------------
 # Optional integrations — remove or leave commented out if unused

--- a/crates/app/Cargo.toml
+++ b/crates/app/Cargo.toml
@@ -20,6 +20,7 @@ base = { workspace = true }
 bon = { workspace = true }
 chrono.workspace = true
 common-runtime = { workspace = true }
+common-telemetry = { workspace = true }
 common-worker = { workspace = true }
 config = { workspace = true }
 futures.workspace = true
@@ -84,7 +85,6 @@ yunara-store = { workspace = true }
 similar = "3.1.0"
 
 [dev-dependencies]
-common-telemetry.workspace = true
 rara-kernel = { workspace = true }
 tempfile = { workspace = true }
 tokio = { workspace = true }

--- a/crates/app/src/lib.rs
+++ b/crates/app/src/lib.rs
@@ -240,6 +240,13 @@ pub struct TelemetryConfig {
     /// Langfuse). Disabled by default.
     #[serde(default)]
     pub otlp:          Option<OtlpConfig>,
+    /// Continuous CPU profiling via Pyroscope. Section omitted = off.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pyroscope:     Option<common_telemetry::profiling::PyroscopeConfig>,
+    /// Deployment environment label (e.g. `"prod"`, `"dev"`). Used as
+    /// a low-cardinality process-level tag on profiling samples.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub env:           Option<String>,
 }
 
 /// OTLP/HTTP traces exporter config (Langfuse-compatible).
@@ -1374,6 +1381,53 @@ mita:
             err.to_string().contains("owner_token must not be empty"),
             "unexpected error: {err}"
         );
+    }
+
+    #[test]
+    fn telemetry_pyroscope_section_absent_yields_none() {
+        // Default: no `telemetry:` section at all → pyroscope disabled, no
+        // agent constructed, zero overhead at startup.
+        let cfg: AppConfig = serde_yaml::from_str(BASE_YAML).expect("base yaml");
+        assert!(cfg.telemetry.pyroscope.is_none());
+        assert!(cfg.telemetry.env.is_none());
+    }
+
+    #[test]
+    fn telemetry_pyroscope_section_parses_required_fields() {
+        let yaml = format!(
+            "{BASE_YAML}\n\
+telemetry:\n  \
+  env: \"prod\"\n  \
+  pyroscope:\n    \
+    enabled: true\n    \
+    endpoint: \"http://10.0.0.183:4040\"\n    \
+    application_name: \"rara\"\n    \
+    sample_rate: 100\n"
+        );
+        let cfg: AppConfig = serde_yaml::from_str(&yaml).expect("yaml");
+        let pyro = cfg.telemetry.pyroscope.expect("pyroscope section parsed");
+        assert!(pyro.enabled);
+        assert_eq!(pyro.endpoint, "http://10.0.0.183:4040");
+        assert_eq!(pyro.application_name, "rara");
+        assert_eq!(pyro.sample_rate, 100);
+        assert_eq!(cfg.telemetry.env.as_deref(), Some("prod"));
+    }
+
+    #[test]
+    fn telemetry_pyroscope_disabled_still_parses() {
+        // `enabled: false` is the documented opt-in-by-default-off shape.
+        let yaml = format!(
+            "{BASE_YAML}\n\
+telemetry:\n  \
+  pyroscope:\n    \
+    enabled: false\n    \
+    endpoint: \"http://localhost:4040\"\n    \
+    application_name: \"rara\"\n    \
+    sample_rate: 100\n"
+        );
+        let cfg: AppConfig = serde_yaml::from_str(&yaml).expect("yaml");
+        let pyro = cfg.telemetry.pyroscope.expect("section present");
+        assert!(!pyro.enabled);
     }
 
     #[test]

--- a/crates/cmd/Cargo.toml
+++ b/crates/cmd/Cargo.toml
@@ -48,6 +48,7 @@ serde_json.workspace = true
 serde_yaml.workspace = true
 shadow-rs = { workspace = true }
 snafu.workspace = true
+sysinfo.workspace = true
 anyhow.workspace = true
 diesel.workspace = true
 diesel_migrations.workspace = true

--- a/crates/cmd/src/main.rs
+++ b/crates/cmd/src/main.rs
@@ -139,8 +139,48 @@ impl ServerArgs {
             None,
         );
 
+        // Continuous profiling (Pyroscope). Held for the lifetime of the
+        // server process — its `Drop` performs graceful shutdown so the
+        // last batch flushes when the process receives SIGTERM/SIGINT and
+        // `run_app` returns cleanly via its existing signal handler.
+        let _profiling_guard = init_profiling(&config)?;
+
         run_app(config).await
     }
+}
+
+/// Wire the Pyroscope profiling agent if enabled in YAML config.
+///
+/// `build_commit` comes from `shadow-rs` (`build::SHORT_COMMIT`), captured
+/// at compile time so the running process can be cross-referenced with the
+/// source tree without relying on runtime git access.
+fn init_profiling(
+    config: &AppConfig,
+) -> Result<Option<common_telemetry::profiling::ProfilingGuard>, Whatever> {
+    let Some(pyro_cfg) = config.telemetry.pyroscope.as_ref() else {
+        return Ok(None);
+    };
+    let env = config.telemetry.env.as_deref().unwrap_or("unknown");
+    let host_buf = hostname_or_unknown();
+    let host = host_buf.as_str();
+    let build_commit = if build_info::build::SHORT_COMMIT.is_empty() {
+        "unknown"
+    } else {
+        build_info::build::SHORT_COMMIT
+    };
+    common_telemetry::profiling::init_pyroscope(pyro_cfg, env, host, build_commit)
+        .whatever_context("Failed to initialise Pyroscope profiling")
+}
+
+/// Best-effort hostname lookup for low-cardinality profiling tags.
+///
+/// Falls back to the `HOSTNAME` env var (set by most shells) and then
+/// `"unknown"` so a missing hostname never blocks profiling startup.
+fn hostname_or_unknown() -> String {
+    sysinfo::System::host_name()
+        .filter(|s| !s.is_empty())
+        .or_else(|| std::env::var("HOSTNAME").ok().filter(|s| !s.is_empty()))
+        .unwrap_or_else(|| "unknown".to_owned())
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/common/telemetry/AGENT.md
+++ b/crates/common/telemetry/AGENT.md
@@ -12,6 +12,7 @@ Telemetry utilities — logging initialization, tracing subscriber setup (with o
 - `src/panic_hook.rs` — Custom panic hook that logs panics via tracing before the default handler.
 - `src/tracing_context.rs` — Utilities for propagating tracing context across async boundaries.
 - `src/tracing_sampler.rs` — Custom tracing sampler for controlling trace sampling rates.
+- `src/profiling.rs` — `init_pyroscope()` wires the Grafana Pyroscope agent (pprof-rs backend) for continuous CPU profiling. Returns a `ProfilingGuard` whose `Drop` performs graceful shutdown (stop → flush → join). Section omitted from YAML = zero overhead, no thread spawned.
 
 ### Features
 
@@ -22,15 +23,19 @@ Telemetry utilities — logging initialization, tracing subscriber setup (with o
 - `init_global_logging()` must be called once at startup — it installs a global tracing subscriber.
 - The returned guard objects (`Vec<WorkerGuard>`) must be kept alive — dropping them flushes and closes log writers.
 - OTLP endpoint configuration comes from `LoggingOptions` — do not hardcode endpoints.
+- The `ProfilingGuard` returned from `init_pyroscope()` must be held for the lifetime of the process — dropping it stops the agent and flushes the last batch.
+- Pyroscope tags are **process-level only** (`env`, `host`, `build_commit`). Per-request labels (`session_id`, `skill_name`, `user_id`, …) MUST NOT be attached — they explode label cardinality on the server and turn flamegraph queries into table scans.
 
 ## What NOT To Do
 
 - Do NOT call `init_global_logging()` more than once — the global subscriber can only be set once.
 - Do NOT drop the logging guards early — log output will stop.
 - Do NOT import `tracing_subscriber::fmt::init()` directly — use this crate's initialization.
+- Do NOT expect Pyroscope to capture async `.await` stalls or tokio mutex contention — `pprof-rs` is OS-thread CPU sampling. For async stall / lock contention diagnosis, enable the `tokio-console` feature flag (separate chore) and connect with the `tokio-console` CLI.
+- Do NOT add per-request labels to Pyroscope tags — see Critical Invariants. Process-level tags only.
 
 ## Dependencies
 
-**Upstream:** `tracing`, `tracing-subscriber`, `tracing-appender`, `opentelemetry` (optional OTLP).
+**Upstream:** `tracing`, `tracing-subscriber`, `tracing-appender`, `opentelemetry` (optional OTLP), `pyroscope` + `pyroscope_pprofrs` (continuous profiling).
 
 **Downstream:** `crates/cmd` (initializes logging at startup).

--- a/crates/common/telemetry/Cargo.toml
+++ b/crates/common/telemetry/Cargo.toml
@@ -25,9 +25,12 @@ opentelemetry = { version = "0.31.0", default-features = false, features = ["tra
 opentelemetry-otlp = { version = "0.31.0", features = ["trace", "metrics", "grpc-tonic", "http-proto"] }
 opentelemetry-semantic-conventions = { version = "0.31.0", features = ["semconv_experimental"] }
 opentelemetry_sdk = { version = "0.31.0", features = ["rt-tokio", "trace", "metrics"] }
+pyroscope = { workspace = true }
+pyroscope_pprofrs = { workspace = true }
 serde.workspace = true
 serde_json = "1.0"
 smart-default = { workspace = true }
+snafu.workspace = true
 tokio.workspace = true
 tracing.workspace = true
 tracing-appender = "0.2.3"

--- a/crates/common/telemetry/src/lib.rs
+++ b/crates/common/telemetry/src/lib.rs
@@ -14,5 +14,6 @@
 
 pub mod logging;
 pub mod panic_hook;
+pub mod profiling;
 pub mod tracing_context;
 pub mod tracing_sampler;

--- a/crates/common/telemetry/src/profiling.rs
+++ b/crates/common/telemetry/src/profiling.rs
@@ -1,0 +1,168 @@
+// Copyright 2025 Rararulab
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Continuous CPU profiling via [Pyroscope](https://github.com/grafana/pyroscope).
+//!
+//! Wraps `pyroscope` + `pyroscope_pprofrs` so the `rara-cli` bootstrap can
+//! turn profiling on/off from YAML config without dragging the underlying
+//! crates into every binary.
+//!
+//! ## Cardinality contract
+//!
+//! Tags attached to profiles are **process-level only** — `env`, `host`,
+//! `build_commit`. Per-request labels (`session_id`, `skill_name`,
+//! `user_id`, …) MUST NOT be added: they explode label cardinality on
+//! the Pyroscope server and turn flamegraph queries into table scans.
+//!
+//! ## Limitation
+//!
+//! `pprof-rs` samples OS-thread CPU only. It does not see async `.await`
+//! stalls or tokio mutex contention — for those, use `tokio-console`
+//! (separate feature flag, tracked as a future chore).
+
+use pyroscope::{PyroscopeAgent, pyroscope::PyroscopeAgentRunning};
+use pyroscope_pprofrs::{PprofConfig, pprof_backend};
+use serde::{Deserialize, Serialize};
+use snafu::{ResultExt, Snafu};
+
+/// Configuration for the Pyroscope profiling agent.
+///
+/// All fields are required (no Rust defaults) — the entire section is
+/// optional in YAML, so omission is the "off" signal.
+#[derive(Debug, Clone, bon::Builder, Serialize, Deserialize)]
+#[builder(on(String, into))]
+pub struct PyroscopeConfig {
+    /// Master switch. When `false`, no agent is constructed and no
+    /// profiling thread is spawned — zero overhead.
+    pub enabled:          bool,
+    /// Pyroscope server endpoint (e.g. `http://10.0.0.183:4040`).
+    pub endpoint:         String,
+    /// Application name reported to Pyroscope (e.g. `"rara"`).
+    pub application_name: String,
+    /// CPU sampling rate in Hz (typical: 100).
+    pub sample_rate:      u32,
+}
+
+/// Errors raised while wiring up the Pyroscope agent.
+#[derive(Debug, Snafu)]
+#[snafu(visibility(pub))]
+pub enum ProfilingError {
+    #[snafu(display("failed to build Pyroscope agent: {source}"))]
+    BuildAgent { source: pyroscope::PyroscopeError },
+
+    #[snafu(display("failed to start Pyroscope agent: {source}"))]
+    StartAgent { source: pyroscope::PyroscopeError },
+}
+
+/// RAII guard that owns the running Pyroscope agent.
+///
+/// Drop performs a best-effort graceful shutdown: `stop()` flushes the
+/// last batch, then `shutdown()` joins the worker thread. Errors during
+/// drop are logged, never panicked, so a crashing collector cannot mask
+/// the original program exit code.
+pub struct ProfilingGuard {
+    agent: Option<PyroscopeAgent<PyroscopeAgentRunning>>,
+}
+
+impl ProfilingGuard {
+    /// Stop and shut down the agent explicitly. Idempotent — calling twice
+    /// (or letting `Drop` finish the job) is safe.
+    pub fn shutdown(mut self) { self.shutdown_inner(); }
+
+    fn shutdown_inner(&mut self) {
+        let Some(agent) = self.agent.take() else {
+            return;
+        };
+        match agent.stop() {
+            Ok(ready) => {
+                ready.shutdown();
+                tracing::info!("Pyroscope agent stopped");
+            }
+            Err(err) => {
+                tracing::warn!(error = %err, "Pyroscope agent stop failed");
+            }
+        }
+    }
+}
+
+impl Drop for ProfilingGuard {
+    fn drop(&mut self) { self.shutdown_inner(); }
+}
+
+/// Initialise the Pyroscope agent if `cfg.enabled` is true.
+///
+/// `build_commit` is wired in by the caller from a build-time mechanism
+/// (see `rara-cli`'s `shadow_rs` integration). It is treated as an
+/// opaque process-lifetime tag, never per-request.
+///
+/// Returns:
+/// - `Ok(Some(guard))` when the agent started — keep the guard alive for the
+///   lifetime of the process.
+/// - `Ok(None)` when `enabled = false` — no agent, no thread, zero cost.
+/// - `Err(_)` when the agent could not be built/started.
+pub fn init_pyroscope(
+    cfg: &PyroscopeConfig,
+    env: &str,
+    host: &str,
+    build_commit: &str,
+) -> Result<Option<ProfilingGuard>, ProfilingError> {
+    if !cfg.enabled {
+        return Ok(None);
+    }
+
+    let pprof = PprofConfig::new().sample_rate(cfg.sample_rate);
+    // `tags` is a Vec<(&str, &str)>, so build owned strings up-front and
+    // borrow into the call. Pyroscope copies them internally.
+    let tags: Vec<(&str, &str)> =
+        vec![("env", env), ("host", host), ("build_commit", build_commit)];
+
+    let agent = PyroscopeAgent::builder(&cfg.endpoint, &cfg.application_name)
+        .backend(pprof_backend(pprof))
+        .tags(tags)
+        .build()
+        .context(BuildAgentSnafu)?;
+
+    let running = agent.start().context(StartAgentSnafu)?;
+    tracing::info!(
+        endpoint = %cfg.endpoint,
+        application = %cfg.application_name,
+        sample_rate = cfg.sample_rate,
+        env, host, build_commit,
+        "Pyroscope continuous profiling started"
+    );
+
+    Ok(Some(ProfilingGuard {
+        agent: Some(running),
+    }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn disabled_returns_none_without_contacting_endpoint() {
+        // Sanity check the zero-overhead contract: with `enabled = false`
+        // we must short-circuit before touching the (unreachable) endpoint.
+        let cfg = PyroscopeConfig::builder()
+            .enabled(false)
+            .endpoint("http://127.0.0.1:1") // unreachable on purpose
+            .application_name("rara-test")
+            .sample_rate(100_u32)
+            .build();
+        let guard =
+            init_pyroscope(&cfg, "test", "host", "deadbeef").expect("disabled path is infallible");
+        assert!(guard.is_none(), "no guard means no agent, no thread");
+    }
+}


### PR DESCRIPTION
## Summary

Integrates the Grafana Pyroscope agent (`pyroscope` + `pyroscope_pprofrs`)
into `rara server` startup, gated on YAML config. Section omitted = zero
overhead, no thread spawned.

- New `common_telemetry::profiling` module: `PyroscopeConfig`, `ProfilingError`, `ProfilingGuard`, `init_pyroscope()`.
- `AppConfig.telemetry` gains an optional `pyroscope:` section + `env:` field.
- `rara server` wires the agent in `crates/cmd/src/main.rs` after logging init; `build_commit` comes from the existing `shadow-rs` integration (`build::SHORT_COMMIT`).
- RAII guard performs graceful shutdown on SIGTERM/SIGINT (Drop → stop → shutdown).
- Tags are process-level only — `env`, `host`, `build_commit`. Per-request labels are forbidden by the cardinality contract documented in `profiling.rs` and `crates/common/telemetry/AGENT.md`.
- `AGENT.md` updated with the pprof-rs limitation: OS-thread CPU sampling only, does not capture async stalls / mutex contention; use tokio-console for those (separate future chore).

## Type of change

| Type | Label |
|------|-------|
| New feature | `enhancement` |

## Component

`core`

## Closes

Closes #1857

## Test plan

- [x] `cargo check --workspace --all-targets` passes
- [x] `cargo +nightly fmt --all -- --check` passes
- [x] `cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings` passes
- [x] `RUSTDOCFLAGS=-D warnings cargo +nightly doc --workspace --no-deps --document-private-items` passes
- [x] `cargo test -p common-telemetry --lib` passes — verifies `enabled: false` short-circuits before touching the endpoint (zero-overhead contract)
- [x] `cargo test -p rara-app --lib telemetry` passes — config parsing for absent / enabled / disabled `telemetry.pyroscope` sections