### PR TITLE
fix(ci): render e2e config under XDG_CONFIG_HOME on read-only $HOME (#1948)

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -57,8 +57,12 @@ jobs:
           OPENAI_BASE_URL: ${{ vars.OPENAI_BASE_URL }}
           OPENAI_MODEL: ${{ vars.OPENAI_MODEL }}
         run: |
-          mkdir -p "$HOME/.config/rara"
-          envsubst < ci/config.template.yaml > "$HOME/.config/rara/config.yaml"
+          # ARC self-hosted runners ship with a read-only $HOME, so render the
+          # config under $RUNNER_TEMP and steer `dirs::config_dir()` there via
+          # XDG_CONFIG_HOME for downstream steps.
+          mkdir -p "$RUNNER_TEMP/xdg-config/rara"
+          envsubst < ci/config.template.yaml > "$RUNNER_TEMP/xdg-config/rara/config.yaml"
+          echo "XDG_CONFIG_HOME=$RUNNER_TEMP/xdg-config" >> "$GITHUB_ENV"
 
       - name: Run real-LLM e2e tests
         env:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -58,11 +58,15 @@ jobs:
           OPENAI_MODEL: ${{ vars.OPENAI_MODEL }}
         run: |
           # ARC self-hosted runners ship with a read-only $HOME, so render the
-          # config under $RUNNER_TEMP and steer `dirs::config_dir()` there via
-          # XDG_CONFIG_HOME for downstream steps.
-          mkdir -p "$RUNNER_TEMP/xdg-config/rara"
+          # config under $RUNNER_TEMP and steer both `dirs::config_dir()` and
+          # `dirs::data_local_dir()` (used by rara_paths::data_dir) there via
+          # the XDG_* env vars for downstream steps.
+          mkdir -p "$RUNNER_TEMP/xdg-config/rara" "$RUNNER_TEMP/xdg-data"
           envsubst < ci/config.template.yaml > "$RUNNER_TEMP/xdg-config/rara/config.yaml"
-          echo "XDG_CONFIG_HOME=$RUNNER_TEMP/xdg-config" >> "$GITHUB_ENV"
+          {
+            echo "XDG_CONFIG_HOME=$RUNNER_TEMP/xdg-config"
+            echo "XDG_DATA_HOME=$RUNNER_TEMP/xdg-data"
+          } >> "$GITHUB_ENV"
 
       - name: Run real-LLM e2e tests
         env:

--- a/ci/config.template.yaml
+++ b/ci/config.template.yaml
@@ -1,5 +1,5 @@
 # CI config template — rendered at job start via `envsubst` into
-# `~/.config/rara/config.yaml`. Only `llm.providers.openai.*` references
+# `$XDG_CONFIG_HOME/rara/config.yaml`. Only `llm.providers.openai.*` references
 # environment variables; the rest is hardcoded CI-safe values so the
 # real-LLM e2e tests have a complete, valid `AppConfig` to load.
 #


### PR DESCRIPTION
## Summary

The `Render rara config from template` step in `.github/workflows/e2e.yml` failed on the ARC self-hosted runner with `mkdir: cannot create directory '/home/runner/.config/rara': Permission denied` — `$HOME` is not writable on `arc-runner-set`.

Render the rendered template under `$RUNNER_TEMP/xdg-config/rara/` and export `XDG_CONFIG_HOME` via `$GITHUB_ENV`. `rara_paths::config_file()` resolves via `dirs::config_dir()`, which honors `XDG_CONFIG_HOME` on Linux, so no Rust-side change is required.

## Type of change

| Type | Label |
|------|-------|
| Bug fix | `bug` |

## Component

`ci`

## Closes

Closes #1948

## Test plan

- [x] Workflow YAML is the only changed file; no Rust compile impact.
- [ ] On merge, the next `E2E (Real LLM)` run on `main` (or via `workflow_dispatch`) reaches the test step instead of failing at config render.