### PR TITLE
fix(web): unify WS base URL resolution across chat + session-events (#1921)

### DIFF
--- a/web/src/adapters/__tests__/ws-base-url.test.ts
+++ b/web/src/adapters/__tests__/ws-base-url.test.ts
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2025 Rararulab
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const STORAGE_KEY = 'rara_backend_url';
+
+// Node 22+ exposes a built-in `globalThis.localStorage` that shadows jsdom's
+// implementation and lacks `setItem`/`getItem` unless launched with
+// `--localstorage-file`. Tests here stub a minimal in-memory Storage so
+// `buildWsBaseUrl`'s override probe runs against predictable state regardless
+// of the host Node version.
+function installLocalStorageStub() {
+  const store = new Map<string, string>();
+  const stub = {
+    getItem: (k: string) => (store.has(k) ? store.get(k)! : null),
+    setItem: (k: string, v: string) => {
+      store.set(k, String(v));
+    },
+    removeItem: (k: string) => {
+      store.delete(k);
+    },
+    clear: () => store.clear(),
+    key: (i: number) => Array.from(store.keys())[i] ?? null,
+    get length() {
+      return store.size;
+    },
+  };
+  vi.stubGlobal('localStorage', stub);
+  Object.defineProperty(window, 'localStorage', { value: stub, configurable: true });
+}
+
+describe('buildWsBaseUrl — shared WS base URL resolver (#1921)', () => {
+  beforeEach(() => {
+    installLocalStorageStub();
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    localStorage.removeItem(STORAGE_KEY);
+    vi.unstubAllGlobals();
+    vi.doUnmock('@/api/client');
+  });
+
+  it('falls back to window.location when no override or BASE_URL is set', async () => {
+    vi.doMock('@/api/client', () => ({
+      BASE_URL: '',
+      getBackendUrl: () => 'http://localhost:25555',
+    }));
+    const { buildWsBaseUrl } = await import('../ws-base-url');
+
+    const loc = window.location;
+    const proto = loc.protocol === 'https:' ? 'wss:' : 'ws:';
+    expect(buildWsBaseUrl()).toBe(`${proto}//${loc.host}`);
+  });
+
+  it('honors rara_backend_url override (http -> ws)', async () => {
+    vi.doMock('@/api/client', () => ({
+      BASE_URL: '',
+      getBackendUrl: () => 'http://10.0.0.183:25555',
+    }));
+    localStorage.setItem(STORAGE_KEY, 'http://10.0.0.183:25555');
+    const { buildWsBaseUrl } = await import('../ws-base-url');
+
+    expect(buildWsBaseUrl()).toBe('ws://10.0.0.183:25555');
+  });
+
+  it('strips a trailing slash from the override URL', async () => {
+    vi.doMock('@/api/client', () => ({
+      BASE_URL: '',
+      getBackendUrl: () => 'https://backend.example.com/',
+    }));
+    localStorage.setItem(STORAGE_KEY, 'https://backend.example.com/');
+    const { buildWsBaseUrl } = await import('../ws-base-url');
+
+    expect(buildWsBaseUrl()).toBe('wss://backend.example.com');
+  });
+
+  it('honors compile-time BASE_URL when no override is set', async () => {
+    vi.doMock('@/api/client', () => ({
+      BASE_URL: 'https://prod.example.com',
+      getBackendUrl: () => 'http://localhost:25555',
+    }));
+    const { buildWsBaseUrl } = await import('../ws-base-url');
+
+    expect(buildWsBaseUrl()).toBe('wss://prod.example.com');
+  });
+});

--- a/web/src/adapters/rara-stream.ts
+++ b/web/src/adapters/rara-stream.ts
@@ -31,13 +31,9 @@ import type { AssistantMessageEventStream } from '@mariozechner/pi-ai';
 import type { Attachment } from '@mariozechner/pi-web-ui';
 import { Type } from '@sinclair/typebox';
 
-import {
-  BASE_URL,
-  getAccessToken,
-  getAuthUser,
-  getBackendUrl,
-  redirectToLogin,
-} from '@/api/client';
+import { buildWsBaseUrl } from './ws-base-url';
+
+import { getAccessToken, getAuthUser, redirectToLogin } from '@/api/client';
 
 // ---------------------------------------------------------------------------
 // WebEvent — frames received from the rara WebSocket chat API
@@ -211,34 +207,13 @@ function buildPartial(
 }
 
 /**
- * Derive the WebSocket URL from the configured API base URL.
+ * Derive the chat WebSocket URL using the shared base-URL resolver.
  *
- * Resolution order mirrors REST (`resolveUrl` in `api/client.ts`):
- * 1. If the user has set a custom `rara_backend_url` in localStorage we
- *    derive WS from that host so REST and WS target the same backend.
- *    Without this, REST follows the override but WS always fell back to
- *    `window.location`, producing "WebSocket connection error" whenever
- *    the override pointed at a remote backend (issue #1622).
- * 2. Otherwise honour an explicit compile-time `BASE_URL`.
- * 3. Otherwise derive from the current page (Vite dev proxy path).
+ * See `buildWsBaseUrl` for the resolution order; this function just appends
+ * the chat path and auth query parameters.
  */
 export function buildWsUrl(sessionKey: string): string {
-  let base: string;
-
-  const override = typeof window !== 'undefined' ? localStorage.getItem('rara_backend_url') : null;
-
-  if (override) {
-    base = getBackendUrl().replace(/^http/, 'ws');
-  } else if ((BASE_URL as string).length > 0) {
-    base = (BASE_URL as string).replace(/^http/, 'ws');
-  } else {
-    const loc = window.location;
-    const proto = loc.protocol === 'https:' ? 'wss:' : 'ws:';
-    base = `${proto}//${loc.host}`;
-  }
-
-  // Strip trailing slash so the joined path has exactly one separator.
-  base = base.replace(/\/$/, '');
+  const base = buildWsBaseUrl();
 
   const user = getAuthUser();
   if (!user) {

--- a/web/src/adapters/ws-base-url.ts
+++ b/web/src/adapters/ws-base-url.ts
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2025 Rararulab
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { BASE_URL, getBackendUrl } from '@/api/client';
+
+/**
+ * Resolve the WebSocket base URL (scheme + host, no trailing slash) used by
+ * every WS endpoint in the app.
+ *
+ * Resolution order mirrors REST (`resolveUrl` in `api/client.ts`):
+ * 1. If the user has set a custom `rara_backend_url` in localStorage we
+ *    derive WS from that host so REST and WS target the same backend.
+ *    Without this, REST follows the override but WS always fell back to
+ *    `window.location`, producing "WebSocket connection error" whenever
+ *    the override pointed at a remote backend (issue #1622, #1921).
+ * 2. Otherwise honour an explicit compile-time `BASE_URL`.
+ * 3. Otherwise derive from the current page (Vite dev proxy path).
+ *
+ * Returns the WS-scheme prefix WITHOUT a trailing slash, e.g.
+ * `ws://10.0.0.183:25555` or `wss://backend.example.com`.
+ */
+export function buildWsBaseUrl(): string {
+  let base: string;
+
+  const override = typeof window !== 'undefined' ? localStorage.getItem('rara_backend_url') : null;
+
+  if (override) {
+    base = getBackendUrl().replace(/^http/, 'ws');
+  } else if ((BASE_URL as string).length > 0) {
+    base = (BASE_URL as string).replace(/^http/, 'ws');
+  } else {
+    const loc = window.location;
+    const proto = loc.protocol === 'https:' ? 'wss:' : 'ws:';
+    base = `${proto}//${loc.host}`;
+  }
+
+  // Strip trailing slash so the joined path has exactly one separator.
+  return base.replace(/\/$/, '');
+}

--- a/web/src/hooks/__tests__/use-session-events.test.tsx
+++ b/web/src/hooks/__tests__/use-session-events.test.tsx
@@ -23,6 +23,10 @@ vi.mock('@/api/client', () => ({
   getAccessToken: () => 'test-token',
 }));
 
+vi.mock('@/adapters/ws-base-url', () => ({
+  buildWsBaseUrl: () => 'ws://localhost:5173',
+}));
+
 interface MockWebSocket {
   url: string;
   onopen: ((ev: Event) => void) | null;

--- a/web/src/hooks/use-session-events.ts
+++ b/web/src/hooks/use-session-events.ts
@@ -16,6 +16,7 @@
 
 import { useEffect, useRef } from 'react';
 
+import { buildWsBaseUrl } from '@/adapters/ws-base-url';
 import { getAccessToken } from '@/api/client';
 
 /**
@@ -72,9 +73,8 @@ export function useSessionEvents({ sessionKey, onTapeAppended }: UseSessionEvent
       const token = getAccessToken();
       if (!token) return;
 
-      const host = window.location.host;
-      const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
-      const url = `${protocol}//${host}/api/v1/kernel/chat/events/${encodeURIComponent(
+      const base = buildWsBaseUrl();
+      const url = `${base}/api/v1/kernel/chat/events/${encodeURIComponent(
         sessionKey,
       )}?token=${encodeURIComponent(token)}`;
 


### PR DESCRIPTION
## Summary

`web/src/hooks/use-session-events.ts` built its WebSocket URL from `window.location`, ignoring both the `rara_backend_url` localStorage override and the compile-time `BASE_URL`. Meanwhile `web/src/adapters/rara-stream.ts` (`buildWsUrl`) handled all three cases. Two WS endpoints disagreed on host whenever a custom backend URL was configured.

This PR extracts the base-URL resolution into a shared helper `web/src/adapters/ws-base-url.ts` (`buildWsBaseUrl()` returning the WS-scheme prefix without trailing slash) and uses it from both call sites. Auth-token logic is unchanged.

## Type of change

| Type | Label |
|------|-------|
| Bug fix | \`bug\` |

## Component

\`ui\`

## Closes

Closes #1921

## Test plan

- [x] New unit tests in \`ws-base-url.test.ts\` cover localStorage override, BASE_URL set, window.location fallback, trailing-slash stripping
- [x] \`npm test -- --run\` passes (114 tests)
- [x] \`npm run typecheck\` passes
- [x] \`npm run build\` passes