### PR TITLE
feat(telemetry): adopt OTel GenAI + OpenInference semconv on spans (#1856)

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -146,8 +146,14 @@ agents:
 #   default_rootfs_image: "alpine:latest"
 
 # ---------------------------------------------------------------------------
-# Telemetry — optional OTLP traces and Pyroscope continuous profiling
+# Telemetry — optional OTLP traces, Pyroscope profiling, and Layer B payload
+# sampling
 # ---------------------------------------------------------------------------
+#
+# Layer A attributes (rara.*, gen_ai.*, openinference.*) are always emitted on
+# spans. Layer B (raw prompts, completions, tool I/O, error chains) is only
+# attached when the `payload_sampling` sampler decides — default off so spans
+# stay low-cardinality and free of user content.
 #
 # Two independent OTLP paths are supported:
 #
@@ -176,6 +182,10 @@ agents:
 #   otlp_endpoint: "http://alloy:4318/v1/traces"
 #   otlp_protocol: "http"
 #   env: "prod"
+#   payload_sampling:
+#     on_error: 1.0         # always sample errored ops
+#     on_success: 0.0       # default off; flip to 0.05 in dev
+#     max_chars: 1000
 #   otlp:
 #     enabled: false
 #     traces_endpoint: "http://10.0.0.183:3000/api/public/otel/v1/traces"

--- a/crates/app/src/lib.rs
+++ b/crates/app/src/lib.rs
@@ -228,10 +228,10 @@ mod gateway_defaults {
 pub struct TelemetryConfig {
     /// OTLP endpoint URL (e.g. `http://alloy:4318/v1/traces`).
     #[serde(default)]
-    pub otlp_endpoint: Option<String>,
+    pub otlp_endpoint:    Option<String>,
     /// Export protocol: `"http"` or `"grpc"`.
     #[serde(default)]
-    pub otlp_protocol: Option<String>,
+    pub otlp_protocol:    Option<String>,
     /// Self-hosted Langfuse / OTLP HTTP traces exporter (opt-in).
     ///
     /// When `enabled`, the application configures an OTLP/HTTP traces
@@ -239,14 +239,18 @@ pub struct TelemetryConfig {
     /// (typically `authorization: "Basic <base64(public:secret)>"` for
     /// Langfuse). Disabled by default.
     #[serde(default)]
-    pub otlp:          Option<OtlpConfig>,
+    pub otlp:             Option<OtlpConfig>,
     /// Continuous CPU profiling via Pyroscope. Section omitted = off.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub pyroscope:     Option<common_telemetry::profiling::PyroscopeConfig>,
+    pub pyroscope:        Option<common_telemetry::profiling::PyroscopeConfig>,
     /// Deployment environment label (e.g. `"prod"`, `"dev"`). Used as
     /// a low-cardinality process-level tag on profiling samples.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub env:           Option<String>,
+    pub env:              Option<String>,
+    /// Layer B payload sampling. When absent, no Layer B attributes are
+    /// emitted — Layer A keeps working as the always-on contract.
+    #[serde(default)]
+    pub payload_sampling: Option<common_telemetry::payload_sampler::PayloadSamplingConfig>,
 }
 
 /// OTLP/HTTP traces exporter config (Langfuse-compatible).

--- a/crates/common/telemetry/AGENT.md
+++ b/crates/common/telemetry/AGENT.md
@@ -13,6 +13,9 @@ Telemetry utilities — logging initialization, tracing subscriber setup (with o
 - `src/tracing_context.rs` — Utilities for propagating tracing context across async boundaries.
 - `src/tracing_sampler.rs` — Custom tracing sampler for controlling trace sampling rates.
 - `src/profiling.rs` — `init_pyroscope()` wires the Grafana Pyroscope agent (pprof-rs backend) for continuous CPU profiling. Returns a `ProfilingGuard` whose `Drop` performs graceful shutdown (stop → flush → join). Section omitted from YAML = zero overhead, no thread spawned.
+- `src/attrs.rs` — **Stable telemetry attribute keys (Layer A contract).** `SCHEMA_VERSION = "0.1.0"`. Re-exports `gen_ai.*` keys from `opentelemetry-semantic-conventions` and adds the `rara.*` namespace + OpenInference `openinference.span.kind`. Renaming any `pub const` here breaks the external detector — that is a major version bump.
+- `src/identifiers.rs` — `pub const` for every tool name, agent name, and guard rule name in rara. Internal call sites that emit `tool.name` / `rara.skill.name` / `rara.guard.rule` MUST reference these constants so renames are caught at compile time.
+- `src/payload_sampler.rs` — Layer B content sampler. `PayloadSamplingConfig` (no `Default`, defaults come from YAML) + `PayloadSampler::decide(Outcome)` returns a `SamplingDecision` enum. Deterministic, lock-free, RNG-free.
 
 ### Features
 
@@ -33,6 +36,9 @@ Telemetry utilities — logging initialization, tracing subscriber setup (with o
 - Do NOT import `tracing_subscriber::fmt::init()` directly — use this crate's initialization.
 - Do NOT expect Pyroscope to capture async `.await` stalls or tokio mutex contention — `pprof-rs` is OS-thread CPU sampling. For async stall / lock contention diagnosis, enable the `tokio-console` feature flag (separate chore) and connect with the `tokio-console` CLI.
 - Do NOT add per-request labels to Pyroscope tags — see Critical Invariants. Process-level tags only.
+- Do NOT hardcode telemetry attribute strings (`"rara.session.id"`, `"gen_ai.request.model"`) at call sites — always reference the `pub const` in `attrs.rs` so the compiler catches schema drift.
+- Do NOT rename or remove a `pub const` in `attrs.rs` without bumping `SCHEMA_VERSION` — downstream detectors pin against the schema.
+- Do NOT add Layer B payload attributes outside the sampler — Layer A attributes are always-on and low-cardinality; Layer B (raw prompts/completions) MUST go through `PayloadSampler::decide` first.
 
 ## Dependencies
 

--- a/crates/common/telemetry/src/attrs.rs
+++ b/crates/common/telemetry/src/attrs.rs
@@ -1,0 +1,243 @@
+// Copyright 2025 Rararulab
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Stable telemetry attribute keys — the contract an external detector reads.
+//!
+//! `SCHEMA_VERSION: 0.1.0`. Adding attributes is a **minor** change. Renaming
+//! or removing one is a **major** change and will break the downstream
+//! detector agent — bump the schema version and announce.
+//!
+//! Three layers, layered by cost and cardinality:
+//!
+//! - **Layer A — always-on, low-cardinality** (this file): the contract. Set on
+//!   every span. The detector decides "is this turn broken?" from these
+//!   attributes alone.
+//! - **Layer B — content sampling** (see [`crate::payload_sampler`]): set only
+//!   when the sampler decides. Bounded by `max_chars`. Used for diagnosis after
+//!   Layer A flags a regression.
+//! - **Layer C — pointers, never embedded payloads**: e.g. [`RARA_LOG_FILE`]
+//!   points to a hourly log file rather than embedding the lines.
+//!
+//! Upstream OTel GenAI semantic conventions are imported via
+//! `opentelemetry_semantic_conventions::attribute::*` — never hardcode the
+//! string form of those keys.
+
+/// The semantic-convention version exported by this module. Bumped when
+/// attributes are renamed or removed. Detectors pin against this value.
+pub const SCHEMA_VERSION: &str = "0.1.0";
+
+// ---------------------------------------------------------------------------
+// rara.* — rara-specific attributes
+// ---------------------------------------------------------------------------
+
+/// Session id (per `rara_session::SessionKey`) that owns the turn.
+///
+/// Detector use: group spans into a single conversation; track per-session
+/// trends (e.g. context bloat over many turns).
+pub const RARA_SESSION_ID: &str = "rara.session.id";
+
+/// Logical agent name (e.g. `"rara"`, `"mita"`) — matches the agent manifest
+/// id. NOT the OS process name.
+///
+/// Detector use: split metrics by agent role; route fix issues to the team
+/// owning that agent.
+pub const RARA_AGENT_NAME: &str = "rara.agent.name";
+
+/// Skill name (when the turn invoked a skill) — matches the static skill
+/// frontmatter `name` field.
+///
+/// Detector use: detect "skill silent no-op" and route fix to the skill's
+/// markdown file.
+pub const RARA_SKILL_NAME: &str = "rara.skill.name";
+
+/// Outcome of the turn. One of: `success`, `error`, `aborted`.
+///
+/// Detector use: top-level success/error split; baseline regression alarm.
+pub const RARA_TURN_OUTCOME: &str = "rara.turn.outcome";
+
+/// Iteration index within the agent loop (0-based). Set on per-iteration
+/// child spans.
+///
+/// Detector use: tool-loop runaway detection (`> 10` is suspicious); also
+/// "skill silent no-op" detection (iteration=0 + no children).
+pub const RARA_TURN_ITERATION: &str = "rara.turn.iteration";
+
+/// Top-level error class on a failed turn. Stable enum-like string.
+/// Examples: `llm_rate_limit`, `llm_timeout`, `tool_execution_failed`,
+/// `guard_blocked`, `cancelled`, `internal`.
+///
+/// Detector use: aggregate error rates by class; route by class.
+pub const RARA_ERROR_KIND: &str = "rara.error.kind";
+
+/// Tool error sub-class. One of: `timeout`, `panic`, `auth`, `rate_limit`,
+/// `invalid_input`, `upstream_error`.
+///
+/// Detector use: per-tool error decomposition; spot which class is spiking.
+pub const RARA_TOOL_ERROR_KIND: &str = "rara.tool.error.kind";
+
+/// Decision returned by the guard pipeline. One of: `allow`, `deny`, `redact`.
+///
+/// Detector use: deny-rate spike alarms; redaction effectiveness.
+pub const RARA_GUARD_DECISION: &str = "rara.guard.decision";
+
+/// Guard rule that fired (matches a `pub const` in
+/// [`crate::identifiers`]).
+///
+/// Detector use: route guard misfires back to the rule definition.
+pub const RARA_GUARD_RULE: &str = "rara.guard.rule";
+
+/// Memory subsystem operation. Examples: `tape_append`, `tape_search`,
+/// `kv_get`, `kv_set`.
+///
+/// Detector use: track memory backend health independently of LLM/tool calls.
+pub const RARA_MEMORY_OPERATION: &str = "rara.memory.operation";
+
+/// Path to the rotating log file containing lines from this turn —
+/// e.g. `/Users/rara/Library/Logs/rara/job.YYYY-MM-DD-HH`. **Layer C
+/// pointer**: full text never embedded in the span.
+///
+/// Detector use: jump from a flagged span straight to the matching log file
+/// for raw context.
+pub const RARA_LOG_FILE: &str = "rara.log.file";
+
+// ---------------------------------------------------------------------------
+// rara.* — Layer B (sampled payload) attributes
+// ---------------------------------------------------------------------------
+
+/// Sampled prompt text (Layer B). Truncation is signalled by
+/// [`RARA_PROMPT_TRUNCATED`].
+pub const RARA_PROMPT: &str = "rara.prompt";
+/// True when [`RARA_PROMPT`] was truncated to the sampler's `max_chars`.
+pub const RARA_PROMPT_TRUNCATED: &str = "rara.prompt.truncated";
+
+/// Sampled completion text (Layer B). Truncation is signalled by
+/// [`RARA_COMPLETION_TRUNCATED`].
+pub const RARA_COMPLETION: &str = "rara.completion";
+/// True when [`RARA_COMPLETION`] was truncated to the sampler's `max_chars`.
+pub const RARA_COMPLETION_TRUNCATED: &str = "rara.completion.truncated";
+
+/// Sampled tool input JSON (Layer B).
+pub const RARA_TOOL_INPUT: &str = "rara.tool.input";
+/// True when [`RARA_TOOL_INPUT`] was truncated.
+pub const RARA_TOOL_INPUT_TRUNCATED: &str = "rara.tool.input.truncated";
+
+/// Sampled tool output JSON (Layer B).
+pub const RARA_TOOL_OUTPUT: &str = "rara.tool.output";
+/// True when [`RARA_TOOL_OUTPUT`] was truncated.
+pub const RARA_TOOL_OUTPUT_TRUNCATED: &str = "rara.tool.output.truncated";
+
+/// Sampled error message chain (Layer B). Always set when sampler decides
+/// "on_error".
+pub const RARA_ERROR_MESSAGE: &str = "rara.error.message";
+
+// ---------------------------------------------------------------------------
+// OpenInference-style span kind attribute
+//
+// OpenInference is not in the OTel semconv crate; we publish the key here
+// so the detector can map every rara span to one of the standard kinds.
+// ---------------------------------------------------------------------------
+
+/// OpenInference span kind. One of [`SPAN_KIND_AGENT`], [`SPAN_KIND_LLM`],
+/// [`SPAN_KIND_TOOL`], [`SPAN_KIND_RETRIEVER`], [`SPAN_KIND_GUARD`].
+pub const OPENINFERENCE_SPAN_KIND: &str = "openinference.span.kind";
+
+/// Root agent turn span kind.
+pub const SPAN_KIND_AGENT: &str = "AGENT";
+/// LLM call span kind.
+pub const SPAN_KIND_LLM: &str = "LLM";
+/// Tool execution span kind.
+pub const SPAN_KIND_TOOL: &str = "TOOL";
+/// Memory/retrieval span kind.
+pub const SPAN_KIND_RETRIEVER: &str = "RETRIEVER";
+/// Guard pipeline span kind. Not part of the upstream OpenInference enum but
+/// used internally so the detector can filter guard spans without parsing the
+/// span name.
+pub const SPAN_KIND_GUARD: &str = "GUARD";
+
+// ---------------------------------------------------------------------------
+// Tool-level attributes (OpenInference-style)
+//
+// `gen_ai.tool.name` from upstream semconv is also valid and used at the
+// LLM-call layer when the model emits a tool call. The keys below describe
+// the tool *execution* span itself.
+// ---------------------------------------------------------------------------
+
+/// Tool name being executed — value MUST come from
+/// [`crate::identifiers`] so renames are caught at compile time.
+pub const TOOL_NAME: &str = "tool.name";
+
+/// Tool execution outcome. One of: `success`, `error`.
+pub const TOOL_OUTCOME: &str = "tool.outcome";
+
+// ---------------------------------------------------------------------------
+// Convenience re-exports of upstream GenAI keys most commonly used on spans.
+//
+// These are thin pass-throughs so call sites can import from one place,
+// but the source of truth is `opentelemetry_semantic_conventions`.
+// ---------------------------------------------------------------------------
+
+/// `gen_ai.request.model` — the model id requested from the provider.
+pub const GEN_AI_REQUEST_MODEL: &str =
+    opentelemetry_semantic_conventions::attribute::GEN_AI_REQUEST_MODEL;
+
+/// `gen_ai.usage.input_tokens` — prompt tokens consumed.
+pub const GEN_AI_USAGE_INPUT_TOKENS: &str =
+    opentelemetry_semantic_conventions::attribute::GEN_AI_USAGE_INPUT_TOKENS;
+
+/// `gen_ai.usage.output_tokens` — completion tokens produced.
+pub const GEN_AI_USAGE_OUTPUT_TOKENS: &str =
+    opentelemetry_semantic_conventions::attribute::GEN_AI_USAGE_OUTPUT_TOKENS;
+
+/// `gen_ai.response.finish_reasons` — provider-reported finish reason(s).
+pub const GEN_AI_RESPONSE_FINISH_REASONS: &str =
+    opentelemetry_semantic_conventions::attribute::GEN_AI_RESPONSE_FINISH_REASONS;
+
+/// `gen_ai.system` — provider system identifier (e.g. `openai`, `anthropic`).
+pub const GEN_AI_SYSTEM: &str = opentelemetry_semantic_conventions::attribute::GEN_AI_SYSTEM;
+
+/// `gen_ai.server.time_to_first_token` — TTFT in seconds. Upstream defines
+/// this only as a metric name; we reuse the same string for the equivalent
+/// span attribute so the detector can join metric and span by key.
+pub const GEN_AI_SERVER_TIME_TO_FIRST_TOKEN: &str =
+    opentelemetry_semantic_conventions::metric::GEN_AI_SERVER_TIME_TO_FIRST_TOKEN;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Stable string values are part of the public contract; the detector
+    /// joins on them. Renaming any of these is a major version bump.
+    #[test]
+    fn rara_keys_have_stable_strings() {
+        assert_eq!(RARA_SESSION_ID, "rara.session.id");
+        assert_eq!(RARA_TURN_OUTCOME, "rara.turn.outcome");
+        assert_eq!(RARA_TOOL_ERROR_KIND, "rara.tool.error.kind");
+        assert_eq!(RARA_GUARD_DECISION, "rara.guard.decision");
+        assert_eq!(RARA_LOG_FILE, "rara.log.file");
+        assert_eq!(OPENINFERENCE_SPAN_KIND, "openinference.span.kind");
+        assert_eq!(SPAN_KIND_AGENT, "AGENT");
+        assert_eq!(SPAN_KIND_LLM, "LLM");
+        assert_eq!(SPAN_KIND_TOOL, "TOOL");
+    }
+
+    #[test]
+    fn upstream_keys_match_semconv() {
+        assert_eq!(GEN_AI_REQUEST_MODEL, "gen_ai.request.model");
+        assert_eq!(GEN_AI_USAGE_INPUT_TOKENS, "gen_ai.usage.input_tokens");
+        assert_eq!(
+            GEN_AI_SERVER_TIME_TO_FIRST_TOKEN,
+            "gen_ai.server.time_to_first_token"
+        );
+    }
+}

--- a/crates/common/telemetry/src/identifiers.rs
+++ b/crates/common/telemetry/src/identifiers.rs
@@ -1,0 +1,495 @@
+// Copyright 2025 Rararulab
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Stable identifier registry for tool names, guard rule names, and the
+//! agent name namespace.
+//!
+//! Internal call sites that emit telemetry attribute *values* (e.g.
+//! `tool.name`, `rara.guard.rule`) MUST use a constant from this module
+//! rather than hardcoding the string. That way, renaming a tool in its
+//! `#[tool(name = "...")]` definition is a compile-time error at every
+//! telemetry call site instead of a silent contract break for the
+//! external detector agent.
+//!
+//! Skills are intentionally NOT enumerated here — they are user-installed,
+//! filesystem-loaded artifacts whose set is dynamic. The `rara.skill.name`
+//! attribute carries whatever the loaded skill's frontmatter declares.
+
+// ---------------------------------------------------------------------------
+// Agent names
+// ---------------------------------------------------------------------------
+
+/// The user-facing rara agent.
+pub const AGENT_RARA: &str = "rara";
+
+/// The background mita agent (memory + soul curation).
+pub const AGENT_MITA: &str = "mita";
+
+// ---------------------------------------------------------------------------
+// Guard rule names — keep in sync with `crates/kernel/src/guard/pattern.rs`.
+// ---------------------------------------------------------------------------
+
+/// Prompt-injection / system-prompt override pattern.
+pub const GUARD_RULE_PROMPT_OVERRIDE: &str = "prompt_override";
+
+/// Destructive shell pattern (rm -rf, format, etc.).
+pub const GUARD_RULE_SHELL_DESTRUCTIVE: &str = "shell_destructive";
+
+/// Data exfiltration pattern (curl + secrets, base64-encoded payloads).
+pub const GUARD_RULE_DATA_EXFILTRATION: &str = "data_exfiltration";
+
+/// Privilege escalation pattern (sudo, setuid, capability grant).
+pub const GUARD_RULE_PRIVILEGE_ESCALATION: &str = "privilege_escalation";
+
+// ---------------------------------------------------------------------------
+// Tool names — generated from `#[tool(name = "...")]` declarations across the
+// workspace. Test-only tools (`add`, `echo`) are excluded.
+// ---------------------------------------------------------------------------
+
+/// Tool `acp-delegate`.
+pub const TOOL_ACP_DELEGATE: &str = "acp-delegate";
+
+/// Tool `artifacts`.
+pub const TOOL_ARTIFACTS: &str = "artifacts";
+
+/// Tool `ask-user`.
+pub const TOOL_ASK_USER: &str = "ask-user";
+
+/// Tool `bash`.
+pub const TOOL_BASH: &str = "bash";
+
+/// Tool `browser-click`.
+pub const TOOL_BROWSER_CLICK: &str = "browser-click";
+
+/// Tool `browser-close`.
+pub const TOOL_BROWSER_CLOSE: &str = "browser-close";
+
+/// Tool `browser-evaluate`.
+pub const TOOL_BROWSER_EVALUATE: &str = "browser-evaluate";
+
+/// Tool `browser-fetch`.
+pub const TOOL_BROWSER_FETCH: &str = "browser-fetch";
+
+/// Tool `browser-navigate-back`.
+pub const TOOL_BROWSER_NAVIGATE_BACK: &str = "browser-navigate-back";
+
+/// Tool `browser-navigate`.
+pub const TOOL_BROWSER_NAVIGATE: &str = "browser-navigate";
+
+/// Tool `browser-press-key`.
+pub const TOOL_BROWSER_PRESS_KEY: &str = "browser-press-key";
+
+/// Tool `browser-snapshot`.
+pub const TOOL_BROWSER_SNAPSHOT: &str = "browser-snapshot";
+
+/// Tool `browser-tabs`.
+pub const TOOL_BROWSER_TABS: &str = "browser-tabs";
+
+/// Tool `browser-type`.
+pub const TOOL_BROWSER_TYPE: &str = "browser-type";
+
+/// Tool `browser-wait-for`.
+pub const TOOL_BROWSER_WAIT_FOR: &str = "browser-wait-for";
+
+/// Tool `cancel-background`.
+pub const TOOL_CANCEL_BACKGROUND: &str = "cancel-background";
+
+/// Tool `composio_accounts`.
+pub const TOOL_COMPOSIO_ACCOUNTS: &str = "composio_accounts";
+
+/// Tool `composio_connect`.
+pub const TOOL_COMPOSIO_CONNECT: &str = "composio_connect";
+
+/// Tool `composio_execute`.
+pub const TOOL_COMPOSIO_EXECUTE: &str = "composio_execute";
+
+/// Tool `composio_list`.
+pub const TOOL_COMPOSIO_LIST: &str = "composio_list";
+
+/// Tool `continue-work`.
+pub const TOOL_CONTINUE_WORK: &str = "continue-work";
+
+/// Tool `create-directory`.
+pub const TOOL_CREATE_DIRECTORY: &str = "create-directory";
+
+/// Tool `create-plan`.
+pub const TOOL_CREATE_PLAN: &str = "create-plan";
+
+/// Tool `create-skill`.
+pub const TOOL_CREATE_SKILL: &str = "create-skill";
+
+/// Tool `debug_trace`.
+pub const TOOL_DEBUG_TRACE: &str = "debug_trace";
+
+/// Tool `delete-file`.
+pub const TOOL_DELETE_FILE: &str = "delete-file";
+
+/// Tool `delete-skill`.
+pub const TOOL_DELETE_SKILL: &str = "delete-skill";
+
+/// Tool `discover-tools`.
+pub const TOOL_DISCOVER_TOOLS: &str = "discover-tools";
+
+/// Tool `dispatch-rara`.
+pub const TOOL_DISPATCH_RARA: &str = "dispatch-rara";
+
+/// Tool `distill-user-notes`.
+pub const TOOL_DISTILL_USER_NOTES: &str = "distill-user-notes";
+
+/// Tool `dock.annotation.add`.
+pub const TOOL_DOCK_ANNOTATION_ADD: &str = "dock.annotation.add";
+
+/// Tool `dock.annotation.remove`.
+pub const TOOL_DOCK_ANNOTATION_REMOVE: &str = "dock.annotation.remove";
+
+/// Tool `dock.annotation.update`.
+pub const TOOL_DOCK_ANNOTATION_UPDATE: &str = "dock.annotation.update";
+
+/// Tool `dock.block.add`.
+pub const TOOL_DOCK_BLOCK_ADD: &str = "dock.block.add";
+
+/// Tool `dock.block.remove`.
+pub const TOOL_DOCK_BLOCK_REMOVE: &str = "dock.block.remove";
+
+/// Tool `dock.block.update`.
+pub const TOOL_DOCK_BLOCK_UPDATE: &str = "dock.block.update";
+
+/// Tool `dock.fact.add`.
+pub const TOOL_DOCK_FACT_ADD: &str = "dock.fact.add";
+
+/// Tool `dock.fact.remove`.
+pub const TOOL_DOCK_FACT_REMOVE: &str = "dock.fact.remove";
+
+/// Tool `dock.fact.update`.
+pub const TOOL_DOCK_FACT_UPDATE: &str = "dock.fact.update";
+
+/// Tool `edit-file`.
+pub const TOOL_EDIT_FILE: &str = "edit-file";
+
+/// Tool `evolve-soul`.
+pub const TOOL_EVOLVE_SOUL: &str = "evolve-soul";
+
+/// Tool `fff-find`.
+pub const TOOL_FFF_FIND: &str = "fff-find";
+
+/// Tool `fff-grep`.
+pub const TOOL_FFF_GREP: &str = "fff-grep";
+
+/// Tool `file-stats`.
+pub const TOOL_FILE_STATS: &str = "file-stats";
+
+/// Tool `find-files`.
+pub const TOOL_FIND_FILES: &str = "find-files";
+
+/// Tool `fold-branch`.
+pub const TOOL_FOLD_BRANCH: &str = "fold-branch";
+
+/// Tool `get-session-info`.
+pub const TOOL_GET_SESSION_INFO: &str = "get-session-info";
+
+/// Tool `grep`.
+pub const TOOL_GREP: &str = "grep";
+
+/// Tool `http-fetch`.
+pub const TOOL_HTTP_FETCH: &str = "http-fetch";
+
+/// Tool `install-acp-agent`.
+pub const TOOL_INSTALL_ACP_AGENT: &str = "install-acp-agent";
+
+/// Tool `install-mcp-server`.
+pub const TOOL_INSTALL_MCP_SERVER: &str = "install-mcp-server";
+
+/// Tool `list-acp-agents`.
+pub const TOOL_LIST_ACP_AGENTS: &str = "list-acp-agents";
+
+/// Tool `list-directory`.
+pub const TOOL_LIST_DIRECTORY: &str = "list-directory";
+
+/// Tool `list-mcp-servers`.
+pub const TOOL_LIST_MCP_SERVERS: &str = "list-mcp-servers";
+
+/// Tool `list-sessions`.
+pub const TOOL_LIST_SESSIONS: &str = "list-sessions";
+
+/// Tool `list-skills`.
+pub const TOOL_LIST_SKILLS: &str = "list-skills";
+
+/// Tool `marketplace-add-source`.
+pub const TOOL_MARKETPLACE_ADD_SOURCE: &str = "marketplace-add-source";
+
+/// Tool `marketplace-browse`.
+pub const TOOL_MARKETPLACE_BROWSE: &str = "marketplace-browse";
+
+/// Tool `marketplace-install`.
+pub const TOOL_MARKETPLACE_INSTALL: &str = "marketplace-install";
+
+/// Tool `marketplace-refresh`.
+pub const TOOL_MARKETPLACE_REFRESH: &str = "marketplace-refresh";
+
+/// Tool `marketplace-search`.
+pub const TOOL_MARKETPLACE_SEARCH: &str = "marketplace-search";
+
+/// Tool `marketplace-uninstall`.
+pub const TOOL_MARKETPLACE_UNINSTALL: &str = "marketplace-uninstall";
+
+/// Tool `memory`.
+pub const TOOL_MEMORY: &str = "memory";
+
+/// Tool `multi-edit`.
+pub const TOOL_MULTI_EDIT: &str = "multi-edit";
+
+/// Tool `query-feed`.
+pub const TOOL_QUERY_FEED: &str = "query-feed";
+
+/// Tool `read-file`.
+pub const TOOL_READ_FILE: &str = "read-file";
+
+/// Tool `read-tape`.
+pub const TOOL_READ_TAPE: &str = "read-tape";
+
+/// Tool `remove-acp-agent`.
+pub const TOOL_REMOVE_ACP_AGENT: &str = "remove-acp-agent";
+
+/// Tool `remove-mcp-server`.
+pub const TOOL_REMOVE_MCP_SERVER: &str = "remove-mcp-server";
+
+/// Tool `schedule-cron`.
+pub const TOOL_SCHEDULE_CRON: &str = "schedule-cron";
+
+/// Tool `schedule-interval`.
+pub const TOOL_SCHEDULE_INTERVAL: &str = "schedule-interval";
+
+/// Tool `schedule-list`.
+pub const TOOL_SCHEDULE_LIST: &str = "schedule-list";
+
+/// Tool `schedule-once`.
+pub const TOOL_SCHEDULE_ONCE: &str = "schedule-once";
+
+/// Tool `schedule-remove`.
+pub const TOOL_SCHEDULE_REMOVE: &str = "schedule-remove";
+
+/// Tool `send-email`.
+pub const TOOL_SEND_EMAIL: &str = "send-email";
+
+/// Tool `send-file`.
+pub const TOOL_SEND_FILE: &str = "send-file";
+
+/// Tool `set-avatar`.
+pub const TOOL_SET_AVATAR: &str = "set-avatar";
+
+/// Tool `settings`.
+pub const TOOL_SETTINGS: &str = "settings";
+
+/// Tool `spawn-background`.
+pub const TOOL_SPAWN_BACKGROUND: &str = "spawn-background";
+
+/// Tool `system-paths`.
+pub const TOOL_SYSTEM_PATHS: &str = "system-paths";
+
+/// Tool `tape-anchor`.
+pub const TOOL_TAPE_ANCHOR: &str = "tape-anchor";
+
+/// Tool `tape-anchors`.
+pub const TOOL_TAPE_ANCHORS: &str = "tape-anchors";
+
+/// Tool `tape-between`.
+pub const TOOL_TAPE_BETWEEN: &str = "tape-between";
+
+/// Tool `tape-checkout-root`.
+pub const TOOL_TAPE_CHECKOUT_ROOT: &str = "tape-checkout-root";
+
+/// Tool `tape-checkout`.
+pub const TOOL_TAPE_CHECKOUT: &str = "tape-checkout";
+
+/// Tool `tape-entries`.
+pub const TOOL_TAPE_ENTRIES: &str = "tape-entries";
+
+/// Tool `tape-info`.
+pub const TOOL_TAPE_INFO: &str = "tape-info";
+
+/// Tool `tape-search`.
+pub const TOOL_TAPE_SEARCH: &str = "tape-search";
+
+/// Tool `task`.
+pub const TOOL_TASK: &str = "task";
+
+/// Tool `update-session-title`.
+pub const TOOL_UPDATE_SESSION_TITLE: &str = "update-session-title";
+
+/// Tool `update-soul-state`.
+pub const TOOL_UPDATE_SOUL_STATE: &str = "update-soul-state";
+
+/// Tool `user-note`.
+pub const TOOL_USER_NOTE: &str = "user-note";
+
+/// Tool `walk-directory`.
+pub const TOOL_WALK_DIRECTORY: &str = "walk-directory";
+
+/// Tool `wechat-login-confirm`.
+pub const TOOL_WECHAT_LOGIN_CONFIRM: &str = "wechat-login-confirm";
+
+/// Tool `wechat-login-start`.
+pub const TOOL_WECHAT_LOGIN_START: &str = "wechat-login-start";
+
+/// Tool `write-file`.
+pub const TOOL_WRITE_FILE: &str = "write-file";
+
+/// Tool `write-skill-draft`.
+pub const TOOL_WRITE_SKILL_DRAFT: &str = "write-skill-draft";
+
+/// Tool `write-user-note`.
+pub const TOOL_WRITE_USER_NOTE: &str = "write-user-note";
+
+/// All tool name constants exported by this module. Useful for tests that
+/// assert the registry has not silently lost a tool.
+pub const ALL_TOOL_NAMES: &[&str] = &[
+    TOOL_ACP_DELEGATE,
+    TOOL_ARTIFACTS,
+    TOOL_ASK_USER,
+    TOOL_BASH,
+    TOOL_BROWSER_CLICK,
+    TOOL_BROWSER_CLOSE,
+    TOOL_BROWSER_EVALUATE,
+    TOOL_BROWSER_FETCH,
+    TOOL_BROWSER_NAVIGATE_BACK,
+    TOOL_BROWSER_NAVIGATE,
+    TOOL_BROWSER_PRESS_KEY,
+    TOOL_BROWSER_SNAPSHOT,
+    TOOL_BROWSER_TABS,
+    TOOL_BROWSER_TYPE,
+    TOOL_BROWSER_WAIT_FOR,
+    TOOL_CANCEL_BACKGROUND,
+    TOOL_COMPOSIO_ACCOUNTS,
+    TOOL_COMPOSIO_CONNECT,
+    TOOL_COMPOSIO_EXECUTE,
+    TOOL_COMPOSIO_LIST,
+    TOOL_CONTINUE_WORK,
+    TOOL_CREATE_DIRECTORY,
+    TOOL_CREATE_PLAN,
+    TOOL_CREATE_SKILL,
+    TOOL_DEBUG_TRACE,
+    TOOL_DELETE_FILE,
+    TOOL_DELETE_SKILL,
+    TOOL_DISCOVER_TOOLS,
+    TOOL_DISPATCH_RARA,
+    TOOL_DISTILL_USER_NOTES,
+    TOOL_DOCK_ANNOTATION_ADD,
+    TOOL_DOCK_ANNOTATION_REMOVE,
+    TOOL_DOCK_ANNOTATION_UPDATE,
+    TOOL_DOCK_BLOCK_ADD,
+    TOOL_DOCK_BLOCK_REMOVE,
+    TOOL_DOCK_BLOCK_UPDATE,
+    TOOL_DOCK_FACT_ADD,
+    TOOL_DOCK_FACT_REMOVE,
+    TOOL_DOCK_FACT_UPDATE,
+    TOOL_EDIT_FILE,
+    TOOL_EVOLVE_SOUL,
+    TOOL_FFF_FIND,
+    TOOL_FFF_GREP,
+    TOOL_FILE_STATS,
+    TOOL_FIND_FILES,
+    TOOL_FOLD_BRANCH,
+    TOOL_GET_SESSION_INFO,
+    TOOL_GREP,
+    TOOL_HTTP_FETCH,
+    TOOL_INSTALL_ACP_AGENT,
+    TOOL_INSTALL_MCP_SERVER,
+    TOOL_LIST_ACP_AGENTS,
+    TOOL_LIST_DIRECTORY,
+    TOOL_LIST_MCP_SERVERS,
+    TOOL_LIST_SESSIONS,
+    TOOL_LIST_SKILLS,
+    TOOL_MARKETPLACE_ADD_SOURCE,
+    TOOL_MARKETPLACE_BROWSE,
+    TOOL_MARKETPLACE_INSTALL,
+    TOOL_MARKETPLACE_REFRESH,
+    TOOL_MARKETPLACE_SEARCH,
+    TOOL_MARKETPLACE_UNINSTALL,
+    TOOL_MEMORY,
+    TOOL_MULTI_EDIT,
+    TOOL_QUERY_FEED,
+    TOOL_READ_FILE,
+    TOOL_READ_TAPE,
+    TOOL_REMOVE_ACP_AGENT,
+    TOOL_REMOVE_MCP_SERVER,
+    TOOL_SCHEDULE_CRON,
+    TOOL_SCHEDULE_INTERVAL,
+    TOOL_SCHEDULE_LIST,
+    TOOL_SCHEDULE_ONCE,
+    TOOL_SCHEDULE_REMOVE,
+    TOOL_SEND_EMAIL,
+    TOOL_SEND_FILE,
+    TOOL_SET_AVATAR,
+    TOOL_SETTINGS,
+    TOOL_SPAWN_BACKGROUND,
+    TOOL_SYSTEM_PATHS,
+    TOOL_TAPE_ANCHOR,
+    TOOL_TAPE_ANCHORS,
+    TOOL_TAPE_BETWEEN,
+    TOOL_TAPE_CHECKOUT_ROOT,
+    TOOL_TAPE_CHECKOUT,
+    TOOL_TAPE_ENTRIES,
+    TOOL_TAPE_INFO,
+    TOOL_TAPE_SEARCH,
+    TOOL_TASK,
+    TOOL_UPDATE_SESSION_TITLE,
+    TOOL_UPDATE_SOUL_STATE,
+    TOOL_USER_NOTE,
+    TOOL_WALK_DIRECTORY,
+    TOOL_WECHAT_LOGIN_CONFIRM,
+    TOOL_WECHAT_LOGIN_START,
+    TOOL_WRITE_FILE,
+    TOOL_WRITE_SKILL_DRAFT,
+    TOOL_WRITE_USER_NOTE,
+];
+
+/// All guard rule name constants exported by this module.
+pub const ALL_GUARD_RULES: &[&str] = &[
+    GUARD_RULE_PROMPT_OVERRIDE,
+    GUARD_RULE_SHELL_DESTRUCTIVE,
+    GUARD_RULE_DATA_EXFILTRATION,
+    GUARD_RULE_PRIVILEGE_ESCALATION,
+];
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn all_tool_names_are_unique() {
+        let mut sorted: Vec<&str> = ALL_TOOL_NAMES.to_vec();
+        sorted.sort_unstable();
+        sorted.dedup();
+        assert_eq!(
+            sorted.len(),
+            ALL_TOOL_NAMES.len(),
+            "duplicate tool name in registry"
+        );
+    }
+
+    #[test]
+    fn all_guard_rules_are_unique() {
+        let mut sorted: Vec<&str> = ALL_GUARD_RULES.to_vec();
+        sorted.sort_unstable();
+        sorted.dedup();
+        assert_eq!(sorted.len(), ALL_GUARD_RULES.len(), "duplicate guard rule");
+    }
+
+    #[test]
+    fn agent_names_are_lowercase() {
+        for name in [AGENT_RARA, AGENT_MITA] {
+            assert_eq!(name, name.to_lowercase(), "agent name must be lowercase");
+        }
+    }
+}

--- a/crates/common/telemetry/src/lib.rs
+++ b/crates/common/telemetry/src/lib.rs
@@ -12,8 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+pub mod attrs;
+pub mod identifiers;
 pub mod logging;
 pub mod panic_hook;
+pub mod payload_sampler;
 pub mod profiling;
 pub mod tracing_context;
 pub mod tracing_sampler;

--- a/crates/common/telemetry/src/payload_sampler.rs
+++ b/crates/common/telemetry/src/payload_sampler.rs
@@ -1,0 +1,252 @@
+// Copyright 2025 Rararulab
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Layer B payload sampler.
+//!
+//! Layer A attributes are always-on and low-cardinality (the contract). Layer
+//! B attributes — prompts, completions, tool input/output, error messages —
+//! carry user content and are gated by this sampler. Defaults skew safe:
+//! **off on success, 100% on error**, with a hard `max_chars` truncation so
+//! a runaway tool output cannot blow up trace ingest.
+//!
+//! Configuration lives in YAML (no Rust-side defaults — see crate guidelines):
+//!
+//! ```yaml
+//! telemetry:
+//!   payload_sampling:
+//!     on_error: 1.0     # sample every error
+//!     on_success: 0.0   # off in prod; 0.05 in dev
+//!     max_chars: 1000   # hard cap per attribute
+//! ```
+
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use serde::{Deserialize, Serialize};
+
+/// Outcome of the operation being sampled.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Outcome {
+    /// The operation succeeded.
+    Success,
+    /// The operation failed.
+    Error,
+}
+
+/// Configuration for the Layer B payload sampler.
+///
+/// All fields are required in YAML — there is no `Default` impl per the
+/// rara config guideline ("no hardcoded defaults in Rust").
+#[derive(Debug, Clone, bon::Builder, Serialize, Deserialize)]
+pub struct PayloadSamplingConfig {
+    /// Sampling probability when [`Outcome::Error`] (range `0.0..=1.0`).
+    pub on_error:   f64,
+    /// Sampling probability when [`Outcome::Success`] (range `0.0..=1.0`).
+    pub on_success: f64,
+    /// Maximum number of bytes (UTF-8 chars) kept per sampled attribute. Any
+    /// payload longer than this is truncated and the corresponding
+    /// `*.truncated` attribute is set to `true`.
+    pub max_chars:  usize,
+}
+
+/// Decision about whether to attach Layer B payloads to a span.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SamplingDecision {
+    /// Skip this span entirely — Layer B attributes MUST NOT be set.
+    Skip,
+    /// Record this span — Layer B attributes MAY be set, truncated to
+    /// `max_chars`.
+    Record {
+        /// Hard cap on attribute string length.
+        max_chars: usize,
+    },
+}
+
+/// Layer B payload sampler.
+///
+/// Implements deterministic, lock-free fractional sampling using a counter
+/// and the configured probabilities. Two independent counters track success
+/// and error decisions so changing one rate doesn't perturb the other.
+#[derive(Debug)]
+pub struct PayloadSampler {
+    config:        PayloadSamplingConfig,
+    success_count: AtomicU64,
+    error_count:   AtomicU64,
+}
+
+impl PayloadSampler {
+    /// Construct a sampler from validated config.
+    ///
+    /// Probabilities outside `[0.0, 1.0]` are clamped to that range; this is
+    /// a defense against typos like `on_error: 100` (meant `1.0`) silently
+    /// causing the sampler to never fire.
+    #[must_use]
+    pub fn new(config: PayloadSamplingConfig) -> Self {
+        let config = PayloadSamplingConfig {
+            on_error:   config.on_error.clamp(0.0, 1.0),
+            on_success: config.on_success.clamp(0.0, 1.0),
+            max_chars:  config.max_chars,
+        };
+        Self {
+            config,
+            success_count: AtomicU64::new(0),
+            error_count: AtomicU64::new(0),
+        }
+    }
+
+    /// Decide whether to attach Layer B payloads for an operation with the
+    /// given outcome. Pure function of the configured rate plus an internal
+    /// counter — does not consult any RNG, so behaviour is reproducible
+    /// under unit tests.
+    #[must_use]
+    pub fn decide(&self, outcome: Outcome) -> SamplingDecision {
+        let (rate, counter) = match outcome {
+            Outcome::Error => (self.config.on_error, &self.error_count),
+            Outcome::Success => (self.config.on_success, &self.success_count),
+        };
+
+        if rate <= 0.0 {
+            return SamplingDecision::Skip;
+        }
+        if rate >= 1.0 {
+            return SamplingDecision::Record {
+                max_chars: self.config.max_chars,
+            };
+        }
+
+        // Counter-based fractional sampling: every Nth call fires, where
+        // N = round(1 / rate). Stable, no entropy required, and trivial to
+        // assert against in tests.
+        let stride = (1.0 / rate).round() as u64;
+        let n = counter.fetch_add(1, Ordering::Relaxed);
+        if stride > 0 && n.is_multiple_of(stride) {
+            SamplingDecision::Record {
+                max_chars: self.config.max_chars,
+            }
+        } else {
+            SamplingDecision::Skip
+        }
+    }
+}
+
+/// Truncate `s` to at most `max_chars` UTF-8 characters, returning the
+/// possibly-truncated string and a flag indicating whether truncation
+/// occurred. Splitting at a character boundary keeps the result valid UTF-8.
+#[must_use]
+pub fn truncate(s: &str, max_chars: usize) -> (String, bool) {
+    if s.chars().count() <= max_chars {
+        return (s.to_owned(), false);
+    }
+    let truncated: String = s.chars().take(max_chars).collect();
+    (truncated, true)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn cfg(on_error: f64, on_success: f64, max_chars: usize) -> PayloadSamplingConfig {
+        PayloadSamplingConfig::builder()
+            .on_error(on_error)
+            .on_success(on_success)
+            .max_chars(max_chars)
+            .build()
+    }
+
+    #[test]
+    fn off_on_success_means_skip() {
+        let sampler = PayloadSampler::new(cfg(1.0, 0.0, 1000));
+        for _ in 0..100 {
+            assert_eq!(sampler.decide(Outcome::Success), SamplingDecision::Skip);
+        }
+    }
+
+    #[test]
+    fn full_on_error_means_record_every_time() {
+        let sampler = PayloadSampler::new(cfg(1.0, 0.0, 1000));
+        for _ in 0..100 {
+            assert!(matches!(
+                sampler.decide(Outcome::Error),
+                SamplingDecision::Record { max_chars: 1000 }
+            ));
+        }
+    }
+
+    #[test]
+    fn fractional_rate_fires_on_expected_stride() {
+        // 1 in 4 successes recorded.
+        let sampler = PayloadSampler::new(cfg(0.0, 0.25, 100));
+        let recorded: Vec<bool> = (0..8)
+            .map(|_| {
+                matches!(
+                    sampler.decide(Outcome::Success),
+                    SamplingDecision::Record { .. }
+                )
+            })
+            .collect();
+        // First call (n=0, n % 4 == 0) records; then every 4th.
+        assert_eq!(
+            recorded,
+            vec![true, false, false, false, true, false, false, false]
+        );
+    }
+
+    #[test]
+    fn out_of_range_probabilities_are_clamped() {
+        // Typo: on_error: 100 (meant 1.0) must NOT silently disable sampling.
+        let sampler = PayloadSampler::new(cfg(100.0, -0.5, 100));
+        assert!(matches!(
+            sampler.decide(Outcome::Error),
+            SamplingDecision::Record { .. }
+        ));
+        assert_eq!(sampler.decide(Outcome::Success), SamplingDecision::Skip);
+    }
+
+    #[test]
+    fn truncate_keeps_short_strings_intact() {
+        let (out, truncated) = truncate("hello", 10);
+        assert_eq!(out, "hello");
+        assert!(!truncated);
+    }
+
+    #[test]
+    fn truncate_cuts_long_strings_at_char_boundary() {
+        let (out, truncated) = truncate("hello world", 5);
+        assert_eq!(out, "hello");
+        assert!(truncated);
+    }
+
+    #[test]
+    fn truncate_handles_multibyte_chars_safely() {
+        let (out, truncated) = truncate("你好世界rara", 3);
+        assert_eq!(out, "你好世");
+        assert!(truncated);
+        // No panic, valid UTF-8.
+        let _ = out.as_bytes();
+    }
+
+    #[test]
+    fn success_and_error_counters_are_independent() {
+        let sampler = PayloadSampler::new(cfg(1.0, 0.5, 100));
+        // Drain a few successes; errors still always fire.
+        for _ in 0..5 {
+            let _ = sampler.decide(Outcome::Success);
+        }
+        for _ in 0..3 {
+            assert!(matches!(
+                sampler.decide(Outcome::Error),
+                SamplingDecision::Record { .. }
+            ));
+        }
+    }
+}

--- a/crates/kernel/Cargo.toml
+++ b/crates/kernel/Cargo.toml
@@ -24,6 +24,7 @@ base.workspace = true
 base64.workspace = true
 bon.workspace = true
 chrono.workspace = true
+common-telemetry.workspace = true
 cron = "0.16"
 crossbeam-queue.workspace = true
 dashmap = "6"
@@ -78,7 +79,6 @@ xxhash-rust = { version = "0.8", features = ["xxh3"] }
 [dev-dependencies]
 async-trait.workspace = true
 chrono.workspace = true
-common-telemetry.workspace = true
 dashmap = "6"
 diesel_migrations.workspace = true
 rara-domain-shared = { workspace = true, features = ["testing"] }

--- a/crates/kernel/src/agent/mod.rs
+++ b/crates/kernel/src/agent/mod.rs
@@ -612,6 +612,34 @@ fn infer_has_tool_calls(pending_tool_calls: &HashMap<u32, PendingToolCall>) -> b
     !pending_tool_calls.is_empty()
 }
 
