### PR TITLE
fix(web): collapse live card by default (#1950)

### DIFF
--- a/web/src/components/agent-live/SingleAgentLiveCard.tsx
+++ b/web/src/components/agent-live/SingleAgentLiveCard.tsx
@@ -40,7 +40,11 @@ const FADE_OUT_MS = 300;
 
 /** Folded header + collapsible timeline for a single active run. */
 export function SingleAgentLiveCard({ run, agentName = 'rara', onOpenTranscript, onStop }: Props) {
-  const [expanded, setExpanded] = useState(true);
+  // Default to collapsed: an expanded card with tool chips reserves
+  // scroll padding equal to its full height (see useLiveCardHeight),
+  // which eats visible message space. A single-line header keeps the
+  // status indicator quiet; users click to drill into the timeline.
+  const [expanded, setExpanded] = useState(false);
   const [nowTick, setNowTick] = useState(() => Date.now());
   const scrollerRef = useRef<HTMLDivElement>(null);
   const [stickToBottom, setStickToBottom] = useState(true);

--- a/web/src/components/agent-live/__tests__/SingleAgentLiveCard.test.tsx
+++ b/web/src/components/agent-live/__tests__/SingleAgentLiveCard.test.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { render, screen, within } from '@testing-library/react';
+import { fireEvent, render, screen, within } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 
 import type { LiveRun } from '../live-run-store';
@@ -52,9 +52,17 @@ function errorItem(seq: number, content: string): TimelineItem {
   return { seq, turn: 0, kind: 'error', content };
 }
 
+// The card defaults to collapsed so it doesn't compress the message column;
+// these tests assert content inside the expandable timeline, so click open
+// after render.
+function expandCard() {
+  fireEvent.click(screen.getByRole('button', { name: /events/ }));
+}
+
 describe('SingleAgentLiveCard', () => {
   it('shows a generic working placeholder when the run has no items or stage', () => {
     render(<SingleAgentLiveCard run={runFixture()} onOpenTranscript={vi.fn()} />);
+    expandCard();
     expect(screen.getByText('正在处理…')).toBeInTheDocument();
   });
 
@@ -77,6 +85,7 @@ describe('SingleAgentLiveCard', () => {
         onOpenTranscript={vi.fn()}
       />,
     );
+    expandCard();
     expect(screen.getAllByText('思考中…').length).toBeGreaterThan(0);
   });
 
@@ -89,6 +98,7 @@ describe('SingleAgentLiveCard', () => {
         onOpenTranscript={vi.fn()}
       />,
     );
+    expandCard();
     expect(screen.getByText('grep')).toBeInTheDocument();
     expect(screen.getByText('fn main')).toBeInTheDocument();
     expect(screen.getByRole('status', { name: 'running' })).toBeInTheDocument();
@@ -106,6 +116,7 @@ describe('SingleAgentLiveCard', () => {
         onOpenTranscript={vi.fn()}
       />,
     );
+    expandCard();
     expect(screen.getByLabelText('completed')).toBeInTheDocument();
   });
 
@@ -121,6 +132,7 @@ describe('SingleAgentLiveCard', () => {
         onOpenTranscript={vi.fn()}
       />,
     );
+    expandCard();
     expect(screen.getByLabelText('errored')).toBeInTheDocument();
     expect(screen.getByText('permission denied')).toBeInTheDocument();
   });
@@ -134,6 +146,7 @@ describe('SingleAgentLiveCard', () => {
         onOpenTranscript={vi.fn()}
       />,
     );
+    expandCard();
     expect(screen.getByLabelText('errored')).toBeInTheDocument();
     expect(screen.getByText('kernel crashed')).toBeInTheDocument();
   });
@@ -150,6 +163,7 @@ describe('SingleAgentLiveCard', () => {
         onOpenTranscript={vi.fn()}
       />,
     );
+    expandCard();
     const names = Array.from(container.querySelectorAll('.font-mono')).map(
       (n) => within(n as HTMLElement).queryByText(/./)?.textContent ?? n.textContent,
     );


### PR DESCRIPTION
## Summary

The in-progress agent live card defaulted to `expanded = true`. Because `useLiveCardHeight` reserves scroll padding equal to the card's measured height, an expanded card with multiple tool chips compressed visible message space.

Default to collapsed so the card renders as a single-line status header (~40px). Users still click to expand and inspect the tool timeline.

## Type of change

| Type | Label |
|------|-------|
| Bug fix | \`bug\` |

## Component

\`ui\`

## Closes

Closes #1950

## Test plan

- [x] \`cd web && npm run build\` passes
- [x] Verified locally that the card stays collapsed by default and expand-on-click still works