### PR TITLE
fix(kernel): inherit parent session LLM override on spawn_agent (#1932)

### DIFF
--- a/crates/kernel/src/kernel.rs
+++ b/crates/kernel/src/kernel.rs
@@ -940,55 +940,61 @@ impl Kernel {
                 .fork_session(&parent_key, &session_key);
         }
 
-        // Persist a SessionEntry for the spawned session so per-session LLM
-        // overrides are visible to downstream resolution (agent::run_turn looks
-        // them up via session_index().get_session). Without this, child tasks
-        // dispatched from a session with a per-session override silently fall
-        // back to the global default LLM (#1932).
+        // Inherit per-session LLM overrides (model / model_provider /
+        // thinking_level) from the parent session by writing a SessionEntry
+        // for the child. Without this, agent::run_turn's lookup via
+        // session_index().get_session() returns None and the child silently
+        // falls back to the global default LLM (#1932).
         //
-        // When spawning from a parent session, copy the override-relevant
-        // fields (model, model_provider, thinking_level) so the child inherits
-        // them. Other metadata (title, system_prompt, message_count, preview,
-        // metadata) starts empty — those are session-local concerns.
+        // We only write the entry when the parent actually has an override to
+        // inherit. Writing for top-level spawns (no parent) or for parents
+        // with no overrides would pollute list_sessions() — that index
+        // enumerates every entry under the directory and feeds the user-facing
+        // session list, which today only contains user-created sessions.
         //
-        // For top-level spawns (no parent), we still write an empty entry so
-        // future lookups are well-defined and consistent with the user-message
-        // path that always materializes a SessionEntry on first contact.
+        // When the parent has no overrides we skip the write entirely:
+        // agent::run_turn's get_session(child) will return None and resolve
+        // to the global default, which is the correct behavior here.
         //
-        // Failure to persist is logged but non-fatal: the spawn proceeds, just
-        // without override inheritance, which matches the prior (broken)
-        // behavior — never block a spawn on metadata bookkeeping.
-        let parent_entry = match parent_id {
-            Some(pid) => self
+        // Failure to persist is logged but non-fatal: the spawn proceeds, the
+        // child just loses override inheritance — never block a spawn on
+        // metadata bookkeeping.
+        if let Some(parent_key) = parent_id.as_ref() {
+            let parent_entry = self
                 .io
                 .session_index()
-                .get_session(&pid)
+                .get_session(parent_key)
                 .await
                 .ok()
-                .flatten(),
-            None => None,
-        };
-        let now = chrono::Utc::now();
-        let child_entry = crate::session::SessionEntry {
-            key:            session_key,
-            title:          None,
-            model:          parent_entry.as_ref().and_then(|p| p.model.clone()),
-            model_provider: parent_entry.as_ref().and_then(|p| p.model_provider.clone()),
-            thinking_level: parent_entry.as_ref().and_then(|p| p.thinking_level.clone()),
-            system_prompt:  None,
-            message_count:  0,
-            preview:        None,
-            metadata:       None,
-            created_at:     now,
-            updated_at:     now,
-        };
-        if let Err(e) = self.io.session_index().create_session(&child_entry).await {
-            tracing::error!(
-                error = %e,
-                session_key = %session_key,
-                parent_id = ?parent_id,
-                "failed to persist SessionEntry for spawned agent — LLM override inheritance disabled for this session"
-            );
+                .flatten();
+            let has_override = parent_entry.as_ref().is_some_and(|p| {
+                p.model.is_some() || p.model_provider.is_some() || p.thinking_level.is_some()
+            });
+            if has_override {
+                let parent = parent_entry.expect("has_override implies parent_entry is Some");
+                let now = chrono::Utc::now();
+                let child_entry = crate::session::SessionEntry {
+                    key:            session_key,
+                    title:          None,
+                    model:          parent.model.clone(),
+                    model_provider: parent.model_provider.clone(),
+                    thinking_level: parent.thinking_level.clone(),
+                    system_prompt:  None,
+                    message_count:  0,
+                    preview:        None,
+                    metadata:       None,
+                    created_at:     now,
+                    updated_at:     now,
+                };
+                if let Err(e) = self.io.session_index().create_session(&child_entry).await {
+                    tracing::error!(
+                        error = %e,
+                        session_key = %session_key,
+                        parent_id = ?parent_id,
+                        "failed to persist SessionEntry for spawned agent — LLM override inheritance disabled for this session"
+                    );
+                }
+            }
         }
 
         crate::metrics::record_session_created(&manifest.name);

--- a/crates/kernel/src/kernel.rs
+++ b/crates/kernel/src/kernel.rs
@@ -940,6 +940,57 @@ impl Kernel {
                 .fork_session(&parent_key, &session_key);
         }
 
+        // Persist a SessionEntry for the spawned session so per-session LLM
+        // overrides are visible to downstream resolution (agent::run_turn looks
+        // them up via session_index().get_session). Without this, child tasks
+        // dispatched from a session with a per-session override silently fall
+        // back to the global default LLM (#1932).
+        //
+        // When spawning from a parent session, copy the override-relevant
+        // fields (model, model_provider, thinking_level) so the child inherits
+        // them. Other metadata (title, system_prompt, message_count, preview,
+        // metadata) starts empty — those are session-local concerns.
+        //
+        // For top-level spawns (no parent), we still write an empty entry so
+        // future lookups are well-defined and consistent with the user-message
+        // path that always materializes a SessionEntry on first contact.
+        //
+        // Failure to persist is logged but non-fatal: the spawn proceeds, just
+        // without override inheritance, which matches the prior (broken)
+        // behavior — never block a spawn on metadata bookkeeping.
+        let parent_entry = match parent_id {
+            Some(pid) => self
+                .io
+                .session_index()
+                .get_session(&pid)
+                .await
+                .ok()
+                .flatten(),
+            None => None,
+        };
+        let now = chrono::Utc::now();
+        let child_entry = crate::session::SessionEntry {
+            key:            session_key,
+            title:          None,
+            model:          parent_entry.as_ref().and_then(|p| p.model.clone()),
+            model_provider: parent_entry.as_ref().and_then(|p| p.model_provider.clone()),
+            thinking_level: parent_entry.as_ref().and_then(|p| p.thinking_level.clone()),
+            system_prompt:  None,
+            message_count:  0,
+            preview:        None,
+            metadata:       None,
+            created_at:     now,
+            updated_at:     now,
+        };
+        if let Err(e) = self.io.session_index().create_session(&child_entry).await {
+            tracing::error!(
+                error = %e,
+                session_key = %session_key,
+                parent_id = ?parent_id,
+                "failed to persist SessionEntry for spawned agent — LLM override inheritance disabled for this session"
+            );
+        }
+
         crate::metrics::record_session_created(&manifest.name);
         crate::metrics::inc_session_active(&manifest.name);
 


### PR DESCRIPTION
## Summary

Background tasks dispatched via `spawn_agent` did not inherit the parent session's per-session LLM override and silently fell back to the global default. This caused real failures where a user switched a session to LLM B, dispatched a task, and watched it run on LLM A (Kimi) and 403 on quota.

Root cause: `handle_spawn_agent` (crates/kernel/src/kernel.rs) registered the child in `process_table` but never wrote a `SessionEntry` to `session_index`. `agent::run_turn` resolves the LLM override by `session_index().get_session(...)`, which returned `None` for every spawned session.

Fix: after inserting the process, look up the parent's `SessionEntry`. **Only when the parent actually has at least one of `model` / `model_provider` / `thinking_level` set**, copy those fields onto a fresh child entry and persist it. When there is no override to inherit (top-level spawns, or a parent with no override), skip the write entirely — `agent::run_turn`'s lookup returns `None` and resolves to the global default, which is the correct behavior. This avoids polluting `list_sessions()` (which feeds the chat UI / CLI session list) with every background task / Mita / sub-agent session. Persistence failures are logged but non-fatal — never block a spawn on metadata bookkeeping.

## Type of change

| Type | Label |
|------|-------|
| Bug fix | `bug` |

## Component

`core`

## Closes

Closes #1932

## Test plan

- [x] `cargo check -p rara-kernel` passes
- [x] `cargo clippy -p rara-kernel --all-targets -- -D warnings` clean
- [x] `cargo +nightly fmt --all` clean
- [x] `cargo test -p rara-kernel --lib` — 562 passed, 0 failed, 1 ignored (previous commit)
- [x] `prek run` passes on changed file
- [ ] Manual e2e on remote: switch session to non-default LLM, dispatch task, confirm task uses inherited LLM (deferred to user)

## Notes

No new automated test was added — the kernel crate currently has no harness that exercises `handle_spawn_agent` end-to-end, and the issue brief asked to skip building scaffolding for a one-off check.