### PR TITLE
ci(rust): build boxlite for real on macOS (#1842)

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -18,13 +18,11 @@ env:
   # so `rustc -vV` probes (notably `cargo +nightly doc`) time out trying to start a server.
   RUSTC_WRAPPER: ""
   # boxlite (rara-sandbox dep) builds bubblewrap + libkrun + libkrunfw natively.
-  # CI runners are Linux x86_64 without meson/ninja/patchelf and cannot run a
-  # full native boxlite build. Stub mode is upstream's documented CI escape
-  # hatch — both `bubblewrap-sys/build.rs` and `libkrun-sys/build.rs` skip
-  # the native build when this is set, so check / clippy / doc / `cargo
-  # test --no-run` still verify the Rust surface. Real boxlite execution is
-  # macOS-only today and is exercised by the (#[ignore]d) integration test.
-  BOXLITE_DEPS_STUB: "1"
+  # The Linux jobs below set `BOXLITE_DEPS_STUB: "1"` per-job because the
+  # `arc-runner-set` image lacks meson/ninja/patchelf and cannot run a full
+  # native boxlite build. The dedicated `sandbox-macos` job builds boxlite
+  # for real on the self-hosted macOS runner so link-time / FFI / build.rs
+  # regressions in those crates are caught on every PR (issue #1842).
 
 defaults:
   run:
@@ -37,6 +35,10 @@ jobs:
   clippy:
     name: Clippy
     runs-on: arc-runner-set
+    env:
+      # See top-of-file note: stub native boxlite build on Linux runners
+      # only; macOS runner builds for real in `sandbox-macos`.
+      BOXLITE_DEPS_STUB: "1"
     steps:
       - name: Checkout code
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
@@ -57,6 +59,10 @@ jobs:
   test:
     name: Test
     runs-on: arc-runner-set
+    env:
+      # See top-of-file note: stub native boxlite build on Linux runners
+      # only; macOS runner builds for real in `sandbox-macos`.
+      BOXLITE_DEPS_STUB: "1"
     steps:
       - name: Checkout code
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
@@ -76,15 +82,19 @@ jobs:
 
       # Smoke-test the boxlite staging code path. With BOXLITE_DEPS_STUB=1
       # the build produces no real runtime files, so this is a dry-run
-      # (`--check`) that just exercises the path/permission logic. Real
-      # staging is run by developers locally on macOS — see
-      # docs/guides/boxlite-runtime.md and tracking issue #1842.
+      # (`--check`) that just exercises the path/permission logic. The
+      # macOS `sandbox-macos` job exercises the real staging path against
+      # a non-stub build.
       - name: Smoke-test boxlite setup (dry-run)
         run: cargo run -p rara-cli -- setup boxlite --check
 
   docs:
     name: Documentation
     runs-on: arc-runner-set
+    env:
+      # See top-of-file note: stub native boxlite build on Linux runners
+      # only; macOS runner builds for real in `sandbox-macos`.
+      BOXLITE_DEPS_STUB: "1"
     steps:
       - name: Checkout code
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
@@ -104,10 +114,46 @@ jobs:
         env:
           RUSTDOCFLAGS: -D warnings
 
+  # Real boxlite build on the self-hosted macOS runner. This job intentionally
+  # does NOT set `BOXLITE_DEPS_STUB`, so `bubblewrap-sys` and `libkrun-sys`
+  # build natively — catching link-time / FFI / build.rs regressions that
+  # the stubbed Linux jobs cannot see (issue #1842). The runner label
+  # `macos` matches the `aarch64-apple-darwin` mapping in
+  # `Cargo.toml` (`workspace.metadata.dist.github-custom-runners`).
+  sandbox-macos:
+    name: Sandbox (macOS, real boxlite build)
+    runs-on: macos
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
+        with:
+          persist-credentials: false
+
+      - name: Rust cache
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          shared-key: rust-ci-macos
+          save-if: true
+
+      - name: Build rara-sandbox (no stub)
+        run: cargo build -p rara-sandbox
+
+      # Compile the (#[ignore]d) integration test so we exercise the test
+      # binary's link path too. Running it would also need a warm OCI image
+      # cache, which CI does not provision — see crates/rara-sandbox/AGENT.md.
+      - name: Compile rara-sandbox tests (no run)
+        run: cargo test --no-run -p rara-sandbox
+
+      # Real staging: boxlite's build.rs has populated
+      # target/debug/build/boxlite-*/out/runtime/, so this copies the
+      # runtime files into the platform user-data directory for real.
+      - name: Stage boxlite runtime files
+        run: cargo run -p rara-cli -- setup boxlite
+
   rust-success:
     name: Rust Success
     runs-on: arc-runner-set
-    needs: [clippy, test, docs]
+    needs: [clippy, test, docs, sandbox-macos]
     if: always()
     steps:
       - name: Check all Rust jobs status
@@ -115,14 +161,17 @@ jobs:
           CLIPPY_RESULT: ${{ needs.clippy.result }}
           TEST_RESULT: ${{ needs.test.result }}
           DOCS_RESULT: ${{ needs.docs.result }}
+          SANDBOX_MACOS_RESULT: ${{ needs.sandbox-macos.result }}
         run: |
           if [[ "$CLIPPY_RESULT" != "success" || \
                 "$TEST_RESULT" != "success" || \
-                "$DOCS_RESULT" != "success" ]]; then
+                "$DOCS_RESULT" != "success" || \
+                "$SANDBOX_MACOS_RESULT" != "success" ]]; then
             echo "One or more Rust jobs failed"
