### PR TITLE
chore(ci): drop setup-mold action — runner image now bakes mold and wget (#1940)

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -48,10 +48,7 @@ jobs:
       - name: Install diesel system libraries
         run: |
           sudo apt-get update
-          sudo apt-get install -y --no-install-recommends libsqlite3-dev libpq-dev wget
-
-      - name: Setup mold linker
-        uses: rui314/setup-mold@9c9c13bf4c3f1adef0cc596abc155580bcb04444 # v1
+          sudo apt-get install -y --no-install-recommends libsqlite3-dev libpq-dev
 
       - name: Run clippy
         run: cargo clippy --workspace --all-targets --no-deps -- -D warnings
@@ -72,10 +69,7 @@ jobs:
       - name: Install diesel system libraries
         run: |
           sudo apt-get update
-          sudo apt-get install -y --no-install-recommends libsqlite3-dev libpq-dev wget
-
-      - name: Setup mold linker
-        uses: rui314/setup-mold@9c9c13bf4c3f1adef0cc596abc155580bcb04444 # v1
+          sudo apt-get install -y --no-install-recommends libsqlite3-dev libpq-dev
 
       - name: Run tests
         run: cargo nextest run --workspace --profile ci
@@ -99,14 +93,6 @@ jobs:
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
         with:
           persist-credentials: false
-
-      - name: Install wget for mold installer
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends wget
-
-      - name: Setup mold linker
-        uses: rui314/setup-mold@9c9c13bf4c3f1adef0cc596abc155580bcb04444 # v1
 
       - name: Generate documentation
         run: cargo +nightly doc --workspace --no-deps --document-private-items


### PR DESCRIPTION
## Summary

The self-hosted `arc-runner-set` image (pods at `10.0.0.168:30080`) now ships `mold` and `wget` pre-installed, so the `rui314/setup-mold` action and the `wget` apt-install steps that fed it are dead weight.

Changes to `.github/workflows/rust.yml`:
- **Clippy** + **Test** jobs: drop the `Setup mold linker` step and remove `wget` from the `Install diesel system libraries` apt-install line (keeps `libsqlite3-dev`, `libpq-dev`).
- **Docs** job: drop both `Install wget for mold installer` and `Setup mold linker` steps entirely — the wget step there existed solely as the setup-mold downloader prerequisite (no diesel libs to install).

Verified no other workflow files reference `setup-mold` or install `wget` for mold purposes. CI passing on this branch is the real proof that clippy/test/docs still link without the action — the runner image already provides mold on `PATH`.

This PR is independent of #1933 and #1941.

## Type of change

| Type | Label |
|------|-------|
| Chore | `chore` |

## Component

`ci`

## Closes

Closes #1940

## Test plan

- [x] CI green on this branch (clippy + test + docs all link successfully without `setup-mold`)