### PR TITLE
fix(web): skip tape_appended reload mid-turn (#1877)

### DIFF
--- a/web/src/pages/PiChat.tsx
+++ b/web/src/pages/PiChat.tsx
@@ -638,12 +638,20 @@ export default function PiChat() {
   // Subscribe to server-pushed session events so tape mutations that
   // arrive outside a live streamFn turn — background-task summaries,
   // future scheduled re-entries — refresh the chat without a manual
-  // refresh. The reload is a full snapshot fetch; mid-stream the
-  // assistant message has not been persisted yet so a concurrent reload
-  // is a no-op replay (#1849).
+  // refresh.
+  //
+  // Skip while the agent is mid-turn: the kernel publishes
+  // `tape_appended` for the user's own message as soon as it persists
+  // (before the assistant has produced anything), and reloading then
+  // calls `agent.replaceMessages` + `reconstructFromMessages` while the
+  // chat-stream WebSocket is still open. That mutation kills the
+  // in-flight chat WS, the live card sees a content-empty close and
+  // synthesizes `stopReason='error'`, and the assistant turn only
+  // surfaces after a manual page refresh (#1877).
   useSessionEvents({
     sessionKey: activeSession?.key ?? null,
     onTapeAppended: () => {
+      if (agentRef.current?.state.isStreaming) return;
       void reloadMessages();
     },
   });


### PR DESCRIPTION
## Summary

Every message in the web UI was flipping the live card to "encountered an error" and the assistant reply only surfaced after a manual page refresh. The session-events WS introduced in #1858 publishes `tape_appended` for the user's own message as soon as the kernel persists it — the frontend's reload then mutates `agent.state.messages` and reruns artifact reconstruction while the chat-stream WS is still open, killing the in-flight turn. Backend log confirms: chat WS opens, server delivers `progress(thinking)` 15 ms later, WS closes 32 ms after upgrade, then every subsequent kernel deliver hits `web publish: no active receivers`.

Skip the reload when `agent.state.isStreaming` is true. Background-task summaries and future scheduled re-entries always land outside a user turn, so #1849's use case is preserved.

## Type of change

| Type | Label |
|------|-------|
| Bug fix | `bug` |

## Component

`ui`

## Closes

Closes #1877

## Test plan

- [x] `bun run build` passes (tsc + vite)
- [x] `bun run test` passes (102 / 102)
- [ ] Manual: send a message in the web UI, live card streams and finishes cleanly, no refresh required