### PR TITLE
fix(kernel): suppress whitespace-only assistant tape entries (#1979)

### DIFF
--- a/crates/kernel/src/agent/mod.rs
+++ b/crates/kernel/src/agent/mod.rs
@@ -71,6 +71,40 @@ use crate::{
 
 /// Estimated chars-per-token ratio for context size estimation.
 const CHARS_PER_TOKEN: usize = 4;
+
+/// Decide whether — and with what canonical `content` — an
+/// intermediate-iteration assistant turn should be persisted to tape.
+///
+/// Reasoning-capable models (MiniMax-M2, gpt-5.4-thinking, …) sometimes
+/// route every output token to `reasoning_content` and leave only stray
+/// whitespace (`"\n"`, `"\n\n"`) in the visible `content`. Persisting that
+/// whitespace verbatim produces tape rows that render as empty assistant
+/// bubbles in the UI and pollute the next turn's context rebuild.
+///
+/// The rule:
+/// - Text is whitespace-only **and** reasoning is empty → return `None` (skip
+///   the `append_message` call entirely). The accompanying tool-call row, if
+///   any, still preserves the cascade-tick boundary established by PR 608.
+/// - Text is whitespace-only but reasoning is non-empty → return `Some("")`
+///   (persist the row with canonical empty content; reasoning carries the real
+///   signal, and the row keeps the cascade-tick boundary).
+/// - Text has any non-whitespace character → return `Some(text)` verbatim (no
+///   trim, no normalization on real content).
+///
+/// The terminal `!has_tool_calls` rejection at line 2175 is unchanged —
+/// it already publishes a structured `TurnError` for empty terminal
+/// turns and is not the gap this helper closes.
+fn intermediate_message_content(text: &str, reasoning: &str) -> Option<String> {
+    if text.trim().is_empty() {
+        if reasoning.is_empty() {
+            None
+        } else {
+            Some(String::new())
+        }
+    } else {
+        Some(text.to_string())
+    }
+}
 /// Context usage threshold (fraction) at which a SHOULD-handoff hint is
 /// injected.
 const CONTEXT_WARN_THRESHOLD: f64 = 0.70;
@@ -2037,24 +2071,31 @@ async fn run_agent_loop_inner(
                     "laziness detected, nudging model to take action"
                 );
                 // Persist intermediate assistant text to tape so the model
-                // sees its own plan in context after rebuild.
-                let _ = tape
-                    .append_message(
-                        tape_name,
-                        {
-                            let mut payload = serde_json::json!({
-                                "role": "assistant",
-                                "content": &accumulated_text,
-                            });
-                            if !accumulated_reasoning.is_empty() {
-                                payload["reasoning_content"] =
-                                    serde_json::json!(&accumulated_reasoning);
-                            }
-                            payload
-                        },
-                        None,
-                    )
-                    .await;
+                // sees its own plan in context after rebuild. Whitespace-only
+                // content with empty reasoning is dropped; whitespace-only
+                // content with non-empty reasoning persists with canonical
+                // empty `content` (see `intermediate_message_content`).
+                if let Some(canonical_content) =
+                    intermediate_message_content(&accumulated_text, &accumulated_reasoning)
+                {
+                    let _ = tape
+                        .append_message(
+                            tape_name,
+                            {
+                                let mut payload = serde_json::json!({
+                                    "role": "assistant",
+                                    "content": canonical_content,
+                                });
+                                if !accumulated_reasoning.is_empty() {
+                                    payload["reasoning_content"] =
+                                        serde_json::json!(&accumulated_reasoning);
+                                }
+                                payload
+                            },
+                            None,
+                        )
+                        .await;
+                }
                 // Persist tier-specific nudge to tape.
                 let _ = tape
                     .append_message(
@@ -2128,23 +2169,31 @@ async fn run_agent_loop_inner(
                     },
                 })
                 .ok();
-                let _ = tape
-                    .append_message(
-                        tape_name,
-                        {
-                            let mut payload = serde_json::json!({
-                                "role": "assistant",
-                                "content": &accumulated_text,
-                            });
-                            if !accumulated_reasoning.is_empty() {
-                                payload["reasoning_content"] =
-                                    serde_json::json!(&accumulated_reasoning);
-                            }
-                            payload
-                        },
-                        meta,
-                    )
-                    .await;
+                // Whitespace-only intermediate content with empty reasoning
+                // is suppressed (see `intermediate_message_content`); the
+                // wake message below still posts so continuation flow
+                // remains observable in tape.
+                if let Some(canonical_content) =
+                    intermediate_message_content(&accumulated_text, &accumulated_reasoning)
+                {
+                    let _ = tape
+                        .append_message(
+                            tape_name,
+                            {
+                                let mut payload = serde_json::json!({
+                                    "role": "assistant",
+                                    "content": canonical_content,
+                                });
+                                if !accumulated_reasoning.is_empty() {
+                                    payload["reasoning_content"] =
+                                        serde_json::json!(&accumulated_reasoning);
+                                }
+                                payload
+                            },
+                            meta,
+                        )
+                        .await;
+                }
 
                 // Persist wake message to tape so it survives the message
                 // rebuild at the top of the next iteration.
@@ -2425,6 +2474,15 @@ async fn run_agent_loop_inner(
         // Persist intermediate assistant message to tape so that
         // `build_cascade` can detect tick boundaries between iterations.
         // Without this, the cascade trace always shows a single tick.
+        //
+        // Suppression rule (issue #1979): when the visible content is
+        // whitespace-only and reasoning is empty, the row is skipped —
+        // the subsequent `ToolCall` row alone preserves the tick boundary
+        // PR 608 introduced. When content is whitespace-only but
+        // reasoning is non-empty, persist with canonical empty `content`
+        // so the UI does not render a stray-newline assistant bubble.
+        if let Some(canonical_content) =
+            intermediate_message_content(&accumulated_text, &accumulated_reasoning)
         {
             let mut meta = crate::memory::LlmEntryMetadata {
                 rara_message_id: rara_message_id.to_string(),
@@ -2444,7 +2502,7 @@ async fn run_agent_loop_inner(
                     {
                         let mut payload = serde_json::json!({
                             "role": "assistant",
-                            "content": &accumulated_text,
+                            "content": canonical_content,
                         });
                         if !accumulated_reasoning.is_empty() {
                             payload["reasoning_content"] =
@@ -3364,7 +3422,8 @@ mod tests {
 
     use super::{
         ContextPressure, PendingToolCall, build_runtime_contract_prompt, classify_context_pressure,
-        infer_has_tool_calls, resolve_soul_prompt, should_remind_tape_search,
+        infer_has_tool_calls, intermediate_message_content, resolve_soul_prompt,
+        should_remind_tape_search,
     };
     #[test]
     fn classify_context_pressure_returns_normal_below_threshold() {
@@ -3493,5 +3552,98 @@ mod tests {
     fn infer_has_tool_calls_false_without_pending_calls() {
         let pending = HashMap::new();
         assert!(!infer_has_tool_calls(&pending));
+    }
+
+    // -----------------------------------------------------------------
+    // intermediate_message_content — issue #1979
+    //
+    // Each test below maps to a Scenario in
+    // `specs/issue-1979-suppress-whitespace-assistant-tape.spec.md`.
+    // -----------------------------------------------------------------
+
+    /// Scenario: whitespace-only content with no reasoning is dropped from
+    /// tape.
+    #[test]
+    fn intermediate_write_drops_whitespace_only_message() {
+        assert_eq!(intermediate_message_content("\n", ""), None);
+        assert_eq!(intermediate_message_content("", ""), None);
+        assert_eq!(intermediate_message_content("   \n\t  ", ""), None);
+    }
+
+    /// Scenario: whitespace content with non-empty reasoning persists with
+    /// empty content (canonicalized to `""`, not the raw whitespace).
+    #[test]
+    fn intermediate_write_canonicalizes_whitespace_content_when_reasoning_present() {
+        assert_eq!(
+            intermediate_message_content("\n\n", "some 55-token chain of thought"),
+            Some(String::new())
+        );
+        assert_eq!(
+            intermediate_message_content("\n", "reasoning"),
+            Some(String::new())
+        );
+    }
+
+    /// Scenario: laziness-nudge intermediate write respects the same gate.
+    /// (The helper is shared across all three intermediate-write sites, so
+    /// the same gate semantics apply at the laziness branch as at the
+    /// cascade-tick branch.)
+    #[test]
+    fn laziness_nudge_suppresses_whitespace_intermediate_message() {
+        assert_eq!(intermediate_message_content("\n", ""), None);
+        assert_eq!(intermediate_message_content("", ""), None);
+    }
+
+    /// Scenario: terminal-turn rejection at line 2175 is unchanged.
+    ///
+    /// This is a regression guard. The intermediate-write fix in
+    /// `intermediate_message_content` must not perturb the existing
+    /// terminal-turn protection added in PR 1641. We assert two things:
+    ///
+    /// 1. `TurnFailureKind::EmptyTurn` still exists on the public surface (the
+    ///    terminal block constructs it unconditionally for empty
+    ///    `accumulated_text`).
+    /// 2. The terminal block in `agent/mod.rs` still gates on
+    ///    `accumulated_text.trim().is_empty()` — a source-level check is the
+    ///    right fidelity here because the surrounding agent loop is not
+    ///    unit-testable in isolation, and `intermediate_message_content`
+    ///    deliberately stays out of the terminal path.
+    #[test]
+    fn terminal_empty_turn_still_emits_turn_error() {
+        // (1) public-surface check — round-trip through PartialEq so this
+        // regression guard catches a rename or removal of the variant.
+        assert_eq!(
+            crate::agent::turn_error::TurnFailureKind::EmptyTurn,
+            crate::agent::turn_error::TurnFailureKind::EmptyTurn
+        );
+        // (2) source-level regression guard
+        let src = include_str!("mod.rs");
+        assert!(
+            src.contains("if accumulated_text.trim().is_empty() || stream_failure.is_some()"),
+            "terminal-turn rejection guard at agent/mod.rs (post-line-2200 block) was removed or \
+             reworded; PR 1641's contract for empty terminal turns must stay intact — see \
+             specs/issue-1979-suppress-whitespace-assistant-tape.spec.md scenario 'terminal-turn \
+             rejection at line 2175 is unchanged'"
+        );
+    }
+
+    /// Scenario: real assistant content is unchanged (no trim, no
+    /// canonicalization on non-whitespace content).
+    #[test]
+    fn non_whitespace_content_persists_byte_for_byte() {
+        assert_eq!(
+            intermediate_message_content("Here's the answer: 42", ""),
+            Some("Here's the answer: 42".to_string())
+        );
+        // Mostly-whitespace but not whitespace-only — must survive intact.
+        assert_eq!(
+            intermediate_message_content("\n\n让我查一下…\n", ""),
+            Some("\n\n让我查一下…\n".to_string())
+        );
+        // Reasoning value must not influence non-whitespace content.
+        assert_eq!(
+            intermediate_message_content("real text", "reasoning"),
+            Some("real text".to_string())
+        );
     }
 }

--- a/crates/kernel/src/llm/scripted.rs
+++ b/crates/kernel/src/llm/scripted.rs
@@ -132,6 +132,18 @@ impl LlmDriver for ScriptedLlmDriver {
         // so omitting them would cause scripted tool calls to be silently
         // dropped.
         let response = self.complete(request).await?;
+        // Reasoning is emitted before content because real reasoning-model
+        // streams (Kimi, MiniMax-M2, gpt-5.4-thinking) interleave or front-
+        // load reasoning tokens — the agent loop builds `accumulated_reasoning`
+        // independently of `accumulated_text`, so the relative order between
+        // the two does not affect downstream state.
+        if let Some(ref reasoning) = response.reasoning_content {
+            let _ = tx
+                .send(StreamDelta::ReasoningDelta {
+                    text: reasoning.clone(),
+                })
+                .await;
+        }
         if let Some(ref text) = response.content {
             let _ = tx.send(StreamDelta::TextDelta { text: text.clone() }).await;
         }

--- a/crates/kernel/tests/whitespace_intermediate_tape_e2e.rs
+++ b/crates/kernel/tests/whitespace_intermediate_tape_e2e.rs
@@ -1,0 +1,212 @@
+// Copyright 2025 Rararulab
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! E2E (lane 2 — scripted LLM) for issue #1979.
+//!
+//! A reasoning-capable model can finalize an intermediate iteration with
+//! whitespace-only `content` while routing all real output to
+//! `reasoning_content`. Before this fix the agent loop persisted that as
+//! `{role: "assistant", content: "\n"}` to the tape — the UI rendered an
+//! empty bubble and the next turn's context rebuild fed the whitespace
+//! row back to the model.
+//!
+//! This test scripts that exact shape via [`ScriptedLlmDriver`] (whitespace
+//! `content` + non-empty `reasoning_content` + a tool call on iteration 1,
+//! plain stop on iteration 2) and asserts that the tape contains **no**
+//! `Message` row with whitespace-only `content` for the affected turn.
+//! The cascade-tick boundary is preserved through the `ToolCall` row.
+
+use std::time::{Duration, Instant};
+
+use rara_kernel::{
+    identity::Principal,
+    llm::{CompletionResponse, StopReason, ToolCallRequest, Usage},
+    memory::TapEntryKind,
+    testing::{FakeTool, TestKernelBuilder, scripted_response},
+};
+use serde_json::json;
+
+/// Build a scripted response that mimics a reasoning model finalizing
+/// whitespace `content` while routing all tokens to `reasoning_content`,
+/// and emitting one valid tool call. The resulting iteration is the
+/// exact shape that produced the empty assistant bubbles in
+/// `315bad61f8c34b137221bd6ec086597c__d6e905d9-fd62-41ca-8918-97b37276f534.
+/// jsonl` (see issue #1979 evidence).
+fn whitespace_with_reasoning_and_tool_call() -> CompletionResponse {
+    CompletionResponse {
+        content:           Some("\n".to_string()),
+        reasoning_content: Some("internal chain of thought".to_string()),
+        tool_calls:        vec![ToolCallRequest {
+            id:        "call-whitespace-1".to_string(),
+            name:      "fake-tool".to_string(),
+            arguments: "{}".to_string(),
+        }],
+        stop_reason:       StopReason::ToolCalls,
+        usage:             Some(Usage {
+            prompt_tokens:     10,
+            completion_tokens: 55,
+            total_tokens:      65,
+        }),
+        model:             "scripted".to_string(),
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn whitespace_intermediate_iteration_does_not_pollute_tape() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+
+    // Iteration 1: whitespace content + reasoning + tool call (the exact
+    // shape that used to write `content: "\n"` to tape).
+    // Iteration 2: plain stop response so the agent loop terminates
+    // cleanly without hitting the terminal empty-turn rejection.
+    let manifest = rara_kernel::agent::AgentManifest {
+        name:                   "test-agent".to_string(),
+        role:                   rara_kernel::agent::AgentRole::Chat,
+        description:            "Test agent".to_string(),
+        model:                  Some("scripted-model".to_string()),
+        system_prompt:          "You are a test agent.".to_string(),
+        soul_prompt:            None,
+        provider_hint:          Some("scripted".to_string()),
+        max_iterations:         Some(3),
+        // Allow the fake tool to be visible to the agent loop.
+        tools:                  vec!["fake-tool".to_string().into()],
+        excluded_tools:         vec![],
+        max_children:           None,
+        max_context_tokens:     None,
+        priority:               Default::default(),
+        metadata:               serde_json::Value::Null,
+        sandbox:                None,
+        default_execution_mode: None,
+        tool_call_limit:        None,
+        worker_timeout_secs:    None,
+        max_continuations:      None,
+        max_output_chars:       None,
+    };
+
+    let fake_tool = std::sync::Arc::new(FakeTool::new(
+        "fake-tool",
+        vec![json!({"ok": true, "result": "tool-output"})],
+    ));
+
+    let tk = TestKernelBuilder::new(tmp.path())
+        .manifest(manifest)
+        .with_tool(fake_tool)
+        .responses(vec![
+            whitespace_with_reasoning_and_tool_call(),
+            scripted_response("done"),
+        ])
+        .build()
+        .await;
+
+    let principal = Principal::lookup("test");
+    let session_key = tk
+        .handle
+        .spawn_named("test-agent", "ping".to_string(), principal, None)
+        .await
+        .expect("spawn agent");
+
+    // Wait for the turn to record so we know the agent loop has finished.
+    let deadline = Instant::now() + Duration::from_secs(30);
+    loop {
+        let traces = tk.handle.get_process_turns(session_key);
+        if !traces.is_empty() {
+            break;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "kernel did not record a turn within 30s"
+        );
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+
+    // Read the tape directly via the kernel's exposed TapeService.
+    let tape_name = session_key.to_string();
+    let entries = tk
+        .handle
+        .tape()
+        .entries(&tape_name)
+        .await
+        .expect("read tape entries");
+
+    // 1. No Message row may carry whitespace-only `content`. This is the primary
+    //    regression assertion for issue #1979 — before the fix the iteration-1
+    //    write produced exactly `content: "\n"`.
+    let whitespace_messages: Vec<_> = entries
+        .iter()
+        .filter(|e| e.kind == TapEntryKind::Message)
+        .filter(|e| {
+            e.payload
+                .get("content")
+                .and_then(|c| c.as_str())
+                .map(|s| !s.is_empty() && s.trim().is_empty())
+                .unwrap_or(false)
+        })
+        .collect();
+    assert!(
+        whitespace_messages.is_empty(),
+        "expected no whitespace-only assistant Message rows, found: {:#?}",
+        whitespace_messages
+            .iter()
+            .map(|e| (e.id, e.payload.clone()))
+            .collect::<Vec<_>>()
+    );
+
+    // 2. The cascade-tick boundary survives: the iteration-1 ToolCall row is still
+    //    present.
+    let tool_call_rows: Vec<_> = entries
+        .iter()
+        .filter(|e| e.kind == TapEntryKind::ToolCall)
+        .collect();
+    assert!(
+        !tool_call_rows.is_empty(),
+        "expected at least one ToolCall row to preserve the cascade tick boundary that PR 608 \
+         introduced; found entries: {:#?}",
+        entries.iter().map(|e| (e.id, e.kind)).collect::<Vec<_>>()
+    );
+
+    // 3. When iteration 1 is suppressed but reasoning was non-empty, the spec
+    //    requires the row to be persisted with canonical empty content (`""`), not
+    //    skipped. Find the assistant Message with matching `reasoning_content` and
+    //    assert `content == ""`.
+    let reasoning_rows: Vec<_> = entries
+        .iter()
+        .filter(|e| e.kind == TapEntryKind::Message)
+        .filter(|e| {
+            e.payload.get("reasoning_content").and_then(|v| v.as_str())
+                == Some("internal chain of thought")
+        })
+        .collect();
+    assert_eq!(
+        reasoning_rows.len(),
+        1,
+        "expected exactly one assistant Message row carrying the scripted reasoning content; \
+         entries: {:#?}",
+        entries
+            .iter()
+            .map(|e| (e.id, e.kind, e.payload.clone()))
+            .collect::<Vec<_>>()
+    );
+    let canonical_content = reasoning_rows[0]
+        .payload
+        .get("content")
+        .and_then(|c| c.as_str())
+        .expect("reasoning row carries a content field");
+    assert_eq!(
+        canonical_content, "",
+        "whitespace content with non-empty reasoning must canonicalize to empty string, got: \
+         {canonical_content:?}"
+    );
+
+    tk.shutdown();
+}

--- a/crates/kernel/tests/whitespace_intermediate_tape_e2e.rs
+++ b/crates/kernel/tests/whitespace_intermediate_tape_e2e.rs
@@ -27,7 +27,10 @@
 //! `Message` row with whitespace-only `content` for the affected turn.
 //! The cascade-tick boundary is preserved through the `ToolCall` row.
 
-use std::time::{Duration, Instant};
+use std::{
+    sync::OnceLock,
+    time::{Duration, Instant},
+};
 
 use rara_kernel::{
     identity::Principal,
@@ -36,6 +39,27 @@ use rara_kernel::{
     testing::{FakeTool, TestKernelBuilder, scripted_response},
 };
 use serde_json::json;
+
+/// Redirect `rara_paths::config_dir()` / `workspace_dir()` to a process-wide
+/// tempdir so the `Kernel::new` initialisation path doesn't attempt to create
+/// `~/.config/rara/workspace`. CI runners (`/home/runner/.config`) aren't
+/// writable by the test process, which surfaces as a `workspace_dir` panic in
+/// `rara_paths` on the first build.
+///
+/// The `OnceLock<TempDir>` is deliberately never dropped — it must outlive the
+/// test because `rara_paths`'s own `OnceLock`s cache the path and never
+/// re-read.
+fn ensure_test_paths_isolated() {
+    static SHARED_TEST_CONFIG: OnceLock<tempfile::TempDir> = OnceLock::new();
+    static INIT: OnceLock<()> = OnceLock::new();
+    INIT.get_or_init(|| {
+        let shared = SHARED_TEST_CONFIG
+            .get_or_init(|| tempfile::tempdir().expect("create shared test config dir"));
+        let _ = std::panic::catch_unwind(|| {
+            rara_paths::set_custom_config_dir(shared.path());
+        });
+    });
+}
 
 /// Build a scripted response that mimics a reasoning model finalizing
 /// whitespace `content` while routing all tokens to `reasoning_content`,
@@ -64,6 +88,7 @@ fn whitespace_with_reasoning_and_tool_call() -> CompletionResponse {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn whitespace_intermediate_iteration_does_not_pollute_tape() {
+    ensure_test_paths_isolated();
     let tmp = tempfile::tempdir().expect("tempdir");
 
     // Iteration 1: whitespace content + reasoning + tool call (the exact

--- a/specs/issue-1979-suppress-whitespace-assistant-tape.spec.md
+++ b/specs/issue-1979-suppress-whitespace-assistant-tape.spec.md
@@ -1,0 +1,248 @@
+spec: task
+name: "issue-1979-suppress-whitespace-assistant-tape"
+inherits: project
+tags: ["kernel", "memory", "tape"]
+---
+
+## Intent
+
+When a reasoning-capable model (MiniMax-M2, gpt-5.4-thinking, etc.) routes
+all of its output tokens to `reasoning_content` and emits only a stray
+whitespace token (`"\n"`, `"\n\n"`, `"\n\n让我查一下…\n"`-with-mostly-whitespace)
+as the visible `content`, the kernel still writes that turn to tape as
+`{role: "assistant", content: "\n"}`. The UI loads the session, sees an
+assistant message with whitespace-only content, and renders an empty
+bubble — the user reads "session 坏了" and reports the agent as broken.
+
+Concrete evidence on the running remote (raratekiAir, verified 2026-04-28):
+
+- Tape file
+  `/Users/rara/Library/Application Support/rara/memory/tapes/315bad61f8c34b137221bd6ec086597c__d6e905d9-fd62-41ca-8918-97b37276f534.jsonl`
+- Affected entries:
+  - id 9: `content: "\n"`, 55 completion tokens all in `reasoning_content`
+  - id 38: `content: "\n\n让我查一下…\n"` (mostly whitespace + truncated)
+  - id 42: `content: "\n"`
+- User-reported turn id: `27df73bb-9656-4e23-bbb9-e724e37162c7`
+
+Reproducer for "what bug appears if we don't do this":
+
+1. Open a session against a reasoning model that splits output between
+   `reasoning_content` and `content` (any MiniMax-M2 deployment, or
+   gpt-5.4-thinking on a turn that calls a tool after long internal
+   reasoning).
+2. Trigger a turn that ends an iteration with a tool call, where the
+   visible-content stream finalizes as a single newline / whitespace-only
+   string (the driver's stream-close salvage from PR 1639 succeeded in
+   producing *some* text, but it was whitespace).
+3. Inspect the tape: a `Message` row with `role=assistant` and
+   `content="\n"` appears between the previous user turn and the
+   `ToolCall` row.
+4. Reload the session in the web UI: the affected turn renders an empty
+   assistant bubble (web's `pi-chat-messages` filter from PR 1727 is
+   render-side only and does not propagate back into the tape).
+5. The next turn's context rebuild feeds the whitespace `assistant`
+   message back into the LLM, so model self-context now contains a row
+   it would never have written deliberately.
+
+Why the existing protection does not catch this: PR 1633
+(`d0dec0a4 feat(kernel): reject empty turns, route failures to error bus`)
+gates `accumulated_text.trim().is_empty()` only on the **terminal**
+`!has_tool_calls` branch at `crates/kernel/src/agent/mod.rs:2175`. The
+**intermediate-iteration write** at `crates/kernel/src/agent/mod.rs:2425-2458`
+— added by PR 608 (`0cb95291 fix(kernel): persist intermediate assistant
+messages to tape for cascade tick detection`) so `build_cascade` can see
+tick boundaries between iterations — has no trim check and runs
+unconditionally before the tool-call write. That is the line that
+produces the polluted rows above.
+
+Goal alignment: signal 4 ("every action is inspectable") — a tape row
+that says `content="\n"` while the model actually emitted 55 reasoning
+tokens is a lie about what happened, and breaks every downstream eval
+trace, replay, and cascade view that reads the tape as ground truth.
+Signal 1 ("the process runs for months without intervention") — the
+whole point of the persistence layer is that it survives untouched; the
+user reporting "session is broken" is exactly the human-intervention
+signal we are trying to drive to zero. Does not cross any "What rara
+is NOT" line: this is internal correctness of rara's own memory layer.
+
+Hermes positioning: not applicable — Hermes does not expose its tape
+format and we have an engineering reason regardless (the cascade tick
+detection rationale from PR 608 still has to hold after the fix).
+
+Prior art search summary:
+
+- `gh issue list --search "reasoning_content tape empty assistant" --state all` —
+  surfaced issue 1627 (MiniMax-M2 empty-content driver bug), issue 1630
+  (epic), issue 1633 (kernel rejection of empty turns); issue 1633
+  explicitly said "Do not write empty assistant records to tape" but only
+  delivered terminal-turn protection.
+- `gh pr list --search "reasoning_content" --state all` — surfaced PR 1639
+  (driver salvage), PR 1641 (kernel rejection, the merge of issue 1633),
+  PR 1447 / 1452 / 1453 (reasoning_content persistence), PR 608
+  (introduced the unconditional intermediate-write at line 2425 that is
+  the root of this bug).
+- `git log --grep reasoning_content` since 180 days — confirms the same
+  set; no commit has revisited the intermediate-write since PR 608 /
+  PR 1641.
+- `git log --since=60.days -- crates/kernel/src/agent/mod.rs` — no recent
+  edit removed a trim/empty check from this area; the gap has been
+  present continuously since issue 1633 shipped.
+
+The fix is **additive** (gate one existing write site), not a reversal
+of any prior decision. PR 608's cascade-tick rationale must still hold:
+when the iteration has tool calls AND `accumulated_text.trim().is_empty()`,
+suppressing the assistant Message row would lose the cascade tick
+boundary. The contract below preserves that boundary by writing the row
+only when there is non-whitespace content OR non-empty `reasoning_content`
+to record (the row carries real signal in the latter case — the tick
+boundary survives, and the UI/cascade can still see "the model thought
+here, then called a tool").
+
+## Decisions
+
+1. The gate lives in `crates/kernel/src/agent/mod.rs` at the
+   intermediate-iteration write site (currently lines 2425–2458). No new
+   crate, no new module, no trait reshuffle.
+2. Suppression rule: skip the `append_message` call when
+   `accumulated_text.trim().is_empty() && accumulated_reasoning.is_empty()`.
+   When `accumulated_text` is whitespace but `accumulated_reasoning` is
+   non-empty, persist the row but with `content` set to the empty string
+   `""` (canonical) and `reasoning_content` populated — preserves cascade
+   tick + carries real signal, and stops the UI from rendering "an
+   assistant said \n".
+3. Same rule on the laziness-nudge intermediate write
+   (`crates/kernel/src/agent/mod.rs:2041-2057`) and the
+   continuation-pending intermediate write (lines 2131–2147). Both
+   currently use `&accumulated_text` directly with no trim guard.
+4. The terminal-turn rejection at line 2175 stays as-is — it already
+   handles the `!has_tool_calls` case correctly via `TurnError`. We do
+   not move it; we only close the intermediate-write gap.
+5. Canonicalization is `accumulated_text = accumulated_text.trim().to_string()`
+   *only* when persisting (not on the in-memory variable used for the
+   downstream stream / cascade), so tool-call branches still see exactly
+   what the model emitted.
+
+## Boundaries
+
+### Allowed Changes
+
+- `crates/kernel/src/agent/mod.rs`: gate the three intermediate-write
+  sites identified above (line 2041, 2131, 2425).
+- `crates/kernel/src/agent/mod.rs` test module (or a new sibling
+  `agent/tape_persist_tests.rs` if the existing module is too crowded):
+  add unit tests covering the four scenarios in Acceptance Criteria.
+- One-line update to `crates/kernel/src/agent/turn_error.rs` only if a
+  new `TurnFailureKind` variant is needed — likely not; the intermediate
+  case is silent suppression, not a `TurnError`.
+- `crates/kernel/tests/whitespace_intermediate_tape_e2e.rs` (new):
+  scripted-LLM lane-2 e2e test required by `docs/guides/workflow.md` for
+  any `crates/kernel/src/` change. Drives one agent turn whose iteration
+  0 has whitespace content + non-empty reasoning + a tool call, then
+  asserts the tape contains no whitespace-only assistant Message rows
+  and that the cascade-tick boundary is preserved by the ToolCall row.
+- `crates/kernel/src/llm/scripted.rs`: extend
+  `ScriptedLlmDriver::stream` to emit `StreamDelta::ReasoningDelta` from
+  `CompletionResponse.reasoning_content`. Without this, the e2e above
+  cannot reproduce the reasoning-model shape that produced the bug —
+  the driver previously dropped reasoning during streaming. The change
+  is additive: existing callers that leave `reasoning_content = None`
+  see no behavioral change.
+- `specs/issue-1979-suppress-whitespace-assistant-tape.spec.md` (this
+  file): present in the change set because it ships in the same PR.
+- **/crates/kernel/src/agent/mod.rs
+- **/crates/kernel/src/llm/scripted.rs
+- **/crates/kernel/tests/whitespace_intermediate_tape_e2e.rs
+- **/specs/issue-1979-suppress-whitespace-assistant-tape.spec.md
+
+### Forbidden
+
+- Do not change `crates/kernel/src/memory/tape/*` — the tape store stays
+  agnostic about what the agent decides to write; this is an agent-loop
+  policy fix.
+- Do not touch `crates/kernel/src/llm/openai.rs` or `llm/stream.rs` —
+  driver-level salvage already shipped in PR 1639 and is not the layer
+  with the gap.
+- Do not touch the web filter (`web/src/pages/__tests__/pi-chat-messages.test.ts`
+  and the production code it covers) — render-side filtering stays as
+  defense-in-depth, but this PR fixes the source so the filter never
+  has to fire.
+- Do not relax the terminal-turn rejection at line 2175 in either
+  direction (do not loosen the trim check, do not extend it to fire on
+  intermediate iterations — those have tool calls, which is real
+  signal even when text is empty).
+- Do not change the cascade-tick boundary semantics: a multi-iteration
+  turn that previously produced N ticks must still produce N ticks
+  after this change.
+
+## Acceptance Criteria
+
+Scenario: whitespace-only content with no reasoning is dropped from tape
+  Given an agent iteration where the LLM driver finalizes
+    `accumulated_text = "\n"`, `accumulated_reasoning = ""`,
+    and emits one valid tool call
+  When the agent loop reaches the intermediate-message-persist block
+    (`crates/kernel/src/agent/mod.rs` line 2425 today)
+  Then no `Message` row is appended to the tape for this iteration
+    (the subsequent `ToolCall` row is still appended)
+  And the cascade-tick count for the resulting turn equals the same
+    turn run with `accumulated_text = "real text"` minus zero
+    (i.e. tick boundary is preserved by the tool-call row alone)
+  Test: `crates/kernel/src/agent/mod.rs` /
+    `intermediate_write_drops_whitespace_only_message`
+
+Scenario: whitespace content with non-empty reasoning persists with empty content
+  Given an agent iteration where the LLM driver finalizes
+    `accumulated_text = "\n\n"`, `accumulated_reasoning = "some 55-token chain of thought"`,
+    and emits one valid tool call
+  When the agent loop reaches the intermediate-message-persist block
+  Then a `Message` row IS appended with `content == ""` (canonical empty,
+    not `"\n\n"`) and `reasoning_content == "some 55-token chain of thought"`
+  And reading that row back from tape yields `content == ""`
+  Test: `crates/kernel/src/agent/mod.rs` /
+    `intermediate_write_canonicalizes_whitespace_content_when_reasoning_present`
+
+Scenario: laziness-nudge intermediate write respects the same gate
+  Given the ack_detector laziness path fires
+    (`crates/kernel/src/agent/mod.rs` line 2030 onward)
+  And `accumulated_text.trim().is_empty() && accumulated_reasoning.is_empty()`
+  When the laziness branch persists its intermediate assistant message
+  Then that `Message` row is suppressed
+  And the subsequent nudge `user` row is still appended (the nudge is
+    semantic, not whitespace)
+  Test: `crates/kernel/src/agent/mod.rs` /
+    `laziness_nudge_suppresses_whitespace_intermediate_message`
+
+Scenario: terminal-turn rejection at line 2175 is unchanged
+  Given an agent iteration where `!has_tool_calls`
+    and `accumulated_text.trim().is_empty()`
+  When the agent loop reaches the terminal block
+  Then a `TurnError` with `failure_kind = EmptyTurn` is published on the
+    event bus, exactly as before
+  And `KernelError::AgentExecution` is returned
+  Test: `crates/kernel/src/agent/mod.rs` /
+    `terminal_empty_turn_still_emits_turn_error`
+    (regression guard — exists or is added; must keep passing)
+
+Scenario: real assistant content is unchanged
+  Given an iteration with `accumulated_text = "Here's the answer: 42"`
+    and any `reasoning_content` value
+  When the agent loop persists the message
+  Then the tape row has `content == "Here's the answer: 42"` byte-for-byte
+    (no trim, no canonicalization on non-whitespace content)
+  Test: `crates/kernel/src/agent/mod.rs` /
+    `non_whitespace_content_persists_byte_for_byte`
+
+## Constraints
+
+- All comments and identifiers in new code must be English (project
+  rule).
+- New tests use the existing in-process tape fake / `TapeService` test
+  harness already used elsewhere in `crates/kernel/src/agent/`; do not
+  introduce `testcontainers` or DB fixtures for this — it is an
+  agent-loop unit test, not an integration test.
+- No new YAML config keys. The trim-and-suppress rule is a mechanism
+  constant (anti-pattern doc, "mechanism vs config"); there is no
+  deployment-relevant reason to make it tunable.
+- Do not amend or reword the cascade-tick comment block at line 2425;
+  add a sibling comment explaining the suppression rule next to the new
+  gate.


### PR DESCRIPTION
## Summary

- Gate the three intermediate-iteration assistant tape writes (lines 2041, 2131, 2425 in `crates/kernel/src/agent/mod.rs`) through a shared `intermediate_message_content` helper.
- Skip persistence when both `accumulated_text.trim().is_empty()` and `accumulated_reasoning.is_empty()`.
- Canonicalize `content` to `""` when text is whitespace-only but reasoning is non-empty — preserves PR #608's cascade-tick semantics while killing UI ghost bubbles and tape pollution.
- Terminal `!has_tool_calls` rejection at line 2175 untouched.
- Scripted LLM driver now emits `ReasoningDelta` from `CompletionResponse.reasoning_content` so the e2e test can faithfully reproduce reasoning-model streams.

Spec: `specs/issue-1979-suppress-whitespace-assistant-tape.spec.md`

## Test plan

- [x] `prek run --all-files` — all 6 hooks pass
- [x] `just spec-lifecycle …` — 5/5 BDD scenarios pass
- [x] `cargo test -p rara-kernel --lib agent::tests::` — 19 passed
- [x] `cargo test -p rara-kernel --test whitespace_intermediate_tape_e2e` — 1 passed
- [x] Reviewer APPROVE (no P0/P1)

Closes #1979