### PR TITLE
ci(rust): remove sandbox-macos job (#1916)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,6 @@ jobs:
     runs-on: arc-runner-set
     outputs:
       code: ${{ steps.filter.outputs.code }}
-      sandbox: ${{ steps.filter.outputs.sandbox }}
     steps:
       - name: Checkout code
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
@@ -44,17 +43,6 @@ jobs:
               - 'rust-toolchain.toml'
               - '.github/workflows/rust.yml'
               - '.github/workflows/ci.yml'
-            # Narrow filter for the macOS-only sandbox-macos job, which
-            # natively builds boxlite (~minutes). On PRs that don't touch
-            # the sandbox crate or its dependency surface, the job is
-            # skipped entirely. Pushes to main always run it.
-            sandbox:
-              - 'crates/rara-sandbox/**'
-              - 'Cargo.toml'
-              - 'Cargo.lock'
-              - 'rust-toolchain.toml'
-              - '.github/workflows/rust.yml'
-              - '.github/workflows/ci.yml'
 
   lint:
     name: Lint
@@ -67,8 +55,6 @@ jobs:
     needs: changes
     if: ${{ needs.changes.outputs.code == 'true' || github.event_name == 'push' }}
     uses: ./.github/workflows/rust.yml
-    with:
-      run-sandbox-macos: ${{ needs.changes.outputs.sandbox == 'true' || github.event_name == 'push' }}
 
   release-pr:
     name: Release PR

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,7 @@ jobs:
     runs-on: arc-runner-set
     outputs:
       code: ${{ steps.filter.outputs.code }}
+      sandbox: ${{ steps.filter.outputs.sandbox }}
     steps:
       - name: Checkout code
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
@@ -43,6 +44,17 @@ jobs:
               - 'rust-toolchain.toml'
               - '.github/workflows/rust.yml'
               - '.github/workflows/ci.yml'
+            # Narrow filter for the macOS-only sandbox-macos job, which
+            # natively builds boxlite (~minutes). On PRs that don't touch
+            # the sandbox crate or its dependency surface, the job is
+            # skipped entirely. Pushes to main always run it.
+            sandbox:
+              - 'crates/rara-sandbox/**'
+              - 'Cargo.toml'
+              - 'Cargo.lock'
+              - 'rust-toolchain.toml'
+              - '.github/workflows/rust.yml'
+              - '.github/workflows/ci.yml'
 
   lint:
     name: Lint
@@ -55,6 +67,8 @@ jobs:
     needs: changes
     if: ${{ needs.changes.outputs.code == 'true' || github.event_name == 'push' }}
     uses: ./.github/workflows/rust.yml
+    with:
+      run-sandbox-macos: ${{ needs.changes.outputs.sandbox == 'true' || github.event_name == 'push' }}
 
   release-pr:
     name: Release PR

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -140,19 +140,6 @@ jobs:
         with:
           persist-credentials: false
 
-      # Cache cargo registry/git checkouts and the rara-sandbox `target/`
-      # subtree. The boxlite build script downloads ~tens of MB of
-      # `libkrunfw` prebuilts and natively compiles `bubblewrap-sys` /
-      # `libkrun-sys`; restoring those build outputs skips the slowest
-      # part of this job. Save only on `main` (default behavior of
-      # `Swatinem/rust-cache@v2`) to avoid PR-induced cache churn.
-      - name: Rust cache (sandbox-macos)
-        uses: Swatinem/rust-cache@98c8021b550208e191a6a3145459bfc9fb29c4c0 # v2.8.0
-        with:
-          shared-key: sandbox-macos
-          # Bust the cache when the boxlite/sandbox surface changes.
-          key: ${{ hashFiles('crates/rara-sandbox/Cargo.toml', 'Cargo.lock') }}
-
       - name: Build rara-sandbox (no stub)
         run: cargo build -p rara-sandbox
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -2,16 +2,6 @@ name: Rust
 
 on:
   workflow_call:
-    inputs:
-      # Caller (ci.yml) computes this from a path filter: false on PRs that
-      # don't touch the sandbox crate or its dependency surface, true on
-      # pushes to main. Defaults to true so direct invocations or future
-      # callers don't accidentally skip the macOS coverage.
-      run-sandbox-macos:
-        description: "Run the sandbox-macos job (slow real boxlite build)."
-        type: boolean
-        required: false
-        default: true
 
 concurrency:
   group: rust-${{ github.event.pull_request.number || github.sha }}
@@ -28,11 +18,11 @@ env:
   # so `rustc -vV` probes (notably `cargo +nightly doc`) time out trying to start a server.
   RUSTC_WRAPPER: ""
   # boxlite (rara-sandbox dep) builds bubblewrap + libkrun + libkrunfw natively.
-  # The Linux jobs below set `BOXLITE_DEPS_STUB: "1"` per-job because the
+  # All Linux jobs set `BOXLITE_DEPS_STUB: "1"` per-job because the
   # `arc-runner-set` image lacks meson/ninja/patchelf and cannot run a full
-  # native boxlite build. The dedicated `sandbox-macos` job builds boxlite
-  # for real on the self-hosted macOS runner so link-time / FFI / build.rs
-  # regressions in those crates are caught on every PR (issue #1842).
+  # native boxlite build. Real boxlite builds happen only on developer
+  # macOS machines today — see #1842 for the plan to add a CI job once a
+  # stable macOS (or properly-provisioned Linux) runner is available.
 
 defaults:
   run:
@@ -46,8 +36,8 @@ jobs:
     name: Clippy
     runs-on: arc-runner-set
     env:
-      # See top-of-file note: stub native boxlite build on Linux runners
-      # only; macOS runner builds for real in `sandbox-macos`.
+      # See top-of-file note: stub native boxlite build — ARC runners
+      # cannot do the real native build today.
       BOXLITE_DEPS_STUB: "1"
     steps:
       - name: Checkout code
@@ -70,8 +60,8 @@ jobs:
     name: Test
     runs-on: arc-runner-set
     env:
-      # See top-of-file note: stub native boxlite build on Linux runners
-      # only; macOS runner builds for real in `sandbox-macos`.
+      # See top-of-file note: stub native boxlite build — ARC runners
+      # cannot do the real native build today.
       BOXLITE_DEPS_STUB: "1"
     steps:
       - name: Checkout code
@@ -92,9 +82,8 @@ jobs:
 
       # Smoke-test the boxlite staging code path. With BOXLITE_DEPS_STUB=1
       # the build produces no real runtime files, so this is a dry-run
-      # (`--check`) that just exercises the path/permission logic. The
-      # macOS `sandbox-macos` job exercises the real staging path against
-      # a non-stub build.
+      # (`--check`) that just exercises the path/permission logic. Real
+      # staging is exercised on developer macOS machines today (#1842).
       - name: Smoke-test boxlite setup (dry-run)
         run: cargo run -p rara-cli -- setup boxlite --check
 
@@ -102,8 +91,8 @@ jobs:
     name: Documentation
     runs-on: arc-runner-set
     env:
-      # See top-of-file note: stub native boxlite build on Linux runners
-      # only; macOS runner builds for real in `sandbox-macos`.
+      # See top-of-file note: stub native boxlite build — ARC runners
+      # cannot do the real native build today.
       BOXLITE_DEPS_STUB: "1"
     steps:
       - name: Checkout code
@@ -124,41 +113,10 @@ jobs:
         env:
           RUSTDOCFLAGS: -D warnings
 
-  # Real boxlite build on the self-hosted macOS runner. This job intentionally
-  # does NOT set `BOXLITE_DEPS_STUB`, so `bubblewrap-sys` and `libkrun-sys`
-  # build natively — catching link-time / FFI / build.rs regressions that
-  # the stubbed Linux jobs cannot see (issue #1842). The runner label
-  # `macos` matches the `aarch64-apple-darwin` mapping in
-  # `Cargo.toml` (`workspace.metadata.dist.github-custom-runners`).
-  sandbox-macos:
-    name: Sandbox (macOS, real boxlite build)
-    runs-on: macos
-    if: ${{ inputs.run-sandbox-macos }}
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
-        with:
-          persist-credentials: false
-
-      - name: Build rara-sandbox (no stub)
-        run: cargo build -p rara-sandbox
-
-      # Compile the (#[ignore]d) integration test so we exercise the test
-      # binary's link path too. Running it would also need a warm OCI image
-      # cache, which CI does not provision — see crates/rara-sandbox/AGENT.md.
-      - name: Compile rara-sandbox tests (no run)
-        run: cargo test --no-run -p rara-sandbox
-
-      # Real staging: boxlite's build.rs has populated
-      # target/debug/build/boxlite-*/out/runtime/, so this copies the
-      # runtime files into the platform user-data directory for real.
-      - name: Stage boxlite runtime files
-        run: cargo run -p rara-cli -- setup boxlite
-
   rust-success:
     name: Rust Success
     runs-on: arc-runner-set
-    needs: [clippy, test, docs, sandbox-macos]
+    needs: [clippy, test, docs]
     if: always()
     steps:
       - name: Check all Rust jobs status
@@ -166,20 +124,14 @@ jobs:
           CLIPPY_RESULT: ${{ needs.clippy.result }}
           TEST_RESULT: ${{ needs.test.result }}
           DOCS_RESULT: ${{ needs.docs.result }}
-          SANDBOX_MACOS_RESULT: ${{ needs.sandbox-macos.result }}
         run: |
-          # `sandbox-macos` is gated by a path filter and may legitimately
-          # report `skipped` on PRs that don't touch the sandbox crate —
-          # treat that as success here so the gate doesn't block merges.
           if [[ "$CLIPPY_RESULT" != "success" || \
                 "$TEST_RESULT" != "success" || \
-                "$DOCS_RESULT" != "success" || \
-                ( "$SANDBOX_MACOS_RESULT" != "success" && "$SANDBOX_MACOS_RESULT" != "skipped" ) ]]; then
+                "$DOCS_RESULT" != "success" ]]; then
             echo "One or more Rust jobs failed"