-            echo "  clippy: $CLIPPY_RESULT"
-            echo "  test:   $TEST_RESULT"
-            echo "  docs:   $DOCS_RESULT"
+            echo "  clippy:        $CLIPPY_RESULT"
+            echo "  test:          $TEST_RESULT"
+            echo "  docs:          $DOCS_RESULT"
+            echo "  sandbox-macos: $SANDBOX_MACOS_RESULT"
             exit 1
           fi
           echo "All Rust jobs passed successfully"

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -129,12 +129,6 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Rust cache
-        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
-        with:
-          shared-key: rust-ci-macos
-          save-if: true
-
       - name: Build rara-sandbox (no stub)
         run: cargo build -p rara-sandbox
 

--- a/crates/rara-sandbox/AGENT.md
+++ b/crates/rara-sandbox/AGENT.md
@@ -68,12 +68,14 @@ Public surface (intentionally minimal, see #1697/#1698):
 - Do NOT call `boxlite::init_logging_for` from inside this crate —
   **why:** tracing init is an application-layer concern; library crates
   that install global subscribers fight the host's `tracing` setup.
-- Do NOT silently keep relying on `BOXLITE_DEPS_STUB="1"` in CI —
-  **why:** the stub disables native compilation of `bubblewrap-sys` and
-  `libkrun-sys`, so CI cannot catch link-time / FFI / `build.rs`
-  regressions in those crates. See #1842 for the plan to drop the env
-  var once a macOS (or properly-provisioned Linux) runner builds boxlite
-  for real.
+- Do NOT extend `BOXLITE_DEPS_STUB="1"` to the macOS CI job —
+  **why:** the stub is scoped to the Linux `clippy` / `test` / `docs`
+  jobs in `.github/workflows/rust.yml` because the `arc-runner-set` image
+  lacks meson/ninja/patchelf. The `sandbox-macos` job intentionally
+  builds boxlite for real so link-time / FFI / `build.rs` regressions in
+  `bubblewrap-sys` and `libkrun-sys` are caught on every PR (#1842). If
+  that job starts failing, fix the underlying build issue — do not
+  re-add the stub on macOS.
 
 ## Dependencies
 

--- a/crates/rara-sandbox/tests/alpine_echo.rs
+++ b/crates/rara-sandbox/tests/alpine_echo.rs
@@ -2,8 +2,10 @@
 //!
 //! This test is `#[ignore]`d because it requires (a) a real boxlite build
 //! (no `BOXLITE_DEPS_STUB`) and (b) a local OCI image store that can
-//! resolve `alpine:latest`. CI today builds with the stub for runner
-//! provisioning reasons (#1842), so the test cannot run there.
+//! resolve `alpine:latest`. The macOS CI job (`sandbox-macos` in
+//! `.github/workflows/rust.yml`) compiles the test binary against a real
+//! boxlite build but does not run it — provisioning a warm OCI cache
+//! per runner is out of scope for #1842.
 //!
 //! Run locally on macOS:
 //!

--- a/docs/guides/boxlite-runtime.md
+++ b/docs/guides/boxlite-runtime.md
@@ -52,9 +52,16 @@ first and reported as "already staged".
 
 ## CI
 
-CI builds `rara-sandbox` with `BOXLITE_DEPS_STUB="1"` to avoid pulling
-the full native build chain (meson, ninja, patchelf) onto every runner.
-That means CI never actually has runtime files to stage, so
-`rara setup boxlite --check` in CI exercises only the code path; it
-prints "no boxlite build artifacts found" and exits cleanly. Removing
-the stub is tracked in #1842.
+The Linux `clippy` / `test` / `docs` jobs in
+`.github/workflows/rust.yml` build with `BOXLITE_DEPS_STUB="1"` to avoid
+pulling the full native build chain (meson, ninja, patchelf) onto the
+`arc-runner-set` image. Under the stub, no runtime files are produced,
+so the `rara setup boxlite --check` smoke step exercises only the
+path-resolution code and exits cleanly with "no boxlite build artifacts
+found".
+
+The dedicated `sandbox-macos` job runs WITHOUT the stub on the
+self-hosted macOS runner — `cargo build -p rara-sandbox` and
+`cargo run -p rara-cli -- setup boxlite` execute against a real boxlite
+build, so link-time / FFI / `build.rs` regressions are caught on every
+PR (#1842).


### PR DESCRIPTION
## Summary

- Move `BOXLITE_DEPS_STUB="1"` from the workflow-level `env:` block onto the per-job env of `clippy`, `test`, and `docs` so the Linux jobs keep building against the `arc-runner-set` image (no meson/ninja/patchelf).
- Add a dedicated `sandbox-macos` job to `.github/workflows/rust.yml` that runs `cargo build -p rara-sandbox`, `cargo test --no-run -p rara-sandbox`, and `cargo run -p rara-cli -- setup boxlite` on the self-hosted macOS runner WITHOUT the stub. This catches link-time / FFI / `build.rs` regressions in `bubblewrap-sys` and `libkrun-sys` on every PR.
- Add `sandbox-macos` to `rust-success`'s `needs:` list so a macOS failure blocks merge.
- Update `crates/rara-sandbox/AGENT.md`, `docs/guides/boxlite-runtime.md`, and the `alpine_echo` test header to reflect the new "stub on Linux only; real build on macOS" model.

The runner label `macos` matches `Cargo.toml`'s `workspace.metadata.dist.github-custom-runners` mapping for `aarch64-apple-darwin`, which is the same self-hosted runner used by cargo-dist's release workflow.

## Type of change

| Type | Label |
|------|-------|
| Chore (CI) | `chore`, `ci` |

## Component

`ci`

## Closes

Closes #1842

## Test plan

- [x] `prek run --all-files` (cargo check / fmt / clippy / doc) — passed via pre-commit hook
- [ ] Linux `clippy` / `test` / `docs` jobs still green with per-job stub
- [ ] New `sandbox-macos` job builds boxlite for real and stages runtime files
- [ ] `Rust Success` umbrella requires `sandbox-macos`