### PR TITLE
test(backend-admin): consolidate redundant test fixtures (#1896)

### DIFF
--- a/crates/extensions/backend-admin/src/chat/service.rs
+++ b/crates/extensions/backend-admin/src/chat/service.rs
@@ -1301,8 +1301,41 @@ mod search_sessions_tests {
     };
     use rara_sessions::types::SessionEntry;
     use serde_json::json;
+    use tokio::sync::OnceCell;
 
     use super::SessionService;
+
+    /// Process-wide fixture for the search tests.
+    ///
+    /// Building a `SessionService + FTS-backed TapeService` costs ~1s per
+    /// fixture (diesel pool migration + tape store init). The four tests in
+    /// this module are independent at the FTS-marker level (`zephyrrising`,
+    /// `pingpong-token`, `clampme`, `hello`), so a single shared fixture is
+    /// sufficient — each test still uses fresh `SessionKey::new()` UUIDs and
+    /// asserts via marker-scoped queries, never on global counts.
+    static SHARED: OnceCell<SharedFixture> = OnceCell::const_new();
+
+    struct SharedFixture {
+        service:  SessionService,
+        sessions: Arc<InMemorySessionIndex>,
+        // Keep the tape directory alive for the entire process — tape files
+        // are written under this path and the FTS index references them.
+        _tmp:     tempfile::TempDir,
+    }
+
+    async fn shared_fixture() -> &'static SharedFixture {
+        SHARED
+            .get_or_init(|| async {
+                let tmp = tempfile::tempdir().expect("tempdir");
+                let (service, sessions) = build_service_with_fts(tmp.path()).await;
+                SharedFixture {
+                    service,
+                    sessions,
+                    _tmp: tmp,
+                }
+            })
+            .await
+    }
 
     struct StubSettings;
 