+/// Classify a tool error message into one of the stable
+/// [`common_telemetry::attrs::RARA_TOOL_ERROR_KIND`] enum values. Pure
+/// string matching — substring rules, lowercase compare. Returning a
+/// concrete category lets the detector aggregate by class without parsing
+/// free-form messages.
+fn classify_tool_error(msg: &str) -> &'static str {
+    let m = msg.to_lowercase();
+    if m.contains("timed out") || m.contains("timeout") {
+        "timeout"
+    } else if m.contains("panic") {
+        "panic"
+    } else if m.contains("permission denied") || m.contains("unauthorized") || m.contains("auth") {
+        "auth"
+    } else if m.contains("rate limit") || m.contains("429") {
+        "rate_limit"
+    } else if m.contains("invalid")
+        || m.contains("validation")
+        || m.contains("expected")
+        || m.contains("not found")
+    {
+        "invalid_input"
+    } else if m.contains("interrupted") {
+        "cancelled"
+    } else {
+        "upstream_error"
+    }
+}
+
 fn sanitize_messages_for_llm(messages: &[llm::Message]) -> Vec<llm::Message> {
     messages
         .iter()
@@ -907,23 +935,68 @@ fn thinking_level_to_config(
 ///
 /// Respects `turn_cancel` at every `tokio::select!` point — both before the
 /// stream starts and during delta consumption.
-#[tracing::instrument(
-    skip(
+#[allow(clippy::too_many_arguments)]
+pub(crate) async fn run_agent_loop(
+    handle: &KernelHandle,
+    session_key: SessionKey,
+    user_text: String,
+    stream_handle: &StreamHandle,
+    turn_cancel: &CancellationToken,
+    tape: crate::memory::TapeService,
+    tape_name: &str,
+    tool_context: crate::tool::ToolContext,
+    milestone_tx: Option<tokio::sync::mpsc::Sender<crate::io::AgentEvent>>,
+    guard_pipeline: Arc<GuardPipeline>,
+    hook_runner: crate::hooks::HookRunnerRef,
+    notification_bus: NotificationBusRef,
+    rara_message_id: crate::io::MessageId,
+    interrupted: &AtomicBool,
+    interrupt_notify: &tokio::sync::Notify,
+) -> crate::error::Result<AgentTurnResult> {
+    // Root agent turn span — Layer A telemetry. Marked as kind=AGENT per
+    // OpenInference so an external detector can identify the turn root
+    // without parsing the span name. Dotted-name attributes (`rara.*`,
+    // `gen_ai.*`, `openinference.*`) are not supported by
+    // `#[tracing::instrument(fields(...))]`, so the span is built manually
+    // and the body runs inside `.instrument(span)` to keep the future
+    // `Send`.
+    let turn_span = info_span!(
+        "agent_turn",
+        session_key = %session_key,
+        model = tracing::field::Empty,
+        "openinference.span.kind" = common_telemetry::attrs::SPAN_KIND_AGENT,
+        "rara.session.id" = %session_key,
+        "rara.agent.name" = tracing::field::Empty,
+        "rara.turn.outcome" = tracing::field::Empty,
+        "rara.error.kind" = tracing::field::Empty,
+        "gen_ai.request.model" = tracing::field::Empty,
+        "gen_ai.usage.input_tokens" = tracing::field::Empty,
+        "gen_ai.usage.output_tokens" = tracing::field::Empty,
+    );
+    use tracing::Instrument as _;
+    run_agent_loop_inner(
         handle,
+        session_key,
+        user_text,
         stream_handle,
         turn_cancel,
         tape,
         tape_name,
+        tool_context,
+        milestone_tx,
         guard_pipeline,
+        hook_runner,
         notification_bus,
+        rara_message_id,
         interrupted,
-        interrupt_notify
-    ),
-    fields(
-        session_key = %session_key,
+        interrupt_notify,
     )
-)]
-pub(crate) async fn run_agent_loop(
+    .instrument(turn_span)
+    .await
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn run_agent_loop_inner(
     handle: &KernelHandle,
     session_key: SessionKey,
     user_text: String,
@@ -1023,6 +1096,16 @@ pub(crate) async fn run_agent_loop(
     };
 
     tracing::Span::current().record("model", model.as_str());
+    // Layer A — populate rara.agent.name + gen_ai.request.model on the root
+    // span as soon as both are resolved. The detector pivots off these.
+    tracing::Span::current().record(
+        common_telemetry::attrs::RARA_AGENT_NAME,
+        manifest.name.as_str(),
+    );
+    tracing::Span::current().record(
+        common_telemetry::attrs::GEN_AI_REQUEST_MODEL,
+        model.as_str(),
+    );
 
     // Model-specific tool-use enforcement, aligned with hermes-agent
     // TOOL_USE_ENFORCEMENT_GUIDANCE + OPENAI_MODEL_EXECUTION_GUIDANCE.
@@ -1424,6 +1507,9 @@ pub(crate) async fn run_agent_loop(
 
         messages = sanitize_messages_for_llm(&messages);
 
+        // LLM call span. Marked as kind=LLM per OpenInference; gen_ai.* fields
+        // are populated as the stream progresses (TTFT on first delta, usage on
+        // Done). `rara.turn.iteration` lets the detector spot tool-loop runaway.
         let iter_span = info_span!(
             "llm_iteration",
             iter = iteration,
@@ -1432,6 +1518,13 @@ pub(crate) async fn run_agent_loop(
             stream_ms = tracing::field::Empty,
             has_tools = tracing::field::Empty,
             tool_count = tracing::field::Empty,
+            "openinference.span.kind" = common_telemetry::attrs::SPAN_KIND_LLM,
+            "rara.turn.iteration" = iteration,
+            "gen_ai.request.model" = model.as_str(),
+            "gen_ai.server.time_to_first_token" = tracing::field::Empty,
+            "gen_ai.usage.input_tokens" = tracing::field::Empty,
+            "gen_ai.usage.output_tokens" = tracing::field::Empty,
+            "gen_ai.response.finish_reasons" = tracing::field::Empty,
         );
         let _iter_guard = iter_span.enter();
 
@@ -1543,12 +1636,13 @@ pub(crate) async fn run_agent_loop(
                     if !text.is_empty() {
                         if first_token_at.is_none() {
                             first_token_at = Some(Instant::now());
+                            let ttft = first_token_at.unwrap().duration_since(stream_start);
+                            iter_span.record("first_token_ms", ttft.as_millis() as u64);
+                            // gen_ai.server.time_to_first_token is in seconds
+                            // per the OTel GenAI spec.
                             iter_span.record(
-                                "first_token_ms",
-                                first_token_at
-                                    .unwrap()
-                                    .duration_since(stream_start)
-                                    .as_millis() as u64,
+                                common_telemetry::attrs::GEN_AI_SERVER_TIME_TO_FIRST_TOKEN,
+                                ttft.as_secs_f64(),
                             );
                         }
                         // Settle reasoning timer on the FIRST TextDelta only
@@ -1654,6 +1748,20 @@ pub(crate) async fn run_agent_loop(
                             output_tokens: cumulative_output_tokens,
                             thinking_ms:   cumulative_thinking_ms,
                         });
+                        iter_span.record(
+                            common_telemetry::attrs::GEN_AI_USAGE_INPUT_TOKENS,
+                            u.prompt_tokens,
+                        );
+                        iter_span.record(
+                            common_telemetry::attrs::GEN_AI_USAGE_OUTPUT_TOKENS,
+                            u.completion_tokens,
+                        );
+                    }
+                    if let Some(ref reason) = last_stop_reason {
+                        iter_span.record(
+                            common_telemetry::attrs::GEN_AI_RESPONSE_FINISH_REASONS,
+                            tracing::field::debug(reason),
+                        );
                     }
                     break;
                 }
@@ -2423,10 +2531,18 @@ pub(crate) async fn run_agent_loop(
                 let notification_bus = notification_bus.clone();
                 let approval_manager = Arc::clone(handle.security().approval());
                 let session_key_for_guard = session_key;
+                // Tool execution span. Marked as kind=TOOL per OpenInference;
+                // `tool.name` carries the registered tool id (matches a const
+                // in `common_telemetry::identifiers`). `tool.outcome` and
+                // `rara.tool.error.kind` are recorded once the call completes.
                 let tool_span = info_span!(
                     "tool_exec",
                     tool_name = name.as_str(),
                     success = tracing::field::Empty,
+                    "openinference.span.kind" = common_telemetry::attrs::SPAN_KIND_TOOL,
+                    "tool.name" = name.as_str(),
+                    "tool.outcome" = tracing::field::Empty,
+                    "rara.tool.error.kind" = tracing::field::Empty,
                 );
                 async move {
                     let _guard = tool_span.enter();
@@ -2437,6 +2553,8 @@ pub(crate) async fn run_agent_loop(
                     if let Some(ref user) = user_ref {
                         if !user.can_use_tool(&name) {
                             tool_span.record("success", false);
+                            tool_span.record("tool.outcome", "error");
+                            tool_span.record("rara.tool.error.kind", "auth");
                             let err = format!(
                                 "permission denied: user '{}' cannot use tool '{name}'",
                                 user.name
@@ -2510,6 +2628,8 @@ pub(crate) async fn run_agent_loop(
                             _ => {
                                 // Denied or timed out — block the tool call.
                                 tool_span.record("success", false);
+                                tool_span.record("tool.outcome", "error");
+                                tool_span.record("rara.tool.error.kind", "auth");
 
                                 let agent_id = session_key_for_guard.into_inner();
                                 notification_bus
@@ -2542,6 +2662,8 @@ pub(crate) async fn run_agent_loop(
                         .await;
                     if pre_hook.is_denied() {
                         tool_span.record("success", false);
+                        tool_span.record("tool.outcome", "error");
+                        tool_span.record("rara.tool.error.kind", "auth");
                         let reason = pre_hook.messages().join("; ");
                         warn!(tool = %name, %reason, "tool call denied by PreToolUse hook");
                         let dur = tool_start.elapsed().as_millis() as u64;
@@ -2572,6 +2694,8 @@ pub(crate) async fn run_agent_loop(
                         // no-op edits without spending the execute budget.
                         if let Err(e) = tool.validate(&args).await {
                             tool_span.record("success", false);
+                            tool_span.record("tool.outcome", "error");
+                            tool_span.record("rara.tool.error.kind", "invalid_input");
                             warn!(tool = %name, args = %args_snapshot, error = %e, "tool validation failed");
                             let dur = tool_start.elapsed().as_millis() as u64;
                             return (
@@ -2600,6 +2724,7 @@ pub(crate) async fn run_agent_loop(
                             _ = tool_cancel.cancelled() => {
                                 let dur = tool_start.elapsed().as_millis() as u64;
                                 tool_span.record("success", false);
+                                tool_span.record("tool.outcome", "error");
                                 return (
                                     false,
                                     crate::tool::ToolOutput::from(
@@ -2614,6 +2739,7 @@ pub(crate) async fn run_agent_loop(
                         match tool_result {
                             Ok(result) => {
                                 tool_span.record("success", true);
+                                tool_span.record("tool.outcome", "success");
                                 let dur = tool_start.elapsed().as_millis() as u64;
                                 info!(tool = %name, duration_ms = dur, "tool call succeeded");
                                 guard_pipeline.post_execute(&session_key_for_guard, &name);
@@ -2639,6 +2765,11 @@ pub(crate) async fn run_agent_loop(
                             }
                             Err(e) => {
                                 tool_span.record("success", false);
+                                tool_span.record("tool.outcome", "error");
+                                tool_span.record(
+                                    "rara.tool.error.kind",
+                                    classify_tool_error(&e.to_string()),
+                                );
                                 warn!(tool = %name, args = %args_snapshot, error = %e, "tool execution failed");
                                 let dur = tool_start.elapsed().as_millis() as u64;
 
@@ -2670,6 +2801,8 @@ pub(crate) async fn run_agent_loop(
                         }
                     } else {
                         tool_span.record("success", false);
+                        tool_span.record("tool.outcome", "error");
+                        tool_span.record("rara.tool.error.kind", "invalid_input");
                         let err = format!("tool not found: {name}");
                         warn!(%err);
                         let dur = tool_start.elapsed().as_millis() as u64;
@@ -3180,9 +3313,11 @@ pub(crate) async fn run_agent_loop(
     // This aligns with the explicit /stop path which returns
     // Err(Interrupted) via turn_cancel.
     if was_interrupted {
+        tracing::Span::current().record(common_telemetry::attrs::RARA_TURN_OUTCOME, "aborted");
         return Err(KernelError::Interrupted);
     }
 
+    tracing::Span::current().record(common_telemetry::attrs::RARA_TURN_OUTCOME, "success");
     Ok(AgentTurnResult {
         text: last_accumulated_text,
         iterations: actual_iterations,


### PR DESCRIPTION
## Summary

Adopt the OTel GenAI + OpenInference semantic conventions on rara's spans, plus a small `rara.*` attribute namespace, so an external detector agent can detect/diagnose/route failures off span attributes without parsing free-form text.

- **Layer A — always-on, low-cardinality (the contract):**
  - New `common-telemetry::attrs` with `SCHEMA_VERSION = "0.1.0"`. `pub const` for all `rara.*` keys + re-exports of `gen_ai.*` keys from `opentelemetry-semantic-conventions = "0.31"` (`semconv_experimental` feature). Renaming any constant = major schema bump.
  - Root agent turn span: `openinference.span.kind = AGENT`, `rara.session.id`, `rara.agent.name`, `gen_ai.request.model`, `rara.turn.outcome`.
  - LLM iteration span: `openinference.span.kind = LLM`, `gen_ai.request.model`, `gen_ai.server.time_to_first_token` (seconds, recorded on first delta), `gen_ai.usage.input_tokens` / `output_tokens`, `gen_ai.response.finish_reasons`, `rara.turn.iteration`.
  - Tool execution span: `openinference.span.kind = TOOL`, `tool.name`, `tool.outcome`, `rara.tool.error.kind` (classified into the stable enum: `timeout` | `panic` | `auth` | `rate_limit` | `invalid_input` | `upstream_error`).

- **Layer B — content sampling (config-driven, default off):**
  - New `common-telemetry::payload_sampler::PayloadSampler` — deterministic stride-based sampling, no RNG, lock-free atomic counters per outcome. UTF-8-safe `truncate()`.
  - `PayloadSamplingConfig` (no `Default` per rara config rule; defaults come from YAML). Plumbed onto `TelemetryConfig` as an optional field; documented in `config.example.yaml`.

- **Stable identifier registry:**
  - New `common-telemetry::identifiers` — `pub const` for every tool, agent, and guard rule. Uniqueness asserted in tests.

## 13-failure-mode dry-run validation

The first 8 rows are the canonical failure modes from #1856; rows 9–13 are 5 additional modes I invented to stress-test the contract.

| # | Failure | Detect | Diagnose | Fix routing | Gaps |
|---|---|---|---|---|---|
| 1 | search_memory tool timeout | `tool.duration` spike + `tool.outcome=error` + `rara.tool.error.kind=timeout` | Layer B `rara.tool.input` | `tool.name` → grep `identifiers.rs` | none |
| 2 | LLM 429 rate limit | `rara.error.kind=llm_rate_limit` + `gen_ai.request.model` | none | retry config | none |
| 3 | Tool loop runaway | `rara.turn.iteration > 10` | child span tree | kernel loop guard | none |
| 4 | Context bloat | `gen_ai.usage.input_tokens` trending over `rara.session.id` | Layer B `rara.prompt` | memory truncation | none |
| 5 | Guard misfire | `rara.guard.decision=deny` rate spike + `rara.guard.rule` | Layer B `rara.prompt` | guard rule edit | none |
| 6 | Slow first token | `gen_ai.server.time_to_first_token` p95 spike | Pyroscope at timestamp | model swap | none |
| 7 | Skill silent no-op | `rara.skill.name` set + `rara.turn.iteration=0` + no child spans | Layer B `rara.completion` | skill markdown | none |
| 8 | Tool error class unknown | `rara.tool.error.kind` enum | Layer B `rara.tool.error.message` | error mapping | none |
| 9 | Auth/permission denied on tool | `tool.outcome=error` + `rara.tool.error.kind=auth` | `tool.name` + Layer B `rara.tool.input` | user permission table | none |
| 10 | Tool argument validation failed | `rara.tool.error.kind=invalid_input` + `tool.name` | Layer B `rara.tool.input` | tool schema or prompt | none |
| 11 | Wrong model auto-routed | unexpected `gen_ai.request.model` per session | `rara.session.id` cross-ref + manifest | manifest model field | none |
| 12 | Repetition-loop truncation | high `gen_ai.usage.output_tokens` + low `gen_ai.response.finish_reasons` quality | Layer B `rara.completion` | frequency_penalty tune | none |
| 13 | Aborted turn (user /stop) | `rara.turn.outcome=aborted` | parent + child span tree | UX cancel UI | none |

Layer A is sufficient for detect + route on every row; Layer B (gated by `PayloadSampler`) is only needed for diagnosis when the failure depends on raw content.

## Type of change

| Type | Label |
|------|-------|
| New feature | `enhancement` |

## Component

`core`

## Closes

Closes #1856

## Test plan

- [x] `cargo check --workspace --all-targets` passes
- [x] `cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings` passes
- [x] `cargo +nightly fmt --all -- --check` passes
- [x] `RUSTDOCFLAGS="-D warnings" cargo +nightly doc --workspace --no-deps --document-private-items` passes
- [x] `cargo test -p common-telemetry` — 13 passed (attrs stability, identifier uniqueness, sampler decisions incl. clamping + multibyte truncation)
- [x] `cargo test -p rara-kernel --lib` — 561 passed
- [x] All 13 dry-run failure modes walked through (table above)