### PR TITLE
refactor(kernel): rename rara_message_id to rara_turn_id (#1978)

### DIFF
--- a/crates/app/src/tools/debug_trace.rs
+++ b/crates/app/src/tools/debug_trace.rs
@@ -16,7 +16,7 @@
 
 use async_trait::async_trait;
 use rara_kernel::{
-    memory::TapeService,
+    memory::{TapeService, read_turn_id},
     tool::{ToolContext, ToolExecute},
 };
 use rara_tool_macro::ToolDef;
@@ -69,14 +69,11 @@ impl ToolExecute for DebugTraceTool {
         let entries: Vec<_> = entries
             .into_iter()
             .filter(|entry| {
-                entry.metadata.as_ref().is_some_and(|m| {
-                    // Honor the legacy `rara_message_id` key on tape entries
-                    // written before issue #1978 alongside the new key.
-                    m.get("rara_turn_id")
-                        .or_else(|| m.get("rara_message_id"))
-                        .and_then(|v| v.as_str())
-                        .is_some_and(|id| id == params.rara_turn_id)
-                })
+                entry
+                    .metadata
+                    .as_ref()
+                    .and_then(read_turn_id)
+                    .is_some_and(|id| id == params.rara_turn_id)
             })
             .collect();
         let formatted: Vec<Value> = entries.iter().map(|entry| {

--- a/crates/app/src/tools/debug_trace.rs
+++ b/crates/app/src/tools/debug_trace.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Tool for tracing a message's execution history by `rara_message_id`.
+//! Tool for tracing a turn's execution history by `rara_turn_id`.
 
 use async_trait::async_trait;
 use rara_kernel::{
@@ -26,19 +26,22 @@ use serde_json::{Value, json};
 
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct DebugTraceParams {
-    /// The rara_message_id to trace.
-    message_id: String,
+    /// The `rara_turn_id` of the turn to trace. Accepts the legacy
+    /// `rara_message_id` key on read so prompt-cached tool calls
+    /// referencing the old parameter name still parse — see issue #1978.
+    #[serde(alias = "rara_message_id", alias = "message_id")]
+    pub rara_turn_id: String,
     /// Maximum number of entries to return (default 50).
-    limit:      Option<u64>,
+    pub limit:        Option<u64>,
 }
 
-/// Searches the session tape for entries associated with a `rara_message_id`.
+/// Searches the session tape for entries associated with a `rara_turn_id`.
 #[derive(ToolDef)]
 #[tool(
     name = "debug_trace",
-    description = "Look up all tape entries related to a specific rara_message_id in the current \
+    description = "Look up all tape entries related to a specific rara_turn_id in the current \
                    session. Returns the full execution trace (messages, tool calls, results) with \
-                   metadata. Only use when the user asks to debug or trace a specific message.",
+                   metadata. Only use when the user asks to debug or trace a specific turn.",
     tier = "deferred",
     read_only,
     concurrency_safe
@@ -60,16 +63,19 @@ impl ToolExecute for DebugTraceTool {
         let tape_name = ctx.session_key.to_string();
         let entries = self
             .tape_service
-            .search(&tape_name, &params.message_id, limit, false)
+            .search(&tape_name, &params.rara_turn_id, limit, false)
             .await
             .map_err(|e| anyhow::anyhow!("tape search failed: {e}"))?;
         let entries: Vec<_> = entries
             .into_iter()
             .filter(|entry| {
-                entry.metadata.as_ref().map_or(false, |m| {
-                    m.get("rara_message_id")
+                entry.metadata.as_ref().is_some_and(|m| {
+                    // Honor the legacy `rara_message_id` key on tape entries
+                    // written before issue #1978 alongside the new key.
+                    m.get("rara_turn_id")
+                        .or_else(|| m.get("rara_message_id"))
                         .and_then(|v| v.as_str())
-                        .map_or(false, |id| id == params.message_id)
+                        .is_some_and(|id| id == params.rara_turn_id)
                 })
             })
             .collect();
@@ -79,7 +85,28 @@ impl ToolExecute for DebugTraceTool {
             obj
         }).collect();
         Ok(
-            json!({"tape_name": tape_name, "message_id": params.message_id, "match_count": formatted.len(), "entries": formatted}),
+            json!({"tape_name": tape_name, "rara_turn_id": params.rara_turn_id, "match_count": formatted.len(), "entries": formatted}),
         )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::DebugTraceParams;
+
+    /// Issue #1978 back-compat: prompt caches generated before the rename
+    /// still reference the legacy `rara_message_id` parameter name. The
+    /// tool's input deserializer must accept that key and parse it into
+    /// the renamed `rara_turn_id` field, so an old cached tool call does
+    /// not produce a hard schema-mismatch failure for the LLM.
+    #[test]
+    fn accepts_legacy_rara_message_id_param() {
+        let input = json!({"rara_message_id": "trace-1"});
+        let parsed: DebugTraceParams =
+            serde_json::from_value(input).expect("legacy key must deserialize");
+        assert_eq!(parsed.rara_turn_id, "trace-1");
+        assert_eq!(parsed.limit, None);
     }
 }

--- a/crates/app/src/tools/send_file.rs
+++ b/crates/app/src/tools/send_file.rs
@@ -230,7 +230,7 @@ mod tests {
             origin_endpoint: origin,
             origin_user_id: None,
             event_queue: build_queue(),
-            rara_message_id: MessageId::new(),
+            rara_turn_id: MessageId::new(),
             context_window_tokens: 0,
             tool_registry: None,
             stream_handle,

--- a/crates/channels/src/telegram/adapter.rs
+++ b/crates/channels/src/telegram/adapter.rs
@@ -853,8 +853,8 @@ fn render_trace_detail(trace: &ExecutionTrace) -> String {
     }
 
     text.push_str(&format!(
-        "\n\n\u{1f194} <b>Message ID</b>\n  <code>{}</code>",
-        trace_html_escape(&trace.rara_message_id),
+        "\n\n\u{1f194} <b>Turn ID</b>\n  <code>{}</code>",
+        trace_html_escape(&trace.rara_turn_id),
     ));
 
     // Telegram message limit is 4096 chars.
@@ -2427,8 +2427,8 @@ async fn handle_cascade_callback(
                 "cascade: loaded tape entries"
             );
 
-            let rara_message_id = match handle.trace_service().get(trace_id).await {
-                Ok(Some(t)) => t.rara_message_id,
+            let rara_turn_id = match handle.trace_service().get(trace_id).await {
+                Ok(Some(t)) => t.rara_turn_id,
                 _ => String::new(),
             };
 
@@ -2449,7 +2449,7 @@ async fn handle_cascade_callback(
             // legacy sessions.
             let cascade = rara_kernel::cascade::load_persisted_cascade(turn_entries)
                 .unwrap_or_else(|| {
-                    rara_kernel::cascade::build_cascade(turn_entries, &rara_message_id)
+                    rara_kernel::cascade::build_cascade(turn_entries, &rara_turn_id)
                 });
 
             tracing::debug!(

--- a/crates/channels/src/telegram/commands/debug.rs
+++ b/crates/channels/src/telegram/commands/debug.rs
@@ -88,13 +88,12 @@ fn render_html(summary: &MessageDebugSummary) -> String {
     let _ = writeln!(
         output,
         "<b>🔍 Debug: <code>{}</code></b>\n",
-        html_escape(&summary.message_id)
+        html_escape(&summary.turn_id)
     );
 
     if summary.is_empty() {
         output.push_str(
-            "<i>No tape entries found for this message ID. It may have expired or never \
-             existed.</i>",
+            "<i>No tape entries found for this turn ID. It may have expired or never existed.</i>",
         );
         return output;
     }

--- a/crates/channels/src/telegram/commands/debug.rs
+++ b/crates/channels/src/telegram/commands/debug.rs
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! `/debug <message_id>` command — retrieve full execution context for a
-//! message by walking the session tape.
+//! `/debug <turn_id>` command — retrieve full execution context for a
+//! turn by walking the session tape.
 //!
 //! Aggregation lives in [`rara_kernel::debug::MessageDebugSummary`]; this
 //! handler only renders the result as Telegram HTML.
@@ -47,8 +47,8 @@ impl CommandHandler for DebugCommandHandler {
     fn commands(&self) -> Vec<CommandDefinition> {
         vec![CommandDefinition {
             name:        "debug".to_owned(),
-            description: "Debug a message by its ID".to_owned(),
-            usage:       Some("/debug <message_id>".to_owned()),
+            description: "Debug a turn by its ID".to_owned(),
+            usage:       Some("/debug <turn_id>".to_owned()),
         }]
     }
 
@@ -57,27 +57,27 @@ impl CommandHandler for DebugCommandHandler {
         command: &CommandInfo,
         context: &CommandContext,
     ) -> Result<CommandResult, KernelError> {
-        let message_id = command.args.trim();
-        if message_id.is_empty() {
+        let turn_id = command.args.trim();
+        if turn_id.is_empty() {
             return Ok(CommandResult::Text(
-                "Usage: /debug <message_id>\n\nThe message ID is shown at the bottom of each \
-                 response trace (🆔 Message ID)."
+                "Usage: /debug <turn_id>\n\nThe turn ID is shown at the bottom of each response \
+                 trace (🆔 Turn ID)."
                     .to_owned(),
             ));
         }
 
         // Exact metadata filter on the current session's tape — returns all
         // entry kinds (messages, tool calls, tool results, events) so the
-        // debug view shows the complete execution context.
+        // debug view shows the complete execution context for this turn.
         let entries = self
             .tape_service
-            .entries_by_message_id(&context.session_key, message_id)
+            .entries_by_turn_id(&context.session_key, turn_id)
             .await
             .map_err(|e| KernelError::Other {
                 message: format!("tape lookup failed: {e}").into(),
             })?;
 
-        let summary = MessageDebugSummary::from_entries(message_id, entries);
+        let summary = MessageDebugSummary::from_entries(turn_id, entries);
         Ok(CommandResult::Html(render_html(&summary)))
     }
 }

--- a/crates/channels/src/web.rs
+++ b/crates/channels/src/web.rs
@@ -333,7 +333,7 @@ pub(crate) fn stream_event_to_web_event(event: StreamEvent) -> Option<WebEvent> 
             iterations,
             tool_calls,
             model,
-            rara_message_id: _,
+            rara_turn_id: _,
             context_window_tokens: _,
         } => Some(WebEvent::TurnMetrics {
             duration_ms,

--- a/crates/cmd/src/chat/mod.rs
+++ b/crates/cmd/src/chat/mod.rs
@@ -949,7 +949,7 @@ fn stream_event_to_cli_event(event: StreamEvent) -> Option<CliEvent> {
             iterations,
             tool_calls,
             model,
-            rara_message_id: _,
+            rara_turn_id: _,
             context_window_tokens: _,
         } => CliEvent::TurnSummary {
             duration_ms,

--- a/crates/cmd/src/debug.rs
+++ b/crates/cmd/src/debug.rs
@@ -12,13 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! `rara debug <message_id>` — print the full execution context for a
+//! `rara debug <turn_id>` — print the full execution context for a
 //! message without booting the chat UI or kernel runtime.
 //!
 //! The `execution_traces` SQLite table is the single source of truth: each
 //! turn writes a fully aggregated [`ExecutionTrace`] (model, tokens,
 //! iterations, thinking, tools, plan, rationale) keyed by
-//! `rara_message_id`.  We render that directly.  The on-disk tape is opened
+//! `rara_turn_id`.  We render that directly.  The on-disk tape is opened
 //! only as a *supplementary* timeline — one fd, streamed line-by-line.
 
 use std::{
@@ -37,15 +37,15 @@ use snafu::{ResultExt, Whatever};
 use yunara_store::diesel_pool::{DieselPoolConfig, DieselSqlitePools, build_sqlite_pools};
 
 #[derive(Debug, Clone, Args)]
-#[command(about = "Inspect a message by its rara_message_id")]
+#[command(about = "Inspect a message by its rara_turn_id")]
 #[command(
-    long_about = "Inspect a message by its rara_message_id.\n\nLooks up the execution trace in \
-                  the SQLite index, then attaches a chronological timeline from the on-disk tape.  \
+    long_about = "Inspect a message by its rara_turn_id.\n\nLooks up the execution trace in the \
+                  SQLite index, then attaches a chronological timeline from the on-disk tape.  \
                   Does not boot the kernel.\n\nExamples:\n  rara debug 01J4M8VW9XYZAB..."
 )]
 pub struct DebugCmd {
-    /// The rara_message_id to inspect.
-    pub message_id: String,
+    /// The rara_turn_id to inspect.
+    pub turn_id: String,
 }
 
 impl DebugCmd {
@@ -56,12 +56,12 @@ impl DebugCmd {
         let trace_service = TraceService::new(pool);
 
         let lookup = trace_service
-            .find_trace_by_message_id(&self.message_id)
+            .find_trace_by_turn_id(&self.turn_id)
             .await
             .whatever_context("trace lookup failed")?;
 
         let Some((session_id, trace)) = lookup else {
-            println!("🔍 Debug: {}", self.message_id);
+            println!("🔍 Debug: {}", self.turn_id);
             println!("{}", "─".repeat(60));
             println!(
                 "No execution trace found for this message ID.\nThe trace may have expired (30 \
@@ -77,7 +77,7 @@ impl DebugCmd {
         let tape_path = find_tape_file(rara_paths::memory_dir(), &session_id);
         let timeline = match tape_path.as_deref() {
             Some(path) => {
-                collect_timeline(path, &self.message_id).whatever_context("failed to read tape")?
+                collect_timeline(path, &self.turn_id).whatever_context("failed to read tape")?
             }
             None => Vec::new(),
         };
@@ -85,7 +85,7 @@ impl DebugCmd {
         println!(
             "{}",
             render(
-                &self.message_id,
+                &self.turn_id,
                 &session_id,
                 tape_path.as_deref(),
                 &trace,
@@ -117,17 +117,17 @@ struct TimelineEvent {
     detail:    String,
 }
 
-/// Stream a single tape file and pull entries that mention `message_id`.
+/// Stream a single tape file and pull entries that mention `turn_id`.
 /// Substring filtering is the hot path; we only invoke `serde_json` on
 /// lines that already match.
-fn collect_timeline(path: &Path, message_id: &str) -> std::io::Result<Vec<TimelineEvent>> {
+fn collect_timeline(path: &Path, turn_id: &str) -> std::io::Result<Vec<TimelineEvent>> {
     let file = File::open(path)?;
     let reader = BufReader::new(file);
 
     let mut events = Vec::new();
     for line in reader.lines() {
         let line = line?;
-        if !line.contains(message_id) {
+        if !line.contains(turn_id) {
             continue;
         }
         let Ok(entry) = serde_json::from_str::<TapEntry>(&line) else {
@@ -205,14 +205,14 @@ fn collect_timeline(path: &Path, message_id: &str) -> std::io::Result<Vec<Timeli
 
 /// Render the full debug view as plain text for terminal output.
 fn render(
-    message_id: &str,
+    turn_id: &str,
     session_id: &str,
     tape_path: Option<&Path>,
     trace: &ExecutionTrace,
     timeline: &[TimelineEvent],
 ) -> String {
     let mut out = String::new();
-    let _ = writeln!(out, "🔍 Debug: {message_id}");
+    let _ = writeln!(out, "🔍 Debug: {turn_id}");
     let _ = writeln!(out, "  Session: {session_id}");
     if let Some(path) = tape_path {
         let _ = writeln!(out, "  Tape:    {}", path.display());

--- a/crates/cmd/src/debug.rs
+++ b/crates/cmd/src/debug.rs
@@ -64,8 +64,8 @@ impl DebugCmd {
             println!("🔍 Debug: {}", self.turn_id);
             println!("{}", "─".repeat(60));
             println!(
-                "No execution trace found for this message ID.\nThe trace may have expired (30 \
-                 day retention), the turn may have failed before persistence, or the ID is for a \
+                "No execution trace found for this turn ID.\nThe trace may have expired (30 day \
+                 retention), the turn may have failed before persistence, or the ID is for a \
                  slash command (which does not produce a turn)."
             );
             return Ok(());

--- a/crates/extensions/backend-admin/src/chat/service.rs
+++ b/crates/extensions/backend-admin/src/chat/service.rs
@@ -718,8 +718,8 @@ impl SessionService {
             return Ok(trace);
         }
 
-        let message_id = format!("{}-{}", key, message_seq);
-        let trace = build_cascade(turn_entries, &message_id);
+        let turn_id = format!("{}-{}", key, message_seq);
+        let trace = build_cascade(turn_entries, &turn_id);
         Ok(trace)
     }
 

--- a/crates/extensions/backend-admin/src/chat/service.rs
+++ b/crates/extensions/backend-admin/src/chat/service.rs
@@ -728,8 +728,8 @@ impl SessionService {
     /// The turn is identified by the seq of any message produced within
     /// it (most commonly the assistant reply the user clicked on). We
     /// find the owning user-message tape entry, read its
-    /// `rara_message_id` metadata, and look the trace up via
-    /// [`TraceService::find_trace_by_message_id`].
+    /// `rara_turn_id` metadata, and look the trace up via
+    /// [`TraceService::find_trace_by_turn_id`].
     ///
     /// Returns `InvalidRequest` when no user message precedes `seq` and
     /// `NotFound` when no trace has been persisted for the resolved
@@ -752,7 +752,7 @@ impl SessionService {
         // Walk the tape mirroring `tap_entries_to_chat_messages`'s seq
         // counter so we can correlate `message_seq` back to the specific
         // user-message TapEntry. We keep that entry's `metadata`
-        // (which is where `rara_message_id` is recorded) rather than
+        // (which is where `rara_turn_id` is recorded) rather than
         // re-deriving it — the kernel writes it at turn start and it
         // uniquely keys the persisted trace row.
         let i_seq = message_seq as i64;
@@ -787,27 +787,25 @@ impl SessionService {
             });
         };
 
-        let rara_message_id = user_entry
+        let rara_turn_id = user_entry
             .metadata
             .as_ref()
-            .and_then(|m| m.get("rara_message_id"))
+            .and_then(|m| m.get("rara_turn_id"))
             .and_then(Value::as_str)
             .ok_or_else(|| ChatError::NotFound {
-                message: format!(
-                    "user message at seq {message_seq} has no rara_message_id metadata"
-                ),
+                message: format!("user message at seq {message_seq} has no rara_turn_id metadata"),
             })?;
 
         let trace = self
             .trace_service
-            .find_trace_by_message_id(rara_message_id)
+            .find_trace_by_turn_id(rara_turn_id)
             .await
             .map_err(|e| ChatError::SessionError {
                 message: format!("failed to query execution trace: {e}"),
             })?;
 
         trace.map(|(_, t)| t).ok_or_else(|| ChatError::NotFound {
-            message: format!("no execution trace recorded for message {rara_message_id}"),
+            message: format!("no execution trace recorded for message {rara_turn_id}"),
         })
     }
 

--- a/crates/kernel/src/agent/mod.rs
+++ b/crates/kernel/src/agent/mod.rs
@@ -539,7 +539,7 @@ pub struct TurnTrace {
     /// Rara internal message ID for end-to-end correlation.
     /// For user-triggered turns this is the `InboundMessage.id`;
     /// for proactive turns a fresh ID is generated at dispatch time.
-    pub rara_message_id:  crate::io::MessageId,
+    pub rara_turn_id:     crate::io::MessageId,
 }
 
 /// Result of a single agent turn.
@@ -590,7 +590,7 @@ impl AgentTurnResult {
                 total_tool_calls: 0,
                 success:          true,
                 error:            None,
-                rara_message_id:  crate::io::MessageId::new(),
+                rara_turn_id:     crate::io::MessageId::new(),
             },
             cascade:               crate::cascade::CascadeTrace::empty(),
         }
@@ -971,7 +971,7 @@ pub(crate) async fn run_agent_loop(
     guard_pipeline: Arc<GuardPipeline>,
     hook_runner: crate::hooks::HookRunnerRef,
     notification_bus: NotificationBusRef,
-    rara_message_id: crate::io::MessageId,
+    rara_turn_id: crate::io::MessageId,
     interrupted: &AtomicBool,
     interrupt_notify: &tokio::sync::Notify,
 ) -> crate::error::Result<AgentTurnResult> {
@@ -1009,7 +1009,7 @@ pub(crate) async fn run_agent_loop(
         guard_pipeline,
         hook_runner,
         notification_bus,
-        rara_message_id,
+        rara_turn_id,
         interrupted,
         interrupt_notify,
     )
@@ -1031,7 +1031,7 @@ async fn run_agent_loop_inner(
     guard_pipeline: Arc<GuardPipeline>,
     hook_runner: crate::hooks::HookRunnerRef,
     notification_bus: NotificationBusRef,
-    rara_message_id: crate::io::MessageId,
+    rara_turn_id: crate::io::MessageId,
     interrupted: &AtomicBool,
     interrupt_notify: &tokio::sync::Notify,
 ) -> crate::error::Result<AgentTurnResult> {
@@ -1236,7 +1236,7 @@ async fn run_agent_loop_inner(
     let mut last_accumulated_text = String::new();
     let turn_start = Instant::now();
     let mut iteration_traces: Vec<IterationTrace> = Vec::new();
-    let mut cascade_asm = crate::cascade::CascadeAssembler::new(rara_message_id.to_string());
+    let mut cascade_asm = crate::cascade::CascadeAssembler::new(rara_turn_id.to_string());
     cascade_asm.push_user(&input_text, jiff::Timestamp::now(), None);
     // Maximum number of LLM error recoveries (tools-disabled retries) allowed
     // per agent turn before the error becomes fatal.
@@ -2115,7 +2115,7 @@ async fn run_agent_loop_inner(
 
                 // Persist intermediate text to tape (not as final).
                 let meta = serde_json::to_value(crate::memory::LlmEntryMetadata {
-                    rara_message_id: rara_message_id.to_string(),
+                    rara_turn_id: rara_turn_id.to_string(),
                     usage: last_usage,
                     model: model.clone(),
                     iteration,
@@ -2212,7 +2212,7 @@ async fn run_agent_loop_inner(
 
             // Persist final assistant message to tape.
             let meta = serde_json::to_value(crate::memory::LlmEntryMetadata {
-                rara_message_id: rara_message_id.to_string(),
+                rara_turn_id: rara_turn_id.to_string(),
                 usage: last_usage,
                 model: model.clone(),
                 iteration,
@@ -2276,7 +2276,7 @@ async fn run_agent_loop_inner(
                 total_tool_calls: tool_calls_made,
                 success: true,
                 error: None,
-                rara_message_id,
+                rara_turn_id,
             };
             // Best-effort mood update — failure is silently logged, never
             // blocks the response.
@@ -2384,8 +2384,8 @@ async fn run_agent_loop_inner(
                                 }]
                             }),
                             serde_json::to_value(crate::memory::ToolResultMetadata {
-                                rara_message_id: rara_message_id.to_string(),
-                                tool_metrics:    vec![crate::memory::ToolMetric {
+                                rara_turn_id: rara_turn_id.to_string(),
+                                tool_metrics: vec![crate::memory::ToolMetric {
                                     name:        tool_call.name.clone(),
                                     duration_ms: 0,
                                     success:     false,
@@ -2427,7 +2427,7 @@ async fn run_agent_loop_inner(
         // Without this, the cascade trace always shows a single tick.
         {
             let mut meta = crate::memory::LlmEntryMetadata {
-                rara_message_id: rara_message_id.to_string(),
+                rara_turn_id: rara_turn_id.to_string(),
                 usage: last_usage,
                 model: model.clone(),
                 iteration,
@@ -2480,7 +2480,7 @@ async fn run_agent_loop_inner(
                 })
                 .collect();
             let tool_call_meta = serde_json::to_value(crate::memory::LlmEntryMetadata {
-                rara_message_id: rara_message_id.to_string(),
+                rara_turn_id: rara_turn_id.to_string(),
                 usage: last_usage,
                 model: model.clone(),
                 iteration,
@@ -2950,7 +2950,7 @@ async fn run_agent_loop_inner(
                     tape_name,
                     serde_json::json!({ "results": results_json.clone() }),
                     serde_json::to_value(crate::memory::ToolResultMetadata {
-                        rara_message_id: rara_message_id.to_string(),
+                        rara_turn_id: rara_turn_id.to_string(),
                         tool_metrics,
                     })
                     .ok(),
@@ -3307,7 +3307,7 @@ async fn run_agent_loop_inner(
         total_tool_calls: tool_calls_made,
         success: false,
         error: Some(exhaustion_error),
-        rara_message_id,
+        rara_turn_id,
     };
     // Best-effort mood update — failure is silently logged, never blocks the
     // response.

--- a/crates/kernel/src/debug.rs
+++ b/crates/kernel/src/debug.rs
@@ -26,8 +26,8 @@ use crate::memory::TapEntry;
 #[derive(Debug, Clone)]
 pub struct MessageDebugSummary {
     /// The `rara_turn_id` this summary describes.
-    pub message_id:    String,
-    /// All tape entries that referenced the message ID.
+    pub turn_id:       String,
+    /// All tape entries that referenced the turn ID.
     pub entries:       Vec<TapEntry>,
     /// LLM model name (first non-empty value seen in metadata).
     pub model:         Option<String>,
@@ -70,14 +70,14 @@ pub struct TimelineItem {
 impl MessageDebugSummary {
     /// Aggregate tape entries into a debug summary. Filters entries to
     /// only those whose `metadata.rara_turn_id` matches the target.
-    pub fn from_entries(message_id: &str, entries: Vec<TapEntry>) -> Self {
+    pub fn from_entries(turn_id: &str, entries: Vec<TapEntry>) -> Self {
         let matched: Vec<TapEntry> = entries
             .into_iter()
             .filter(|e| {
                 e.metadata.as_ref().is_some_and(|m| {
                     m.get("rara_turn_id")
                         .and_then(|v| v.as_str())
-                        .is_some_and(|id| id == message_id)
+                        .is_some_and(|id| id == turn_id)
                 })
             })
             .collect();
@@ -176,7 +176,7 @@ impl MessageDebugSummary {
         }
 
         Self {
-            message_id: message_id.to_owned(),
+            turn_id: turn_id.to_owned(),
             entries: matched,
             model,
             input_tokens,
@@ -189,6 +189,6 @@ impl MessageDebugSummary {
         }
     }
 
-    /// Returns true if no tape entries matched the message ID.
+    /// Returns true if no tape entries matched the turn ID.
     pub fn is_empty(&self) -> bool { self.entries.is_empty() }
 }

--- a/crates/kernel/src/debug.rs
+++ b/crates/kernel/src/debug.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 //! Message debug summary — aggregates tape entries belonging to a single
-//! `rara_message_id` into a structured view used by both the Telegram
+//! `rara_turn_id` into a structured view used by both the Telegram
 //! `/debug` command and the `rara debug` CLI subcommand.
 //!
 //! This module is presentation-agnostic. It produces structured data
@@ -25,7 +25,7 @@ use crate::memory::TapEntry;
 /// Aggregated debug view of a single message turn.
 #[derive(Debug, Clone)]
 pub struct MessageDebugSummary {
-    /// The `rara_message_id` this summary describes.
+    /// The `rara_turn_id` this summary describes.
     pub message_id:    String,
     /// All tape entries that referenced the message ID.
     pub entries:       Vec<TapEntry>,
@@ -69,13 +69,13 @@ pub struct TimelineItem {
 
 impl MessageDebugSummary {
     /// Aggregate tape entries into a debug summary. Filters entries to
-    /// only those whose `metadata.rara_message_id` matches the target.
+    /// only those whose `metadata.rara_turn_id` matches the target.
     pub fn from_entries(message_id: &str, entries: Vec<TapEntry>) -> Self {
         let matched: Vec<TapEntry> = entries
             .into_iter()
             .filter(|e| {
                 e.metadata.as_ref().is_some_and(|m| {
-                    m.get("rara_message_id")
+                    m.get("rara_turn_id")
                         .and_then(|v| v.as_str())
                         .is_some_and(|id| id == message_id)
                 })

--- a/crates/kernel/src/io.rs
+++ b/crates/kernel/src/io.rs
@@ -1001,7 +1001,7 @@ pub enum StreamEvent {
         iterations:            usize,
         tool_calls:            usize,
         model:                 String,
-        rara_message_id:       String,
+        rara_turn_id:          String,
         /// Authoritative context window size (in tokens) for the model used
         /// this turn. Populated from
         /// `ModelCapabilities::context_window_tokens`. `None` only if

--- a/crates/kernel/src/kernel.rs
+++ b/crates/kernel/src/kernel.rs
@@ -1699,7 +1699,7 @@ impl Kernel {
             .append_message(
                 &tape_name,
                 tape_payload,
-                Some(serde_json::json!({"rara_message_id": msg.id.to_string()})),
+                Some(serde_json::json!({"rara_turn_id": msg.id.to_string()})),
             )
             .await
         {
@@ -2321,7 +2321,7 @@ impl Kernel {
                 .append_message(
                     &tape_name,
                     tape_payload,
-                    Some(serde_json::json!({"rara_message_id": msg.id.to_string()})),
+                    Some(serde_json::json!({"rara_turn_id": msg.id.to_string()})),
                 )
                 .await
             {
@@ -2585,7 +2585,7 @@ impl Kernel {
                     origin_endpoint: origin_endpoint.clone(),
                     origin_user_id,
                     event_queue: event_queue.clone(),
-                    rara_message_id: msg_id.clone(),
+                    rara_turn_id: msg_id.clone(),
                     context_window_tokens: 0,
                     tool_registry: None, // set later in agent loop with live registry
                     stream_handle: None, // set per-tool-call in agent loop
@@ -2604,9 +2604,9 @@ impl Kernel {
                     user_text
                 };
 
-                // Use the inbound message ID as the turn's rara_message_id
+                // Use the inbound message ID as the turn's rara_turn_id
                 // for end-to-end correlation.
-                let rara_message_id = msg_id.clone();
+                let rara_turn_id = msg_id.clone();
 
                 // Fire pre_turn lifecycle hooks.
                 lifecycle_hooks
@@ -2631,7 +2631,7 @@ impl Kernel {
                         guard_pipeline,
                         hook_runner,
                         notification_bus,
-                        rara_message_id,
+                        rara_turn_id,
                         &interrupted,
                         &interrupt_notify,
                     )
@@ -2650,7 +2650,7 @@ impl Kernel {
                         guard_pipeline,
                         hook_runner,
                         notification_bus,
-                        rara_message_id,
+                        rara_turn_id,
                         &interrupted,
                         &interrupt_notify,
                     )
@@ -2692,7 +2692,7 @@ impl Kernel {
                         iterations:            result.iterations,
                         tool_calls:            result.tool_calls,
                         model:                 result.model.clone(),
-                        rara_message_id:       result.trace.rara_message_id.to_string(),
+                        rara_turn_id:       result.trace.rara_turn_id.to_string(),
                         context_window_tokens: result.context_window_tokens,
                     });
                     stream_handle.emit(crate::io::StreamEvent::TurnUsage {

--- a/crates/kernel/src/memory/mod.rs
+++ b/crates/kernel/src/memory/mod.rs
@@ -151,7 +151,7 @@ pub use fork_metadata::{ForkMetadata, get_fork_metadata, set_fork_metadata};
 use jiff::Timestamp;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
-pub use service::{TapeInfo, TapeSearchHit, TapeService, current_tape};
+pub use service::{TapeInfo, TapeSearchHit, TapeService, current_tape, read_turn_id};
 pub use store::FileTapeStore;
 pub use tree::{AnchorNode, AnchorTree, ForkEdge, SessionBranch};
 

--- a/crates/kernel/src/memory/mod.rs
+++ b/crates/kernel/src/memory/mod.rs
@@ -241,8 +241,15 @@ pub enum TapEntryKind {
 /// that the tape alone is sufficient for post-hoc observability analysis.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct LlmEntryMetadata {
-    /// Internal message ID for end-to-end correlation.
-    pub rara_message_id:   String,
+    /// Per-turn correlation handle. One inbound user message produces a
+    /// single id which is then attached to every tape entry generated
+    /// during the resulting turn (user message, assistant text, reasoning,
+    /// every tool_call, every tool_result). Used by `entries_by_turn_id`
+    /// and the `/debug` flow to retrieve the full execution context of a
+    /// turn. The `serde(alias)` accepts the legacy `rara_message_id` key
+    /// from on-disk tapes written before the rename — see issue #1978.
+    #[serde(alias = "rara_message_id")]
+    pub rara_turn_id:      String,
     /// Token consumption for this LLM iteration.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub usage:             Option<crate::llm::Usage>,
@@ -264,10 +271,14 @@ pub struct LlmEntryMetadata {
 /// Metadata attached to `ToolResult` tape entries.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ToolResultMetadata {
-    /// Internal message ID for end-to-end correlation.
-    pub rara_message_id: String,
+    /// Per-turn correlation handle. Mirrors `LlmEntryMetadata::rara_turn_id`
+    /// on `ToolResult` entries so a turn's tool-call results are retrievable
+    /// alongside the LLM messages they belong to. Accepts the legacy
+    /// `rara_message_id` key on read for tapes written before #1978.
+    #[serde(alias = "rara_message_id")]
+    pub rara_turn_id: String,
     /// Per-tool execution metrics.
-    pub tool_metrics:    Vec<ToolMetric>,
+    pub tool_metrics: Vec<ToolMetric>,
 }
 
 /// Execution metrics for a single tool call.

--- a/crates/kernel/src/memory/service.rs
+++ b/crates/kernel/src/memory/service.rs
@@ -45,7 +45,7 @@ thread_local! {
 ///
 /// Returns `None` when neither key is present or the value is not a
 /// string.
-pub(crate) fn read_turn_id(metadata: &Value) -> Option<&str> {
+pub fn read_turn_id(metadata: &Value) -> Option<&str> {
     metadata
         .get("rara_turn_id")
         .or_else(|| metadata.get("rara_message_id"))

--- a/crates/kernel/src/memory/service.rs
+++ b/crates/kernel/src/memory/service.rs
@@ -39,6 +39,19 @@ thread_local! {
     static TAPE_CONTEXT: std::cell::RefCell<Option<String>> = const { std::cell::RefCell::new(None) };
 }
 
+/// Read the per-turn correlation id from a tape entry's metadata JSON,
+/// preferring the current key `rara_turn_id` and falling back to the
+/// legacy `rara_message_id` key for tapes written before issue #1978.
+///
+/// Returns `None` when neither key is present or the value is not a
+/// string.
+pub(crate) fn read_turn_id(metadata: &Value) -> Option<&str> {
+    metadata
+        .get("rara_turn_id")
+        .or_else(|| metadata.get("rara_message_id"))
+        .and_then(|v| v.as_str())
+}
+
 /// Queries shorter than this skip fuzzy matching to avoid noisy results.
 const MIN_FUZZY_QUERY_LENGTH: usize = 3;
 /// Minimum normalized similarity ratio for a fuzzy hit.
@@ -775,26 +788,30 @@ impl TapeService {
         Ok(entries.last().map(|e| e.id).unwrap_or(0))
     }
 
-    /// Find all tape entries (any kind) whose `metadata.rara_message_id`
+    /// Find all tape entries (any kind) whose `metadata.rara_turn_id`
     /// matches the given ID. Unlike [`Self::search`], this is an exact
     /// metadata filter — no text ranking, no kind restriction.
     ///
     /// Used by the `/debug` command to retrieve the full execution context
     /// (messages + tool calls + tool results) for a single turn.
-    pub async fn entries_by_message_id(
+    ///
+    /// Reads both `rara_turn_id` (current key) and `rara_message_id`
+    /// (legacy key, present in tape JSONL files written before issue
+    /// #1978). New writers only emit the new key, but existing on-disk
+    /// tapes are append-only and must remain readable.
+    pub async fn entries_by_turn_id(
         &self,
         tape_name: &str,
-        message_id: &str,
+        turn_id: &str,
     ) -> TapResult<Vec<TapEntry>> {
         let entries = self.store.read(tape_name).await?.unwrap_or_default();
         Ok(entries
             .into_iter()
             .filter(|e| {
-                e.metadata.as_ref().is_some_and(|m| {
-                    m.get("rara_message_id")
-                        .and_then(|v| v.as_str())
-                        .is_some_and(|id| id == message_id)
-                })
+                e.metadata
+                    .as_ref()
+                    .and_then(read_turn_id)
+                    .is_some_and(|id| id == turn_id)
             })
             .collect())
     }

--- a/crates/kernel/src/plan.rs
+++ b/crates/kernel/src/plan.rs
@@ -257,7 +257,7 @@ pub(crate) async fn run_plan_loop(
     guard_pipeline: Arc<GuardPipeline>,
     hook_runner: crate::hooks::HookRunnerRef,
     notification_bus: NotificationBusRef,
-    rara_message_id: crate::io::MessageId,
+    rara_turn_id: crate::io::MessageId,
     interrupted: &AtomicBool,
     interrupt_notify: &tokio::sync::Notify,
 ) -> Result<AgentTurnResult> {
@@ -394,7 +394,7 @@ pub(crate) async fn run_plan_loop(
                     guard_pipeline.clone(),
                     hook_runner.clone(),
                     notification_bus.clone(),
-                    rara_message_id,
+                    rara_turn_id,
                     interrupted,
                     interrupt_notify,
                     &mut total_iterations,
@@ -706,7 +706,7 @@ pub(crate) async fn run_plan_loop(
             } else {
                 None
             },
-            rara_message_id,
+            rara_turn_id,
         },
         cascade:               crate::cascade::CascadeTrace::empty(),
     })
@@ -1297,7 +1297,7 @@ async fn execute_inline_step(
     guard_pipeline: Arc<GuardPipeline>,
     hook_runner: crate::hooks::HookRunnerRef,
     notification_bus: NotificationBusRef,
-    rara_message_id: crate::io::MessageId,
+    rara_turn_id: crate::io::MessageId,
     interrupted: &AtomicBool,
     interrupt_notify: &tokio::sync::Notify,
     total_iterations: &mut usize,
@@ -1362,7 +1362,7 @@ async fn execute_inline_step(
         guard_pipeline,
         hook_runner,
         notification_bus,
-        rara_message_id,
+        rara_turn_id,
         interrupted,
         interrupt_notify,
     )
@@ -1473,7 +1473,7 @@ mod tests {
                 total_tool_calls: 25,
                 success,
                 error: error.map(|s| s.to_owned()),
-                rara_message_id: MessageId::new(),
+                rara_turn_id: MessageId::new(),
             },
             cascade:               crate::cascade::CascadeTrace {
                 message_id: String::new(),

--- a/crates/kernel/src/tool/background_common.rs
+++ b/crates/kernel/src/tool/background_common.rs
@@ -75,7 +75,7 @@ pub(crate) async fn spawn_and_register_background(
             agent_name: manifest.name.clone(),
             description: manifest.description.clone(),
             created_at: jiff::Timestamp::now(),
-            trigger_message_id: context.rara_message_id.clone(),
+            trigger_message_id: context.rara_turn_id.clone(),
             origin_endpoint: context.origin_endpoint.clone(),
         },
     );

--- a/crates/kernel/src/tool/mod.rs
+++ b/crates/kernel/src/tool/mod.rs
@@ -356,7 +356,7 @@ pub struct ToolContext {
     /// Event queue for pushing outbound events.
     pub event_queue:           crate::queue::ShardedQueueRef,
     /// The inbound message ID that triggered the current turn.
-    pub rara_message_id:       crate::io::MessageId,
+    pub rara_turn_id:          crate::io::MessageId,
     /// Context window size in tokens for the current model.
     pub context_window_tokens: usize,
     /// Live tool registry for the current session (includes dynamic MCP tools).
@@ -378,7 +378,7 @@ impl std::fmt::Debug for ToolContext {
             .field("origin_endpoint", &self.origin_endpoint)
             .field("origin_user_id", &self.origin_user_id)
             .field("event_queue", &"...")
-            .field("rara_message_id", &self.rara_message_id)
+            .field("rara_turn_id", &self.rara_turn_id)
             .field("context_window_tokens", &self.context_window_tokens)
             .field("tool_registry", &self.tool_registry.as_ref().map(|_| "..."))
             .field("stream_handle", &self.stream_handle.as_ref().map(|_| "..."))

--- a/crates/kernel/src/tool/schedule.rs
+++ b/crates/kernel/src/tool/schedule.rs
@@ -371,7 +371,7 @@ mod tests {
             origin_endpoint:       None,
             origin_user_id:        None,
             event_queue:           build_queue(),
-            rara_message_id:       MessageId::new(),
+            rara_turn_id:          MessageId::new(),
             context_window_tokens: 0,
             tool_registry:         None,
             stream_handle:         None,

--- a/crates/kernel/src/trace/builder.rs
+++ b/crates/kernel/src/trace/builder.rs
@@ -284,11 +284,11 @@ impl TraceBuilder {
     /// would yield an empty trace, which is acceptable because the
     /// single caller (the kernel turn task) invokes it exactly once.
     ///
-    /// `rara_message_id` is the [`crate::io::MessageId`] string form that
+    /// `rara_turn_id` is the [`crate::io::MessageId`] string form that
     /// correlates this turn back to the triggering inbound message; it is
     /// passed in rather than observed because it originates outside the
     /// stream (from the dispatch metadata).
-    pub fn finalize(&self, rara_message_id: String) -> ExecutionTrace {
+    pub fn finalize(&self, rara_turn_id: String) -> ExecutionTrace {
         let duration_secs = self.turn_started.elapsed().as_secs();
         let State {
             model,
@@ -346,7 +346,7 @@ impl TraceBuilder {
             plan_steps,
             turn_rationale,
             tools,
-            rara_message_id,
+            rara_turn_id,
         }
     }
 
@@ -436,7 +436,7 @@ mod tests {
             iterations:            3,
             tool_calls:            2,
             model:                 "gpt-5".into(),
-            rara_message_id:       "ignored".into(),
+            rara_turn_id:          "ignored".into(),
             context_window_tokens: Some(128_000),
         });
         let trace = b.finalize(mid());

--- a/crates/kernel/src/trace/mod.rs
+++ b/crates/kernel/src/trace/mod.rs
@@ -67,8 +67,12 @@ pub struct ExecutionTrace {
     pub turn_rationale:   Option<String>,
     /// Tool execution records.
     pub tools:            Vec<ToolTraceEntry>,
-    /// Rara internal message ID for end-to-end correlation.
-    pub rara_message_id:  String,
+    /// Per-turn correlation handle. Stable across every entry produced by
+    /// the same inbound message. Accepts the legacy `rara_message_id` key
+    /// on read for `execution_traces.trace_data` rows persisted before
+    /// issue #1978.
+    #[serde(alias = "rara_message_id")]
+    pub rara_turn_id:     String,
 }
 
 /// Record of a single tool invocation within a turn.
@@ -215,29 +219,34 @@ impl TraceService {
         Ok(row.map(|r| r.session_id))
     }
 
-    /// Find the session and full execution trace for a `rara_message_id`.
+    /// Find the session and full execution trace for a `rara_turn_id`.
     ///
     /// Returns the indexed `session_id` column plus the parsed
     /// [`ExecutionTrace`] from `trace_data` — the trace already aggregates
     /// model, tokens, iterations, thinking, tools, plan steps, and
     /// rationale, so callers do not need to re-derive these from tape
     /// entries.
+    ///
+    /// Reads both `$.rara_turn_id` (current key) and `$.rara_message_id`
+    /// (legacy key) via `COALESCE`. Existing rows written before issue
+    /// #1978 carry the legacy key; new writes only emit the new key.
     #[tracing::instrument(skip_all)]
-    pub async fn find_trace_by_message_id(
+    pub async fn find_trace_by_turn_id(
         &self,
-        message_id: &str,
+        turn_id: &str,
     ) -> Result<Option<(String, ExecutionTrace)>> {
         use diesel::OptionalExtension;
 
         let mut conn = self.pools.reader.get().await.context(DieselPoolSnafu)?;
 
-        // `json_extract(trace_data, '$.rara_message_id') = ?` has no DSL
-        // analogue — diesel lacks a cross-backend JSON1 helper. Emit the
-        // predicate via `sql::<Bool>` per docs/guides/db-diesel-migration.md.
+        // No diesel DSL exists for SQLite JSON1; emit the predicate as raw
+        // SQL per docs/guides/db-diesel-migration.md. `COALESCE` lets one
+        // query match both the new and legacy keys without a UNION.
         let predicate = diesel::dsl::sql::<diesel::sql_types::Bool>(
-            "json_extract(trace_data, '$.rara_message_id') = ",
+            "COALESCE(json_extract(trace_data, '$.rara_turn_id'), json_extract(trace_data, \
+             '$.rara_message_id')) = ",
         )
-        .bind::<Text, _>(message_id);
+        .bind::<Text, _>(turn_id);
 
         let row: Option<TraceSessionAndDataRow> = execution_traces::table
             .filter(predicate)

--- a/crates/kernel/tests/tape_metadata_back_compat.rs
+++ b/crates/kernel/tests/tape_metadata_back_compat.rs
@@ -1,0 +1,150 @@
+// Copyright 2025 Rararulab
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Back-compat coverage for the `rara_message_id` → `rara_turn_id` rename
+//! (issue #1978). The on-disk tape JSONL format must keep loading entries
+//! whose metadata still uses the legacy `rara_message_id` key, while new
+//! writes only emit the new `rara_turn_id` key. The `entries_by_turn_id`
+//! lookup must accept both keys interchangeably so a single tape file
+//! that mixes legacy + new entries returns the full turn.
+
+use rara_kernel::memory::{FileTapeStore, LlmEntryMetadata, TapeService};
+use serde_json::json;
+
+/// Scenario: Tape metadata serializes the new turn-id key.
+///
+/// Given a fresh `LlmEntryMetadata` constructed with `rara_turn_id`
+/// "abc-123", serializing to JSON must emit the key `rara_turn_id` and
+/// must NOT emit the legacy `rara_message_id` key. Confirms the writer
+/// only produces the new key going forward.
+#[test]
+fn serializes_rara_turn_id() {
+    let metadata = LlmEntryMetadata {
+        rara_turn_id:      "abc-123".to_owned(),
+        usage:             None,
+        model:             "test-model".to_owned(),
+        iteration:         0,
+        stream_ms:         10,
+        first_token_ms:    None,
+        reasoning_content: None,
+    };
+
+    let value = serde_json::to_value(&metadata).expect("serialize should succeed");
+    let object = value
+        .as_object()
+        .expect("metadata serializes to a JSON object");
+
+    assert_eq!(
+        object.get("rara_turn_id").and_then(|v| v.as_str()),
+        Some("abc-123"),
+        "writer must emit the new rara_turn_id key",
+    );
+    assert!(
+        !object.contains_key("rara_message_id"),
+        "writer must not emit the legacy rara_message_id key",
+    );
+}
+
+/// Scenario: Tape metadata deserializes the legacy `rara_message_id` key.
+///
+/// Given a JSON object using the legacy key set to "legacy-id-xyz",
+/// deserialization into `LlmEntryMetadata` must succeed and the parsed
+/// `rara_turn_id` must equal that value. Covers the on-disk back-compat
+/// contract for tape JSONL files written before issue #1978.
+#[test]
+fn accepts_legacy_rara_message_id() {
+    let raw = json!({
+        "rara_message_id": "legacy-id-xyz",
+        "model": "legacy-model",
+        "iteration": 2,
+        "stream_ms": 42,
+    });
+
+    let parsed: LlmEntryMetadata =
+        serde_json::from_value(raw).expect("legacy key must deserialize");
+
+    assert_eq!(parsed.rara_turn_id, "legacy-id-xyz");
+    assert_eq!(parsed.model, "legacy-model");
+    assert_eq!(parsed.iteration, 2);
+    assert_eq!(parsed.stream_ms, 42);
+}
+
+/// Scenario: `entries_by_turn_id` returns all entries of a turn for both
+/// legacy and new metadata.
+///
+/// Given a tape containing two entries whose metadata uses the legacy
+/// key `rara_message_id` set to "turn-A" and one entry whose metadata
+/// uses the new key `rara_turn_id` also set to "turn-A", invoking
+/// `TapeService::entries_by_turn_id` with "turn-A" must return all
+/// three entries. This is the single test that nails the rename:
+/// before the change the lookup would have missed the new-keyed entry
+/// (or, depending on direction, the legacy ones); after the change
+/// both keys are honored.
+#[tokio::test]
+async fn entries_by_turn_id_back_compat() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let store = FileTapeStore::new(tmp.path(), tmp.path())
+        .await
+        .expect("file store");
+    let tape = TapeService::new(store);
+
+    let tape_name = "back-compat-tape";
+
+    // Two entries written with the legacy key shape, as on-disk tapes
+    // produced before issue #1978 would have looked.
+    tape.append_message(
+        tape_name,
+        json!({"role": "user", "content": "first legacy entry"}),
+        Some(json!({"rara_message_id": "turn-A"})),
+    )
+    .await
+    .expect("append legacy entry 1");
+
+    tape.append_message(
+        tape_name,
+        json!({"role": "assistant", "content": "second legacy entry"}),
+        Some(json!({"rara_message_id": "turn-A"})),
+    )
+    .await
+    .expect("append legacy entry 2");
+
+    // One entry written with the new key shape (post-#1978 producer).
+    tape.append_message(
+        tape_name,
+        json!({"role": "assistant", "content": "third new-key entry"}),
+        Some(json!({"rara_turn_id": "turn-A"})),
+    )
+    .await
+    .expect("append new-key entry");
+
+    // Sanity: an unrelated turn must not pollute the result.
+    tape.append_message(
+        tape_name,
+        json!({"role": "user", "content": "unrelated turn"}),
+        Some(json!({"rara_turn_id": "turn-B"})),
+    )
+    .await
+    .expect("append unrelated entry");
+
+    let hits = tape
+        .entries_by_turn_id(tape_name, "turn-A")
+        .await
+        .expect("entries_by_turn_id");
+
+    assert_eq!(
+        hits.len(),
+        3,
+        "legacy + new metadata keys must be matched together",
+    );
+}

--- a/specs/issue-1978-rename-rara-message-id-to-turn-id.spec.md
+++ b/specs/issue-1978-rename-rara-message-id-to-turn-id.spec.md
@@ -1,0 +1,383 @@
+spec: task
+name: "issue-1978-rename-rara-message-id-to-turn-id"
+inherits: project
+tags: ["kernel", "channels", "ui", "core"]
+---
+
+## Intent
+
+The field `rara_message_id` is named after a single message, but it
+semantically identifies an entire turn. One inbound user message produces
+exactly one `rara_message_id`, and that same id is then attached as
+metadata to every tape entry generated during the turn — the user message
+entry, the assistant text entry, the reasoning entry, every tool_call
+entry, and every tool_result entry. A modest single-tool turn already
+fans the same id out to 5 tape entries; a multi-tool turn easily reaches
+9+.
+
+Concrete evidence (verified in production data):
+- Tape file: `/Users/rara/Library/Application Support/rara/memory/tapes/315bad61f8c34b137221bd6ec086597c__d6e905d9-fd62-41ca-8918-97b37276f534.jsonl`
+- The id `27df73bb-9656-4e23-bbb9-e724e37162c7` appears in the
+  `metadata.rara_message_id` of TapEntry ids 36, 38, 39, 40, 42, 43, 44,
+  46 — nine entries, one id.
+
+This is intentional in the kernel layer (see Prior art below) — the id
+is the turn-level correlation handle that powers `entries_by_message_id`,
+which the `/debug` Telegram command, `rara debug <id>` CLI, the
+`debug_trace` agent tool, and the web `ExecutionTraceModal` all use to
+retrieve the full set of entries belonging to one turn. The semantics are
+correct. **The name lies about them.** Worse, the user-facing surfaces
+amplify the lie:
+
+- Telegram detail panel renders a row literally labelled "Message ID".
+- `web/src/components/chat/ExecutionTraceModal.tsx` displays it as the
+  trace's message id.
+- `web/src/api/kernel-types.ts` exposes the field as `rara_message_id`
+  to every frontend consumer.
+- The `debug_trace` agent tool description says "search by
+  rara_message_id" — so when rara itself reasons about its own debug
+  flow, it reads the misleading word.
+- The CLI subcommand is `rara debug <message_id>`.
+
+Reproducer for "what bug appears if we don't do this": (1) a user
+reports a bug and includes "this is the message id: `27df...`",
+copy-pasted from the Telegram detail panel. (2) Whoever debugs (human or
+rara via `debug_trace`) opens the trace and gets back nine tape entries
+all carrying that id. (3) The natural follow-up question — "which one
+is the actual user message? which one is the assistant reply you saw?"
+— has no clean answer because the user assumed one ID = one message.
+The debug round-trip burns extra context purely on naming-induced
+confusion. (4) Tooling that takes a `rara_message_id` argument (CLI,
+agent tool, telegram `/debug`) returns a turn-shaped result, not a
+message-shaped result, but the parameter name promises the latter. The
+mismatch is invisible until the user is already confused. The bug is
+not "the system computes the wrong thing" — it is "the system's
+self-description teaches every consumer the wrong mental model."
+
+Goal alignment: this advances `goal.md` signal 4 ("every action is
+inspectable. Each decision can be pulled from the eval interface as a
+raw trace, score, and replayable record. No 'I don't know why it did
+that.'"). The primary debug handle on the primary inspection surface
+must teach the right mental model. Mislabelling the most-used
+correlation id directly degrades inspectability across Telegram, web,
+CLI, and the agent's own self-debug path. Does not cross any "What rara
+is NOT" line.
+
+Hermes positioning: not applicable. This is internal naming hygiene on
+rara's debug substrate, no analog in Hermes Agent's public surface.
+
+Prior art search summary (the wall this spec must clear):
+
+- `gh issue list --search "rara_message_id" --state all` returned:
+  - issue 335 (closed) "feat(kernel,telegram): rara_message_id end-to-end
+    tracing and debug_trace tool" — **the original design**. Spec
+    explicitly states: "InboundMessage.id ... is the entire turn's
+    rara_message_id, all the way through agent loop -> TurnTrace ->
+    TurnMetrics -> channel adapter." So the per-turn semantics are
+    intentional and load-bearing; only the name is wrong.
+  - issue 1127 "/debug command for Telegram message context retrieval" —
+    consumer of the field; depends on the same per-turn fan-out.
+  - issue 548 "enrich tape entry metadata with latency, model" —
+    extended `LlmEntryMetadata` alongside `rara_message_id`.
+  - issue 1613 "own ExecutionTrace construction + persistence" —
+    refactored storage of the trace but kept the field name.
+- `gh pr list --search "rara_message_id" --state all` returned PRs 337,
+  339, 1136, 1138, 1156, 1614 — every PR that has touched this field
+  reinforced its current name. None proposed a rename. None challenged
+  the naming.
+- `git log --grep "rename.*message_id|turn_id"` since 365 days returned
+  no hits. Nobody has attempted this rename before.
+- `git log --grep "trigger_message_id"` returned commit 002c81e1 "track
+  trigger_message_id on background tasks" — there is one adjacent
+  field, `trigger_message_id`, on background tasks that is genuinely
+  per-message (it points at the inbound that *triggered* the
+  background task). That field's name is correct as-is and is out of
+  scope.
+- `rg "rara_message_id"` returned 75 references across 21 files
+  (kernel, channels, app, cmd, extensions, web). Comprehensive list
+  captured in Allowed Changes below.
+- `rg "rara_turn_id"` returned 0 hits. Name is free.
+
+No prior decision is being reversed. Issue 335 chose
+"`InboundMessage.id` is the turn id" — that decision stands. This spec
+only renames the field to match what 335 already declared it does.
+
+## Decisions
+
+### Rename, do not redesign
+
+The kernel-level semantics ("one id per turn, attached to every entry of
+that turn, used to retrieve the turn's full execution context") are
+correct and stay. This spec changes the *name* on every surface to
+`rara_turn_id`. No new field is introduced; no per-message id is
+invented; the existing `TapEntry.id: u64` remains the per-entry handle
+for anyone who actually needs to point at one entry inside a turn.
+
+The single test that nails this lane: a `Test:` selector binds to the
+existing `entries_by_message_id` test surface (renamed to
+`entries_by_turn_id`); the function returns the same nine entries it
+returned before, but the field on `LlmEntryMetadata` and
+`ToolResultMetadata` is now `rara_turn_id`. Fail before, pass after.
+
+### Tape JSONL is on-disk data; backward compatibility is mandatory
+
+Existing tape files in `~/Library/Application Support/rara/memory/tapes/`
+have `"rara_message_id"` literal keys baked into their JSON metadata.
+They cannot be retroactively rewritten — they are append-only artefacts
+of past sessions. The deserializer must accept both keys; the serializer
+writes only the new key.
+
+Concretely: `LlmEntryMetadata` and `ToolResultMetadata` use a
+`#[serde(alias = "rara_message_id")] pub rara_turn_id: String` for the
+field. Serde aliases are only used during deserialization, so old tapes
+load and new tapes write `rara_turn_id`. The JSON-pointer lookups in
+`memory/service.rs::entries_by_turn_id` (and the duplicate logic in
+`debug_trace.rs`, `debug.rs`, `chat/service.rs`) must check both keys —
+encapsulated in a single helper, e.g.
+`fn read_turn_id(metadata: &Value) -> Option<&str>` that tries
+`rara_turn_id` first, falls back to `rara_message_id`. Producer-side
+code only ever writes the new key.
+
+### User-facing surface labels follow
+
+The naming lie is most damaging at the surfaces the user reads. The
+rename includes:
+
+- Telegram detail panel: "Message ID" label becomes "Turn ID"
+  (`crates/channels/src/telegram/adapter.rs` near line 857).
+- Web `ExecutionTraceModal.tsx`: the displayed label and any prop names
+  follow.
+- CLI `rara debug <message_id>` becomes `rara debug <turn_id>`. The
+  positional argument keeps the same shape (a UUID); only the label and
+  help text change. No deprecated alias for the CLI flag is introduced
+  — the CLI takes a positional, not a named flag, so there is nothing
+  to alias.
+- `debug_trace` agent tool: parameter name and tool description rename.
+  The tool's input JSON schema property changes from `rara_message_id`
+  to `rara_turn_id`. **Backward-compat for the LLM:** the tool's input
+  deserializer accepts both keys (same alias trick) so an old prompt
+  cache referencing the old name does not produce a hard failure. New
+  tool description and schema only mention the new name.
+
+### TurnTrace and TurnMetrics field names rename together
+
+`TurnTrace.rara_message_id` and `StreamEvent::TurnMetrics.rara_message_id`
+both rename. The frontend type `web/src/api/kernel-types.ts` follows.
+There is no in-flight network compatibility story to preserve — the
+backend and frontend ship as one binary on the remote in this repo's
+deployment model, and stream events are not persisted.
+
+### Why not "add docs and AGENT.md instead"
+
+Documentation cannot fix a misleading public string. The user reads
+"Message ID" in the UI, copies that ID, says "this message ID";
+the engineer or the agent looks at a parameter named `rara_message_id`
+and reasons about it as a message id. AGENT.md and a `///` doc comment
+are read by agents writing kernel code, not by users reading the UI or
+LLMs invoking `debug_trace`. Doc-only fixes leave the failure mode in
+place at every surface where it actually triggers.
+
+### Why not "split into per-message + per-turn ids"
+
+`TapEntry.id: u64` (defined in `crates/kernel/src/memory/mod.rs:340`)
+already serves as the per-entry handle. The reproducer's nine-entry
+turn was identified by ids "36, 38, 39, 40, 42, 43, 44, 46" — that
+numbering is `TapEntry.id`. Adding a second uuid-shaped per-message id
+to every tape entry would be net-new feature work with no current
+consumer; conflating it with this rename would balloon the diff and
+muddy the BDD scenarios. If a per-entry user-facing UUID is needed
+later, it lands as a separate issue.
+
+## Boundaries
+
+### Allowed Changes
+
+- **/crates/kernel/src/memory/mod.rs
+- **/crates/kernel/src/memory/service.rs
+- **/crates/kernel/src/agent/mod.rs
+- **/crates/kernel/src/kernel.rs
+- **/crates/kernel/src/io.rs
+- **/crates/kernel/src/trace/builder.rs
+- **/crates/kernel/src/trace/mod.rs
+- **/crates/kernel/src/plan.rs
+- **/crates/kernel/src/debug.rs
+- **/crates/kernel/src/tool/mod.rs
+- **/crates/kernel/src/tool/schedule.rs
+- **/crates/kernel/src/tool/background_common.rs
+- **/crates/app/src/tools/debug_trace.rs
+- **/crates/app/src/tools/send_file.rs
+- **/crates/channels/src/telegram/adapter.rs
+- **/crates/channels/src/telegram/commands/debug.rs
+- **/crates/channels/src/web.rs
+- **/crates/cmd/src/debug.rs
+- **/crates/cmd/src/chat/mod.rs
+- **/crates/extensions/backend-admin/src/chat/service.rs
+- **/web/src/api/kernel-types.ts
+- **/web/src/components/chat/ExecutionTraceModal.tsx
+- **/crates/kernel/tests/tape_metadata_back_compat.rs
+- **/specs/issue-1978-rename-rara-message-id-to-turn-id.spec.md
+
+Producer-side rename (struct field + serializer):
+
+- `crates/kernel/src/memory/mod.rs` — rename
+  `LlmEntryMetadata.rara_message_id` and
+  `ToolResultMetadata.rara_message_id` to `rara_turn_id`; add
+  `#[serde(alias = "rara_message_id")]` on each.
+- `crates/kernel/src/agent/mod.rs` — rename `TurnTrace.rara_message_id`
+  to `rara_turn_id`; rename all local `let rara_message_id = ...`
+  bindings; rename function parameters and field initializers.
+- `crates/kernel/src/kernel.rs` — rename the metadata-emission sites
+  (lines around 1702 and 2324 that build
+  `serde_json::json!({"rara_message_id": ...})` to write
+  `"rara_turn_id"` instead) and rename `let rara_message_id = ...`
+  bindings around the turn dispatch.
+- `crates/kernel/src/io.rs` — rename `StreamEvent::TurnMetrics`
+  field around line 1004.
+- `crates/kernel/src/trace/builder.rs`,
+  `crates/kernel/src/trace/mod.rs` — rename through the trace
+  builder.
+- `crates/kernel/src/plan.rs` — rename usages.
+- `crates/kernel/src/debug.rs` — rename uses, including the doc
+  comments at the top of the module.
+- `crates/kernel/src/tool/mod.rs`,
+  `crates/kernel/src/tool/schedule.rs`,
+  `crates/kernel/src/tool/background_common.rs` — rename
+  call sites.
+- `crates/kernel/src/memory/service.rs` —
+  rename `entries_by_message_id` to `entries_by_turn_id`; the
+  inner JSON-pointer lookup uses a helper that reads `rara_turn_id`
+  first, falls back to `rara_message_id`.
+
+Consumer rename:
+
+- `crates/app/src/tools/debug_trace.rs` — rename the agent-tool
+  parameter to `rara_turn_id`, update tool description and JSON schema,
+  add input deserialization alias for `rara_message_id`.
+- `crates/app/src/tools/send_file.rs` — rename the test/synthetic
+  field follower (line 233 area).
+- `crates/channels/src/telegram/adapter.rs` — rename the
+  `rara_message_id` references; update the user-facing label
+  ("Message ID" becomes "Turn ID") around line 857; rename
+  `let rara_message_id = ...` around line 2430.
+- `crates/channels/src/web.rs` — rename the destructure
+  `rara_message_id: _`.
+- `crates/cmd/src/debug.rs` — rename CLI argument, help text, and
+  doc comments; the CLI takes a positional UUID so only labels change.
+- `crates/cmd/src/chat/mod.rs` — rename the destructure.
+- `crates/extensions/backend-admin/src/chat/service.rs` — rename
+  the `let rara_message_id = ...`, the metadata lookup (use the
+  same helper that handles both keys), and the doc comments around
+  lines 731 to 810.
+
+Frontend rename:
+
+- `web/src/api/kernel-types.ts` — rename the two field declarations
+  (lines 111 and 481) from `rara_message_id: string` to
+  `rara_turn_id: string`.
+- `web/src/components/chat/ExecutionTraceModal.tsx` — rename the
+  property access on line 156 and update the displayed label from
+  "Message ID" to "Turn ID".
+
+Tests:
+
+- `crates/kernel/tests/tape_metadata_back_compat.rs` — new test, see
+  Completion Criteria.
+- Existing tests that reference `rara_message_id` follow the rename.
+  No new test names are introduced beyond the back-compat test;
+  scenario selectors below bind to it and to the `entries_by_turn_id`
+  surface.
+
+Doc/comment updates:
+
+- All `///` doc comments and `//!` module-level docs in the files
+  above that mention "rara_message_id" follow the rename. The
+  per-turn semantics (one id per inbound message, attached to every
+  entry of the resulting turn) become the explicit doc text rather
+  than implicit knowledge.
+
+### Forbidden
+
+- Do NOT introduce a per-entry user-facing UUID alongside `rara_turn_id`.
+  `TapEntry.id: u64` already covers per-entry addressing. Inventing a
+  second handle is the option C alternative, explicitly rejected.
+- Do NOT migrate or rewrite existing tape JSONL files on disk. They
+  remain append-only history; the loader's `serde(alias)` is the entire
+  back-compat surface.
+- Do NOT remove the `serde(alias = "rara_message_id")` or the JSON-key
+  fallback in the metadata-lookup helper. They are the contract that
+  keeps every existing tape file readable. Removing them is a future
+  decision behind its own issue.
+- Do NOT rename `trigger_message_id` (on background tasks). That field
+  genuinely is per-message and its name is correct.
+- Do NOT change `OutboundEnvelope.id` or `OutboundEnvelope.in_reply_to`.
+  Those are unrelated to this rename.
+- Do NOT introduce a deprecation warning emitted at runtime when an old
+  tape with `rara_message_id` is loaded. Silent acceptance is the
+  desired UX — it is not an error condition.
+- Do NOT add a YAML config knob to control whether the writer emits
+  the old name. Per the mechanism-vs-config rule, this is not config
+  surface.
+- Do NOT mark any new test `#[ignore]`.
+- Do NOT introduce a separate Rust type alias `pub type TurnId =
+  String` in this PR. The existing `crate::io::MessageId` newtype stays
+  on the kernel side as the typed handle (since it really is the
+  inbound message id that becomes the turn id); only the *field name*
+  on metadata structs and on TurnTrace/TurnMetrics renames. A typed
+  `TurnId` newtype is a future refactor beyond this issue's scope.
+
+## Completion Criteria
+
+Scenario: Tape metadata serializes the new turn-id key
+  Test:
+    Package: rara-kernel
+    Filter: tape_metadata_back_compat::serializes_rara_turn_id
+  Given a fresh LlmEntryMetadata constructed with rara_turn_id "abc-123"
+  When the metadata is serialized to JSON via serde_json::to_value
+  Then the resulting JSON object contains key "rara_turn_id" with value "abc-123" and contains no key named "rara_message_id"
+
+Scenario: Tape metadata deserializes legacy rara_message_id key
+  Test:
+    Package: rara-kernel
+    Filter: tape_metadata_back_compat::accepts_legacy_rara_message_id
+  Given a JSON object containing the key "rara_message_id" with value "legacy-id-xyz" and the other required LlmEntryMetadata fields
+  When the JSON is deserialized into LlmEntryMetadata via serde_json::from_value
+  Then deserialization succeeds and the resulting metadata's rara_turn_id field equals "legacy-id-xyz"
+
+Scenario: entries_by_turn_id returns all entries of a turn for both legacy and new metadata
+  Test:
+    Package: rara-kernel
+    Filter: tape_metadata_back_compat::entries_by_turn_id_back_compat
+  Given a tape containing two entries whose metadata uses the legacy key "rara_message_id" set to "turn-A" and one entry whose metadata uses the new key "rara_turn_id" also set to "turn-A"
+  When TapeService::entries_by_turn_id is invoked with "turn-A"
+  Then exactly three entries are returned
+
+Scenario: debug_trace agent tool accepts both old and new parameter names
+  Test:
+    Package: rara-app
+    Filter: debug_trace::accepts_legacy_rara_message_id_param
+  Given a debug_trace tool input JSON object that contains the legacy key "rara_message_id" set to "trace-1"
+  When the input is deserialized into the tool's input struct
+  Then deserialization succeeds and the parsed rara_turn_id equals "trace-1"
+
+## Out of Scope
+
+- Introducing a typed `TurnId` newtype distinct from `MessageId` on the
+  Rust side. The current `MessageId` newtype keeps semantic accuracy at
+  the IO layer ("this is the inbound message id") and the rename only
+  needs to reach as far as the *field names* on metadata and trace
+  structs.
+- Adding a per-entry user-facing UUID handle. `TapEntry.id: u64` is the
+  existing primitive and is sufficient.
+- Renaming `trigger_message_id` on background tasks. That field is
+  genuinely per-message.
+- Migrating or rewriting on-disk tape JSONL files. Back-compat lives in
+  the deserializer.
+- Removing the `serde(alias = "rara_message_id")` after some grace
+  period. That is a future decision behind its own issue, after
+  evidence shows no recent tape file still uses the old key.
+- Any change to `OutboundEnvelope.id`, `OutboundEnvelope.in_reply_to`,
+  or the inbound/outbound id semantics generally.
+- Telemetry / OTel attribute renames (e.g. if a span attribute is
+  named `rara.message_id`). If any such attribute exists, it follows
+  in a separate issue scoped to telemetry semconv (issue 1856 line of
+  work).

--- a/web/src/api/kernel-types.ts
+++ b/web/src/api/kernel-types.ts
@@ -108,7 +108,7 @@ export type StreamEvent =
       iterations: number;
       tool_calls: number;
       model: string;
-      rara_message_id: string;
+      rara_turn_id: string;
     }
   | {
       type: 'plan_created';
@@ -477,6 +477,6 @@ export interface ExecutionTrace {
   /** High-level rationale the LLM stated for this turn, when any. */
   turn_rationale?: string;
   tools: ToolTraceEntry[];
-  /** Rara internal message ID for end-to-end correlation. */
-  rara_message_id: string;
+  /** Per-turn correlation handle: stable across every entry produced by the same inbound message. */
+  rara_turn_id: string;
 }

--- a/web/src/components/chat/ExecutionTraceModal.tsx
+++ b/web/src/components/chat/ExecutionTraceModal.tsx
@@ -151,9 +151,9 @@ function TraceBody({ trace }: { trace: ExecutionTrace }) {
         </div>
       </Section>
 
-      <Section emoji="🆔" title="Message ID">
+      <Section emoji="🆔" title="Turn ID">
         <code className="block rounded bg-muted/60 px-2 py-1 font-mono text-xs break-all">
-          {trace.rara_message_id}
+          {trace.rara_turn_id}
         </code>
       </Section>
     </div>


### PR DESCRIPTION
## Summary

The field `rara_message_id` was misnamed since #335 — it's actually a per-turn correlation handle, not a per-message id. One id is shared across user msg + assistant text + reasoning + every tool_call/tool_result in the same turn (often 9+ tape entries). The misleading name caused user-facing confusion when reporting bugs and led debuggers astray.

- Rename `rara_message_id` → `rara_turn_id` end-to-end across kernel/channels/app/cmd/extensions/web (24 files).
- `#[serde(alias = "rara_message_id")]` on read paths so existing tape JSONL files keep loading.
- Writers emit only the new key.
- `debug_trace` agent tool aliases its input param so prompt-cache references to the old name still work.
- `read_turn_id` helper centralizes JSON-pointer fallback for non-serde paths (legacy → new).
- User-visible Telegram + CLI strings + `MessageDebugSummary.message_id` field renamed.

Spec: `specs/issue-1978-rename-rara-message-id-to-turn-id.spec.md`

## Test plan

- [x] `prek run --all-files` — all hooks pass
- [x] `just spec-lifecycle …` — 4/4 BDD scenarios pass
- [x] `cd web && bun run build` — clean
- [x] Reviewer 2 rounds: original commit + fix-up for 4 P1 findings → APPROVE
- [x] `rg -i "message[- _]?id"` sweep — only intentional back-compat aliases / fallbacks remain

Closes #1978