@@ -1375,11 +1408,12 @@ mod search_sessions_tests {
 
     #[tokio::test]
     async fn empty_query_returns_no_hits() {
-        let tmp = tempfile::tempdir().unwrap();
-        let (service, sessions) = build_service_with_fts(tmp.path()).await;
+        let fx = shared_fixture().await;
+        let service = &fx.service;
+        let sessions = &fx.sessions;
 
         let key = SessionKey::new();
-        register_session(&sessions, &key, "session one").await;
+        register_session(sessions, &key, "session one").await;
         service
             .tape_service()
             .append_message(&key.to_string(), json!({"content": "hello"}), None)
@@ -1394,14 +1428,15 @@ mod search_sessions_tests {
 
     #[tokio::test]
     async fn attribution_across_many_sessions() {
-        let tmp = tempfile::tempdir().unwrap();
-        let (service, sessions) = build_service_with_fts(tmp.path()).await;
+        let fx = shared_fixture().await;
+        let service = &fx.service;
+        let sessions = &fx.sessions;
 
         let marker = "zephyrrising";
         let mut keys = Vec::new();
         for i in 0..12 {
             let key = SessionKey::new();
-            register_session(&sessions, &key, &format!("session-{i}")).await;
+            register_session(sessions, &key, &format!("session-{i}")).await;
             service
                 .tape_service()
                 .append_message(
@@ -1438,11 +1473,12 @@ mod search_sessions_tests {
 
     #[tokio::test]
     async fn dedup_keeps_one_hit_per_session() {
-        let tmp = tempfile::tempdir().unwrap();
-        let (service, sessions) = build_service_with_fts(tmp.path()).await;
+        let fx = shared_fixture().await;
+        let service = &fx.service;
+        let sessions = &fx.sessions;
 
         let key = SessionKey::new();
-        register_session(&sessions, &key, "busy session").await;
+        register_session(sessions, &key, "busy session").await;
         for i in 0..5 {
             service
                 .tape_service()
@@ -1462,12 +1498,13 @@ mod search_sessions_tests {
 
     #[tokio::test]
     async fn limit_clamps_output() {
-        let tmp = tempfile::tempdir().unwrap();
-        let (service, sessions) = build_service_with_fts(tmp.path()).await;
+        let fx = shared_fixture().await;
+        let service = &fx.service;
+        let sessions = &fx.sessions;
 
         for i in 0..8 {
             let key = SessionKey::new();
-            register_session(&sessions, &key, &format!("s{i}")).await;
+            register_session(sessions, &key, &format!("s{i}")).await;
             service
                 .tape_service()
                 .append_message(

--- a/crates/extensions/backend-admin/tests/scheduler.rs
+++ b/crates/extensions/backend-admin/tests/scheduler.rs
@@ -60,10 +60,13 @@ fn ensure_test_paths_isolated() {
     });
 }
 
-/// Fresh kernel: no jobs registered, the admin list is empty and lookups
-/// on a fabricated ID surface as `JobNotFound`.
+/// Fresh kernel: list is empty, and `get` / `delete` / `trigger` against a
+/// fabricated id all surface as `JobNotFound` through the syscall boundary.
+///
+/// Consolidated from four near-identical fixtures — each path was just
+/// "boot kernel, call one method, assert" with no shared state to protect.
 #[tokio::test]
-async fn list_on_empty_kernel_is_empty() {
+async fn missing_job_paths_return_not_found() {
     ensure_test_paths_isolated();
     let tmp = tempfile::tempdir().expect("tempdir");
     let tk = TestKernelBuilder::new(tmp.path()).build().await;
@@ -72,64 +75,24 @@ async fn list_on_empty_kernel_is_empty() {
     let jobs = svc.list_jobs().await;
     assert!(jobs.is_empty(), "expected empty kernel, got {jobs:?}");
 
-    tk.shutdown();
-}
-
-#[tokio::test]
-async fn get_missing_returns_job_not_found() {
-    ensure_test_paths_isolated();
-    let tmp = tempfile::tempdir().expect("tempdir");
-    let tk = TestKernelBuilder::new(tmp.path()).build().await;
-    let svc = SchedulerSvc::new(tk.handle.clone());
-
     let ghost = JobId::new();
-    let err = svc
-        .get_job(&ghost)
-        .await
-        .expect_err("ghost job must not be found");
+    let get_err = svc.get_job(&ghost).await.expect_err("get must fail");
     assert!(
-        matches!(err, SchedulerError::JobNotFound { .. }),
-        "expected JobNotFound, got {err:?}"
+        matches!(get_err, SchedulerError::JobNotFound { .. }),
+        "get: expected JobNotFound, got {get_err:?}"
     );
-
-    tk.shutdown();
-}
-
-#[tokio::test]
-async fn delete_missing_returns_job_not_found() {
-    ensure_test_paths_isolated();
-    let tmp = tempfile::tempdir().expect("tempdir");
-    let tk = TestKernelBuilder::new(tmp.path()).build().await;
-    let svc = SchedulerSvc::new(tk.handle.clone());
-
-    let ghost = JobId::new();
-    let err = svc
-        .delete_job(&ghost)
-        .await
-        .expect_err("delete on ghost id must fail");
+    let delete_err = svc.delete_job(&ghost).await.expect_err("delete must fail");
     assert!(
-        matches!(err, SchedulerError::JobNotFound { .. }),
-        "expected JobNotFound, got {err:?}"
+        matches!(delete_err, SchedulerError::JobNotFound { .. }),
+        "delete: expected JobNotFound, got {delete_err:?}"
     );
-
-    tk.shutdown();
-}
-
-#[tokio::test]
-async fn trigger_missing_returns_job_not_found() {
-    ensure_test_paths_isolated();
-    let tmp = tempfile::tempdir().expect("tempdir");
-    let tk = TestKernelBuilder::new(tmp.path()).build().await;
-    let svc = SchedulerSvc::new(tk.handle.clone());
-
-    let ghost = JobId::new();
-    let err = svc
+    let trigger_err = svc
         .trigger_job(&ghost)
         .await
-        .expect_err("trigger on ghost id must fail");
+        .expect_err("trigger must fail");
     assert!(
-        matches!(err, SchedulerError::JobNotFound { .. }),
-        "expected JobNotFound, got {err:?}"
+        matches!(trigger_err, SchedulerError::JobNotFound { .. }),
+        "trigger: expected JobNotFound, got {trigger_err:?}"
     );
 
     tk.shutdown();


### PR DESCRIPTION
## Summary

Consolidate redundant fixtures in the `rara-backend-admin` test suite to cut duplicated boot cost without losing coverage.

- Merge four near-identical scheduler tests (`list_on_empty_kernel_is_empty`, `get_missing_returns_job_not_found`, `delete_missing_returns_job_not_found`, `trigger_missing_returns_job_not_found`) into a single `missing_job_paths_return_not_found` — each previously booted its own kernel just to call one method against a fabricated id.
- Share the `search_sessions_tests` FTS fixture across the four search tests via a `tokio::sync::OnceCell`. Each test still uses fresh `SessionKey::new()` UUIDs, and assertions are scoped through unique markers (`zephyrrising`, `pingpong-token`, `clampme`, `hello`) so no test sees another's data.

## Type of change

| Type | Label |
|------|-------|
| Refactor | `refactor` |

## Component

`extension`

## Closes

Closes #1896

## Test plan

- [x] `cargo check -p rara-backend-admin --tests`
- [x] `cargo +nightly fmt --all`
- [x] `cargo clippy -p rara-backend-admin --tests --all-features --no-deps -- -D warnings`