### PR TITLE
fix(web): auto-reconnect chat WebSocket and add grace period before marking live card failed (#1880)

### DIFF
--- a/web/src/adapters/__tests__/rara-stream.test.ts
+++ b/web/src/adapters/__tests__/rara-stream.test.ts
@@ -306,6 +306,10 @@ describe('createRaraStreamFn — WebSocket auto-reconnect (#1880)', () => {
     void streamFn(fakeModel(), userContext('hi'));
 
     // Drive 5 failed reconnect cycles. Backoffs are [250, 500, 1000, 2000, 4000].
+    // The first socket opens then drops; subsequent reconnect attempts
+    // never reach `onopen` (simulating a backend that stays unreachable),
+    // so the per-outage budget actually gets exhausted instead of being
+    // reset every cycle.
     const backoffs = [250, 500, 1_000, 2_000, 4_000];
     let socketIdx = 0;
     {
@@ -318,9 +322,7 @@ describe('createRaraStreamFn — WebSocket auto-reconnect (#1880)', () => {
       vi.advanceTimersByTime(delay + 1);
       const ws = MockWebSocket.instances[socketIdx];
       if (!ws) break;
-      // Reconnect attempt opens but immediately drops without ever
-      // succeeding — exhausting the budget.
-      ws.onopen?.(new Event('open'));
+      // Reconnect attempt drops without ever opening — exhausts the budget.
       ws.onclose?.(new CloseEvent('close'));
       socketIdx += 1;
     }
@@ -328,6 +330,31 @@ describe('createRaraStreamFn — WebSocket auto-reconnect (#1880)', () => {
     // After the 5th failed retry, the next onclose should emit reconnect_failed.
     expect(events.find((e) => e.type === '__stream_reconnect_failed')).toBeDefined();
     expect(events.find((e) => e.type === '__stream_closed')).toBeDefined();
+  });
+
+  it('resets the retry budget after every successful reopen', () => {
+    const events: { type: string; attempt?: number }[] = [];
+    const streamFn = createRaraStreamFn(
+      () => 'sess-reset',
+      undefined,
+      (_sk, ev) => events.push(ev as { type: string; attempt?: number }),
+    );
+    void streamFn(fakeModel(), userContext('hi'));
+
+    // First outage: drop, reconnect succeeds (attempt #1).
+    const ws1 = MockWebSocket.instances[0]!;
+    ws1.onopen?.(new Event('open'));
+    ws1.onclose?.(new CloseEvent('close'));
+    expect(events.filter((e) => e.type === '__stream_reconnecting').at(-1)?.attempt).toBe(1);
+    vi.advanceTimersByTime(300);
+    const ws2 = MockWebSocket.instances[1]!;
+    ws2.onopen?.(new Event('open'));
+
+    // Second outage: drop again. If the budget reset on reopen, the next
+    // `__stream_reconnecting` event must report attempt=1 (full budget),
+    // not attempt=2 (per-turn ceiling).
+    ws2.onclose?.(new CloseEvent('close'));
+    expect(events.filter((e) => e.type === '__stream_reconnecting').at(-1)?.attempt).toBe(1);
   });
 
   it('does not reconnect after a clean done frame', () => {

--- a/web/src/adapters/__tests__/rara-stream.test.ts
+++ b/web/src/adapters/__tests__/rara-stream.test.ts
@@ -239,3 +239,111 @@ describe('createRaraStreamFn — relay Map stability across invocations (#1732)'
     });
   });
 });
+
+// ---------------------------------------------------------------------------
+// WebSocket auto-reconnect (#1880)
+// ---------------------------------------------------------------------------
+
+describe('createRaraStreamFn — WebSocket auto-reconnect (#1880)', () => {
+  beforeEach(() => {
+    installLocalStorageStub();
+    localStorage.setItem('access_token', 'test-token');
+    localStorage.setItem(
+      'auth_user',
+      JSON.stringify({ user_id: 'alice', role: 'Admin', is_admin: true }),
+    );
+    MockWebSocket.instances = [];
+    vi.stubGlobal('WebSocket', MockWebSocket as unknown as typeof WebSocket);
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    localStorage.removeItem('access_token');
+    localStorage.removeItem('auth_user');
+    vi.unstubAllGlobals();
+  });
+
+  it('emits __stream_reconnecting and reconnects after onclose without done', () => {
+    const events: { type: string }[] = [];
+    const streamFn = createRaraStreamFn(
+      () => 'sess-recon',
+      undefined,
+      (_sk, ev) => events.push(ev),
+    );
+    void streamFn(fakeModel(), userContext('hi'));
+    const ws1 = MockWebSocket.instances[0]!;
+    ws1.onopen?.(new Event('open'));
+    expect(events.some((e) => e.type === '__stream_started')).toBe(true);
+
+    // Simulate transport drop (socket close without a `done` first).
+    ws1.onclose?.(new CloseEvent('close'));
+    // The reconnecting frame should fire synchronously on close.
+    expect(events.find((e) => e.type === '__stream_reconnecting')).toBeDefined();
+    // No __stream_closed yet — we are mid-grace window.
+    expect(events.some((e) => e.type === '__stream_closed')).toBe(false);
+
+    // Advance past first backoff (250ms) — a fresh socket should open.
+    vi.advanceTimersByTime(300);
+    expect(MockWebSocket.instances).toHaveLength(2);
+    const ws2 = MockWebSocket.instances[1]!;
+    ws2.onopen?.(new Event('open'));
+    // Reconnect must NOT re-send the user payload (backend has buffered).
+    expect(ws2.sent).toHaveLength(0);
+
+    // Backend resumes and finishes — observer eventually sees done + closed.
+    ws2.emit({ type: 'done' });
+    expect(events.some((e) => e.type === '__stream_closed')).toBe(true);
+  });
+
+  it('gives up after MAX_RECONNECT_ATTEMPTS and emits __stream_reconnect_failed', () => {
+    const events: { type: string }[] = [];
+    const streamFn = createRaraStreamFn(
+      () => 'sess-fail',
+      undefined,
+      (_sk, ev) => events.push(ev),
+    );
+    void streamFn(fakeModel(), userContext('hi'));
+
+    // Drive 5 failed reconnect cycles. Backoffs are [250, 500, 1000, 2000, 4000].
+    const backoffs = [250, 500, 1_000, 2_000, 4_000];
+    let socketIdx = 0;
+    {
+      const ws = MockWebSocket.instances[socketIdx]!;
+      ws.onopen?.(new Event('open'));
+      ws.onclose?.(new CloseEvent('close'));
+      socketIdx += 1;
+    }
+    for (const delay of backoffs) {
+      vi.advanceTimersByTime(delay + 1);
+      const ws = MockWebSocket.instances[socketIdx];
+      if (!ws) break;
+      // Reconnect attempt opens but immediately drops without ever
+      // succeeding — exhausting the budget.
+      ws.onopen?.(new Event('open'));
+      ws.onclose?.(new CloseEvent('close'));
+      socketIdx += 1;
+    }
+
+    // After the 5th failed retry, the next onclose should emit reconnect_failed.
+    expect(events.find((e) => e.type === '__stream_reconnect_failed')).toBeDefined();
+    expect(events.find((e) => e.type === '__stream_closed')).toBeDefined();
+  });
+
+  it('does not reconnect after a clean done frame', () => {
+    const events: { type: string }[] = [];
+    const streamFn = createRaraStreamFn(
+      () => 'sess-done',
+      undefined,
+      (_sk, ev) => events.push(ev),
+    );
+    void streamFn(fakeModel(), userContext('hi'));
+    const ws1 = MockWebSocket.instances[0]!;
+    ws1.onopen?.(new Event('open'));
+    ws1.emit({ type: 'done' });
+    // `done` calls ws.close() which fires onclose. Verify no retry.
+    vi.advanceTimersByTime(10_000);
+    expect(MockWebSocket.instances).toHaveLength(1);
+    expect(events.some((e) => e.type === '__stream_reconnecting')).toBe(false);
+  });
+});

--- a/web/src/adapters/rara-stream.ts
+++ b/web/src/adapters/rara-stream.ts
@@ -109,12 +109,40 @@ type WebEvent =
 /** Callback that returns the current session key for WebSocket connections. */
 export type SessionKeyFn = () => string | undefined;
 
+// ---------------------------------------------------------------------------
+// Reconnect tuning
+//
+// Mechanism-level constants — intentionally not config (see
+// `docs/guides/anti-patterns.md`: "Mechanism constants are not config").
+// Bounded exponential backoff: each entry is the wait BEFORE the
+// corresponding 1-based retry attempt. The list length implicitly caps
+// the retry budget.
+// ---------------------------------------------------------------------------
+
+const RECONNECT_BACKOFF_MS = [250, 500, 1_000, 2_000, 4_000] as const;
+const RECONNECT_BACKOFF_CAP_MS = 5_000;
+const MAX_RECONNECT_ATTEMPTS = RECONNECT_BACKOFF_MS.length;
+
 /**
- * Synthetic lifecycle frames the stream injects before opening / after
- * closing the WebSocket. They cannot collide with backend events because
- * the double-underscore prefix is reserved here.
+ * Synthetic lifecycle frames the stream injects around the WebSocket
+ * lifetime. They cannot collide with backend events because the
+ * double-underscore prefix is reserved here.
+ *
+ * - `__stream_started`: emitted once when the first WS connection opens.
+ * - `__stream_reconnecting`: emitted each time the WS drops mid-run and
+ *   we are about to wait `delayMs` before retrying (`attempt` is 1-based).
+ * - `__stream_reconnect_failed`: emitted after exhausting
+ *   {@link MAX_RECONNECT_ATTEMPTS} retries without re-establishing the
+ *   socket. Always immediately followed by `__stream_closed`.
+ * - `__stream_closed`: emitted exactly once when the stream reaches a
+ *   terminal state (server-emitted `done`/`error`/`message`, or
+ *   reconnect attempts exhausted).
  */
-type StreamLifecycleEvent = { type: '__stream_started' } | { type: '__stream_closed' };
+type StreamLifecycleEvent =
+  | { type: '__stream_started' }
+  | { type: '__stream_reconnecting'; attempt: number; delayMs: number }
+  | { type: '__stream_reconnect_failed'; attempts: number }
+  | { type: '__stream_closed' };
 
 /**
  * Shape of events the stream can publish to an external observer (e.g.
@@ -431,8 +459,8 @@ export function createRaraStreamFn(
   ): AssistantMessageEventStream => {
     const stream = createAssistantMessageEventStream();
 
-    const sessionKey = getSessionKey();
-    if (!sessionKey) {
+    const sessionKeyMaybe = getSessionKey();
+    if (!sessionKeyMaybe) {
       const errorMsg = buildPartial(
         model,
         [{ type: 'text', text: 'No active session key set.' }],
@@ -444,6 +472,9 @@ export function createRaraStreamFn(
       stream.end(errorMsg);
       return stream;
     }
+    // Rebind to a non-nullable const so nested closures (`emitLifecycle`,
+    // `connect`) keep the narrowed type without re-checking.
+    const sessionKey: string = sessionKeyMaybe;
 
     const userPayload = extractUserPayload(context, getPendingAttachments?.() ?? []);
     const wsUrl = buildWsUrl(sessionKey);
@@ -495,24 +526,67 @@ export function createRaraStreamFn(
       return block;
     }
 
-    // Connect WebSocket asynchronously
-    try {
+    // Run-level reconnect bookkeeping. `streamFinished` flips true as
+    // soon as the backend signals a terminal state (`done` / `error` /
+    // `message`) so the matching `ws.onclose` skips the reconnect path.
+    // `reconnectAttempts` counts retries that have already been spent;
+    // it resets back to 0 every time a fresh socket reaches `onopen` so
+    // a brief outage doesn't permanently consume the budget.
+    let streamFinished = false;
+    let reconnectAttempts = 0;
+    let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+    let activeWs: WebSocket | null = null;
+    // `firstConnect` distinguishes the initial socket open (where we emit
+    // `__stream_started` and send the user payload) from a reconnect open
+    // (where the backend will replay buffered events for the same
+    // session_key — see companion backend issue #1882).
+    let firstConnect = true;
+
+    /** Emit a synthetic lifecycle frame to the observer, swallowing throws. */
+    function emitLifecycle(event: StreamLifecycleEvent): void {
+      if (!onWebEvent) return;
+      try {
+        onWebEvent(sessionKey, event);
+      } catch (err) {
+        console.warn('rara-stream: observer threw on lifecycle', err);
+      }
+    }
+
+    /**
+     * Emit terminal `__stream_closed` and reject any tool-result promises
+     * that the backend never resolved. Idempotent — guarded by `streamFinished`.
+     */
+    function finalizeStream(): void {
+      if (streamFinished) return;
+      streamFinished = true;
+      emitLifecycle({ type: '__stream_closed' });
+      rejectPendingToolResults(pendingToolResults, 'WebSocket closed before tool result');
+    }
+
+    function clearReconnectTimer(): void {
+      if (reconnectTimer !== null) {
+        clearTimeout(reconnectTimer);
+        reconnectTimer = null;
+      }
+    }
+
+    function connect(): void {
       const ws = new WebSocket(wsUrl);
+      activeWs = ws;
 
       ws.onopen = () => {
-        // Emit start event
-        safePush({ type: 'start', partial: buildPartial(model, content, currentUsage) });
-        // Synthetic stream-open frame for observers; see ws.onclose below
-        // for the matching close frame.
-        if (onWebEvent) {
-          try {
-            onWebEvent(sessionKey, { type: '__stream_started' });
-          } catch (err) {
-            console.warn('rara-stream: observer threw on open', err);
-          }
+        if (firstConnect) {
+          firstConnect = false;
+          safePush({ type: 'start', partial: buildPartial(model, content, currentUsage) });
+          emitLifecycle({ type: '__stream_started' });
+          // Send the user message exactly once — on reconnect the
+          // backend has buffered events for this session_key and will
+          // replay them, so re-sending would double-fire the turn.
+          ws.send(userPayload);
         }
-        // Send user message
-        ws.send(userPayload);
+        // No __stream_started on reconnect: the live card is already in
+        // a 'reconnecting' state and we want it to resume into the same
+        // run, not start a fresh one.
       };
 
       ws.onmessage = (ev: MessageEvent) => {
@@ -684,6 +758,9 @@ export function createRaraStreamFn(
             finalMsg.stopReason = 'stop';
             safePush({ type: 'done', reason: 'stop', message: finalMsg });
             safeEnd(finalMsg);
+            // Mark before close so the matching onclose treats this as
+            // a normal terminal exit and skips the reconnect path.
+            finalizeStream();
             ws.close();
             break;
           }
@@ -698,6 +775,7 @@ export function createRaraStreamFn(
             finalMsg.stopReason = 'stop';
             safePush({ type: 'done', reason: 'stop', message: finalMsg });
             safeEnd(finalMsg);
+            finalizeStream();
             ws.close();
             break;
           }
@@ -708,6 +786,8 @@ export function createRaraStreamFn(
             errorMsg.errorMessage = event.message;
             safePush({ type: 'error', reason: 'error', error: errorMsg });
             safeEnd(errorMsg);
+            // Backend signalled an unrecoverable error; do not retry.
+            finalizeStream();
             ws.close();
             break;
           }
@@ -752,40 +832,77 @@ export function createRaraStreamFn(
         }
       };
 
-      ws.onerror = () => {
-        const errorMsg = buildPartial(model, content, currentUsage);
-        errorMsg.stopReason = 'error';
-        errorMsg.errorMessage = 'WebSocket connection error';
-        safePush({ type: 'error', reason: 'error', error: errorMsg });
-        safeEnd(errorMsg);
-        rejectPendingToolResults(pendingToolResults, 'WebSocket connection error');
-      };
+      // `onerror` is intentionally a no-op: browsers always fire
+      // `onclose` after `onerror`, and routing all reconnect / finalize
+      // logic through `onclose` keeps the state machine single-sourced.
+      ws.onerror = () => {};
 
       ws.onclose = () => {
-        // Synthetic stream-close frame so observers can finalize without
-        // an extra lifecycle callback. `__stream_closed` is namespaced
-        // so it cannot collide with a real backend-emitted event type.
-        if (onWebEvent) {
-          try {
-            onWebEvent(sessionKey, { type: '__stream_closed' });
-          } catch (err) {
-            console.warn('rara-stream: observer threw on close', err);
-          }
-        }
-        // Ensure stream is ended if WS closes unexpectedly
-        if (!streamEnded) {
+        // Stale handler firing after we already moved on (e.g. user
+        // navigated away or another reconnect cycle replaced this socket).
+        if (ws !== activeWs) return;
+
+        // Terminal exit (done/error/message arrived first) — observer
+        // already received `__stream_closed` via `finalizeStream()`.
+        if (streamFinished) return;
+
+        if (reconnectAttempts >= MAX_RECONNECT_ATTEMPTS) {
+          // Give up. Surface the failure both to pi-agent-core's stream
+          // (so the assistant message resolves with an error) and to the
+          // observer (so the live card flips out of 'reconnecting').
+          emitLifecycle({
+            type: '__stream_reconnect_failed',
+            attempts: reconnectAttempts,
+          });
           const finalMsg = buildPartial(model, content, currentUsage);
-          finalMsg.stopReason = content.length > 0 ? 'stop' : 'error';
-          if (content.length > 0) {
-            safePush({ type: 'done', reason: 'stop', message: finalMsg });
-          } else {
-            finalMsg.errorMessage = 'WebSocket closed unexpectedly';
-            safePush({ type: 'error', reason: 'error', error: finalMsg });
-          }
+          finalMsg.stopReason = 'error';
+          finalMsg.errorMessage = `WebSocket reconnect failed after ${reconnectAttempts} attempts`;
+          safePush({ type: 'error', reason: 'error', error: finalMsg });
           safeEnd(finalMsg);
+          finalizeStream();
+          return;
         }
-        rejectPendingToolResults(pendingToolResults, 'WebSocket closed before tool result');
+
+        // Schedule a retry. The live card observer treats
+        // `__stream_reconnecting` as a grace window — it stays mounted
+        // and does NOT flip to `failed` until reconnect_failed arrives.
+        const delayMs = RECONNECT_BACKOFF_MS[reconnectAttempts] ?? RECONNECT_BACKOFF_CAP_MS;
+        const attempt = reconnectAttempts + 1;
+        reconnectAttempts = attempt;
+        emitLifecycle({ type: '__stream_reconnecting', attempt, delayMs });
+        clearReconnectTimer();
+        reconnectTimer = setTimeout(() => {
+          reconnectTimer = null;
+          // Bail if a terminal event landed while we were waiting (race
+          // window: backend could push a final frame on a still-open
+          // socket the user manually closed). Defensive only.
+          if (streamFinished) return;
+          try {
+            connect();
+          } catch (err) {
+            // Synchronous throw from `new WebSocket()` (e.g. bad URL,
+            // CSP block). Treat as a fully-spent attempt and recurse
+            // through onclose-style logic by simulating it.
+            console.warn('rara-stream: reconnect failed to construct WebSocket', err);
+            if (reconnectAttempts >= MAX_RECONNECT_ATTEMPTS) {
+              emitLifecycle({
+                type: '__stream_reconnect_failed',
+                attempts: reconnectAttempts,
+              });
+              const finalMsg = buildPartial(model, content, currentUsage);
+              finalMsg.stopReason = 'error';
+              finalMsg.errorMessage = err instanceof Error ? err.message : 'Reconnect failed';
+              safePush({ type: 'error', reason: 'error', error: finalMsg });
+              safeEnd(finalMsg);
+              finalizeStream();
+            }
+          }
+        }, delayMs);
       };
+    }
+
+    try {
+      connect();
     } catch (err) {
       const errorMsg = buildPartial(model, content, currentUsage);
       errorMsg.stopReason = 'error';
@@ -799,9 +916,11 @@ export function createRaraStreamFn(
 }
 
 /**
- * Fail any tool-result promises the kernel never finished. Called from
- * `ws.onerror` / `ws.onclose` so pi-agent-core's loop sees a concrete
- * rejection rather than hanging on an abandoned `tool_call_start`.
+ * Fail any tool-result promises the kernel never finished. Called only
+ * from `finalizeStream()` — i.e. when the stream reaches a terminal
+ * state (server-emitted `done`/`error`, or reconnect attempts
+ * exhausted). Intermediate WS drops do NOT reject pending promises so
+ * the kernel can resolve them on the resumed socket.
  */
 function rejectPendingToolResults(pending: Map<string, PendingToolResult>, reason: string): void {
   for (const slot of pending.values()) {

--- a/web/src/adapters/rara-stream.ts
+++ b/web/src/adapters/rara-stream.ts
@@ -584,6 +584,9 @@ export function createRaraStreamFn(
           // replay them, so re-sending would double-fire the turn.
           ws.send(userPayload);
         }
+        // Reset the retry budget on every successful open so a brief
+        // outage doesn't permanently consume it (no-op on first connect).
+        reconnectAttempts = 0;
         // No __stream_started on reconnect: the live card is already in
         // a 'reconnecting' state and we want it to resume into the same
         // run, not start a fresh one.

--- a/web/src/components/agent-live/AgentTranscriptDialog.tsx
+++ b/web/src/components/agent-live/AgentTranscriptDialog.tsx
@@ -164,6 +164,8 @@ function StatusIcon({ status }: { status: RunStatus }) {
   switch (status) {
     case 'running':
       return <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />;
+    case 'reconnecting':
+      return <Loader2 className="h-4 w-4 animate-spin text-amber-500" />;
     case 'completed':
       return <CheckCircle2 className="h-4 w-4 text-emerald-500" />;
     case 'failed':
@@ -179,6 +181,11 @@ function statusChrome(status: RunStatus): { label: string; cls: string } {
       return {
         label: 'Running',
         cls: 'border-border/60 bg-muted/50 text-muted-foreground',
+      };
+    case 'reconnecting':
+      return {
+        label: 'Reconnecting',
+        cls: 'border-amber-500/40 bg-amber-500/10 text-amber-700 dark:text-amber-300',
       };
     case 'completed':
       return {

--- a/web/src/components/agent-live/SingleAgentLiveCard.tsx
+++ b/web/src/components/agent-live/SingleAgentLiveCard.tsx
@@ -51,7 +51,9 @@ export function SingleAgentLiveCard({ run, agentName = 'rara', onOpenTranscript,
   // when a new run takes the active slot (different runId) or when the
   // run flips back to running (defensive — should not happen today).
   useEffect(() => {
-    if (run.status === 'running') {
+    // Non-terminal states (running/reconnecting) never fade — the run
+    // is still live as far as the user is concerned.
+    if (run.status === 'running' || run.status === 'reconnecting') {
       setFading(false);
       return;
     }
@@ -66,7 +68,7 @@ export function SingleAgentLiveCard({ run, agentName = 'rara', onOpenTranscript,
 
   // 1 Hz tick while the run is live so the elapsed chip updates.
   useEffect(() => {
-    if (run.status !== 'running') return;
+    if (run.status !== 'running' && run.status !== 'reconnecting') return;
     const id = window.setInterval(() => setNowTick(Date.now()), 1000);
     return () => window.clearInterval(id);
   }, [run.status]);
@@ -92,15 +94,20 @@ export function SingleAgentLiveCard({ run, agentName = 'rara', onOpenTranscript,
     setShowLatest(!atBottom);
   };
 
-  const isRunning = run.status === 'running';
+  // Treat `reconnecting` as a soft-running state for header chrome —
+  // the run is alive on the backend; we're just briefly off the wire.
+  const isRunning = run.status === 'running' || run.status === 'reconnecting';
   const elapsed = (run.endedAt ?? nowTick) - run.startedAt;
-  const headerLabel = isRunning
-    ? `${agentName} is working`
-    : run.status === 'failed'
-      ? `${agentName} encountered an error`
-      : run.status === 'cancelled'
-        ? `${agentName} was interrupted`
-        : `${agentName} finished`;
+  const headerLabel =
+    run.status === 'running'
+      ? `${agentName} is working`
+      : run.status === 'reconnecting'
+        ? `${agentName} is reconnecting…`
+        : run.status === 'failed'
+          ? `${agentName} encountered an error`
+          : run.status === 'cancelled'
+            ? `${agentName} was interrupted`
+            : `${agentName} finished`;
   const redactedItems = useMemo(() => run.items.map(redactItem), [run.items]);
   // Newest chip first (hermes pattern) while running; chronological order is
   // nicer once the turn settles so the viewer can read the recap top-down.
@@ -251,6 +258,15 @@ function RunStatusDot({ status }: { status: LiveRun['status'] }) {
       <span
         className="flex h-2 w-2 shrink-0 animate-pulse rounded-full bg-emerald-500"
         aria-hidden
+      />
+    );
+  }
+  if (status === 'reconnecting') {
+    // Amber dot — non-terminal but degraded; mirrors the StatusBadge.
+    return (
+      <span
+        className="flex h-2 w-2 shrink-0 animate-pulse rounded-full bg-amber-500"
+        aria-label="reconnecting"
       />
     );
   }

--- a/web/src/components/agent-live/TaskRunHistory.tsx
+++ b/web/src/components/agent-live/TaskRunHistory.tsx
@@ -140,7 +140,8 @@ function StatusIcon({ status }: { status: RunStatus }) {
     case 'cancelled':
       return <Ban className="h-3.5 w-3.5 text-muted-foreground" />;
     case 'running':
-      // Unreachable — the history section never renders running runs.
+    case 'reconnecting':
+      // Unreachable — the history section never renders non-terminal runs.
       return <CheckCircle2 className="h-3.5 w-3.5 text-muted-foreground" />;
   }
 }
@@ -155,6 +156,8 @@ function statusLabel(status: RunStatus): string {
       return 'Cancelled';
     case 'running':
       return 'Running';
+    case 'reconnecting':
+      return 'Reconnecting';
   }
 }
 

--- a/web/src/components/agent-live/__tests__/live-run-store.test.ts
+++ b/web/src/components/agent-live/__tests__/live-run-store.test.ts
@@ -23,6 +23,10 @@ import type { TimelineItem } from '@/api/kernel-types';
 
 const startEvent = { type: '__stream_started' } satisfies PublicWebEvent;
 const closeEvent = { type: '__stream_closed' } satisfies PublicWebEvent;
+const reconnectingEvent = (attempt = 1, delayMs = 250) =>
+  ({ type: '__stream_reconnecting', attempt, delayMs }) satisfies PublicWebEvent;
+const reconnectFailedEvent = (attempts = 5) =>
+  ({ type: '__stream_reconnect_failed', attempts }) satisfies PublicWebEvent;
 
 function toolStart(id: string, name: string, args: Record<string, unknown> = {}): PublicWebEvent {
   return { type: 'tool_call_start', id, name, arguments: args } satisfies PublicWebEvent;
@@ -205,6 +209,56 @@ describe('LiveRunStore auto-dismiss', () => {
     vi.advanceTimersByTime(AUTO_DISMISS_MS);
     expect(store.snapshot(sk).active).toBeNull();
     expect(store.snapshot(sk).history).toHaveLength(0);
+  });
+});
+
+describe('LiveRunStore reconnect grace period (#1880)', () => {
+  it('flips to reconnecting on __stream_reconnecting without finalizing', () => {
+    const store = new LiveRunStore();
+    const sk = 'rec1';
+    store.publish(sk, startEvent);
+    store.publish(sk, toolStart('a', 'Grep'));
+    store.publish(sk, reconnectingEvent(1, 250));
+    const slice = store.snapshot(sk);
+    expect(slice.active?.status).toBe('reconnecting');
+    expect(slice.active?.endedAt).toBeNull();
+    // Items survive — the user can still see what ran before the drop.
+    expect(slice.active?.items.length).toBeGreaterThan(0);
+  });
+
+  it('resumes to running when a backend frame arrives after reconnecting', () => {
+    const store = new LiveRunStore();
+    const sk = 'rec2';
+    store.publish(sk, startEvent);
+    store.publish(sk, reconnectingEvent());
+    expect(store.snapshot(sk).active?.status).toBe('reconnecting');
+    // Resumed socket delivers a tool_call_start — status flips back.
+    store.publish(sk, toolStart('a', 'Grep'));
+    expect(store.snapshot(sk).active?.status).toBe('running');
+  });
+
+  it('finalizes as completed if reconnected stream ends with done', () => {
+    const store = new LiveRunStore();
+    const sk = 'rec3';
+    store.publish(sk, startEvent);
+    store.publish(sk, reconnectingEvent());
+    store.publish(sk, { type: 'done' } satisfies PublicWebEvent);
+    expect(store.snapshot(sk).active?.status).toBe('completed');
+  });
+
+  it('flips to failed only after __stream_reconnect_failed (not on bare close)', () => {
+    const store = new LiveRunStore();
+    const sk = 'rec4';
+    store.publish(sk, startEvent);
+    store.publish(sk, reconnectingEvent());
+    // A spurious __stream_closed mid-reconnect must NOT mark failed.
+    store.publish(sk, closeEvent);
+    expect(store.snapshot(sk).active?.status).toBe('reconnecting');
+    // Now backoff exhausts.
+    store.publish(sk, reconnectFailedEvent(5));
+    const slice = store.snapshot(sk);
+    expect(slice.active?.status).toBe('failed');
+    expect(slice.active?.error).toContain('reconnect failed');
   });
 });
 

--- a/web/src/components/agent-live/live-run-store.ts
+++ b/web/src/components/agent-live/live-run-store.ts
@@ -32,8 +32,15 @@
 import type { PublicWebEvent } from '@/adapters/rara-stream';
 import type { TimelineItem } from '@/api/kernel-types';
 
-/** Status of a single agent run. */
-export type RunStatus = 'running' | 'completed' | 'failed' | 'cancelled';
+/** Status of a single agent run.
+ *
+ * `reconnecting` is a transient state: the underlying WebSocket dropped
+ * mid-run and the rara-stream adapter is retrying with backoff. The run
+ * stays visible in the live card; it transitions back to `running` if a
+ * subsequent server frame arrives, or to `failed` if reconnect attempts
+ * are exhausted (signalled by `__stream_reconnect_failed`).
+ */
+export type RunStatus = 'running' | 'reconnecting' | 'completed' | 'failed' | 'cancelled';
 
 /** One agent run — either currently active or moved into history. */
 export interface LiveRun {
@@ -195,9 +202,10 @@ export class LiveRunStore {
     prev: LiveRun | null,
     next: LiveRun | null,
   ): void {
-    // If the active run is gone (retired) or is running again, drop any
-    // pending dismissal — there is nothing terminal to clear.
-    if (!next || next.status === 'running') {
+    // If the active run is gone (retired) or is in a non-terminal state
+    // (`running` / `reconnecting`), drop any pending dismissal —
+    // nothing terminal to clear.
+    if (!next || next.status === 'running' || next.status === 'reconnecting') {
       this.cancelAutoDismiss(sessionKey);
       return;
     }
@@ -276,7 +284,7 @@ export function reduce(
     // card instead of an abrupt unmount on `done`.
     const prev = slice.active;
     const retired = prev
-      ? prev.status === 'running'
+      ? prev.status === 'running' || prev.status === 'reconnecting'
         ? finalize(prev, 'cancelled', 'Stream restarted')
         : prev
       : null;
@@ -295,15 +303,42 @@ export function reduce(
     return { active, history };
   }
 
+  if (type === '__stream_reconnecting') {
+    // Transient drop — keep items, flip status so the card can show a
+    // grace-period indicator instead of "failed". A subsequent server
+    // frame on the resumed socket transitions back to `running` via
+    // `bumpToRunningIfReconnecting()` (called below for any data event).
+    if (!slice.active) return slice;
+    if (slice.active.status !== 'running' && slice.active.status !== 'reconnecting') {
+      return slice;
+    }
+    return { ...slice, active: { ...slice.active, status: 'reconnecting' } };
+  }
+
+  if (type === '__stream_reconnect_failed') {
+    if (!slice.active) return slice;
+    if (slice.active.status === 'completed' || slice.active.status === 'failed') {
+      return slice;
+    }
+    const message = `WebSocket reconnect failed after ${
+      readNumber(event, 'attempts') ?? 0
+    } attempts`;
+    return {
+      ...slice,
+      active: finalize({ ...slice.active, error: message }, 'failed', message),
+    };
+  }
+
   if (type === '__stream_closed') {
     if (!slice.active) return slice;
-    // Already terminal (done/error arrived before close) — nothing to do;
-    // the card stays pinned in the active slot until the next run.
+    // Already terminal (done/error/reconnect_failed arrived before close)
+    // — nothing to do; the card stays pinned until the next run.
     if (slice.active.status !== 'running') {
       return slice;
     }
-    // WebSocket hung up mid-flight — mark cancelled but keep visible so
-    // the viewer can inspect what ran before the drop.
+    // WebSocket hung up cleanly mid-flight without any reconnect signal
+    // (e.g. session reset, tab navigation) — mark cancelled but keep
+    // visible so the viewer can inspect what ran before the drop.
     return {
       ...slice,
       active: finalize(slice.active, 'cancelled', 'Stream closed'),
@@ -312,7 +347,12 @@ export function reduce(
 
   // All remaining events need an active run.
   if (!slice.active) return slice;
-  const run = slice.active;
+  // Any backend frame arriving while we were `reconnecting` proves the
+  // resumed socket is delivering data — flip back to `running` so the
+  // card stops showing the grace-period indicator. Final status events
+  // (`done` / `error`) further below will overwrite this as needed.
+  const run: LiveRun =
+    slice.active.status === 'reconnecting' ? { ...slice.active, status: 'running' } : slice.active;
 
   switch (type) {
     case 'done': {
@@ -467,6 +507,11 @@ function readString(obj: object, key: string): string | null {
 function readBool(obj: object, key: string): boolean | null {
   const v = (obj as Record<string, unknown>)[key];
   return typeof v === 'boolean' ? v : null;
+}
+
+function readNumber(obj: object, key: string): number | null {
+  const v = (obj as Record<string, unknown>)[key];
+  return typeof v === 'number' ? v : null;
 }
 
 function readRecord(obj: object, key: string): Record<string, unknown> | null {


### PR DESCRIPTION
## Summary

When the chat WebSocket dropped mid-run, the live card immediately flipped to `failed` and any in-flight tool-result promises rejected, even if the disconnect was a transient network blip. This change adds bounded exponential-backoff auto-reconnect inside the `rara-stream` adapter and a `reconnecting` grace state in the live-run store so the UI shows an amber "Reconnecting…" indicator instead of failing.

- `rara-stream.ts`: bounded backoff (`[250, 500, 1_000, 2_000, 4_000]` ms, 5 attempts max) on unexpected `onclose`. Emits new synthetic lifecycle frames `__stream_reconnecting` and `__stream_reconnect_failed`. Pending tool-result promises are no longer rejected on intermediate drops — only on terminal finalization. Stale `onclose` handlers from replaced sockets are ignored via `ws !== activeWs` guard.
- `live-run-store.ts`: new `reconnecting` `RunStatus`. Any backend frame arriving in `reconnecting` flips the run back to `running`. `__stream_reconnect_failed` finalizes as `failed` with an explanatory message.
- UI (`SingleAgentLiveCard`, `AgentTranscriptDialog`, `TaskRunHistory`): treat `reconnecting` as a soft-running state — header reads "is reconnecting…", amber pulsing dot / spinner, no fade.

Backend buffer-replay (so the resumed socket replays missed frames for the same `session_key`) is tracked separately under #1882.

## Type of change

| Type | Label |
|------|-------|
| Bug fix | `bug` |

## Component

`ui`

## Closes

Closes #1880

## Test plan

- [x] `npm run build` passes (only unrelated KaTeX-fonts / pi-web-ui externalization warnings)
- [x] `npm test -- --run` passes — 16 files, 109 tests, including new specs:
  - `rara-stream.test.ts` — emits `__stream_reconnecting` and reconnects after `onclose` without `done`; emits `__stream_reconnect_failed` after exhausting retries
  - `live-run-store.test.ts` — `reconnecting` grace period, resume-to-running, finalize-as-failed-on-exhaustion