### PR TITLE
chore(ci): remove Swatinem/rust-cache from rust.yml (#1878)

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -51,16 +51,6 @@ jobs:
       - name: Setup mold linker
         uses: rui314/setup-mold@9c9c13bf4c3f1adef0cc596abc155580bcb04444 # v1
 
-      - name: Rust cache
-        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
-        with:
-          shared-key: rust-ci
-          # Save on all branches: main runs get cancelled by concurrency
-          # before reaching the save step, so main-only save-if leaves the
-          # cache permanently empty. All branches share `shared-key: rust-ci`,
-          # so concurrent saves overwrite rather than accumulate.
-          save-if: true
-
       - name: Run clippy
         run: cargo clippy --workspace --all-targets --no-deps -- -D warnings
 
@@ -80,16 +70,6 @@ jobs:
 
       - name: Setup mold linker
         uses: rui314/setup-mold@9c9c13bf4c3f1adef0cc596abc155580bcb04444 # v1
-
-      - name: Rust cache
-        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
-        with:
-          shared-key: rust-ci
-          # Save on all branches: main runs get cancelled by concurrency
-          # before reaching the save step, so main-only save-if leaves the
-          # cache permanently empty. All branches share `shared-key: rust-ci`,
-          # so concurrent saves overwrite rather than accumulate.
-          save-if: true
 
       - name: Run tests
         run: cargo nextest run --workspace
@@ -118,16 +98,6 @@ jobs:
 
       - name: Setup mold linker
         uses: rui314/setup-mold@9c9c13bf4c3f1adef0cc596abc155580bcb04444 # v1
-
-      - name: Rust cache
-        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
-        with:
-          shared-key: rust-ci
-          # Save on all branches: main runs get cancelled by concurrency
-          # before reaching the save step, so main-only save-if leaves the
-          # cache permanently empty. All branches share `shared-key: rust-ci`,
-          # so concurrent saves overwrite rather than accumulate.
-          save-if: true
 
       - name: Generate documentation
         run: cargo +nightly doc --workspace --no-deps --document-private-items


### PR DESCRIPTION
## Summary

Remove `Swatinem/rust-cache` from the three Rust CI jobs (clippy / test / docs). The cache added in #1756 didn't deliver reliable speedup on the ARC runner — relying on mold + the warm runner image instead.

## Type of change

| Type | Label |
|------|-------|
| Chore | `chore` |

## Component

`ci`

## Closes

Closes #1878

## Test plan

- [x] CI runs on this PR (clippy / test / docs) without the cache step