### PR TITLE
fix(web): SessionMenu copy fallback for non-secure contexts (#1957)

### DIFF
--- a/web/src/components/SessionMenu.tsx
+++ b/web/src/components/SessionMenu.tsx
@@ -38,6 +38,35 @@ interface SessionMenuProps {
 }
 
 /**
+ * Copy `text` to the clipboard via the legacy `document.execCommand('copy')`
+ * path. Used as a fallback when `navigator.clipboard` is unavailable, which
+ * happens whenever the page is served from a non-secure context (e.g. a LAN
+ * IP without TLS). Returns `true` on success.
+ *
+ * The textarea is positioned off-screen and marked readonly so the operation
+ * does not flash UI, scroll the page, or pop the keyboard on iOS.
+ */
+function copyTextFallback(text: string): boolean {
+  if (typeof document === 'undefined') return false;
+  const textarea = document.createElement('textarea');
+  textarea.value = text;
+  textarea.setAttribute('readonly', '');
+  textarea.style.position = 'fixed';
+  textarea.style.top = '-9999px';
+  textarea.style.left = '0';
+  textarea.style.opacity = '0';
+  document.body.appendChild(textarea);
+  try {
+    textarea.select();
+    return document.execCommand('copy');
+  } catch {
+    return false;
+  } finally {
+    document.body.removeChild(textarea);
+  }
+}
+
+/**
  * Hover-revealed `⋯` menu attached to a session row or the chat-page header
  * title. Exposes two actions: copy the session id to the clipboard, and
  * regenerate the session title via the backend.
@@ -48,16 +77,29 @@ export function SessionMenu({ sessionKey, ariaLabel, onRegenerated }: SessionMen
   const [error, setError] = useState<string | null>(null);
 
   const handleCopy = async () => {
+    // `navigator.clipboard` is only defined in secure contexts (https /
+    // localhost). When the dev server is reached over a LAN IP it is
+    // `undefined`, so optional-chain the call and fall back to the legacy
+    // `document.execCommand('copy')` path before surfacing an error.
     try {
-      await navigator.clipboard.writeText(sessionKey);
+      if (navigator.clipboard?.writeText) {
+        await navigator.clipboard.writeText(sessionKey);
+        setCopied(true);
+        setTimeout(() => setCopied(false), 1200);
+        return;
+      }
+    } catch {
+      // fall through to the execCommand fallback
+    }
+
+    if (copyTextFallback(sessionKey)) {
       setCopied(true);
       setTimeout(() => setCopied(false), 1200);
-    } catch {
-      // Clipboard write may fail (insecure context, denied permission).
-      // The menu item is a debug affordance — surface the failure inline.
-      setError('复制失败');
-      setTimeout(() => setError(null), 1500);
+      return;
     }
+
+    setError('复制失败');
+    setTimeout(() => setError(null), 1500);
   };
 
   const handleRegenerate = async (e: Event) => {


### PR DESCRIPTION
## Summary

- 顶部 header 的 SessionMenu「复制 session id」在 LAN IP（如 `http://10.0.0.183:5173`）下无反应——`navigator.clipboard` 仅在 secure context 可用，写入抛错后 Radix `onSelect` 关菜单，inline 错误来不及渲染。
- 兜底：clipboard API 走可选链先试一次，失败或 API 不存在就用临时 `<textarea>` + `document.execCommand('copy')`（off-screen, readonly，避免视觉闪烁和 iOS 键盘弹出）。
- 两路都失败才显示「复制失败」。

## Type of change

| Type | Label |
|------|-------|
| Bug fix | `bug` |

## Component

`ui`

## Closes

Closes #1957

## Test plan

- [x] `cd web && bun run build` passes
- [x] 手测：通过 `http://10.0.0.183:5173`（LAN IP，非安全上下文）打开页面，点击 header ⋯ → 复制 session id → 粘贴验证
- [x] 手测：通过 `http://localhost:5173`（secure context）走 clipboard API 主路径