### PR TITLE
chore(kernel): event-driven wait_for_turn for kernel e2e tests (#2005)

### DIFF
--- a/crates/channels/tests/web_session_smoke.rs
+++ b/crates/channels/tests/web_session_smoke.rs
@@ -308,6 +308,12 @@ async fn session_ws_prompt_reaches_kernel() {
             .expect("ws connect");
     let _ = next_event(&mut ws).await; // hello
 
+    // Subscribe to the per-session event bus *before* sending the prompt so
+    // a fast scripted turn cannot complete before the subscription exists.
+    // Wakeup is then driven by the kernel's `TurnMetrics` event rather than
+    // by wall-clock polling.
+    let waiter = tk.watch_turn(session_key);
+
     let prompt = serde_json::json!({
         "type": "prompt",
         "content": "hello server",
@@ -317,20 +323,15 @@ async fn session_ws_prompt_reaches_kernel() {
         .await
         .expect("send prompt");
 
-    // Wait for the kernel to register a session + complete a turn driven
-    // by this prompt. Polling matches the pattern used in `web_e2e.rs`.
-    let deadline = std::time::Instant::now() + Duration::from_secs(30);
-    let traces = loop {
-        let traces = tk.handle.get_process_turns(session_key);
-        if !traces.is_empty() {
-            break traces;
-        }
-        assert!(
-            std::time::Instant::now() < deadline,
-            "kernel did not record a turn for the prompt within 30s"
-        );
-        tokio::time::sleep(Duration::from_millis(50)).await;
-    };
+    waiter
+        .wait(Duration::from_secs(30))
+        .await
+        .expect("turn metrics");
+    let traces = tk.handle.get_process_turns(session_key);
+    assert!(
+        !traces.is_empty(),
+        "kernel emitted TurnMetrics but recorded no turn"
+    );
     let turn = traces.last().expect("at least one turn");
     assert!(turn.success, "turn should succeed: {:?}", turn.error);
     let preview = turn

--- a/crates/kernel/src/testing.rs
+++ b/crates/kernel/src/testing.rs
@@ -32,8 +32,9 @@ use yunara_store::diesel_pool::{DieselPoolConfig, DieselSqlitePools, build_sqlit
 
 use crate::{
     agent::{AgentManifest, AgentRegistry, AgentRole, ManifestLoader},
+    error::KernelError,
     handle::KernelHandle,
-    identity::{KernelUser, Permission, Role, UserStoreRef},
+    identity::{KernelUser, Lookup, Permission, Principal, Role, UserStoreRef},
     io::{IOSubsystem, StreamEvent},
     kernel::{Kernel, KernelConfig},
     llm::{CompletionResponse, DriverRegistry, LlmDriverRef, ScriptedLlmDriver, StopReason},
@@ -532,6 +533,48 @@ impl TestKernel {
             session_key,
             handle: self.handle.clone(),
         }
+    }
+
+    /// Subscribe to the per-session event bus *and then* spawn a named agent
+    /// keyed by the same [`SessionKey`], returning the key plus a
+    /// [`TurnWaiter`] that observes the next [`StreamEvent::TurnMetrics`].
+    ///
+    /// This is the race-free counterpart to manually calling
+    /// [`KernelHandle::spawn_named`] followed by [`Self::watch_turn`]: a fast
+    /// scripted turn can complete in well under a millisecond, so a
+    /// subscription established *after* the spawn returns may miss the only
+    /// `TurnMetrics` event the kernel emits. Pre-allocating the session key
+    /// lets us subscribe before the agent task is even started, closing the
+    /// window entirely.
+    ///
+    /// ```ignore
+    /// let (session_key, waiter) = tk
+    ///     .spawn_named_watching("test-agent", "ping", Principal::lookup("test"))
+    ///     .await
+    ///     .expect("spawn");
+    /// waiter.wait(Duration::from_secs(30)).await.expect("turn metrics");
+    /// ```
+    pub async fn spawn_named_watching(
+        &self,
+        agent_name: &str,
+        input: impl Into<String>,
+        principal: Principal<Lookup>,
+    ) -> crate::error::Result<(SessionKey, TurnWaiter)> {
+        let manifest =
+            self.handle
+                .agent_registry()
+                .get(agent_name)
+                .ok_or(KernelError::ManifestNotFound {
+                    name: agent_name.to_string(),
+                })?;
+        // Pre-allocate the session key so we can subscribe to its event bus
+        // before the spawn — see the doc comment for the race rationale.
+        let session_key = SessionKey::new();
+        let waiter = self.watch_turn(session_key);
+        self.handle
+            .spawn_with_input(manifest, input.into(), principal, None, Some(session_key))
+            .await?;
+        Ok((session_key, waiter))
     }
 
     /// Seed a pre-built [`JobEntry`](crate::schedule::JobEntry) directly onto

--- a/crates/kernel/src/testing.rs
+++ b/crates/kernel/src/testing.rs
@@ -22,9 +22,11 @@ use std::{
     collections::{HashMap, VecDeque},
     path::{Path, PathBuf},
     sync::{Arc, Mutex, Once, OnceLock},
+    time::Duration,
 };
 
 use async_trait::async_trait;
+use tokio::sync::broadcast;
 use tokio_util::sync::CancellationToken;
 use yunara_store::diesel_pool::{DieselPoolConfig, DieselSqlitePools, build_sqlite_pools};
 
@@ -32,12 +34,12 @@ use crate::{
     agent::{AgentManifest, AgentRegistry, AgentRole, ManifestLoader},
     handle::KernelHandle,
     identity::{KernelUser, Permission, Role, UserStoreRef},
-    io::IOSubsystem,
+    io::{IOSubsystem, StreamEvent},
     kernel::{Kernel, KernelConfig},
     llm::{CompletionResponse, DriverRegistry, LlmDriverRef, ScriptedLlmDriver, StopReason},
     memory::{FileTapeStore, TapeService},
     security::{ApprovalManager, ApprovalPolicy, SecuritySubsystem},
-    session::test_utils::InMemorySessionIndex,
+    session::{SessionKey, test_utils::InMemorySessionIndex},
     tool::{AgentTool, AgentToolRef, ToolContext, ToolOutput, ToolRegistry},
 };
 
@@ -497,6 +499,41 @@ impl TestKernel {
     /// Shut down the kernel gracefully.
     pub fn shutdown(&self) { self.cancel_token.cancel(); }
 
+    /// Subscribe to the per-session event bus *before* a prompt is sent and
+    /// return a [`TurnWaiter`] that resolves when the next
+    /// [`StreamEvent::TurnMetrics`] arrives.
+    ///
+    /// Call this **before** spawning the agent / sending the prompt — a fast
+    /// scripted turn can complete in well under a second, and a subscription
+    /// established after the prompt would miss the only `TurnMetrics` the
+    /// kernel emits. The intended call shape is:
+    ///
+    /// ```ignore
+    /// let waiter = tk.watch_turn(session_key);
+    /// // send prompt / spawn agent here ...
+    /// waiter.wait(Duration::from_secs(30)).await.expect("turn metrics");
+    /// ```
+    ///
+    /// `TurnMetrics` drives the wakeup; the helper then performs a short
+    /// bounded check that the per-session process-turn trace has actually
+    /// been pushed to the process table. The kernel emits `TurnMetrics`
+    /// from the agent task and pushes the trace from the kernel event-loop
+    /// task that handles `TurnCompleted`, so the two are sequenced but live
+    /// in separate task chains and the trace can lag the metrics by a
+    /// scheduler hop. This bridges that gap without falling back to
+    /// wall-clock-only polling.
+    pub fn watch_turn(&self, session_key: SessionKey) -> TurnWaiter {
+        let rx = self
+            .handle
+            .stream_hub()
+            .subscribe_session_events(&session_key);
+        TurnWaiter {
+            rx,
+            session_key,
+            handle: self.handle.clone(),
+        }
+    }
+
     /// Seed a pre-built [`JobEntry`](crate::schedule::JobEntry) directly onto
     /// the wheel, bypassing the `RegisterJob` syscall path.
     ///
@@ -507,6 +544,72 @@ impl TestKernel {
     /// deliberately named to warn off in-crate callers.
     pub fn seed_job(&self, entry: crate::schedule::JobEntry) {
         self.handle.__seed_job_unsafe_test_harness(entry);
+    }
+}
+
+/// Handle returned by [`TestKernel::watch_turn`] that awaits the next
+/// turn-complete event on a per-session event subscription established
+/// before the prompt was sent.
+///
+/// The subscription lives in the receiver, so the bus retains events until
+/// [`Self::wait`] is called even if the turn completes immediately after
+/// the prompt is dispatched.
+pub struct TurnWaiter {
+    rx:          broadcast::Receiver<StreamEvent>,
+    session_key: SessionKey,
+    handle:      KernelHandle,
+}
+
+impl TurnWaiter {
+    /// Block until the next turn for this session has completed and its
+    /// turn trace is observable via [`KernelHandle::get_process_turns`],
+    /// or `timeout` elapses.
+    ///
+    /// Wakeup is driven by [`StreamEvent::TurnMetrics`] on the per-session
+    /// event bus — that event fires once per turn just before the agent
+    /// task closes its stream. The kernel then dispatches a `TurnCompleted`
+    /// event which the kernel event-loop task handles by calling
+    /// `push_turn_trace`. Because those two steps live in separate tasks,
+    /// after the metrics wakeup we yield and re-check `get_process_turns`
+    /// on a short fixed interval, all bounded by the same `timeout`.
+    ///
+    /// The timeout is a safety bound — on a healthy turn the function
+    /// returns as soon as the trace lands (typically within one scheduler
+    /// hop of the metrics event), not when the deadline fires.
+    pub async fn wait(mut self, timeout: Duration) -> std::result::Result<(), String> {
+        tokio::time::timeout(timeout, async {
+            // Phase 1: wait for the turn-complete event.
+            loop {
+                match self.rx.recv().await {
+                    Ok(StreamEvent::TurnMetrics { .. }) => break,
+                    Ok(_) => continue,
+                    Err(broadcast::error::RecvError::Lagged(_)) => continue,
+                    Err(broadcast::error::RecvError::Closed) => {
+                        return Err(format!(
+                            "session event bus for {} closed before TurnMetrics arrived",
+                            self.session_key
+                        ));
+                    }
+                }
+            }
+
+            // Phase 2: bridge the cross-task gap until the trace lands in
+            // the process table. The first yield is usually enough; the
+            // 5 ms cadence is just a backstop for runners under heavy load.
+            loop {
+                if !self.handle.get_process_turns(self.session_key).is_empty() {
+                    return Ok(());
+                }
+                tokio::time::sleep(Duration::from_millis(5)).await;
+            }
+        })
+        .await
+        .map_err(|_| {
+            format!(
+                "timed out after {:?} waiting for turn trace on session {}",
+                timeout, self.session_key
+            )
+        })?
     }
 }
 

--- a/crates/kernel/tests/e2e_contract_lane2_scripted.rs
+++ b/crates/kernel/tests/e2e_contract_lane2_scripted.rs
@@ -27,11 +27,7 @@
 //!
 //! Companion to `e2e_contract_lane1_no_llm.rs` (lane 1, no LLM).
 
-use std::{
-    path::PathBuf,
-    sync::Once,
-    time::{Duration, Instant},
-};
+use std::{path::PathBuf, sync::Once, time::Duration};
 
 use rara_kernel::{
     identity::Principal,
@@ -85,21 +81,15 @@ async fn lane2_scripted_single_turn_records_expected_trace() {
         .await
         .expect("spawn agent");
 
-    // Wait for the agent loop to record a turn. Polling matches the
-    // pattern used by other kernel-DI e2e tests (e.g.
-    // `web_session_smoke::session_ws_prompt_reaches_kernel`).
-    let deadline = Instant::now() + Duration::from_secs(30);
-    let traces = loop {
-        let traces = tk.handle.get_process_turns(session_key);
-        if !traces.is_empty() {
-            break traces;
-        }
-        assert!(
-            Instant::now() < deadline,
-            "kernel did not record a turn within 30s"
-        );
-        tokio::time::sleep(Duration::from_millis(50)).await;
-    };
+    // Wait for the agent loop to record a turn via the per-session event
+    // bus rather than wall-clock polling — the kernel emits `TurnMetrics`
+    // immediately before pushing the turn trace, so on return the trace
+    // table is guaranteed populated.
+    tk.watch_turn(session_key)
+        .wait(Duration::from_secs(30))
+        .await
+        .expect("turn metrics");
+    let traces = tk.handle.get_process_turns(session_key);
 
     assert_eq!(traces.len(), 1, "expected exactly one recorded turn");
     let turn = &traces[0];

--- a/crates/kernel/tests/e2e_contract_lane2_scripted.rs
+++ b/crates/kernel/tests/e2e_contract_lane2_scripted.rs
@@ -71,13 +71,13 @@ async fn lane2_scripted_single_turn_records_expected_trace() {
         .build()
         .await;
 
-    // `spawn_named` posts a `SpawnAgent` event to the kernel's queue and
-    // awaits the resulting session key — the tightest single-turn entry
-    // point that reaches the LLM driver.
+    // `spawn_named_watching` pre-allocates the session key, subscribes to
+    // its event bus, *then* posts the `SpawnAgent` event — closing the race
+    // window where a fast scripted turn could emit `TurnMetrics` before a
+    // post-spawn subscription was established.
     let principal = Principal::lookup("test");
-    let session_key = tk
-        .handle
-        .spawn_named("test-agent", "ping".to_string(), principal, None)
+    let (session_key, waiter) = tk
+        .spawn_named_watching("test-agent", "ping", principal)
         .await
         .expect("spawn agent");
 
@@ -85,7 +85,7 @@ async fn lane2_scripted_single_turn_records_expected_trace() {
     // bus rather than wall-clock polling — the kernel emits `TurnMetrics`
     // immediately before pushing the turn trace, so on return the trace
     // table is guaranteed populated.
-    tk.watch_turn(session_key)
+    waiter
         .wait(Duration::from_secs(30))
         .await
         .expect("turn metrics");

--- a/crates/kernel/tests/whitespace_intermediate_tape_e2e.rs
+++ b/crates/kernel/tests/whitespace_intermediate_tape_e2e.rs
@@ -27,10 +27,7 @@
 //! `Message` row with whitespace-only `content` for the affected turn.
 //! The cascade-tick boundary is preserved through the `ToolCall` row.
 
-use std::{
-    sync::OnceLock,
-    time::{Duration, Instant},
-};
+use std::{sync::OnceLock, time::Duration};
 
 use rara_kernel::{
     identity::Principal,
@@ -141,19 +138,15 @@ async fn whitespace_intermediate_iteration_does_not_pollute_tape() {
         .await
         .expect("spawn agent");
 
-    // Wait for the turn to record so we know the agent loop has finished.
-    let deadline = Instant::now() + Duration::from_secs(30);
-    loop {
-        let traces = tk.handle.get_process_turns(session_key);
-        if !traces.is_empty() {
-            break;
-        }
-        assert!(
-            Instant::now() < deadline,
-            "kernel did not record a turn within 30s"
-        );
-        tokio::time::sleep(Duration::from_millis(50)).await;
-    }
+    // Subscribe to the session event bus immediately after spawn (before the
+    // agent loop has reached the LLM call) and await `TurnMetrics`. This is
+    // the event-driven replacement for the deadline+sleep poll: wakeup is
+    // driven by the kernel emitting the turn-complete event; the timeout is
+    // a safety bound that should never fire on a healthy turn.
+    tk.watch_turn(session_key)
+        .wait(Duration::from_secs(30))
+        .await
+        .expect("turn metrics");
 
     // Read the tape directly via the kernel's exposed TapeService.
     let tape_name = session_key.to_string();

--- a/crates/kernel/tests/whitespace_intermediate_tape_e2e.rs
+++ b/crates/kernel/tests/whitespace_intermediate_tape_e2e.rs
@@ -131,19 +131,18 @@ async fn whitespace_intermediate_iteration_does_not_pollute_tape() {
         .build()
         .await;
 
+    // `spawn_named_watching` pre-allocates the session key and subscribes to
+    // its event bus *before* the kernel starts the agent task — so even a
+    // turn that completes in microseconds cannot emit `TurnMetrics` before
+    // the receiver exists. Wakeup is driven by the kernel emitting the
+    // turn-complete event; the timeout is a safety bound.
     let principal = Principal::lookup("test");
-    let session_key = tk
-        .handle
-        .spawn_named("test-agent", "ping".to_string(), principal, None)
+    let (session_key, waiter) = tk
+        .spawn_named_watching("test-agent", "ping", principal)
         .await
         .expect("spawn agent");
 
-    // Subscribe to the session event bus immediately after spawn (before the
-    // agent loop has reached the LLM call) and await `TurnMetrics`. This is
-    // the event-driven replacement for the deadline+sleep poll: wakeup is
-    // driven by the kernel emitting the turn-complete event; the timeout is
-    // a safety bound that should never fire on a healthy turn.
-    tk.watch_turn(session_key)
+    waiter
         .wait(Duration::from_secs(30))
         .await
         .expect("turn metrics");


### PR DESCRIPTION
## Summary

Replaces deadline+sleep polling in two kernel e2e tests with event-driven waits on the per-session `TurnMetrics` stream, plus a race-free helper that subscribes before spawn.

Spec: `specs/issue-2005-event-driven-test-wait.spec.md`. Closes #2005.

## Changes

Two commits on this branch:

1. `5156d34f` — initial implementation: add `TestKernel::watch_turn(session_key) -> TurnWaiter`. `TurnWaiter::wait(timeout)` blocks on `StreamEvent::TurnMetrics` for that session, then yields until `get_process_turns` is non-empty (the metrics event and the trace push live on separate kernel tasks). Migrates `e2e_contract_lane2_scripted`, `whitespace_intermediate_tape_e2e`, and `channels::web_session_smoke` off the old `loop { sleep; check } until deadline` pattern.

2. `07cac84c` — reviewer P2 fix: the two kernel-crate call sites subscribed *after* `spawn_named` returned, leaving a microsecond-level race window for fast scripted turns. Added `TestKernel::spawn_named_watching` which pre-allocates a `SessionKey`, subscribes via `watch_turn`, then calls `spawn_with_input(..., desired_session_key = Some(key))` — the kernel honors the desired key, so the subscriber is guaranteed to exist before any agent task starts. `web_session_smoke` was already race-free (it allocates the session key client-side via `SessionKey::new()`) and was left untouched.

## Test plan

- [x] `cargo test -p rara-kernel --test e2e_contract_lane2_scripted --test whitespace_intermediate_tape_e2e` — 5 consecutive runs, 5/5 green
- [x] `prek run --all-files` — clean (cargo check / fmt / clippy / doc / AGENT.md / web lint-staged)
- [ ] CI green on this PR