-            echo "  clippy:        $CLIPPY_RESULT"
-            echo "  test:          $TEST_RESULT"
-            echo "  docs:          $DOCS_RESULT"
-            echo "  sandbox-macos: $SANDBOX_MACOS_RESULT"
+            echo "  clippy: $CLIPPY_RESULT"
+            echo "  test:   $TEST_RESULT"
+            echo "  docs:   $DOCS_RESULT"
             exit 1
           fi
           echo "All Rust jobs passed successfully"

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -2,6 +2,16 @@ name: Rust
 
 on:
   workflow_call:
+    inputs:
+      # Caller (ci.yml) computes this from a path filter: false on PRs that
+      # don't touch the sandbox crate or its dependency surface, true on
+      # pushes to main. Defaults to true so direct invocations or future
+      # callers don't accidentally skip the macOS coverage.
+      run-sandbox-macos:
+        description: "Run the sandbox-macos job (slow real boxlite build)."
+        type: boolean
+        required: false
+        default: true
 
 concurrency:
   group: rust-${{ github.event.pull_request.number || github.sha }}
@@ -123,11 +133,25 @@ jobs:
   sandbox-macos:
     name: Sandbox (macOS, real boxlite build)
     runs-on: macos
+    if: ${{ inputs.run-sandbox-macos }}
     steps:
       - name: Checkout code
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
         with:
           persist-credentials: false
