### PR TITLE
feat(sandbox): expose volumes + network + working_dir on SandboxConfig/ExecRequest (#1937)

### DIFF
--- a/crates/rara-sandbox/AGENT.md
+++ b/crates/rara-sandbox/AGENT.md
@@ -23,6 +23,14 @@ Public surface (intentionally minimal, see #1697/#1698):
   `ExecOutcome::stdout: boxlite::ExecStdout` is a
   `futures::Stream<Item = String>`
 - `Sandbox::destroy(self) -> Result<()>`
+- `SandboxConfig` exposes `volumes: Vec<VolumeMount>`,
+  `network: NetworkPolicy`, and `working_dir: Option<String>` — all forwarded
+  to boxlite (#1937). `ExecRequest::working_dir` further allows per-exec
+  overrides via `boxlite::BoxCommand::working_dir`.
+- `VolumeMount` and `NetworkPolicy` are wrapper types over
+  `boxlite::runtime::options::VolumeSpec` / `boxlite::NetworkSpec`. We do not
+  re-export the boxlite types directly — same rule as the rest of this
+  crate's public surface, so the kernel never imports `boxlite::*`.
 
 ## Critical Invariants
 
@@ -32,6 +40,11 @@ Public surface (intentionally minimal, see #1697/#1698):
 - **No hardcoded rootfs image / paths.** The image reference is a required
   `SandboxConfig` field; the application layer reads it from YAML and
   passes it through. Do not add an `impl Default for SandboxConfig`.
+  `NetworkPolicy` *does* implement `Default` — the value mirrors
+  `boxlite::NetworkSpec::default` (`Enabled { allow_net: [] }`) so a YAML
+  config that omits `network` keeps the historical `run_code` behavior.
+  This is the only `Default` impl in the crate and exists solely to make
+  `#[serde(default)]` on `SandboxConfig::network` legal.
 - **No noop impls, no mock backend.** `docs/guides/anti-patterns.md`
   forbids silent `Ok(())` trait impls. If you need to test a caller
   without a real VM, fake it at the caller boundary — not inside this

--- a/crates/rara-sandbox/Cargo.toml
+++ b/crates/rara-sandbox/Cargo.toml
@@ -25,4 +25,5 @@ tokio = { workspace = true }
 tracing = { workspace = true }
 
 [dev-dependencies]
+serde_yaml = { workspace = true }
 tokio = { workspace = true }

--- a/crates/rara-sandbox/src/config.rs
+++ b/crates/rara-sandbox/src/config.rs
@@ -1,6 +1,6 @@
 //! Configuration types for sandbox creation and command execution.
 
-use std::time::Duration;
+use std::{path::PathBuf, time::Duration};
 
 use bon::Builder;
 use serde::{Deserialize, Serialize};
@@ -21,6 +21,14 @@ use serde::{Deserialize, Serialize};
 /// sandbox:
 ///   rootfs_image: "alpine:latest"
 ///   name: "my-agent-sandbox"
+///   volumes:
+///     - host_path: "/Users/me/work"
+///       guest_path: "/work"
+///       read_only: false
+///   network:
+///     mode: enabled
+///     allow_net: ["github.com"]
+///   working_dir: "/work"
 /// ```
 #[derive(Debug, Clone, Builder, Serialize, Deserialize)]
 pub struct SandboxConfig {
@@ -31,14 +39,35 @@ pub struct SandboxConfig {
     /// Optional human-readable box name. When `None`, boxlite generates one.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
+
+    /// Host-to-guest filesystem mounts forwarded to
+    /// [`boxlite::BoxOptions::volumes`]. Empty means no extra mounts beyond
+    /// what the rootfs image provides.
+    #[serde(default)]
+    #[builder(default)]
+    pub volumes: Vec<VolumeMount>,
+
+    /// Network policy forwarded to [`boxlite::BoxOptions::network`].
+    ///
+    /// Defaults to [`NetworkPolicy::Enabled`] with an empty allow-list, which
+    /// matches boxlite's own default and preserves the historical `run_code`
+    /// behavior of full outbound access.
+    #[serde(default)]
+    #[builder(default = NetworkPolicy::Enabled { allow_net: Vec::new() })]
+    pub network: NetworkPolicy,
+
+    /// Default working directory for commands executed in the sandbox.
+    /// Forwarded to [`boxlite::BoxOptions::working_dir`]. `None` means the
+    /// guest image's default (typically `/`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub working_dir: Option<String>,
 }
 
 /// Description of a single command to run inside a [`Sandbox`](crate::Sandbox).
 ///
 /// Mirrors the subset of [`boxlite::BoxCommand`] that rara actually uses
-/// today. Extra boxlite knobs (`tty`, `user`, `working_dir`) can be added
-/// here when a concrete caller needs them — not before, to keep the API
-/// surface minimal.
+/// today. Extra boxlite knobs (`tty`, `user`) can be added here when a
+/// concrete caller needs them — not before, to keep the API surface minimal.
 #[derive(Debug, Clone, Builder)]
 pub struct ExecRequest {
     /// Executable to invoke inside the sandbox (e.g. `"echo"`, `"python"`).
@@ -54,4 +83,152 @@ pub struct ExecRequest {
 
     /// Optional hard timeout enforced by boxlite.
     pub timeout: Option<Duration>,
+
+    /// Per-exec working directory override. When `None`, boxlite falls back
+    /// to [`SandboxConfig::working_dir`] (and ultimately the image default).
+    pub working_dir: Option<String>,
+}
+
+/// A single host-to-guest filesystem mount.
+///
+/// Mirrors `boxlite::runtime::options::VolumeSpec` but keeps `host_path` typed
+/// as [`PathBuf`] so callers compose it with the rest of the rara codebase
+/// (which uses `PathBuf` everywhere) without stringly-typed paperwork. The
+/// conversion to boxlite's `String`-typed `host_path` happens once in
+/// [`Sandbox::create`](crate::Sandbox::create).
+#[derive(Debug, Clone, Builder, Serialize, Deserialize)]
+pub struct VolumeMount {
+    /// Absolute path on the host. Boxlite requires absolute paths.
+    pub host_path: PathBuf,
+
+    /// Mount target inside the guest, e.g. `/work`.
+    pub guest_path: String,
+
+    /// When true, the mount is read-only from inside the guest.
+    #[serde(default)]
+    #[builder(default)]
+    pub read_only: bool,
+}
+
+/// Network policy applied to the whole sandbox.
+///
+/// Wrapper over [`boxlite::NetworkSpec`]. We expose our own type because
+/// `crates/rara-sandbox/AGENT.md` forbids re-exporting boxlite types — this
+/// crate's job is to insulate the kernel from boxlite API churn.
+///
+/// # YAML form
+///
+/// Serialized with an internal `mode` tag so YAML stays human-readable and
+/// the disabled variant doesn't need a dummy `allow_net` key:
+///
+/// ```yaml
+/// network:
+///   mode: enabled
+///   allow_net: ["github.com", "*.crates.io"]
+/// ```
+///
+/// ```yaml
+/// network:
+///   mode: disabled
+/// ```
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "mode", rename_all = "snake_case")]
+pub enum NetworkPolicy {
+    /// Network is up. Empty `allow_net` means full outbound access; a
+    /// non-empty list pins the guest to those hosts/CIDRs only.
+    Enabled {
+        /// Host patterns or CIDRs the guest may reach. See
+        /// [`boxlite::NetworkSpec`] for the exact pattern grammar.
+        #[serde(default)]
+        allow_net: Vec<String>,
+    },
+    /// No network interface in the guest at all.
+    Disabled,
+}
+
+impl Default for NetworkPolicy {
+    /// Mirror boxlite's own [`NetworkSpec::default`](boxlite::NetworkSpec) —
+    /// network up, empty allow-list = full outbound. Required so
+    /// `#[serde(default)]` on [`SandboxConfig::network`] works when YAML
+    /// omits the field; preserves `run_code`'s historical behavior.
+    fn default() -> Self {
+        Self::Enabled {
+            allow_net: Vec::new(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sandbox_config_defaults_match_boxlite() {
+        let cfg = SandboxConfig::builder()
+            .rootfs_image("alpine:latest".to_owned())
+            .build();
+
+        assert!(cfg.volumes.is_empty());
+        assert!(cfg.working_dir.is_none());
+        match cfg.network {
+            NetworkPolicy::Enabled { allow_net } => assert!(allow_net.is_empty()),
+            NetworkPolicy::Disabled => panic!("default network must be Enabled"),
+        }
+    }
+
+    #[test]
+    fn network_policy_enabled_yaml_roundtrip() {
+        let yaml = "mode: enabled\nallow_net:\n  - github.com\n";
+        let parsed: NetworkPolicy = serde_yaml::from_str(yaml).unwrap();
+        let allow = match &parsed {
+            NetworkPolicy::Enabled { allow_net } => allow_net.clone(),
+            NetworkPolicy::Disabled => panic!("expected Enabled"),
+        };
+        assert_eq!(allow, vec!["github.com".to_owned()]);
+
+        let reserialized = serde_yaml::to_string(&parsed).unwrap();
+        let reparsed: NetworkPolicy = serde_yaml::from_str(&reserialized).unwrap();
+        assert!(matches!(reparsed, NetworkPolicy::Enabled { .. }));
+    }
+
+    #[test]
+    fn network_policy_disabled_yaml_roundtrip() {
+        let yaml = "mode: disabled\n";
+        let parsed: NetworkPolicy = serde_yaml::from_str(yaml).unwrap();
+        assert!(matches!(parsed, NetworkPolicy::Disabled));
+
+        let reserialized = serde_yaml::to_string(&parsed).unwrap();
+        let reparsed: NetworkPolicy = serde_yaml::from_str(&reserialized).unwrap();
+        assert!(matches!(reparsed, NetworkPolicy::Disabled));
+    }
+
+    #[test]
+    fn network_policy_enabled_default_allow_net() {
+        // `mode: enabled` with no `allow_net` key should deserialize cleanly
+        // — boxlite's own NetworkSpec uses the same shape.
+        let parsed: NetworkPolicy = serde_yaml::from_str("mode: enabled\n").unwrap();
+        match parsed {
+            NetworkPolicy::Enabled { allow_net } => assert!(allow_net.is_empty()),
+            NetworkPolicy::Disabled => panic!("expected Enabled"),
+        }
+    }
+
+    #[test]
+    fn volume_mount_builder() {
+        let mount = VolumeMount::builder()
+            .host_path(PathBuf::from("/tmp/host"))
+            .guest_path("/work".to_owned())
+            .read_only(true)
+            .build();
+        assert_eq!(mount.host_path, PathBuf::from("/tmp/host"));
+        assert_eq!(mount.guest_path, "/work");
+        assert!(mount.read_only);
+
+        // read_only defaults to false when omitted.
+        let rw = VolumeMount::builder()
+            .host_path(PathBuf::from("/tmp/host"))
+            .guest_path("/work".to_owned())
+            .build();
+        assert!(!rw.read_only);
+    }
 }

--- a/crates/rara-sandbox/src/lib.rs
+++ b/crates/rara-sandbox/src/lib.rs
@@ -48,6 +48,6 @@ mod config;
 mod error;
 mod sandbox;
 
-pub use config::{ExecRequest, SandboxConfig};
+pub use config::{ExecRequest, NetworkPolicy, SandboxConfig, VolumeMount};
 pub use error::{BoxliteSnafu, Result, SandboxError};
 pub use sandbox::{ExecOutcome, Sandbox};

--- a/crates/rara-sandbox/src/sandbox.rs
+++ b/crates/rara-sandbox/src/sandbox.rs
@@ -1,13 +1,14 @@
 //! Concrete [`Sandbox`] handle backed by a boxlite `LiteBox`.
 
 use boxlite::{
-    BoxCommand, BoxOptions, BoxliteRuntime, ExecStderr, ExecStdout, Execution, LiteBox, RootfsSpec,
+    BoxCommand, BoxOptions, BoxliteRuntime, ExecStderr, ExecStdout, Execution, LiteBox,
+    NetworkSpec, RootfsSpec, runtime::options::VolumeSpec,
 };
 use snafu::ResultExt;
 use tracing::instrument;
 
 use crate::{
-    config::{ExecRequest, SandboxConfig},
+    config::{ExecRequest, NetworkPolicy, SandboxConfig, VolumeMount},
     error::{BoxliteSnafu, MissingStdoutSnafu, Result},
 };
 
@@ -58,6 +59,9 @@ impl Sandbox {
         let runtime = BoxliteRuntime::default_runtime();
         let options = BoxOptions {
             rootfs: RootfsSpec::Image(config.rootfs_image),
+            volumes: config.volumes.into_iter().map(volume_to_boxlite).collect(),
+            network: network_to_boxlite(config.network),
+            working_dir: config.working_dir,
             ..Default::default()
         };
         let litebox = runtime
@@ -84,6 +88,9 @@ impl Sandbox {
         }
         if let Some(timeout) = request.timeout {
             command = command.timeout(timeout);
+        }
+        if let Some(working_dir) = request.working_dir {
+            command = command.working_dir(working_dir);
         }
 
         let mut execution = self.litebox.exec(command).await.context(BoxliteSnafu)?;
@@ -116,5 +123,24 @@ impl Sandbox {
             .await
             .context(BoxliteSnafu)?;
         Ok(())
+    }
+}
+
+/// Translate a [`VolumeMount`] into boxlite's `String`-typed
+/// [`VolumeSpec`]. boxlite stores `host_path` as `String` (see
+/// `boxlite/runtime/options.rs`) so we lossily render the `PathBuf` once
+/// here rather than leaking that detail to callers.
+fn volume_to_boxlite(mount: VolumeMount) -> VolumeSpec {
+    VolumeSpec {
+        host_path:  mount.host_path.to_string_lossy().into_owned(),
+        guest_path: mount.guest_path,
+        read_only:  mount.read_only,
+    }
+}
+
+fn network_to_boxlite(policy: NetworkPolicy) -> NetworkSpec {
+    match policy {
+        NetworkPolicy::Enabled { allow_net } => NetworkSpec::Enabled { allow_net },
+        NetworkPolicy::Disabled => NetworkSpec::Disabled,
     }
 }


### PR DESCRIPTION
## Summary

Part of #1936. Widen `rara-sandbox`'s public surface so future PRs in the stack can pass volumes, network policy, and working_dir to boxlite without touching this crate again. Pure crate-level change — no callers migrate, every new field has a default that preserves existing `run_code` behavior byte-for-byte.

- `SandboxConfig` gains `volumes: Vec<VolumeMount>`, `network: NetworkPolicy`, and `working_dir: Option<String>`.
- `ExecRequest` gains `working_dir: Option<String>` for per-exec override (boxlite's `BoxCommand::working_dir`).
- New wrapper types `VolumeMount` and `NetworkPolicy` insulate the kernel from boxlite's API churn — same rule already applied to the rest of this crate's surface (re-exporting boxlite types is forbidden by `AGENT.md`).
- `NetworkPolicy::default` mirrors `boxlite::NetworkSpec::default` (`Enabled { allow_net: [] }`), so YAML that omits `network` keeps the historical full-outbound behavior.
- `NetworkPolicy` uses `#[serde(tag = "mode", rename_all = "snake_case")]` so YAML reads cleanly: `network: { mode: enabled, allow_net: [...] }` or `network: { mode: disabled }`.
- `AGENT.md` updated with the new surface and a note explaining why `NetworkPolicy` is the only `Default` impl in the crate.

## Type of change

| Type | Label |
|------|-------|
| New feature | `enhancement` |

## Component

`core`

## Closes

Closes #1937

## Test plan

- [x] `cargo check -p rara-sandbox` passes
- [x] `cargo test -p rara-sandbox --lib` passes (5 tests, including default values + `NetworkPolicy` YAML round-trip + `VolumeMount` builder)
- [x] `cargo check --all --all-targets` passes (no caller breaks)
- [x] `prek run --files <changed>` passes (cargo check / fmt / clippy / doc all green)