### PR TITLE
fix(telemetry): build OTLP blocking client before tokio runtime (#1982)

### DIFF
--- a/crates/cmd/src/main.rs
+++ b/crates/cmd/src/main.rs
@@ -56,114 +56,127 @@ enum Commands {
 #[command(long_about = "Start the job server with all services.\n\nExamples:\n  job server")]
 struct ServerArgs {}
 
-impl ServerArgs {
-    async fn run() -> Result<(), Whatever> {
-        // Load config first (Consul KV or env vars) so observability
-        // settings are available before initialising the tracing subscriber.
-        let config = AppConfig::new().whatever_context("Failed to load config")?;
+/// Sync prelude for the `server` command.
+///
+/// Why this is a separate function (and not part of an `async fn run`):
+/// `init_global_logging` constructs the OTLP HTTP exporter, which uses
+/// `reqwest::blocking::Client::builder().build()`. That builder spawns
+/// and immediately drops a temporary tokio Runtime on the calling thread.
+/// Dropping a Runtime while another Runtime is current panics in tokio
+/// 1.x ("Cannot drop a runtime in a context where blocking is not
+/// allowed"). So all logging / OTLP / Pyroscope construction must happen
+/// **before** the outer tokio Runtime exists.
+///
+/// Returns the loaded config plus the guards that must outlive the
+/// process (file appender flush guards + Pyroscope shutdown guard).
+type ServerInitGuards = (
+    AppConfig,
+    Vec<common_telemetry::logging::LoggingWorkerGuard>,
+    Option<common_telemetry::profiling::ProfilingGuard>,
+);
 
-        let logs_dir = rara_paths::logs_dir();
-        std::fs::create_dir_all(logs_dir).expect("failed to create logs directory");
-        let logs_dir_str = logs_dir.to_string_lossy().into_owned();
+fn init_server_sync() -> Result<ServerInitGuards, Whatever> {
+    let config = AppConfig::new().whatever_context("Failed to load config")?;
 
-        // Pinned OpenTelemetry semantic-convention schema URL for the OTLP
-        // traces exporter. Pinning the version lets backends (Langfuse,
-        // Tempo, etc.) interpret span attributes against a known semconv
-        // release rather than a moving target.
-        const OTEL_SCHEMA_URL: &str = "https://opentelemetry.io/schemas/1.40.0";
+    let logs_dir = rara_paths::logs_dir();
+    std::fs::create_dir_all(logs_dir).expect("failed to create logs directory");
+    let logs_dir_str = logs_dir.to_string_lossy().into_owned();
 
-        let langfuse_otlp = config
-            .telemetry
-            .otlp
-            .as_ref()
-            .filter(|o| o.enabled.unwrap_or(false));
+    // Pinned OpenTelemetry semantic-convention schema URL for the OTLP
+    // traces exporter. Pinning the version lets backends (Langfuse,
+    // Tempo, etc.) interpret span attributes against a known semconv
+    // release rather than a moving target.
+    const OTEL_SCHEMA_URL: &str = "https://opentelemetry.io/schemas/1.40.0";
 
-        let mut logging_opts = if let Some(otlp) = langfuse_otlp {
-            use common_telemetry::logging::{LoggingOptions, OtlpExportProtocol};
-            let Some(endpoint) = otlp.traces_endpoint.clone() else {
-                whatever!("telemetry.otlp.enabled = true requires telemetry.otlp.traces_endpoint");
-            };
-            LoggingOptions {
-                dir: logs_dir_str,
-                enable_otlp_tracing: true,
-                otlp_endpoint: Some(endpoint),
-                otlp_export_protocol: Some(OtlpExportProtocol::Http),
-                otlp_headers: otlp.headers.clone(),
-                otlp_schema_url: Some(OTEL_SCHEMA_URL.to_string()),
-                otlp_deployment_environment: otlp.deployment_environment.clone(),
-                ..Default::default()
-            }
-        } else if let Some(ref endpoint) = config
-            .telemetry
-            .otlp_endpoint
-            .as_deref()
-            .filter(|s| !s.is_empty())
-        {
-            use common_telemetry::logging::{LoggingOptions, OtlpExportProtocol};
-            let protocol = config.telemetry.otlp_protocol.as_deref().map(|p| match p {
-                "grpc" => OtlpExportProtocol::Grpc,
-                _ => OtlpExportProtocol::Http,
-            });
-            LoggingOptions {
-                dir: logs_dir_str,
-                enable_otlp_tracing: true,
-                otlp_endpoint: Some(endpoint.to_string()),
-                otlp_export_protocol: protocol,
-                otlp_schema_url: Some(OTEL_SCHEMA_URL.to_string()),
-                ..Default::default()
-            }
-        } else if std::env::var("KUBERNETES_SERVICE_HOST").is_ok() {
-            // Running in Kubernetes — auto-connect to Alloy OTLP collector.
-            use common_telemetry::logging::{LoggingOptions, OtlpExportProtocol};
-            tracing::info!("Kubernetes detected — auto-enabling OTLP tracing to Alloy");
-            LoggingOptions {
-                dir: logs_dir_str,
-                enable_otlp_tracing: true,
-                otlp_endpoint: Some("http://rara-infra-alloy:4318/v1/traces".to_string()),
-                otlp_export_protocol: Some(OtlpExportProtocol::Http),
-                otlp_schema_url: Some(OTEL_SCHEMA_URL.to_string()),
-                log_format: common_telemetry::logging::LogFormat::Json,
-                ..Default::default()
-            }
-        } else {
-            common_telemetry::logging::LoggingOptions {
-                dir: logs_dir_str,
-                ..Default::default()
-            }
+    let langfuse_otlp = config
+        .telemetry
+        .otlp
+        .as_ref()
+        .filter(|o| o.enabled.unwrap_or(false));
+
+    let mut logging_opts = if let Some(otlp) = langfuse_otlp {
+        use common_telemetry::logging::{LoggingOptions, OtlpExportProtocol};
+        let Some(endpoint) = otlp.traces_endpoint.clone() else {
+            whatever!("telemetry.otlp.enabled = true requires telemetry.otlp.traces_endpoint");
         };
-
-        // Overlay OTLP logs config — independent of trace export so users
-        // can ship logs to Loki without also wiring traces. Reads from the
-        // same `telemetry.otlp` section because logs and traces share the
-        // deployment-environment label and the OTLP family.
-        if let Some(otlp) = config.telemetry.otlp.as_ref()
-            && otlp.logs_enabled.unwrap_or(false)
-        {
-            let Some(logs_endpoint) = otlp.logs_endpoint.clone() else {
-                whatever!(
-                    "telemetry.otlp.logs_enabled = true requires telemetry.otlp.logs_endpoint"
-                );
-            };
-            logging_opts.enable_otlp_logs = true;
-            logging_opts.otlp_logs_endpoint = Some(logs_endpoint);
-            logging_opts.otlp_logs_headers = otlp.logs_headers.clone();
+        LoggingOptions {
+            dir: logs_dir_str,
+            enable_otlp_tracing: true,
+            otlp_endpoint: Some(endpoint),
+            otlp_export_protocol: Some(OtlpExportProtocol::Http),
+            otlp_headers: otlp.headers.clone(),
+            otlp_schema_url: Some(OTEL_SCHEMA_URL.to_string()),
+            otlp_deployment_environment: otlp.deployment_environment.clone(),
+            ..Default::default()
         }
+    } else if let Some(ref endpoint) = config
+        .telemetry
+        .otlp_endpoint
+        .as_deref()
+        .filter(|s| !s.is_empty())
+    {
+        use common_telemetry::logging::{LoggingOptions, OtlpExportProtocol};
+        let protocol = config.telemetry.otlp_protocol.as_deref().map(|p| match p {
+            "grpc" => OtlpExportProtocol::Grpc,
+            _ => OtlpExportProtocol::Http,
+        });
+        LoggingOptions {
+            dir: logs_dir_str,
+            enable_otlp_tracing: true,
+            otlp_endpoint: Some(endpoint.to_string()),
+            otlp_export_protocol: protocol,
+            otlp_schema_url: Some(OTEL_SCHEMA_URL.to_string()),
+            ..Default::default()
+        }
+    } else if std::env::var("KUBERNETES_SERVICE_HOST").is_ok() {
+        // Running in Kubernetes — auto-connect to Alloy OTLP collector.
+        use common_telemetry::logging::{LoggingOptions, OtlpExportProtocol};
+        tracing::info!("Kubernetes detected — auto-enabling OTLP tracing to Alloy");
+        LoggingOptions {
+            dir: logs_dir_str,
+            enable_otlp_tracing: true,
+            otlp_endpoint: Some("http://rara-infra-alloy:4318/v1/traces".to_string()),
+            otlp_export_protocol: Some(OtlpExportProtocol::Http),
+            otlp_schema_url: Some(OTEL_SCHEMA_URL.to_string()),
+            log_format: common_telemetry::logging::LogFormat::Json,
+            ..Default::default()
+        }
+    } else {
+        common_telemetry::logging::LoggingOptions {
+            dir: logs_dir_str,
+            ..Default::default()
+        }
+    };
 
-        let _guards = common_telemetry::logging::init_global_logging(
-            "rara",
-            &logging_opts,
-            &common_telemetry::logging::TracingOptions::default(),
-            None,
-        );
-
-        // Continuous profiling (Pyroscope). Held for the lifetime of the
-        // server process — its `Drop` performs graceful shutdown so the
-        // last batch flushes when the process receives SIGTERM/SIGINT and
-        // `run_app` returns cleanly via its existing signal handler.
-        let _profiling_guard = init_profiling(&config)?;
-
-        run_app(config).await
+    // Overlay OTLP logs config — independent of trace export so users
+    // can ship logs to Loki without also wiring traces. Reads from the
+    // same `telemetry.otlp` section because logs and traces share the
+    // deployment-environment label and the OTLP family.
+    if let Some(otlp) = config.telemetry.otlp.as_ref()
+        && otlp.logs_enabled.unwrap_or(false)
+    {
+        let Some(logs_endpoint) = otlp.logs_endpoint.clone() else {
+            whatever!("telemetry.otlp.logs_enabled = true requires telemetry.otlp.logs_endpoint");
+        };
+        logging_opts.enable_otlp_logs = true;
+        logging_opts.otlp_logs_endpoint = Some(logs_endpoint);
+        logging_opts.otlp_logs_headers = otlp.logs_headers.clone();
     }
+
+    let guards = common_telemetry::logging::init_global_logging(
+        "rara",
+        &logging_opts,
+        &common_telemetry::logging::TracingOptions::default(),
+        None,
+    );
+
+    // Continuous profiling (Pyroscope). Held for the lifetime of the
+    // server process — its `Drop` performs graceful shutdown so the
+    // last batch flushes when the process receives SIGTERM/SIGINT and
+    // `run_app` returns cleanly via its existing signal handler.
+    let profiling_guard = init_profiling(&config)?;
+
+    Ok((config, guards, profiling_guard))
 }
 
 /// Wire the Pyroscope profiling agent if enabled in YAML config.
@@ -391,21 +404,49 @@ impl GatewayArgs {
     }
 }
 
-#[tokio::main]
-async fn main() -> Result<(), Whatever> {
+/// Manually construct the multi-threaded tokio runtime instead of using
+/// `#[tokio::main]`.
+///
+/// Why: the `server` command's logging init builds an OTLP HTTP exporter
+/// via `reqwest::blocking::Client::builder().build()`, which internally
+/// constructs and immediately drops a temporary tokio Runtime on the
+/// calling thread. Dropping a Runtime while another Runtime is current
+/// panics in tokio 1.x ("Cannot drop a runtime in a context where
+/// blocking is not allowed"). So we must perform sync logging /
+/// telemetry construction **before** entering the outer runtime, then
+/// `block_on` the async work afterwards.
+fn main() -> Result<(), Whatever> {
     rustls::crypto::ring::default_provider()
         .install_default()
         .expect("failed to install rustls crypto provider");
 
     let cli = Cli::parse();
+
+    // Perform any sync, pre-runtime initialization for the chosen
+    // subcommand, then build the runtime and dispatch the async body.
     match cli.commands {
-        Commands::Server(_) => ServerArgs::run().await,
-        Commands::Chat(args) => args.run().await,
-        Commands::Top(args) => args.run().await,
-        Commands::Gateway(_) => GatewayArgs::run().await,
-        Commands::Login(cmd) => cmd.run().await,
-        Commands::Setup(cmd) => cmd.run().await,
-        Commands::Wechat(cmd) => cmd.run().await,
-        Commands::Debug(cmd) => cmd.run().await,
+        Commands::Server(_) => {
+            // Sync logging + Pyroscope init MUST run before the runtime
+            // exists — see module-level comment above.
+            let (config, _guards, _profiling_guard) = init_server_sync()?;
+            build_runtime()?.block_on(run_app(config))
+        }
+        Commands::Chat(args) => build_runtime()?.block_on(args.run()),
+        Commands::Top(args) => build_runtime()?.block_on(args.run()),
+        Commands::Gateway(_) => build_runtime()?.block_on(GatewayArgs::run()),
+        Commands::Login(cmd) => build_runtime()?.block_on(cmd.run()),
+        Commands::Setup(cmd) => build_runtime()?.block_on(cmd.run()),
+        Commands::Wechat(cmd) => build_runtime()?.block_on(cmd.run()),
+        Commands::Debug(cmd) => build_runtime()?.block_on(cmd.run()),
     }
+}
+
+/// Build the multi-thread tokio runtime that `#[tokio::main]` would have
+/// produced. Kept identical to the implicit defaults so behavior outside
+/// of "what runs first" is unchanged.
+fn build_runtime() -> Result<tokio::runtime::Runtime, Whatever> {
+    tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .whatever_context("failed to build tokio runtime")
 }

--- a/crates/common/telemetry/src/logging.rs
+++ b/crates/common/telemetry/src/logging.rs
@@ -40,6 +40,10 @@ use opentelemetry_sdk::{
 use opentelemetry_semantic_conventions::resource;
 use serde::{Deserialize, Deserializer, Serialize, de};
 use smart_default::SmartDefault;
+/// Re-export so binary crates that hold the guards returned by
+/// `init_global_logging` can name their type without depending on
+/// `tracing-appender` directly.
+pub use tracing_appender::non_blocking::WorkerGuard as LoggingWorkerGuard;
 use tracing_appender::{
     non_blocking::WorkerGuard,
     rolling::{RollingFileAppender, Rotation},
@@ -902,4 +906,239 @@ fn init_logger_provider(
         .with_batch_exporter(exporter)
         .with_resource(resource)
         .build()
+}
+
+#[cfg(test)]
+#[allow(unsafe_code)]
+mod tests {
+    //! Tests for the OTLP construction site fix (issue #1982).
+    //!
+    //! These tests run in plain `#[test]` mode — i.e. no outer tokio
+    //! Runtime is active on the calling thread. That mirrors the fixed
+    //! production codepath, where `init_logging` runs synchronously
+    //! before `Runtime::new()` in `fn main()`. If any of these test
+    //! functions panicked with "Cannot drop a runtime in a context where
+    //! blocking is not allowed", the fix would have regressed.
+    //!
+    //! Note: we intentionally exercise `build_otlp_exporter` and
+    //! `build_otlp_http_client` directly rather than going through
+    //! `init_global_logging`, because the latter installs a process-wide
+    //! global subscriber via `Once` — only one `#[test]` could use it
+    //! per test binary. The panic root-cause we are guarding against
+    //! lives in `reqwest::blocking::Client::builder().build()`, which is
+    //! reached via `build_otlp_http_client`, which is called from all
+    //! three `build_otlp_*` / `init_*_provider` helpers — so testing the
+    //! helper directly is equivalent.
+
+    use std::{
+        io::{Read, Write},
+        net::{SocketAddr, TcpListener, TcpStream},
+        sync::mpsc,
+        thread,
+        time::Duration,
+    };
+
+    use opentelemetry::trace::{Tracer, TracerProvider as _};
+    use opentelemetry_sdk::trace::SdkTracerProvider;
+
+    use super::*;
+
+    /// Scenario 1: telemetry init does not panic when OTLP is enabled.
+    ///
+    /// The pre-fix codepath called
+    /// `reqwest::blocking::Client::builder().build()` from inside
+    /// `#[tokio::main]` and panicked with "Cannot drop a runtime in a
+    /// context where blocking is not allowed". The fix moves the call out
+    /// of the async context — this test reproduces the synchronous (no
+    /// outer Runtime) call shape that production now uses.
+    #[test]
+    fn otlp_init_does_not_panic_from_production_codepath() {
+        // No tokio runtime is current on this thread — that is the
+        // shape of the post-fix call from `init_server_sync` in
+        // `crates/cmd/src/main.rs`.
+        assert!(
+            tokio::runtime::Handle::try_current().is_err(),
+            "test precondition: no tokio runtime should be current",
+        );
+
+        let opts = LoggingOptions {
+            enable_otlp_tracing: true,
+            otlp_endpoint: Some("http://127.0.0.1:1/".to_string()),
+            otlp_export_protocol: Some(OtlpExportProtocol::Http),
+            ..Default::default()
+        };
+
+        // The exporter builds the HTTP client synchronously. If the
+        // panic regresses, this line aborts the test thread.
+        let _exporter = build_otlp_exporter(&opts);
+    }
+
+    /// Scenario 2: OTLP HTTP client preserves `.no_proxy()`.
+    ///
+    /// `reqwest::blocking::Client` does not expose its proxy
+    /// configuration via a public getter, so we observe the behavior:
+    /// set `HTTPS_PROXY` to an unreachable address, ask the client to
+    /// hit an HTTPS URL pointing at a local TCP listener, and check
+    /// where the connection actually lands. With `.no_proxy()` the
+    /// client connects to our listener; without it, the client would
+    /// try the proxy address instead.
+    #[test]
+    fn otlp_http_client_bypasses_env_proxy() {
+        // Bind a local listener that records the first incoming peer.
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind local listener");
+        let addr = listener.local_addr().expect("local addr");
+        let (tx, rx) = mpsc::channel::<()>();
+
+        let listener_thread = thread::spawn(move || {
+            // Accept one connection and signal — that's enough to prove
+            // the client targeted us, not the env proxy.
+            if let Ok((mut stream, _peer)) = listener.accept() {
+                let _ = tx.send(());
+                // Drain anything the client wrote so it doesn't block.
+                let mut buf = [0u8; 64];
+                let _ = stream.set_read_timeout(Some(Duration::from_millis(200)));
+                let _ = stream.read(&mut buf);
+            }
+        });
+
+        // SAFETY: `set_var` is unsafe in 2024 edition because env vars
+        // are process-global. This test does not run in parallel with
+        // other tests that read `HTTPS_PROXY` (unique to this test in
+        // this crate). The variable is restored before the test exits.
+        let prev = std::env::var("HTTPS_PROXY").ok();
+        unsafe {
+            std::env::set_var("HTTPS_PROXY", "http://127.0.0.1:1");
+        }
+
+        let client = build_otlp_http_client();
+        // A short timeout keeps the test fast — we only need to see
+        // *which* address the client tried to connect to.
+        let url = format!("http://{addr}/");
+        let _ = client
+            .post(&url)
+            .timeout(Duration::from_secs(2))
+            .body("ping")
+            .send();
+
+        // Restore the env var before asserting.
+        unsafe {
+            match prev {
+                Some(v) => std::env::set_var("HTTPS_PROXY", v),
+                None => std::env::remove_var("HTTPS_PROXY"),
+            }
+        }
+
+        let connected = rx.recv_timeout(Duration::from_secs(3)).is_ok();
+        let _ = listener_thread.join();
+        assert!(
+            connected,
+            "OTLP blocking client honored HTTPS_PROXY instead of bypassing it — .no_proxy() \
+             regression"
+        );
+    }
+
+    /// Scenario 3: batch exporter delivers spans via the blocking client.
+    ///
+    /// Stand up a minimal HTTP server on a local port, point an OTLP
+    /// trace pipeline at it, emit one span, shut the provider down (which
+    /// drains any pending batches synchronously), and assert the server
+    /// received at least one POST. Specifically guards against:
+    ///   1. "Cannot drop a runtime in a context where blocking is not allowed"
+    ///      — would surface if `reqwest::blocking::Client` construction landed
+    ///      back inside an async context.
+    ///   2. "there is no reactor running" — would surface if we regressed to
+    ///      async `reqwest::Client` on the BatchSpan processor's std::thread.
+    #[test]
+    fn otlp_trace_export_round_trip_via_blocking_client() {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind stub server");
+        let addr: SocketAddr = listener.local_addr().expect("local addr");
+        let _ = listener.set_nonblocking(false);
+
+        let (post_tx, post_rx) = mpsc::channel::<()>();
+
+        // Minimal HTTP/1.1 server. Loops accepting connections until the
+        // test drops the listener (server_done flag) or the loop exits
+        // naturally on a closed socket. Each connection gets one response.
+        let stop_flag = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let stop_flag_for_thread = stop_flag.clone();
+        let server_thread = thread::spawn(move || {
+            // Short accept timeout so the loop can poll the stop flag.
+            let _ = listener.set_nonblocking(true);
+            while !stop_flag_for_thread.load(std::sync::atomic::Ordering::SeqCst) {
+                match listener.accept() {
+                    Ok((stream, _)) => handle_one_post(stream, &post_tx),
+                    Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => {
+                        thread::sleep(Duration::from_millis(50));
+                    }
+                    Err(_) => break,
+                }
+            }
+        });
+
+        let opts = LoggingOptions {
+            enable_otlp_tracing: true,
+            otlp_endpoint: Some(format!("http://{addr}/v1/traces")),
+            otlp_export_protocol: Some(OtlpExportProtocol::Http),
+            ..Default::default()
+        };
+
+        // Build the exporter the same way `init_global_logging` does,
+        // but assemble the provider locally so this test does not
+        // collide with the process-global `Once` guard inside
+        // `init_global_logging`.
+        let exporter = build_otlp_exporter(&opts);
+        let resource = build_otel_resource("test", None, &opts);
+        let provider = SdkTracerProvider::builder()
+            .with_batch_exporter(exporter)
+            .with_sampler(opentelemetry_sdk::trace::Sampler::AlwaysOn)
+            .with_resource(resource)
+            .build();
+        let tracer = provider.tracer("otlp_trace_export_round_trip_via_blocking_client");
+
+        // Emit one span and shut down the provider on a worker thread so
+        // we can bound the wait. `shutdown` drains pending batches
+        // synchronously through the blocking exporter — this is the
+        // codepath that would panic on the regression.
+        let provider_for_worker = provider.clone();
+        let worker = thread::spawn(move || {
+            let span = tracer.start("test-span");
+            drop(span);
+            // `shutdown` flushes pending batches and is the canonical
+            // synchronization point in 0.31 — `force_flush` returns
+            // before the send completes for the standard processor.
+            let _ = provider_for_worker.shutdown();
+        });
+
+        // Wait up to 5s for the stub server to record a POST.
+        let got_post = post_rx.recv_timeout(Duration::from_secs(5)).is_ok();
+
+        // Tear down: signal server, drop provider, join threads.
+        stop_flag.store(true, std::sync::atomic::Ordering::SeqCst);
+        let _ = worker.join();
+        // Open a throwaway connection so the server's accept loop wakes
+        // up and observes the stop flag immediately.
+        let _ = TcpStream::connect_timeout(&addr, Duration::from_millis(200));
+        let _ = server_thread.join();
+
+        assert!(
+            got_post,
+            "BatchSpanProcessor did not deliver any POST to the stub OTLP server within 5s",
+        );
+    }
+
+    fn handle_one_post(mut stream: TcpStream, post_tx: &mpsc::Sender<()>) {
+        let _ = stream.set_nonblocking(false);
+        let _ = stream.set_read_timeout(Some(Duration::from_secs(2)));
+        let mut buf = [0u8; 4096];
+        let n = stream.read(&mut buf).unwrap_or(0);
+        let request = String::from_utf8_lossy(&buf[..n]);
+        if request.starts_with("POST ") {
+            let _ = post_tx.send(());
+        }
+        // 200 OK with empty body is enough for OTel's HTTP exporter to
+        // treat the export as successful.
+        let _ =
+            stream.write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 0\r\nConnection: close\r\n\r\n");
+        let _ = stream.flush();
+    }
 }

--- a/specs/issue-1982-otlp-exporter-async-runtime.spec.md
+++ b/specs/issue-1982-otlp-exporter-async-runtime.spec.md
@@ -1,0 +1,303 @@
+spec: task
+name: "issue-1982-otlp-exporter-async-runtime"
+inherits: project
+tags: ["telemetry", "otlp", "tokio"]
+---
+
+## Intent
+
+`rara server` panics on startup before reaching READY whenever
+`telemetry.otlp.enabled: true` (the current remote config on
+raratekiAir). `rara gateway` exhausts its three restart attempts and
+exits, so `just run` is unusable until the OTLP path is rolled back.
+
+The panic is:
+
+```
+thread 'main' panicked at .../tokio-1.50.0/src/runtime/blocking/shutdown.rs:51:
+Cannot drop a runtime in a context where blocking is not allowed.
+```
+
+The trigger is the helper introduced in PR 1962 / commit a048dbc5,
+`crates/common/telemetry/src/logging.rs:763`:
+
+```rust
+fn build_otlp_http_client() -> reqwest::blocking::Client {
+    reqwest::blocking::Client::builder()
+        .no_proxy()
+        .build()
+        ...
+}
+```
+
+`reqwest::blocking::Client::build()` constructs and immediately drops a
+temporary tokio Runtime on the calling thread. PR 1962 calls this helper
+synchronously from `init_logging` (via `build_otlp_exporter`,
+`init_meter_provider`, and `init_logger_provider`), which all run inside
+the outer `#[tokio::main]` async context of `rara server`. Dropping a
+Runtime while another Runtime is current panics in tokio 1.x — hence
+the crash on the very first OTLP-related call.
+
+This is the third revision in this area in two months and the prior-art
+chain matters: PR 1931 introduced async `reqwest::Client` injection so
+the OTLP exporter could enforce `.no_proxy()` (rara routes Telegram
+traffic through an outbound HTTP proxy that must be bypassed for
+self-hosted Loki / Langfuse / OTLP collector). Issue 1960 / PR 1962
+flipped to `reqwest::blocking::Client` because OTel's
+`BatchSpanProcessor` / `BatchLogProcessor` / `PeriodicReader` run on
+dedicated OS threads with no tokio runtime, so async reqwest panicked
+there with "no reactor running". The blocking direction is correct for
+those worker threads, but the construction site (inside `#[tokio::main]`)
+is wrong, and PR 1962's manual test "Boot rara on local-rara" was left
+unchecked in the test plan — that is the one box that would have caught
+this.
+
+### Direction (option C — upstream-canonical, locked by user)
+
+The first draft of this spec proposed reverting to async
+`reqwest::Client` and binding OTel batch processors to the tokio runtime
+via `rt-tokio` (option 2). That premise does not hold for
+`opentelemetry_sdk` 0.31's standard processors: `rt-tokio` only enables
+`runtime::Tokio` for the experimental `*_with_async_runtime::*` types,
+which are gated behind separate `experimental_*` Cargo features.
+Standard `BatchSpanProcessor` / `BatchLogProcessor` / `PeriodicReader`
+always run on dedicated `std::thread` OS threads with
+`futures_executor::block_on`, regardless of whether `rt-tokio` is
+enabled. There is no public 0.31 API that binds the standard processors
+to a tokio runtime without flipping experimental features.
+
+A research agent surveyed 6+ OSS Rust projects shipping
+`opentelemetry-otlp` over HTTP and identified the patterns:
+
+- **Pattern 3** (`reqwest::blocking::Client` + standard BSP /
+  `PeriodicReader` / log batch processor): used by
+  **opentelemetry-rust's own upstream example**
+  (`opentelemetry-otlp/examples/basic-otlp-http/`) and by
+  `ZcashFoundation/zebra` in production (with explanatory source
+  comment: "This works without an async runtime because:
+  1. reqwest-blocking-client doesn't need tokio
+  2. BatchSpanProcessor spawns its own background thread"). 3 projects
+  total. **This is the upstream-blessed path.**
+- Pattern 2 (async reqwest + experimental async-runtime BSP): 4 projects
+  (spin, openobserve, fluree, casper). Locks us into `experimental_*`
+  features.
+- Pattern 1 (async reqwest + `Handle::block_on` bridging adapter):
+  **0 OSS adopters**. Folklore.
+- Pattern 5 (custom non-`reqwest` `HttpClient` impl): deno (hyper),
+  sqlpage (awc). Bespoke and out of scope.
+
+PR 1962's *direction* — `reqwest::blocking::Client` + standard BSP — is
+already pattern 3 and matches upstream. The bug is purely in the
+**construction site**: `reqwest::blocking::Client::builder().build()`
+is called from inside `#[tokio::main]`, where dropping the temporary
+tokio Runtime that `reqwest::blocking` creates internally panics.
+
+The fix keeps `reqwest::blocking::Client` + standard processors (no
+feature flips, no `experimental_*` gates, no custom `HttpClient`) and
+moves the construction off the async context. Two viable mechanisms;
+the implementer picks the cleaner one against the actual call graph in
+`crates/app/`:
+
+1. **Preferred**: invoke `init_logging` synchronously **before** the
+   tokio runtime is constructed in `fn main()`. If the binary uses
+   `#[tokio::main]`, switch to a manually-constructed
+   `tokio::runtime::Runtime` so `init_logging` can run before
+   `Runtime::new()` returns. This matches normal production Rust
+   practice (subscriber installed before the first trace event = before
+   the runtime).
+2. **Fallback** (only if `init_logging` genuinely cannot run
+   pre-runtime due to dependencies surfaced during implementation):
+   wrap each `reqwest::blocking::Client::builder().build()` call inside
+   `tokio::task::spawn_blocking(...).await` so the temp-runtime drop
+   happens off the async context.
+
+The implementer investigates the call graph and picks option 1 if
+feasible. Either way, no Cargo feature flips, no nested `Runtime::new()`
+inside async code, no custom `HttpClient` adapter.
+
+### Reproducer for "what bug appears if we don't do this"
+
+1. SSH to `local-rara`, `cd ~/code/rararulab/rara`, `just run`.
+2. The current `config.yaml` has `telemetry.otlp.enabled: true`.
+3. `rara gateway` spawns `rara server`. `init_logging` reaches
+   `build_otlp_http_client()` from inside `#[tokio::main]`.
+4. `reqwest::blocking::Client::builder().build()` constructs a temporary
+   tokio Runtime and drops it on the current thread, which already has
+   an outer Runtime — tokio panics with "Cannot drop a runtime in a
+   context where blocking is not allowed."
+5. `rara server` exits before emitting READY. Gateway supervisor
+   restarts it; same panic. After three attempts, gateway exits.
+6. Observed: `just run` produces the exact log the user pasted; remote
+   is unusable until OTLP is disabled or the binary is rolled back.
+
+### Goal alignment
+
+Signal 1 ("the process runs for months without intervention"). A
+gateway that crash-loops on every cold start is the exact opposite of
+that signal — and right now it does not even take "months", it takes
+one boot. Signal 4 ("every action is inspectable") — this is the
+telemetry path itself; without it, no traces, no metrics, no logs reach
+Langfuse / Loki / the OTLP collector, so every downstream eval and
+replay is blind. Does not cross any "What rara is NOT" line.
+
+Hermes positioning: not applicable — telemetry plumbing is internal
+infrastructure, not a user-facing feature.
+
+### Prior art
+
+- opentelemetry-rust upstream HTTP example (pattern 3, the canonical
+  recipe):
+  https://github.com/open-telemetry/opentelemetry-rust/tree/main/opentelemetry-otlp/examples/basic-otlp-http
+- ZcashFoundation/zebra production usage of the same pattern, with the
+  load-bearing source comment about why no async runtime is needed:
+  https://github.com/ZcashFoundation/zebra/blob/main/zebrad/src/components/tracing/otel.rs
+- Issue 1960 / PR 1962 (the immediate cause of the regression — flipped
+  to `reqwest::blocking::Client` for the right reason, panicked because
+  it was built inside `#[tokio::main]`).
+- PR 1931 (introduced `.no_proxy()` enforcement on the OTLP client;
+  must be preserved across this change).
+- PRs 1855 / 1857 / 1928 / 1949 / 1952 (full chain of telemetry work
+  in this area).
+
+`rg "reqwest::blocking|build_otlp|reqwest-blocking-client|reqwest-client"`
+in tree confirms the helper lives only at
+`crates/common/telemetry/src/logging.rs:763` and is called from three
+sites (`build_otlp_exporter` 770, `init_meter_provider` 851,
+`init_logger_provider` 894).
+
+This direction does NOT reverse the `.no_proxy()` decision from
+PR 1931 (preserved on the blocking client) and does NOT reverse the
+"batch processors must not panic with no reactor running" decision
+from PR 1962 — pattern 3 satisfies it by keeping the standard
+processors on their own OS threads with the synchronous client, exactly
+as upstream documents.
+
+## Decisions
+
+1. Keep `reqwest::blocking::Client` (do **not** flip back to async
+   `reqwest::Client`). `.no_proxy()` is preserved on the blocking
+   builder.
+2. Keep `crates/common/telemetry/Cargo.toml` features as PR 1962 left
+   them: `opentelemetry-otlp` uses `reqwest-blocking-client`; `reqwest`
+   keeps its `blocking` feature. Do **not** enable any
+   `experimental_*` feature on `opentelemetry_sdk`. `rt-tokio` may stay
+   in the feature list (harmless under standard processors) or be
+   removed if it is unused — implementer's call against `cargo check`.
+3. Keep the standard `BatchSpanProcessor` / `BatchLogProcessor` /
+   `PeriodicReader` (they run on dedicated OS threads with
+   `futures_executor::block_on`; that is the upstream-canonical
+   arrangement under pattern 3). Do not switch to
+   `*_with_async_runtime::*`.
+4. Fix the **construction site**, not the client choice. Preferred:
+   invoke `init_logging` synchronously before the tokio runtime is
+   constructed in the binary's `fn main()` (switch from
+   `#[tokio::main]` to a manually-constructed
+   `tokio::runtime::Runtime` if needed). Fallback: wrap each
+   `reqwest::blocking::Client::builder().build()` call in
+   `tokio::task::spawn_blocking(...).await`. Implementer picks against
+   the actual call graph in `crates/app/`.
+5. Do not introduce a custom `HttpClient` impl (no hyper, no awc, no
+   bespoke adapter). Pattern 3 is sufficient.
+6. No new YAML config keys. The construction-site fix is a mechanism
+   choice — operators have no deployment-relevant reason to tune it.
+
+## Boundaries
+
+### Allowed Changes
+
+- `**/crates/common/telemetry/src/logging.rs`
+- `**/crates/common/telemetry/Cargo.toml`
+- `**/crates/common/telemetry/tests/**`
+- `**/crates/cmd/src/main.rs`
+- `**/Cargo.lock`
+- `**/specs/issue-1982-otlp-exporter-async-runtime.spec.md`
+
+### Forbidden
+
+- `**/config.example.yaml`
+- `**/config.yaml`
+- `**/crates/common/telemetry/src/lib.rs`
+- `**/crates/common/telemetry/src/metrics.rs`
+- `**/crates/common/telemetry/src/tracing.rs`
+- `**/crates/kernel/**`
+- `**/web/**`
+
+## Completion Criteria
+
+Scenario: telemetry init does not panic when OTLP is enabled
+  Given an `init_logging` call exercised the way the production binary
+    invokes it (synchronous, before the tokio runtime is current — or
+    via `spawn_blocking` if the fallback mechanism was chosen)
+    with `LoggingOptions { otlp_enabled: true, otlp_endpoint: "http://127.0.0.1:1/", ..default }`
+  When the function returns
+  Then it returns `Ok(())` (or the project's normal logging-init result)
+    without panicking
+  And no thread in the test process has panicked with
+    `"Cannot drop a runtime in a context where blocking is not allowed"`
+  Test:
+    Package: common-telemetry
+    Filter: otlp_init_does_not_panic_from_production_codepath
+
+Scenario: OTLP HTTP client preserves no_proxy
+  Given the helper `build_otlp_http_client()`
+  When the resulting `reqwest::blocking::Client` is inspected via its
+    public surface (issue a request to a URL whose `HTTPS_PROXY` would
+    otherwise route it through a captive proxy address)
+  Then the request is attempted directly, not through the env-var proxy
+    (assertion can be done by setting `HTTPS_PROXY=http://127.0.0.1:1`
+    in the test, expecting a connection failure to the actual target's
+    DNS/IP rather than to `127.0.0.1:1`)
+  Test:
+    Package: common-telemetry
+    Filter: otlp_http_client_bypasses_env_proxy
+
+Scenario: batch exporter delivers spans via the blocking client
+  Given a `tracing` span emitted after `init_logging` initialized the
+    OTLP trace pipeline against a local stub HTTP server (the standard
+    `BatchSpanProcessor` runs on its own OS thread, intentionally not
+    in any tokio runtime — this is pattern 3)
+  When the BatchSpanProcessor flushes
+  Then the stub HTTP server receives at least one POST to the OTLP
+    traces path within 5 seconds
+  And no panic occurs in the test process (specifically, no
+    `"Cannot drop a runtime in a context where blocking is not allowed"`
+    and no `"there is no reactor running"`)
+  Test:
+    Package: common-telemetry
+    Filter: otlp_trace_export_round_trip_via_blocking_client
+
+## Constraints
+
+- All comments and identifiers in new code must be English (project
+  rule).
+- No new YAML config keys (mechanism vs config rule, see
+  `feedback_mechanism_vs_config.md`).
+- Preserve `.no_proxy()` on the blocking client — do not regress
+  PR 1931's fix during the construction-site rewrite.
+- Do not enable any `experimental_*` feature on `opentelemetry_sdk`.
+  The standard processors plus `reqwest::blocking::Client` is
+  upstream-canonical (pattern 3).
+- Do not introduce a custom `HttpClient` impl. Stay on
+  `reqwest-blocking-client`.
+- Do not introduce a nested `tokio::runtime::Runtime::new()` inside
+  async code. The "manually-constructed runtime in `fn main()`"
+  mechanism is fine because it is the *only* runtime, constructed
+  before any async context exists.
+- Pin the construction-site fix against the version already in
+  `Cargo.toml` (opentelemetry_sdk 0.31). Do not bump the dependency to
+  reach for `*_with_async_runtime::*` — that is explicitly out of
+  scope.
+
+## Out of Scope
+
+- Bumping `opentelemetry`, `opentelemetry-otlp`, or `opentelemetry_sdk`
+  versions.
+- Adding new OTLP exporters (e.g., a different trace backend).
+- Switching to `*_with_async_runtime::*` processors or any
+  `experimental_*` feature.
+- Refactoring `init_logging`'s overall structure beyond what is
+  required to move the construction site off the async context.
+- Changing the `.no_proxy()` policy itself.
+- Touching the gateway supervisor's restart-budget logic — even though
+  the symptom involved gateway giving up after three attempts, the
+  gateway behavior is correct; the bug is in the child.


### PR DESCRIPTION
## Summary

PR #1962 fixed #1960 by switching the OTLP exporter to `reqwest::blocking::Client`, but called `Client::builder().build()` from inside `#[tokio::main]`. `reqwest::blocking` spins up a temporary tokio runtime to drive the build; dropping that temp runtime from inside the outer tokio runtime panics with `Cannot drop a runtime in a context where blocking is not allowed`. Result: every `rara server` boot crashed before becoming READY.

This PR moves `init_logging` ahead of the tokio runtime construction in `crates/cmd/src/main.rs`, matching the upstream `opentelemetry-rust` `basic-otlp-http` example and zebra's production setup. All of #1962's choices (`reqwest::blocking::Client`, `reqwest-blocking-client` feature, standard `BatchSpanProcessor`) are preserved — only the construction site is fixed.

Closes #1982

## Test plan

- [x] BDD lifecycle 3/3 scenarios passing (`just spec-lifecycle specs/issue-1982-otlp-exporter-async-runtime.spec.md`)
- [x] `prek run --all-files` clean
- [x] `cargo build --workspace` clean
- [ ] Post-merge: gateway auto-update picks up new binary on `local-rara`; `rara server` reaches READY without panic (user verifies post-merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)