### PR TITLE
chore(ci): configure mold linker via .cargo/config.toml on Linux (#2009)

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,18 @@
+# Cargo configuration. This file is the single source of truth for
+# rustflags so that future linker/lint flag additions don't get silently
+# dropped by an env-level `RUSTFLAGS` override (cargo replaces, never
+# merges, when env `RUSTFLAGS` is set). See issue #2009.
+#
+# Any future RUSTFLAGS additions go here, NOT in `.github/workflows/*.yml`
+# `env:` blocks.
+
+# Linux CI runners (`arc-runner-set`) have `mold` baked into the image
+# (#1942) but rustc was never told to use it — so every link step fell
+# back to GNU ld. This stanza closes that gap.
+#
+# Target-scoped: macOS dev machines see no change (mold doesn't run on
+# Darwin). `linker = "clang"` is the canonical mold invocation per
+# mold's README and matches tokio / bevy / helix configs.
+[target.x86_64-unknown-linux-gnu]
+linker = "clang"
+rustflags = ["-C", "link-arg=-fuse-ld=mold", "-D", "warnings"]

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -9,7 +9,10 @@ concurrency:
 
 env:
   CARGO_TERM_COLOR: always
-  RUSTFLAGS: -Dwarnings
+  # RUSTFLAGS intentionally unset here — `.cargo/config.toml` is the single
+  # source of truth (it carries `-D warnings` plus the mold linker flag).
+  # Setting env `RUSTFLAGS` would replace (not merge) the config.toml
+  # rustflags array, silently dropping `-fuse-ld=mold`. See #2009.
   RUST_BACKTRACE: true
   CARGO_INCREMENTAL: false
   CARGO_NET_RETRY: 10
@@ -49,6 +52,18 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends libsqlite3-dev libpq-dev
+
+      # TEMPORARY (#2009): pre-flight check that `clang` + `mold` exist on
+      # the arc-runner image before we rely on `linker = "clang"` and
+      # `-fuse-ld=mold` in `.cargo/config.toml`. Drop this step once the
+      # initial CI run on this PR confirms both binaries are present.
+      - name: Pre-flight — verify clang and mold are on PATH
+        run: |
+          set -euxo pipefail
+          command -v clang
+          clang --version
+          command -v mold
+          mold --version
 
       - name: Run clippy
         run: cargo clippy --workspace --all-targets --no-deps -- -D warnings

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -53,18 +53,6 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends libsqlite3-dev libpq-dev
 
-      # TEMPORARY (#2009): pre-flight check that `clang` + `mold` exist on
-      # the arc-runner image before we rely on `linker = "clang"` and
-      # `-fuse-ld=mold` in `.cargo/config.toml`. Drop this step once the
-      # initial CI run on this PR confirms both binaries are present.
-      - name: Pre-flight — verify clang and mold are on PATH
-        run: |
-          set -euxo pipefail
-          command -v clang
-          clang --version
-          command -v mold
-          mold --version
-
       - name: Run clippy
         run: cargo clippy --workspace --all-targets --no-deps -- -D warnings
 

--- a/.gitignore
+++ b/.gitignore
@@ -63,7 +63,9 @@ site/.astro/
 # Local git worktrees (in-repo)
 .worktrees/
 
-.cargo/
+.cargo/*
+# Track the project-wide cargo config (linker flags, target stanzas) — see #2009
+!.cargo/config.toml
 
 # Node (Playwright screenshot script)
 node_modules/


### PR DESCRIPTION
## Summary

Wires rustc to actually use mold on the Linux ARC runner. Closes #2009.

This is the third (and final) move in a chain:
- PR #1769 added `setup-mold` action to install mold on each CI run
- PR #1942 dropped that action because the runner image now bakes mold
- **This PR** finally tells rustc to invoke it via `.cargo/config.toml` `[target.x86_64-unknown-linux-gnu]` stanza

Without this PR mold was installed but unused — `RUSTFLAGS: -Dwarnings` env in `rust.yml` was overriding `.cargo/config.toml` rustflags entirely (cargo: env wins, no merge), the same trap PR #1769/#1942 walked through.

The fix folds `-D warnings` into the rustflags array and removes the env override, making `.cargo/config.toml` the single source of truth.

## Pre-flight verification

A temporary debug step in the clippy job runs `clang --version && mold --version` to surface the actual ARC runner toolchain. Will be dropped in a follow-up commit on this branch once we have one CI run's output. If clang is absent, switch to `linker = "cc"`.

## Test plan

- [x] macOS local `cargo check --workspace --all-targets` — green (target-scoped stanza)
- [x] `prek run --all-files` — green
- [x] No other `RUSTFLAGS:` env override in any workflow file (swept)
- [ ] CI Linux clippy job pre-flight step surfaces clang+mold versions
- [ ] After successful pre-flight, follow-up commit drops the debug step
- [ ] Before/after `Rust / Test` duration delta posted in this PR after pre-flight settles

Closes #2009