### PR TITLE
fix(kernel): write session/start anchor in handle_spawn_agent (#2011)

### DIFF
--- a/crates/kernel/src/kernel.rs
+++ b/crates/kernel/src/kernel.rs
@@ -965,6 +965,16 @@ impl Kernel {
             "process spawned via event loop"
         );
 
+        // Write the `session/start` anchor before any tape entry so every
+        // session has a checkout-able boundary at creation time. Idempotent:
+        // re-spawn (e.g. Mita) skips if an anchor already exists. Logged but
+        // not fatal — losing the anchor degrades checkout, but a missing
+        // anchor must not abort the spawn itself.
+        let tape_name = session_key.to_string();
+        if let Err(e) = self.tape_service.ensure_bootstrap_anchor(&tape_name).await {
+            error!(error = %e, %session_key, "failed to write session/start anchor");
+        }
+
         // Deliver the initial input to the spawned process.
         // The synthetic UserMessage uses session_key so that
         // handle_user_message finds this process via direct table lookup.
@@ -1880,12 +1890,9 @@ impl Kernel {
         if !self.process_table.contains(&session_key) {
             info!("Mita session not found, bootstrapping");
 
-            // Ensure tape exists with a bootstrap anchor.
-            let tape_name = session_key.to_string();
-            if let Err(e) = self.tape_service.ensure_bootstrap_anchor(&tape_name).await {
-                error!(error = %e, "failed to bootstrap Mita tape");
-                return;
-            }
+            // Tape bootstrap (`session/start` anchor) now happens inside
+            // `handle_spawn_agent`, so the heartbeat path no longer needs
+            // to call `ensure_bootstrap_anchor` directly.
 
             let manifest = match self.agent_registry.get("mita") {
                 Some(m) => m,


### PR DESCRIPTION
## Summary

Move the `ensure_bootstrap_anchor` call from `handle_mita_heartbeat` into `handle_spawn_agent` so every new session bootstraps its `session/start` anchor at session-creation time. Fixes the persistent red `anchor_checkout_e2e::anchor_checkout_roundtrip` failure in `e2e.yml` (only 2/8 recent runs were green) — the app-level test goes through `spawn_named` → `handle_spawn_agent`, which previously skipped the bootstrap and left the tape anchor-less, causing checkout to fail with `anchors found: 0`.

## Type of change

`bug`

## Component

`core` (kernel crate)

## Closes

Closes #2011

## Changes

- `crates/kernel/src/kernel.rs::handle_spawn_agent` — call `ensure_bootstrap_anchor` after the new session/tape is created.
- `crates/kernel/src/kernel.rs::handle_mita_heartbeat` — remove the now-redundant bootstrap call (heartbeat path also flows through spawn).

Diff is 13 insertions / 6 deletions in a single file.

## Test plan

- [x] `cargo check --workspace --all-targets`
- [x] `cargo +nightly fmt --all`
- [x] `cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings`
- [x] `prek run --all-files`
- [x] Reviewer pre-push pass: zero P0/P1/P2/P3 findings
- [ ] CI green — most importantly `e2e.yml` Real-LLM E2E (this is the verification the issue calls for; cannot be reproduced locally without LLM credentials)

## Verification target

The bug only reproduces under the real-LLM E2E lane (`e2e.yml::anchor_checkout_roundtrip`). Local `cargo test -p rara-app --test anchor_checkout_e2e` requires LLM credentials and is intentionally gated to that workflow. CI on this PR is the verification surface.