### PR TITLE
chore(telemetry): map spans to Langfuse-recognized attributes (#2002)

### DIFF
--- a/crates/app/src/lib.rs
+++ b/crates/app/src/lib.rs
@@ -813,9 +813,32 @@ pub async fn start_with_options(
         boot::McpDynamicToolProvider::new(rara.mcp_manager.clone()),
     ));
 
+    // Build the Layer B payload sampler. Default-on so the Langfuse UI
+    // renders trace Input / Output without per-deployment YAML — operators
+    // who want to dial back `on_success` set the field explicitly.
+    let payload_sampler = Arc::new(
+        common_telemetry::payload_sampler::PayloadSampler::from_optional_config(
+            config.telemetry.payload_sampling.clone(),
+        ),
+    );
+
+    // Reuse the existing `telemetry.otlp.deployment_environment` YAML key as
+    // the source for `langfuse.environment`. Adding a new YAML key would
+    // collide with `anti-patterns.md` ("would a deploy operator have a real
+    // reason to pick a different value?" — they already pick this one for
+    // `deployment.environment.name`). Falls back to `telemetry.env`.
+    let langfuse_environment = config
+        .telemetry
+        .otlp
+        .as_ref()
+        .and_then(|o| o.deployment_environment.clone())
+        .or_else(|| config.telemetry.env.clone());
+
     let kernel_config = rara_kernel::kernel::KernelConfig {
         mita_heartbeat_interval: Some(config.mita.heartbeat_interval),
         context_folding: config.context_folding.clone(),
+        payload_sampler: Some(payload_sampler),
+        langfuse_environment,
         ..Default::default()
     };
 

--- a/crates/common/telemetry/src/attrs.rs
+++ b/crates/common/telemetry/src/attrs.rs
@@ -14,7 +14,7 @@
 
 //! Stable telemetry attribute keys — the contract an external detector reads.
 //!
-//! `SCHEMA_VERSION: 0.1.0`. Adding attributes is a **minor** change. Renaming
+//! `SCHEMA_VERSION: 0.2.0`. Adding attributes is a **minor** change. Renaming
 //! or removing one is a **major** change and will break the downstream
 //! detector agent — bump the schema version and announce.
 //!
@@ -25,17 +25,20 @@
 //!   attributes alone.
 //! - **Layer B — content sampling** (see [`crate::payload_sampler`]): set only
 //!   when the sampler decides. Bounded by `max_chars`. Used for diagnosis after
-//!   Layer A flags a regression.
+//!   Layer A flags a regression. Layer B payloads are written under the
+//!   `langfuse.*.input` / `langfuse.*.output` keys so Langfuse renders them in
+//!   its UI directly.
 //! - **Layer C — pointers, never embedded payloads**: e.g. [`RARA_LOG_FILE`]
 //!   points to a hourly log file rather than embedding the lines.
 //!
 //! Upstream OTel GenAI semantic conventions are imported via
 //! `opentelemetry_semantic_conventions::attribute::*` — never hardcode the
-//! string form of those keys.
+//! string form of those keys. Langfuse-specific keys (`langfuse.*`) are not
+//! in the OTel semconv registry and are hardcoded here.
 
 /// The semantic-convention version exported by this module. Bumped when
 /// attributes are renamed or removed. Detectors pin against this value.
-pub const SCHEMA_VERSION: &str = "0.1.0";
+pub const SCHEMA_VERSION: &str = "0.2.0";
 
 // ---------------------------------------------------------------------------
 // rara.* — rara-specific attributes
@@ -115,28 +118,6 @@ pub const RARA_LOG_FILE: &str = "rara.log.file";
 // rara.* — Layer B (sampled payload) attributes
 // ---------------------------------------------------------------------------
 
-/// Sampled prompt text (Layer B). Truncation is signalled by
-/// [`RARA_PROMPT_TRUNCATED`].
-pub const RARA_PROMPT: &str = "rara.prompt";
-/// True when [`RARA_PROMPT`] was truncated to the sampler's `max_chars`.
-pub const RARA_PROMPT_TRUNCATED: &str = "rara.prompt.truncated";
-
-/// Sampled completion text (Layer B). Truncation is signalled by
-/// [`RARA_COMPLETION_TRUNCATED`].
-pub const RARA_COMPLETION: &str = "rara.completion";
-/// True when [`RARA_COMPLETION`] was truncated to the sampler's `max_chars`.
-pub const RARA_COMPLETION_TRUNCATED: &str = "rara.completion.truncated";
-
-/// Sampled tool input JSON (Layer B).
-pub const RARA_TOOL_INPUT: &str = "rara.tool.input";
-/// True when [`RARA_TOOL_INPUT`] was truncated.
-pub const RARA_TOOL_INPUT_TRUNCATED: &str = "rara.tool.input.truncated";
-
-/// Sampled tool output JSON (Layer B).
-pub const RARA_TOOL_OUTPUT: &str = "rara.tool.output";
-/// True when [`RARA_TOOL_OUTPUT`] was truncated.
-pub const RARA_TOOL_OUTPUT_TRUNCATED: &str = "rara.tool.output.truncated";
-
 /// Sampled error message chain (Layer B). Always set when sampler decides
 /// "on_error".
 pub const RARA_ERROR_MESSAGE: &str = "rara.error.message";
