### PR TITLE
fix(telemetry): use blocking reqwest client for OTLP exporters (#1960)

### DIFF
--- a/crates/common/telemetry/Cargo.toml
+++ b/crates/common/telemetry/Cargo.toml
@@ -23,7 +23,7 @@ lazy_static = "1.4"
 once_cell = "1.19"
 opentelemetry = { version = "0.31.0", default-features = false, features = ["trace", "metrics", "logs"] }
 opentelemetry-appender-tracing = { version = "0.31.0" }
-opentelemetry-otlp = { version = "0.31.0", features = ["trace", "metrics", "logs", "grpc-tonic", "http-proto", "reqwest-client"] }
+opentelemetry-otlp = { version = "0.31.0", features = ["trace", "metrics", "logs", "grpc-tonic", "http-proto", "reqwest-blocking-client"] }
 opentelemetry-semantic-conventions = { version = "0.31.0", features = ["semconv_experimental"] }
 opentelemetry_sdk = { version = "0.31.0", features = ["rt-tokio", "trace", "metrics", "logs"] }
 pyroscope = { workspace = true }
@@ -31,7 +31,7 @@ pyroscope_pprofrs = { workspace = true }
 # Pinned to 0.12 to match opentelemetry-http 0.31's reqwest dep — the
 # `HttpClient` trait impl is only visible for the version that crate links
 # against. Workspace reqwest is 0.13.
-reqwest = { version = "0.12", default-features = false, features = ["rustls-tls"] }
+reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "blocking"] }
 serde.workspace = true
 serde_json = "1.0"
 smart-default = { workspace = true }

--- a/crates/common/telemetry/src/logging.rs
+++ b/crates/common/telemetry/src/logging.rs
@@ -754,13 +754,14 @@ fn build_otel_resource(
     }
 }
 
-/// Build a `reqwest::Client` configured for OTLP HTTP exporters.
+/// Build a `reqwest::blocking::Client` configured for OTLP HTTP exporters.
 ///
 /// OTLP exporters target collectors on the LAN (Alloy, Langfuse, Loki). They
-/// must NOT honor `HTTP_PROXY` / `HTTPS_PROXY` from the environment — a
-/// developer's outbound proxy would silently misroute observability traffic.
-fn build_otlp_http_client() -> reqwest::Client {
-    reqwest::Client::builder()
+/// must NOT honor `HTTP_PROXY` / `HTTPS_PROXY` from the environment, and
+/// OTel's BatchProcessor / PeriodicReader threads have no tokio runtime, so we
+/// use the blocking client.
+fn build_otlp_http_client() -> reqwest::blocking::Client {
+    reqwest::blocking::Client::builder()
         .no_proxy()
         .build()
         .expect("Failed to build reqwest client for OTLP HTTP exporter")


### PR DESCRIPTION
## Summary

OTel BatchSpanProcessor / BatchLogProcessor / PeriodicReader each run on dedicated OS threads with no tokio runtime. PR #1931 injected an async `reqwest::Client` to enforce `.no_proxy()`, which made every export from those threads panic with `there is no reactor running, must be called from the context of a Tokio 1.x runtime` — so #1931's proxy fix never actually delivered telemetry, and #1949's logs path inherited the same panic.

Switch the shared `build_otlp_http_client()` helper to `reqwest::blocking::Client`, flip the `opentelemetry-otlp` feature from `reqwest-client` to `reqwest-blocking-client`, and add `blocking` to the direct `reqwest` features. opentelemetry-otlp 0.31's `HttpClient` trait impl picks up the blocking variant under that feature, so all three call sites (`build_otlp_exporter`, `init_meter_provider`, `init_logger_provider`) keep their existing `.with_http_client(build_otlp_http_client())` wiring.

## Type of change

| Type | Label |
|------|-------|
| Bug fix | `bug` |

## Component

`core`

## Closes

Closes #1960

## Test plan

- [x] `cargo check -p common-telemetry`
- [x] `cargo clippy -p common-telemetry --all-targets --all-features --no-deps -- -D warnings`
- [x] `prek run --all-files`
- [ ] Boot rara with `telemetry.otlp.enabled: true` on local-rara and confirm no `there is no reactor running` panics in stderr