### PR TITLE
fix(kernel): resolve subagent LLM overrides via parent-chain walk (#1958)

### DIFF
--- a/crates/kernel/src/agent/mod.rs
+++ b/crates/kernel/src/agent/mod.rs
@@ -924,6 +924,36 @@ fn thinking_level_to_config(
     })
 }
 
+/// Walk the parent_id chain in the process table to find the root ancestor
+/// of `key`. The root is the first session whose `parent_id` is `None`.
+///
+/// Used by `run_turn` to locate the SessionEntry holding LLM overrides:
+/// child (task subagent) sessions don't have their own SessionEntry, so
+/// children inherit the root's pinned model/provider/thinking_level by
+/// looking it up at turn time (#1958).
+fn root_session_key(handle: &KernelHandle, key: SessionKey) -> SessionKey {
+    walk_to_root(handle.process_table().as_ref(), key)
+}
+
+/// Inner helper: walk the parent_id chain in `table` from `key` to the root.
+///
+/// Falls back to the last reachable session if any ancestor is missing from
+/// the table (e.g. already reaped) or if the depth cap is hit. The cap is a
+/// belt-and-suspenders guard against accidental cycles — `max_children=0`
+/// for task workers means real chains are 1–2 deep in practice.
+pub(crate) fn walk_to_root(table: &crate::session::SessionTable, key: SessionKey) -> SessionKey {
+    const MAX_DEPTH: usize = 32;
+    let mut current = key;
+    for _ in 0..MAX_DEPTH {
+        match table.with(&current, |s| s.parent_id) {
+            Some(Some(parent)) => current = parent,
+            // Reached the root, or session not found in table — stop.
+            Some(None) | None => return current,
+        }
+    }
+    current
+}
+
 /// Execute a single agent turn inline: build messages, stream LLM responses,
 /// execute tool calls, and emit [`StreamEvent`]s directly.
 ///
@@ -1069,9 +1099,16 @@ async fn run_agent_loop_inner(
     // Load per-session LLM overrides (model + thinking level) from the
     // session index. A user-facing UI can pin these via the admin chat
     // session API; when unset we fall back to the agent manifest defaults.
+    //
+    // Child (task subagent) sessions do NOT have their own SessionEntry
+    // — only root user-facing sessions do (#1958). Walk the in-memory
+    // parent chain in `process_table` to find the root, and read the
+    // overrides from the root's SessionEntry. This way children inherit
+    // their parent's pinned model without polluting the session list.
+    let root_session_key = root_session_key(handle, session_key);
     let session_entry = handle
         .session_index()
-        .get_session(&session_key)
+        .get_session(&root_session_key)
         .await
         .ok()
         .flatten();

--- a/crates/kernel/src/agent/mod.rs
+++ b/crates/kernel/src/agent/mod.rs
@@ -924,18 +924,10 @@ fn thinking_level_to_config(
     })
 }
 
-/// Walk the parent_id chain in the process table to find the root ancestor
-/// of `key`. The root is the first session whose `parent_id` is `None`.
+/// Walk the parent_id chain in `table` from `key` to the root.
 ///
-/// Used by `run_turn` to locate the SessionEntry holding LLM overrides:
-/// child (task subagent) sessions don't have their own SessionEntry, so
-/// children inherit the root's pinned model/provider/thinking_level by
-/// looking it up at turn time (#1958).
-fn root_session_key(handle: &KernelHandle, key: SessionKey) -> SessionKey {
-    walk_to_root(handle.process_table().as_ref(), key)
-}
-
-/// Inner helper: walk the parent_id chain in `table` from `key` to the root.
+/// A root session (no `parent_id`) returns `current` unchanged on the first
+/// iteration — the function is a no-op for top-level sessions.
 ///
 /// Falls back to the last reachable session if any ancestor is missing from
 /// the table (e.g. already reaped) or if the depth cap is hit. The cap is a
