### PR TITLE
fix(web): gate tape_appended reload on chat WS lifecycle (#1923)

### DIFF
--- a/web/src/lib/__tests__/tape-reload-gate.test.ts
+++ b/web/src/lib/__tests__/tape-reload-gate.test.ts
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2025 Rararulab
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+
+import { TapeReloadGate } from '../tape-reload-gate';
+
+describe('TapeReloadGate', () => {
+  it('reloads immediately when no chat WS turn is in flight', () => {
+    const reload = vi.fn();
+    const gate = new TapeReloadGate({ reload });
+
+    gate.onTapeAppended();
+    gate.onTapeAppended();
+
+    expect(reload).toHaveBeenCalledTimes(2);
+  });
+
+  it('drops tape_appended events while a turn is in flight (chat WS owns content)', () => {
+    const reload = vi.fn();
+    const gate = new TapeReloadGate({ reload });
+
+    gate.onStreamStarted();
+    gate.onTapeAppended(); // user message persisted
+    gate.onTapeAppended(); // assistant message persisted
+    expect(reload).not.toHaveBeenCalled();
+  });
+
+  it('flushes one reload on stream close when events were queued', () => {
+    const reload = vi.fn();
+    const gate = new TapeReloadGate({ reload });
+
+    gate.onStreamStarted();
+    gate.onTapeAppended();
+    gate.onTapeAppended();
+    gate.onStreamClosed();
+
+    expect(reload).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not reload on stream close if no events were queued', () => {
+    const reload = vi.fn();
+    const gate = new TapeReloadGate({ reload });
+
+    gate.onStreamStarted();
+    gate.onStreamClosed();
+
+    expect(reload).not.toHaveBeenCalled();
+  });
+
+  it('reloads normally after a turn ends', () => {
+    const reload = vi.fn();
+    const gate = new TapeReloadGate({ reload });
+
+    gate.onStreamStarted();
+    gate.onStreamClosed();
+    expect(reload).not.toHaveBeenCalled();
+
+    // Background-task summary lands later — should reload as before.
+    gate.onTapeAppended();
+    expect(reload).toHaveBeenCalledTimes(1);
+  });
+
+  it('treats a spurious close (no started) as a no-op', () => {
+    const reload = vi.fn();
+    const gate = new TapeReloadGate({ reload });
+
+    gate.onStreamClosed();
+    expect(reload).not.toHaveBeenCalled();
+
+    gate.onTapeAppended();
+    expect(reload).toHaveBeenCalledTimes(1);
+  });
+
+  it('handles back-to-back turns independently', () => {
+    const reload = vi.fn();
+    const gate = new TapeReloadGate({ reload });
+
+    // Turn 1 — events queued, one flush.
+    gate.onStreamStarted();
+    gate.onTapeAppended();
+    gate.onStreamClosed();
+    expect(reload).toHaveBeenCalledTimes(1);
+
+    // Turn 2 — no events, no flush.
+    gate.onStreamStarted();
+    gate.onStreamClosed();
+    expect(reload).toHaveBeenCalledTimes(1);
+
+    // Turn 3 — events queued again, second flush.
+    gate.onStreamStarted();
+    gate.onTapeAppended();
+    gate.onStreamClosed();
+    expect(reload).toHaveBeenCalledTimes(2);
+  });
+});

--- a/web/src/lib/tape-reload-gate.ts
+++ b/web/src/lib/tape-reload-gate.ts
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2025 Rararulab
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Decides when a `tape_appended` server event should trigger a full
+ * `reloadMessages()` of the active session.
+ *
+ * The chat WebSocket (`createRaraStreamFn`) is the source of truth while
+ * a turn is in flight: it streams the assistant's text directly into
+ * pi-agent-core's message buffer. If `tape_appended` fires during that
+ * window — which happens for the user's own message as soon as the
+ * kernel persists it, and again for the assistant message right after
+ * `done` — and the React layer reacts by calling
+ * `agent.replaceMessages` + `reconstructFromMessages`, the in-flight WS
+ * content is clobbered. The user sees a blank turn even though the
+ * backend has the full reply persisted (#1877, #1923).
+ *
+ * Driving the gate from `agent.state.isStreaming` was insufficient
+ * because pi-agent-core only flips `isStreaming = true` on the first
+ * stream event, leaving a race window between submit and first event.
+ * The chat WS adapter, by contrast, emits explicit lifecycle frames
+ * (`__stream_started` / `__stream_closed` / `__stream_reconnect_failed`)
+ * that bracket the entire turn.
+ *
+ * Rules:
+ * 1. Outside an in-flight turn, every `tape_appended` reloads — that's
+ *    the original `useSessionEvents` contract for background-task
+ *    summaries.
+ * 2. `tape_appended` events arriving while a turn is in flight are
+ *    dropped: the chat WS already owns the rendered content.
+ * 3. If at least one `tape_appended` fired during the in-flight window,
+ *    a single reload is flushed when the turn closes. This catches
+ *    background-task summaries that happened to land mid-turn.
+ */
+export interface TapeReloadGateCallbacks {
+  /** Invoked when the gate decides a reload should happen. */
+  reload: () => void;
+}
+
+export class TapeReloadGate {
+  private inFlight = false;
+  private pending = false;
+  private readonly callbacks: TapeReloadGateCallbacks;
+
+  constructor(callbacks: TapeReloadGateCallbacks) {
+    this.callbacks = callbacks;
+  }
+
+  /** Mark the chat WS turn boundary open. Idempotent. */
+  onStreamStarted(): void {
+    this.inFlight = true;
+  }
+
+  /**
+   * Mark the chat WS turn boundary closed. Flushes a single reload if
+   * any `tape_appended` events were skipped during the window. Idempotent.
+   */
+  onStreamClosed(): void {
+    if (!this.inFlight) {
+      // Spurious close (e.g. duplicate lifecycle frame) — nothing to do.
+      this.pending = false;
+      return;
+    }
+    this.inFlight = false;
+    if (this.pending) {
+      this.pending = false;
+      this.callbacks.reload();
+    }
+  }
+
+  /**
+   * Decide whether a `tape_appended` event should reload now. When a
+   * turn is in flight, defers to {@link onStreamClosed}.
+   */
+  onTapeAppended(): void {
+    if (this.inFlight) {
+      this.pending = true;
+      return;
+    }
+    this.callbacks.reload();
+  }
+}

--- a/web/src/pages/PiChat.tsx
+++ b/web/src/pages/PiChat.tsx
@@ -79,6 +79,7 @@ import { useLiveCardHeight } from '@/hooks/use-live-card-height';
 import { useSessionDelete } from '@/hooks/use-session-delete';
 import { useSessionEvents } from '@/hooks/use-session-events';
 import { UNKNOWN_MODEL_SENTINEL, isUnknownModel, syntheticModel } from '@/lib/synthetic-model';
+import { TapeReloadGate } from '@/lib/tape-reload-gate';
 import { renderTurnChipCard } from '@/tools/turn-chip-card';
 const ACTIVE_SESSION_KEY = 'rara.activeSessionKey';
 
@@ -339,6 +340,21 @@ export default function PiChat() {
   // from the pre-#1554 selector). `null` = not yet loaded; we fail-open
   // in that window so the restore isn't blocked on an unrelated fetch.
   const validProvidersRef = useRef<Set<string> | null>(null);
+  // Holds the latest `reloadMessages` closure so the long-lived gate can
+  // call into it without the gate being recreated on every render.
+  const reloadMessagesRef = useRef<(() => Promise<void>) | null>(null);
+  // Gate for `tape_appended` server events. Driven by the chat WS adapter's
+  // `__stream_started` / `__stream_closed` lifecycle frames so reloads
+  // never clobber in-flight assistant text. See `TapeReloadGate` for the
+  // full reasoning (#1877, #1923).
+  const tapeReloadGateRef = useRef<TapeReloadGate | null>(null);
+  if (!tapeReloadGateRef.current) {
+    tapeReloadGateRef.current = new TapeReloadGate({
+      reload: () => {
+        void reloadMessagesRef.current?.();
+      },
+    });
+  }
   // Guards against double-invocations of `handleUseDefault` while a PATCH
   // + settings fetch is still in flight. Backend no-ops the duplicate
   // write (see #1569 round-1 fix) but the UI would still redundantly
@@ -618,6 +634,10 @@ export default function PiChat() {
     }
   }, []);
 
+  // Wire the latest `reloadMessages` closure into the ref the
+  // long-lived `TapeReloadGate` calls into.
+  reloadMessagesRef.current = reloadMessages;
+
   /** Create a new empty session and switch to it. */
   const newSession = useCallback(async () => {
     const created = await api.post<ChatSession>('/api/v1/chat/sessions', {});
@@ -641,19 +661,18 @@ export default function PiChat() {
   // future scheduled re-entries — refresh the chat without a manual
   // refresh.
   //
-  // Skip while the agent is mid-turn: the kernel publishes
-  // `tape_appended` for the user's own message as soon as it persists
-  // (before the assistant has produced anything), and reloading then
-  // calls `agent.replaceMessages` + `reconstructFromMessages` while the
-  // chat-stream WebSocket is still open. That mutation kills the
-  // in-flight chat WS, the live card sees a content-empty close and
-  // synthesizes `stopReason='error'`, and the assistant turn only
-  // surfaces after a manual page refresh (#1877).
+  // The decision of "is it safe to reload" is delegated to
+  // `TapeReloadGate`, which is fed by the chat WS adapter's
+  // `__stream_started` / `__stream_closed` lifecycle frames in
+  // `onWebEvent` below. Driving the gate from `agent.state.isStreaming`
+  // is unsafe: pi-agent-core only sets that after the first stream
+  // event arrives, leaving a race window between submit and first event
+  // where `tape_appended` for the user message would clobber the
+  // in-flight assistant text via `replaceMessages` (#1877, #1923).
   useSessionEvents({
     sessionKey: activeSession?.key ?? null,
     onTapeAppended: () => {
-      if (agentRef.current?.state.isStreaming) return;
-      void reloadMessages();
+      tapeReloadGateRef.current?.onTapeAppended();
     },
   });
 
@@ -838,6 +857,17 @@ export default function PiChat() {
               liveRunStore.publish(sessionKey, event);
               if (event.type === 'approval_requested' || event.type === 'approval_resolved') {
                 void queryClientRef.current.invalidateQueries({ queryKey: ['kernel-approvals'] });
+              }
+              // Bracket the chat WS turn so `tape_appended` events that
+              // arrive while the WS is the source of truth don't trigger
+              // a `replaceMessages` reload that would clobber in-flight
+              // assistant text (#1877, #1923). `__stream_reconnect_failed`
+              // is always immediately followed by `__stream_closed`, so
+              // we only listen on the close edge.
+              if (event.type === '__stream_started') {
+                tapeReloadGateRef.current?.onStreamStarted();
+              } else if (event.type === '__stream_closed') {
+                tapeReloadGateRef.current?.onStreamClosed();
               }
             },
           ),


### PR DESCRIPTION
## Summary

Replace `agent.state.isStreaming` with chat WS adapter lifecycle frames (`__stream_started` / `__stream_closed`) as the gate for `tape_appended`-driven reloads. The previous gate had a race window between submit and the first stream event where `tape_appended` for the user message could call `replaceMessages` + `reconstructFromMessages` on top of the in-flight WS, killing the assistant turn (real repro on session 48ca6c78 — backend persisted reply len=2836 but UI showed nothing). A symmetric race exists at turn end between `done` flipping `isStreaming=false` and the assistant `tape_appended` arriving.

Introduces `TapeReloadGate` — a small pure helper — that:
- drops `tape_appended` events that arrive while a chat WS turn is in flight (the WS owns the rendered content), and
- flushes a single reload on `__stream_closed` if any events were skipped, so background-task summaries that happen to land mid-turn are not lost.

Background-task `tape_appended` events that arrive **outside** any chat WS turn still trigger an immediate reload — the original `useSessionEvents` contract is preserved.

## Type of change

| Type | Label |
|------|-------|
| Bug fix | `bug` |

## Component

`ui`

## Closes

Closes #1923

## Test plan

- [x] New `TapeReloadGate` unit tests (7 cases) cover: outside-turn reload, in-flight drop, single-flush on close, no-flush when no queued events, post-turn reload, spurious-close handling, back-to-back turns
- [x] `npm test -- --run` (117 tests pass)
- [x] `npm run typecheck` clean
- [x] `npm run build` clean
- [x] `npm run lint` clean