+
+      # Cache cargo registry/git checkouts and the rara-sandbox `target/`
+      # subtree. The boxlite build script downloads ~tens of MB of
+      # `libkrunfw` prebuilts and natively compiles `bubblewrap-sys` /
+      # `libkrun-sys`; restoring those build outputs skips the slowest
+      # part of this job. Save only on `main` (default behavior of
+      # `Swatinem/rust-cache@v2`) to avoid PR-induced cache churn.
+      - name: Rust cache (sandbox-macos)
+        uses: Swatinem/rust-cache@98c8021b550208e191a6a3145459bfc9fb29c4c0 # v2.8.0
+        with:
+          shared-key: sandbox-macos
+          # Bust the cache when the boxlite/sandbox surface changes.
+          key: ${{ hashFiles('crates/rara-sandbox/Cargo.toml', 'Cargo.lock') }}
 
       - name: Build rara-sandbox (no stub)
         run: cargo build -p rara-sandbox
@@ -157,10 +181,13 @@ jobs:
           DOCS_RESULT: ${{ needs.docs.result }}
           SANDBOX_MACOS_RESULT: ${{ needs.sandbox-macos.result }}
         run: |
+          # `sandbox-macos` is gated by a path filter and may legitimately
+          # report `skipped` on PRs that don't touch the sandbox crate —
+          # treat that as success here so the gate doesn't block merges.
           if [[ "$CLIPPY_RESULT" != "success" || \
                 "$TEST_RESULT" != "success" || \
                 "$DOCS_RESULT" != "success" || \
-                "$SANDBOX_MACOS_RESULT" != "success" ]]; then
+                ( "$SANDBOX_MACOS_RESULT" != "success" && "$SANDBOX_MACOS_RESULT" != "skipped" ) ]]; then
             echo "One or more Rust jobs failed"
             echo "  clippy:        $CLIPPY_RESULT"
             echo "  test:          $TEST_RESULT"

