### PR TITLE
fix(channels): buffer per-session events when no WS receivers attached and replay on reattach (#1882)

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -25,6 +25,28 @@ grpc:
   server_address: "127.0.0.1:50051"
 
 # ---------------------------------------------------------------------------
+# Web channel — per-session reply buffer (required)
+# ---------------------------------------------------------------------------
+#
+# When a long-running task completes while the user has closed their tab,
+# the WebSocket broadcast has zero receivers and the reply would be lost
+# (#1882). The reply buffer holds "important" events (final messages,
+# errors, task completions, progress) per session for `ttl` so a
+# reattaching client can replay them in publish order.
+#
+# All three caps are required — there are no Rust-side defaults.
+#   - capacity_events: max number of buffered events per session
+#   - capacity_bytes:  max total serialized bytes per session
+#   - ttl:             how long an event survives before lazy eviction
+# Whichever cap fills first triggers FIFO eviction.
+
+web:
+  reply_buffer:
+    capacity_events: 256
+    capacity_bytes: 2097152   # 2 MiB
+    ttl: 5m
+
+# ---------------------------------------------------------------------------
 # Owner authentication (required)
 # ---------------------------------------------------------------------------
 #

--- a/crates/app/src/config_sync.rs
+++ b/crates/app/src/config_sync.rs
@@ -313,6 +313,12 @@ gateway:
   repo_url: "https://github.com/example/repo"
   bot_token: "456:DEF"
   chat_id: 789
+
+web:
+  reply_buffer:
+    capacity_events: 256
+    capacity_bytes: 2097152
+    ttl: "5m"
 "#;
 
     #[test]

--- a/crates/app/src/lib.rs
+++ b/crates/app/src/lib.rs
@@ -1343,6 +1343,11 @@ users:
     platforms: []
 mita:
   heartbeat_interval: "30m"
+web:
+  reply_buffer:
+    capacity_events: 256
+    capacity_bytes: 2097152
+    ttl: "5m"
 "#;
 
     #[test]

--- a/crates/app/src/lib.rs
+++ b/crates/app/src/lib.rs
@@ -148,6 +148,22 @@ pub struct AppConfig {
     /// `docs/guides/anti-patterns.md`).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub sandbox:                Option<SandboxToolConfig>,
+    /// Web channel tunables (required) — currently the per-session reply
+    /// buffer caps for the always-on no-listener replay (#1882).
+    pub web:                    WebChannelConfig,
+}
+
+/// Configuration for the Web channel adapter.
+///
+/// Currently carries only the
+/// [`rara_channels::web_reply_buffer::ReplyBufferConfig`]; nested under `web`
+/// so future per-channel tunables (e.g. broadcast capacities, idle timeouts)
+/// land in the same YAML neighbourhood without touching the top level.
+#[derive(Debug, Clone, bon::Builder, Serialize, Deserialize)]
+pub struct WebChannelConfig {
+    /// Per-session reply-buffer caps. All three sub-fields are required —
+    /// see [`rara_channels::web_reply_buffer`] and `config.example.yaml`.
+    pub reply_buffer: rara_channels::web_reply_buffer::ReplyBufferConfig,
 }
 
 /// Configuration for the `run_code` sandbox tool.
@@ -523,16 +539,19 @@ pub async fn start_with_options(
     // the same shutdown signal as every other long-running task.
     let cancellation_token = CancellationToken::new();
 
-    // The web reply buffer is always wired in production — see
-    // `web_reply_buffer` module docs for why this is a mechanism, not
-    // a YAML knob. The sweeper runs until `cancellation_token` fires.
-    let reply_buffer = rara_channels::web_reply_buffer::ReplyBuffer::new();
+    // The web reply buffer is always wired in production — the
+    // mechanism is unconditional but the caps are user-tunable knobs
+    // sourced from `web.reply_buffer` in YAML. The sweeper runs until
+    // `cancellation_token` fires.
+    let reply_buffer =
+        rara_channels::web_reply_buffer::ReplyBuffer::new(config.web.reply_buffer.clone());
     Arc::clone(&reply_buffer).spawn_sweeper(cancellation_token.clone());
 
     let web_adapter = Arc::new(
         rara_channels::web::WebAdapter::new(
             config.owner_token.clone(),
             config.owner_user_id.clone(),
+            config.web.reply_buffer.clone(),
         )
         .with_stt_service(stt_service.clone())
         .with_reply_buffer(reply_buffer),

--- a/crates/channels/Cargo.toml
+++ b/crates/channels/Cargo.toml
@@ -9,8 +9,10 @@ anyhow = { workspace = true }
 async-trait = { workspace = true }
 axum = { workspace = true, features = ["ws"] }
 base64 = { workspace = true }
+bon = { workspace = true }
 chrono = { workspace = true }
 dashmap = "6"
+humantime-serde = "1"
 futures = { workspace = true }
 governor = "0.10"
 image = { workspace = true }

--- a/crates/channels/src/web.rs
+++ b/crates/channels/src/web.rs
@@ -658,6 +658,19 @@ impl WebAdapter {
         Self::get_or_create_adapter_bus(&self.adapter_events, *session_key).subscribe()
     }
 
+    /// Test-only: mirror the production WS/SSE reattach path —
+    /// `get_or_create_adapter_bus` followed by an atomic
+    /// [`ReplyBuffer::subscribe_and_drain`]. Returns the live receiver
+    /// and the drained backlog.
+    #[doc(hidden)]
+    pub fn reattach_for_test(
+        &self,
+        session_key: &SessionKey,
+    ) -> (broadcast::Receiver<WebEvent>, Vec<WebEvent>) {
+        let bus = Self::get_or_create_adapter_bus(&self.adapter_events, *session_key);
+        self.reply_buffer.subscribe_and_drain(session_key, &bus)
+    }
+
     /// Get or create the per-session adapter-event broadcast sender.
     ///
     /// Kept deliberately minimal — the heavy fan-out path (kernel stream
@@ -1103,13 +1116,16 @@ async fn handle_ws(socket: WebSocket, params: SessionQuery, state: WebAdapterSta
     // (e.g. POST /messages) even before the first WS subscriber shows up —
     // get_or_create ensures the sender exists before publishers try to emit.
     let adapter_bus = WebAdapter::get_or_create_adapter_bus(&state.adapter_events, session_key);
-    let mut adapter_rx = adapter_bus.subscribe();
 
-    // Drain any "important" events buffered during a no-listener window
-    // BEFORE the live forwarder starts pushing into the same mpsc, so the
-    // socket sees buffered events first in publish order. The buffer is
-    // not removed on drain — see `web_reply_buffer` module docs for why.
-    let backlog = state.reply_buffer.snapshot(&session_key);
+    // Atomically subscribe to the adapter bus AND drain any "important"
+    // events buffered during a no-listener window. Holding the per-session
+    // mutex across both ops is what guarantees no event reaches this WS
+    // twice (via both the live broadcast and the snapshot) and that a
+    // second reattach within the TTL window does not replay drained events
+    // — see `web_reply_buffer` module docs for the invariant.
+    let (mut adapter_rx, backlog) = state
+        .reply_buffer
+        .subscribe_and_drain(&session_key, &adapter_bus);
     if !backlog.is_empty() {
         debug!(
             session_key = %session_key_str,
@@ -1352,10 +1368,12 @@ async fn sse_handler(
     let (ev_tx, ev_rx) = mpsc::unbounded_channel::<WebEvent>();
 
     let adapter_bus = WebAdapter::get_or_create_adapter_bus(&state.adapter_events, session_key);
-    let mut adapter_rx = adapter_bus.subscribe();
 
-    // Drain any buffered "important" events before live tail starts.
-    let backlog = state.reply_buffer.snapshot(&session_key);
+    // Atomic subscribe + drain — see WS reattach above and the
+    // `web_reply_buffer` module docs for the invariant.
+    let (mut adapter_rx, backlog) = state
+        .reply_buffer
+        .subscribe_and_drain(&session_key, &adapter_bus);
     if !backlog.is_empty() {
         debug!(
             session_key = %params.session_key,

--- a/crates/channels/src/web.rs
+++ b/crates/channels/src/web.rs
@@ -82,7 +82,7 @@ use serde::{Deserialize, Serialize};
 use tokio::sync::{RwLock, broadcast, mpsc, watch};
 use tracing::{debug, error, info, warn};
 
-use crate::web_reply_buffer::ReplyBuffer;
+use crate::web_reply_buffer::{ReplyBuffer, ReplyBufferConfig};
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -478,7 +478,7 @@ pub struct SendMessageResponse {
 /// # Usage
 ///
 /// ```rust,ignore
-/// let adapter = WebAdapter::new(owner_token, owner_user_id);
+/// let adapter = WebAdapter::new(owner_token, owner_user_id, reply_buffer_config);
 /// let router = adapter.router();
 /// // Mount into your axum app:
 /// // app.nest("/chat", router)
@@ -527,12 +527,22 @@ pub struct WebAdapter {
 impl WebAdapter {
     /// Create a new `WebAdapter`.
     ///
-    /// Both `owner_token` and `owner_user_id` are required — invalid
-    /// "no auth" / "anonymous caller" states are unrepresentable.
-    /// Boot-time validation (`validate_owner_auth`) guarantees a
-    /// non-empty token and that `owner_user_id` matches a configured
-    /// user before reaching this constructor.
-    pub fn new(owner_token: String, owner_user_id: String) -> Self {
+    /// `owner_token` and `owner_user_id` are required — invalid "no auth"
+    /// / "anonymous caller" states are unrepresentable. Boot-time
+    /// validation (`validate_owner_auth`) guarantees a non-empty token
+    /// and that `owner_user_id` matches a configured user before reaching
+    /// this constructor.
+    ///
+    /// `reply_buffer_config` carries the per-session reply-buffer caps
+    /// sourced from YAML (`web.reply_buffer.{capacity_events,
+    /// capacity_bytes, ttl}`). Tests that need shared access to the
+    /// underlying [`ReplyBuffer`] should override it via
+    /// [`Self::with_reply_buffer`] after construction.
+    pub fn new(
+        owner_token: String,
+        owner_user_id: String,
+        reply_buffer_config: ReplyBufferConfig,
+    ) -> Self {
         let (shutdown_tx, shutdown_rx) = watch::channel(false);
         Self {
             adapter_events: Arc::new(DashMap::new()),
@@ -544,7 +554,7 @@ impl WebAdapter {
             shutdown_tx,
             shutdown_rx,
             stt_service: None,
-            reply_buffer: ReplyBuffer::new(),
+            reply_buffer: ReplyBuffer::new(reply_buffer_config),
         }
     }
 
@@ -682,41 +692,33 @@ impl WebAdapter {
         event: WebEvent,
     ) {
         let event_kind: &'static str = (&event).into();
-        // Only clone the event when it actually needs buffering — keeps
-        // streaming hot paths (TextDelta / ReasoningDelta / …) at zero
-        // extra allocations.
-        let needs_buffer = ReplyBuffer::should_buffer(&event);
-        if let Some(tx) = buses.get(session_key) {
-            let receiver_count = tx.receiver_count();
-            tracing::debug!(
-                session_key = %session_key,
-                receiver_count,
-                event_kind,
-                "web publish_adapter_event"
-            );
-            let send_result = if needs_buffer {
-                let for_buf = event.clone();
-                let r = tx.send(event);
-                reply_buffer.append(session_key, for_buf);
-                r
-            } else {
-                tx.send(event)
-            };
-            if send_result.is_err() {
-                tracing::warn!(
+        // Always create the bus so the buffer's per-session lock has a
+        // stable broadcast handle to coordinate with — `subscribe_and_drain`
+        // expects the same handle, and creating-on-publish removes a
+        // race where a reattach finds no bus and a parallel publish
+        // creates one without taking the buffer lock.
+        let tx = Self::get_or_create_adapter_bus(buses, *session_key);
+        let receiver_count = tx.receiver_count();
+        tracing::debug!(
+            session_key = %session_key,
+            receiver_count,
+            event_kind,
+            "web publish_adapter_event"
+        );
+        // `publish` holds the per-session mutex across "buffer append"
+        // + "broadcast send" so reattach cannot interleave between the
+        // two halves and double-deliver a single event.
+        match reply_buffer.publish(session_key, &tx, event) {
+            Ok(_) => {}
+            Err(_) => {
+                // SendError only fires when there are zero receivers.
+                // The event was still buffered (when `should_buffer`
+                // returns true) so a future reattach will see it.
+                tracing::debug!(
                     session_key = %session_key,
                     event_kind,
-                    "web publish: no active receivers"
+                    "web publish: no active receivers (event buffered for replay)"
                 );
-            }
-        } else {
-            tracing::debug!(
-                session_key = %session_key,
-                event_kind,
-                "web publish_adapter_event: no bus yet"
-            );
-            if needs_buffer {
-                reply_buffer.append(session_key, event);
             }
         }
     }

--- a/crates/channels/src/web_reply_buffer.rs
+++ b/crates/channels/src/web_reply_buffer.rs
@@ -1,11 +1,43 @@
+// Copyright 2025 Rararulab
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 //! Always-on per-session reply buffer for the Web channel.
 //!
-//! The buffer is a structural correctness fix, not a tunable feature: when a
-//! long-running task completes while the user has closed their tab, the
-//! WS broadcast has zero receivers and the event would otherwise be silently
-//! dropped (issue #1804). Capacity, TTL, and sweeper interval are mechanism
-//! parameters that live as `const` next to the code, **not** deployment
-//! configuration — there is no YAML knob to disable buffering.
+//! When a long-running task completes while the user has closed their tab,
+//! the WS broadcast has zero receivers and the event would otherwise be
+//! silently dropped (issues #1804 / #1882). This buffer holds "important"
+//! events for a configurable TTL window so a reattaching client can replay
+//! them in order before resuming live publish.
+//!
+//! ## Critical invariants
+//!
+//! - **Per-session isolation**: each [`SessionKey`] has its own ring; one
+//!   session's buffer cannot be drained by another session's reattach.
+//! - **No double-deliver**: publish (`broadcast::send` + buffer append) and
+//!   reattach (`subscribe` + buffer drain) are serialised by a per-session
+//!   `parking_lot::Mutex`. Any publish strictly before drain lands only in the
+//!   snapshot; any publish strictly after drain lands only on the broadcast.
+//!   There is no window where a single event reaches both paths.
+//! - **Hard memory bound**: bounded by both event count and total bytes —
+//!   whichever cap fills first triggers FIFO eviction. Buffering can never OOM
+//!   regardless of producer rate.
+//! - **TTL**: events older than [`ReplyBufferConfig::ttl`] are evicted lazily
+//!   on every publish/drain (so no idle session needs a sweep), and a
+//!   low-frequency background sweeper drops fully-empty session entries.
+//!
+//! Configuration lives in YAML (`web.reply_buffer.{capacity_events,
+//! capacity_bytes, ttl}`); there are no Rust-side defaults.
 
 use std::{
     collections::VecDeque,
@@ -16,46 +48,128 @@ use std::{
 use dashmap::DashMap;
 use parking_lot::Mutex;
 use rara_kernel::session::SessionKey;
+use serde::{Deserialize, Serialize};
+use tokio::sync::broadcast;
 use tokio_util::sync::CancellationToken;
 
 use crate::web::WebEvent;
 
-/// Maximum number of "important" events retained per session before FIFO
-/// eviction.
-const REPLY_BUFFER_CAPACITY: usize = 64;
+/// User-tunable bounds for [`ReplyBuffer`]. All three fields are required —
+/// the buffer has no Rust-side defaults; callers must source values from
+/// YAML configuration (see `config.example.yaml`).
+#[derive(Debug, Clone, bon::Builder, Serialize, Deserialize)]
+pub struct ReplyBufferConfig {
+    /// Maximum number of buffered events per session before FIFO eviction.
+    pub capacity_events: usize,
+    /// Maximum total serialized bytes per session before FIFO eviction.
+    /// Bytes are estimated from `serde_json::to_string(&event).len()`.
+    pub capacity_bytes:  usize,
+    /// How long an individual event survives in the buffer before being
+    /// evicted on the next publish or drain.
+    #[serde(with = "humantime_serde")]
+    pub ttl:             Duration,
+}
 
-/// How long after the last write a session's buffer is kept before the
-/// sweeper drops it.
-const REPLY_BUFFER_TTL: Duration = Duration::from_mins(10);
+/// One buffered event with the timestamp used for TTL eviction and the
+/// pre-computed serialized size used for the byte-cap accounting.
+struct Buffered {
+    event:     WebEvent,
+    queued_at: Instant,
+    bytes:     usize,
+}
 
-/// How often the sweeper checks for expired sessions.
-const REPLY_BUFFER_SWEEP_INTERVAL: Duration = Duration::from_mins(1);
-
-/// One session's bounded ring of important events plus a last-write
-/// timestamp used by the TTL sweeper.
+/// Per-session bounded ring with byte accounting and a TTL cursor.
+///
+/// The mutex around this struct is the serialisation point for the
+/// "no double deliver" invariant: see module docs.
 struct SessionBuffer {
-    events:     VecDeque<WebEvent>,
+    events:     VecDeque<Buffered>,
+    bytes:      usize,
     last_write: Instant,
 }
 
-/// Per-session reply buffer registry. Shared across all WS / SSE
-/// handlers and the `ChannelAdapter::send` path.
+impl SessionBuffer {
+    fn new() -> Self {
+        Self {
+            events:     VecDeque::new(),
+            bytes:      0,
+            last_write: Instant::now(),
+        }
+    }
+
+    /// Drop events older than `ttl`. Called on every publish/drain so an
+    /// abandoned session stops returning stale data even if no sweeper
+    /// has run yet.
+    fn evict_expired(&mut self, ttl: Duration, now: Instant) {
+        while let Some(front) = self.events.front() {
+            if now.duration_since(front.queued_at) <= ttl {
+                break;
+            }
+            let dropped = self
+                .events
+                .pop_front()
+                .expect("front exists per peek above");
+            self.bytes = self.bytes.saturating_sub(dropped.bytes);
+        }
+    }
+
+    /// Append `event`, FIFO-evicting until both the event-count and
+    /// byte-count caps are satisfied.
+    fn push(&mut self, event: WebEvent, bytes: usize, cfg: &ReplyBufferConfig) {
+        // Evict by count first so a flood of tiny events still leaves
+        // room for the new entry without blowing the byte cap.
+        while self.events.len() >= cfg.capacity_events
+            || (self.bytes + bytes > cfg.capacity_bytes && !self.events.is_empty())
+        {
+            let Some(dropped) = self.events.pop_front() else {
+                break;
+            };
+            self.bytes = self.bytes.saturating_sub(dropped.bytes);
+        }
+        self.events.push_back(Buffered {
+            event,
+            queued_at: Instant::now(),
+            bytes,
+        });
+        self.bytes += bytes;
+        self.last_write = Instant::now();
+    }
+}
+
+/// Per-session reply buffer registry shared across all WS / SSE handlers
+/// and the [`crate::web::WebAdapter`] publish path.
 pub struct ReplyBuffer {
+    config:   ReplyBufferConfig,
     sessions: DashMap<SessionKey, Arc<Mutex<SessionBuffer>>>,
 }
 
+/// Sweeper interval for dropping fully-empty session entries. The
+/// per-event TTL is enforced inline on publish/drain; the sweeper only
+/// reclaims map slots whose buffer has been empty long enough that no
+/// reattach is realistically going to need them. This is a mechanism
+/// constant, not a knob — see `docs/guides/anti-patterns.md` "Mechanism
+/// constants are not config".
+const SESSION_SWEEP_INTERVAL: Duration = Duration::from_mins(1);
+
 impl ReplyBuffer {
-    /// Construct a new empty buffer.
-    pub fn new() -> Arc<Self> {
+    /// Construct an empty buffer wired to `config`.
+    ///
+    /// Returned as `Arc` because every consumer (`WebAdapter`, the WS
+    /// handler, the sweeper task) holds its own reference.
+    #[must_use]
+    pub fn new(config: ReplyBufferConfig) -> Arc<Self> {
         Arc::new(Self {
+            config,
             sessions: DashMap::new(),
         })
     }
 
     /// Decide whether an event must survive a "no listeners" publish.
     ///
-    /// Streaming chunks intentionally fall through to `false` — replaying
-    /// a partial token stream after the fact has no useful UX.
+    /// Streaming chunks (`TextDelta`, `ReasoningDelta`, …) intentionally
+    /// fall through to `false` — replaying a partial token stream after
+    /// the fact has no useful UX.
+    #[must_use]
     pub fn should_buffer(event: &WebEvent) -> bool {
         matches!(
             event,
@@ -66,77 +180,157 @@ impl ReplyBuffer {
         )
     }
 
-    /// Append an event to the session's ring, evicting the oldest entry
-    /// when capacity is exceeded.
-    pub fn append(&self, session_key: &SessionKey, event: WebEvent) {
-        let entry = self
-            .sessions
-            .entry(session_key.clone())
-            .or_insert_with(|| {
-                Arc::new(Mutex::new(SessionBuffer {
-                    events:     VecDeque::with_capacity(REPLY_BUFFER_CAPACITY),
-                    last_write: Instant::now(),
-                }))
-            })
-            .clone();
+    /// Atomic publish: under the per-session mutex, optionally append
+    /// `event` to the buffer (when [`Self::should_buffer`] is true) and
+    /// then broadcast it via `tx`. Holding the lock across both steps is
+    /// what guarantees the "no double-deliver" invariant relative to
+    /// [`Self::subscribe_and_drain`]. Returns the result of `tx.send` so
+    /// the caller can log "no receivers" the same way as before.
+    pub fn publish(
+        &self,
+        session_key: &SessionKey,
+        tx: &broadcast::Sender<WebEvent>,
+        event: WebEvent,
+    ) -> Result<usize, broadcast::error::SendError<WebEvent>> {
+        let needs_buffer = Self::should_buffer(&event);
+        let bytes = if needs_buffer {
+            estimated_bytes(&event)
+        } else {
+            0
+        };
+
+        let entry = self.session_entry(session_key);
         let mut guard = entry.lock();
-        if guard.events.len() == REPLY_BUFFER_CAPACITY {
-            guard.events.pop_front();
+        let now = Instant::now();
+        guard.evict_expired(self.config.ttl, now);
+        if needs_buffer {
+            guard.push(event.clone(), bytes, &self.config);
         }
-        guard.events.push_back(event);
-        guard.last_write = Instant::now();
+        // The send happens inside the lock so a concurrent
+        // `subscribe_and_drain` cannot insert itself between the buffer
+        // append and the broadcast emission.
+        tx.send(event)
+    }
+
+    /// Atomically subscribe to `tx` and drain any buffered events that
+    /// have not yet expired. Returns the receiver and the drained
+    /// events in publish order. The buffer is cleared as part of this
+    /// operation — re-subscribing later will not see the same events
+    /// twice (per-connection idempotency).
+    ///
+    /// New events that arrive *after* this call return via the
+    /// receiver only and are NOT re-buffered for this connection
+    /// (publishes that race with drain block on the same mutex; see
+    /// [`Self::publish`]).
+    pub fn subscribe_and_drain(
+        &self,
+        session_key: &SessionKey,
+        tx: &broadcast::Sender<WebEvent>,
+    ) -> (broadcast::Receiver<WebEvent>, Vec<WebEvent>) {
+        let entry = self.session_entry(session_key);
+        let mut guard = entry.lock();
+        // Subscribe BEFORE draining so any publish that arrives after we
+        // release the lock is delivered live; we already hold the lock
+        // so no concurrent publish can sneak between subscribe + drain.
+        let rx = tx.subscribe();
+        let now = Instant::now();
+        guard.evict_expired(self.config.ttl, now);
+        let drained: Vec<WebEvent> = guard.events.drain(..).map(|b| b.event).collect();
+        guard.bytes = 0;
+        (rx, drained)
     }
 
     /// Snapshot of currently buffered events for `session_key`, in
-    /// publish order (oldest first). Returns an empty vec if the
-    /// session has no buffer.
-    ///
-    /// The buffer is **not** drained — see module-level docs for why.
+    /// publish order, with TTL eviction applied. Provided for tests and
+    /// metrics; the production WS reattach path uses
+    /// [`Self::subscribe_and_drain`] instead.
+    #[must_use]
     pub fn snapshot(&self, session_key: &SessionKey) -> Vec<WebEvent> {
         let Some(entry) = self.sessions.get(session_key).map(|e| e.clone()) else {
             return Vec::new();
         };
-        entry.lock().events.iter().cloned().collect()
+        let mut guard = entry.lock();
+        guard.evict_expired(self.config.ttl, Instant::now());
+        guard.events.iter().map(|b| b.event.clone()).collect()
     }
 
     /// Number of currently tracked sessions — exposed for tests / metrics.
     #[doc(hidden)]
+    #[must_use]
     pub fn session_count(&self) -> usize { self.sessions.len() }
 
-    /// Spawn the TTL sweeper. Returns immediately; the sweeper runs in
-    /// the background until `cancel` fires.
+    /// Spawn the background sweeper that drops fully-empty session
+    /// entries. Returns immediately; the sweeper runs until `cancel`
+    /// fires.
     pub fn spawn_sweeper(self: Arc<Self>, cancel: CancellationToken) {
         tokio::spawn(async move {
-            let mut ticker = tokio::time::interval(REPLY_BUFFER_SWEEP_INTERVAL);
+            let mut ticker = tokio::time::interval(SESSION_SWEEP_INTERVAL);
             ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
             loop {
                 tokio::select! {
                     _ = cancel.cancelled() => return,
                     _ = ticker.tick() => {
-                        self.sweep_expired(REPLY_BUFFER_TTL);
+                        self.sweep();
                     }
                 }
             }
         });
     }
 
-    /// Remove sessions whose `last_write` is older than `ttl`. Pulled out
-    /// for direct unit testing.
+    /// Sweeper body, pulled out for direct unit testing. Drops session
+    /// entries whose buffers are empty after TTL eviction.
     #[doc(hidden)]
-    pub fn sweep_expired(&self, ttl: Duration) {
+    pub fn sweep(&self) {
         let now = Instant::now();
+        let ttl = self.config.ttl;
         let victims: Vec<SessionKey> = self
             .sessions
             .iter()
             .filter_map(|entry| {
-                let guard = entry.value().lock();
-                (now.duration_since(guard.last_write) > ttl).then(|| entry.key().clone())
+                let mut guard = entry.value().lock();
+                guard.evict_expired(ttl, now);
+                guard.events.is_empty().then_some(*entry.key())
             })
             .collect();
         for k in victims {
-            self.sessions.remove(&k);
+            // Re-check under the per-entry lock so a publish racing with
+            // sweep does not lose its append.
+            if let Some((_, arc)) = self.sessions.remove_if(&k, |_, v| {
+                let g = v.lock();
+                g.events.is_empty()
+            }) {
+                drop(arc);
+            }
         }
     }
+
+    fn session_entry(&self, session_key: &SessionKey) -> Arc<Mutex<SessionBuffer>> {
+        self.sessions
+            .entry(*session_key)
+            .or_insert_with(|| Arc::new(Mutex::new(SessionBuffer::new())))
+            .clone()
+    }
+}
+
+/// Test-only [`ReplyBufferConfig`] with generous caps suitable for
+/// integration tests that don't care about eviction behaviour. Production
+/// code MUST source caps from YAML (see `config.example.yaml`).
+#[doc(hidden)]
+#[must_use]
+pub fn test_config() -> ReplyBufferConfig {
+    ReplyBufferConfig::builder()
+        .capacity_events(256)
+        .capacity_bytes(2 * 1024 * 1024)
+        .ttl(Duration::from_mins(1))
+        .build()
+}
+
+/// Best-effort serialised byte estimate used for the byte cap. We pay
+/// this cost only when `should_buffer` is true, so the streaming hot
+/// path is unaffected. Falls back to a small constant when the event
+/// somehow fails to serialize (no `WebEvent` variant currently does).
+fn estimated_bytes(event: &WebEvent) -> usize {
+    serde_json::to_string(event).map(|s| s.len()).unwrap_or(64)
 }
 
 #[cfg(test)]
@@ -144,10 +338,25 @@ mod tests {
     use std::time::Duration;
 
     use rara_kernel::{io::BackgroundTaskStatus, session::SessionKey};
+    use tokio::sync::broadcast;
 
-    use super::{REPLY_BUFFER_CAPACITY, ReplyBuffer, WebEvent};
+    use super::{ReplyBuffer, ReplyBufferConfig, WebEvent};
+
+    fn cfg() -> ReplyBufferConfig {
+        ReplyBufferConfig::builder()
+            .capacity_events(256)
+            .capacity_bytes(2 * 1024 * 1024)
+            .ttl(Duration::from_mins(1))
+            .build()
+    }
 
     fn session() -> SessionKey { SessionKey::new() }
+
+    fn msg(s: &str) -> WebEvent {
+        WebEvent::Message {
+            content: s.to_owned(),
+        }
+    }
 
     #[test]
     fn streaming_events_are_not_buffered() {
@@ -157,18 +366,11 @@ mod tests {
         assert!(!ReplyBuffer::should_buffer(&WebEvent::ReasoningDelta {
             text: "x".to_owned(),
         }));
-        assert!(!ReplyBuffer::should_buffer(&WebEvent::ToolCallStart {
-            name:      "t".to_owned(),
-            id:        "id".to_owned(),
-            arguments: serde_json::json!({}),
-        }));
     }
 
     #[test]
     fn important_events_are_buffered() {
-        assert!(ReplyBuffer::should_buffer(&WebEvent::Message {
-            content: "hi".to_owned(),
-        }));
+        assert!(ReplyBuffer::should_buffer(&msg("hi")));
         assert!(ReplyBuffer::should_buffer(&WebEvent::Error {
             message: "bad".to_owned(),
         }));
@@ -183,21 +385,11 @@ mod tests {
 
     #[test]
     fn append_then_snapshot_returns_events_in_order() {
-        let buf = ReplyBuffer::new();
+        let buf = ReplyBuffer::new(cfg());
         let s = session();
-        buf.append(
-            &s,
-            WebEvent::Message {
-                content: "first".to_owned(),
-            },
-        );
-        buf.append(
-            &s,
-            WebEvent::Message {
-                content: "second".to_owned(),
-            },
-        );
-
+        let (tx, _rx) = broadcast::channel(16);
+        buf.publish(&s, &tx, msg("first")).ok();
+        buf.publish(&s, &tx, msg("second")).ok();
         let snap = buf.snapshot(&s);
         assert_eq!(snap.len(), 2);
         match (&snap[0], &snap[1]) {
@@ -210,53 +402,143 @@ mod tests {
     }
 
     #[test]
-    fn snapshot_does_not_drain() {
-        let buf = ReplyBuffer::new();
+    fn cap_by_event_count_evicts_oldest() {
+        let cfg = ReplyBufferConfig::builder()
+            .capacity_events(256)
+            .capacity_bytes(usize::MAX)
+            .ttl(Duration::from_mins(1))
+            .build();
+        let buf = ReplyBuffer::new(cfg);
         let s = session();
-        buf.append(
-            &s,
-            WebEvent::Message {
-                content: "x".to_owned(),
-            },
-        );
-        assert_eq!(buf.snapshot(&s).len(), 1);
-        assert_eq!(buf.snapshot(&s).len(), 1);
-    }
-
-    #[test]
-    fn capacity_overflow_evicts_oldest() {
-        let buf = ReplyBuffer::new();
-        let s = session();
-        for i in 0..=REPLY_BUFFER_CAPACITY {
-            buf.append(
-                &s,
-                WebEvent::Message {
-                    content: format!("m{i}"),
-                },
-            );
+        let (tx, _rx) = broadcast::channel(16);
+        for i in 0..300 {
+            buf.publish(&s, &tx, msg(&format!("m{i}"))).ok();
         }
         let snap = buf.snapshot(&s);
-        assert_eq!(snap.len(), REPLY_BUFFER_CAPACITY);
-        // Oldest ("m0") should have been evicted; first remaining is "m1".
+        assert_eq!(snap.len(), 256);
         match &snap[0] {
-            WebEvent::Message { content } => assert_eq!(content, "m1"),
+            WebEvent::Message { content } => {
+                // First retained should be m44 (300 - 256 = 44 evicted).
+                assert_eq!(content, "m44");
+            }
             other => panic!("unexpected: {other:?}"),
         }
     }
 
     #[test]
-    fn sweep_expired_drops_idle_sessions() {
-        let buf = ReplyBuffer::new();
+    fn cap_by_byte_count_evicts_oldest() {
+        // Each serialized message is roughly the JSON `{"type":"message",
+        // "content":"..."}` plus payload length. Pick a tight byte cap
+        // that forces eviction within 10 sends.
+        let cfg = ReplyBufferConfig::builder()
+            .capacity_events(usize::MAX)
+            .capacity_bytes(200)
+            .ttl(Duration::from_mins(1))
+            .build();
+        let buf = ReplyBuffer::new(cfg);
         let s = session();
-        buf.append(
-            &s,
-            WebEvent::Message {
-                content: "x".to_owned(),
-            },
+        let (tx, _rx) = broadcast::channel(16);
+        for i in 0..10 {
+            buf.publish(&s, &tx, msg(&format!("payload-{i:03}"))).ok();
+        }
+        let snap = buf.snapshot(&s);
+        // Some events MUST have been evicted to satisfy the byte cap.
+        assert!(
+            snap.len() < 10,
+            "byte cap should have evicted old events; got {} events",
+            snap.len()
         );
-        assert_eq!(buf.session_count(), 1);
+    }
 
-        buf.sweep_expired(Duration::from_nanos(0));
+    #[test]
+    fn ttl_drops_old_events_on_drain() {
+        let cfg = ReplyBufferConfig::builder()
+            .capacity_events(256)
+            .capacity_bytes(usize::MAX)
+            .ttl(Duration::from_millis(20))
+            .build();
+        let buf = ReplyBuffer::new(cfg);
+        let s = session();
+        let (tx, _rx) = broadcast::channel(16);
+        buf.publish(&s, &tx, msg("stale")).ok();
+        std::thread::sleep(Duration::from_millis(40));
+        buf.publish(&s, &tx, msg("fresh")).ok();
+
+        let (_rx2, drained) = buf.subscribe_and_drain(&s, &tx);
+        assert_eq!(drained.len(), 1, "stale event must be TTL-evicted");
+        match &drained[0] {
+            WebEvent::Message { content } => assert_eq!(content, "fresh"),
+            other => panic!("unexpected: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn subscribe_and_drain_clears_buffer() {
+        let buf = ReplyBuffer::new(cfg());
+        let s = session();
+        let (tx, _rx) = broadcast::channel(16);
+        buf.publish(&s, &tx, msg("a")).ok();
+        buf.publish(&s, &tx, msg("b")).ok();
+
+        let (_rx2, drained) = buf.subscribe_and_drain(&s, &tx);
+        assert_eq!(drained.len(), 2);
+        // Second drain returns nothing because the first cleared it.
+        let (_rx3, drained2) = buf.subscribe_and_drain(&s, &tx);
+        assert!(drained2.is_empty());
+    }
+
+    #[test]
+    fn per_session_isolation() {
+        let buf = ReplyBuffer::new(cfg());
+        let s1 = session();
+        let s2 = session();
+        let (tx1, _rx1) = broadcast::channel(16);
+        let (tx2, _rx2) = broadcast::channel(16);
+        buf.publish(&s1, &tx1, msg("for-1")).ok();
+        buf.publish(&s2, &tx2, msg("for-2")).ok();
+
+        let (_, drained_s2) = buf.subscribe_and_drain(&s2, &tx2);
+        assert_eq!(drained_s2.len(), 1);
+        // s1's buffer must remain intact.
+        assert_eq!(buf.snapshot(&s1).len(), 1);
+    }
+
+    #[test]
+    fn sweep_drops_empty_sessions() {
+        let buf = ReplyBuffer::new(cfg());
+        let s = session();
+        let (tx, _rx) = broadcast::channel(16);
+        buf.publish(&s, &tx, msg("x")).ok();
+        // Drain to leave the entry empty, then sweep.
+        let _ = buf.subscribe_and_drain(&s, &tx);
+        assert_eq!(buf.session_count(), 1);
+        buf.sweep();
         assert_eq!(buf.session_count(), 0);
+    }
+
+    #[test]
+    fn no_double_deliver_after_drain() {
+        // Mid-flight scenario: subscribe_and_drain, then immediately
+        // publish — the receiver must see the new event ONCE (live), and
+        // a second drain must not re-emit it.
+        let buf = ReplyBuffer::new(cfg());
+        let s = session();
+        let (tx, _rx) = broadcast::channel(16);
+        buf.publish(&s, &tx, msg("buffered")).ok();
+
+        let (mut rx, drained) = buf.subscribe_and_drain(&s, &tx);
+        assert_eq!(drained.len(), 1);
+
+        // New publish goes to the receiver and is also re-buffered for
+        // any future reattach — but THIS receiver only sees it via
+        // broadcast (no duplicate path).
+        buf.publish(&s, &tx, msg("after-drain")).ok();
+        let live = rx.try_recv().expect("receive new event");
+        match live {
+            WebEvent::Message { content } => assert_eq!(content, "after-drain"),
+            other => panic!("unexpected: {other:?}"),
+        }
+        // No second copy queued for the same receiver.
+        assert!(rx.try_recv().is_err());
     }
 }

--- a/crates/channels/tests/web_buffer_e2e.rs
+++ b/crates/channels/tests/web_buffer_e2e.rs
@@ -143,3 +143,56 @@ async fn listener_loss_is_recovered_via_buffer_snapshot() {
         other => panic!("expected WebEvent::Message, got {other:?}"),
     }
 }
+
+/// Regression for the original #1882 P0: the WS / SSE reattach path must
+/// drain the buffer atomically with subscription, so a *second* reattach
+/// inside the TTL window does not replay events the first reattach
+/// already received. Pre-fix, both reattach sites called `subscribe()` +
+/// `snapshot()` (snapshot does not clear), so the second reattach
+/// re-played the same events — visible as duplicate messages on tab
+/// refresh.
+#[tokio::test]
+async fn second_reattach_does_not_replay_drained_events() {
+    let buffer = ReplyBuffer::new(rara_channels::web_reply_buffer::test_config());
+    let adapter = WebAdapter::new(
+        "tok".to_owned(),
+        "user".to_owned(),
+        rara_channels::web_reply_buffer::test_config(),
+    )
+    .with_reply_buffer(Arc::clone(&buffer));
+
+    let session_key = SessionKey::new();
+    let endpoint = web_endpoint(&session_key);
+
+    // Publish with no listener attached — lands in the buffer.
+    adapter
+        .send(
+            &endpoint,
+            PlatformOutbound::Reply {
+                content:       "missed-while-away".to_owned(),
+                attachments:   Vec::new(),
+                reply_context: None,
+            },
+        )
+        .await
+        .expect("egress send while no listener");
+
+    // First reattach: drains the backlog.
+    let (_rx1, backlog1) = adapter.reattach_for_test(&session_key);
+    assert_eq!(backlog1.len(), 1, "first reattach drains the backlog");
+    match &backlog1[0] {
+        WebEvent::Message { content } => assert_eq!(content, "missed-while-away"),
+        other => panic!("expected WebEvent::Message, got {other:?}"),
+    }
+    // Drop the first "WS" by dropping its receiver.
+    drop(_rx1);
+
+    // Second reattach to the same session_key inside the TTL window must
+    // see ZERO buffered events — the first drain cleared the buffer.
+    let (_rx2, backlog2) = adapter.reattach_for_test(&session_key);
+    assert!(
+        backlog2.is_empty(),
+        "second reattach must not replay drained events; got {} events",
+        backlog2.len()
+    );
+}

--- a/crates/channels/tests/web_buffer_e2e.rs
+++ b/crates/channels/tests/web_buffer_e2e.rs
@@ -62,9 +62,13 @@ fn subscribe(
 
 #[tokio::test]
 async fn happy_path_reply_reaches_subscribed_listener() {
-    let buffer = ReplyBuffer::new();
-    let adapter =
-        WebAdapter::new("tok".to_owned(), "user".to_owned()).with_reply_buffer(Arc::clone(&buffer));
+    let buffer = ReplyBuffer::new(rara_channels::web_reply_buffer::test_config());
+    let adapter = WebAdapter::new(
+        "tok".to_owned(),
+        "user".to_owned(),
+        rara_channels::web_reply_buffer::test_config(),
+    )
+    .with_reply_buffer(Arc::clone(&buffer));
 
     let session_key = SessionKey::new();
     let mut rx = subscribe(&adapter, &session_key);
@@ -100,9 +104,13 @@ async fn happy_path_reply_reaches_subscribed_listener() {
 
 #[tokio::test]
 async fn listener_loss_is_recovered_via_buffer_snapshot() {
-    let buffer = ReplyBuffer::new();
-    let adapter =
-        WebAdapter::new("tok".to_owned(), "user".to_owned()).with_reply_buffer(Arc::clone(&buffer));
+    let buffer = ReplyBuffer::new(rara_channels::web_reply_buffer::test_config());
+    let adapter = WebAdapter::new(
+        "tok".to_owned(),
+        "user".to_owned(),
+        rara_channels::web_reply_buffer::test_config(),
+    )
+    .with_reply_buffer(Arc::clone(&buffer));
 
     let session_key = SessionKey::new();
 

--- a/crates/channels/tests/web_e2e.rs
+++ b/crates/channels/tests/web_e2e.rs
@@ -126,7 +126,11 @@ async fn web_text_message_reaches_kernel() {
         .build()
         .await;
 
-    let adapter = WebAdapter::new("test-owner-token".to_owned(), "test-user".to_owned());
+    let adapter = WebAdapter::new(
+        "test-owner-token".to_owned(),
+        "test-user".to_owned(),
+        rara_channels::web_reply_buffer::test_config(),
+    );
     adapter
         .start(tk.handle.clone())
         .await
@@ -194,8 +198,12 @@ async fn web_audio_message_is_transcribed_via_stt() {
         .build()
         .await;
 
-    let adapter = WebAdapter::new("test-owner-token".to_owned(), "test-user".to_owned())
-        .with_stt_service(Some(stt));
+    let adapter = WebAdapter::new(
+        "test-owner-token".to_owned(),
+        "test-user".to_owned(),
+        rara_channels::web_reply_buffer::test_config(),
+    )
+    .with_stt_service(Some(stt));
     adapter
         .start(tk.handle.clone())
         .await

--- a/crates/channels/tests/web_ws_drain.rs
+++ b/crates/channels/tests/web_ws_drain.rs
@@ -79,10 +79,14 @@ where
 
 #[tokio::test]
 async fn ws_drains_backlog_before_live_events() {
-    let buffer = ReplyBuffer::new();
+    let buffer = ReplyBuffer::new(rara_channels::web_reply_buffer::test_config());
     let adapter = Arc::new(
-        WebAdapter::new(OWNER_TOKEN.to_owned(), OWNER_USER_ID.to_owned())
-            .with_reply_buffer(Arc::clone(&buffer)),
+        WebAdapter::new(
+            OWNER_TOKEN.to_owned(),
+            OWNER_USER_ID.to_owned(),
+            rara_channels::web_reply_buffer::test_config(),
+        )
+        .with_reply_buffer(Arc::clone(&buffer)),
     );
 
     // Mount the adapter under /chat to mirror production wiring.
@@ -169,6 +173,7 @@ async fn ws_rejects_invalid_owner_token() {
     let adapter = Arc::new(WebAdapter::new(
         OWNER_TOKEN.to_owned(),
         OWNER_USER_ID.to_owned(),
+        rara_channels::web_reply_buffer::test_config(),
     ));
     let app = axum::Router::new().nest("/chat", adapter.router());
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0")


### PR DESCRIPTION
## Summary

Always-on per-session `ReplyBuffer` for the Web channel. When a long-running task completes while the user has closed their tab, the WS broadcast has zero receivers and the event would otherwise be silently dropped. This change buffers "important" events (`Message`, `Error`, `BackgroundTaskDone`, `Progress`) in a TTL- and byte-bounded ring per session. A reattaching WS / SSE client drains the buffer in publish order before the live forwarder starts.

The publish + drain paths are serialised under a per-session `parking_lot::Mutex`, guaranteeing no double-delivery: any publish strictly before a drain lands only in the snapshot; any publish strictly after lands only on the broadcast.

Caps are sourced from YAML (`web.reply_buffer.{capacity_events, capacity_bytes, ttl}`) — no Rust-side defaults, per `docs/guides/anti-patterns.md`. A low-frequency background sweeper drops fully-empty session entries (mechanism constant, not a knob).

## Type of change

| Type | Label |
|------|-------|
| Bug fix | `bug` |

## Component

`backend`

## Closes

Closes #1882

## Test plan

- [x] `cargo check --all --all-targets` passes
- [x] `cargo clippy -p rara-channels --all-targets --all-features --no-deps -- -D warnings` passes
- [x] `cargo test -p rara-channels` — 141 passed, 5 ignored (includes new `web_buffer_e2e` and `web_ws_drain` integration tests)
- [x] `prek run` on all touched files passes (fmt, clippy, doc, AGENT.md)