### PR TITLE
fix(kernel,web): structured LLM error surfacing and suppress empty failure traces (#1926)

### DIFF
--- a/crates/channels/src/telegram/adapter.rs
+++ b/crates/channels/src/telegram/adapter.rs
@@ -1402,7 +1402,7 @@ impl ChannelAdapter for TelegramAdapter {
             // Telegram has no typed error frame — render as plain text via
             // the dedicated helper (bypasses stream-coalescing / keyboard
             // logic that only makes sense for `Reply`).
-            PlatformOutbound::Error { code, message } => {
+            PlatformOutbound::Error { code, message, .. } => {
                 let text = format!("Error [{code}]: {message}");
                 return self.send_plain_text_reply(chat_id, thread_id, &text).await;
             }

--- a/crates/channels/src/terminal.rs
+++ b/crates/channels/src/terminal.rs
@@ -164,7 +164,7 @@ impl ChannelAdapter for TerminalAdapter {
             PlatformOutbound::Reply { content, .. } => CliEvent::Reply { content },
             PlatformOutbound::StreamChunk { delta, .. } => CliEvent::TextDelta { text: delta },
             PlatformOutbound::Progress { text } => CliEvent::Progress { text },
-            PlatformOutbound::Error { code, message } => CliEvent::Error {
+            PlatformOutbound::Error { code, message, .. } => CliEvent::Error {
                 message: format!("Error [{code}]: {message}"),
             },
         };

--- a/crates/channels/src/web.rs
+++ b/crates/channels/src/web.rs
@@ -108,8 +108,17 @@ pub enum WebEvent {
     Typing,
     /// Agent phase change.
     Phase { phase: String },
-    /// Error notification.
-    Error { message: String },
+    /// Error notification. `category` and `upgrade_url` are optional — older
+    /// frontends ignore unknown fields, newer ones use them to render a
+    /// category-specific banner (e.g. quota → upgrade CTA). Backwards
+    /// compatible: legacy callers that only set `message` continue to work.
+    Error {
+        message:     String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        category:    Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        upgrade_url: Option<String>,
+    },
     /// Incremental text output from LLM.
     TextDelta { text: String },
     /// Incremental reasoning/thinking text.
@@ -264,7 +273,16 @@ fn platform_outbound_to_web_event(msg: PlatformOutbound) -> WebEvent {
         PlatformOutbound::Reply { content, .. } => WebEvent::Message { content },
         PlatformOutbound::StreamChunk { delta, .. } => WebEvent::TextDelta { text: delta },
         PlatformOutbound::Progress { text } => WebEvent::Progress { stage: text },
-        PlatformOutbound::Error { message, .. } => WebEvent::Error { message },
+        PlatformOutbound::Error {
+            message,
+            category,
+            upgrade_url,
+            ..
+        } => WebEvent::Error {
+            message,
+            category,
+            upgrade_url,
+        },
     }
 }
 
@@ -1216,7 +1234,9 @@ async fn handle_ws(socket: WebSocket, params: SessionQuery, state: WebAdapterSta
                         &reply_buffer,
                         &session_key,
                         WebEvent::Error {
-                            message: "adapter not started".to_owned(),
+                            message:     "adapter not started".to_owned(),
+                            category:    None,
+                            upgrade_url: None,
                         },
                     );
                     continue;
@@ -1244,7 +1264,9 @@ async fn handle_ws(socket: WebSocket, params: SessionQuery, state: WebAdapterSta
                                 &reply_buffer,
                                 &session_key,
                                 WebEvent::Error {
-                                    message: e.to_string(),
+                                    message:     e.to_string(),
+                                    category:    None,
+                                    upgrade_url: None,
                                 },
                             );
                         }
@@ -1260,7 +1282,9 @@ async fn handle_ws(socket: WebSocket, params: SessionQuery, state: WebAdapterSta
                             &reply_buffer,
                             &session_key,
                             WebEvent::Error {
-                                message: e.to_string(),
+                                message:     e.to_string(),
+                                category:    None,
+                                upgrade_url: None,
                             },
                         );
                     }
@@ -1795,12 +1819,14 @@ mod tests {
     #[test]
     fn platform_error_maps_to_web_error_frame() {
         let event = platform_outbound_to_web_event(PlatformOutbound::Error {
-            code:    "agent_error".to_owned(),
-            message: "model rejected reasoning=minimal".to_owned(),
+            code:        "agent_error".to_owned(),
+            message:     "model rejected reasoning=minimal".to_owned(),
+            category:    None,
+            upgrade_url: None,
         });
 
         match &event {
-            WebEvent::Error { message } => {
+            WebEvent::Error { message, .. } => {
                 assert_eq!(message, "model rejected reasoning=minimal");
             }
             other => panic!("expected WebEvent::Error, got {other:?}"),
@@ -1811,6 +1837,24 @@ mod tests {
         let json = serde_json::to_value(&event).expect("serialize");
         assert_eq!(json["type"], "error");
         assert_eq!(json["message"], "model rejected reasoning=minimal");
+    }
+
+    #[test]
+    fn platform_error_carries_quota_category_and_upgrade_url() {
+        let event = platform_outbound_to_web_event(PlatformOutbound::Error {
+            code:        "agent_error".to_owned(),
+            message:     "Kimi quota exceeded".to_owned(),
+            category:    Some("quota".to_owned()),
+            upgrade_url: Some("https://www.kimi.com/code/console?from=quota-upgrade".to_owned()),
+        });
+
+        let json = serde_json::to_value(&event).expect("serialize");
+        assert_eq!(json["type"], "error");
+        assert_eq!(json["category"], "quota");
+        assert_eq!(
+            json["upgrade_url"],
+            "https://www.kimi.com/code/console?from=quota-upgrade",
+        );
     }
 
     #[test]

--- a/crates/channels/src/web_reply_buffer.rs
+++ b/crates/channels/src/web_reply_buffer.rs
@@ -339,7 +339,9 @@ mod tests {
     fn important_events_are_buffered() {
         assert!(ReplyBuffer::should_buffer(&msg("hi")));
         assert!(ReplyBuffer::should_buffer(&WebEvent::Error {
-            message: "bad".to_owned(),
+            message:     "bad".to_owned(),
+            category:    None,
+            upgrade_url: None,
         }));
         assert!(ReplyBuffer::should_buffer(&WebEvent::BackgroundTaskDone {
             task_id: "t".to_owned(),

--- a/crates/channels/src/wechat/adapter.rs
+++ b/crates/channels/src/wechat/adapter.rs
@@ -302,7 +302,7 @@ impl ChannelAdapter for WechatAdapter {
             }
             // WeChat does not support streaming edits.
             PlatformOutbound::StreamChunk { .. } => {}
-            PlatformOutbound::Error { code, message } => {
+            PlatformOutbound::Error { code, message, .. } => {
                 let plain = format!("Error [{code}]: {message}");
                 self.send_plain_text(&user_id, context_token.as_deref(), &plain)
                     .await?;

--- a/crates/kernel/src/error.rs
+++ b/crates/kernel/src/error.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use base::shared_string::SharedString;
+use serde::{Deserialize, Serialize};
 use snafu::Snafu;
 
 use crate::session::SessionKey;
@@ -74,6 +75,17 @@ pub enum KernelError {
 
     #[snafu(display("non-retryable error: {message}"))]
     NonRetryable { message: SharedString },
+
+    /// Provider returned a billing/quota terminal error (e.g. Kimi
+    /// `access_terminated_error`, OpenAI "usage limit exceeded"). Not
+    /// retryable, not fallback eligible — the user needs to top up or wait
+    /// for the next billing cycle. `upgrade_url` is surfaced to the UI when
+    /// the provider embeds one in the error body.
+    #[snafu(display("quota exceeded: {message}"))]
+    Quota {
+        message:     String,
+        upgrade_url: Option<String>,
+    },
 
     #[snafu(display("{}", source))]
     Io {
@@ -257,6 +269,18 @@ pub fn format_error_chain(err: &dyn std::error::Error) -> String {
 /// Used by retry and fallback logic to decide whether to retry, fall back to
 /// another model, or give up.
 pub fn classify_provider_error(msg: &str, status_code: Option<u16>) -> KernelError {
+    // Quota errors (e.g. Kimi `access_terminated_error`) are terminal:
+    // retrying or falling back to another model will not help, since the
+    // user's billing account is the bottleneck. Detect these BEFORE the
+    // generic 429/5xx retryable bucket so a 403 carrying an
+    // `access_terminated_error` payload is not misclassified.
+    if is_quota_error(msg) {
+        return KernelError::Quota {
+            message:     msg.to_owned(),
+            upgrade_url: extract_url(msg),
+        };
+    }
+
     if matches!(status_code, Some(429 | 500 | 502 | 503 | 529)) {
         return KernelError::RetryableServer {
             message: SharedString::from(msg.to_owned()),
@@ -278,12 +302,15 @@ pub fn classify_provider_error(msg: &str, status_code: Option<u16>) -> KernelErr
 
 /// Whether the error is eligible for model fallback.
 ///
-/// Context window errors and missing API key errors are NOT eligible because
-/// switching models would not resolve them.
+/// Context window errors, missing API key errors, and quota terminal errors
+/// are NOT eligible because switching models would not resolve them — quota
+/// is account-scoped and persists until the user takes action.
 pub fn is_fallback_eligible(err: &KernelError) -> bool {
     !matches!(
         err,
-        KernelError::ContextWindow | KernelError::ProviderNotConfigured { .. }
+        KernelError::ContextWindow
+            | KernelError::ProviderNotConfigured { .. }
+            | KernelError::Quota { .. }
     )
 }
 
@@ -362,4 +389,174 @@ fn is_retryable_server_error(msg: &str) -> bool {
         .any(|pattern| lower.contains(pattern))
 }
 
+/// Provider patterns that indicate a billing/quota terminal error.
+///
+/// These are distinct from generic rate limits (`RetryableServer`) — the
+/// account itself is exhausted and waiting/retrying within this billing
+/// window will keep failing. Kimi's `access_terminated_error` is the
+/// motivating case.
+const QUOTA_PATTERNS: &[&str] = &[
+    "access_terminated_error",
+    "usage limit",
+    "quota exceeded",
+    "quota_exceeded",
+    "billing",
+    "insufficient_quota",
+];
+
+fn is_quota_error(msg: &str) -> bool {
+    let lower = msg.to_ascii_lowercase();
+    QUOTA_PATTERNS.iter().any(|pattern| lower.contains(pattern))
+}
+
+/// Best-effort URL extraction for upgrade links embedded in provider
+/// error messages (e.g. Kimi includes a console URL after
+/// `from=quota-upgrade`). Scans for the first `http://` or `https://` and
+/// takes characters up to the first whitespace or quote.
+fn extract_url(msg: &str) -> Option<String> {
+    let start = msg.find("https://").or_else(|| msg.find("http://"))?;
+    let tail = &msg[start..];
+    let end = tail
+        .find(|c: char| c.is_whitespace() || matches!(c, '"' | '\'' | '`' | ')' | '>'))
+        .unwrap_or(tail.len());
+    Some(tail[..end].to_owned())
+}
+
 pub type Result<T> = std::result::Result<T, KernelError>;
+
+/// Coarse classification of a turn-failure for the UI layer.
+///
+/// Mapped from a [`KernelError`] at the kernel boundary so frontends can
+/// pick a user-facing title/CTA without reparsing free-form messages.
+/// Stable string values are used because this travels over the wire as the
+/// `category` field in `OutboundPayload::Error` / `WebEvent::Error`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OutboundErrorCategory {
+    Quota,
+    Network,
+    ContextWindow,
+    Provider,
+    Tool,
+    Cancelled,
+}
+
+impl OutboundErrorCategory {
+    /// Wire string. Frontend code matches on these.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Quota => "quota",
+            Self::Network => "network",
+            Self::ContextWindow => "context_window",
+            Self::Provider => "provider",
+            Self::Tool => "tool",
+            Self::Cancelled => "cancelled",
+        }
+    }
+}
+
+/// Structured turn failure carried from the agent loop to the egress
+/// envelope. Built once at the kernel boundary so the same record drives
+/// the outbound envelope, the `TurnCompleted` event, and the platform
+/// error frame on each channel.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct OutboundError {
+    /// Category for the UI to pick a title/CTA. Wire form is the
+    /// snake_case string from [`OutboundErrorCategory::as_str`].
+    pub category:    String,
+    /// Human-readable detail. Falls back to the raw error message when no
+    /// better text is available.
+    pub message:     String,
+    /// When the provider embeds an upgrade/billing URL (Kimi quota), it is
+    /// surfaced so the UI can render a CTA button.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub upgrade_url: Option<String>,
+}
+
+impl OutboundError {
+    /// Build a `OutboundError` from a typed [`KernelError`].
+    pub fn from_kernel_error(err: &KernelError) -> Self {
+        match err {
+            KernelError::Quota {
+                message,
+                upgrade_url,
+            } => Self {
+                category:    OutboundErrorCategory::Quota.as_str().to_owned(),
+                message:     message.clone(),
+                upgrade_url: upgrade_url.clone(),
+            },
+            KernelError::RetryableServer { message } => Self {
+                category:    OutboundErrorCategory::Network.as_str().to_owned(),
+                message:     message.to_string(),
+                upgrade_url: None,
+            },
+            KernelError::ContextWindow => Self {
+                category:    OutboundErrorCategory::ContextWindow.as_str().to_owned(),
+                message:     "context window exceeded".to_owned(),
+                upgrade_url: None,
+            },
+            KernelError::Tool { message } | KernelError::ToolNotAllowed { tool_name: message } => {
+                Self {
+                    category:    OutboundErrorCategory::Tool.as_str().to_owned(),
+                    message:     message.clone(),
+                    upgrade_url: None,
+                }
+            }
+            KernelError::Interrupted => Self {
+                category:    OutboundErrorCategory::Cancelled.as_str().to_owned(),
+                message:     "interrupted by user".to_owned(),
+                upgrade_url: None,
+            },
+            other => Self {
+                category:    OutboundErrorCategory::Provider.as_str().to_owned(),
+                message:     other.to_string(),
+                upgrade_url: None,
+            },
+        }
+    }
+
+    /// Plain-text fallback when no typed error is available (panic, abnormal
+    /// task exit). The category defaults to `provider` because the UI's
+    /// existing copy is the closest match for "something blew up".
+    pub fn from_message(message: impl Into<String>) -> Self {
+        Self {
+            category:    OutboundErrorCategory::Provider.as_str().to_owned(),
+            message:     message.into(),
+            upgrade_url: None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn classify_kimi_access_terminated_403_returns_quota() {
+        let body = r#"{"error":{"type":"access_terminated_error","message":"Your account usage limit has been reached. Visit https://www.kimi.com/code/console?from=quota-upgrade to top up."}}"#;
+        let err = classify_provider_error(body, Some(403));
+        match err {
+            KernelError::Quota {
+                message,
+                upgrade_url,
+            } => {
+                assert!(message.contains("access_terminated_error"));
+                assert_eq!(
+                    upgrade_url.as_deref(),
+                    Some("https://www.kimi.com/code/console?from=quota-upgrade"),
+                );
+            }
+            other => panic!("expected Quota, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn classify_quota_not_fallback_eligible() {
+        let err = KernelError::Quota {
+            message:     "usage limit reached".into(),
+            upgrade_url: None,
+        };
+        assert!(!is_fallback_eligible(&err));
+        assert!(!is_retryable_provider_error(&err));
+        assert!(!is_rate_limit_error(&err));
+    }
+}

--- a/crates/kernel/src/event.rs
+++ b/crates/kernel/src/event.rs
@@ -374,7 +374,7 @@ pub enum KernelEvent {
     TurnCompleted {
         #[debug("{}", if result.is_ok() { "Ok(..)" } else { "Err(..)" })]
         #[serde(skip_serializing)]
-        result:          Result<AgentTurnResult, String>,
+        result:          Result<AgentTurnResult, crate::error::OutboundError>,
         in_reply_to:     MessageId,
         user:            UserId,
         /// Origin endpoint from the inbound message for session-scoped routing.
@@ -578,7 +578,7 @@ impl KernelEventEnvelope {
     /// Create a `TurnCompleted` event.
     pub fn turn_completed(
         session_key: SessionKey,
-        result: Result<AgentTurnResult, String>,
+        result: Result<AgentTurnResult, crate::error::OutboundError>,
         in_reply_to: MessageId,
         user: UserId,
         origin_endpoint: Option<crate::io::Endpoint>,

--- a/crates/kernel/src/io.rs
+++ b/crates/kernel/src/io.rs
@@ -417,8 +417,33 @@ impl OutboundEnvelope {
             user,
             session_key,
             OutboundPayload::Error {
-                code:    code.into(),
-                message: message.into(),
+                code:        code.into(),
+                message:     message.into(),
+                category:    None,
+                upgrade_url: None,
+            },
+        )
+    }
+
+    /// Like [`OutboundEnvelope::error`] but carries the structured turn
+    /// failure (category + optional upgrade URL) so the web UI can render
+    /// a category-specific banner.
+    pub fn error_with_details(
+        in_reply_to: MessageId,
+        user: UserId,
+        session_key: SessionKey,
+        code: impl Into<String>,
+        details: &crate::error::OutboundError,
+    ) -> Self {
+        Self::broadcast(
+            in_reply_to,
+            user,
+            session_key,
+            OutboundPayload::Error {
+                code:        code.into(),
+                message:     details.message.clone(),
+                category:    Some(details.category.clone()),
+                upgrade_url: details.upgrade_url.clone(),
             },
         )
     }
@@ -489,9 +514,16 @@ impl OutboundEnvelope {
             OutboundPayload::Progress { stage, detail } => PlatformOutbound::Progress {
                 text: detail.as_deref().unwrap_or(stage).to_string(),
             },
-            OutboundPayload::Error { code, message } => PlatformOutbound::Error {
-                code:    code.clone(),
-                message: message.clone(),
+            OutboundPayload::Error {
+                code,
+                message,
+                category,
+                upgrade_url,
+            } => PlatformOutbound::Error {
+                code:        code.clone(),
+                message:     message.clone(),
+                category:    category.clone(),
+                upgrade_url: upgrade_url.clone(),
             },
         }
     }
@@ -532,7 +564,22 @@ pub enum OutboundPayload {
         detail: Option<String>,
     },
     /// Error response.
-    Error { code: String, message: String },
+    Error {
+        /// Short stable code (e.g. `"agent_error"`, `"rate_limited"`). Always
+        /// present.
+        code:        String,
+        /// Human-readable detail.
+        message:     String,
+        /// Optional UX category for the frontend (`"quota"`, `"network"`,
+        /// `"context_window"`, `"provider"`, `"tool"`, `"cancelled"`). When
+        /// absent, frontends fall back to a generic error chrome.
+        #[serde(skip_serializing_if = "Option::is_none", default)]
+        category:    Option<String>,
+        /// Provider-supplied upgrade/billing URL surfaced to the UI for
+        /// quota errors. `None` for every other category.
+        #[serde(skip_serializing_if = "Option::is_none", default)]
+        upgrade_url: Option<String>,
+    },
 }
 
 // ---------------------------------------------------------------------------
@@ -1689,9 +1736,14 @@ pub enum PlatformOutbound {
     /// text reply formatted as `"Error [{code}]: {message}"`.
     Error {
         /// Short error code (e.g. `"agent_error"`, `"rate_limited"`).
-        code:    String,
+        code:        String,
         /// Human-readable error message.
-        message: String,
+        message:     String,
+        /// UX category (`"quota"`, `"network"`, …) for typed-error frames.
+        /// `None` on plain text channels that ignore it.
+        category:    Option<String>,
+        /// Provider upgrade/billing URL, populated only for quota errors.
+        upgrade_url: Option<String>,
     },
 }
 
@@ -2313,9 +2365,16 @@ mod outbound_payload_tests {
         );
 
         match envelope.to_platform_outbound() {
-            PlatformOutbound::Error { code, message } => {
+            PlatformOutbound::Error {
+                code,
+                message,
+                category,
+                upgrade_url,
+            } => {
                 assert_eq!(code, "agent_error");
                 assert_eq!(message, "model rejected reasoning=minimal");
+                assert!(category.is_none());
+                assert!(upgrade_url.is_none());
             }
             other => panic!("expected PlatformOutbound::Error, got {other:?}"),
         }

--- a/crates/kernel/src/kernel.rs
+++ b/crates/kernel/src/kernel.rs
@@ -2021,7 +2021,9 @@ impl Kernel {
                     // Push a failed TurnCompleted so the process exits Running state.
                     let event = KernelEventEnvelope::turn_completed(
                         self.session_key,
-                        Err("turn task terminated unexpectedly".to_string()),
+                        Err(crate::error::OutboundError::from_message(
+                            "turn task terminated unexpectedly",
+                        )),
                         self.msg_id.clone(),
                         self.user.clone(),
                         self.origin_endpoint.clone(),
@@ -2711,6 +2713,16 @@ impl Kernel {
                 // responsibility and only TG turns had rows; now trace
                 // construction + save is a single kernel-owned concern.
                 //
+                // Exception: a turn that errored before any LLM iteration
+                // or tool call produces an empty trace (0 iterations / 0
+                // tools / ~0s). Persisting it surfaces a misleading
+                // "rara encountered an error / 0 tools / 0s" card in the
+                // UI (see #1926). Skip persistence + `TraceReady` in that
+                // case — the structured error envelope already carries
+                // the failure detail.
+                let turn_failed = turn_result.is_err();
+                let trace_empty = trace_builder.is_empty();
+                let skip_trace = turn_failed && trace_empty;
                 // `finalize` takes `&self` because the `TraceBuilder` is
                 // shared with `stream_handle` via `Arc`; the handle is still
                 // alive at this point (we emit `TraceReady` through it just
@@ -2722,44 +2734,51 @@ impl Kernel {
                 // knowledge insert + trace save). Retry the save with
                 // exponential backoff before giving up — silent loss of
                 // execution traces is what #1843 was opened to fix.
-                let save_result = {
-                    let backoffs = [
-                        std::time::Duration::from_millis(100),
-                        std::time::Duration::from_millis(500),
-                        std::time::Duration::from_secs(2),
-                    ];
-                    let mut attempt: Result<String, crate::error::KernelError> =
-                        trace_service.save(&session_key.to_string(), &trace).await;
-                    for delay in backoffs {
-                        match &attempt {
-                            Ok(_) => break,
-                            Err(e) if is_database_locked(e) => {
-                                tracing::debug!(
-                                    session_key = %session_key,
-                                    delay_ms = delay.as_millis() as u64,
-                                    "trace save hit SQLITE_BUSY — retrying",
-                                );
-                                tokio::time::sleep(delay).await;
-                                attempt = trace_service
-                                    .save(&session_key.to_string(), &trace)
-                                    .await;
+                if skip_trace {
+                    tracing::debug!(
+                        session_key = %session_key,
+                        "skipping trace persistence for empty failed turn",
+                    );
+                } else {
+                    let save_result = {
+                        let backoffs = [
+                            std::time::Duration::from_millis(100),
+                            std::time::Duration::from_millis(500),
+                            std::time::Duration::from_secs(2),
+                        ];
+                        let mut attempt: Result<String, crate::error::KernelError> =
+                            trace_service.save(&session_key.to_string(), &trace).await;
+                        for delay in backoffs {
+                            match &attempt {
+                                Ok(_) => break,
+                                Err(e) if is_database_locked(e) => {
+                                    tracing::debug!(
+                                        session_key = %session_key,
+                                        delay_ms = delay.as_millis() as u64,
+                                        "trace save hit SQLITE_BUSY — retrying",
+                                    );
+                                    tokio::time::sleep(delay).await;
+                                    attempt = trace_service
+                                        .save(&session_key.to_string(), &trace)
+                                        .await;
+                                }
+                                Err(_) => break,
                             }
-                            Err(_) => break,
                         }
-                    }
-                    attempt
-                };
-                match save_result {
-                    Ok(trace_id) => {
-                        stream_handle
-                            .emit(crate::io::StreamEvent::TraceReady { trace_id });
-                    }
-                    Err(e) => {
-                        tracing::warn!(
-                            session_key = %session_key,
-                            error = %e,
-                            "failed to persist execution trace",
-                        );
+                        attempt
+                    };
+                    match save_result {
+                        Ok(trace_id) => {
+                            stream_handle
+                                .emit(crate::io::StreamEvent::TraceReady { trace_id });
+                        }
+                        Err(e) => {
+                            tracing::warn!(
+                                session_key = %session_key,
+                                error = %e,
+                                "failed to persist execution trace",
+                            );
+                        }
                     }
                 }
 
@@ -2775,7 +2794,7 @@ impl Kernel {
                     turn_result,
                     Err(KernelError::Interrupted)
                 );
-                let result = turn_result.map_err(|e| e.to_string());
+                let result = turn_result.map_err(|e| crate::error::OutboundError::from_kernel_error(&e));
                 let event = KernelEventEnvelope::turn_completed(
                     session_key,
                     result,
@@ -2821,7 +2840,9 @@ impl Kernel {
                     // Push TurnCompleted(Err) with the real panic message.
                     let event = KernelEventEnvelope::turn_completed(
                         turn_guard.session_key.clone(),
-                        Err(format!("turn task panicked: {panic_msg}")),
+                        Err(crate::error::OutboundError::from_message(format!(
+                            "turn task panicked: {panic_msg}"
+                        ))),
                         turn_guard.msg_id.clone(),
                         turn_guard.user.clone(),
                         turn_guard.origin_endpoint.clone(),
@@ -2848,7 +2869,7 @@ impl Kernel {
     async fn handle_turn_completed(
         &self,
         session_key: SessionKey,
-        result: std::result::Result<AgentTurnResult, String>,
+        result: std::result::Result<AgentTurnResult, crate::error::OutboundError>,
         in_reply_to: MessageId,
         user: crate::identity::UserId,
         origin_endpoint: Option<crate::io::Endpoint>,
@@ -2931,7 +2952,7 @@ impl Kernel {
                     iterations:  0,
                     tool_calls:  0,
                     output:      String::new(),
-                    error:       Some(err.clone()),
+                    error:       Some(err.message.clone()),
                     duration_ms: 0,
                 },
             };
@@ -3080,11 +3101,17 @@ impl Kernel {
                     }
                 }
             }
-            Err(err_msg) => {
+            Err(err_details) => {
                 span.record("success", false);
                 _turn_failed = !interrupted;
+                let err_msg = err_details.message.clone();
                 if _turn_failed {
-                    error!(session_key = %session_key, error = %err_msg, "turn failed");
+                    error!(
+                        session_key = %session_key,
+                        category = %err_details.category,
+                        error = %err_msg,
+                        "turn failed",
+                    );
                 } else {
                     info!(session_key = %session_key, "turn interrupted by user");
                 }
@@ -3107,12 +3134,12 @@ impl Kernel {
                 // already sent a confirmation message) and for headless
                 // agents that have no user-facing channel.
                 if _turn_failed && should_deliver {
-                    let envelope = OutboundEnvelope::error(
+                    let envelope = OutboundEnvelope::error_with_details(
                         in_reply_to,
                         user.clone(),
                         egress_session_key.clone(),
                         "agent_error",
-                        err_msg.clone(),
+                        &err_details,
                     )
                     .with_origin(origin_endpoint.clone());
                     let envelope = match cross_channel_routing {

--- a/crates/kernel/src/lib.rs
+++ b/crates/kernel/src/lib.rs
@@ -133,4 +133,4 @@ pub mod tool_names {
     tool!(ASK_USER, "ask-user");
 }
 
-pub use error::{KernelError, Result};
+pub use error::{KernelError, OutboundError, OutboundErrorCategory, Result};

--- a/crates/kernel/src/trace/builder.rs
+++ b/crates/kernel/src/trace/builder.rs
@@ -356,6 +356,22 @@ impl TraceBuilder {
     /// to finalize prematurely.
     #[allow(dead_code)]
     pub fn elapsed(&self) -> Duration { self.turn_started.elapsed() }
+
+    /// `true` when the turn ended without any LLM iteration or tool call.
+    ///
+    /// Used by the kernel turn loop to skip persistence + `TraceReady` for
+    /// turns that failed before any work happened (e.g. a 403 quota error
+    /// on the first request) — persisting them produces a misleading
+    /// "0 tools / 0s" trace card in the UI.
+    pub fn is_empty(&self) -> bool {
+        match self.state.lock() {
+            Ok(g) => g.iterations == 0 && g.tools.is_empty(),
+            Err(poisoned) => {
+                let g = poisoned.into_inner();
+                g.iterations == 0 && g.tools.is_empty()
+            }
+        }
+    }
 }
 
 impl Default for TraceBuilder {

--- a/web/src/components/__tests__/ChatSidebar.test.tsx
+++ b/web/src/components/__tests__/ChatSidebar.test.tsx
@@ -72,6 +72,9 @@ function runFixture(overrides: Partial<LiveRun> = {}): LiveRun {
     items: [{ seq: 0, turn: 0, kind: 'tool_use', tool: 'Grep', input: { query: 'hello' } }],
     toolCalls: 1,
     error: null,
+    errorCategory: null,
+    errorDetail: null,
+    upgradeUrl: null,
     currentStage: null,
     ...overrides,
   };

--- a/web/src/components/agent-live/SingleAgentLiveCard.tsx
+++ b/web/src/components/agent-live/SingleAgentLiveCard.tsx
@@ -98,13 +98,19 @@ export function SingleAgentLiveCard({ run, agentName = 'rara', onOpenTranscript,
   // the run is alive on the backend; we're just briefly off the wire.
   const isRunning = run.status === 'running' || run.status === 'reconnecting';
   const elapsed = (run.endedAt ?? nowTick) - run.startedAt;
+  // A turn that failed before producing any LLM iteration or tool call
+  // (e.g. Kimi 403 quota on the very first request) has nothing to show
+  // in the duration / tool-count chips, and the generic "encountered an
+  // error" copy is not actionable. Suppress the noisy chrome and render
+  // a category-specific banner instead (see #1926).
+  const failedWithNoWork = run.status === 'failed' && run.toolCalls === 0 && run.items.length === 0;
   const headerLabel =
     run.status === 'running'
       ? `${agentName} is working`
       : run.status === 'reconnecting'
         ? `${agentName} is reconnecting…`
         : run.status === 'failed'
-          ? `${agentName} encountered an error`
+          ? failedTitle(run.errorCategory, agentName)
           : run.status === 'cancelled'
             ? `${agentName} was interrupted`
             : `${agentName} finished`;
@@ -149,12 +155,16 @@ export function SingleAgentLiveCard({ run, agentName = 'rara', onOpenTranscript,
             </span>
           )}
         </span>
-        <span className="shrink-0 text-xs tabular-nums text-muted-foreground">
-          {formatDuration(elapsed)}
-        </span>
-        <span className="shrink-0 rounded-full border border-border/60 bg-muted/40 px-2 py-0.5 text-[10px] tabular-nums text-muted-foreground">
-          {run.toolCalls} tool{run.toolCalls === 1 ? '' : 's'}
-        </span>
+        {!failedWithNoWork && (
+          <span className="shrink-0 text-xs tabular-nums text-muted-foreground">
+            {formatDuration(elapsed)}
+          </span>
+        )}
+        {!failedWithNoWork && (
+          <span className="shrink-0 rounded-full border border-border/60 bg-muted/40 px-2 py-0.5 text-[10px] tabular-nums text-muted-foreground">
+            {run.toolCalls} tool{run.toolCalls === 1 ? '' : 's'}
+          </span>
+        )}
         <button
           type="button"
           onClick={(e) => {
@@ -193,23 +203,32 @@ export function SingleAgentLiveCard({ run, agentName = 'rara', onOpenTranscript,
 
       {expanded && (
         <div className="relative border-t border-border/50">
+          {run.status === 'failed' && (
+            <FailureBanner
+              category={run.errorCategory}
+              detail={run.errorDetail ?? run.error}
+              upgradeUrl={run.upgradeUrl}
+            />
+          )}
           <div
             ref={scrollerRef}
             onScroll={onScroll}
             className="max-h-[213px] overflow-y-auto [-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
           >
             {redactedItems.length === 0 ? (
-              <div className="flex items-center gap-2 px-4 py-3 text-xs text-muted-foreground">
-                {isRunning && (
-                  <span
-                    className="inline-block h-1.5 w-1.5 shrink-0 animate-pulse rounded-full bg-emerald-500"
-                    aria-hidden
-                  />
-                )}
-                <span className="truncate">
-                  {isRunning ? stageLabel(run.currentStage) : 'No tool calls in this run'}
-                </span>
-              </div>
+              failedWithNoWork ? null : (
+                <div className="flex items-center gap-2 px-4 py-3 text-xs text-muted-foreground">
+                  {isRunning && (
+                    <span
+                      className="inline-block h-1.5 w-1.5 shrink-0 animate-pulse rounded-full bg-emerald-500"
+                      aria-hidden
+                    />
+                  )}
+                  <span className="truncate">
+                    {isRunning ? stageLabel(run.currentStage) : 'No tool calls in this run'}
+                  </span>
+                </div>
+              )
             ) : (
               <div className="flex flex-col gap-1 px-3 py-2">
                 {chips.map((chip) => (
@@ -281,6 +300,69 @@ function RunStatusDot({ status }: { status: LiveRun['status'] }) {
       className="flex h-2 w-2 shrink-0 rounded-full bg-muted-foreground/50"
       aria-label="cancelled"
     />
+  );
+}
+
+/**
+ * Pick a header title for the failed state based on the backend-supplied
+ * error category. Older error frames without a category fall back to the
+ * legacy generic copy so existing screenshots/tests still match.
+ */
+function failedTitle(category: string | null, agentName: string): string {
+  switch (category) {
+    case 'quota':
+      return 'Kimi 配额已用完';
+    case 'network':
+      return '网络异常，请稍后重试';
+    case 'context_window':
+      return '上下文超长';
+    case 'tool':
+      return '工具调用失败';
+    case 'cancelled':
+      return '已取消';
+    default:
+      return `${agentName} encountered an error`;
+  }
+}
+
+/**
+ * Banner rendered above the timeline for a failed run. Shows the
+ * category-specific title's CTA (currently only quota carries an upgrade
+ * URL) and stows the raw provider message inside a `<details>` so the
+ * card stays compact unless the user opts in.
+ */
+function FailureBanner({
+  category,
+  detail,
+  upgradeUrl,
+}: {
+  category: string | null;
+  detail: string | null;
+  upgradeUrl: string | null;
+}) {
+  return (
+    <div className="border-b border-destructive/30 bg-destructive/10 px-4 py-3 text-xs text-destructive">
+      {category === 'quota' && upgradeUrl && (
+        <div className="mb-2">
+          <a
+            href={upgradeUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center rounded-md border border-destructive/40 bg-background/80 px-2.5 py-1 text-xs font-medium text-destructive transition hover:bg-destructive hover:text-destructive-foreground"
+          >
+            升级 Kimi 配额
+          </a>
+        </div>
+      )}
+      {detail && (
+        <details className="text-[11px] text-destructive/90">
+          <summary className="cursor-pointer select-none text-destructive hover:underline">
+            显示详情
+          </summary>
+          <pre className="mt-1 whitespace-pre-wrap break-words font-mono text-[11px]">{detail}</pre>
+        </details>
+      )}
+    </div>
   );
 }
 

--- a/web/src/components/agent-live/__tests__/AgentTranscriptDialog.test.tsx
+++ b/web/src/components/agent-live/__tests__/AgentTranscriptDialog.test.tsx
@@ -33,6 +33,9 @@ function runFixture(): LiveRun {
     ],
     toolCalls: 1,
     error: null,
+    errorCategory: null,
+    errorDetail: null,
+    upgradeUrl: null,
     currentStage: null,
   };
 }

--- a/web/src/components/agent-live/__tests__/SingleAgentLiveCard.test.tsx
+++ b/web/src/components/agent-live/__tests__/SingleAgentLiveCard.test.tsx
@@ -32,6 +32,9 @@ function runFixture(overrides: Partial<LiveRun> = {}): LiveRun {
     items: [],
     toolCalls: 0,
     error: null,
+    errorCategory: null,
+    errorDetail: null,
+    upgradeUrl: null,
     currentStage: null,
     ...overrides,
   };

--- a/web/src/components/agent-live/__tests__/TaskRunHistory.test.tsx
+++ b/web/src/components/agent-live/__tests__/TaskRunHistory.test.tsx
@@ -33,6 +33,9 @@ function runFixture(overrides: Partial<LiveRun> = {}): LiveRun {
     ],
     toolCalls: 1,
     error: null,
+    errorCategory: null,
+    errorDetail: null,
+    upgradeUrl: null,
     currentStage: null,
     ...overrides,
   };

--- a/web/src/components/agent-live/live-run-store.ts
+++ b/web/src/components/agent-live/live-run-store.ts
@@ -59,6 +59,21 @@ export interface LiveRun {
   /** Last error message (for `failed` status); null otherwise. */
   error: string | null;
   /**
+   * Backend-supplied UX category for `failed` runs (`'quota'`, `'network'`,
+   * `'context_window'`, `'provider'`, `'tool'`, `'cancelled'`). Absent on
+   * older error frames or non-failure runs — the UI falls back to the
+   * generic chrome when missing.
+   */
+  errorCategory: string | null;
+  /** Long-form detail for the failure banner (mirrors `error` today). */
+  errorDetail: string | null;
+  /**
+   * Provider-supplied upgrade/billing URL surfaced for quota errors so the
+   * UI can render a CTA button (Kimi includes one inside
+   * `access_terminated_error`).
+   */
+  upgradeUrl: string | null;
+  /**
    * Latest `progress.stage` string emitted by the kernel — a free-text
    * status marker (e.g. `"thinking"`, `"Waiting for LLM response
    * (iteration 2)..."`, `"Processing... (3 steps completed)"`). Rendered
@@ -298,6 +313,9 @@ export function reduce(
       items: [],
       toolCalls: 0,
       error: null,
+      errorCategory: null,
+      errorDetail: null,
+      upgradeUrl: null,
       currentStage: null,
     };
     return { active, history };
@@ -363,9 +381,21 @@ export function reduce(
     }
     case 'error': {
       const message = readString(event, 'message') ?? 'Unknown error';
+      const category = readString(event, 'category');
+      const upgradeUrl = readString(event, 'upgrade_url');
       return {
         ...slice,
-        active: finalize({ ...run, error: message }, 'failed', message),
+        active: finalize(
+          {
+            ...run,
+            error: message,
+            errorCategory: category,
+            errorDetail: message,
+            upgradeUrl,
+          },
+          'failed',
+          message,
+        ),
       };
     }
     case 'reasoning_delta': {


### PR DESCRIPTION
## Summary

When Kimi (and any other provider) returned a billing/quota terminal 403, the live-run card rendered as `rara encountered an error / 0 tools / 0s` — no category, no detail, no upgrade path. This PR threads a structured error category from the kernel all the way to the UI and stops persisting the phantom all-zero trace.

- New `KernelError::Quota { message, upgrade_url }` detected in `classify_provider_error` ahead of the generic 429/5xx bucket; excluded from `is_fallback_eligible` because switching models doesn't fix an exhausted billing account.
- Agent loop skips `trace_builder.finalize()` and `TraceReady` when the turn fails before any LLM iteration or tool call, so the UI never sees an empty trace card.
- `OutboundEnvelope::error()` now carries `category` (quota / network / context_window / tool / cancelled / provider) and optional `upgrade_url`. Existing channel adapters just ignore the new fields.
- `live-run-store.ts` parses the new fields; `SingleAgentLiveCard.tsx` swaps the misleading "0s / 0 tools" chrome for a category-specific banner. Quota gets a CTA pointing at the provider's upgrade URL; the raw provider message is folded into a `<details>`.

## Type of change

| Type | Label |
|------|-------|
| Bug fix | `bug` |

## Component

`core` (kernel + web frontend)

## Closes

Closes #1926

## Test plan

- [x] `cargo check --workspace --all-targets` passes
- [x] `cargo +nightly fmt --all -- --check` passes
- [x] `cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings` clean
- [x] `cargo test -p rara-kernel` — 603 passed, 5 ignored (includes new quota detection unit tests)
- [x] `cd web && npm run build` succeeds
- [x] `cd web && npx vitest run` — 110 passed, 0 failed
- [ ] Manual repro: trigger a 403 quota response from Kimi and verify the card shows the new banner with upgrade CTA