### PR TITLE
fix(web): guard message reload against session switch race (#1867)

### DIFF
--- a/web/src/pages/PiChat.tsx
+++ b/web/src/pages/PiChat.tsx
@@ -554,10 +554,14 @@ export default function PiChat() {
       const msgs = await api.get<ChatMessageData[]>(
         `/api/v1/chat/sessions/${encodeURIComponent(session.key)}/messages?limit=200`,
       );
+      // Bail if the user has switched away while the fetch was in flight
+      // — otherwise we would `replaceMessages` the now-active session
+      // with this one's tape. See #1867 for the full repro.
+      if (agentRef.current?.sessionId !== session.key) return;
       const agentMsgs = toAgentMessages(msgs);
       if (agentMsgs.length > 0) {
         agent.replaceMessages(agentMsgs);
-      } else if (agentRef.current?.sessionId === session.key) {
+      } else {
         // Really an empty session (not just a stale backend count) —
         // reveal the welcome overlay now that we know for sure.
         setShowWelcome(true);
@@ -583,14 +587,25 @@ export default function PiChat() {
     });
   }, []);
 
-  /** Reload current session messages (e.g. after voice message completes). */
+  /**
+   * Reload current session messages (e.g. after voice message completes,
+   * or on a server-pushed `tape_appended` event).
+   *
+   * Snapshots `agent.sessionId` at call time and re-checks it before
+   * mutating the agent's state. Without this guard, a `tape_appended`
+   * fetch for session A that lands after the user has already switched
+   * to session B would `replaceMessages` B with A's tape, leaking
+   * messages across sessions (#1867).
+   */
   const reloadMessages = useCallback(async () => {
     const agent = agentRef.current;
     if (!agent?.sessionId) return;
+    const requestedSessionId = agent.sessionId;
     try {
       const msgs = await api.get<ChatMessageData[]>(
-        `/api/v1/chat/sessions/${encodeURIComponent(agent.sessionId)}/messages?limit=200`,
+        `/api/v1/chat/sessions/${encodeURIComponent(requestedSessionId)}/messages?limit=200`,
       );
+      if (agentRef.current?.sessionId !== requestedSessionId) return;
       const agentMsgs = toAgentMessages(msgs);
       agent.replaceMessages(agentMsgs);
       await chatPanelRef.current?.artifactsPanel?.reconstructFromMessages(


### PR DESCRIPTION
## Summary

After #1858 every `tape_appended` event triggers `reloadMessages` (`PiChat.tsx:587`), which fetches `/sessions/<id>/messages` and calls `agent.replaceMessages`. The fetch URL captures `agent.sessionId` at call time, but the post-fetch `replaceMessages` did NOT re-check it. If the user switched sessions while the request was in flight, the agent's state for the new session was overwritten with the old session's tape — messages from one session leaked into another (recipe in #1867).

`switchSession` had the same latent race (PiChat.tsx:558-559); pre-#1858 it took fast clicking to repro, but the new high-frequency event source made it trivial.

Fix in both spots: snapshot `agent.sessionId` before the fetch, bail before `replaceMessages` if it no longer matches.

## Type of change

| Type | Label |
|------|-------|
| Bug fix | `bug` |

## Component

`ui`

## Closes

Closes #1867

## Test plan

- [x] Verified repro before fix: send message in session A, click session B during the assistant reply → A's messages briefly appear in B
- [x] After fix: rapid switching during streaming no longer cross-pollinates
- [x] `bun run build` passes
- [x] No new tests added — race is hard to reproduce reliably in vitest without faked timers + faked WS; covered by manual repro