### PR TITLE
ci(test): add real-LLM e2e job using OPENAI_API_KEY secret (#1941)

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,74 @@
+name: E2E (Real LLM)
+
+# Real-LLM e2e flows (`real_tape_flow`, `anchor_checkout_e2e`) against an
+# OpenAI-compatible provider. Triggers on `main` push + manual dispatch only —
+# **not** on pull_request, to avoid burning provider tokens on every push.
+# Maintainer must configure `OPENAI_API_KEY` (secret), `OPENAI_BASE_URL` (var),
+# and `OPENAI_MODEL` (var) in repo settings; without them the job fails fast
+# at config render.
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: e2e-real-llm-${{ github.sha }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: true
+  CARGO_INCREMENTAL: false
+  CARGO_NET_RETRY: 10
+  RUSTUP_MAX_RETRIES: 10
+  # Disable the runner image's preset sccache wrapper — no backend is configured.
+  RUSTC_WRAPPER: ""
+
+defaults:
+  run:
+    shell: bash
+
+permissions:
+  contents: read
+
+jobs:
+  real-llm-e2e:
+    name: Real-LLM E2E
+    runs-on: arc-runner-set
+    env:
+      # ARC runners can't build native boxlite (meson/ninja/patchelf missing),
+      # mirroring the rust.yml jobs.
+      BOXLITE_DEPS_STUB: "1"
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
+        with:
+          persist-credentials: false
+
+      - name: Install diesel system libraries
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends libsqlite3-dev libpq-dev
+
+      - name: Render rara config from template
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          OPENAI_BASE_URL: ${{ vars.OPENAI_BASE_URL }}
+          OPENAI_MODEL: ${{ vars.OPENAI_MODEL }}
+        run: |
+          mkdir -p "$HOME/.config/rara"
+          envsubst < ci/config.template.yaml > "$HOME/.config/rara/config.yaml"
+
+      - name: Run real-LLM e2e tests
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          OPENAI_BASE_URL: ${{ vars.OPENAI_BASE_URL }}
+          OPENAI_MODEL: ${{ vars.OPENAI_MODEL }}
+          RARA_REAL_TAPE_SOAK_SECS: "120"
+          RARA_REAL_TAPE_TURN_TIMEOUT_SECS: "60"
+        run: |
+          cargo test -p rara-app \
+            --test real_tape_flow \
+            --test anchor_checkout_e2e \
+            -- --ignored --nocapture

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -13,7 +13,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: e2e-real-llm-${{ github.sha }}
+  group: e2e-real-llm-${{ github.run_id }}
   cancel-in-progress: true
 
 env:
@@ -49,7 +49,7 @@ jobs:
       - name: Install diesel system libraries
         run: |
           sudo apt-get update
-          sudo apt-get install -y --no-install-recommends libsqlite3-dev libpq-dev
+          sudo apt-get install -y --no-install-recommends libsqlite3-dev libpq-dev gettext-base
 
       - name: Render rara config from template
         env:
@@ -71,4 +71,4 @@ jobs:
           cargo test -p rara-app \
             --test real_tape_flow \
             --test anchor_checkout_e2e \
-            -- --ignored --nocapture
+            -- --ignored

--- a/ci/config.template.yaml
+++ b/ci/config.template.yaml
@@ -1,0 +1,34 @@
+# CI config template — rendered at job start via `envsubst` into
+# `~/.config/rara/config.yaml`. Only `llm.providers.openai.*` references
+# environment variables; the rest is hardcoded CI-safe values so the
+# real-LLM e2e tests have a complete, valid `AppConfig` to load.
+#
+# See `config.example.yaml` for the canonical reference and field docs.
+
+http:
+  bind_address: "127.0.0.1:25555"
+  cors_allowed_origins:
+    - "http://localhost:5173"
+
+grpc:
+  bind_address: "127.0.0.1:50051"
+  server_address: "127.0.0.1:50051"
+
+owner_token: "ci-owner-token-not-a-real-secret"
+owner_user_id: "ci"
+
+users:
+  - name: "ci"
+    role: root
+    platforms: []
+
+mita:
+  heartbeat_interval: "30m"
+
+llm:
+  default_provider: "openai"
+  providers:
+    openai:
+      base_url: "${OPENAI_BASE_URL}"
+      api_key: "${OPENAI_API_KEY}"
+      default_model: "${OPENAI_MODEL}"


### PR DESCRIPTION
## Summary

Restores real-LLM e2e coverage lost in #1930 (scripted-LLM tests removed). Adds a new GitHub Actions workflow `.github/workflows/e2e.yml` that exercises `real_tape_flow` and `anchor_checkout_e2e` against an OpenAI-compatible provider, plus a config template `ci/config.template.yaml` that materializes `~/.config/rara/config.yaml` from GitHub secrets/vars at job start.

- Triggers: `push: branches: [main]` + `workflow_dispatch`. **Not** on `pull_request` — explicit maintainer preference to avoid burning provider tokens per push.
- Soak knobs tightened for CI: `RARA_REAL_TAPE_SOAK_SECS=120`, `RARA_REAL_TAPE_TURN_TIMEOUT_SECS=60`.
- No Rust code changes — `AppConfig::new()` and the soak env vars already exist.

## Type of change

| Type | Label |
|------|-------|
| New feature | `enhancement` |

## Component

`ci`

## Closes

Closes #1941

## Maintainer follow-up (out of scope for this PR)

The new job will not pass until the maintainer configures these in repo Settings:
- Secret `OPENAI_API_KEY`
- Variable `OPENAI_BASE_URL`
- Variable `OPENAI_MODEL`

Until then the job will fail at config render. Since the workflow only triggers on `main` push + manual dispatch, **it will not run on this PR at all** — only the standard rust/lint/web checks gate this PR.

## Independence

This PR is independent of #1933 and #1940. The only assumption shared with #1940 is that the `arc-runner-set` image bakes `mold` and `wget` — this workflow correspondingly skips the `setup-mold` action and the `wget` apt install.

## Test plan

- [x] `envsubst` renders the template to valid YAML (verified locally with `python -c yaml.safe_load`)
- [x] Template covers every `AppConfig` required field (`owner_token`, `owner_user_id`, `users`, `mita`); other top-level sections rely on safe defaults from #1913
- [x] `prek` passes on changed files (no rust hooks triggered)
- [ ] CI on this PR is green (rust + lint + web — the new e2e job is intentionally not triggered here)
- [ ] After merge, the new e2e job appears in the workflow list and runs on the next `main` push (verified post-merge once secrets/vars are set)