@@ -1105,7 +1097,7 @@ async fn run_agent_loop_inner(
     // parent chain in `process_table` to find the root, and read the
     // overrides from the root's SessionEntry. This way children inherit
     // their parent's pinned model without polluting the session list.
-    let root_session_key = root_session_key(handle, session_key);
+    let root_session_key = walk_to_root(handle.process_table().as_ref(), session_key);
     let session_entry = handle
         .session_index()
         .get_session(&root_session_key)

--- a/crates/kernel/src/kernel.rs
+++ b/crates/kernel/src/kernel.rs
@@ -934,62 +934,11 @@ impl Kernel {
                 .fork_session(&parent_key, &session_key);
         }
 
-        // Inherit per-session LLM overrides (model / model_provider /
-        // thinking_level) from the parent session by writing a SessionEntry
-        // for the child. Without this, agent::run_turn's lookup via
-        // session_index().get_session() returns None and the child silently
-        // falls back to the global default LLM (#1932).
-        //
-        // We only write the entry when the parent actually has an override to
-        // inherit. Writing for top-level spawns (no parent) or for parents
-        // with no overrides would pollute list_sessions() — that index
-        // enumerates every entry under the directory and feeds the user-facing
-        // session list, which today only contains user-created sessions.
-        //
-        // When the parent has no overrides we skip the write entirely:
-        // agent::run_turn's get_session(child) will return None and resolve
-        // to the global default, which is the correct behavior here.
-        //
-        // Failure to persist is logged but non-fatal: the spawn proceeds, the
-        // child just loses override inheritance — never block a spawn on
-        // metadata bookkeeping.
-        if let Some(parent_key) = parent_id.as_ref() {
-            let parent_entry = self
-                .io
-                .session_index()
-                .get_session(parent_key)
-                .await
-                .ok()
-                .flatten();
-            let has_override = parent_entry.as_ref().is_some_and(|p| {
-                p.model.is_some() || p.model_provider.is_some() || p.thinking_level.is_some()
-            });
-            if has_override {
-                let parent = parent_entry.expect("has_override implies parent_entry is Some");
-                let now = chrono::Utc::now();
-                let child_entry = crate::session::SessionEntry {
-                    key:            session_key,
-                    title:          None,
-                    model:          parent.model.clone(),
-                    model_provider: parent.model_provider.clone(),
-                    thinking_level: parent.thinking_level.clone(),
-                    system_prompt:  None,
-                    message_count:  0,
-                    preview:        None,
-                    metadata:       None,
-                    created_at:     now,
-                    updated_at:     now,
-                };
-                if let Err(e) = self.io.session_index().create_session(&child_entry).await {
-                    tracing::error!(
-                        error = %e,
-                        session_key = %session_key,
-                        parent_id = ?parent_id,
-                        "failed to persist SessionEntry for spawned agent — LLM override inheritance disabled for this session"
-                    );
-                }
-            }
-        }
+        // Per-session LLM overrides (model / model_provider / thinking_level)
+        // are NOT persisted for child sessions. Children are ephemeral and
+        // must not leak into the user-facing session list (#1958). Instead,
+        // `agent::run_turn` walks the parent_id chain in `process_table` at
+        // turn time and reads overrides from the root ancestor's SessionEntry.
 
         crate::metrics::record_session_created(&manifest.name);
         crate::metrics::inc_session_active(&manifest.name);

--- a/crates/kernel/src/session/mod.rs
+++ b/crates/kernel/src/session/mod.rs
@@ -1249,4 +1249,42 @@ mod state_transition_tests {
         // method returning `false` for a not-found session.
         assert!(table.with_mut(&missing, |_| ()).is_none());
     }
+
+    /// #1958 — `walk_to_root` walks `parent_id` until it finds the root
+    /// (the first session with `parent_id == None`). Children inherit
+    /// the root's pinned LLM overrides at turn time without persisting
+    /// their own SessionEntry.
+    #[test]
+    fn walk_to_root_finds_root_ancestor() {
+        let table = SessionTable::new();
+
+        let root = make_session(SessionState::Ready);
+        let root_key = root.session_key;
+        table.insert(root);
+
+        let mut child = make_session(SessionState::Ready);
+        child.parent_id = Some(root_key);
+        let child_key = child.session_key;
+        table.insert(child);
+
+        let mut grandchild = make_session(SessionState::Ready);
+        grandchild.parent_id = Some(child_key);
+        let grandchild_key = grandchild.session_key;
+        table.insert(grandchild);
+
+        // Root walks to itself.
+        assert_eq!(crate::agent::walk_to_root(&table, root_key), root_key);
+        // Direct child resolves to root.
+        assert_eq!(crate::agent::walk_to_root(&table, child_key), root_key);
+        // Grandchild resolves to root.
+        assert_eq!(crate::agent::walk_to_root(&table, grandchild_key), root_key);
+    }
+
+    #[test]
+    fn walk_to_root_handles_missing_session() {
+        let table = SessionTable::new();
+        // Not inserted — walk_to_root returns the input key as a safe fallback.
+        let orphan = SessionKey::new();
+        assert_eq!(crate::agent::walk_to_root(&table, orphan), orphan);
+    }
 }


### PR DESCRIPTION
## Summary

Stop persisting child `SessionEntry` files for spawned subagents. Children are ephemeral and were leaking into the user-facing session list (e.g. `task` tool spawns showing up under `sessions/index/`). Instead, resolve LLM overrides at `run_turn` time by walking the in-memory `parent_id` chain in `process_table` up to the root, then reading the root's `SessionEntry`.

This reverses the persistence approach added in #1932 in favour of an in-memory walk that has no UX side effects.

## Changes

- `crates/kernel/src/kernel.rs::handle_spawn_agent` — removed the conditional `session_index().create_session(&child_entry)` block that persisted children whenever the parent had any LLM override pinned. Replaced the doc comment with the new resolution model.
- `crates/kernel/src/agent/mod.rs::run_turn` — the override lookup now walks `parent_id` to the root via a new `walk_to_root` helper, so children inherit the root's pinned model without their own SessionEntry.
- `crates/kernel/src/session/mod.rs` — added unit tests for `walk_to_root` covering the root, child, grandchild, and missing-session cases.

Other `session_index().get_session()` callsites (preview update, image metadata, title generation, mita/admin/tool paths) all gracefully skip when the entry is missing — that's the correct behaviour for child sessions, no changes needed.

## Type of change

| Type | Label |
|------|-------|
| Bug fix | `bug` |

## Component

`core`

## Closes

Closes #1958

## Test plan

- [x] `cargo check -p rara-kernel` passes
- [x] `cargo test -p rara-kernel` — 562 passed, 5 ignored
- [x] `prek run --all-files` — all hooks Passed
- [x] New unit tests `walk_to_root_finds_root_ancestor` and `walk_to_root_handles_missing_session` cover the parent-chain walk