### PR TITLE
ci(rust): cap nextest concurrency to fix slow CI test runs (#1911)

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,0 +1,20 @@
+# Nextest configuration.
+#
+# The `ci` profile is used by `.github/workflows/rust.yml` on the
+# `arc-runner-set` self-hosted runners. ARC pods report the underlying
+# node's `nproc` (often 16+) while having a much smaller cgroup CPU quota,
+# so nextest's default `test-threads = num_cpus` over-subscribes the pod —
+# individual tests get inflated wall-clock times (sub-second locally,
+# 50s+ on CI) and the multi-thread tokio runtimes inside each test compound
+# the starvation. See #1911.
+
+[profile.ci]
+# Cap parallel test processes to a value that comfortably fits within an
+# ARC pod's CPU quota. 4 keeps tokio worker threads (2-4 per test) within
+# the pod budget and eliminates the starvation-induced wall-clock blow-up.
+test-threads = 4
+
+# Surface accidentally-slow tests instead of letting them sit forever.
+# `terminate-after = 3` kills tests that exceed the period three times in a
+# row, so a hung test fails the run rather than burning the job timeout.
+slow-timeout = { period = "60s", terminate-after = 3 }

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -72,7 +72,7 @@ jobs:
         uses: rui314/setup-mold@9c9c13bf4c3f1adef0cc596abc155580bcb04444 # v1
 
       - name: Run tests
-        run: cargo nextest run --workspace
+        run: cargo nextest run --workspace --profile ci
 
       # Smoke-test the boxlite staging code path. With BOXLITE_DEPS_STUB=1
       # the build produces no real runtime files, so this is a dry-run


### PR DESCRIPTION
## Summary

On the `arc-runner-set` self-hosted runners, individual tests have been showing 50–69s wall-clock (e.g. `memory::service::tests::search_across_tapes_*`, `web_e2e::*`) while the same tests run in **~0.04s** locally. Total Summary on a recent CI run: **94.7s for 1051 tests** with two `web_e2e` flakes — the wall clock is dominated by oversubscription, not real test work.

Root cause: nextest defaults `test-threads = num_cpus`, but ARC pods report the underlying node's `nproc` (often 16+) while having a much smaller cgroup CPU quota. Each test process additionally spins a multi-thread tokio runtime → severe thread oversubscription and starvation.

This PR adds a `[profile.ci]` to a new `.config/nextest.toml` that caps `test-threads = 4` and surfaces hung tests via `slow-timeout`. The workflow switches to `--profile ci` so locally `just test` keeps full parallelism.

## Type of change

| Type | Label |
|------|-------|
| Maintenance / CI | `chore` |

## Component

`ci`

## Closes

Closes #1911

## Test plan

- [x] Verified `nextest profile: ci` loads when running with `--profile ci` (local)
- [x] Verified the targeted slow tests pass under the ci profile (`memory::service::tests::search_across_tapes_*` → 0.034s each)
- [x] Local full-workspace `cargo nextest run --workspace --all-features` still passes 1056 tests (default profile unchanged)
- [ ] CI green on this PR (validates the new profile path through the workflow)