### PR TITLE
chore(app): drop unused agentfs-sdk (#1891)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -139,7 +139,6 @@ members = [
 ]
 
 [workspace.dependencies]
-agentfs-sdk = "0.6"
 anyhow = "^1.0"
 argon2 = "0.5"
 async-openai = { version = "0.33", features = ["chat-completion"] }

--- a/crates/app/Cargo.toml
+++ b/crates/app/Cargo.toml
@@ -12,7 +12,6 @@ categories.workspace = true
 description = "Application orchestration and lifecycle management for rara"
 
 [dependencies]
-agentfs-sdk = { workspace = true }
 anyhow.workspace = true
 async-trait = { workspace = true }
 axum = { workspace = true }


### PR DESCRIPTION
## Summary

Removes the dead `agentfs-sdk` dependency from `crates/app/Cargo.toml`
and the workspace dependency table. No source under `crates/`
references `agentfs_sdk` or `agentfs::` — the audit / KV path it was
originally added for (#451) now sits on diesel directly.

## Why this matters today

Carrying the dependency was breaking CI:

- Pulls `turso` (rust-native SQLite) → `aegis 0.9.7`. `aegis` builds
  embedded C from a `libaegis` git submodule that cargo never
  auto-inits, so `softaes.c` is missing on a fresh checkout and the
  Linux clippy / test / docs jobs all fail to compile.
- `turso` also pulls `rusqlite 0.37` → `libsqlite3-sys 0.35`, which
  collides on `links = "sqlite3"` with the `libsqlite3-sys 0.30`
  pinned by `diesel 2.3` — exactly the class of bug the
  sqlx → diesel migration (#1702) set out to root-cause. `cargo
  tree` cannot resolve the graph today.

Removing the dep unblocks both, with zero behaviour change.

## Type of change

| Type | Label |
|------|-------|
| Chore | `chore` |

## Component

`core`

## Closes

Closes #1891

## Test plan

- [x] `cargo check --all --all-targets` passes locally (workspace
      compiles cleanly without `agentfs-sdk`)
- [x] No `agentfs_sdk` or `agentfs::` references remain in the tree