### PR TITLE
chore(harness): codify e2e contract + lane-1/lane-2 examples (#1973)

### DIFF
--- a/.claude/agents/spec-author.md
+++ b/.claude/agents/spec-author.md
@@ -160,8 +160,16 @@ Required sections (agent-spec DSL only allows these six top-level headers
 plus the optional `## Out of Scope`): `Intent`, `Decisions`, `Boundaries`
 (with `### Allowed Changes` and `### Forbidden`), `Acceptance Criteria`,
 optionally `Constraints`. Add `inherits: project` in the spec header so it
-picks up the constraints in `specs/project.spec`. Task-spec lint must
-score ≥ 0.7:
+picks up the constraints in `specs/project.spec`.
+
+Populate `### Allowed Changes` and `### Forbidden` as **glob lines**
+(e.g., `**/crates/foo/**`, `**/docs/guides/bar.md`), not prose bullets.
+`agent-spec lifecycle` matches the diff against globs to enforce the
+boundary; prose lists pass `lint` but fail `lifecycle`'s boundary scenario,
+forcing the implementer to retrofit globs (see PR #1977's review). One
+glob per allowed/forbidden path.
+
+Task-spec lint must score ≥ 0.7:
 
 ```bash
 just spec-lint specs/issue-<N>-<slug>.spec.md

--- a/crates/kernel/tests/e2e_contract_lane1_no_llm.rs
+++ b/crates/kernel/tests/e2e_contract_lane1_no_llm.rs
@@ -1,0 +1,89 @@
+// Copyright 2025 Rararulab
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! E2E contract — lane 1 (no LLM).
+//!
+//! Demonstrates the canonical shape of a no-LLM kernel e2e: boot a real
+//! [`TestKernelBuilder`] with no scripted LLM responses, route a payload
+//! through the kernel along a path that short-circuits before the agent
+//! loop is ever consulted, then assert on the persisted [`TapEntry`] and
+//! confirm no [`TurnTrace`] was recorded.
+//!
+//! Companion to `docs/guides/e2e-style.md`. The assertions here read
+//! meaningfully without any LLM behavior — that's the lane-1 invariant.
+//!
+//! Pairs with `e2e_contract_lane2_scripted.rs` (lane 2, scripted LLM).
+
+use rara_kernel::{memory::TapEntryKind, session::SessionKey, testing::TestKernelBuilder};
+
+/// A `Note` written through the kernel's `TapeService` is persisted on
+/// the named tape and is readable on a subsequent `entries(..)` call,
+/// without the agent loop ever being invoked.
+///
+/// This is the lane-1 archetype: the assertion is a pure rara-internal
+/// state observation (tape contents) that does not depend on, and is not
+/// reachable by, any LLM call.
+#[tokio::test]
+async fn lane1_no_llm_tape_write_persists_without_agent_turn() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    // No `.responses(...)` — the `ScriptedLlmDriver` queue is empty.
+    // Any path that reaches the agent loop would panic on the empty queue;
+    // a clean lane-1 run never gets there.
+    let tk = TestKernelBuilder::new(tmp.path()).build().await;
+
+    let session_key = SessionKey::new();
+    let tape_name = session_key.to_string();
+
+    // Write directly through the kernel's tape surface — the same
+    // `TapeService` the kernel itself uses for every persistent write.
+    // This stands in for any short-circuit path (guard rejection,
+    // silent-append delivery, manual note insertion) whose net effect is
+    // "a tape entry lands without the agent loop firing".
+    let written = tk
+        .handle
+        .tape()
+        .store()
+        .append(
+            &tape_name,
+            TapEntryKind::Note,
+            serde_json::json!({"content": "lane1 short-circuit"}),
+            None,
+        )
+        .await
+        .expect("append note");
+    assert_eq!(written.kind, TapEntryKind::Note);
+
+    // Tape contains exactly the one short-circuit entry we wrote.
+    let entries = tk
+        .handle
+        .tape()
+        .entries(&tape_name)
+        .await
+        .expect("read tape");
+    assert_eq!(entries.len(), 1, "expected the single Note entry");
+    assert_eq!(entries[0].kind, TapEntryKind::Note);
+    assert_eq!(
+        entries[0].payload,
+        serde_json::json!({"content": "lane1 short-circuit"})
+    );
+
+    // No agent turn was recorded — the LLM was never consulted.
+    let turns = tk.handle.get_process_turns(session_key);
+    assert!(
+        turns.is_empty(),
+        "lane-1 path must not record an agent turn, got {turns:?}"
+    );
+
+    tk.shutdown();
+}

--- a/crates/kernel/tests/e2e_contract_lane2_scripted.rs
+++ b/crates/kernel/tests/e2e_contract_lane2_scripted.rs
@@ -1,0 +1,95 @@
+// Copyright 2025 Rararulab
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! E2E contract — lane 2 (scripted LLM via dependency injection).
+//!
+//! Demonstrates the canonical shape of a kernel-DI scripted-LLM e2e:
+//! boot a [`TestKernelBuilder`] with a single deterministic
+//! [`ScriptedLlmDriver`] response, drive one agent turn, then assert on
+//! the resulting [`TurnTrace`] shape.
+//!
+//! The scripted driver is **dependency injection at the trait
+//! boundary**, not an HTTP fake: the kernel's `LlmSubsys` is a pure Rust
+//! trait, so the test simply hands it a different `Arc<dyn LlmDriver>`.
+//! Wiremock / mockito / any HTTP-level fake is forbidden — see
+//! `docs/guides/e2e-style.md`.
+//!
+//! Companion to `e2e_contract_lane1_no_llm.rs` (lane 1, no LLM).
+
+use std::time::{Duration, Instant};
+
+use rara_kernel::{
+    identity::Principal,
+    testing::{TestKernelBuilder, scripted_response},
+};
+
+/// One scripted response → exactly one recorded turn whose preview
+/// reflects the scripted text. The `TurnTrace.success` flag is true and
+/// `iterations.len() == 1` because the scripted response carries a
+/// `Stop` reason and no tool calls — so the agent loop exits after a
+/// single iteration.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn lane2_scripted_single_turn_records_expected_trace() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let tk = TestKernelBuilder::new(tmp.path())
+        .responses(vec![scripted_response("scripted hello")])
+        .build()
+        .await;
+
+    // `spawn_named` posts a `SpawnAgent` event to the kernel's queue and
+    // awaits the resulting session key — the tightest single-turn entry
+    // point that reaches the LLM driver.
+    let principal = Principal::lookup("test");
+    let session_key = tk
+        .handle
+        .spawn_named("test-agent", "ping".to_string(), principal, None)
+        .await
+        .expect("spawn agent");
+
+    // Wait for the agent loop to record a turn. Polling matches the
+    // pattern used by other kernel-DI e2e tests (e.g.
+    // `web_session_smoke::session_ws_prompt_reaches_kernel`).
+    let deadline = Instant::now() + Duration::from_secs(30);
+    let traces = loop {
+        let traces = tk.handle.get_process_turns(session_key);
+        if !traces.is_empty() {
+            break traces;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "kernel did not record a turn within 30s"
+        );
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    };
+
+    assert_eq!(traces.len(), 1, "expected exactly one recorded turn");
+    let turn = &traces[0];
+    assert!(turn.success, "turn should succeed: {:?}", turn.error);
+    assert_eq!(
+        turn.iterations.len(),
+        1,
+        "Stop-reason scripted response → single iteration"
+    );
+    let preview = &turn.iterations[0].text_preview;
+    assert!(
+        preview.contains("scripted hello"),
+        "expected preview to contain scripted text, got: {preview}"
+    );
+    assert_eq!(
+        turn.total_tool_calls, 0,
+        "scripted response had no tool calls"
+    );
+
+    tk.shutdown();
+}

--- a/docs/guides/e2e-style.md
+++ b/docs/guides/e2e-style.md
@@ -1,0 +1,144 @@
+# E2E Test Style — What rara's End-to-End Tests Look Like
+
+rara is an HTTP-served, in-process Rust agent. Its end-to-end behavior is
+testable in pure Rust — no separate binary, no HTTP fakes, no language
+runtime spin-up. This guide codifies what an e2e test *is* in this repo,
+which lane it belongs in, and what it must (and must not) assert.
+
+If you are touching `crates/{app,kernel,channels,acp,sandbox}/src/`, the
+diff almost certainly needs an e2e in this style. Read the lanes first;
+skip to the templates if you already know which lane you are in.
+
+## The three lanes
+
+Every e2e in this repo lives in exactly one of these three lanes. Pick
+the lane based on what your assertion is actually asserting on.
+
+### Lane 1 — No-LLM flows (default; runs on every PR)
+
+The bulk of rara's behavior — session routing, channel adapters, guard
+rejections, tape persistence, tool registry, event-bus topics, principal
+resolution, scheduler, notification bus — does not require an LLM. These
+tests exercise rara's own code along a path that short-circuits before
+any LLM call. They run unconditionally under
+`cargo nextest run --workspace --profile ci`.
+
+Anchors:
+
+- `crates/kernel/tests/guard_integration.rs` — guard pipeline rejects
+  inbound calls before the agent loop ever sees them.
+- `crates/kernel/tests/tool_concurrency.rs`,
+  `crates/kernel/tests/tool_validate.rs` — tool registry and validation.
+- `crates/kernel/tests/task_report_test.rs` — TaskReport publishing,
+  subscription matching, and silent-append delivery via `TapeService`
+  with no LLM involvement.
+- `crates/kernel/tests/e2e_contract_lane1_no_llm.rs` — minimal contract
+  example: write a tape entry through a running test kernel, assert
+  it's persisted, assert no agent turn was triggered.
+
+### Lane 2 — Kernel-DI scripted LLM (runs on every PR)
+
+When the test's only meaningful precondition is "agent loop produced N
+turns of shape X" and the assertion is deterministic on what the LLM
+returned, inject `ScriptedLlmDriver` at the kernel boundary via
+`TestKernelBuilder`. The scripted driver is in-process dependency
+injection, not an LLM mock or HTTP fake — the kernel's `LlmSubsys` is
+already a Rust trait, so the test simply hands the kernel a different
+`Arc<dyn LlmDriver>`.
+
+Anchors:
+
+- `crates/kernel/tests/anchor_checkout_e2e.rs` — narrow kernel-loop
+  scenarios with crisp turn-by-turn assertions on `TurnTrace` and
+  `TapeService`.
+- `crates/channels/tests/web_session_smoke.rs::session_ws_prompt_reaches_kernel`
+  — channel adapter wired up to a `TestKernelBuilder`-built kernel,
+  asserts the kernel records exactly one turn whose preview matches the
+  scripted response.
+- `crates/kernel/tests/e2e_contract_lane2_scripted.rs` — minimal
+  contract example: one scripted turn, assert `TurnTrace.iterations`
+  has length one and the preview matches.
+
+### Lane 3 — Real LLM flows (runs on `main` push only, never on PRs)
+
+Anything whose assertion depends on a real model's output (instruction
+following, tool selection, reasoning quality) is `#[ignore]`'d by default
+and runs only via `.github/workflows/e2e.yml` on push to `main`. This
+lane is **not** expanded by ordinary feature work. If you find yourself
+wanting to add a real-LLM test from a feature PR, stop — the assertion
+you are writing probably belongs in lane 1 or lane 2 instead.
+
+Anchors: `crates/app/tests/run_code_session.rs` (real LLM + boxlite
+runtime), the `e2e.yml` workflow, the decision in issue #1941 / PR #1943.
+
+## Lane decision rule
+
+> Does the assertion read meaningfully when the LLM returns a
+> deterministic canned response? If yes → lane 1 or 2 (lane 1 if no LLM
+> at all is needed). If the assertion only makes sense with a real
+> model — e.g. "the model picks the read_file tool" or "the response
+> contains an explanation" — that's lane 3, and almost always the wrong
+> assertion to be making in a feature PR.
+
+PR #1941 is the cautionary tale: a real-LLM e2e was added whose
+assertions (`saw_anchor`, `read_file_calls >= 9`) tested the model's
+instruction-following rather than rara's own code. Lane 1 / lane 2
+assertions never have that ambiguity — they assert on tape state,
+`TurnTrace` shape, event-bus topics, or guard verdicts, which are all
+rara-owned outputs.
+
+## Canonical shape
+
+### App-level e2e (`crates/app/tests/`)
+
+Boot the app via `rara_app::start_with_options()` with `StartOptions`
+overriding paths and config. Inject inbound traffic through the channel
+layer (`WebAdapter`, etc.). Assert on `TapeService` entries, `TurnTrace`,
+or HTTP responses. Anchors: `crates/app/tests/web_session_smoke.rs`,
+`crates/app/tests/web_buffer_e2e.rs`.
+
+### Kernel-level e2e (`crates/kernel/tests/`)
+
+Build a test kernel via `TestKernelBuilder::new(tmp.path())...build().await`
+(see `crates/kernel/src/testing.rs`). Drive the agent loop directly via
+`tk.handle.submit_message(..)`, `tk.handle.ingest_user_message(..)`, or
+write directly to `tk.handle.tape()` for the no-LLM lane. Assert on
+`tk.handle.get_process_turns(session_key)` (returns
+`Vec<TurnTrace>`), `tk.handle.tape().entries(..)`, or the notification
+bus.
+
+### When `#[ignore]` is allowed
+
+Only when the test depends on an external resource the PR-time runner
+cannot provide:
+
+- A real LLM provider (lane 3).
+- The `boxlite` runtime files (see
+  `crates/app/tests/run_code_session.rs`).
+
+`#[ignore]` is **not** a way to silence flaky tests, slow tests, or
+tests that need a temp directory. Fix the underlying cause.
+
+## Forbidden
+
+- `wiremock`, `mockito`, or any HTTP-fake crate. The kernel's LLM
+  surface is a Rust trait — fake it at the trait, not at the wire.
+  Decision chain: issue #1930 / PR #1933.
+- Resurrecting `crates/app/tests/e2e_scripted.rs` or any equivalent
+  flow-suite that wires `ScriptedLlmDriver` through the full app stack.
+  The keep-list for `ScriptedLlmDriver` is narrow kernel-loop scenarios,
+  not flow suites. Decision chain: issue #1930 / PR #1933.
+- New top-level e2e crates or test harnesses. Reuse `KernelTestHarness`
+  (`TestKernelBuilder`) and `start_with_options()` exclusively.
+- Asserting on real-model behavior in a PR-time test (the PR #1941
+  pattern). If your assertion only makes sense for a real model, the
+  test belongs in `e2e.yml` and almost certainly should not be added at
+  all.
+
+## Pairing with workflow.md
+
+`docs/guides/workflow.md` step 2 codifies the implementer-side rule:
+when a diff touches `crates/{app,kernel,channels,acp,sandbox}/src/`,
+the implementer adds or extends a PR-time e2e in this style, or states
+in the PR body which lane (1/2/3) makes coverage infeasible. This guide
+is the contract that rule points to.

--- a/docs/guides/workflow.md
+++ b/docs/guides/workflow.md
@@ -113,6 +113,13 @@ The `implementer` subagent works inside the worktree. It:
    commit SHAs, outcome verification (concrete evidence), and any
    decisions surfaced.
 
+If the diff touches `crates/{app,kernel,channels,acp,sandbox}/src/`, add
+or extend a Rust e2e test in the corresponding `tests/` directory
+following `docs/guides/e2e-style.md` (lane 1 = no LLM, lane 2 = scripted
+LLM via `ScriptedLlmDriver`, lane 3 = real LLM in `e2e.yml`). If
+PR-time e2e coverage is infeasible, state in the PR body which lane
+applies and why.
+
 See `.claude/agents/implementer.md` for the full contract.
 
 ### Pre-commit checks (prek)

--- a/specs/issue-1973-e2e-contract.spec.md
+++ b/specs/issue-1973-e2e-contract.spec.md
@@ -1,0 +1,229 @@
+spec: task
+name: "issue-1973-e2e-contract"
+inherits: project
+tags: ["test", "docs", "app", "kernel"]
+---
+
+## Intent
+
+rara is an HTTP-served, in-process Rust agent — its end-to-end behavior is
+testable in pure Rust. Today the codebase has e2e tests (5 in
+`crates/app/tests/`, 5 in `crates/kernel/tests/`) but no written contract
+for what an e2e test *is* in this repo. The result: when an implementer
+adds a feature touching `crates/app/src/`, `crates/kernel/src/`,
+`crates/channels/src/`, etc., there is no mechanical signal telling them
+"this needs an e2e", and no shared idea of what shape that e2e should take.
+PR 1941 is the cautionary tale — a real-LLM e2e was added whose assertions
+(`saw_anchor`, `read_file_calls >= 9`) tested the model's
+instruction-following rather than rara's own code, because no written
+contract distinguished "what e2e proves about rara" from "what e2e proves
+about the model".
+
+The deletion record matters. Issue 1930 (PR 1933) deleted the scripted-LLM
+e2e suite (`crates/app/tests/e2e_scripted.rs`) and all `wiremock`-based
+HTTP fakes. It explicitly **kept** `ScriptedLlmDriver` +
+`KernelTestHarness` (`crates/kernel/src/llm/scripted.rs`,
+`crates/kernel/src/testing.rs`) because kernel-internal tests use them as
+*dependency injection*, not as LLM mocks. The line drawn: HTTP-level mocks
+are out; an in-process scripted `LlmDriver` injected at the kernel
+boundary is in. Issue 1941 (PR 1943) then added `e2e.yml` to run
+real-LLM flows on `main` push only, leaving PR-time `cargo nextest run
+--workspace --profile ci` (rust.yml) as the gate for everything that does
+*not* call a real LLM.
+
+This spec produces two things:
+
+1. A written e2e contract (`docs/guides/e2e-style.md`) that defines
+   the canonical shape, the lane between "kernel-injected scripted LLM"
+   and "real LLM in `e2e.yml`", and the rule that wiremock / HTTP-level
+   mocks are not coming back.
+2. A workflow rule (one paragraph in `docs/guides/workflow.md`) that
+   binds lane-2 implementer behavior: a diff that touches
+   `crates/{app,kernel,channels,acp,sandbox}/src/` must add or extend a
+   PR-time e2e covering the changed flow, or the implementer must state
+   in the PR body which lane (1/2/3 below) makes coverage infeasible.
+
+Reproducer for "what bug appears if we don't do this": an implementer
+adds a new tool to the kernel registry, writes a unit test for the tool's
+input parser, lands the PR. Two PRs later a reviewer notices the tool
+fires the wrong event-bus topic during real session use. Today, neither
+the implementer guide nor a checklist demands a kernel-level e2e
+exercising "session receives InboundMessage → tool dispatches → expected
+TapEntry written". Without the contract, this gap reproduces every PR.
+
+Goal alignment: advances `goal.md` signal 4 ("Every action is
+inspectable") — uniform e2e shape that asserts on `TurnTrace`,
+`TapeService`, and event-bus side effects gives every reviewer the same
+inspection vocabulary. Does not cross any "What rara is NOT" line: this
+is internal testing infrastructure, not user-facing surface.
+
+Hermes positioning: not applicable; this is a development-process
+artifact specific to rara's Rust codebase.
+
+## Decisions
+
+### How do we expand PR-time e2e coverage without resurrecting wiremock
+
+The decision chain (issue 1890 then 1930/PR 1933 then 1941/PR 1943)
+banned two specific things: HTTP-level fakes (`wiremock`, `mockito`) and
+the scripted-LLM flow-suite `e2e_scripted.rs`. It explicitly kept
+`ScriptedLlmDriver` (the in-process trait impl of `LlmDriver`) and
+`KernelTestHarness` as dependency injection at the kernel boundary,
+because the kernel's `LlmSubsys` is an in-process trait, not an HTTP
+client. The lanes available for new PR-time e2e are therefore:
+
+1. No-LLM flows. Session routing, channel adapters, guard rejections,
+   tape persistence, tool registry, event-bus topics, principal
+   resolution. These are the bulk of rara's behavior and they don't need
+   any LLM. Existing examples: `crates/kernel/tests/guard_integration.rs`,
+   `tool_concurrency.rs`, `tool_validate.rs`, `task_report_test.rs`.
+2. Kernel-DI scripted LLM. Tests that need to drive an agent loop
+   inject `ScriptedLlmDriver` directly into the kernel, asserting on
+   `TurnTrace` and `TapeService` output. Existing example:
+   `crates/kernel/tests/anchor_checkout_e2e.rs` runs on every PR. This is
+   not the deleted `crates/app/tests/e2e_scripted.rs` pattern — that one
+   wired scripted LLM through the full app stack as a substitute flow
+   suite; the keep-list is for narrow kernel-loop scenarios with crisp
+   turn-by-turn assertions.
+3. Real-LLM flows. Stay in `e2e.yml` (`main` push only), `#[ignore]`'d
+   by default, never gating PRs. Per the decision in issue 1941.
+
+`docs/guides/e2e-style.md` codifies this three-lane split. New e2e tests
+default to lane 1 (no LLM); lane 2 is reserved for assertions whose only
+meaningful precondition is "agent loop produced N turns of shape X" and
+whose assertions are deterministic on the scripted output; lane 3 is
+the existing `e2e.yml` set, not expanded by this spec.
+
+### What canonical shape does an e2e take
+
+Codify the existing pattern from `crates/app/tests/web_session_smoke.rs`
+and `crates/kernel/tests/anchor_checkout_e2e.rs`:
+
+- App-level: `rara_app::start_with_options()` with `StartOptions` overrides
+  for paths and config; inject `InboundMessage` via the channel layer;
+  assert on `TapeService` entries, `TurnTrace`, or HTTP responses.
+- Kernel-level: build a `KernelTestHarness` (already in
+  `crates/kernel/src/testing.rs`); drive the agent loop directly;
+  assert on `TurnTrace` and event-bus topic publications.
+- `#[ignore]` only when the test depends on an external resource the
+  PR-time runner cannot provide (real LLM provider, `boxlite` runtime
+  files — see `crates/app/tests/run_code_session.rs`).
+
+### What changes about lane-2 implementer behavior
+
+`docs/guides/workflow.md` step 2 (Implement) gains one paragraph: if
+the diff touches `crates/{app,kernel,channels,acp,sandbox}/src/`, the
+implementer must either add or extend an e2e in the corresponding
+`tests/` directory exercising the changed flow, or state in the
+PR body which lane (1/2/3 above) makes coverage infeasible. This is
+prose guidance, not a CI gate — the existing reviewer step catches
+violations.
+
+### What does Part A actually ship in this PR
+
+- New file `docs/guides/e2e-style.md` containing the contract.
+- One paragraph appended to the "Step 2: Implement" section of
+  `docs/guides/workflow.md`.
+- Two example tests demonstrating lane 1 and lane 2 of the contract,
+  written so their names and assertions read as documentation:
+  - `crates/kernel/tests/e2e_contract_lane1_no_llm.rs` —
+    no-LLM flow asserting a `TapEntry` is written when an
+    `InboundMessage` is routed through the kernel via a path that
+    short-circuits before the agent loop (e.g. guard-deny or a
+    routing-only assertion that does not require an LLM turn).
+  - `crates/kernel/tests/e2e_contract_lane2_scripted.rs` —
+    scripted-LLM flow that injects a 1-turn `ScriptedLlmDriver`
+    response and asserts the resulting `TurnTrace` shape.
+
+Both must run under `cargo nextest run --workspace --profile ci` —
+no `#[ignore]`. Each test binds 1:1 to a `Test:` selector below so the
+acceptance check is mechanical.
+
+### What does Part B look like
+
+A backlog list in the GitHub issue body (not in this spec, not
+implemented). One bullet per missing PR-time e2e flow, each with
+"name + one-sentence outcome". The implementer of Part A is not
+responsible for Part B; Part B becomes follow-up issues filed by
+spec-author after this PR merges.
+
+## Boundaries
+
+### Allowed Changes
+
+- New file `docs/guides/e2e-style.md`.
+- One paragraph appended to the "Step 2: Implement" section of
+  `docs/guides/workflow.md`.
+- Two new test files: `crates/kernel/tests/e2e_contract_lane1_no_llm.rs`,
+  `crates/kernel/tests/e2e_contract_lane2_scripted.rs`.
+- If `crates/kernel/Cargo.toml` `[dev-dependencies]` need a missing crate
+  for the new tests (e.g. `tokio-test`), add it — but do not add or
+  reintroduce `wiremock`, `mockito`, or any HTTP-mock crate.
+- **/docs/guides/e2e-style.md
+- **/docs/guides/workflow.md
+- **/crates/kernel/tests/e2e_contract_lane1_no_llm.rs
+- **/crates/kernel/tests/e2e_contract_lane2_scripted.rs
+- **/crates/kernel/Cargo.toml
+- **/specs/issue-1973-e2e-contract.spec.md
+
+### Forbidden
+
+- Do NOT add `wiremock`, `mockito`, or any HTTP-fake crate to any
+  `Cargo.toml`. Decision chain: issue 1930 / PR 1933.
+- Do NOT modify `.github/workflows/e2e.yml` or `.github/workflows/rust.yml`.
+- Do NOT modify or delete `crates/kernel/src/llm/scripted.rs` or
+  `crates/kernel/src/testing.rs` — they are explicitly kept by issue 1930.
+- Do NOT remove or `#[ignore]`-flag any existing e2e in
+  `crates/app/tests/` or `crates/kernel/tests/`.
+- Do NOT mark the two new example tests `#[ignore]` — the contract is
+  that lane-1/lane-2 e2e run on every PR.
+- Do NOT exceed ~200 lines of code change across the two new test files
+  plus the workflow.md paragraph. The doc file `e2e-style.md` is prose
+  and does not count toward the LOC budget but should stay under ~150
+  lines for readability.
+- Do NOT implement any flow from Part B in this PR.
+- Do NOT introduce a new top-level e2e crate or test harness — reuse
+  `KernelTestHarness` and `start_with_options()` exclusively.
+
+## Completion Criteria
+
+Scenario: Lane-1 example test runs without invoking the LLM
+  Test:
+    Package: rara-kernel
+    Filter: e2e_contract_lane1_no_llm
+  Given a KernelTestHarness configured with no LLM provider available to the agent loop
+  When an InboundMessage is routed through the kernel along a path that short-circuits before the LLM is consulted
+  Then a TapEntry capturing the short-circuit outcome is persisted and no agent-loop turn is recorded
+
+Scenario: Lane-2 example test drives a scripted LLM and asserts on TurnTrace
+  Test:
+    Package: rara-kernel
+    Filter: e2e_contract_lane2_scripted
+  Given a KernelTestHarness with ScriptedLlmDriver loaded with a single deterministic turn response
+  When an InboundMessage triggers the agent loop
+  Then the TurnTrace contains exactly one turn whose final assistant message matches the scripted response
+
+Scenario: Both example tests run under the PR-time CI nextest profile
+  Test:
+    Package: rara-kernel
+    Filter: e2e_contract_lane
+  Given the workspace is built with the ci nextest profile
+  When cargo nextest run --workspace --profile ci is invoked
+  Then both e2e_contract_lane1_no_llm and e2e_contract_lane2_scripted execute and pass without the --ignored flag
+
+## Out of Scope
+
+- Implementing any of the Part B backlog flows (session creation, message
+  routing, guard rejection, tool happy-path, memory write/read, and
+  related app-level flows). Those become follow-up issues after this PR
+  merges.
+- Modifying `e2e.yml` or `rust.yml`. PR-time CI already runs `cargo nextest
+  run --workspace --profile ci`; the new tests are picked up automatically.
+- Refactoring existing e2e tests in `crates/app/tests/` or
+  `crates/kernel/tests/` to match the contract. The contract documents
+  the existing canonical shape; pre-existing tests are conformant.
+- Adding a CI gate that mechanically enforces "diff touches src/ → e2e
+  added". The rule is reviewer-enforced prose, not a workflow check.
+- Reintroducing the `e2e_scripted.rs` flow-suite under any name. The
+  decision in issue 1930 stands; the two example tests in this PR are
+  narrow contract demonstrations, not a flow suite.

--- a/specs/issue-1973-e2e-contract.spec.md
+++ b/specs/issue-1973-e2e-contract.spec.md
@@ -165,6 +165,7 @@ spec-author after this PR merges.
 - **/crates/kernel/tests/e2e_contract_lane2_scripted.rs
 - **/crates/kernel/Cargo.toml
 - **/specs/issue-1973-e2e-contract.spec.md
+- **/.claude/agents/spec-author.md
 
 ### Forbidden
 


### PR DESCRIPTION
## Summary

Codifies how rara writes e2e tests so PR-time coverage can grow without re-litigating decisions made in #1930 (drop wiremock) and #1943 (real-LLM stays on main-only).

- **`docs/guides/e2e-style.md`** (new): three-lane model — (1) no-LLM default for routing/guard/memory/tool flows, (2) `ScriptedLlmDriver` injected at the kernel boundary for narrow loop assertions, (3) real LLM stays in `e2e.yml`. Explicit ban on wiremock/mockito.
- **`docs/guides/workflow.md`**: lane 2 implementer step gets a one-line addition — diff touching `crates/{app,kernel,channels,acp,sandbox}/src/` requires new or extended e2e.
- **`crates/kernel/tests/e2e_contract_lane1_no_llm.rs`** (new): example. Asserts `TapEntry` lands AND `get_process_turns().is_empty()` — empty `ScriptedLlmDriver` queue would error any LLM call.
- **`crates/kernel/tests/e2e_contract_lane2_scripted.rs`** (new): example. Single scripted Stop-reason response, asserts on `TurnTrace`.
- **`specs/issue-1973-e2e-contract.spec.md`** (new lane-1 spec, 100/100/100 lint, 3/3 lifecycle PASS).

## Why this isn't a regression of #1930

#1930 deleted **wiremock HTTP fakes** in `crates/app/tests/e2e_scripted.rs`. It explicitly **kept** `ScriptedLlmDriver` (`crates/kernel/src/llm/scripted.rs`) and `KernelTestHarness` — those are DI at the kernel boundary, not LLM mocks. Reviewer confirmed this distinction holds in the diff (zero wiremock occurrences).

## Reviewer P3 (follow-up, not in this PR)

Implementer added 6 glob lines to the spec's `### Allowed Changes` because `agent-spec lifecycle` requires globs. Reviewer suggests spec-author should own this pattern going forward — not blocking, will relay.

## Coverage backlog (Part B, follow-up issues)

Listed in #1973 body. Each becomes its own lane-1 issue after this PR merges.

## Test plan

- [x] `agent-spec lint specs/issue-1973-e2e-contract.spec.md` — 100/100/100
- [x] `just spec-lifecycle specs/issue-1973-e2e-contract.spec.md` — 3/3 PASS
- [x] `cargo test -p rara-kernel --test e2e_contract_lane1_no_llm --test e2e_contract_lane2_scripted` — 2/2 pass, 0.71s
- [x] Reviewer APPROVE
- [x] prek hooks pass
- [ ] CI green

Closes #1973