### PR TITLE
feat(web,backend): block image send when model has no vision support (#1956)

### DIFF
--- a/crates/extensions/backend-admin/src/chat/model_catalog.rs
+++ b/crates/extensions/backend-admin/src/chat/model_catalog.rs
@@ -24,7 +24,7 @@ use std::{
     time::{Duration, Instant},
 };
 
-use rara_kernel::llm::LlmModelListerRef;
+use rara_kernel::llm::{LlmModelListerRef, ModelCapabilities};
 use serde::Serialize;
 use tokio::sync::Mutex;
 use tracing::{debug, warn};
@@ -40,13 +40,18 @@ const CACHE_TTL: Duration = Duration::from_mins(5);
 #[derive(Debug, Clone, Serialize, utoipa::ToSchema)]
 pub struct ChatModel {
     /// OpenRouter model identifier (e.g. `"openai/gpt-4o"`).
-    pub id:             String,
+    pub id:              String,
     /// Human-friendly display name.
-    pub name:           String,
+    pub name:            String,
     /// Maximum context window in tokens.
-    pub context_length: u32,
+    pub context_length:  u32,
     /// Whether the user has pinned this model as a favorite.
-    pub is_favorite:    bool,
+    pub is_favorite:     bool,
+    /// Whether the model accepts image input. Surfaced so the frontend can
+    /// pre-flight image attachments and refuse to send to a text-only model,
+    /// instead of letting the kernel silently drop the image block at
+    /// request build time.
+    pub supports_vision: bool,
 }
 
 // ---------------------------------------------------------------------------
@@ -116,10 +121,11 @@ fn curated_fallback(favorite_ids: &[String]) -> Vec<ChatModel> {
     let mut models: Vec<ChatModel> = CURATED_MODELS
         .iter()
         .map(|m| ChatModel {
-            id:             m.id.to_owned(),
-            name:           m.name.to_owned(),
-            context_length: m.context_length,
-            is_favorite:    favorite_ids.iter().any(|f| f == m.id),
+            id:              m.id.to_owned(),
+            name:            m.name.to_owned(),
+            context_length:  m.context_length,
+            is_favorite:     favorite_ids.iter().any(|f| f == m.id),
+            supports_vision: ModelCapabilities::detect(None, m.id).supports_vision,
         })
         .collect();
     apply_favorite_sort(&mut models);
@@ -139,9 +145,10 @@ struct CacheEntry {
 /// flag, which is applied at query time).
 #[derive(Clone)]
 struct RawModel {
-    id:             String,
-    name:           String,
-    context_length: u32,
+    id:              String,
+    name:            String,
+    context_length:  u32,
+    supports_vision: bool,
 }
 
 // ---------------------------------------------------------------------------
@@ -231,10 +238,17 @@ impl ModelCatalog {
 
         Ok(models
             .into_iter()
-            .map(|m| RawModel {
-                id:             m.id.clone(),
-                name:           m.id,
-                context_length: 0,
+            .map(|m| {
+                // No provider hint here: `LlmModelLister::list_models()` does not
+                // carry one. The substring matcher in `is_known_vision_model`
+                // still resolves well-known model ids correctly.
+                let supports_vision = ModelCapabilities::detect(None, &m.id).supports_vision;
+                RawModel {
+                    id: m.id.clone(),
+                    name: m.id,
+                    context_length: 0,
+                    supports_vision,
+                }
             })
             .collect())
     }
@@ -245,10 +259,11 @@ impl ModelCatalog {
         let mut models: Vec<ChatModel> = raw
             .iter()
             .map(|m| ChatModel {
-                id:             m.id.clone(),
-                name:           m.name.clone(),
-                context_length: m.context_length,
-                is_favorite:    favorite_ids.iter().any(|f| f == &m.id),
+                id:              m.id.clone(),
+                name:            m.name.clone(),
+                context_length:  m.context_length,
+                is_favorite:     favorite_ids.iter().any(|f| f == &m.id),
+                supports_vision: m.supports_vision,
             })
             .collect();
         apply_favorite_sort(&mut models);

--- a/web/src/agent/rara-agent.ts
+++ b/web/src/agent/rara-agent.ts
@@ -57,6 +57,8 @@ import type {
 } from '@mariozechner/pi-ai';
 import type { UserMessageWithAttachments } from '@mariozechner/pi-web-ui';
 
+import { getModelCapabilities } from '../api/model-capabilities';
+
 import {
   type LifecycleEvent,
   type PromptContent,
@@ -76,6 +78,34 @@ import type {
 // ---------------------------------------------------------------------------
 // Construction
 // ---------------------------------------------------------------------------
+
+/**
+ * Thrown by `RaraAgent.prompt()` when the user attempts to send an image
+ * to a model whose `supports_vision` is `false`. The host (`<pi-chat-panel>`)
+ * surfaces the throw to its existing error UI; the composer keeps the
+ * unsent image attachment so the user can switch models or remove it.
+ */
+export class RaraVisionUnsupportedError extends Error {
+  readonly modelId: string;
+
+  constructor(modelId: string) {
+    super(`当前模型「${modelId}」不支持图片，请切换到支持 vision 的模型，或先移除图片再发送`);
+    this.name = 'RaraVisionUnsupportedError';
+    this.modelId = modelId;
+  }
+}
+
+/**
+ * True when `input` carries at least one inline image block — the only
+ * shape `prepareUserInput` would translate into a wire-level `image_base64`
+ * block. Document attachments and plain-text content do not trigger the
+ * vision gate.
+ */
+function inputHasImage(input: string | UserMessageWithAttachments): boolean {
+  if (typeof input === 'string') return false;
+  if (typeof input.content === 'string') return false;
+  return input.content.some((c) => c.type === 'image');
+}
 
 export interface RaraAgentOptions {
   /** Initial session key. May be set/changed later via `agent.sessionId = …`. */
@@ -350,6 +380,25 @@ export class RaraAgent {
     }
     if (!this.client) {
       throw new Error('No active session — set sessionId before prompting');
+    }
+
+    // Vision pre-flight: if the input carries an image and the selected
+    // model is known to be text-only, refuse the send before any state
+    // mutation. Fail-open on lookup miss (model id absent from the
+    // catalog, or the catalog fetch failed) — a stale frontend cache must
+    // not permanently block image sends.
+    if (inputHasImage(input)) {
+      const modelId = this._state.model.id;
+      try {
+        const caps = await getModelCapabilities();
+        if (caps.get(modelId) === false) {
+          throw new RaraVisionUnsupportedError(modelId);
+        }
+      } catch (err) {
+        if (err instanceof RaraVisionUnsupportedError) throw err;
+        // Catalog fetch failed — log and fall through (fail-open).
+        console.warn('RaraAgent: model capabilities lookup failed, allowing send', err);
+      }
     }
 
     const { wire, local } = prepareUserInput(input);

--- a/web/src/api/model-capabilities.ts
+++ b/web/src/api/model-capabilities.ts
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2025 Rararulab
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Model capability lookup — backed by `GET /api/v1/chat/models`.
+ *
+ * Used by `RaraAgent.prompt()` to pre-flight image attachments: when the
+ * selected model has `supports_vision === false` we refuse the send so the
+ * kernel never silently drops the image block (which would otherwise be
+ * replaced by a `[image: current model does not support vision]`
+ * placeholder at request build time).
+ *
+ * The catalog rarely changes during a session, so we cache the result of
+ * the first fetch indefinitely. Callers that need a fresh view (e.g. after
+ * favoriting/unfavoriting) call `refreshModelCapabilities()`.
+ */
+
+import { api } from './client';
+
+interface ChatModelDto {
+  id: string;
+  name: string;
+  context_length: number;
+  is_favorite: boolean;
+  supports_vision: boolean;
+}
+
+/** Lookup from model id to whether the model accepts image input. */
+export type ModelCapabilityMap = Map<string, boolean>;
+
+let inflight: Promise<ModelCapabilityMap> | null = null;
+
+async function fetchCapabilityMap(): Promise<ModelCapabilityMap> {
+  const models = await api.get<ChatModelDto[]>('/api/v1/chat/models');
+  const map: ModelCapabilityMap = new Map();
+  for (const m of models) {
+    map.set(m.id, m.supports_vision);
+  }
+  return map;
+}
+
+/**
+ * Return the cached capability map, fetching once on first call.
+ *
+ * Failures (network, auth) reject the promise and clear the cached
+ * promise so the next caller can retry. This is intentional: the gate
+ * downstream is fail-open (unknown model id → allow send) so a single
+ * fetch failure must not permanently block image sends.
+ */
+export function getModelCapabilities(): Promise<ModelCapabilityMap> {
+  if (!inflight) {
+    inflight = fetchCapabilityMap().catch((err) => {
+      inflight = null;
+      throw err;
+    });
+  }
+  return inflight;
+}
+
+/** Force a re-fetch on the next `getModelCapabilities()` call. */
+export function refreshModelCapabilities(): void {
+  inflight = null;
+}


### PR DESCRIPTION
## Summary

Two-layer fix so the user gets a friendly toast instead of a silently-dropped image block when sending to a text-only model:

- **Backend** (`rara-backend-admin`): `ChatModel` (and the `RawModel` cache + `curated_fallback`) now carry `supports_vision`, sourced from `rara_kernel::llm::ModelCapabilities::detect(None, &id).supports_vision` so the value tracks the same heuristic the kernel uses internally — no hand-maintained list, no drift.
- **Frontend**:
  - New `web/src/api/model-capabilities.ts` — one-shot cached fetcher of `GET /api/v1/chat/models`, exposing `getModelCapabilities()` + `refreshModelCapabilities()`.
  - `RaraAgent.prompt()` pre-flights image inputs: if `state.model.id` lookup returns `false`, throw `RaraVisionUnsupportedError` **before** any state mutation (no `messages` push, no `isStreaming` flip, no stream lifecycle open). The composer's image stays put. Lookup is **fail-open** — unknown model id or fetch failure allows the send through, so a stale frontend catalog cannot permanently block image-capable models.

UI string is Chinese ("当前模型「X」不支持图片，请切换到支持 vision 的模型，或先移除图片再发送"); code/comments are English.

## Type of change

| Type | Label |
|------|-------|
| Enhancement | `enhancement` |

## Component

`ui` + `backend`

## Closes

Closes #1956

## Test plan

- [x] `cargo check -p rara-backend-admin` — clean
- [x] `cargo clippy -p rara-backend-admin --all-targets --all-features --no-deps -- -D warnings` — clean
- [x] `bun run build` (web) — clean
- [x] `bunx vitest run src/agent/` — 23 passed (3 files), no regressions
- [x] `prek run --files <changed>` — all hooks pass (cargo check / fmt / clippy / doc, AGENT.md, web lint-staged)
- [ ] Manual verification with a deepseek-chat-only model: paste image → send → toast surfaces, image attachment preserved, no backend turn fired.
- [ ] Manual verification with a vision-capable model (e.g. claude-sonnet-4): unchanged behavior.