### PR TITLE
feat(web): show session id on title hover (#1872)

### DIFF
--- a/web/src/components/ChatSidebar.tsx
+++ b/web/src/components/ChatSidebar.tsx
@@ -225,6 +225,7 @@ export function ChatSidebar({
                   <button
                     type="button"
                     onClick={() => onSelect(s)}
+                    title={s.key}
                     className="min-w-0 flex-1 cursor-pointer text-left px-2 py-1.5 bg-transparent"
                   >
                     <div className="truncate text-[13px] leading-tight">

--- a/web/src/pages/PiChat.tsx
+++ b/web/src/pages/PiChat.tsx
@@ -1005,7 +1005,10 @@ export default function PiChat() {
             sits on the right. */}
         {activeSession && !showWelcome && !isInitializing && (
           <header className="flex h-14 shrink-0 items-center justify-between gap-4 border-b border-border/60 px-6">
-            <h1 className="min-w-0 flex-1 truncate text-sm font-semibold text-foreground">
+            <h1
+              className="min-w-0 flex-1 truncate text-sm font-semibold text-foreground"
+              title={activeSession.key}
+            >
               {activeSession.title || activeSession.preview || '新对话'}
             </h1>
             {activeSession.model && (


### PR DESCRIPTION
## Summary

Add native HTML `title` attribute to:
- The session header `<h1>` in `web/src/pages/PiChat.tsx` (shows `activeSession.key` on hover)
- The session row `<button>` in `web/src/components/ChatSidebar.tsx` (shows `s.key` on hover)

No new tooltip component or styling — just the native browser hover tooltip.

## Type of change

| Type | Label |
|------|-------|
| New feature | `enhancement` |

## Component

`ui`

## Closes

Closes #1872

## Test plan

- [x] `cd web && npm run build` passes
- [x] Hover over the chat header title reveals the session key
- [x] Hover over a sidebar session row reveals its session key
- [x] Existing delete-button `title="删除"` is preserved