### PR TITLE
chore(harness): codify auto-chaining (spec-author → implementer) in workflow.md (#1969)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,6 +45,7 @@ These artifacts are authoritative — your work is accountable to them, not just
 ## Development Workflow
 
 All changes — no matter how small — follow the issue → worktree → PR → merge flow. No exceptions.
+Once the plan is acknowledged, chain steps without re-asking — see the "Auto-chaining" section in `docs/guides/workflow.md`.
 
 @docs/guides/workflow.md
 @docs/guides/commit-style.md

--- a/docs/guides/workflow.md
+++ b/docs/guides/workflow.md
@@ -67,6 +67,22 @@ hands the user's request (verbatim) to spec-author. Spec-author:
 
 See `.claude/agents/spec-author.md` for the full contract.
 
+## Auto-chaining
+
+Once the user has acknowledged the proposed plan, the parent agent chains
+through the workflow steps mechanically: spec-author → worktree + implementer
+→ reviewer → push → PR → merge. Do NOT insert a confirmation round-trip
+between steps. In particular, after spec-author returns an issue number,
+the parent dispatches the implementer **directly** — do not ask the user
+"要不要派 implementer 把它做掉？" / "should I dispatch implementer?". The
+plan was already approved; re-asking is sycophancy, not safety.
+
+Confirmation IS still required for: (a) merging to `main` (the final
+gate), (b) destructive git operations (`reset --hard`, force-push,
+`branch -D` on shared branches), (c) `pkill` / restart on the remote
+backend. Everything between issue-filed and PR-green-and-reviewed runs
+without re-asking.
+
 ## Step 1: Worktree
 
 ```bash


### PR DESCRIPTION
## Summary

Promotes the soft `feedback_act_dont_ask.md` memory rule (2026-04-25) into a hard `docs/guides/workflow.md` rule. After the user acknowledges the proposed plan, the parent agent chains spec-author → implementer → reviewer mechanically; re-asking "shall I dispatch implementer?" between steps is sycophancy, not safety.

## Why this isn't just a memory update

Memory is loaded into context but can be missed or decay. The rule recurred (2026-04-25 → 2026-04-28). Recurrence = soft form insufficient → harden into harness docs the agent reads as part of `CLAUDE.md` boot.

## Scope

- `docs/guides/workflow.md` +16: new "Auto-chaining" subsection between Step 0 and Step 1, with reverse example + named exceptions (merge to main / destructive git / remote backend restart).
- `CLAUDE.md` +1: one-line pointer.
- No changes to `.claude/agents/*`, hooks, slash commands, specs, or the existing `## Anti-sycophancy` block.

## Reviewer note (P3 nit, not addressed in this PR)

Reviewer flagged minor friction between the new "merging to main needs confirmation" exception and `## Step 5: Merge`'s "standing approval" line (added in #1965). They reconcile — both refer to the user's already-given pre-approval — but a future reader could get whiplash. Left as-is per reviewer's "do not block" guidance; can be tightened in a follow-up if it actually trips someone.

## Test plan

- [x] Reviewer APPROVE — full acceptance check + 60-day regression-decision check
- [x] prek hooks pass (no Rust touched, doc-only)
- [ ] CI green

Closes #1969