### PR TITLE
chore(ci): per-area paths-filter buckets + e2e gating (#1995)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,10 @@ jobs:
     name: Detect Changes
     runs-on: arc-runner-set
     outputs:
-      code: ${{ steps.filter.outputs.code }}
+      rust: ${{ steps.filter.outputs.rust }}
+      web: ${{ steps.filter.outputs.web }}
+      docs: ${{ steps.filter.outputs.docs }}
+      specs: ${{ steps.filter.outputs.specs }}
     steps:
       - name: Checkout code
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
@@ -35,25 +38,36 @@ jobs:
         id: filter
         with:
           filters: |
-            code:
+            rust:
               - 'crates/**'
               - 'api/**'
               - 'Cargo.toml'
               - 'Cargo.lock'
               - 'rust-toolchain.toml'
-              - '.github/workflows/rust.yml'
               - '.github/workflows/ci.yml'
+              - '.github/workflows/rust.yml'
+              - '.github/workflows/lint.yml'
+              - '.github/workflows/e2e.yml'
+            web:
+              - 'web/**'
+              - '.github/workflows/web-ci.yml'
+            docs:
+              - 'docs/**'
+              - '*.md'
+              - 'README*'
+            specs:
+              - 'specs/**'
 
   lint:
     name: Lint
     needs: changes
-    if: ${{ needs.changes.outputs.code == 'true' || github.event_name == 'push' }}
+    if: ${{ needs.changes.outputs.rust == 'true' || github.event_name == 'push' }}
     uses: ./.github/workflows/lint.yml
 
   rust:
     name: Rust
     needs: changes
-    if: ${{ needs.changes.outputs.code == 'true' || github.event_name == 'push' }}
+    if: ${{ needs.changes.outputs.rust == 'true' || github.event_name == 'push' }}
     uses: ./.github/workflows/rust.yml
 
   release-pr:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -31,10 +31,43 @@ defaults:
 
 permissions:
   contents: read
+  pull-requests: read
 
 jobs:
+  changes:
+    name: Detect Changes
+    runs-on: arc-runner-set
+    outputs:
+      rust: ${{ steps.filter.outputs.rust }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
+        with:
+          fetch-depth: 0
+
+      - name: Filter paths
+        uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
+        id: filter
+        with:
+          filters: |
+            rust:
+              - 'crates/**'
+              - 'api/**'
+              - 'Cargo.toml'
+              - 'Cargo.lock'
+              - 'rust-toolchain.toml'
+              - '.github/workflows/ci.yml'
+              - '.github/workflows/rust.yml'
+              - '.github/workflows/lint.yml'
+              - '.github/workflows/e2e.yml'
+
   real-llm-e2e:
     name: Real-LLM E2E
+    needs: changes
+    # Skip the real-LLM suite when nothing in the rust bucket changed on a
+    # push to main (e.g. docs- or specs-only merges). workflow_dispatch
+    # always runs so maintainers can trigger ad-hoc.
+    if: ${{ needs.changes.outputs.rust == 'true' || github.event_name == 'workflow_dispatch' }}
     runs-on: arc-runner-set
     env:
       # ARC runners can't build native boxlite (meson/ninja/patchelf missing),


### PR DESCRIPTION
## Summary

- Extend `ci.yml`'s existing `changes` job to emit 4 per-area outputs (`rust` / `web` / `docs` / `specs`); `lint` + `rust` jobs gate on `rust == 'true' || github.event_name == 'push'`
- Add a sibling `changes` job to `e2e.yml`; `real-llm-e2e` skips on push-to-main when `rust` bucket unchanged (saves OpenAI tokens on docs/specs-only merges)
- Renamed existing `code` output → `rust` (atomic; only consumer was the same file)

Closes #1995

## Test plan

- [ ] On this PR: `Detect Changes` runs, emits `rust=true`; `Lint` + `Rust` run (this PR edits `.github/workflows/ci.yml` which is in the `rust` bucket)
- [ ] Post-merge follow-up: open a `specs/**`-only PR — confirm `Lint` + `Rust` skip cleanly (status `success`/`skipped`, not `pending`)
- [ ] Post-merge follow-up: merge a `docs/**`-only PR to `main` — confirm `E2E (Real LLM)` skips