--- a/docs/guides/boxlite-runtime.md
+++ b/docs/guides/boxlite-runtime.md
@@ -60,8 +60,8 @@ so the `rara setup boxlite --check` smoke step exercises only the
 path-resolution code and exits cleanly with "no boxlite build artifacts
 found".
 
-The dedicated `sandbox-macos` job runs WITHOUT the stub on the
-self-hosted macOS runner — `cargo build -p rara-sandbox` and
-`cargo run -p rara-cli -- setup boxlite` execute against a real boxlite
-build, so link-time / FFI / `build.rs` regressions are caught on every
-PR (#1842).
+There is no CI job that builds boxlite without the stub today. The
+self-hosted macOS runner introduced in #1842 was removed in #1916
+because its network reachability was too unreliable to gate every PR
+on. Real boxlite builds happen only on developer macOS machines until
+a stable runner is provisioned — see #1842 for the long-term plan.


### PR DESCRIPTION
## Summary

The macOS self-hosted runner introduced in #1842 has been too unreliable to gate every PR on:
- Two consecutive runs in this PR failed at `actions/checkout` with HTTP/2 framing errors and 443 timeouts (the macOS runner can't consistently reach github.com).
- The first attempt added `Swatinem/rust-cache` to amortize boxlite's native build; CI measured the post-step cache upload at **~17min** — worse than the rebuild it was meant to skip.

This PR drops the `sandbox-macos` job entirely. The Linux `clippy` / `test` / `docs` jobs already cover the Rust surface under `BOXLITE_DEPS_STUB="1"`. Real boxlite builds happen on developer macOS machines today; #1842 stays open as the plan for a future stable runner.

Reverts the path filter + `workflow_call` input added earlier in this branch (no longer needed). Updates `docs/guides/boxlite-runtime.md` to match.

## Type of change

| Type | Label |
|------|-------|
| Maintenance / CI | `chore` |

## Component

`ci`

## Closes

Closes #1916

## Test plan

- [x] `rust-success` deps no longer reference `sandbox-macos`
- [x] `ci.yml` no longer references the removed `sandbox` filter or `run-sandbox-macos` input
- [x] `docs/guides/boxlite-runtime.md` updated
- [ ] CI green on this PR (Linux jobs only)