### PR TITLE
feat(channels): add server-side WS keepalive ping (#1967)

### DIFF
--- a/crates/channels/src/web_session.rs
+++ b/crates/channels/src/web_session.rs
@@ -52,7 +52,13 @@
 //! [`Hello`]: crate::web::WebEvent::Hello
 //! [`TapeAppended`]: crate::web::WebEvent::TapeAppended
 
-use std::sync::Arc;
+use std::{
+    sync::{
+        Arc,
+        atomic::{AtomicU64, Ordering},
+    },
+    time::Duration,
+};
 
 use axum::{
     extract::{
@@ -69,6 +75,47 @@ use rara_kernel::{
 use serde::Deserialize;
 use tokio::sync::{broadcast, mpsc};
 use tracing::{debug, error, info, warn};
+
+/// Server-side WebSocket keepalive interval for the persistent per-session
+/// WS. Idle connections to a non-loopback backend get reaped by intermediate
+/// NAT mappings, browser tab throttling, or LAN routers in the 30s–5min
+/// window, even though the backend is healthy (see #1967). Emitting a
+/// `Ping` frame at this cadence keeps the wire warm so the mapping survives.
+///
+/// This is mechanism tuning — not deploy-relevant — so it lives as a Rust
+/// `const` next to the function it tunes (see
+/// `docs/guides/anti-patterns.md` "Mechanism constants are not config"),
+/// not a YAML knob. Production cadence is 30 seconds.
+const SESSION_WS_KEEPALIVE_INTERVAL: Duration = Duration::from_secs(30);
+
+/// Test-only override for [`SESSION_WS_KEEPALIVE_INTERVAL`], expressed in
+/// milliseconds. Zero (the default) means "use the production const".
+///
+/// `#[cfg(test)]` cannot be used here because integration tests in
+/// `crates/channels/tests/` link against the library crate compiled
+/// without the `test` cfg, so a `cfg(test)`-gated const would always be
+/// the production value at the call site. An atomic override set by
+/// integration tests via [`set_session_ws_keepalive_interval_for_tests`]
+/// is the smallest indirection that lets the BDD scenarios finish in
+/// sub-second walltime without polluting the production code path with
+/// a Cargo feature.
+static SESSION_WS_KEEPALIVE_OVERRIDE_MS: AtomicU64 = AtomicU64::new(0);
+
+/// Override the server-side keepalive ping interval for testing. Setting
+/// the value to zero restores the production constant. Not part of the
+/// public API stability surface — integration tests only.
+#[doc(hidden)]
+pub fn set_session_ws_keepalive_interval_for_tests(interval: Option<Duration>) {
+    let ms = interval.map(|d| d.as_millis() as u64).unwrap_or(0);
+    SESSION_WS_KEEPALIVE_OVERRIDE_MS.store(ms, Ordering::Relaxed);
+}
+
+fn session_ws_keepalive_interval() -> Duration {
+    match SESSION_WS_KEEPALIVE_OVERRIDE_MS.load(Ordering::Relaxed) {
+        0 => SESSION_WS_KEEPALIVE_INTERVAL,
+        ms => Duration::from_millis(ms),
+    }
+}
 
 use crate::web::{
     WebAdapter, WebAdapterState, WebEvent, bearer_token_from_headers, build_raw_platform_message,
@@ -333,6 +380,11 @@ async fn handle_session_ws(
     let send_task = {
         let session_key_str = session_key_str.clone();
         tokio::spawn(async move {
+            // First tick fires immediately; skip it so the first ping
+            // lands one full interval after connect rather than racing
+            // the `hello` frame.
+            let mut keepalive = tokio::time::interval(session_ws_keepalive_interval());
+            keepalive.tick().await;
             loop {
                 tokio::select! {
                     msg = ws_event_rx.recv() => {
@@ -355,6 +407,22 @@ async fn handle_session_ws(
                             );
                             break;
                         }
+                    }
+                    _ = keepalive.tick() => {
+                        // tungstenite/axum auto-replies Pong at the
+                        // protocol layer regardless of payload, so an
+                        // empty Ping is sufficient to keep the wire warm.
+                        if ws_tx.send(Message::Ping(Vec::new().into())).await.is_err() {
+                            debug!(
+                                session_key = %session_key_str,
+                                "session WS keepalive ping failed, closing"
+                            );
+                            break;
+                        }
+                        debug!(
+                            session_key = %session_key_str,
+                            "session WS keepalive ping"
+                        );
                     }
                     _ = shutdown_rx.changed() => {
                         debug!(

--- a/crates/channels/tests/web_session_smoke.rs
+++ b/crates/channels/tests/web_session_smoke.rs
@@ -32,6 +32,7 @@ use futures::{SinkExt, StreamExt};
 use rara_channels::{
     web::{WebAdapter, WebEvent},
     web_reply_buffer::ReplyBuffer,
+    web_session::set_session_ws_keepalive_interval_for_tests,
 };
 use rara_kernel::{
     channel::{adapter::ChannelAdapter, types::ChannelType},
@@ -62,6 +63,7 @@ fn init_test_env() {
         rara_paths::set_custom_data_dir(&data);
         rara_paths::set_custom_config_dir(&config);
     });
+    init_test_keepalive();
 }
 
 fn web_endpoint(session_key: &SessionKey) -> Endpoint {
@@ -94,6 +96,18 @@ where
     }
 }
 
+/// Shrink the server-side keepalive ping interval to a sub-second value
+/// for the entire test binary so the BDD scenarios bound to the
+/// keepalive feature finish in well under a second. All other tests
+/// already tolerate (or ignore) `Ping` frames, so a global override is
+/// safe.
+fn init_test_keepalive() {
+    static INIT: Once = Once::new();
+    INIT.call_once(|| {
+        set_session_ws_keepalive_interval_for_tests(Some(Duration::from_millis(200)));
+    });
+}
+
 /// Boot the adapter under an axum loopback server, returning the bound
 /// address, the adapter, and the server task handle.
 async fn boot_adapter(
@@ -103,6 +117,7 @@ async fn boot_adapter(
     Arc<WebAdapter>,
     tokio::task::JoinHandle<()>,
 ) {
+    init_test_keepalive();
     let adapter = Arc::new(
         WebAdapter::new(OWNER_TOKEN.to_owned(), OWNER_USER_ID.to_owned())
             .with_reply_buffer(Arc::clone(&buffer)),
@@ -381,12 +396,19 @@ async fn session_ws_abort_dispatches_interrupt_signal() {
     // With a started adapter, send_signal succeeds (the queued event is
     // a fire-and-forget signal — handle.rs::send_signal). The wire
     // contract: the WS must NOT push any error frame back to the client.
-    // A short timeout proves no frame arrives.
-    let timed = tokio::time::timeout(Duration::from_millis(300), ws.next()).await;
-    assert!(
-        timed.is_err(),
-        "abort against a started adapter must not surface an Error frame; got: {timed:?}"
-    );
+    // Drain transport-level keepalive pings (#1967) and assert no
+    // application frame surfaces within the window.
+    let deadline = std::time::Instant::now() + Duration::from_millis(300);
+    while std::time::Instant::now() < deadline {
+        let remaining = deadline.saturating_duration_since(std::time::Instant::now());
+        match tokio::time::timeout(remaining, ws.next()).await {
+            Ok(Some(Ok(Message::Ping(_) | Message::Pong(_)))) => continue,
+            Ok(other) => {
+                panic!("abort against a started adapter must not surface a frame; got: {other:?}")
+            }
+            Err(_) => break,
+        }
+    }
 
     ws.send(Message::Close(None)).await.ok();
     drop(ws);
@@ -516,14 +538,168 @@ async fn session_ws_forwards_tape_appended_from_notification_bus() {
             timestamp:   jiff::Timestamp::now(),
         })
         .await;
-    let timed = tokio::time::timeout(Duration::from_millis(200), ws.next()).await;
-    assert!(
-        timed.is_err(),
-        "cross-session TapeAppended must be filtered, got: {timed:?}"
-    );
+    // Drain transport-level keepalive pings (#1967) so we only assert
+    // on application frames; no JSON frame must arrive in the window.
+    let deadline = std::time::Instant::now() + Duration::from_millis(200);
+    while std::time::Instant::now() < deadline {
+        let remaining = deadline.saturating_duration_since(std::time::Instant::now());
+        match tokio::time::timeout(remaining, ws.next()).await {
+            Ok(Some(Ok(Message::Ping(_) | Message::Pong(_)))) => continue,
+            Ok(other) => panic!("cross-session TapeAppended must be filtered, got: {other:?}"),
+            Err(_) => break,
+        }
+    }
 
     ws.send(Message::Close(None)).await.ok();
     drop(ws);
     server.abort();
     tk.shutdown();
+}
+
+/// Server-side keepalive: an idle persistent session WS must receive
+/// periodic `Ping` frames from the server. Bound to scenario
+/// `Server emits periodic Ping frames on an idle persistent session WS`
+/// in `specs/issue-1967-session-ws-keepalive.spec.md`.
+///
+/// The test interval is set to 200 ms via the `#[cfg(test)]` const in
+/// `web_session.rs`; idling for ~700 ms gives at least three ticks and
+/// therefore at least two observed pings (with margin for scheduling).
+/// `tokio_tungstenite` exposes `Ping` frames raw on the client side, so
+/// counting them does not require any server hook.
+#[tokio::test]
+async fn session_ws_emits_periodic_ping_when_idle() {
+    let buffer = ReplyBuffer::new();
+    let (addr, _adapter, server) = boot_adapter(Arc::clone(&buffer)).await;
+
+    let session_key = SessionKey::new();
+    let (mut ws, _resp) =
+        tokio_tungstenite::connect_async(&session_url(addr, &session_key, OWNER_TOKEN))
+            .await
+            .expect("ws connect");
+
+    // Drain the initial `hello` so what we observe afterwards is
+    // strictly the keepalive cadence, not connect-time traffic.
+    let _ = next_event(&mut ws).await;
+
+    // Idle for >3 keepalive intervals (200 ms) and count pings observed.
+    let deadline = std::time::Instant::now() + Duration::from_millis(700);
+    let mut pings = 0u32;
+    while std::time::Instant::now() < deadline {
+        let remaining = deadline.saturating_duration_since(std::time::Instant::now());
+        match tokio::time::timeout(remaining, ws.next()).await {
+            Ok(Some(Ok(Message::Ping(_)))) => pings += 1,
+            Ok(Some(Ok(Message::Pong(_)))) => {}
+            Ok(Some(Ok(Message::Close(_)))) => panic!("server closed during idle keepalive"),
+            Ok(Some(Ok(other))) => panic!("unexpected non-ping frame during idle: {other:?}"),
+            Ok(Some(Err(e))) => panic!("ws error during idle: {e:?}"),
+            Ok(None) => panic!("ws stream ended during idle"),
+            Err(_) => break,
+        }
+    }
+    assert!(
+        pings >= 2,
+        "expected >=2 server-emitted pings within ~700ms idle window, got {pings}"
+    );
+
+    // Connection still alive: a follow-up close + drop must succeed.
+    ws.send(Message::Close(None))
+        .await
+        .expect("close after idle keepalive");
+    drop(ws);
+    server.abort();
+}
+
+/// Keepalive must not interfere with normal event delivery. Bound to
+/// scenario `Periodic ping does not interfere with normal event delivery`
+/// in `specs/issue-1967-session-ws-keepalive.spec.md`.
+///
+/// Publish an adapter event after one or two keepalive ticks have already
+/// fired, then assert (a) the event lands as the next `Text` frame and
+/// (b) at least one keepalive ping is observed in the idle window
+/// surrounding the event.
+#[tokio::test]
+async fn session_ws_ping_does_not_disturb_events() {
+    let buffer = ReplyBuffer::new();
+    let (addr, adapter, server) = boot_adapter(Arc::clone(&buffer)).await;
+
+    let session_key = SessionKey::new();
+    let endpoint = web_endpoint(&session_key);
+
+    let (mut ws, _resp) =
+        tokio_tungstenite::connect_async(&session_url(addr, &session_key, OWNER_TOKEN))
+            .await
+            .expect("ws connect");
+    let _ = next_event(&mut ws).await; // hello
+
+    // Sleep through ~2 ping ticks (200ms each) so a ping has definitely
+    // fired before the event is published.
+    tokio::time::sleep(Duration::from_millis(450)).await;
+
+    adapter
+        .send(
+            &endpoint,
+            PlatformOutbound::Reply {
+                content:       "during-keepalive".to_owned(),
+                attachments:   Vec::new(),
+                reply_context: None,
+            },
+        )
+        .await
+        .expect("egress send during keepalive");
+
+    // Drain frames until we observe the JSON event; record any pings
+    // along the way.
+    let mut pings_before = 0u32;
+    let mut got_event = false;
+    let event_deadline = std::time::Instant::now() + Duration::from_secs(2);
+    while std::time::Instant::now() < event_deadline && !got_event {
+        let remaining = event_deadline.saturating_duration_since(std::time::Instant::now());
+        match tokio::time::timeout(remaining, ws.next()).await {
+            Ok(Some(Ok(Message::Ping(_)))) => pings_before += 1,
+            Ok(Some(Ok(Message::Text(t)))) => {
+                let ev: WebEvent = serde_json::from_str(t.as_str()).expect("WebEvent JSON");
+                match ev {
+                    WebEvent::Message { content } => {
+                        assert_eq!(content, "during-keepalive");
+                        got_event = true;
+                    }
+                    other => panic!("unexpected event during keepalive: {other:?}"),
+                }
+            }
+            Ok(Some(Ok(Message::Pong(_)))) => {}
+            Ok(Some(Ok(Message::Close(_)))) => panic!("server closed unexpectedly"),
+            Ok(Some(Ok(other))) => panic!("unexpected frame: {other:?}"),
+            Ok(Some(Err(e))) => panic!("ws error: {e:?}"),
+            Ok(None) => panic!("stream ended unexpectedly"),
+            Err(elapsed) => panic!("timed out waiting for event during keepalive: {elapsed}"),
+        }
+    }
+    assert!(got_event, "did not observe the published event");
+
+    // Continue draining for one more interval window to confirm pings
+    // keep arriving on schedule after the event lands.
+    let post_deadline = std::time::Instant::now() + Duration::from_millis(450);
+    let mut pings_after = 0u32;
+    while std::time::Instant::now() < post_deadline {
+        let remaining = post_deadline.saturating_duration_since(std::time::Instant::now());
+        match tokio::time::timeout(remaining, ws.next()).await {
+            Ok(Some(Ok(Message::Ping(_)))) => pings_after += 1,
+            Ok(Some(Ok(Message::Pong(_)))) => {}
+            Ok(Some(Ok(Message::Text(_)))) => {}
+            Ok(Some(Ok(Message::Close(_)))) => panic!("server closed after event"),
+            Ok(Some(Ok(other))) => panic!("unexpected frame after event: {other:?}"),
+            Ok(Some(Err(e))) => panic!("ws error after event: {e:?}"),
+            Ok(None) => panic!("stream ended after event"),
+            Err(_) => break,
+        }
+    }
+    assert!(
+        pings_before + pings_after >= 1,
+        "expected at least one keepalive ping around the event delivery, got {pings_before} \
+         before + {pings_after} after"
+    );
+
+    ws.send(Message::Close(None)).await.ok();
+    drop(ws);
+    server.abort();
 }

--- a/specs/issue-1967-session-ws-keepalive.spec.md
+++ b/specs/issue-1967-session-ws-keepalive.spec.md
@@ -1,0 +1,120 @@
+spec: task
+name: "issue-1967-session-ws-keepalive"
+inherits: project
+tags: [bug, channels, websocket]
+---
+
+## Intent
+
+The persistent per-session WebSocket handler in `crates/channels/src/web_session.rs`
+has no server-side keepalive. The `handle_session_ws` task spawns three forwarders
+plus a `send_task` and a `recv_task` that `select!` on each other and a shutdown
+signal — there is no `tokio::time::interval` driving periodic pings, and no `Pong`
+frames are emitted in response to client pings either. `axum::extract::ws::WebSocket`
+does NOT auto-ping by default; long-lived sockets that carry no application data
+during an idle period therefore have no traffic on the wire.
+
+If we do not do this, the following concrete bug appears. Reproducer:
+
+1. Backend runs on `raratekiAir` (`10.0.0.183:25555`); the frontend runs locally
+   at `http://localhost:5173` with `localStorage.rara_backend_url=http://10.0.0.183:25555`,
+   bypassing the Vite proxy so the browser opens the WS straight at the LAN host.
+2. The user connects, idles (no prompt sent), and waits.
+3. After 30s–5min — well below any explicit server timeout — the connection is
+   reaped by an intermediate hop (Firefox tab throttling, NAT mapping in
+   `10.0.0.0/8` routers, intermediate firewall). Server log
+   (`/Users/rara/Library/Logs/rara/job.*` on `local-rara`) shows
+   `persistent session WS auth via owner token` → `response status=101` →
+   `persistent session WS closed` cycles at 04:11:22→04:12:04 (42s) and
+   04:12:14→04:16:49 (4.5min). The frontend then logs
+   `Firefox can't establish a connection to ws://10.0.0.183:25555/api/session/...`
+   on every reconnect attempt because the new connection races the same fate.
+
+The fix landed in PR 1883 (issue 1880) added bounded-backoff auto-reconnect on
+the **frontend** — that addresses UI failure modes when a drop has already
+happened, but does not prevent the drop. The drop itself is what produces the
+console spam and the burned reconnect budget. Server-side ping at a fixed
+interval (well below typical NAT-reap windows) keeps the wire warm and the
+mapping alive.
+
+`grep -n "ping\|pong\|keepalive\|interval\|heartbeat" crates/channels/src/web_session.rs`
+returns nothing — confirmed greenfield gap. PR 1935 (the original scaffold)
+never wired keepalive; PR 1883 only touched the frontend. No prior commit
+removed server-side WS keepalive, so this is not a regression-decision reversal.
+
+This advances `goal.md` signal 1 ("The process runs for months without
+intervention") — a WS that survives idle periods is part of "runs for months"
+on real LAN topologies, not just localhost dev.
+
+## Decisions
+
+- Server emits `Message::Ping` on a fixed interval from inside the existing
+  `send_task`. Interval is a Rust `const` next to `handle_session_ws` (mechanism
+  tuning, not deploy-relevant — see `docs/guides/anti-patterns.md` "Mechanism
+  constants are not config"). Initial value: 30 seconds.
+- The recv loop already accepts `Message::Pong` implicitly via the existing
+  `_ => continue` arm; no extra handling required for client-initiated pongs.
+- Explicit handling for client-initiated `Message::Ping` is not needed — `axum`
+  / `tungstenite` automatically replies `Pong` to inbound `Ping` frames at the
+  protocol layer. The change is strictly: server starts emitting pings.
+- Inactivity-based disconnect (e.g. "close after N missed pongs") is OUT OF
+  SCOPE. The bug is "wire goes silent → NAT kills mapping", not "client is
+  unresponsive but socket pretends to be open". Adding a missed-pong watchdog
+  would solve a different problem and risks regressions for slow-network users.
+
+## Boundaries
+
+### Allowed Changes
+- `crates/channels/src/web_session.rs` — add periodic ping in `send_task`'s
+  `tokio::select!` via a `tokio::time::interval`. Add a `const` for the
+  interval next to the function.
+- `crates/channels/tests/web_session_smoke.rs` — add the integration test
+  bound to the scenarios below.
+- `specs/issue-1967-session-ws-keepalive.spec.md`
+- **/crates/channels/src/web_session.rs
+- **/crates/channels/tests/web_session_smoke.rs
+- **/specs/issue-1967-session-ws-keepalive.spec.md
+
+### Forbidden
+- Do NOT add a YAML config knob for the ping interval. Mechanism tuning is a
+  Rust `const` — see `docs/guides/anti-patterns.md`.
+- Do NOT add ping/keepalive to the legacy chat WS in `crates/channels/src/web.rs`.
+  That endpoint is being phased out; PR 1935 already deleted the legacy split
+  but kept some compat surface. Touching it widens scope.
+- Do NOT add a missed-pong disconnect watchdog. See Decisions.
+- Do NOT change the frontend (`web/src/agent/session-ws-client.ts` etc.) —
+  PR 1883 already handles client-side reconnect. No frontend change is needed
+  for keepalive itself, since browsers auto-reply `Pong` to `Ping` at the
+  protocol layer.
+- The keepalive interval must live in `send_task` so it composes with the
+  existing `select!` and shutdown handling — adding a sibling `sleep`-loop
+  task in any of the three forwarders is out of scope.
+
+## Completion Criteria
+
+Scenario: Server emits periodic Ping frames on an idle persistent session WS
+  Test:
+    Package: rara-channels
+    Filter: session_ws_emits_periodic_ping_when_idle
+  Given a persistent session WS connected and authenticated
+    And the test overrides the ping interval to a short value (e.g. 100ms via test-only setter or a #[cfg(test)] const)
+  When the client stays idle for at least three intervals
+  Then the client receives at least two Ping frames from the server
+    And the connection remains open
+
+Scenario: Periodic ping does not interfere with normal event delivery
+  Test:
+    Package: rara-channels
+    Filter: session_ws_ping_does_not_disturb_events
+  Given a persistent session WS connected and authenticated
+  When an adapter event is published while the ping interval is active
+  Then the client receives the JSON event frame in order
+    And ping frames continue to be emitted on schedule
+
+## Out of Scope
+
+- Frontend changes (PR 1883 already handles reconnect symptoms)
+- Missed-pong disconnect watchdog
+- Keepalive on the legacy `crates/channels/src/web.rs` chat WS
+- A YAML knob for ping interval
+- Changes to the gateway / supervisor process


### PR DESCRIPTION
## Summary
- Adds a 30s `tokio::time::interval` arm to the persistent per-session WS handler in `crates/channels/src/web_session.rs`, sending an empty `Message::Ping` each tick. Idle WS connections previously got dropped by intermediate NAT/routers/Firefox after 30s–5min, producing a reconnect loop visible to users as console spam (`Firefox can't establish a connection to ws://...`).
- Interval is a Rust `const` per `docs/guides/anti-patterns.md` mechanism-vs-config rule — no YAML knob. Test-only `AtomicU64` override via `set_session_ws_keepalive_interval_for_tests` so integration tests run sub-second.
- BDD-bound integration tests in `crates/channels/tests/web_session_smoke.rs` verify periodic ping emission and that ping doesn't disturb application event delivery.

## Test plan
- [x] `cargo test -p rara-channels` — 141 passed
- [x] `just spec-lifecycle specs/issue-1967-session-ws-keepalive.spec.md` — 2/2 scenarios PASS, 100% quality
- [x] `prek run --all-files` — all hooks Passed
- [x] Reviewer APPROVE on local worktree (review-before-push)
- [ ] CI green

Closes #1967