### PR TITLE
fix(web,channels): finish #1852 nits — TS StreamEvent variant + cross-crate doc xref (#1869)

### DIFF
--- a/crates/channels/src/web.rs
+++ b/crates/channels/src/web.rs
@@ -115,9 +115,16 @@ pub enum WebEvent {
     /// Incremental reasoning/thinking text.
     ReasoningDelta { text: String },
     /// Discard any in-flight assistant text the client has rendered for the
-    /// current turn. Emitted by the kernel before a tool-call batch and
-    /// before the anti-laziness nudge restarts the iteration, so the next
-    /// `TextDelta` stream is not appended on top of abandoned narration.
+    /// current turn. Emitted by the kernel from two sites in
+    /// `crates/kernel/src/agent/mod.rs`:
+    ///
+    /// - the tool-call branch (around line 1676) — clears intermediate
+    ///   narration before the upcoming `ToolCallStart` arrives;
+    /// - the anti-laziness nudge branch (around line 1935) — clears the
+    ///   abandoned ack text before the next iteration's `TextDelta` stream.
+    ///
+    /// Without this signal, the next `TextDelta` stream would be appended
+    /// on top of the now-stale narration on the client.
     TextClear,
     /// A tool call has started.
     ToolCallStart {

--- a/web/src/api/kernel-types.ts
+++ b/web/src/api/kernel-types.ts
@@ -88,6 +88,7 @@ export type PlanStepStatusEvent =
 export type StreamEvent =
   | { type: 'text_delta'; text: string }
   | { type: 'reasoning_delta'; text: string }
+  | { type: 'text_clear' }
   | {
       type: 'tool_call_start';
       name: string;


### PR DESCRIPTION
## Summary

Two follow-up nits from PR #1860 / issue #1869:

- `web/src/api/kernel-types.ts`: add `| { type: 'text_clear' }` to the `StreamEvent` discriminated union. The handler in `use-session-timeline.ts` already matches `case 'text_clear'`, and after #1852 the kernel actually emits the event — so the union now matches the wire contract.
- `crates/channels/src/web.rs`: expand the `WebEvent::TextClear` rustdoc to cross-link both kernel emit sites (`crates/kernel/src/agent/mod.rs` ~1676 tool-call branch, ~1935 anti-laziness nudge branch) so the contract is two-way navigable across crates.

## Type of change

| Type | Label |
|------|-------|
| Bug fix | `bug` |

## Component

`ui` + `core`

## Closes

Closes #1869

## Test plan

- [x] `cargo check --all --all-targets` passes
- [x] `cargo +nightly fmt --all -- --check` passes
- [x] `cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings` passes
- [x] `RUSTDOCFLAGS="-D warnings" cargo +nightly doc --workspace --no-deps --document-private-items` passes
- [x] `cargo test -p rara-channels` passes
- [x] `prek run --all-files` passes
- [x] `web/ bun run build` passes
- [x] `web/ bun run lint` passes