### PR TITLE
feat(cmd): make `setup boxlite` self-sufficient via release tarball download (#1980)

### DIFF
--- a/crates/cmd/Cargo.toml
+++ b/crates/cmd/Cargo.toml
@@ -32,6 +32,7 @@ common-telemetry.workspace = true
 crossterm.workspace = true
 dirs.workspace = true
 eventsource-stream.workspace = true
+flate2 = "1"
 futures.workspace = true
 indexmap.workspace = true
 open.workspace = true
@@ -49,6 +50,8 @@ serde_yaml.workspace = true
 shadow-rs = { workspace = true }
 snafu.workspace = true
 sysinfo.workspace = true
+tar = "0.4"
+tempfile.workspace = true
 anyhow.workspace = true
 diesel.workspace = true
 diesel_migrations.workspace = true
@@ -63,8 +66,8 @@ yunara-store.workspace = true
 shadow-rs = { workspace = true }
 
 [dev-dependencies]
+axum.workspace = true
 rara-sessions = { workspace = true }
-tempfile.workspace = true
 
 [lints]
 workspace = true

--- a/crates/cmd/src/setup/boxlite.rs
+++ b/crates/cmd/src/setup/boxlite.rs
@@ -13,15 +13,19 @@
 // limitations under the License.
 
 //! Stage boxlite's runtime artifacts into a stable user-data directory so
-//! `rara-sandbox` can find them at runtime without each user manually
-//! copying files out of cargo's `target/` tree.
+//! `rara-sandbox` can find them at runtime — without requiring the user to
+//! first run `cargo build -p rara-sandbox`.
+//!
+//! The pipeline mirrors `whisper_install.rs::ensure_whisper`:
+//! detect → download → verify → report. The source of truth is the
+//! prebuilt tarball on the boxlite GitHub release page; rara never reads
+//! cargo's `target/` directory.
 //!
 //! See `docs/guides/boxlite-runtime.md` for the user-facing flow.
 
 use std::{
     fs,
     path::{Path, PathBuf},
-    time::SystemTime,
 };
 
 use snafu::{ResultExt, Whatever};
@@ -37,22 +41,22 @@ use super::prompt;
 /// preference), not a YAML knob.
 const BOXLITE_VERSION: &str = "v0.8.2";
 
-/// Files that boxlite's runtime expects to find in its staging directory
-/// before the first VM will start. Names mirror
-/// `crates/rara-sandbox/AGENT.md` footgun #3.
-const RUNTIME_FILES: &[&str] = &[
-    "boxlite-guest",
-    "boxlite-shim",
-    "mke2fs",
-    "debugfs",
-    #[cfg(target_os = "macos")]
-    "libkrunfw.dylib",
-    #[cfg(target_os = "linux")]
-    "libkrunfw.so",
-];
+/// Base URL for the upstream boxlite release archive. Appended with
+/// `{version}/boxlite-runtime-{version}-{target}.tar.gz`.
+const BOXLITE_RELEASE_URL_BASE: &str = "https://github.com/boxlite-ai/boxlite/releases/download";
+
+/// Env var that overrides the full tarball URL. Matches the upstream
+/// `build.rs` contract so air-gapped installs and tests can point at a
+/// mirror.
+const BOXLITE_RUNTIME_URL_ENV: &str = "BOXLITE_RUNTIME_URL";
+
+/// Files the boxlite runtime needs by exact name. The versioned `libkrunfw`
+/// SONAME (e.g. `libkrunfw.5.dylib`) is discovered separately because it
+/// changes across boxlite versions.
+const REQUIRED_NAMED_FILES: &[&str] = &["boxlite-shim", "boxlite-guest", "mke2fs", "debugfs"];
 
 /// Files that should be marked executable on unix.
-const EXECUTABLE_FILES: &[&str] = &["boxlite-guest", "boxlite-shim", "mke2fs", "debugfs"];
+const EXECUTABLE_FILES: &[&str] = &["boxlite-shim", "boxlite-guest", "mke2fs", "debugfs"];
 
 /// Stamp file boxlite's own embedded-runtime extractor checks to short-
 /// circuit re-extraction. We write the same stamp so eager staging is a
@@ -61,73 +65,152 @@ const COMPLETE_STAMP: &str = ".complete";
 
 /// Outcome of a boxlite staging run, surfaced to the caller for logging /
 /// CI assertions.
+#[derive(Debug)]
 pub enum StageOutcome {
     /// Files were copied into place (or already present and valid).
     Staged {
         /// Destination directory containing the staged runtime.
         dest: PathBuf,
     },
-    /// Build artifacts were not found. This is the expected state in CI
-    /// when `BOXLITE_DEPS_STUB=1` was used at build time, or when the user
-    /// has not yet run `cargo build -p rara-sandbox`.
-    NoArtifacts,
-    /// `--check` was requested; the discovered source is reported but
-    /// nothing was copied.
+    /// `--check` was requested; the planned URL + destination are
+    /// reported but nothing was downloaded or written.
     CheckOnly {
-        /// Build directory that would be the staging source.
-        source: Option<PathBuf>,
+        /// Tarball URL that would be downloaded.
+        url:  String,
         /// Destination directory that would receive the files.
-        dest:   PathBuf,
+        dest: PathBuf,
     },
 }
 
-/// Stage boxlite's runtime artifacts from cargo's build directory into the
-/// platform user-data dir.
+/// Internal options for the staging pipeline. The public entry point fills
+/// these from the running platform; tests substitute hermetic values.
+struct SetupOptions {
+    /// Tarball URL to download. Already overridden by env var if set.
+    url:  String,
+    /// Destination directory for the staged runtime files.
+    dest: PathBuf,
+}
+
+/// Stage boxlite's runtime artifacts by downloading the official prebuilt
+/// tarball and extracting it into the platform user-data dir.
 ///
-/// `check_only` skips the copy step — useful for CI smoke tests that want
-/// to exercise the code path without depending on a real boxlite build.
+/// `check_only` skips the download + filesystem mutation and only prints
+/// what *would* happen — useful for CI smoke tests.
 #[instrument(skip_all, fields(check_only))]
 pub async fn run_boxlite_setup(check_only: bool) -> Result<StageOutcome, Whatever> {
     prompt::print_step("Boxlite Runtime Staging");
 
+    let target = host_target().whatever_context("boxlite is not supported on this host")?;
+    let url = resolve_runtime_url(target);
     let dest = staged_runtime_dir()?;
-    println!("  destination: {}", dest.display());
 
-    let source = locate_build_runtime().whatever_context("failed to scan target/ for boxlite")?;
+    let opts = SetupOptions { url, dest };
+    run_boxlite_setup_with(check_only, &opts).await
+}
+
+/// Core pipeline, parameterised on URL + destination so unit tests can
+/// substitute a hermetic HTTP fixture and tempdir without touching
+/// `dirs::data_local_dir()` or the network.
+async fn run_boxlite_setup_with(
+    check_only: bool,
+    opts: &SetupOptions,
+) -> Result<StageOutcome, Whatever> {
+    println!("  destination: {}", opts.dest.display());
+    println!("  source:      {}", opts.url);
 
     if check_only {
-        match &source {
-            Some(src) => prompt::print_ok(&format!("would stage from {}", src.display())),
-            None => println!(
-                "  no boxlite build artifacts found (run `cargo build -p rara-sandbox` first, or \
-                 BOXLITE_DEPS_STUB was set)"
-            ),
+        prompt::print_ok("check mode: no download, no copy");
+        return Ok(StageOutcome::CheckOnly {
+            url:  opts.url.clone(),
+            dest: opts.dest.clone(),
+        });
+    }
+
+    if opts.dest.join(COMPLETE_STAMP).is_file() && has_required_files(&opts.dest) {
+        prompt::print_ok(&format!("already staged at {}", opts.dest.display()));
+        return Ok(StageOutcome::Staged {
+            dest: opts.dest.clone(),
+        });
+    }
+
+    let tmp = tempfile::tempdir().whatever_context("failed to create temp dir for extraction")?;
+    let archive_path = tmp.path().join("boxlite-runtime.tar.gz");
+
+    println!("  downloading {} ...", opts.url);
+    download_file(&opts.url, &archive_path).await?;
+
+    let extract_root = tmp.path().join("extract");
+    fs::create_dir_all(&extract_root).whatever_context("failed to create extraction directory")?;
+    extract_tarball(&archive_path, &extract_root)?;
+
+    let staging_src = locate_extracted_runtime(&extract_root)?;
+    verify_extracted_files(&staging_src)?;
+
+    stage_runtime(&staging_src, &opts.dest).whatever_context(format!(
+        "failed to stage runtime to {}",
+        opts.dest.display()
+    ))?;
+
+    prompt::print_ok(&format!("staged at {}", opts.dest.display()));
+    Ok(StageOutcome::Staged {
+        dest: opts.dest.clone(),
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Platform resolution
+// ---------------------------------------------------------------------------
+
+/// `(os, arch)` pair recognised by the upstream release artefact naming.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum HostTarget {
+    DarwinArm64,
+    LinuxX64Gnu,
+    LinuxArm64Gnu,
+}
+
+impl HostTarget {
+    /// Tarball suffix as produced by the boxlite release pipeline.
+    fn tarball_target(self) -> &'static str {
+        match self {
+            HostTarget::DarwinArm64 => "darwin-arm64",
+            HostTarget::LinuxX64Gnu => "linux-x64-gnu",
+            HostTarget::LinuxArm64Gnu => "linux-arm64-gnu",
         }
-        return Ok(StageOutcome::CheckOnly { source, dest });
     }
+}
 
-    let Some(source) = source else {
-        prompt::print_err(
-            "no boxlite build artifacts found under target/. Either build rara-sandbox without \
-             BOXLITE_DEPS_STUB, or skip staging on this platform.",
-        );
-        return Ok(StageOutcome::NoArtifacts);
-    };
+/// Resolve the running host's target. Returns `Err` for unsupported
+/// platforms — boxlite simply has no release artefact for them.
+fn host_target() -> Result<HostTarget, String> {
+    resolve_target(std::env::consts::OS, std::env::consts::ARCH)
+}
 
-    if dest.join(COMPLETE_STAMP).is_file() && has_required_files(&dest) {
-        prompt::print_ok(&format!("already staged at {}", dest.display()));
-        return Ok(StageOutcome::Staged { dest });
+/// Pure helper for `host_target`, separated so tests can exercise the
+/// "unsupported platform" branch without mocking the global env consts.
+fn resolve_target(os: &str, arch: &str) -> Result<HostTarget, String> {
+    match (os, arch) {
+        ("macos", "aarch64") => Ok(HostTarget::DarwinArm64),
+        ("linux", "x86_64") => Ok(HostTarget::LinuxX64Gnu),
+        ("linux", "aarch64") => Ok(HostTarget::LinuxArm64Gnu),
+        _ => Err(format!("unsupported (os, arch) pair: ({os}, {arch})")),
     }
+}
 
-    stage_runtime(&source, &dest)
-        .whatever_context(format!("failed to stage runtime to {}", dest.display()))?;
-
-    prompt::print_ok(&format!(
-        "staged {} files at {}",
-        RUNTIME_FILES.len(),
-        dest.display()
-    ));
-    Ok(StageOutcome::Staged { dest })
+/// Build the tarball URL for the given target, honoring the
+/// `BOXLITE_RUNTIME_URL` env override (matches upstream's `build.rs`).
+fn resolve_runtime_url(target: HostTarget) -> String {
+    if let Ok(override_url) = std::env::var(BOXLITE_RUNTIME_URL_ENV) {
+        if !override_url.is_empty() {
+            return override_url;
+        }
+    }
+    format!(
+        "{base}/{version}/boxlite-runtime-{version}-{target}.tar.gz",
+        base = BOXLITE_RELEASE_URL_BASE,
+        version = BOXLITE_VERSION,
+        target = target.tarball_target(),
+    )
 }
 
 /// Resolve the destination staging directory.
@@ -142,71 +225,183 @@ fn staged_runtime_dir() -> Result<PathBuf, Whatever> {
     Ok(base.join("boxlite").join("runtimes").join(BOXLITE_VERSION))
 }
 
-/// Find the newest `target/*/build/boxlite-*/out/runtime` directory that
-/// holds the expected runtime files.
-///
-/// The cargo build hash is unstable across feature sets, so we glob and
-/// pick the newest match rather than reproducing cargo's hashing.
-fn locate_build_runtime() -> std::io::Result<Option<PathBuf>> {
-    let target_dir = workspace_target_dir();
-    if !target_dir.is_dir() {
-        return Ok(None);
+// ---------------------------------------------------------------------------
+// Download + extract
+// ---------------------------------------------------------------------------
+
+/// Download a file via reqwest with progress display every ~5%.
+async fn download_file(url: &str, dest: &Path) -> Result<(), Whatever> {
+    use std::io::Write;
+
+    use futures::StreamExt;
+    use tokio::io::AsyncWriteExt;
+
+    let client = reqwest::Client::new();
+    let resp = client
+        .get(url)
+        .send()
+        .await
+        .whatever_context("download request failed")?;
+
+    if !resp.status().is_success() {
+        snafu::whatever!("download failed: HTTP {} from {url}", resp.status());
     }
 
-    // Profile subdirs to scan. `release` first so production builds win
-    // ties when both a debug and release build exist.
-    let candidates = ["release", "debug"]
-        .iter()
-        .map(|profile| target_dir.join(profile).join("build"))
-        .filter(|p| p.is_dir())
-        .flat_map(|build_dir| collect_boxlite_runtimes(&build_dir))
-        .flatten();
+    let total = resp.content_length();
+    let mut stream = resp.bytes_stream();
+    let mut file = tokio::fs::File::create(dest)
+        .await
+        .whatever_context("failed to create output file")?;
 
-    let newest = candidates
-        .filter(|p| has_required_files(p))
-        .max_by_key(|p| {
-            fs::metadata(p)
-                .and_then(|m| m.modified())
-                .unwrap_or(SystemTime::UNIX_EPOCH)
-        });
+    let mut downloaded: u64 = 0;
+    let mut last_pct: u64 = 0;
 
-    Ok(newest)
+    while let Some(chunk) = stream.next().await {
+        let chunk = chunk.whatever_context("error reading download stream")?;
+        file.write_all(&chunk)
+            .await
+            .whatever_context("error writing to file")?;
+        downloaded += chunk.len() as u64;
+
+        if let Some(total) = total {
+            let pct = downloaded * 100 / total;
+            if pct >= last_pct + 5 {
+                last_pct = pct;
+                print!("\r  downloading... {pct}%");
+                std::io::stdout().flush().ok();
+            }
+        }
+    }
+
+    file.flush()
+        .await
+        .whatever_context("failed to flush file")?;
+
+    if total.is_some() {
+        println!("\r  downloading... 100%");
+    }
+
+    Ok(())
 }
 
-/// Yield every `boxlite-*/out/runtime` directory inside a
-/// `target/<profile>/build/`.
-fn collect_boxlite_runtimes(build_dir: &Path) -> std::io::Result<Vec<PathBuf>> {
-    let mut out = Vec::new();
-    for entry in fs::read_dir(build_dir)? {
-        let entry = entry?;
-        let name = entry.file_name();
-        let Some(name) = name.to_str() else { continue };
-        if !name.starts_with("boxlite-") {
+/// Extract a `.tar.gz` archive into `dest`. Uses the rust `flate2` + `tar`
+/// crates; we do not shell out to `tar` (hides errors from snafu and
+/// breaks on machines where `tar` lacks `--strip-components`).
+fn extract_tarball(archive: &Path, dest: &Path) -> Result<(), Whatever> {
+    let file = fs::File::open(archive)
+        .whatever_context(format!("failed to open archive {}", archive.display()))?;
+    let gz = flate2::read::GzDecoder::new(file);
+    let mut tar = tar::Archive::new(gz);
+    tar.unpack(dest)
+        .whatever_context(format!("failed to extract archive into {}", dest.display()))?;
+    Ok(())
+}
+
+/// The upstream tarball wraps everything under a `boxlite-runtime/`
+/// directory. Find that directory; if absent (some mirrors flatten the
+/// layout), fall back to `dest` itself when it directly holds the files.
+fn locate_extracted_runtime(extract_root: &Path) -> Result<PathBuf, Whatever> {
+    let nested = extract_root.join("boxlite-runtime");
+    if nested.is_dir() {
+        return Ok(nested);
+    }
+    if has_named_files(extract_root) {
+        return Ok(extract_root.to_path_buf());
+    }
+    snafu::whatever!(
+        "extracted archive does not contain a `boxlite-runtime/` directory at {}",
+        extract_root.display()
+    );
+}
+
+/// Confirm every required named binary plus exactly one platform-correct
+/// versioned `libkrunfw` entry is present in `dir`.
+fn verify_extracted_files(dir: &Path) -> Result<(), Whatever> {
+    for name in REQUIRED_NAMED_FILES {
+        let p = dir.join(name);
+        if !p.is_file() {
+            snafu::whatever!(
+                "tarball is missing required file `{name}` at {}",
+                p.display()
+            );
+        }
+    }
+    find_libkrunfw(dir)?;
+    Ok(())
+}
+
+/// Discover the versioned `libkrunfw` filename in `dir`. Returns the
+/// just-the-filename string, not the full path. Errors loudly if zero or
+/// more than one candidate exists.
+fn find_libkrunfw(dir: &Path) -> Result<String, Whatever> {
+    let entries = fs::read_dir(dir)
+        .whatever_context(format!("failed to read directory {}", dir.display()))?;
+
+    let mut matches: Vec<String> = Vec::new();
+    for entry in entries {
+        let entry = entry.whatever_context("failed to read directory entry")?;
+        let Some(name) = entry.file_name().to_str().map(str::to_owned) else {
             continue;
-        }
-        let runtime = entry.path().join("out").join("runtime");
-        if runtime.is_dir() {
-            out.push(runtime);
+        };
+        if is_libkrunfw_soname(&name) {
+            matches.push(name);
         }
     }
-    Ok(out)
+
+    match matches.len() {
+        0 => snafu::whatever!(
+            "tarball is missing the versioned libkrunfw library (expected e.g. libkrunfw.5.dylib \
+             on macOS or libkrunfw.so.5 on linux) in {}",
+            dir.display()
+        ),
+        1 => Ok(matches.pop().expect("len == 1 just checked")),
+        _ => snafu::whatever!(
+            "tarball contains multiple libkrunfw candidates {:?}; expected exactly one",
+            matches
+        ),
+    }
 }
 
-/// True if every required runtime file is present in `dir`.
-fn has_required_files(dir: &Path) -> bool {
-    RUNTIME_FILES.iter().all(|name| dir.join(name).is_file())
+/// Recognise `libkrunfw.<digits>.dylib` (macOS) or
+/// `libkrunfw.so.<digits>(.<digits>)*` (linux). Pure string match; we
+/// avoid pulling in `regex` for one call site.
+fn is_libkrunfw_soname(name: &str) -> bool {
+    if cfg!(target_os = "macos") {
+        let Some(rest) = name.strip_prefix("libkrunfw.") else {
+            return false;
+        };
+        let Some(version) = rest.strip_suffix(".dylib") else {
+            return false;
+        };
+        !version.is_empty() && version.chars().all(|c| c.is_ascii_digit())
+    } else if cfg!(target_os = "linux") {
+        let Some(rest) = name.strip_prefix("libkrunfw.so.") else {
+            return false;
+        };
+        !rest.is_empty()
+            && rest
+                .split('.')
+                .all(|seg| !seg.is_empty() && seg.chars().all(|c| c.is_ascii_digit()))
+    } else {
+        false
+    }
 }
 
-/// Resolve the workspace target directory, honoring `CARGO_TARGET_DIR`
-/// for users who keep build artefacts outside the repo (common on shared
-/// CI runners and dev setups). Falls back to `./target` when unset; the
-/// setup binary is invoked from the workspace root via `just` or
-/// `cargo run`, so the relative path resolves correctly.
-fn workspace_target_dir() -> PathBuf {
-    std::env::var_os("CARGO_TARGET_DIR")
-        .map(PathBuf::from)
-        .unwrap_or_else(|| PathBuf::from("target"))
+/// Cheap "do the four named files exist" probe used as a fallback for
+/// flat-layout archives.
+fn has_named_files(dir: &Path) -> bool {
+    REQUIRED_NAMED_FILES
+        .iter()
+        .all(|name| dir.join(name).is_file())
 }
+
+/// Full "is the destination already a valid staging dir" probe: every
+/// named binary plus a versioned libkrunfw.
+fn has_required_files(dir: &Path) -> bool { has_named_files(dir) && find_libkrunfw(dir).is_ok() }
+
+// ---------------------------------------------------------------------------
+// Stage to destination
+// ---------------------------------------------------------------------------
 
 /// Copy required files from `source` to `dest`, set unix permissions to
 /// match boxlite's expectations, then write a `.complete` stamp.
@@ -217,7 +412,17 @@ fn workspace_target_dir() -> PathBuf {
 fn stage_runtime(source: &Path, dest: &Path) -> std::io::Result<()> {
     fs::create_dir_all(dest)?;
 
-    for name in RUNTIME_FILES {
+    let libkrunfw_name =
+        find_libkrunfw(source).map_err(|e| std::io::Error::other(e.to_string()))?;
+
+    // Build the file list: 4 named binaries + the versioned libkrunfw.
+    let mut to_copy: Vec<String> = REQUIRED_NAMED_FILES
+        .iter()
+        .map(|s| (*s).to_owned())
+        .collect();
+    to_copy.push(libkrunfw_name);
+
+    for name in &to_copy {
         let src = source.join(name);
         let dst = dest.join(name);
         // Remove first to avoid `text file busy` if a previous boxlite
@@ -229,7 +434,7 @@ fn stage_runtime(source: &Path, dest: &Path) -> std::io::Result<()> {
         #[cfg(unix)]
         {
             use std::os::unix::fs::PermissionsExt;
-            let mode = if EXECUTABLE_FILES.contains(name) {
+            let mode = if EXECUTABLE_FILES.contains(&name.as_str()) {
                 0o755
             } else {
                 0o644
@@ -242,13 +447,292 @@ fn stage_runtime(source: &Path, dest: &Path) -> std::io::Result<()> {
     Ok(())
 }
 
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
 #[cfg(test)]
 mod tests {
-    use std::fs::File;
+    use std::{
+        net::SocketAddr,
+        sync::{
+            Arc,
+            atomic::{AtomicUsize, Ordering},
+        },
+    };
 
+    use axum::{Router, body::Body, http::StatusCode, response::Response, routing::get};
     use tempfile::tempdir;
+    use tokio::net::TcpListener;
 
     use super::*;
+
+    // -----------------------------------------------------------------
+    // Test fixture: build a tarball matching the upstream layout.
+    // -----------------------------------------------------------------
+
+    /// Files to put inside the synthesised tarball.
+    struct FixtureContents {
+        /// Set to `false` to omit `boxlite-guest` from the archive (used
+        /// by the "missing required file" scenario).
+        include_boxlite_guest: bool,
+    }
+
+    impl Default for FixtureContents {
+        fn default() -> Self {
+            Self {
+                include_boxlite_guest: true,
+            }
+        }
+    }
+
+    /// Build a `.tar.gz` mirroring the upstream
+    /// `boxlite-runtime-vX.Y.Z-<target>.tar.gz` layout: a top-level
+    /// `boxlite-runtime/` directory holding the runtime files.
+    fn build_fixture_tarball(contents: &FixtureContents) -> Vec<u8> {
+        let mut buf: Vec<u8> = Vec::new();
+        {
+            let gz = flate2::write::GzEncoder::new(&mut buf, flate2::Compression::fast());
+            let mut tar = tar::Builder::new(gz);
+
+            let mut add = |name: &str, body: &[u8], mode: u32| {
+                let mut header = tar::Header::new_gnu();
+                header.set_size(body.len() as u64);
+                header.set_mode(mode);
+                header.set_cksum();
+                tar.append_data(&mut header, format!("boxlite-runtime/{name}"), body)
+                    .expect("append fixture entry");
+            };
+
+            add("boxlite-shim", b"#!fake shim\n", 0o755);
+            if contents.include_boxlite_guest {
+                add("boxlite-guest", b"#!fake guest\n", 0o755);
+            }
+            add("mke2fs", b"#!fake mke2fs\n", 0o755);
+            add("debugfs", b"#!fake debugfs\n", 0o755);
+            // Versioned libkrunfw — match the platform suffix.
+            #[cfg(target_os = "macos")]
+            add("libkrunfw.5.dylib", b"fake libkrunfw\n", 0o644);
+            #[cfg(target_os = "linux")]
+            add("libkrunfw.so.5", b"fake libkrunfw\n", 0o644);
+
+            tar.into_inner()
+                .expect("close tar builder")
+                .finish()
+                .expect("close gz encoder");
+        }
+        buf
+    }
+
+    /// Hermetic in-process HTTP server that serves a single fixed payload
+    /// and counts hits. Bound to `127.0.0.1:0`.
+    struct FixtureServer {
+        url:       String,
+        hits:      Arc<AtomicUsize>,
+        _shutdown: tokio::sync::oneshot::Sender<()>,
+    }
+
+    impl FixtureServer {
+        async fn start(payload: Vec<u8>) -> Self {
+            let listener = TcpListener::bind("127.0.0.1:0")
+                .await
+                .expect("bind ephemeral port");
+            let addr: SocketAddr = listener.local_addr().expect("local addr");
+            let hits = Arc::new(AtomicUsize::new(0));
+
+            let payload = Arc::new(payload);
+            let hits_for_handler = hits.clone();
+            let app = Router::new().route(
+                "/runtime.tar.gz",
+                get(move || {
+                    let payload = payload.clone();
+                    let hits = hits_for_handler.clone();
+                    async move {
+                        hits.fetch_add(1, Ordering::SeqCst);
+                        Response::builder()
+                            .status(StatusCode::OK)
+                            .header("content-type", "application/gzip")
+                            .header("content-length", payload.len().to_string())
+                            .body(Body::from((*payload).clone()))
+                            .unwrap()
+                    }
+                }),
+            );
+
+            let (tx, rx) = tokio::sync::oneshot::channel::<()>();
+            tokio::spawn(async move {
+                let server = axum::serve(listener, app).with_graceful_shutdown(async move {
+                    let _ = rx.await;
+                });
+                let _ = server.await;
+            });
+
+            Self {
+                url: format!("http://{addr}/runtime.tar.gz"),
+                hits,
+                _shutdown: tx,
+            }
+        }
+    }
+
+    // -----------------------------------------------------------------
+    // Scenario tests (BDD selectors in spec map to these names).
+    // -----------------------------------------------------------------
+
+    #[tokio::test]
+    async fn fresh_setup_downloads_and_stages_all_files() {
+        let server = FixtureServer::start(build_fixture_tarball(&FixtureContents::default())).await;
+        let dest_dir = tempdir().unwrap();
+        let opts = SetupOptions {
+            url:  server.url.clone(),
+            dest: dest_dir.path().to_path_buf(),
+        };
+
+        let outcome = run_boxlite_setup_with(false, &opts)
+            .await
+            .expect("staging should succeed against the fixture server");
+
+        match outcome {
+            StageOutcome::Staged { dest } => assert_eq!(dest, opts.dest),
+            StageOutcome::CheckOnly { .. } => panic!("expected Staged, got CheckOnly"),
+        }
+
+        for name in REQUIRED_NAMED_FILES {
+            assert!(
+                dest_dir.path().join(name).is_file(),
+                "missing staged file {name}"
+            );
+        }
+        let libkrunfw = find_libkrunfw(dest_dir.path()).expect("staged libkrunfw present");
+        #[cfg(target_os = "macos")]
+        assert_eq!(libkrunfw, "libkrunfw.5.dylib");
+        #[cfg(target_os = "linux")]
+        assert_eq!(libkrunfw, "libkrunfw.so.5");
+
+        assert!(
+            dest_dir.path().join(COMPLETE_STAMP).is_file(),
+            ".complete stamp must be written"
+        );
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            for name in EXECUTABLE_FILES {
+                let mode = fs::metadata(dest_dir.path().join(name))
+                    .unwrap()
+                    .permissions()
+                    .mode()
+                    & 0o777;
+                assert_eq!(mode, 0o755, "{name} should be 0o755");
+            }
+            let lib_mode = fs::metadata(dest_dir.path().join(&libkrunfw))
+                .unwrap()
+                .permissions()
+                .mode()
+                & 0o777;
+            assert_eq!(lib_mode, 0o644, "libkrunfw should be 0o644");
+        }
+    }
+
+    #[tokio::test]
+    async fn idempotent_skip_when_already_complete() {
+        let server = FixtureServer::start(build_fixture_tarball(&FixtureContents::default())).await;
+        let dest_dir = tempdir().unwrap();
+
+        // Pre-populate destination with a valid staging layout.
+        for name in REQUIRED_NAMED_FILES {
+            fs::write(dest_dir.path().join(name), b"existing").unwrap();
+        }
+        #[cfg(target_os = "macos")]
+        fs::write(dest_dir.path().join("libkrunfw.5.dylib"), b"existing").unwrap();
+        #[cfg(target_os = "linux")]
+        fs::write(dest_dir.path().join("libkrunfw.so.5"), b"existing").unwrap();
+        fs::write(dest_dir.path().join(COMPLETE_STAMP), BOXLITE_VERSION).unwrap();
+
+        let original_bytes = fs::read(dest_dir.path().join("boxlite-shim")).unwrap();
+        let opts = SetupOptions {
+            url:  server.url.clone(),
+            dest: dest_dir.path().to_path_buf(),
+        };
+
+        let outcome = run_boxlite_setup_with(false, &opts)
+            .await
+            .expect("idempotent re-run should succeed");
+        assert!(matches!(outcome, StageOutcome::Staged { .. }));
+
+        // No HTTP request was made.
+        assert_eq!(
+            server.hits.load(Ordering::SeqCst),
+            0,
+            "server must not be hit on idempotent run"
+        );
+        // Existing files are unchanged byte-for-byte.
+        let after_bytes = fs::read(dest_dir.path().join("boxlite-shim")).unwrap();
+        assert_eq!(original_bytes, after_bytes);
+    }
+
+    #[tokio::test]
+    async fn check_only_is_pure_dry_run() {
+        let server = FixtureServer::start(build_fixture_tarball(&FixtureContents::default())).await;
+        let dest_dir = tempdir().unwrap();
+        let opts = SetupOptions {
+            url:  server.url.clone(),
+            dest: dest_dir.path().to_path_buf(),
+        };
+
+        let outcome = run_boxlite_setup_with(true, &opts)
+            .await
+            .expect("--check should succeed");
+
+        match outcome {
+            StageOutcome::CheckOnly { url, dest } => {
+                assert_eq!(url, opts.url);
+                assert_eq!(dest, opts.dest);
+            }
+            StageOutcome::Staged { .. } => panic!("expected CheckOnly, got Staged"),
+        }
+        assert_eq!(server.hits.load(Ordering::SeqCst), 0);
+        assert!(!dest_dir.path().join(COMPLETE_STAMP).exists());
+        assert!(fs::read_dir(dest_dir.path()).unwrap().next().is_none());
+    }
+
+    #[tokio::test]
+    async fn missing_required_file_in_tarball_errors_cleanly() {
+        let server = FixtureServer::start(build_fixture_tarball(&FixtureContents {
+            include_boxlite_guest: false,
+        }))
+        .await;
+        let dest_dir = tempdir().unwrap();
+        let opts = SetupOptions {
+            url:  server.url.clone(),
+            dest: dest_dir.path().to_path_buf(),
+        };
+
+        let err = run_boxlite_setup_with(false, &opts)
+            .await
+            .expect_err("staging must fail when a required file is absent");
+        let msg = format!("{err}");
+        assert!(
+            msg.contains("boxlite-guest"),
+            "error message must name the missing file, got: {msg}"
+        );
+        assert!(
+            !dest_dir.path().join(COMPLETE_STAMP).exists(),
+            "no stamp must be written on failure"
+        );
+    }
+
+    #[test]
+    fn unsupported_platform_errors_cleanly() {
+        let err = resolve_target("freebsd", "x86_64").expect_err("freebsd is unsupported");
+        assert!(err.contains("freebsd"));
+        assert!(err.contains("x86_64"));
+
+        // Sanity: every supported pair resolves.
+        assert!(resolve_target("macos", "aarch64").is_ok());
+        assert!(resolve_target("linux", "x86_64").is_ok());
+        assert!(resolve_target("linux", "aarch64").is_ok());
+    }
 
     #[test]
     fn version_matches_sandbox_dep() {
@@ -261,13 +745,65 @@ mod tests {
         );
     }
 
-    #[test]
-    fn has_required_files_detects_missing() {
-        let dir = tempdir().unwrap();
-        assert!(!has_required_files(dir.path()));
-        for name in RUNTIME_FILES {
-            File::create(dir.path().join(name)).unwrap();
+    #[tokio::test]
+    async fn target_dir_is_never_consulted() {
+        // Lay down a `target/release/build/boxlite-deadbeef/out/runtime/`
+        // populated with garbage. The new pipeline must ignore it
+        // entirely — staging proceeds purely from the downloaded tarball.
+        let scratch = tempdir().unwrap();
+        let bogus_runtime = scratch
+            .path()
+            .join("target")
+            .join("release")
+            .join("build")
+            .join("boxlite-deadbeef")
+            .join("out")
+            .join("runtime");
+        fs::create_dir_all(&bogus_runtime).unwrap();
+        for name in REQUIRED_NAMED_FILES {
+            fs::write(bogus_runtime.join(name), b"GARBAGE").unwrap();
         }
-        assert!(has_required_files(dir.path()));
+
+        let server = FixtureServer::start(build_fixture_tarball(&FixtureContents::default())).await;
+        let dest_dir = tempdir().unwrap();
+        let opts = SetupOptions {
+            url:  server.url.clone(),
+            // Destination intentionally lives inside the scratch dir so
+            // any "consulted target/" bug would be visible.
+            dest: dest_dir.path().to_path_buf(),
+        };
+
+        run_boxlite_setup_with(false, &opts)
+            .await
+            .expect("staging should succeed independent of target/");
+
+        // Staged content must come from the fixture (real signature),
+        // not from `target/` (would be the literal "GARBAGE" payload).
+        let shim = fs::read(dest_dir.path().join("boxlite-shim")).unwrap();
+        assert_ne!(shim, b"GARBAGE", "staged file must not come from target/");
+        assert_eq!(server.hits.load(Ordering::SeqCst), 1);
+    }
+
+    // -----------------------------------------------------------------
+    // Supplementary unit tests for helpers.
+    // -----------------------------------------------------------------
+
+    #[test]
+    fn libkrunfw_pattern_recognises_versioned_soname() {
+        #[cfg(target_os = "macos")]
+        {
+            assert!(is_libkrunfw_soname("libkrunfw.5.dylib"));
+            assert!(is_libkrunfw_soname("libkrunfw.42.dylib"));
+            assert!(!is_libkrunfw_soname("libkrunfw.dylib"));
+            assert!(!is_libkrunfw_soname("libkrunfw.5.so"));
+            assert!(!is_libkrunfw_soname("libkrunfw.x.dylib"));
+        }
+        #[cfg(target_os = "linux")]
+        {
+            assert!(is_libkrunfw_soname("libkrunfw.so.5"));
+            assert!(is_libkrunfw_soname("libkrunfw.so.5.0"));
+            assert!(!is_libkrunfw_soname("libkrunfw.so"));
+            assert!(!is_libkrunfw_soname("libkrunfw.5.dylib"));
+        }
     }
 }

--- a/crates/rara-sandbox/AGENT.md
+++ b/crates/rara-sandbox/AGENT.md
@@ -150,19 +150,25 @@ person if they aren't written down.
 3. **Runtime files need staging.** boxlite expects the following files
    to be present at its runtime directory before the first box will
    start:
-   - `boxlite-guest`
-   - `libkrunfw.dylib` (macOS) / `libkrunfw.so` (linux)
-   - `mke2fs`
    - `boxlite-shim`
+   - `boxlite-guest`
+   - `mke2fs`
    - `debugfs`
+   - the versioned `libkrunfw` SONAME — `libkrunfw.5.dylib` on macOS or
+     `libkrunfw.so.5` on Linux for boxlite v0.8.2. Boxlite's runtime
+     `dlopen`s the versioned filename embedded in the binary; an
+     unversioned `libkrunfw.dylib`/`libkrunfw.so` symlink is **not**
+     required.
 
    Staging is automated via `rara setup boxlite` (see
-   `docs/guides/boxlite-runtime.md`). The destination is:
+   `docs/guides/boxlite-runtime.md`). It downloads the upstream prebuilt
+   runtime tarball directly — no `cargo build -p rara-sandbox` is
+   required first. The destination is:
    - macOS: `~/Library/Application Support/boxlite/runtimes/v0.8.2/`
    - Linux: `$XDG_DATA_HOME/boxlite/runtimes/v0.8.2/`
      (fallback `~/.local/share/boxlite/runtimes/v0.8.2/`)
 
-   Run `cargo build -p rara-sandbox` once (without `BOXLITE_DEPS_STUB`)
-   so boxlite's build.rs downloads the platform tarball, then run
-   `rara setup boxlite` to copy the files into place. The version
-   segment must match the `tag = "v…"` in this crate's `Cargo.toml`.
+   The version segment must match the `tag = "v…"` in this crate's
+   `Cargo.toml`; `BOXLITE_VERSION` in `crates/cmd/src/setup/boxlite.rs`
+   is enforced against that tag by the `version_matches_sandbox_dep`
+   test.

--- a/docs/guides/boxlite-runtime.md
+++ b/docs/guides/boxlite-runtime.md
@@ -1,35 +1,39 @@
 # Boxlite Runtime Staging
 
 `rara-sandbox` wraps boxlite (a microVM library) for hardware-isolated code
-execution. Boxlite needs five runtime files (`boxlite-guest`,
-`boxlite-shim`, `mke2fs`, `debugfs`, and `libkrunfw.dylib`/`.so`) to be
-present at a stable user-data path before the first VM will start.
+execution. Boxlite needs five runtime files to be present at a stable
+user-data path before the first VM will start:
 
-`rara setup boxlite` copies those files out of cargo's build directory
-into that path. Run it once per machine, after the first
-`cargo build -p rara-sandbox`.
+- `boxlite-shim`
+- `boxlite-guest`
+- `mke2fs`
+- `debugfs`
+- the versioned `libkrunfw` SONAME (e.g. `libkrunfw.5.dylib` on macOS, or
+  `libkrunfw.so.5` on Linux). Boxlite's runtime `dlopen`s the versioned
+  filename — the unversioned `libkrunfw.dylib`/`libkrunfw.so` is **not**
+  required.
+
+`rara setup boxlite` downloads the official prebuilt runtime tarball from
+the boxlite GitHub release page and extracts those files into the
+platform user-data path. No `cargo build` is required first — staging is
+a self-contained download → verify → copy pipeline.
 
 ## When to run
 
 - **First-time setup** on a developer machine that will use sandboxed
   code execution.
 - **After bumping the boxlite tag** in `crates/rara-sandbox/Cargo.toml` —
-  the destination directory is keyed by version, so a new tag means a new
-  empty directory.
-- **After `cargo clean`** wipes the build artefacts; re-run
-  `cargo build -p rara-sandbox` first, then re-stage.
+  the destination directory is keyed by version, so a new tag means a
+  fresh download. `BOXLITE_VERSION` in
+  `crates/cmd/src/setup/boxlite.rs` must move lockstep with that tag.
 
 ## Usage
 
 ```bash
-# Build rara-sandbox so boxlite's build.rs downloads the platform tarball
-# into target/<profile>/build/boxlite-<hash>/out/runtime/.
-cargo build -p rara-sandbox
-
-# Copy the runtime files into the platform user-data directory.
+# Download + stage the runtime files into the platform user-data dir.
 cargo run -p rara-cli -- setup boxlite
 
-# Dry-run: print where the files would come from / go to, without copying.
+# Dry-run: print the planned URL + destination without touching network or disk.
 cargo run -p rara-cli -- setup boxlite --check
 ```
 
@@ -44,24 +48,55 @@ These match boxlite's own embedded-runtime fallback paths, so the eager
 stamp file (`.complete`) lets boxlite's lazy extractor short-circuit on
 the first VM boot.
 
+## Mirrored / air-gapped installs
+
+Set the `BOXLITE_RUNTIME_URL` environment variable to point at a mirrored
+copy of the upstream tarball. The variable matches upstream `build.rs`'s
+own override knob; when set, it takes precedence over the derived
+`{base}/{version}/boxlite-runtime-{version}-{target}.tar.gz` URL.
+
+```bash
+BOXLITE_RUNTIME_URL=https://mirror.example.com/boxlite-runtime-v0.8.2-darwin-arm64.tar.gz \
+  cargo run -p rara-cli -- setup boxlite
+```
+
 ## Idempotence
 
 Re-running `rara setup boxlite` on an already-staged directory is a
 no-op — the `.complete` stamp written at the end of staging is checked
-first and reported as "already staged".
+first and reported as "already staged". No HTTP request is made on the
+idempotent path.
+
+## Failure modes
+
+- **Tarball missing a required file** → loud error naming the missing
+  file. No `.complete` stamp is written, so a re-run will retry.
+- **Network failure / 4xx / 5xx** → loud error including the URL.
+- **Unsupported platform** (anything other than `darwin-arm64`,
+  `linux-x64-gnu`, `linux-arm64-gnu`) → loud error naming the
+  `(os, arch)` pair. boxlite has no release artefact for the host.
+
+## Supported platforms
+
+The upstream release pipeline ships tarballs for:
+
+- `darwin-arm64` (macOS, Apple Silicon)
+- `linux-x64-gnu`
+- `linux-arm64-gnu`
+
+Other targets — including macOS x86_64 — are not currently supported by
+upstream and `setup boxlite` errors loudly on them.
 
 ## CI
 
 The Linux `clippy` / `test` / `docs` jobs in
 `.github/workflows/rust.yml` build with `BOXLITE_DEPS_STUB="1"` to avoid
 pulling the full native build chain (meson, ninja, patchelf) onto the
-`arc-runner-set` image. Under the stub, no runtime files are produced,
-so the `rara setup boxlite --check` smoke step exercises only the
-path-resolution code and exits cleanly with "no boxlite build artifacts
-found".
+`arc-runner-set` image. Staging itself is exercised in unit tests via a
+hermetic in-process HTTP fixture — no real network access from CI.
 
-There is no CI job that builds boxlite without the stub today. The
+There is no CI job that downloads the real upstream tarball today. The
 self-hosted macOS runner introduced in #1842 was removed in #1916
 because its network reachability was too unreliable to gate every PR
-on. Real boxlite builds happen only on developer macOS machines until
-a stable runner is provisioned — see #1842 for the long-term plan.
+on. Real-tarball staging happens only on developer machines until a
+stable runner is provisioned — see #1842 for the long-term plan.

--- a/specs/issue-1980-setup-boxlite-self-sufficient.spec.md
+++ b/specs/issue-1980-setup-boxlite-self-sufficient.spec.md
@@ -1,0 +1,372 @@
+spec: task
+name: "issue-1980-setup-boxlite-self-sufficient"
+inherits: project
+tags: ["cmd", "setup", "sandbox", "boxlite"]
+---
+
+## Intent
+
+`./bin/rara setup boxlite` must be self-sufficient end-to-end, the same
+way `rara setup whisper` is. Today it is not: on a fresh checkout (no
+prior `cargo build`) it errors with "no boxlite build artifacts found
+under target/", and even after the documented `cargo build -p
+rara-sandbox` the staging still fails because the actual build artifacts
+on disk do not match what `RUNTIME_FILES` expects. Setup is supposed to
+*do* the work, not narrate prerequisites the user has to satisfy.
+
+Concrete reproducer (verified 2026-04-28 on remote `raratekiAir`,
+darwin-arm64, repo at `/Users/rara/code/rararulab/rara`, boxlite tag
+`v0.8.2`):
+
+1. After `cargo build -p rara-sandbox` (default mode, no
+   `BOXLITE_DEPS_STUB`), inspect what is actually produced:
+   `target/{release,debug}/build/boxlite-<hash>/out/runtime/` contains
+   exactly `debugfs`, `mke2fs`, `libkrunfw.5.dylib`. It does NOT contain
+   `boxlite-guest`, does NOT contain `boxlite-shim`, and does NOT
+   contain a bare `libkrunfw.dylib`.
+2. Run `./bin/rara setup boxlite`. Output: "no boxlite build artifacts
+   found under target/. Either build rara-sandbox without
+   BOXLITE_DEPS_STUB, or skip staging on this platform." Exit code
+   non-zero (well — `Ok(StageOutcome::NoArtifacts)`, but the user-visible
+   message is an error and no staging happened).
+3. The published staging directory at
+   `~/Library/Application Support/boxlite/runtimes/v0.8.2/` is empty,
+   so the next `Sandbox::create` call inside rara-app falls through to
+   boxlite's own embedded-runtime extractor — which itself errors
+   because the rara binary was not compiled with `embedded-runtime`
+   feature. Sandboxed code execution is unreachable on a fresh dev
+   machine despite the user having run every documented step.
+
+Why the current code reads target/ at all: PR 1844 (issue 1699) was
+written under the belief that boxlite's `build.rs` populates
+`OUT_DIR/runtime/` with all five files in default `Source` mode. Reading
+the upstream `build.rs` at tag `v0.8.2`
+(`~/.cargo/git/checkouts/boxlite-0764168f2430805e/da71624/src/boxlite/build.rs`)
+shows three modes selected by `BOXLITE_DEPS_STUB`:
+
+- unset → `Source`: builds native -sys crates from source, calls
+  `bundle_boxlite_deps` which copies only library files via
+  `is_library_file` filter and skips symlinks (lines 80-85). Result on
+  darwin-arm64: `mke2fs`, `debugfs`, `libkrunfw.5.dylib` — no
+  `boxlite-guest`, no `boxlite-shim`, no unversioned `libkrunfw.dylib`.
+  The shim/guest are only collected when the `embedded-runtime` cargo
+  feature is on; rara-sandbox does not enable it.
+- `1` → `Stub`: skips everything; CI clippy mode.
+- `2` → `Prebuilt`: downloads the official
+  `boxlite-runtime-v{version}-{target}.tar.gz` from GitHub Releases,
+  extracts it, and calls `create_library_symlinks` to add the
+  unversioned `libkrunfw.dylib` symlink alongside `libkrunfw.5.dylib`.
+
+I confirmed by `curl`+`tar -tzf` that
+`https://github.com/boxlite-ai/boxlite/releases/download/v0.8.2/boxlite-runtime-v0.8.2-darwin-arm64.tar.gz`
+contains exactly `boxlite-runtime/{boxlite-shim,boxlite-guest,mke2fs,debugfs,libkrunfw.5.dylib}`.
+Equivalent tarballs ship for `linux-x64-gnu` and `linux-arm64-gnu`. This
+is the artifact the upstream maintainers ship as "the runtime files for
+downstream consumers", and it is the artifact `setup boxlite` should
+hand to the user.
+
+The cleanest fix is therefore: `setup boxlite` downloads that tarball
+itself, the same way `setup whisper` downloads the whisper.cpp model
+file. No `cargo build` dependency, no scanning of `target/`, no
+`BOXLITE_DEPS_STUB=2` toggle the user has to know about. The download
++ extract + verify path is the entire setup, which is what makes it
+self-sufficient.
+
+Goal alignment: signal 1 ("the process runs for months without
+intervention") — bootstrap correctness is upstream of every long-run
+property; if a fresh checkout cannot reach a working sandbox, every
+year-out goal is gated on a manual workaround. Signal 4 ("every action
+is inspectable") indirectly: a working sandbox is what lets `run_code`
+produce the inspectable execution traces. Does not cross any "What
+rara is NOT" line — this is rara's own bootstrap pipeline, single-user,
+local-only, and inspectable on disk via the `.complete` stamp.
+
+Hermes positioning: not applicable. Hermes Agent does not expose a
+sandboxed code-execution facility, so there is no upstream behavior to
+match or differ from.
+
+Prior art search summary:
+
+- `gh pr list --search "boxlite"` → PR 1840 / 1844 (the original
+  staging implementation we are replacing), PR 1881 (real macOS CI
+  build, since reverted), PR 1917 (removed sandbox-macos CI job), PR
+  1939 / 1946 (sandbox config evolution, unrelated to staging
+  mechanism). PR 1844 is the direct prior art for this work; this
+  spec supersedes its `target/`-scan strategy with a download strategy.
+- `git log --grep boxlite --since=180.days` → no commit since PR 1844
+  has touched the `crates/cmd/src/setup/boxlite.rs` staging logic.
+  The mechanism has been broken since merge; nobody hit it because
+  `--check` (the only path exercised in CI) does not perform the
+  copy and exits cleanly even when no artifacts exist.
+- `gh issue list --search "boxlite"` → only #1699 (closed by PR 1844)
+  and #1702 (sqlx → diesel migration, unrelated). No reverted decision
+  to walk back, no in-flight RFC to coordinate with.
+- `git log --since=30.days -- crates/cmd/src/setup/boxlite.rs` → empty.
+  No recent edits; this is a clean replacement, not a reversion of
+  fresh work.
+
+This is **additive in spirit** to PR 1844's contract (the destination
+path, the `.complete` stamp, the version-pinning constant, the
+idempotence rule all stay) and **replaces** PR 1844's source-discovery
+strategy (scan `target/` → download from upstream releases). No
+prior decision is being undone; the prior decision was incomplete,
+and we are completing it.
+
+## Decisions
+
+1. **Source of truth: download the prebuilt tarball.** `setup boxlite`
+   downloads
+   `https://github.com/boxlite-ai/boxlite/releases/download/{BOXLITE_VERSION}/boxlite-runtime-{BOXLITE_VERSION}-{target}.tar.gz`
+   where `{target}` is one of `darwin-arm64`, `linux-x64-gnu`,
+   `linux-arm64-gnu` per the host's `CARGO_CFG_TARGET_OS` /
+   `CARGO_CFG_TARGET_ARCH` (resolved at runtime via `std::env::consts`,
+   not cargo cfg, since this binary already ran). On any other host,
+   exit with a clear "boxlite unsupported on this platform" message —
+   no silent skip, per the project's "no noop fallback" rule.
+2. **`RUNTIME_FILES` matches what the tarball actually ships** —
+   `["boxlite-shim", "boxlite-guest", "mke2fs", "debugfs",
+   "libkrunfw.5.dylib"]` on macOS and the equivalent
+   `libkrunfw.so.<v>` SONAME on Linux. No bare `libkrunfw.dylib` /
+   `libkrunfw.so` is required: boxlite's runtime `dlopen`s the
+   versioned SONAME (build.rs comment lines 81-85: "runtime linker
+   uses the full versioned name embedded in the binary"). The
+   versioned filename is part of the contract; the fix to the constant
+   is therefore a correctness fix, not an arbitrary rename.
+3. **Discover the libkrunfw filename from the tarball, do not hard-code
+   the version**. Boxlite v0.8.2 ships `libkrunfw.5.dylib` today;
+   bumping `BOXLITE_VERSION` later may bump the SONAME. After
+   extraction, the staging step verifies presence of the four named
+   binaries (`boxlite-shim`, `boxlite-guest`, `mke2fs`, `debugfs`) plus
+   "exactly one `libkrunfw.<digits>.dylib`" on macOS and "exactly one
+   `libkrunfw.so.<digits>(.<digits>)*`" on Linux. Failing this
+   invariant is a hard error with a precise message naming the
+   tarball URL — never silent.
+4. **Pipeline shape mirrors `ensure_whisper`**: detect → download →
+   verify → report. Each step a named function in the same file. The
+   `--check` flag prints what would be downloaded (URL, expected
+   filenames, destination path) without touching the network or the
+   filesystem; current `--check` semantics survive but its meaning
+   shifts from "is target/ populated" to "is staging complete".
+5. **Idempotence preserved**. The `.complete` stamp check at the start
+   stays; if the destination already has a valid stamp and the
+   required files, `setup boxlite` reports "already staged" and exits
+   cleanly without re-downloading. This is byte-for-byte equivalent
+   to PR 1844's behavior on the happy path.
+6. **Download lives in the same file**. We reuse the `download_file`
+   helper pattern from `whisper_install.rs` (reqwest + bytes_stream +
+   progress), and add a `tar -xzf` extraction step. The existing
+   `flate2` + `tar` crates are already in the workspace
+   (`Cargo.lock`); add them as direct deps to `crates/cmd/Cargo.toml`
+   if not already there. We do not shell out to `tar` — keep the
+   pipeline platform-agnostic and dependency-explicit (matches the
+   project rule "errors at application boundaries via `whatever`",
+   and shelling out hides failure modes from snafu).
+7. **No `cargo build` invocation**. `setup boxlite` does not run
+   cargo. The previous "you must run `cargo build -p rara-sandbox`
+   first" requirement is removed from `docs/guides/boxlite-runtime.md`.
+   Setup downloads what it needs; the user runs cargo when they want
+   to build rara, not as a side-quest for staging.
+8. **`BOXLITE_VERSION` stays a Rust const**, matched against the git
+   tag in `crates/rara-sandbox/Cargo.toml` by the existing
+   `version_matches_sandbox_dep` test. This is correct as-is per the
+   project's "mechanism vs config" rule — no operator has a real
+   reason to override the boxlite version independently of the
+   sandbox crate.
+9. **Error messages distinguish three states**: (a) destination
+   already complete (success), (b) network / extraction failure
+   (actionable error with URL), (c) platform unsupported (clear
+   exit). The current single "no artifacts" branch goes away because
+   it represents a state the new pipeline cannot reach.
+
+## Boundaries
+
+### Allowed Changes
+
+- `crates/cmd/src/setup/boxlite.rs`: replace `locate_build_runtime`,
+  `collect_boxlite_runtimes`, `workspace_target_dir`, and the
+  `StageOutcome::NoArtifacts` branch with the new
+  download → extract → verify pipeline. Keep `staged_runtime_dir`,
+  `stage_runtime` (now copying from a temp extraction dir, not from
+  `target/`), the `.complete` stamp logic, the `EXECUTABLE_FILES`
+  permission rule, and the `version_matches_sandbox_dep` test
+  unchanged.
+- `crates/cmd/src/setup/boxlite.rs` test module: rename
+  `has_required_files_detects_missing` to keep parity with the new
+  `RUNTIME_FILES` set, and add a unit test asserting that the
+  per-platform tarball URL pattern resolves correctly for
+  darwin-arm64, linux-x64-gnu, linux-arm64-gnu.
+- `crates/cmd/src/setup/boxlite.rs`: add an integration test that
+  uses a hermetic local HTTP fixture (axum or `tiny_http` + a
+  pre-built sample tarball checked into `crates/cmd/tests/fixtures/`)
+  to exercise the full download → extract → stage path without
+  hitting the network. The `BOXLITE_RUNTIME_URL` env var (already a
+  hook in upstream's `build.rs`) becomes the override knob the test
+  uses to point at the local fixture.
+- `crates/cmd/Cargo.toml`: add `flate2` and `tar` as direct deps if
+  not already present.
+- `docs/guides/boxlite-runtime.md`: update to remove the "run
+  `cargo build -p rara-sandbox` first" prerequisite. Document the
+  new download flow, the destination path (unchanged), and the
+  `BOXLITE_RUNTIME_URL` override for offline / mirrored installs.
+- `crates/rara-sandbox/AGENT.md` "footgun #3" paragraph: update the
+  required-files list to include the versioned SONAME and remove the
+  "build first, then stage" instruction.
+- **/crates/cmd/src/setup/boxlite.rs
+- **/crates/cmd/Cargo.toml
+- **/docs/guides/boxlite-runtime.md
+- **/crates/rara-sandbox/AGENT.md
+- **/specs/issue-1980-setup-boxlite-self-sufficient.spec.md
+
+### Forbidden
+
+- Do not change `BOXLITE_VERSION` or its location in
+  `crates/cmd/src/setup/boxlite.rs`. The constant stays.
+- Do not introduce a YAML config knob for the runtime URL or version.
+  The override mechanism is the existing `BOXLITE_RUNTIME_URL` env
+  var (matches upstream's contract); there is no per-deployment
+  reason to bake a URL into `config.yaml`.
+- Do not touch `crates/rara-sandbox/Cargo.toml`. The git tag stays at
+  `v0.8.2`. This issue is about staging, not bumping boxlite.
+- Do not enable the `embedded-runtime` cargo feature on
+  `rara-sandbox`. That path doubles the binary size on every build
+  and exists to serve a different (Python/Node SDK) shape; rara's
+  staging strategy is on-disk under user-data, not embedded in the
+  binary.
+- Do not add `boxlite` itself or any `boxlite-*` crate as a direct
+  dep of `rara-cli` or `crates/cmd`. Setup must not require building
+  any boxlite -sys crate.
+- Do not shell out to `curl` or `tar`. Download via `reqwest`,
+  extract via `flate2 + tar` rust crates. Shelling out hides errors
+  from `snafu` and breaks on machines where `tar` lacks
+  `--strip-components`.
+- Do not delete the `--check` flag. It changes meaning slightly (now
+  reports "would download X to Y" instead of "would copy from
+  target/X to Y") but the CLI surface and exit codes stay.
+- Do not change the destination path
+  (`~/Library/Application Support/boxlite/runtimes/<version>/` on
+  macOS, XDG fallback on Linux). It is contractual with boxlite's
+  own embedded-runtime extractor.
+
+## Acceptance Criteria
+
+Scenario: fresh machine setup completes end-to-end without prior cargo build
+  Given a host with no `target/` directory in the repo and an empty
+    `~/Library/Application Support/boxlite/runtimes/v0.8.2/`
+  And `BOXLITE_RUNTIME_URL` points to a local hermetic HTTP fixture
+    that serves a copy of `boxlite-runtime-v0.8.2-darwin-arm64.tar.gz`
+  When `run_boxlite_setup(check_only = false)` is invoked
+  Then the destination directory contains `boxlite-shim`,
+    `boxlite-guest`, `mke2fs`, `debugfs`, `libkrunfw.5.dylib`,
+    and `.complete`
+  And `boxlite-shim`, `boxlite-guest`, `mke2fs`, `debugfs` are
+    mode `0o755` on unix
+  And `libkrunfw.5.dylib` is mode `0o644` on unix
+  And the function returns `Ok(StageOutcome::Staged { dest })`
+  Test:
+    Package: rara-cli
+    Filter: boxlite::fresh_setup_downloads_and_stages_all_files
+
+Scenario: re-running on an already-staged directory is a no-op
+  Given the destination directory already contains all five required
+    files plus a valid `.complete` stamp matching `BOXLITE_VERSION`
+  When `run_boxlite_setup(check_only = false)` is invoked
+  Then no HTTP request is made (assert via fixture-server hit count == 0)
+  And the destination is unchanged byte-for-byte
+  And the function returns `Ok(StageOutcome::Staged { dest })` with
+    the "already staged" log line
+  Test:
+    Package: rara-cli
+    Filter: boxlite::idempotent_skip_when_already_complete
+
+Scenario: --check prints the planned download without touching disk or network
+  Given an empty destination directory
+  When `run_boxlite_setup(check_only = true)` is invoked
+  Then no HTTP request is made
+  And the destination directory remains empty (no `.complete` stamp)
+  And the function returns `Ok(StageOutcome::CheckOnly { .. })`
+  And the printed output names the tarball URL and the destination path
+  Test:
+    Package: rara-cli
+    Filter: boxlite::check_only_is_pure_dry_run
+
+Scenario: tarball missing a required file fails loudly
+  Given `BOXLITE_RUNTIME_URL` points to a fixture tarball that omits
+    `boxlite-guest`
+  When `run_boxlite_setup(check_only = false)` is invoked
+  Then the function returns `Err(_)` (`Whatever` context naming
+    `boxlite-guest` as the missing file)
+  And no `.complete` stamp is written to the destination
+  And any partially-extracted files in the destination are removed
+    (so a re-run does not see a half-staged dir)
+  Test:
+    Package: rara-cli
+    Filter: boxlite::missing_required_file_in_tarball_errors_cleanly
+
+Scenario: unsupported platform fails loudly with a precise message
+  Given a host whose `(target_os, target_arch)` is not one of
+    `(macos, aarch64)`, `(linux, x86_64)`, `(linux, aarch64)`
+    (simulated by overriding the platform-resolution function in a
+    unit test)
+  When platform resolution runs at the start of setup
+  Then the function returns `Err(_)` (`Whatever` context naming the
+    unsupported `(os, arch)` pair)
+  And no destination directory is created
+  Test:
+    Package: rara-cli
+    Filter: boxlite::unsupported_platform_errors_cleanly
+
+Scenario: BOXLITE_VERSION still matches the rara-sandbox git tag
+  Given `crates/rara-sandbox/Cargo.toml` pins boxlite at tag `vX.Y.Z`
+  When the `version_matches_sandbox_dep` test runs
+  Then `BOXLITE_VERSION` equals `vX.Y.Z`
+  Test:
+    Package: rara-cli
+    Filter: boxlite::version_matches_sandbox_dep
+
+Scenario: target/ is not consulted at any point in the pipeline
+  Given a `target/release/build/boxlite-deadbeef/out/runtime/` populated
+    with deliberately-wrong garbage files
+  When `run_boxlite_setup(check_only = false)` is invoked
+  Then the garbage in `target/` is ignored entirely (no read, no copy)
+  And staging proceeds purely from the downloaded tarball
+  Test:
+    Package: rara-cli
+    Filter: boxlite::target_dir_is_never_consulted
+
+## Constraints
+
+- All comments and identifiers in new code must be English (project
+  rule).
+- Errors at this layer are application-boundary, so `snafu::Whatever`
+  + `.whatever_context("...")` is correct (matches `whisper_install.rs`).
+  Do not introduce a domain `BoxliteSetupError` enum — there is no
+  caller that needs to match on variants.
+- The download client is `reqwest` (already a workspace dep used by
+  `whisper_install.rs`); the extraction is `flate2::read::GzDecoder`
+  + `tar::Archive`. No process-spawning, no `Command::new("tar")`.
+- Progress reporting follows `whisper_install.rs`'s every-5%
+  pattern. Do not introduce `indicatif` or another progress crate
+  for one call site.
+- The integration test uses a hermetic in-process HTTP server (a
+  `tiny_http` thread or `axum::Router` on a `tokio::spawn` listener
+  bound to `127.0.0.1:0`) so CI does not depend on `github.com`
+  reachability.
+- No new YAML config keys. `BOXLITE_RUNTIME_URL` (env var) is the
+  override knob, matching upstream's `build.rs` contract.
+
+## Out of Scope
+
+- Bumping `BOXLITE_VERSION` past `v0.8.2`. Track that separately
+  when there is a reason to upgrade.
+- Re-enabling the `sandbox-macos` CI job removed in PR 1917. The
+  long-term plan from PR 1842 still applies; this issue does not
+  change that.
+- Replacing rara's "stage to user-data dir" strategy with boxlite's
+  `embedded-runtime` cargo feature. The on-disk strategy is
+  intentional (binary size, separate update lifecycle for runtime
+  vs binary).
+- Building the boxlite -sys crates from source on the user's
+  machine. The point of this issue is to make that unnecessary.
+- Wiring `setup boxlite` into a top-level `setup` orchestrator that
+  also runs `setup whisper`. That is a separate UX issue if anyone
+  wants it; today both subcommands stand alone.


### PR DESCRIPTION
## Summary

Replace the `target/`-scan strategy in `rara setup boxlite` with a self-contained download → extract → verify → stage pipeline modeled on `setup whisper`. Setup now downloads the official prebuilt runtime tarball from `https://github.com/boxlite-ai/boxlite/releases/download/{version}/boxlite-runtime-{version}-{target}.tar.gz` and stages the five required files into the platform user-data dir — no `cargo build -p rara-sandbox` prerequisite, no scanning of build directories that the default boxlite `Source` mode never populates.

The previous code looked for `boxlite-guest`, `boxlite-shim`, and a bare `libkrunfw.dylib` under `target/.../build/boxlite-*/out/runtime/`, none of which boxlite v0.8.2's `build.rs` produces in default mode (only `Prebuilt` mode or the `embedded-runtime` cargo feature does). The runtime `dlopen`s the versioned SONAME (`libkrunfw.5.dylib` / `libkrunfw.so.5`), so the correctness fix is to (a) match what's actually shipped and (b) skip the cargo build altogether — the upstream release tarball ships exactly the right artefacts.

Spec: `specs/issue-1980-setup-boxlite-self-sufficient.spec.md`

## Type of change

| Type | Label |
|------|-------|
| New feature | `enhancement` |

## Component

`core`

## What changed

- New helpers: `host_target` / `resolve_target` (platform → tarball suffix, errors loudly on unsupported `(os, arch)` pairs), `resolve_runtime_url` (honors `BOXLITE_RUNTIME_URL` env override matching upstream's `build.rs` contract), `download_file` + `extract_tarball` (reqwest + flate2/tar, no shelling out), `find_libkrunfw` (discovers the versioned SONAME so future boxlite bumps don't require re-coding the constant).
- `RUNTIME_FILES` becomes `REQUIRED_NAMED_FILES` (4 named binaries) + the discovered libkrunfw entry.
- Idempotence preserved via the existing `.complete` stamp; `--check` semantics shift from "is `target/` populated" to "is staging complete" but the CLI surface and exit code stay.
- Tests use a hermetic in-process `axum` server bound to `127.0.0.1:0` plus a synthesised tarball matching the upstream layout; no network access from CI. All 7 BDD scenarios in the spec bind to real test functions.
- `flate2`, `tar`, `tempfile` move to runtime deps; `axum` to dev-deps. No new YAML config keys.
- Docs: `docs/guides/boxlite-runtime.md` rewritten to remove the `cargo build -p rara-sandbox` prerequisite and document the `BOXLITE_RUNTIME_URL` override. `crates/rara-sandbox/AGENT.md` footgun #3 updated with the versioned-SONAME requirement.

## Closes

Closes #1980

## Test plan

- [x] `cargo check --workspace --all-targets`
- [x] `cargo +nightly fmt --all`
- [x] `cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings`
- [x] `prek run --all-files`
- [x] `cargo test -p rara-cmd` — all setup::boxlite tests pass against hermetic axum tarball server
- [x] `just spec-lifecycle specs/issue-1980-setup-boxlite-self-sufficient.spec.md` — all 7 BDD scenarios pass
- [x] Reviewer APPROVE at `f764f8ff` (zero P0/P1/P2; P3 nits ratified, deferred)