### PR TITLE
feat(backend): regenerate session title endpoint (#1884)

### DIFF
--- a/crates/app/src/lib.rs
+++ b/crates/app/src/lib.rs
@@ -670,6 +670,14 @@ pub async fn start_with_options(
 
     let (_kernel_arc, kernel_handle) = kernel.start(cancellation_token.clone());
 
+    // Inject the kernel handle into the session service so endpoints that
+    // need to drive the kernel directly (e.g. POST .../regenerate-title)
+    // can reach it. `BackendState::init` had to run before kernel boot so
+    // the handle is wired in here.
+    backend
+        .session_service
+        .set_kernel_handle(kernel_handle.clone());
+
     // Spawn the feed dispatch task — consumes events from all transports,
     // persists them to the data_feed_events table, and routes matching events
     // to subscribing sessions via SubscriptionRegistry.

--- a/crates/extensions/backend-admin/src/chat/error.rs
+++ b/crates/extensions/backend-admin/src/chat/error.rs
@@ -42,6 +42,10 @@ pub enum ChatError {
     /// The requested resource does not exist (generic 404).
     #[snafu(display("not found: {message}"))]
     NotFound { message: String },
+
+    /// Session title regeneration failed (LLM call or persistence step).
+    #[snafu(display("title generation failed: {message}"))]
+    TitleGenerationFailed { message: String },
 }
 
 /// Convert a sessions-layer error into a chat-domain error.
@@ -62,11 +66,12 @@ impl From<rara_sessions::error::SessionError> for ChatError {
 
 /// Maps [`ChatError`] variants to HTTP status codes:
 ///
-/// | Variant            | Status              |
-/// |--------------------|---------------------|
-/// | `SessionNotFound`  | `404 Not Found`     |
-/// | `InvalidRequest`   | `400 Bad Request`   |
-/// | `SessionError`     | `500 Internal`      |
+/// | Variant                 | Status              |
+/// |-------------------------|---------------------|
+/// | `SessionNotFound`       | `404 Not Found`     |
+/// | `InvalidRequest`        | `400 Bad Request`   |
+/// | `SessionError`          | `500 Internal`      |
+/// | `TitleGenerationFailed` | `500 Internal`      |
 ///
 /// Server errors (`5xx`) are logged at the `error` level.
 impl axum::response::IntoResponse for ChatError {
@@ -76,7 +81,9 @@ impl axum::response::IntoResponse for ChatError {
                 axum::http::StatusCode::NOT_FOUND
             }
             Self::InvalidRequest { .. } => axum::http::StatusCode::BAD_REQUEST,
-            Self::SessionError { .. } => axum::http::StatusCode::INTERNAL_SERVER_ERROR,
+            Self::SessionError { .. } | Self::TitleGenerationFailed { .. } => {
+                axum::http::StatusCode::INTERNAL_SERVER_ERROR
+            }
         };
         let message = self.to_string();
         if status.is_server_error() {

--- a/crates/extensions/backend-admin/src/chat/router.rs
+++ b/crates/extensions/backend-admin/src/chat/router.rs
@@ -30,6 +30,7 @@
 //! | `GET`    | `/api/v1/chat/sessions/{key}`                        | Get a session          |
 //! | `PATCH`  | `/api/v1/chat/sessions/{key}`                        | Update session fields  |
 //! | `DELETE` | `/api/v1/chat/sessions/{key}`                        | Delete a session       |
+//! | `POST`   | `/api/v1/chat/sessions/{key}/regenerate-title`       | Regenerate title       |
 //! | `PUT`    | `/api/v1/chat/channel-bindings`                      | Bind a channel         |
 //! | `GET`    | `/api/v1/chat/channel-bindings/{type}/{id}`           | Get channel binding    |
 
@@ -285,6 +286,7 @@ fn session_routes(service: SessionService) -> OpenApiRouter {
         .routes(routes!(create_session, list_sessions))
         .routes(routes!(search_sessions))
         .routes(routes!(get_session, update_session, delete_session))
+        .routes(routes!(regenerate_session_title))
         .routes(routes!(list_messages, clear_messages))
         .routes(routes!(get_cascade_trace))
         .routes(routes!(get_execution_trace))
@@ -496,6 +498,33 @@ async fn delete_session(
 ) -> Result<StatusCode, ChatError> {
     service.delete_session(&parse_session_key(&key)?).await?;
     Ok(StatusCode::NO_CONTENT)
+}
+
+/// `POST /api/v1/chat/sessions/{key}/regenerate-title` — re-run the title
+/// generator against the session's tape, overwriting any existing title.
+///
+/// Synchronous: returns 200 with the updated [`SessionEntry`] only after
+/// the new title has been persisted, so the frontend can refresh straight
+/// away. Returns 404 when the session does not exist and 500 when the
+/// underlying LLM call or persistence step fails.
+#[utoipa::path(
+    post,
+    path = "/api/v1/chat/sessions/{key}/regenerate-title",
+    tag = "chat",
+    params(("key" = String, Path, description = "Session key")),
+    responses(
+        (status = 200, description = "Session with refreshed title", body = Object),
+        (status = 404, description = "Session not found"),
+        (status = 500, description = "Title generation failed"),
+    )
+)]
+#[instrument(skip(service))]
+async fn regenerate_session_title(
+    State(service): State<SessionService>,
+    Path(key): Path<String>,
+) -> Result<Json<SessionEntry>, ChatError> {
+    let session = service.regenerate_title(&parse_session_key(&key)?).await?;
+    Ok(Json(session))
 }
 
 /// `GET /api/v1/chat/sessions/{key}/messages` — list conversation messages.

--- a/crates/extensions/backend-admin/src/chat/service.rs
+++ b/crates/extensions/backend-admin/src/chat/service.rs
@@ -22,7 +22,7 @@
 //! Session metadata is managed by [`SessionIndexRef`]. Message persistence has
 //! moved to the tape subsystem via [`TapeService`].
 
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
 
 use chrono::Utc;
 use rara_domain_shared::settings::{SettingsProvider, keys};
@@ -33,6 +33,7 @@ use rara_kernel::{
     channel::types::{
         ChannelType, ChatMessage, MessageContent, MessageRole, ToolCall as ChannelToolCall,
     },
+    handle::KernelHandle,
     llm::{Message, Role},
     memory::{TapEntry, TapEntryKind, TapeSearchHit, TapeService},
     session::SessionIndexRef,
@@ -374,6 +375,14 @@ pub struct SessionService {
     model_catalog:     ModelCatalog,
     /// Settings provider for reading and writing flat KV settings.
     settings_provider: Arc<dyn SettingsProvider>,
+    /// Late-bound kernel handle, set after the kernel has booted.
+    ///
+    /// `BackendState::init` runs before `Kernel::start` so the handle is
+    /// not available at construction time; the bootstrap path calls
+    /// [`Self::set_kernel_handle`] once the kernel is up. Methods that
+    /// require kernel access ([`Self::regenerate_title`]) error out
+    /// cleanly if invoked before the handle is set.
+    kernel_handle:     Arc<OnceLock<KernelHandle>>,
 }
 
 impl SessionService {
@@ -402,7 +411,28 @@ impl SessionService {
             trace_service,
             model_catalog: ModelCatalog::new(model_lister),
             settings_provider,
+            kernel_handle: Arc::new(OnceLock::new()),
         }
+    }
+
+    /// Inject the live kernel handle once the kernel has booted.
+    ///
+    /// Called exactly once from the bootstrap path. Subsequent calls are
+    /// silently ignored because the underlying `OnceLock` only accepts
+    /// the first value — a re-init attempt almost certainly indicates a
+    /// double-boot bug rather than legitimate replacement.
+    pub fn set_kernel_handle(&self, handle: KernelHandle) {
+        let _ = self.kernel_handle.set(handle);
+    }
+
+    /// Borrow the injected kernel handle, or return a 500-mapped error
+    /// when the bootstrap path has not yet wired it.
+    fn kernel_handle(&self) -> Result<&KernelHandle, ChatError> {
+        self.kernel_handle
+            .get()
+            .ok_or_else(|| ChatError::SessionError {
+                message: "kernel handle not initialised".to_string(),
+            })
     }
 
     // -- model catalog ------------------------------------------------------
@@ -522,6 +552,29 @@ impl SessionService {
         let updated = self.session_index.update_session(&session).await?;
         info!(key = %key, "session fields updated");
         Ok(updated)
+    }
+
+    /// Re-run the session-title generator against the current tape and
+    /// return the freshly persisted [`SessionEntry`].
+    ///
+    /// Synchronous from the caller's perspective — the call returns only
+    /// after the new title has been written, so the frontend can refresh
+    /// straight away. Unlike the post-first-turn auto-trigger, this path
+    /// overwrites any existing title so the user can replace a poor
+    /// auto-generated one.
+    #[instrument(skip(self))]
+    pub async fn regenerate_title(&self, key: &SessionKey) -> Result<SessionEntry, ChatError> {
+        // Surface a clean 404 before the LLM round-trip so a stale key
+        // does not pay for an LLM call.
+        let _ = self.get_session(key).await?;
+        self.kernel_handle()?
+            .regenerate_session_title(key)
+            .await
+            .map_err(|e| ChatError::TitleGenerationFailed {
+                message: e.to_string(),
+            })?;
+        // Re-fetch so the response reflects the new title and updated_at.
+        self.get_session(key).await
     }
 
     /// Delete a session.

--- a/crates/kernel/src/handle.rs
+++ b/crates/kernel/src/handle.rs
@@ -948,6 +948,52 @@ impl KernelHandle {
         .await
     }
 
+    /// Re-run session title generation against the current tape, overwriting
+    /// any existing title.
+    ///
+    /// Reuses the same generator as the post-first-turn auto-trigger but
+    /// skips the `title.is_none()` gate so the caller can replace a poor
+    /// auto-generated title or refresh the title after a topic shift. The
+    /// call is synchronous: it returns only after the new title has been
+    /// persisted to the session index (or generation has failed).
+    ///
+    /// Returns [`KernelError::SessionNotFound`] when no session exists for
+    /// `session_key`, and a wrapped [`KernelError::Whatever`] when the
+    /// underlying LLM call or persistence step fails.
+    pub async fn regenerate_session_title(&self, session_key: &SessionKey) -> Result<()> {
+        // Verify the session exists before doing the LLM round-trip so a
+        // stale `key` returns a clean 404 instead of a noisy "tape not
+        // found" surface.
+        let exists = self
+            .session_index()
+            .get_session(session_key)
+            .await
+            .map_err(|e| KernelError::Session {
+                message: e.to_string(),
+            })?
+            .is_some();
+        if !exists {
+            return Err(KernelError::SessionNotFound { key: *session_key });
+        }
+
+        let tape_name = session_key.to_string();
+        crate::kernel::generate_session_title(
+            &self.tape,
+            &tape_name,
+            self.driver_registry.as_ref(),
+            self.agent_registry.as_ref(),
+            self.session_index().as_ref(),
+            &self.io,
+            session_key,
+            true,
+        )
+        .await
+        .map_err(|e| KernelError::Whatever {
+            message: format!("session title regeneration failed: {e}"),
+            source:  Some(e),
+        })
+    }
+
     /// Deliver a system-generated message to a session, triggering an LLM turn.
     ///
     /// Used by the notification bus to deliver proactive-turn notifications.

--- a/crates/kernel/src/kernel.rs
+++ b/crates/kernel/src/kernel.rs
@@ -3240,6 +3240,7 @@ impl Kernel {
                         session_index.as_ref(),
                         &io,
                         &sk,
+                        false,
                     )
                     .await
                     {
@@ -3476,7 +3477,15 @@ fn finalize_title(
 /// keyed by the `title_gen` manifest, so driver + model + max-length stay in
 /// one atomic snapshot (see #1637). Errors are propagated to the caller for
 /// logging.
-async fn generate_session_title(
+/// Generate a sidebar title for a session by feeding the first user/assistant
+/// turn into the `title_gen` agent and persisting the result back onto the
+/// session entry.
+///
+/// Exposed at `pub(crate)` visibility so [`crate::handle::KernelHandle`] can
+/// drive it on demand for the regenerate-title endpoint. The auto-trigger in
+/// `process_turn_completion` gates on `title.is_none()`; on-demand callers
+/// intentionally skip that gate so they can overwrite a poor existing title.
+pub(crate) async fn generate_session_title(
     tape_service: &crate::memory::TapeService,
     tape_name: &str,
     driver_registry: &crate::llm::DriverRegistry,
@@ -3484,6 +3493,7 @@ async fn generate_session_title(
     session_index: &dyn crate::session::SessionIndex,
     io: &Arc<crate::io::IOSubsystem>,
     session_key: &SessionKey,
+    overwrite_existing: bool,
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     use crate::memory::TapEntryKind;
 
@@ -3596,7 +3606,12 @@ async fn generate_session_title(
             // with a stale generated one is user-visible damage. The
             // up-front `entry.title.is_none()` gate at the call site is
             // advisory — this is the authoritative compare-and-persist.
-            if entry.title.is_some() {
+            //
+            // When the caller explicitly asked for regeneration
+            // (`overwrite_existing = true`), we skip the guard: the user
+            // clicked "regenerate" precisely because the existing title
+            // is wrong, so overwriting is the desired behaviour.
+            if !overwrite_existing && entry.title.is_some() {
                 tracing::info!(
                     session_key = %session_key,
                     existing_title = ?entry.title,


### PR DESCRIPTION
## Summary

Adds `POST /api/v1/chat/sessions/{key}/regenerate-title`. Re-runs the existing `generate_session_title` helper against the session's tape and returns the freshly persisted `SessionEntry`. Synchronous so the frontend can refresh immediately after the click.

- `kernel::generate_session_title` gains an `overwrite_existing` flag; the post-first-turn auto-trigger keeps the old `title.is_none()` semantics, the on-demand path skips it.
- `KernelHandle::regenerate_session_title` exposes the helper publicly with proper `KernelError` mapping (404 / 500).
- `SessionService` gets a late-bound `Arc<OnceLock<KernelHandle>>` because `BackendState::init` runs before `Kernel::start`; the bootstrap path in `rara-app` injects the handle right after `kernel.start()`.
- New `ChatError::TitleGenerationFailed` variant maps to 500 with a real error variant (no `anyhow::anyhow!`).

## Type of change

| Type | Label |
|------|-------|
| New feature | `enhancement` |

## Component

`backend`

## Closes

Closes #1884

## Test plan

- [x] `cargo check --all --all-targets` passes
- [x] `prek run --all-files` (cargo check + fmt + clippy + doc + AGENT.md) passes
- [ ] Unit test for `SessionService::regenerate_title` skipped: the existing test harness in `service.rs` uses an `InMemorySessionIndex` and a stub LLM lister; constructing a real `KernelHandle` for a unit test requires a full kernel boot (`Kernel::start`) plus a working `DriverRegistry` against a real LLM, which the harness does not yet support. Coverage is exercised end-to-end via the route once a CI/staging instance is wired up.