@@ -179,6 +160,75 @@ pub const TOOL_NAME: &str = "tool.name";
 
 /// Tool execution outcome. One of: `success`, `error`.
 pub const TOOL_OUTCOME: &str = "tool.outcome";
+
+// ---------------------------------------------------------------------------
+// langfuse.* — Langfuse-recognized attributes
+//
+// Langfuse maps these directly into its UI's session/user/environment filters
+// and the trace/observation Input/Output panels. They are NOT in the OTel
+// semconv registry; the canonical reference is the Langfuse OTel docs:
+// https://langfuse.com/docs/opentelemetry/get-started
+// ---------------------------------------------------------------------------
+
+/// Langfuse session id — Langfuse groups traces sharing this value into a
+/// single session view.
+pub const LANGFUSE_SESSION_ID: &str = "langfuse.session.id";
+
+/// Langfuse user id — surfaces in the per-user breakdown.
+pub const LANGFUSE_USER_ID: &str = "langfuse.user.id";
+
+/// Trace-level input (typically the user's prompt for the turn). Rendered in
+/// the Langfuse traces list "Input" column.
+pub const LANGFUSE_TRACE_INPUT: &str = "langfuse.trace.input";
+
+/// Trace-level output (typically the final assistant reply). Rendered in the
+/// Langfuse traces list "Output" column.
+pub const LANGFUSE_TRACE_OUTPUT: &str = "langfuse.trace.output";
+
+/// Deployment environment label (e.g. `"dev"`, `"prod"`). Lets Langfuse
+/// filter / aggregate by environment.
+pub const LANGFUSE_ENVIRONMENT: &str = "langfuse.environment";
+
+/// Observation type. Langfuse-recognized values: `"generation"` for LLM
+/// calls, `"span"` for everything else (tool execution, root agent turn).
+pub const LANGFUSE_OBSERVATION_TYPE: &str = "langfuse.observation.type";
+
+/// Observation type value: an LLM generation. Maps to Langfuse's
+/// `GENERATION` observation, which expects model + usage + input + output.
+pub const OBSERVATION_TYPE_GENERATION: &str = "generation";
+
+/// Observation type value: a generic span (root turn, tool execution, etc.).
+pub const OBSERVATION_TYPE_SPAN: &str = "span";
+
+/// Per-observation input payload. For LLM observations, the serialized
+/// request messages; for tool observations, the call arguments.
+pub const LANGFUSE_OBSERVATION_INPUT: &str = "langfuse.observation.input";
+
+/// Per-observation output payload. For LLM observations, the assistant
+/// response; for tool observations, the tool result JSON.
+pub const LANGFUSE_OBSERVATION_OUTPUT: &str = "langfuse.observation.output";
+
+/// Observation severity level. Langfuse-recognized values include
+/// `DEBUG`, `DEFAULT`, `WARNING`, `ERROR`. Rara only sets this to
+/// [`OBSERVATION_LEVEL_ERROR`] on tool-failure spans; absence implies
+/// `DEFAULT`.
+pub const LANGFUSE_OBSERVATION_LEVEL: &str = "langfuse.observation.level";
+
+/// Observation level value used on errored tool / generation observations.
+pub const OBSERVATION_LEVEL_ERROR: &str = "ERROR";
+
+/// JSON-serialized model parameters (temperature, max_tokens, top_p, …)
+/// attached to LLM generation observations.
+pub const LANGFUSE_OBSERVATION_MODEL_PARAMETERS: &str = "langfuse.observation.model.parameters";
+
+/// JSON-serialized token usage details (e.g.
+/// `{"input": 123, "output": 456}`). Optional — Langfuse already reads
+/// `gen_ai.usage.*` for primary token counts.
+pub const LANGFUSE_OBSERVATION_USAGE_DETAILS: &str = "langfuse.observation.usage_details";
+
+/// JSON-serialized cost details. Optional — populated only when the
+/// provider returns explicit USD costs.
+pub const LANGFUSE_OBSERVATION_COST_DETAILS: &str = "langfuse.observation.cost_details";
 
 // ---------------------------------------------------------------------------
 // Convenience re-exports of upstream GenAI keys most commonly used on spans.
@@ -239,5 +289,45 @@ mod tests {
             GEN_AI_SERVER_TIME_TO_FIRST_TOKEN,
             "gen_ai.server.time_to_first_token"
         );
