### PR TITLE
fix(web): bound session-events WS reconnect attempts (#1922)

### DIFF
--- a/web/src/hooks/__tests__/use-session-events.test.tsx
+++ b/web/src/hooks/__tests__/use-session-events.test.tsx
@@ -15,6 +15,7 @@
  */
 
 import { renderHook } from '@testing-library/react';
+import { act } from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { useSessionEvents } from '../use-session-events';
@@ -33,6 +34,7 @@ interface MockWebSocket {
 }
 
 let lastSocket: MockWebSocket | null = null;
+const sockets: MockWebSocket[] = [];
 
 class FakeWebSocket implements MockWebSocket {
   url: string;
@@ -46,6 +48,7 @@ class FakeWebSocket implements MockWebSocket {
     this.url = url;
     // eslint-disable-next-line @typescript-eslint/no-this-alias
     lastSocket = this;
+    sockets.push(this);
   }
 
   close() {
@@ -56,6 +59,8 @@ class FakeWebSocket implements MockWebSocket {
 describe('useSessionEvents', () => {
   beforeEach(() => {
     lastSocket = null;
+    sockets.length = 0;
+    vi.useFakeTimers();
     Object.defineProperty(globalThis, 'WebSocket', {
       writable: true,
       configurable: true,
@@ -71,6 +76,7 @@ describe('useSessionEvents', () => {
   });
 
   afterEach(() => {
+    vi.useRealTimers();
     vi.restoreAllMocks();
   });
 
@@ -121,5 +127,98 @@ describe('useSessionEvents', () => {
     const onTapeAppended = vi.fn();
     renderHook(() => useSessionEvents({ sessionKey: null, onTapeAppended }));
     expect(lastSocket).toBeNull();
+  });
+
+  it('stops reconnecting after the retry budget is exhausted', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const onTapeAppended = vi.fn();
+    renderHook(() => useSessionEvents({ sessionKey: 'sess-abc', onTapeAppended }));
+
+    // Initial connect + 5 retries = 6 sockets total. The 6th close exhausts.
+    for (let i = 0; i < 6; i += 1) {
+      const sock = lastSocket!;
+      act(() => {
+        sock.onclose?.(new CloseEvent('close'));
+      });
+      act(() => {
+        vi.runOnlyPendingTimers();
+      });
+    }
+
+    expect(sockets.length).toBe(6);
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('resets the retry budget when a hello frame arrives', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const onTapeAppended = vi.fn();
+    renderHook(() => useSessionEvents({ sessionKey: 'sess-abc', onTapeAppended }));
+
+    // Burn 4 of the 5 retries with immediate closes.
+    for (let i = 0; i < 4; i += 1) {
+      const sock = lastSocket!;
+      act(() => {
+        sock.onclose?.(new CloseEvent('close'));
+      });
+      act(() => {
+        vi.runOnlyPendingTimers();
+      });
+    }
+    // 5 sockets so far (1 initial + 4 retries).
+    expect(sockets.length).toBe(5);
+
+    // Hello frame on the live socket resets the budget.
+    act(() => {
+      lastSocket!.onmessage?.(
+        new MessageEvent('message', { data: JSON.stringify({ type: 'hello' }) }),
+      );
+    });
+
+    // Now we should be able to absorb a full new budget of 5 retries.
+    for (let i = 0; i < 5; i += 1) {
+      const sock = lastSocket!;
+      act(() => {
+        sock.onclose?.(new CloseEvent('close'));
+      });
+      act(() => {
+        vi.runOnlyPendingTimers();
+      });
+    }
+    expect(sockets.length).toBe(10); // 5 pre-hello + 5 post-hello retries.
+    expect(warnSpy).not.toHaveBeenCalled();
+
+    // One more close past the new budget triggers the warn.
+    act(() => {
+      lastSocket!.onclose?.(new CloseEvent('close'));
+    });
+    act(() => {
+      vi.runOnlyPendingTimers();
+    });
+    expect(sockets.length).toBe(10);
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('cancels pending retries when sessionKey changes', () => {
+    const onTapeAppended = vi.fn();
+    const { rerender } = renderHook(
+      ({ key }: { key: string | null }) => useSessionEvents({ sessionKey: key, onTapeAppended }),
+      { initialProps: { key: 'sess-abc' as string | null } },
+    );
+
+    // Trigger a close so a retry is queued for sess-abc.
+    act(() => {
+      lastSocket!.onclose?.(new CloseEvent('close'));
+    });
+    const beforeSwitch = sockets.length;
+
+    // Switch session — the queued retry must NOT fire for sess-abc.
+    rerender({ key: 'sess-xyz' });
+    act(() => {
+      vi.runOnlyPendingTimers();
+    });
+
+    // After rerender, exactly one new socket opens for sess-xyz.
+    expect(sockets.length).toBe(beforeSwitch + 1);
+    expect(lastSocket!.url).toContain('sess-xyz');
   });
 });

--- a/web/src/hooks/use-session-events.ts
+++ b/web/src/hooks/use-session-events.ts
@@ -38,17 +38,24 @@ export interface UseSessionEventsOptions {
   onTapeAppended: (event: { entry_id: number; role: string | null; timestamp: string }) => void;
 }
 
-const INITIAL_BACKOFF_MS = 1_000;
-const MAX_BACKOFF_MS = 30_000;
+// Mechanism-tuning constants — internal knobs, not deploy-relevant config.
+// Aligned with `rara-stream.ts`: bounded retry budget so a permanently dead
+// backend cannot spin reconnect attempts forever.
+const RECONNECT_BACKOFF_MS = [250, 500, 1_000, 2_000, 4_000] as const;
+const MAX_RECONNECT_ATTEMPTS = RECONNECT_BACKOFF_MS.length;
 
 /**
  * Maintain a persistent WebSocket subscription to the kernel's session
  * event bus so the UI sees tape mutations that arrive outside a live
  * user turn (background-task summaries, scheduled re-entries, …).
  *
- * Reconnects with capped exponential backoff. Lifecycle is tied to
- * `sessionKey`: switching sessions closes the old socket and opens a
- * new one; setting `sessionKey` to `null` closes the socket cleanly.
+ * Reconnects with a bounded retry budget ({@link MAX_RECONNECT_ATTEMPTS}).
+ * The backend may close a socket immediately after `onopen` (before the
+ * `Hello` frame) when the kernel handle is not yet attached, so the retry
+ * counter is reset only on receipt of a `Hello` frame — `onopen` alone is
+ * not proof of a live connection. Lifecycle is tied to `sessionKey`:
+ * switching sessions closes the old socket and opens a new one; setting
+ * `sessionKey` to `null` closes the socket cleanly.
  */
 export function useSessionEvents({ sessionKey, onTapeAppended }: UseSessionEventsOptions): void {
   // Stable ref so the effect does not re-subscribe when callers pass a
@@ -62,7 +69,7 @@ export function useSessionEvents({ sessionKey, onTapeAppended }: UseSessionEvent
   useEffect(() => {
     if (!sessionKey) return;
 
-    let backoff = INITIAL_BACKOFF_MS;
+    let attempts = 0;
     let cancelled = false;
     let ws: WebSocket | null = null;
     let retryTimer: ReturnType<typeof setTimeout> | null = null;
@@ -80,15 +87,17 @@ export function useSessionEvents({ sessionKey, onTapeAppended }: UseSessionEvent
 
       ws = new WebSocket(url);
 
-      ws.onopen = () => {
-        backoff = INITIAL_BACKOFF_MS;
-      };
-
       ws.onmessage = (ev) => {
         let frame: SessionEventFrame;
         try {
           frame = JSON.parse(ev.data) as SessionEventFrame;
         } catch {
+          return;
+        }
+        if (frame.type === 'hello') {
+          // Hello is the only signal the connection is truly alive — backend
+          // can early-close after `onopen` if the kernel handle is missing.
+          attempts = 0;
           return;
         }
         if (frame.type === 'tape_appended') {
@@ -107,8 +116,14 @@ export function useSessionEvents({ sessionKey, onTapeAppended }: UseSessionEvent
       ws.onclose = () => {
         ws = null;
         if (cancelled) return;
-        const delay = backoff;
-        backoff = Math.min(backoff * 2, MAX_BACKOFF_MS);
+        if (attempts >= MAX_RECONNECT_ATTEMPTS) {
+          console.warn(
+            `[useSessionEvents] giving up after ${MAX_RECONNECT_ATTEMPTS} reconnect attempts for session ${sessionKey}`,
+          );
+          return;
+        }
+        const delay = RECONNECT_BACKOFF_MS[attempts];
+        attempts += 1;
         retryTimer = setTimeout(connect, delay);
       };
     };


### PR DESCRIPTION
## Summary

The session-events WebSocket hook reconnected forever with exponential backoff, and reset the backoff on `onopen`. The backend (`crates/channels/src/web_session_events.rs`) has an early-close path between accept and the `Hello` frame when the kernel handle is missing, so a dead socket still tripped `onopen` and the next `onclose` simply grew the next delay — leading to unbounded retry storms.

This PR mirrors the bounded retry strategy already in `rara-stream.ts`:

- Cap reconnect attempts at 5 with a fixed backoff array `[250, 500, 1000, 2000, 4000]` ms (mechanism constants, kept as `const` per anti-patterns guide — not YAML).
- Treat the `Hello` frame, not `onopen`, as the "connection alive" signal that resets the retry budget.
- After exhausting the budget, log a single `console.warn` and stop. No UI failure callback — the only consumer (`PiChat.tsx`) wants pure side-effect behaviour.

## Type of change

| Type | Label |
|------|-------|
| Bug fix | `bug` |

## Component

`ui`

## Closes

Closes #1922

## Test plan

- [x] New unit tests cover budget exhaustion, Hello frame resets budget, sessionKey change cancels pending retries
- [x] `npm test` passes (113/113)
- [x] `npm run build` passes
- [x] `npx tsc --noEmit` passes