### PR TITLE
fix(telemetry): disable HTTP proxy for OTLP exporter (#1928)

### DIFF
--- a/crates/common/telemetry/Cargo.toml
+++ b/crates/common/telemetry/Cargo.toml
@@ -22,11 +22,15 @@ derive_more = { workspace = true }
 lazy_static = "1.4"
 once_cell = "1.19"
 opentelemetry = { version = "0.31.0", default-features = false, features = ["trace", "metrics"] }
-opentelemetry-otlp = { version = "0.31.0", features = ["trace", "metrics", "grpc-tonic", "http-proto"] }
+opentelemetry-otlp = { version = "0.31.0", features = ["trace", "metrics", "grpc-tonic", "http-proto", "reqwest-client"] }
 opentelemetry-semantic-conventions = { version = "0.31.0", features = ["semconv_experimental"] }
 opentelemetry_sdk = { version = "0.31.0", features = ["rt-tokio", "trace", "metrics"] }
 pyroscope = { workspace = true }
 pyroscope_pprofrs = { workspace = true }
+# Pinned to 0.12 to match opentelemetry-http 0.31's reqwest dep — the
+# `HttpClient` trait impl is only visible for the version that crate links
+# against. Workspace reqwest is 0.13.
+reqwest = { version = "0.12", default-features = false, features = ["rustls-tls"] }
 serde.workspace = true
 serde_json = "1.0"
 smart-default = { workspace = true }

--- a/crates/common/telemetry/src/logging.rs
+++ b/crates/common/telemetry/src/logging.rs
@@ -754,13 +754,21 @@ fn build_otlp_exporter(opts: &LoggingOptions) -> SpanExporter {
             .build()
             .expect("Failed to create OTLP gRPC exporter "),
 
-        OtlpExportProtocol::Http => SpanExporter::builder()
-            .with_http()
-            .with_endpoint(endpoint)
-            .with_protocol(Protocol::HttpBinary)
-            .with_headers(opts.otlp_headers.clone())
-            .build()
-            .expect("Failed to create OTLP HTTP exporter "),
+        OtlpExportProtocol::Http => {
+            // OTLP must not honor HTTP_PROXY — internal collectors live on the LAN.
+            let http_client = reqwest::Client::builder()
+                .no_proxy()
+                .build()
+                .expect("Failed to build reqwest client for OTLP HTTP exporter");
+            SpanExporter::builder()
+                .with_http()
+                .with_http_client(http_client)
+                .with_endpoint(endpoint)
+                .with_protocol(Protocol::HttpBinary)
+                .with_headers(opts.otlp_headers.clone())
+                .build()
+                .expect("Failed to create OTLP HTTP exporter ")
+        }
     }
 }
 
@@ -804,12 +812,20 @@ fn init_meter_provider(
             .with_endpoint(&endpoint)
             .build()
             .expect("failed to build OTLP gRPC metric exporter"),
-        OtlpExportProtocol::Http => opentelemetry_otlp::MetricExporter::builder()
-            .with_http()
-            .with_endpoint(&endpoint)
-            .with_headers(opts.otlp_headers.clone())
-            .build()
-            .expect("failed to build OTLP HTTP metric exporter"),
+        OtlpExportProtocol::Http => {
+            // OTLP must not honor HTTP_PROXY — internal collectors live on the LAN.
+            let http_client = reqwest::Client::builder()
+                .no_proxy()
+                .build()
+                .expect("failed to build reqwest client for OTLP HTTP metric exporter");
+            opentelemetry_otlp::MetricExporter::builder()
+                .with_http()
+                .with_http_client(http_client)
+                .with_endpoint(&endpoint)
+                .with_headers(opts.otlp_headers.clone())
+                .build()
+                .expect("failed to build OTLP HTTP metric exporter")
+        }
     };
 
     let reader = opentelemetry_sdk::metrics::PeriodicReader::builder(exporter)


### PR DESCRIPTION
## Summary

OTLP traces from the production rara backend fail to reach the self-hosted Langfuse collector at `10.0.0.168:30840` because the rara process inherits clash/mihomo proxy env vars (`HTTP_PROXY` / `HTTPS_PROXY`) and `opentelemetry-otlp` 0.31's default `reqwest::Client` honors them. `NO_PROXY=10.0.0.0/8` is unreliable across HTTP clients and traffic is misrouted, producing repeated `BatchSpanProcessor.ExportError ... HostUnreachable`.

OTLP traffic to internal collectors should never traverse an outbound HTTP proxy. Fix: build an explicit `reqwest::Client` with `.no_proxy()` and inject it into both the `SpanExporter` and `MetricExporter` HTTP builders via `.with_http_client(...)`. The gRPC path (tonic) does not read env-var proxies, so it is left unchanged.

Required dep changes in `crates/common/telemetry/Cargo.toml`:

- Enable the `reqwest-client` feature on `opentelemetry-otlp` to bring in the `HttpClient for reqwest::Client` impl.
- Add a direct `reqwest = "0.12"` dep, pinned to match `opentelemetry-http` 0.31's reqwest version. Workspace reqwest is `0.13`, but the `HttpClient` trait is only visible for the version `opentelemetry-http` links against. `reqwest 0.12` is already in the dep tree transitively, so `Cargo.lock` is unchanged.

## Type of change

| Type | Label |
|------|-------|
| Bug fix | `bug` |

## Component

`core`

## Closes

Closes #1928

## Test plan

- [x] `cargo check -p common-telemetry` passes
- [x] `cargo clippy --workspace --all-targets --all-features --no-deps` passes
- [x] `cargo +nightly fmt --all -- --check` passes
- [x] Pre-commit gate (cargo check / fmt / clippy / doc) passes on the final commit
- [ ] Verify post-deploy on raratekiAir: `BatchSpanProcessor.ExportError` stops, traces appear in Langfuse