+    }
+
+    /// Langfuse keys are hardcoded — Langfuse does not publish a semconv
+    /// crate. Renaming any of these silently empties the Langfuse UI panels,
+    /// which is exactly what #2002 fixed; pin the strings.
+    #[test]
+    fn langfuse_keys_have_stable_strings() {
+        assert_eq!(LANGFUSE_SESSION_ID, "langfuse.session.id");
+        assert_eq!(LANGFUSE_USER_ID, "langfuse.user.id");
+        assert_eq!(LANGFUSE_TRACE_INPUT, "langfuse.trace.input");
+        assert_eq!(LANGFUSE_TRACE_OUTPUT, "langfuse.trace.output");
+        assert_eq!(LANGFUSE_ENVIRONMENT, "langfuse.environment");
+        assert_eq!(LANGFUSE_OBSERVATION_TYPE, "langfuse.observation.type");
+        assert_eq!(OBSERVATION_TYPE_GENERATION, "generation");
+        assert_eq!(OBSERVATION_TYPE_SPAN, "span");
+        assert_eq!(LANGFUSE_OBSERVATION_INPUT, "langfuse.observation.input");
+        assert_eq!(LANGFUSE_OBSERVATION_OUTPUT, "langfuse.observation.output");
+        assert_eq!(LANGFUSE_OBSERVATION_LEVEL, "langfuse.observation.level");
+        assert_eq!(OBSERVATION_LEVEL_ERROR, "ERROR");
+        assert_eq!(
+            LANGFUSE_OBSERVATION_MODEL_PARAMETERS,
+            "langfuse.observation.model.parameters"
+        );
+        assert_eq!(
+            LANGFUSE_OBSERVATION_USAGE_DETAILS,
+            "langfuse.observation.usage_details"
+        );
+        assert_eq!(
+            LANGFUSE_OBSERVATION_COST_DETAILS,
+            "langfuse.observation.cost_details"
+        );
+    }
+
+    #[test]
+    fn schema_version_is_bumped_for_langfuse_renames() {
+        // 0.1.0 -> 0.2.0 was the major bump that removed `rara.prompt`,
+        // `rara.completion`, `rara.tool.input`, `rara.tool.output` (plus
+        // their `*.truncated` siblings) in favour of the `langfuse.*`
+        // observation keys. Detectors pin against this value.
+        assert_eq!(SCHEMA_VERSION, "0.2.0");
     }
 }

--- a/crates/common/telemetry/src/payload_sampler.rs
+++ b/crates/common/telemetry/src/payload_sampler.rs
@@ -20,19 +20,40 @@
 //! **off on success, 100% on error**, with a hard `max_chars` truncation so
 //! a runaway tool output cannot blow up trace ingest.
 //!
-//! Configuration lives in YAML (no Rust-side defaults — see crate guidelines):
+//! Configuration is optional in YAML — when omitted the sampler still runs
+//! with safe built-in defaults (the mechanism is default-on; suppressing
+//! payloads requires an explicit `on_error: 0.0`):
 //!
 //! ```yaml
 //! telemetry:
 //!   payload_sampling:
 //!     on_error: 1.0     # sample every error
-//!     on_success: 0.0   # off in prod; 0.05 in dev
-//!     max_chars: 1000   # hard cap per attribute
+//!     on_success: 1.0   # 1.0 needed to populate Langfuse Input/Output
+//!     max_chars: 4000   # hard cap per attribute
 //! ```
 
 use std::sync::atomic::{AtomicU64, Ordering};
 
 use serde::{Deserialize, Serialize};
+
+/// Default per-attribute character cap when no explicit `max_chars` is given.
+///
+/// Tuned so trace ingest stays well under typical OTLP payload limits
+/// (Langfuse ingest tolerates up to a few hundred KB per attribute, but
+/// keeping the cap at 4 KB keeps the UI snappy and protects against
+/// runaway tool outputs). Mechanism-level tuning lives next to the
+/// mechanism per the rara `anti-patterns.md` guideline; not exposed as YAML.
+pub const DEFAULT_MAX_CHARS: usize = 4_000;
+
+/// Default sampling rate on errored operations. Errors are always
+/// interesting; sample every one.
+pub const DEFAULT_ON_ERROR: f64 = 1.0;
+
+/// Default sampling rate on successful operations. The Langfuse UI needs
+/// `langfuse.*.input` / `langfuse.*.output` populated to show the trace
+/// content panel as non-empty (#2002), so the default-on rate is `1.0`.
+/// Operators who want to dial this back set `on_success` explicitly in YAML.
+pub const DEFAULT_ON_SUCCESS: f64 = 1.0;
 
 /// Outcome of the operation being sampled.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -45,18 +66,29 @@ pub enum Outcome {
 
 /// Configuration for the Layer B payload sampler.
 ///
-/// All fields are required in YAML — there is no `Default` impl per the
-/// rara config guideline ("no hardcoded defaults in Rust").
+/// Fields are optional in YAML; when absent the corresponding
+/// `DEFAULT_ON_*` / `DEFAULT_MAX_CHARS` constant from this module is
+/// used. Missing the whole `payload_sampling` block falls back to a
+/// fully default-on sampler — see [`PayloadSampler::from_optional_config`].
 #[derive(Debug, Clone, bon::Builder, Serialize, Deserialize)]
 pub struct PayloadSamplingConfig {
     /// Sampling probability when [`Outcome::Error`] (range `0.0..=1.0`).
-    pub on_error:   f64,
+    /// Defaults to [`DEFAULT_ON_ERROR`] when absent.
+    #[serde(default)]
+    pub on_error:   Option<f64>,
     /// Sampling probability when [`Outcome::Success`] (range `0.0..=1.0`).
-    pub on_success: f64,
-    /// Maximum number of bytes (UTF-8 chars) kept per sampled attribute. Any
-    /// payload longer than this is truncated and the corresponding
-    /// `*.truncated` attribute is set to `true`.
-    pub max_chars:  usize,
+    /// Defaults to [`DEFAULT_ON_SUCCESS`] when absent — the Langfuse UI
+    /// needs the input / output attributes populated to render content,
+    /// so the mechanism is default-on.
+    #[serde(default)]
+    pub on_success: Option<f64>,
+    /// Maximum number of UTF-8 chars kept per sampled attribute. Any
+    /// payload longer than this is truncated; the truncation marker
+    /// `… [truncated]` is appended in-band so reviewers can tell the
+    /// payload was cut.
+    /// Defaults to [`DEFAULT_MAX_CHARS`] when absent.
+    #[serde(default)]
+    pub max_chars:  Option<usize>,
 }
 
 /// Decision about whether to attach Layer B payloads to a span.
