### PR TITLE
fix(ci): add memory.knowledge.* to ci/config.template.yaml (#1997)

### DIFF
--- a/ci/config.template.yaml
+++ b/ci/config.template.yaml
@@ -32,3 +32,9 @@ llm:
       base_url: "${OPENAI_BASE_URL}"
       api_key: "${OPENAI_API_KEY}"
       default_model: "${OPENAI_MODEL}"
+
+knowledge:
+  embedding_model: "text-embedding-3-small"
+  embedding_dimensions: 1536
+  search_top_k: 10
+  similarity_threshold: 0.85


### PR DESCRIPTION
## Summary

- Append `knowledge:` block (4 keys) to `ci/config.template.yaml`; values verbatim from `config.example.yaml:97-101`
- Unblocks `E2E (Real LLM)` boot path; `init_knowledge_service` (`crates/app/src/boot.rs:884`) was hard-failing on `memory.knowledge.embedding_model is not configured` after #1993 unmasked the gap
- No Rust changes

Closes #1997

## Boot-path config audit

| # | `boot.rs` | Required key | Template |
|---|---|---|---|
| 1 | `:354` | `llm.default_provider` | ✅ existing |
| 2 | `:419` | `llm.providers.openai.default_model` | ✅ `${OPENAI_MODEL}` |
| 3 | `:884` | `memory.knowledge.embedding_model` | ✅ added |
| 4 | `:889` | `memory.knowledge.embedding_dimensions` | ✅ added |
| 5 | `:895` | `memory.knowledge.search_top_k` | ✅ added |
| 6 | `:901` | `memory.knowledge.similarity_threshold` | ✅ added |

Reviewer also flagged `:702` — runtime `SettingsMappings::get` for user-id resolution, not a boot config read. Out of scope.

## Test plan

- [ ] `E2E (Real LLM)` workflow run on this PR's branch passes the boot phase (no `… is not configured` failure)
- [ ] If `anchor_checkout_roundtrip` still fails, the failure is a different (real LLM round-trip) reason — not config load