### PR TITLE
feat(web): hover menu on session items with copy id + regenerate title (#1885)

### DIFF
--- a/web/src/components/ChatSidebar.tsx
+++ b/web/src/components/ChatSidebar.tsx
@@ -17,6 +17,7 @@
 import { PanelLeftClose, PanelLeft, Plus, Search, Settings, Trash2 } from 'lucide-react';
 import { useEffect, useState } from 'react';
 
+import { SessionMenu } from './SessionMenu';
 import { SidebarRunHistory } from './SidebarRunHistory';
 
 import { api } from '@/api/client';
@@ -36,6 +37,9 @@ interface ChatSidebarProps {
    * session the caller should switch to when the deleted row was
    * the active one, or `null` when no sessions are left. */
   onDeleteSession: (key: string, fallback: ChatSession | null) => void;
+  /** Notify the parent when a session's metadata changed in-place (e.g. the
+   * user regenerated its title) so the page-header copy can stay in sync. */
+  onSessionUpdated?: (session: ChatSession) => void;
   /** Bump this from the parent to force a session-list refetch (e.g. after
    * creating a new session or receiving the first message of a fresh one). */
   refreshKey: number;
@@ -67,6 +71,7 @@ export function ChatSidebar({
   onOpenSearch,
   onOpenSettings,
   onDeleteSession,
+  onSessionUpdated,
   refreshKey,
 }: ChatSidebarProps) {
   const [collapsed, setCollapsed] = useState<boolean>(() => {
@@ -235,15 +240,27 @@ export function ChatSidebar({
                       {formatRelativeDate(s.updated_at)}
                     </div>
                   </button>
-                  <button
-                    type="button"
-                    onClick={(e) => handleDelete(s.key, e)}
-                    aria-label={`删除 ${s.title ?? '会话'}`}
-                    className="shrink-0 rounded p-1 mr-1 mt-1 text-muted-foreground/0 transition-[color,opacity] hover:bg-destructive/10 hover:text-destructive group-hover:text-muted-foreground group-hover:opacity-100"
-                    title="删除"
-                  >
-                    <Trash2 className="h-3 w-3" />
-                  </button>
+                  <div className="mt-1 mr-1 flex shrink-0 items-center gap-0.5 opacity-0 transition-opacity group-hover:opacity-100">
+                    <SessionMenu
+                      sessionKey={s.key}
+                      ariaLabel={s.title ?? '会话'}
+                      onRegenerated={(updated) => {
+                        setSessions((prev) =>
+                          prev.map((row) => (row.key === updated.key ? updated : row)),
+                        );
+                        onSessionUpdated?.(updated);
+                      }}
+                    />
+                    <button
+                      type="button"
+                      onClick={(e) => handleDelete(s.key, e)}
+                      aria-label={`删除 ${s.title ?? '会话'}`}
+                      className="shrink-0 rounded p-1 text-muted-foreground transition-colors hover:bg-destructive/10 hover:text-destructive cursor-pointer"
+                      title="删除"
+                    >
+                      <Trash2 className="h-3 w-3" />
+                    </button>
+                  </div>
                 </div>
               ))
             )}

--- a/web/src/components/SessionMenu.tsx
+++ b/web/src/components/SessionMenu.tsx
@@ -26,7 +26,6 @@ import {
 
 import { api } from '@/api/client';
 import type { ChatSession } from '@/api/types';
-import { cn } from '@/lib/utils';
 
 interface SessionMenuProps {
   /** Session this menu acts on. Only `key` is required at call time. */
@@ -36,9 +35,6 @@ interface SessionMenuProps {
   /** Called with the refreshed session after a successful title regeneration
    *  so the caller can update its local cache (e.g. the page-header title). */
   onRegenerated?: (session: ChatSession) => void;
-  /** Extra classes for the trigger button — used by the sidebar to apply
-   *  the hover-reveal pattern, while the page header always shows it. */
-  triggerClassName?: string;
 }
 
 /**
@@ -46,12 +42,7 @@ interface SessionMenuProps {
  * title. Exposes two actions: copy the session id to the clipboard, and
  * regenerate the session title via the backend.
  */
-export function SessionMenu({
-  sessionKey,
-  ariaLabel,
-  onRegenerated,
-  triggerClassName,
-}: SessionMenuProps) {
+export function SessionMenu({ sessionKey, ariaLabel, onRegenerated }: SessionMenuProps) {
   const [copied, setCopied] = useState(false);
   const [regenerating, setRegenerating] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -97,10 +88,7 @@ export function SessionMenu({
           aria-label={ariaLabel ? `更多操作 — ${ariaLabel}` : '更多操作'}
           title="更多操作"
           onClick={(e) => e.stopPropagation()}
-          className={cn(
-            'shrink-0 rounded p-1 text-muted-foreground transition-colors hover:bg-secondary/60 hover:text-foreground cursor-pointer',
-            triggerClassName,
-          )}
+          className="shrink-0 cursor-pointer rounded p-1 text-muted-foreground transition-colors hover:bg-secondary/60 hover:text-foreground"
         >
           <MoreHorizontal className="h-3.5 w-3.5" />
         </button>

--- a/web/src/components/SessionMenu.tsx
+++ b/web/src/components/SessionMenu.tsx
@@ -1,0 +1,133 @@
+/*
+ * Copyright 2025 Rararulab
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Check, Loader2, MoreHorizontal, RefreshCw } from 'lucide-react';
+import { useState } from 'react';
+
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from './ui/dropdown-menu';
+
+import { api } from '@/api/client';
+import type { ChatSession } from '@/api/types';
+import { cn } from '@/lib/utils';
+
+interface SessionMenuProps {
+  /** Session this menu acts on. Only `key` is required at call time. */
+  sessionKey: string;
+  /** Optional accessible label suffix (e.g. session title) for the trigger. */
+  ariaLabel?: string;
+  /** Called with the refreshed session after a successful title regeneration
+   *  so the caller can update its local cache (e.g. the page-header title). */
+  onRegenerated?: (session: ChatSession) => void;
+  /** Extra classes for the trigger button — used by the sidebar to apply
+   *  the hover-reveal pattern, while the page header always shows it. */
+  triggerClassName?: string;
+}
+
+/**
+ * Hover-revealed `⋯` menu attached to a session row or the chat-page header
+ * title. Exposes two actions: copy the session id to the clipboard, and
+ * regenerate the session title via the backend.
+ */
+export function SessionMenu({
+  sessionKey,
+  ariaLabel,
+  onRegenerated,
+  triggerClassName,
+}: SessionMenuProps) {
+  const [copied, setCopied] = useState(false);
+  const [regenerating, setRegenerating] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(sessionKey);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1200);
+    } catch {
+      // Clipboard write may fail (insecure context, denied permission).
+      // The menu item is a debug affordance — surface the failure inline.
+      setError('复制失败');
+      setTimeout(() => setError(null), 1500);
+    }
+  };
+
+  const handleRegenerate = async (e: Event) => {
+    // Keep the menu open while the request is in flight so the loading
+    // state is visible; Radix would otherwise close on selection.
+    e.preventDefault();
+    if (regenerating) return;
+    setRegenerating(true);
+    setError(null);
+    try {
+      const updated = await api.post<ChatSession>(
+        `/api/v1/chat/sessions/${encodeURIComponent(sessionKey)}/regenerate-title`,
+      );
+      onRegenerated?.(updated);
+    } catch {
+      setError('重新生成失败');
+      setTimeout(() => setError(null), 2000);
+    } finally {
+      setRegenerating(false);
+    }
+  };
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <button
+          type="button"
+          aria-label={ariaLabel ? `更多操作 — ${ariaLabel}` : '更多操作'}
+          title="更多操作"
+          onClick={(e) => e.stopPropagation()}
+          className={cn(
+            'shrink-0 rounded p-1 text-muted-foreground transition-colors hover:bg-secondary/60 hover:text-foreground cursor-pointer',
+            triggerClassName,
+          )}
+        >
+          <MoreHorizontal className="h-3.5 w-3.5" />
+        </button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" onClick={(e) => e.stopPropagation()}>
+        <DropdownMenuItem onSelect={() => void handleCopy()}>
+          {copied ? (
+            <Check className="h-3.5 w-3.5 text-green-600" />
+          ) : (
+            <Check className="h-3.5 w-3.5 opacity-0" />
+          )}
+          <span>{copied ? '已复制' : '复制 session id'}</span>
+        </DropdownMenuItem>
+        <DropdownMenuItem disabled={regenerating} onSelect={(e) => void handleRegenerate(e)}>
+          {regenerating ? (
+            <Loader2 className="h-3.5 w-3.5 animate-spin" />
+          ) : (
+            <RefreshCw className="h-3.5 w-3.5" />
+          )}
+          <span>{regenerating ? '生成中…' : '重新生成标题'}</span>
+        </DropdownMenuItem>
+        {error && (
+          <div className="px-2 py-1 text-[11px] text-destructive" role="alert">
+            {error}
+          </div>
+        )}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/web/src/pages/PiChat.tsx
+++ b/web/src/pages/PiChat.tsx
@@ -71,6 +71,7 @@ import {
 import { ChatSidebar } from '@/components/ChatSidebar';
 import { ChatWelcome } from '@/components/ChatWelcome';
 import { RaraModelDialog } from '@/components/RaraModelDialog';
+import { SessionMenu } from '@/components/SessionMenu';
 import { SessionSearchDialog } from '@/components/SessionSearchDialog';
 import { useSettingsModal } from '@/components/settings/SettingsModalProvider';
 import { VoiceRecorder } from '@/components/VoiceRecorder';
@@ -354,10 +355,6 @@ export default function PiChat() {
   // creating a new session or sending the first message of a fresh one).
   const [modelDialogOpen, setModelDialogOpen] = useState(false);
   const [resetError, setResetError] = useState<string | null>(null);
-  // Brief inline confirmation after copying the session id from the
-  // page-header title — auto-clears after ~1200ms so the title text
-  // returns to normal without any toast plumbing.
-  const [copiedSessionId, setCopiedSessionId] = useState(false);
   // `true` when the active session has no messages — we render a welcome
   // overlay in that window so the chat page isn't just an input box on
   // empty canvas. Flipped off on the first send and on session switches
@@ -1004,6 +1001,11 @@ export default function PiChat() {
         onOpenSearch={() => setSearchOpen(true)}
         onOpenSettings={() => openSettings()}
         onDeleteSession={handleSessionDeleted}
+        onSessionUpdated={(updated) => {
+          // Keep the page header in sync when the user regenerates the
+          // active session's title from the sidebar menu.
+          if (updated.key === activeSession?.key) setActiveSession(updated);
+        }}
         refreshKey={sidebarRefreshKey}
       />
       <main ref={setMainEl} className="relative flex min-h-0 min-w-0 flex-1 flex-col">
@@ -1017,25 +1019,22 @@ export default function PiChat() {
             sits on the right. */}
         {activeSession && !showWelcome && !isInitializing && (
           <header className="flex h-14 shrink-0 items-center justify-between gap-4 border-b border-border/60 px-6">
-            <button
-              type="button"
-              className="min-w-0 flex-1 cursor-pointer select-none truncate text-left text-sm font-semibold text-foreground"
-              title={activeSession.key}
-              onClick={async () => {
-                try {
-                  await navigator.clipboard.writeText(activeSession.key);
-                  setCopiedSessionId(true);
-                  setTimeout(() => setCopiedSessionId(false), 1200);
-                } catch {
-                  // Clipboard write may fail (insecure context, denied
-                  // permission). This is a debug affordance, so swallow.
-                }
-              }}
-            >
-              {copiedSessionId
-                ? '已复制 session id'
-                : activeSession.title || activeSession.preview || '新对话'}
-            </button>
+            <div className="flex min-w-0 flex-1 items-center gap-1">
+              <span
+                className="min-w-0 flex-1 select-text truncate text-sm font-semibold text-foreground"
+                title={activeSession.key}
+              >
+                {activeSession.title || activeSession.preview || '新对话'}
+              </span>
+              <SessionMenu
+                sessionKey={activeSession.key}
+                ariaLabel={activeSession.title ?? '当前会话'}
+                onRegenerated={(updated) => {
+                  setActiveSession(updated);
+                  setSidebarRefreshKey((k) => k + 1);
+                }}
+              />
+            </div>
             {activeSession.model && (
               <span className="shrink-0 truncate rounded-full border border-border/60 px-2.5 py-0.5 text-xs text-muted-foreground">
                 {activeSession.model}


### PR DESCRIPTION
## Summary

Add a hover-revealed `⋯` overflow menu on every session item — both in the sidebar list and on the chat-page header title — exposing two actions:

1. **复制 session id** — writes `session.key` to the clipboard.
2. **重新生成标题** — calls `POST /api/v1/chat/sessions/{key}/regenerate-title` (depends on #1884), then refreshes the sidebar list and re-syncs the active-session metadata when the regenerated row is the one being viewed.

Also removes the broken click-to-copy on the page-header title (`PiChat.tsx`): the title is now plain text and the new menu sits beside it. The transient `copiedSessionId` state and its timeout are gone.

The new `SessionMenu` component is shared between the sidebar row and the page header. In the sidebar it follows the same hover-reveal pattern as the existing delete (`Trash2`) button; in the header it's always visible.

## Type of change

| Type | Label |
|------|-------|
| New feature | `enhancement` |

## Component

`ui`

## Closes

Closes #1885

## Test plan

- [x] `npm run build` passes (no TS errors)
- [x] `npm run lint` clean
- [x] `prettier --check` clean on touched files

## Notes

- Depends on backend endpoint from #1884 — should not merge until that PR is merged so the endpoint exists.