@@ -79,29 +111,54 @@ pub enum SamplingDecision {
 /// and error decisions so changing one rate doesn't perturb the other.
 #[derive(Debug)]
 pub struct PayloadSampler {
-    config:        PayloadSamplingConfig,
+    config:        ResolvedConfig,
     success_count: AtomicU64,
     error_count:   AtomicU64,
 }
 
+/// Resolved sampler parameters with all `Option` fields filled in. Internal
+/// only — the public surface remains [`PayloadSamplingConfig`] which keeps
+/// fields optional so YAML can omit them.
+#[derive(Debug, Clone, Copy)]
+struct ResolvedConfig {
+    on_error:   f64,
+    on_success: f64,
+    max_chars:  usize,
+}
+
 impl PayloadSampler {
-    /// Construct a sampler from validated config.
+    /// Construct a sampler from a config block. Missing fields fall back to
+    /// the `DEFAULT_*` constants in this module.
     ///
     /// Probabilities outside `[0.0, 1.0]` are clamped to that range; this is
     /// a defense against typos like `on_error: 100` (meant `1.0`) silently
     /// causing the sampler to never fire.
     #[must_use]
     pub fn new(config: PayloadSamplingConfig) -> Self {
-        let config = PayloadSamplingConfig {
-            on_error:   config.on_error.clamp(0.0, 1.0),
-            on_success: config.on_success.clamp(0.0, 1.0),
-            max_chars:  config.max_chars,
+        let resolved = ResolvedConfig {
+            on_error:   config.on_error.unwrap_or(DEFAULT_ON_ERROR).clamp(0.0, 1.0),
+            on_success: config
+                .on_success
+                .unwrap_or(DEFAULT_ON_SUCCESS)
+                .clamp(0.0, 1.0),
+            max_chars:  config.max_chars.unwrap_or(DEFAULT_MAX_CHARS),
         };
         Self {
-            config,
+            config:        resolved,
             success_count: AtomicU64::new(0),
-            error_count: AtomicU64::new(0),
+            error_count:   AtomicU64::new(0),
         }
+    }
+
+    /// Default-on sampler used when YAML omits the `payload_sampling` block.
+    ///
+    /// Mechanism-level tuning lives next to the mechanism per the rara
+    /// `anti-patterns.md` guideline ("would a deploy operator have a real
+    /// reason to pick a different value?" — for Langfuse trace UI population
+    /// the answer is no, so the defaults are a `const`, not a YAML knob).
+    #[must_use]
+    pub fn from_optional_config(config: Option<PayloadSamplingConfig>) -> Self {
+        Self::new(config.unwrap_or_else(|| PayloadSamplingConfig::builder().build()))
     }
 
     /// Decide whether to attach Layer B payloads for an operation with the
@@ -151,6 +208,29 @@ pub fn truncate(s: &str, max_chars: usize) -> (String, bool) {
     (truncated, true)
 }
 
+/// In-band truncation marker appended to a sampled payload that exceeded
+/// `max_chars`. Set in-band rather than as a separate `*.truncated` boolean
+/// because Langfuse does not recognize bespoke `*.truncated` keys (#2002),
+/// and a reviewer reading the trace JSON or UI needs an obvious cue.
+pub const TRUNCATION_MARKER: &str = " … [truncated]";
+
+/// Truncate `s` to at most `max_chars` UTF-8 characters and, when truncation
+/// occurred, append [`TRUNCATION_MARKER`]. Returned string is always valid
+/// UTF-8 and at most `max_chars + TRUNCATION_MARKER.chars().count()` chars.
+///
+/// This is the helper agent-loop spans should call before writing
+/// `langfuse.observation.input` / `langfuse.observation.output`: Langfuse
+/// reads those keys verbatim, so the marker must live inside the value.
+#[must_use]
+pub fn truncate_with_marker(s: &str, max_chars: usize) -> String {
+    let (out, truncated) = truncate(s, max_chars);
+    if truncated {
+        format!("{out}{TRUNCATION_MARKER}")
+    } else {
+        out
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -169,6 +249,35 @@ mod tests {
         for _ in 0..100 {
             assert_eq!(sampler.decide(Outcome::Success), SamplingDecision::Skip);
         }
+    }
+
+    #[test]
+    fn from_optional_config_none_falls_back_to_defaults_on() {
+        // Mechanism is default-on per #2002 — `None` config must NOT mean
+        // "sampler disabled". Both success and error fire on the first call.
+        let sampler = PayloadSampler::from_optional_config(None);
+        assert!(matches!(
+            sampler.decide(Outcome::Success),
+            SamplingDecision::Record { max_chars }
+                if max_chars == DEFAULT_MAX_CHARS
+        ));
+        assert!(matches!(
+            sampler.decide(Outcome::Error),
+            SamplingDecision::Record { max_chars }
+                if max_chars == DEFAULT_MAX_CHARS
+        ));
+    }
+
+    #[test]
+    fn config_omits_fields_falls_back_to_defaults() {
+        // Operator wrote `payload_sampling: {}` — every field absent.
+        let cfg = PayloadSamplingConfig::builder().build();
+        let sampler = PayloadSampler::new(cfg);
+        assert!(matches!(
+            sampler.decide(Outcome::Success),
+            SamplingDecision::Record { max_chars }
+                if max_chars == DEFAULT_MAX_CHARS
+        ));
     }
 
     #[test]
@@ -233,6 +342,17 @@ mod tests {
         assert!(truncated);
         // No panic, valid UTF-8.
         let _ = out.as_bytes();
+    }
+
+    #[test]
+    fn truncate_with_marker_appends_marker_only_when_cut() {
+        // Short payload — marker MUST NOT appear, otherwise reviewers see
+        // `[truncated]` on every short trace.
+        let short = truncate_with_marker("hi", 10);
+        assert_eq!(short, "hi");
+        // Long payload — marker appended in-band so Langfuse UI shows it.
+        let long = truncate_with_marker("hello world", 5);
+        assert_eq!(long, format!("hello{TRUNCATION_MARKER}"));
     }
 
     #[test]

--- a/crates/kernel/src/agent/mod.rs
+++ b/crates/kernel/src/agent/mod.rs
@@ -1016,6 +1016,16 @@ pub(crate) async fn run_agent_loop(
     // `#[tracing::instrument(fields(...))]`, so the span is built manually
     // and the body runs inside `.instrument(span)` to keep the future
     // `Send`.
+    // The Langfuse UI keys (`langfuse.*`) live alongside the existing
+    // `rara.*` Layer A keys: detector contract is unchanged, but Langfuse
+    // recognises the `langfuse.*` namespace and renders the trace's
+    // session / user / environment / Input / Output columns from these
+    // values (#2002).
+    let langfuse_environment = handle
+        .config()
+        .langfuse_environment
+        .clone()
+        .unwrap_or_else(|| "unknown".to_string());
     let turn_span = info_span!(
         "agent_turn",
         session_key = %session_key,
@@ -1028,6 +1038,12 @@ pub(crate) async fn run_agent_loop(
         "gen_ai.request.model" = tracing::field::Empty,
         "gen_ai.usage.input_tokens" = tracing::field::Empty,
         "gen_ai.usage.output_tokens" = tracing::field::Empty,
+        "langfuse.session.id" = %session_key,
+        "langfuse.user.id" = tool_context.user_id.as_str(),
+        "langfuse.environment" = langfuse_environment.as_str(),
+        "langfuse.observation.type" = common_telemetry::attrs::OBSERVATION_TYPE_SPAN,
+        "langfuse.trace.input" = tracing::field::Empty,
+        "langfuse.trace.output" = tracing::field::Empty,
     );
     use tracing::Instrument as _;
     run_agent_loop_inner(
@@ -1069,6 +1085,23 @@ async fn run_agent_loop_inner(
     interrupted: &AtomicBool,
     interrupt_notify: &tokio::sync::Notify,
 ) -> crate::error::Result<AgentTurnResult> {
+    // Layer B trace input — record the user's prompt on the root agent_turn
+    // span so the Langfuse traces list shows non-empty Input. Sampled +
+    // truncated via the configured PayloadSampler so a multi-MB pasted log
+    // doesn't blow up trace ingest.
+    if let Some(sampler) = handle.config().payload_sampler.as_ref() {
+        if let common_telemetry::payload_sampler::SamplingDecision::Record { max_chars } =
+            sampler.decide(common_telemetry::payload_sampler::Outcome::Success)
+        {
+            let preview =
+                common_telemetry::payload_sampler::truncate_with_marker(&user_text, max_chars);
+            tracing::Span::current().record(
+                common_telemetry::attrs::LANGFUSE_TRACE_INPUT,
+                preview.as_str(),
+            );
+        }
+    }
+
     // Query context via syscalls.
     let manifest = handle.session_manifest(session_key)?;
     let full_tools = handle.session_tool_registry(session_key).await?;
@@ -1573,6 +1606,19 @@ async fn run_agent_loop_inner(
         // LLM call span. Marked as kind=LLM per OpenInference; gen_ai.* fields
         // are populated as the stream progresses (TTFT on first delta, usage on
         // Done). `rara.turn.iteration` lets the detector spot tool-loop runaway.
+        //
+        // Langfuse-recognized keys (`langfuse.observation.*`) sit alongside the
+        // detector-contract keys so the same span renders correctly in the
+        // Langfuse UI without losing detector compatibility.
+        //
+        // Provider name is derived from the resolved override / hint chain;
+        // changing `DriverRegistry::resolve` to return the driver name was a
+        // larger blast radius than #2002 needed, so we approximate with the
+        // hint that was supplied.
+        let llm_provider: &str = provider_override
+            .as_deref()
+            .or(provider_hint)
+            .unwrap_or("default");
         let iter_span = info_span!(
             "llm_iteration",
             iter = iteration,
@@ -1584,10 +1630,15 @@ async fn run_agent_loop_inner(
             "openinference.span.kind" = common_telemetry::attrs::SPAN_KIND_LLM,
             "rara.turn.iteration" = iteration,
             "gen_ai.request.model" = model.as_str(),
+            "gen_ai.system" = llm_provider,
             "gen_ai.server.time_to_first_token" = tracing::field::Empty,
             "gen_ai.usage.input_tokens" = tracing::field::Empty,
             "gen_ai.usage.output_tokens" = tracing::field::Empty,
             "gen_ai.response.finish_reasons" = tracing::field::Empty,
+            "langfuse.observation.type" = common_telemetry::attrs::OBSERVATION_TYPE_GENERATION,
+            "langfuse.observation.input" = tracing::field::Empty,
+            "langfuse.observation.output" = tracing::field::Empty,
+            "langfuse.observation.model.parameters" = tracing::field::Empty,
         );
         let _iter_guard = iter_span.enter();
 
@@ -1637,6 +1688,35 @@ async fn run_agent_loop_inner(
             top_p:               None,
             emit_reasoning:      false,
         };
+
+        // Layer B — sample the request messages onto the LLM span. Langfuse
+        // renders this as the observation's Input panel; without it the
+        // generation observation in the UI shows "(no input)".
+        if let Some(sampler) = handle.config().payload_sampler.as_ref() {
+            if let common_telemetry::payload_sampler::SamplingDecision::Record { max_chars } =
+                sampler.decide(common_telemetry::payload_sampler::Outcome::Success)
+            {
+                let serialized = serde_json::to_string(&request.messages).unwrap_or_default();
+                let preview =
+                    common_telemetry::payload_sampler::truncate_with_marker(&serialized, max_chars);
+                iter_span.record(
+                    common_telemetry::attrs::LANGFUSE_OBSERVATION_INPUT,
+                    preview.as_str(),
+                );
+                // Model parameters — JSON so Langfuse renders them as a
+                // structured panel rather than a flat string.
+                let params = serde_json::json!({
+                    "temperature": request.temperature,
+                    "max_tokens": request.max_tokens,
+                    "frequency_penalty": request.frequency_penalty,
+                    "parallel_tool_calls": request.parallel_tool_calls,
+                });
+                iter_span.record(
+                    common_telemetry::attrs::LANGFUSE_OBSERVATION_MODEL_PARAMETERS,
+                    params.to_string().as_str(),
+                );
+            }
+        }
 
         // Start streaming via LlmDriver
         let (tx, mut rx) = mpsc::channel::<llm::StreamDelta>(128);
@@ -1954,6 +2034,38 @@ async fn run_agent_loop_inner(
 
         iter_span.record("stream_ms", stream_start.elapsed().as_millis() as u64);
         iter_span.record("has_tools", has_tool_calls);
+
+        // Layer B — sample the assistant output onto the LLM span. Combines
+        // visible text with any tool-call summary so the Langfuse UI shows
+        // what the model produced this iteration, even on tool-only turns.
+        if let Some(sampler) = handle.config().payload_sampler.as_ref() {
+            if let common_telemetry::payload_sampler::SamplingDecision::Record { max_chars } =
+                sampler.decide(common_telemetry::payload_sampler::Outcome::Success)
+            {
+                let tool_summary: Vec<serde_json::Value> = pending_tool_calls
+                    .values()
+                    .map(|tc| {
+                        serde_json::json!({
+                            "id": tc.id,
+                            "name": tc.name,
+                            "arguments": tc.arguments_buf,
+                        })
+                    })
+                    .collect();
+                let output = serde_json::json!({
+                    "text": accumulated_text,
+                    "tool_calls": tool_summary,
+                });
+                let preview = common_telemetry::payload_sampler::truncate_with_marker(
+                    &output.to_string(),
+                    max_chars,
+                );
+                iter_span.record(
+                    common_telemetry::attrs::LANGFUSE_OBSERVATION_OUTPUT,
+                    preview.as_str(),
+                );
+            }
+        }
 
         {
             let text_preview: String = accumulated_text.chars().take(500).collect();
@@ -2630,11 +2742,36 @@ async fn run_agent_loop_inner(
                     "tool.name" = name.as_str(),
                     "tool.outcome" = tracing::field::Empty,
                     "rara.tool.error.kind" = tracing::field::Empty,
+                    "langfuse.observation.type" = common_telemetry::attrs::OBSERVATION_TYPE_SPAN,
+                    "langfuse.observation.input" = tracing::field::Empty,
+                    "langfuse.observation.output" = tracing::field::Empty,
+                    "langfuse.observation.level" = tracing::field::Empty,
                 );
+                let payload_sampler = handle.config().payload_sampler.clone();
                 async move {
                     let _guard = tool_span.enter();
                     let tool_start = Instant::now();
                     info!(tool = %name, args = %args, "tool call started");
+
+                    // Record the tool call arguments as the observation's
+                    // Input panel — sampled + truncated so a multi-MB JSON
+                    // does not pollute the trace.
+                    if let Some(sampler) = payload_sampler.as_ref() {
+                        if let common_telemetry::payload_sampler::SamplingDecision::Record {
+                            max_chars,
+                        } =
+                            sampler.decide(common_telemetry::payload_sampler::Outcome::Success)
+                        {
+                            let preview = common_telemetry::payload_sampler::truncate_with_marker(
+                                &args.to_string(),
+                                max_chars,
+                            );
+                            tool_span.record(
+                                common_telemetry::attrs::LANGFUSE_OBSERVATION_INPUT,
+                                preview.as_str(),
+                            );
+                        }
+                    }
 
                     // Runtime permission guard — deny if user cannot use this tool.
                     if let Some(ref user) = user_ref {
@@ -2825,6 +2962,24 @@ async fn run_agent_loop_inner(
                             Ok(result) => {
                                 tool_span.record("success", true);
                                 tool_span.record("tool.outcome", "success");
+                                // Layer B — record the tool result JSON as
+                                // the observation Output panel so reviewers
+                                // see what the tool returned without leaving
+                                // Langfuse.
+                                if let Some(sampler) = payload_sampler.as_ref() {
+                                    if let common_telemetry::payload_sampler::SamplingDecision::Record { max_chars } =
+                                        sampler.decide(common_telemetry::payload_sampler::Outcome::Success)
+                                    {
+                                        let preview = common_telemetry::payload_sampler::truncate_with_marker(
+                                            &result.json.to_string(),
+                                            max_chars,
+                                        );
+                                        tool_span.record(
+                                            common_telemetry::attrs::LANGFUSE_OBSERVATION_OUTPUT,
+                                            preview.as_str(),
+                                        );
+                                    }
+                                }
                                 let dur = tool_start.elapsed().as_millis() as u64;
                                 info!(tool = %name, duration_ms = dur, "tool call succeeded");
                                 guard_pipeline.post_execute(&session_key_for_guard, &name);
@@ -2855,6 +3010,27 @@ async fn run_agent_loop_inner(
                                     "rara.tool.error.kind",
                                     classify_tool_error(&e.to_string()),
                                 );
+                                // Layer B — record the error message as the
+                                // observation Output and bump severity to
+                                // ERROR so Langfuse highlights the row.
+                                tool_span.record(
+                                    common_telemetry::attrs::LANGFUSE_OBSERVATION_LEVEL,
+                                    common_telemetry::attrs::OBSERVATION_LEVEL_ERROR,
+                                );
+                                if let Some(sampler) = payload_sampler.as_ref() {
+                                    if let common_telemetry::payload_sampler::SamplingDecision::Record { max_chars } =
+                                        sampler.decide(common_telemetry::payload_sampler::Outcome::Error)
+                                    {
+                                        let preview = common_telemetry::payload_sampler::truncate_with_marker(
+                                            &e.to_string(),
+                                            max_chars,
+                                        );
+                                        tool_span.record(
+                                            common_telemetry::attrs::LANGFUSE_OBSERVATION_OUTPUT,
+                                            preview.as_str(),
+                                        );
+                                    }
+                                }
                                 warn!(tool = %name, args = %args_snapshot, error = %e, "tool execution failed");
                                 let dur = tool_start.elapsed().as_millis() as u64;
 
@@ -3403,6 +3579,23 @@ async fn run_agent_loop_inner(
     }
 
     tracing::Span::current().record(common_telemetry::attrs::RARA_TURN_OUTCOME, "success");
+    // Layer B trace output — final assistant text on the agent_turn root.
+    // Without this Langfuse renders empty Output in the traces list, even
+    // though Layer A (rara.*) was set correctly.
+    if let Some(sampler) = handle.config().payload_sampler.as_ref() {
+        if let common_telemetry::payload_sampler::SamplingDecision::Record { max_chars } =
+            sampler.decide(common_telemetry::payload_sampler::Outcome::Success)
+        {
+            let preview = common_telemetry::payload_sampler::truncate_with_marker(
+                &last_accumulated_text,
+                max_chars,
+            );
+            tracing::Span::current().record(
+                common_telemetry::attrs::LANGFUSE_TRACE_OUTPUT,
+                preview.as_str(),
+            );
+        }
+    }
     Ok(AgentTurnResult {
         text: last_accumulated_text,
         iterations: actual_iterations,

--- a/crates/kernel/src/agent/mod.rs
+++ b/crates/kernel/src/agent/mod.rs
@@ -1021,11 +1021,12 @@ pub(crate) async fn run_agent_loop(
     // recognises the `langfuse.*` namespace and renders the trace's
     // session / user / environment / Input / Output columns from these
     // values (#2002).
-    let langfuse_environment = handle
-        .config()
-        .langfuse_environment
-        .clone()
-        .unwrap_or_else(|| "unknown".to_string());
+    // `langfuse.environment` is optional trace metadata: when unset we skip
+    // recording the field rather than writing a literal `"unknown"`, so the
+    // Langfuse UI does not show a permanently-empty environment partition.
+    // Contrast with `gen_ai.system` below, which falls back to `"unknown"`
+    // because Langfuse generation observations require it.
+    let langfuse_environment = handle.config().langfuse_environment.clone();
     let turn_span = info_span!(
         "agent_turn",
         session_key = %session_key,
@@ -1040,11 +1041,14 @@ pub(crate) async fn run_agent_loop(
         "gen_ai.usage.output_tokens" = tracing::field::Empty,
         "langfuse.session.id" = %session_key,
         "langfuse.user.id" = tool_context.user_id.as_str(),
-        "langfuse.environment" = langfuse_environment.as_str(),
+        "langfuse.environment" = tracing::field::Empty,
         "langfuse.observation.type" = common_telemetry::attrs::OBSERVATION_TYPE_SPAN,
         "langfuse.trace.input" = tracing::field::Empty,
         "langfuse.trace.output" = tracing::field::Empty,
     );
+    if let Some(env) = langfuse_environment.as_deref() {
+        turn_span.record("langfuse.environment", env);
+    }
     use tracing::Instrument as _;
     run_agent_loop_inner(
         handle,
@@ -1618,7 +1622,7 @@ async fn run_agent_loop_inner(
         let llm_provider: &str = provider_override
             .as_deref()
             .or(provider_hint)
-            .unwrap_or("default");
+            .unwrap_or("unknown");
         let iter_span = info_span!(
             "llm_iteration",
             iter = iteration,

--- a/crates/kernel/src/kernel.rs
+++ b/crates/kernel/src/kernel.rs
@@ -152,6 +152,22 @@ pub struct KernelConfig {
     /// Tool execution hook commands (PreToolUse / PostToolUse /
     /// PostToolUseFailure).
     pub hooks:                   HooksConfig,
+    /// Layer B payload sampler used by `agent::run_agent_loop` to gate
+    /// whether the prompt / completion / tool-input / tool-output payloads
+    /// are recorded on spans (as `langfuse.*.input` / `langfuse.*.output`).
+    ///
+    /// `None` means the agent loop skips payload recording entirely.
+    /// `app/src/lib.rs` populates this from `telemetry.payload_sampling`,
+    /// falling back to a default-on sampler so the Langfuse UI never shows
+    /// blank Input / Output panels (#2002).
+    #[default(_code = "None")]
+    pub payload_sampler:         Option<Arc<common_telemetry::payload_sampler::PayloadSampler>>,
+    /// Deployment environment label (e.g. `"dev"`, `"prod"`) emitted on
+    /// agent_turn spans as `langfuse.environment` so Langfuse can filter
+    /// traces by environment. Reuses
+    /// `telemetry.otlp.deployment_environment` from YAML — no new key.
+    #[default(_code = "None")]
+    pub langfuse_environment:    Option<String>,
 }
 
 /// Shared reference to a


### PR DESCRIPTION
## Summary

Fix the Langfuse OTel integration: trace input/output were rendering empty in the Langfuse UI because rara was emitting only `rara.*` private span keys, which Langfuse does not recognize. This PR adds the Langfuse-recognized `langfuse.*` keys (session, user, environment, observation type, trace input/output, observation input/output, model parameters) alongside the existing `rara.*` and `gen_ai.*` / `openinference.*` keys, so the same span renders correctly without breaking detector compatibility.

Scope:
- `agent_turn` span: add `langfuse.session.id`, `langfuse.user.id`, `langfuse.environment`, `langfuse.observation.type`, `langfuse.trace.input`, `langfuse.trace.output`.
- `llm_iteration` span: add `langfuse.observation.{type,input,output,model.parameters}` + `gen_ai.system`.
- Tool span: add `langfuse.observation.{type,input,output}`.
- Sampler now sees these spans (LLM/tool spans were previously off the Langfuse sampling path).
- Drop 4 unused attribute constants in `common-telemetry`: SCHEMA_VERSION `0.1.0` -> `0.2.0`.

Closes #2002

## Decisions deviating from issue defaults

- `langfuse.environment` reuses `telemetry.otlp.deployment_environment` (fallback `telemetry.env`); no new YAML key.
- `langfuse.environment` is skipped when unset (not written as `"unknown"`).
- `gen_ai.system` falls back to `"unknown"` (not skipped) because Langfuse generation observations require it.
- `gen_ai.system` derives from `provider_override` -> `provider_hint`, not driver name.
- `langfuse.trace.input` is recorded at turn start so it is set even on early-error paths.

## Verification

- `prek run --all-files` green.
- `common-telemetry` 22 unit tests pass.
- `rara-app` 92 unit tests pass.
- Live Langfuse e2e is human-eyes verification post-merge.

## Test plan

- [x] `prek run --all-files`
- [x] `cargo test -p common-telemetry`
- [x] `cargo test -p rara-app`
- [ ] Post-merge Langfuse UI smoke