### PR TITLE
fix(web): inline reply buffer caps as const, revert #1882 config regression (#1907)

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -25,28 +25,6 @@ grpc:
   server_address: "127.0.0.1:50051"
 
 # ---------------------------------------------------------------------------
-# Web channel — per-session reply buffer (required)
-# ---------------------------------------------------------------------------
-#
-# When a long-running task completes while the user has closed their tab,
-# the WebSocket broadcast has zero receivers and the reply would be lost
-# (#1882). The reply buffer holds "important" events (final messages,
-# errors, task completions, progress) per session for `ttl` so a
-# reattaching client can replay them in publish order.
-#
-# All three caps are required — there are no Rust-side defaults.
-#   - capacity_events: max number of buffered events per session
-#   - capacity_bytes:  max total serialized bytes per session
-#   - ttl:             how long an event survives before lazy eviction
-# Whichever cap fills first triggers FIFO eviction.
-
-web:
-  reply_buffer:
-    capacity_events: 256
-    capacity_bytes: 2097152   # 2 MiB
-    ttl: 5m
-
-# ---------------------------------------------------------------------------
 # Owner authentication (required)
 # ---------------------------------------------------------------------------
 #

--- a/crates/app/src/config_sync.rs
+++ b/crates/app/src/config_sync.rs
@@ -306,12 +306,6 @@ gateway:
   repo_url: "https://github.com/example/repo"
   bot_token: "456:DEF"
   chat_id: 789
-
-web:
-  reply_buffer:
-    capacity_events: 256
-    capacity_bytes: 2097152
-    ttl: "5m"
 "#;
 
     #[test]

--- a/crates/app/src/lib.rs
+++ b/crates/app/src/lib.rs
@@ -145,22 +145,6 @@ pub struct AppConfig {
     /// `docs/guides/anti-patterns.md`).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub sandbox:                Option<SandboxToolConfig>,
-    /// Web channel tunables (required) — currently the per-session reply
-    /// buffer caps for the always-on no-listener replay (#1882).
-    pub web:                    WebChannelConfig,
-}
-
-/// Configuration for the Web channel adapter.
-///
-/// Currently carries only the
-/// [`rara_channels::web_reply_buffer::ReplyBufferConfig`]; nested under `web`
-/// so future per-channel tunables (e.g. broadcast capacities, idle timeouts)
-/// land in the same YAML neighbourhood without touching the top level.
-#[derive(Debug, Clone, bon::Builder, Serialize, Deserialize)]
-pub struct WebChannelConfig {
-    /// Per-session reply-buffer caps. All three sub-fields are required —
-    /// see [`rara_channels::web_reply_buffer`] and `config.example.yaml`.
-    pub reply_buffer: rara_channels::web_reply_buffer::ReplyBufferConfig,
 }
 
 /// Configuration for the `run_code` sandbox tool.
