### PR TITLE
fix(ci): align user name with anchor_checkout e2e test (#2000)

### DIFF
--- a/ci/config.template.yaml
+++ b/ci/config.template.yaml
@@ -15,10 +15,10 @@ grpc:
   server_address: "127.0.0.1:50051"
 
 owner_token: "ci-owner-token-not-a-real-secret"
-owner_user_id: "ci"
+owner_user_id: "ryan"
 
 users:
-  - name: "ci"
+  - name: "ryan"
     role: root
     platforms: []
 


### PR DESCRIPTION
Closes #2000

## Summary

- `ci/config.template.yaml`: `owner_user_id` and `users[0].name` `"ci"` → `"ryan"` to match `anchor_checkout_e2e.rs:85` (hardcoded `Principal::lookup("ryan")`)
- Unblocks `E2E (Real LLM)` — boot now reaches turn 1 (post-#1997), which then panicked on `UserNotFound { name: "ryan" }`
- No Rust changes