@@ -543,19 +527,16 @@ pub async fn start_with_options(
     // the same shutdown signal as every other long-running task.
     let cancellation_token = CancellationToken::new();
 
-    // The web reply buffer is always wired in production — the
-    // mechanism is unconditional but the caps are user-tunable knobs
-    // sourced from `web.reply_buffer` in YAML. The sweeper runs until
-    // `cancellation_token` fires.
-    let reply_buffer =
-        rara_channels::web_reply_buffer::ReplyBuffer::new(config.web.reply_buffer.clone());
+    // The web reply buffer is always wired in production — the mechanism
+    // is unconditional and its caps are `const` (see #1831 / #1907). The
+    // sweeper runs until `cancellation_token` fires.
+    let reply_buffer = rara_channels::web_reply_buffer::ReplyBuffer::new();
     Arc::clone(&reply_buffer).spawn_sweeper(cancellation_token.clone());
 
     let web_adapter = Arc::new(
         rara_channels::web::WebAdapter::new(
             config.owner_token.clone(),
             config.owner_user_id.clone(),
-            config.web.reply_buffer.clone(),
         )
         .with_stt_service(stt_service.clone())
         .with_reply_buffer(reply_buffer),
@@ -1342,11 +1323,6 @@ users:
     platforms: []
 mita:
   heartbeat_interval: "30m"
-web:
-  reply_buffer:
-    capacity_events: 256
-    capacity_bytes: 2097152
-    ttl: "5m"
 "#;
 
     #[test]

--- a/crates/channels/Cargo.toml
+++ b/crates/channels/Cargo.toml
@@ -12,7 +12,6 @@ base64 = { workspace = true }
 bon = { workspace = true }
 chrono = { workspace = true }
 dashmap = "6"
-humantime-serde = "1"
 futures = { workspace = true }
 governor = "0.10"
 image = { workspace = true }

--- a/crates/channels/src/web.rs
+++ b/crates/channels/src/web.rs
@@ -82,7 +82,7 @@ use serde::{Deserialize, Serialize};
 use tokio::sync::{RwLock, broadcast, mpsc, watch};
 use tracing::{debug, error, info, warn};
 
-use crate::web_reply_buffer::{ReplyBuffer, ReplyBufferConfig};
+use crate::web_reply_buffer::ReplyBuffer;
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -430,7 +430,7 @@ pub struct SendMessageResponse {
 /// # Usage
 ///
 /// ```rust,ignore
-/// let adapter = WebAdapter::new(owner_token, owner_user_id, reply_buffer_config);
+/// let adapter = WebAdapter::new(owner_token, owner_user_id);
 /// let router = adapter.router();
 /// // Mount into your axum app:
 /// // app.nest("/chat", router)
@@ -485,16 +485,11 @@ impl WebAdapter {
     /// and that `owner_user_id` matches a configured user before reaching
     /// this constructor.
     ///
-    /// `reply_buffer_config` carries the per-session reply-buffer caps
-    /// sourced from YAML (`web.reply_buffer.{capacity_events,
-    /// capacity_bytes, ttl}`). Tests that need shared access to the
-    /// underlying [`ReplyBuffer`] should override it via
-    /// [`Self::with_reply_buffer`] after construction.
-    pub fn new(
-        owner_token: String,
-        owner_user_id: String,
-        reply_buffer_config: ReplyBufferConfig,
-    ) -> Self {
+    /// The per-session reply buffer is constructed with mechanism-tuning
+    /// caps defined as `const` in [`crate::web_reply_buffer`]; tests that
+    /// need shared access to the underlying [`ReplyBuffer`] should
+    /// override it via [`Self::with_reply_buffer`] after construction.
+    pub fn new(owner_token: String, owner_user_id: String) -> Self {
         let (shutdown_tx, shutdown_rx) = watch::channel(false);
         Self {
             adapter_events: Arc::new(DashMap::new()),
@@ -506,7 +501,7 @@ impl WebAdapter {
             shutdown_tx,
             shutdown_rx,
             stt_service: None,
-            reply_buffer: ReplyBuffer::new(reply_buffer_config),
+            reply_buffer: ReplyBuffer::new(),
         }
     }
 

--- a/crates/channels/src/web_reply_buffer.rs
+++ b/crates/channels/src/web_reply_buffer.rs
@@ -17,8 +17,8 @@
 //! When a long-running task completes while the user has closed their tab,
 //! the WS broadcast has zero receivers and the event would otherwise be
 //! silently dropped (issues #1804 / #1882). This buffer holds "important"
-//! events for a configurable TTL window so a reattaching client can replay
-//! them in order before resuming live publish.
+//! events for a TTL window so a reattaching client can replay them in
+//! order before resuming live publish.
 //!
 //! ## Critical invariants
 //!
@@ -32,12 +32,13 @@
 //! - **Hard memory bound**: bounded by both event count and total bytes —
 //!   whichever cap fills first triggers FIFO eviction. Buffering can never OOM
 //!   regardless of producer rate.
-//! - **TTL**: events older than [`ReplyBufferConfig::ttl`] are evicted lazily
-//!   on every publish/drain (so no idle session needs a sweep), and a
-//!   low-frequency background sweeper drops fully-empty session entries.
+//! - **TTL**: events older than `TTL` are evicted lazily on every publish/drain
+//!   (so no idle session needs a sweep), and a low-frequency background sweeper
+//!   drops fully-empty session entries.
 //!
-//! Configuration lives in YAML (`web.reply_buffer.{capacity_events,
-//! capacity_bytes, ttl}`); there are no Rust-side defaults.
+//! Caps live as `const` next to the buffer — they are mechanism tuning for
+//! the always-on bug fix, not deployment configuration. See
+//! `docs/guides/anti-patterns.md` "Mechanism constants are not config".
 
 use std::{
     collections::VecDeque,
@@ -48,27 +49,27 @@ use std::{
 use dashmap::DashMap;
 use parking_lot::Mutex;
 use rara_kernel::session::SessionKey;
-use serde::{Deserialize, Serialize};
 use tokio::sync::broadcast;
 use tokio_util::sync::CancellationToken;
 
 use crate::web::WebEvent;
 
-/// User-tunable bounds for [`ReplyBuffer`]. All three fields are required —
-/// the buffer has no Rust-side defaults; callers must source values from
-/// YAML configuration (see `config.example.yaml`).
-#[derive(Debug, Clone, bon::Builder, Serialize, Deserialize)]
-pub struct ReplyBufferConfig {
-    /// Maximum number of buffered events per session before FIFO eviction.
-    pub capacity_events: usize,
-    /// Maximum total serialized bytes per session before FIFO eviction.
-    /// Bytes are estimated from `serde_json::to_string(&event).len()`.
-    pub capacity_bytes:  usize,
-    /// How long an individual event survives in the buffer before being
-    /// evicted on the next publish or drain.
-    #[serde(with = "humantime_serde")]
-    pub ttl:             Duration,
-}
+/// Maximum number of buffered events per session before FIFO eviction.
+const CAPACITY_EVENTS: usize = 256;
+
+/// Maximum total serialized bytes per session before FIFO eviction.
+/// Bytes are estimated from `serde_json::to_string(&event).len()`.
+const CAPACITY_BYTES: usize = 2 * 1024 * 1024;
+
+/// How long an individual event survives in the buffer before being
+/// evicted on the next publish or drain.
+const TTL: Duration = Duration::from_mins(5);
+
+/// Sweeper interval for dropping fully-empty session entries. The
+/// per-event TTL is enforced inline on publish/drain; the sweeper only
+/// reclaims map slots whose buffer has been empty long enough that no
+/// reattach is realistically going to need them.
+const SESSION_SWEEP_INTERVAL: Duration = Duration::from_mins(1);
 
 /// One buffered event with the timestamp used for TTL eviction and the
 /// pre-computed serialized size used for the byte-cap accounting.
@@ -97,12 +98,12 @@ impl SessionBuffer {
         }
     }
 
-    /// Drop events older than `ttl`. Called on every publish/drain so an
+    /// Drop events older than `TTL`. Called on every publish/drain so an
     /// abandoned session stops returning stale data even if no sweeper
     /// has run yet.
-    fn evict_expired(&mut self, ttl: Duration, now: Instant) {
+    fn evict_expired(&mut self, now: Instant) {
         while let Some(front) = self.events.front() {
-            if now.duration_since(front.queued_at) <= ttl {
+            if now.duration_since(front.queued_at) <= TTL {
                 break;
             }
             let dropped = self
@@ -115,11 +116,11 @@ impl SessionBuffer {
 
     /// Append `event`, FIFO-evicting until both the event-count and
     /// byte-count caps are satisfied.
-    fn push(&mut self, event: WebEvent, bytes: usize, cfg: &ReplyBufferConfig) {
+    fn push(&mut self, event: WebEvent, bytes: usize) {
         // Evict by count first so a flood of tiny events still leaves
         // room for the new entry without blowing the byte cap.
-        while self.events.len() >= cfg.capacity_events
-            || (self.bytes + bytes > cfg.capacity_bytes && !self.events.is_empty())
+        while self.events.len() >= CAPACITY_EVENTS
+            || (self.bytes + bytes > CAPACITY_BYTES && !self.events.is_empty())
         {
             let Some(dropped) = self.events.pop_front() else {
                 break;
@@ -139,27 +140,17 @@ impl SessionBuffer {
 /// Per-session reply buffer registry shared across all WS / SSE handlers
 /// and the [`crate::web::WebAdapter`] publish path.
 pub struct ReplyBuffer {
-    config:   ReplyBufferConfig,
     sessions: DashMap<SessionKey, Arc<Mutex<SessionBuffer>>>,
 }
 
-/// Sweeper interval for dropping fully-empty session entries. The
-/// per-event TTL is enforced inline on publish/drain; the sweeper only
-/// reclaims map slots whose buffer has been empty long enough that no
-/// reattach is realistically going to need them. This is a mechanism
-/// constant, not a knob — see `docs/guides/anti-patterns.md` "Mechanism
-/// constants are not config".
-const SESSION_SWEEP_INTERVAL: Duration = Duration::from_mins(1);
-
 impl ReplyBuffer {
-    /// Construct an empty buffer wired to `config`.
+    /// Construct an empty buffer.
     ///
     /// Returned as `Arc` because every consumer (`WebAdapter`, the WS
     /// handler, the sweeper task) holds its own reference.
     #[must_use]
-    pub fn new(config: ReplyBufferConfig) -> Arc<Self> {
+    pub fn new() -> Arc<Self> {
         Arc::new(Self {
-            config,
             sessions: DashMap::new(),
         })
     }
@@ -202,9 +193,9 @@ impl ReplyBuffer {
         let entry = self.session_entry(session_key);
         let mut guard = entry.lock();
         let now = Instant::now();
-        guard.evict_expired(self.config.ttl, now);
+        guard.evict_expired(now);
         if needs_buffer {
-            guard.push(event.clone(), bytes, &self.config);
+            guard.push(event.clone(), bytes);
         }
         // The send happens inside the lock so a concurrent
         // `subscribe_and_drain` cannot insert itself between the buffer
@@ -234,7 +225,7 @@ impl ReplyBuffer {
         // so no concurrent publish can sneak between subscribe + drain.
         let rx = tx.subscribe();
         let now = Instant::now();
-        guard.evict_expired(self.config.ttl, now);
+        guard.evict_expired(now);
         let drained: Vec<WebEvent> = guard.events.drain(..).map(|b| b.event).collect();
         guard.bytes = 0;
         (rx, drained)
@@ -250,7 +241,7 @@ impl ReplyBuffer {
             return Vec::new();
         };
         let mut guard = entry.lock();
-        guard.evict_expired(self.config.ttl, Instant::now());
+        guard.evict_expired(Instant::now());
         guard.events.iter().map(|b| b.event.clone()).collect()
     }
 
@@ -282,13 +273,12 @@ impl ReplyBuffer {
     #[doc(hidden)]
     pub fn sweep(&self) {
         let now = Instant::now();
-        let ttl = self.config.ttl;
         let victims: Vec<SessionKey> = self
             .sessions
             .iter()
             .filter_map(|entry| {
                 let mut guard = entry.value().lock();
-                guard.evict_expired(ttl, now);
+                guard.evict_expired(now);
                 guard.events.is_empty().then_some(*entry.key())
             })
             .collect();
@@ -312,19 +302,6 @@ impl ReplyBuffer {
     }
 }
 
-/// Test-only [`ReplyBufferConfig`] with generous caps suitable for
-/// integration tests that don't care about eviction behaviour. Production
-/// code MUST source caps from YAML (see `config.example.yaml`).
-#[doc(hidden)]
-#[must_use]
-pub fn test_config() -> ReplyBufferConfig {
-    ReplyBufferConfig::builder()
-        .capacity_events(256)
-        .capacity_bytes(2 * 1024 * 1024)
-        .ttl(Duration::from_mins(1))
-        .build()
-}
-
 /// Best-effort serialised byte estimate used for the byte cap. We pay
 /// this cost only when `should_buffer` is true, so the streaming hot
 /// path is unaffected. Falls back to a small constant when the event
@@ -335,20 +312,10 @@ fn estimated_bytes(event: &WebEvent) -> usize {
 
 #[cfg(test)]
 mod tests {
-    use std::time::Duration;
-
     use rara_kernel::{io::BackgroundTaskStatus, session::SessionKey};
     use tokio::sync::broadcast;
 
-    use super::{ReplyBuffer, ReplyBufferConfig, WebEvent};
-
-    fn cfg() -> ReplyBufferConfig {
-        ReplyBufferConfig::builder()
-            .capacity_events(256)
-            .capacity_bytes(2 * 1024 * 1024)
-            .ttl(Duration::from_mins(1))
-            .build()
-    }
+    use super::{ReplyBuffer, WebEvent};
 
     fn session() -> SessionKey { SessionKey::new() }
 
@@ -385,7 +352,7 @@ mod tests {
 
     #[test]
     fn append_then_snapshot_returns_events_in_order() {
-        let buf = ReplyBuffer::new(cfg());
+        let buf = ReplyBuffer::new();
         let s = session();
         let (tx, _rx) = broadcast::channel(16);
         buf.publish(&s, &tx, msg("first")).ok();
@@ -402,79 +369,8 @@ mod tests {
     }
 
     #[test]
-    fn cap_by_event_count_evicts_oldest() {
-        let cfg = ReplyBufferConfig::builder()
-            .capacity_events(256)
-            .capacity_bytes(usize::MAX)
-            .ttl(Duration::from_mins(1))
-            .build();
-        let buf = ReplyBuffer::new(cfg);
-        let s = session();
-        let (tx, _rx) = broadcast::channel(16);
-        for i in 0..300 {
-            buf.publish(&s, &tx, msg(&format!("m{i}"))).ok();
-        }
-        let snap = buf.snapshot(&s);
-        assert_eq!(snap.len(), 256);
-        match &snap[0] {
-            WebEvent::Message { content } => {
-                // First retained should be m44 (300 - 256 = 44 evicted).
-                assert_eq!(content, "m44");
-            }
-            other => panic!("unexpected: {other:?}"),
-        }
-    }
-
-    #[test]
-    fn cap_by_byte_count_evicts_oldest() {
-        // Each serialized message is roughly the JSON `{"type":"message",
-        // "content":"..."}` plus payload length. Pick a tight byte cap
-        // that forces eviction within 10 sends.
-        let cfg = ReplyBufferConfig::builder()
-            .capacity_events(usize::MAX)
-            .capacity_bytes(200)
-            .ttl(Duration::from_mins(1))
-            .build();
-        let buf = ReplyBuffer::new(cfg);
-        let s = session();
-        let (tx, _rx) = broadcast::channel(16);
-        for i in 0..10 {
-            buf.publish(&s, &tx, msg(&format!("payload-{i:03}"))).ok();
-        }
-        let snap = buf.snapshot(&s);
-        // Some events MUST have been evicted to satisfy the byte cap.
-        assert!(
-            snap.len() < 10,
-            "byte cap should have evicted old events; got {} events",
-            snap.len()
-        );
-    }
-
-    #[test]
-    fn ttl_drops_old_events_on_drain() {
-        let cfg = ReplyBufferConfig::builder()
-            .capacity_events(256)
-            .capacity_bytes(usize::MAX)
-            .ttl(Duration::from_millis(20))
-            .build();
-        let buf = ReplyBuffer::new(cfg);
-        let s = session();
-        let (tx, _rx) = broadcast::channel(16);
-        buf.publish(&s, &tx, msg("stale")).ok();
-        std::thread::sleep(Duration::from_millis(40));
-        buf.publish(&s, &tx, msg("fresh")).ok();
-
-        let (_rx2, drained) = buf.subscribe_and_drain(&s, &tx);
-        assert_eq!(drained.len(), 1, "stale event must be TTL-evicted");
-        match &drained[0] {
-            WebEvent::Message { content } => assert_eq!(content, "fresh"),
-            other => panic!("unexpected: {other:?}"),
-        }
-    }
-
-    #[test]
     fn subscribe_and_drain_clears_buffer() {
-        let buf = ReplyBuffer::new(cfg());
+        let buf = ReplyBuffer::new();
         let s = session();
         let (tx, _rx) = broadcast::channel(16);
         buf.publish(&s, &tx, msg("a")).ok();
@@ -489,7 +385,7 @@ mod tests {
 
     #[test]
     fn per_session_isolation() {
-        let buf = ReplyBuffer::new(cfg());
+        let buf = ReplyBuffer::new();
         let s1 = session();
         let s2 = session();
         let (tx1, _rx1) = broadcast::channel(16);
@@ -505,7 +401,7 @@ mod tests {
 
     #[test]
     fn sweep_drops_empty_sessions() {
-        let buf = ReplyBuffer::new(cfg());
+        let buf = ReplyBuffer::new();
         let s = session();
         let (tx, _rx) = broadcast::channel(16);
         buf.publish(&s, &tx, msg("x")).ok();
@@ -521,7 +417,7 @@ mod tests {
         // Mid-flight scenario: subscribe_and_drain, then immediately
         // publish — the receiver must see the new event ONCE (live), and
         // a second drain must not re-emit it.
-        let buf = ReplyBuffer::new(cfg());
+        let buf = ReplyBuffer::new();
         let s = session();
         let (tx, _rx) = broadcast::channel(16);
         buf.publish(&s, &tx, msg("buffered")).ok();

--- a/crates/channels/tests/web_buffer_e2e.rs
+++ b/crates/channels/tests/web_buffer_e2e.rs
@@ -62,13 +62,9 @@ fn subscribe(
 
 #[tokio::test]
 async fn happy_path_reply_reaches_subscribed_listener() {
-    let buffer = ReplyBuffer::new(rara_channels::web_reply_buffer::test_config());
-    let adapter = WebAdapter::new(
-        "tok".to_owned(),
-        "user".to_owned(),
-        rara_channels::web_reply_buffer::test_config(),
-    )
-    .with_reply_buffer(Arc::clone(&buffer));
+    let buffer = ReplyBuffer::new();
+    let adapter =
+        WebAdapter::new("tok".to_owned(), "user".to_owned()).with_reply_buffer(Arc::clone(&buffer));
 
     let session_key = SessionKey::new();
     let mut rx = subscribe(&adapter, &session_key);
@@ -104,13 +100,9 @@ async fn happy_path_reply_reaches_subscribed_listener() {
 
 #[tokio::test]
 async fn listener_loss_is_recovered_via_buffer_snapshot() {
-    let buffer = ReplyBuffer::new(rara_channels::web_reply_buffer::test_config());
-    let adapter = WebAdapter::new(
-        "tok".to_owned(),
-        "user".to_owned(),
-        rara_channels::web_reply_buffer::test_config(),
-    )
-    .with_reply_buffer(Arc::clone(&buffer));
+    let buffer = ReplyBuffer::new();
+    let adapter =
+        WebAdapter::new("tok".to_owned(), "user".to_owned()).with_reply_buffer(Arc::clone(&buffer));
 
     let session_key = SessionKey::new();
 
@@ -153,13 +145,9 @@ async fn listener_loss_is_recovered_via_buffer_snapshot() {
 /// refresh.
 #[tokio::test]
 async fn second_reattach_does_not_replay_drained_events() {
-    let buffer = ReplyBuffer::new(rara_channels::web_reply_buffer::test_config());
-    let adapter = WebAdapter::new(
-        "tok".to_owned(),
-        "user".to_owned(),
-        rara_channels::web_reply_buffer::test_config(),
-    )
-    .with_reply_buffer(Arc::clone(&buffer));
+    let buffer = ReplyBuffer::new();
+    let adapter =
+        WebAdapter::new("tok".to_owned(), "user".to_owned()).with_reply_buffer(Arc::clone(&buffer));
 
     let session_key = SessionKey::new();
     let endpoint = web_endpoint(&session_key);

--- a/crates/channels/tests/web_e2e.rs
+++ b/crates/channels/tests/web_e2e.rs
@@ -126,11 +126,7 @@ async fn web_text_message_reaches_kernel() {
         .build()
         .await;
 
-    let adapter = WebAdapter::new(
-        "test-owner-token".to_owned(),
-        "test-user".to_owned(),
-        rara_channels::web_reply_buffer::test_config(),
-    );
+    let adapter = WebAdapter::new("test-owner-token".to_owned(), "test-user".to_owned());
     adapter
         .start(tk.handle.clone())
         .await
@@ -198,12 +194,8 @@ async fn web_audio_message_is_transcribed_via_stt() {
         .build()
         .await;
 
-    let adapter = WebAdapter::new(
-        "test-owner-token".to_owned(),
-        "test-user".to_owned(),
-        rara_channels::web_reply_buffer::test_config(),
-    )
-    .with_stt_service(Some(stt));
+    let adapter = WebAdapter::new("test-owner-token".to_owned(), "test-user".to_owned())
+        .with_stt_service(Some(stt));
     adapter
         .start(tk.handle.clone())
         .await

--- a/crates/channels/tests/web_ws_drain.rs
+++ b/crates/channels/tests/web_ws_drain.rs
@@ -79,14 +79,10 @@ where
 
 #[tokio::test]
 async fn ws_drains_backlog_before_live_events() {
-    let buffer = ReplyBuffer::new(rara_channels::web_reply_buffer::test_config());
+    let buffer = ReplyBuffer::new();
     let adapter = Arc::new(
-        WebAdapter::new(
-            OWNER_TOKEN.to_owned(),
-            OWNER_USER_ID.to_owned(),
-            rara_channels::web_reply_buffer::test_config(),
-        )
-        .with_reply_buffer(Arc::clone(&buffer)),
+        WebAdapter::new(OWNER_TOKEN.to_owned(), OWNER_USER_ID.to_owned())
+            .with_reply_buffer(Arc::clone(&buffer)),
     );
 
     // Mount the adapter under /chat to mirror production wiring.
@@ -173,7 +169,6 @@ async fn ws_rejects_invalid_owner_token() {
     let adapter = Arc::new(WebAdapter::new(
         OWNER_TOKEN.to_owned(),
         OWNER_USER_ID.to_owned(),
-        rara_channels::web_reply_buffer::test_config(),
     ));
     let app = axum::Router::new().nest("/chat", adapter.router());
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0")


### PR DESCRIPTION
## Summary

#1882 reintroduced `WebChannelConfig { reply_buffer: ReplyBufferConfig { capacity_events, capacity_bytes, ttl } }` as a required YAML field on `AppConfig`, reverting the explicit decision in #1831 that these are mechanism constants, not deployment configuration. Pre-#1882 `config.yaml` files now fail to boot with `missing configuration field "web"`, sending the gateway supervisor into a restart loop.

This PR restores #1831's design exactly:

- Delete `WebChannelConfig` from `crates/app/src/lib.rs` and `ReplyBufferConfig` from `crates/channels/src/web_reply_buffer.rs`.
- Move `capacity_events` (256), `capacity_bytes` (2 MiB), and `ttl` (5 min) into module-level `const` next to `ReplyBuffer` — values match the YAML defaults #1882 shipped, so the always-on bug fix from #1882 (per-session buffering with no-WS replay-on-reattach) keeps working unchanged.
- `ReplyBuffer::new()` and `WebAdapter::new()` lose the config args.
- Drop the `web:` block from `config.example.yaml` and from the `AppConfig` test fixtures in `lib.rs` / `config_sync.rs`.
- Remove the now-unused `humantime-serde` dep from `crates/channels/Cargo.toml`.

The bug-fix logic introduced by #1882 (per-session ring buffer + atomic `subscribe_and_drain` reattach) is fully preserved — only the YAML plumbing is reverted.

## Type of change

| Type | Label |
|------|-------|
| Bug fix | `bug` |

## Component

`backend`

## Closes

Closes #1907

## Test plan

- [x] `cargo check --workspace --all-targets` passes
- [x] `cargo +nightly fmt --all` clean
- [x] `cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings` clean
- [x] `prek run --all-files` passes
- [x] `cargo test -p rara-channels` passes (139 passed)
- [x] `cargo test -p rara-app` passes (83 passed)