### PR TITLE
fix(backend-admin): route chat-model lister/embedder through DriverRegistry (#2014)

### DIFF
--- a/crates/app/src/boot.rs
+++ b/crates/app/src/boot.rs
@@ -266,45 +266,21 @@ pub(crate) async fn boot(
 
     let agent_registry = Arc::new(load_default_registry(title_gen_max_output_chars));
 
-    // -- default provider model lister / embedder ----------------------------
+    // -- runtime model lister / embedder -------------------------------------
     //
-    // OAuth-based providers (kimi-code, codex) don't have base_url/api_key in
-    // settings — they resolve credentials dynamically.  Build the appropriate
-    // OpenAiDriver variant so model listing and embedding work end-to-end.
+    // Both refs route through `DriverRegistry` so a settings-driven switch
+    // of `llm.default_provider` (PATCH /api/v1/settings) takes effect on
+    // the next call without a process restart. The registry already owns
+    // a per-provider `OpenAiDriver` for every configured provider (see
+    // `build_driver_registry`), and that builder also registers each one
+    // as the lister + embedder for its provider name. Issue #2014.
 
-    let default_provider = {
-        use rara_domain_shared::settings::keys;
-        settings_provider
-            .get_first(&[keys::LLM_DEFAULT_PROVIDER, keys::LLM_PROVIDER])
-            .await
-            .unwrap_or_else(|| "openrouter".to_owned())
-    };
-    let default_driver: Arc<rara_kernel::llm::OpenAiDriver> = match default_provider.as_str() {
-        "kimi-code" => Arc::new(rara_kernel::llm::OpenAiDriver::with_credential_resolver(
-            Arc::new(rara_kimi_oauth::KimiCredentialResolver),
-            rara_kernel::llm::OpenAiDriver::DEFAULT_SSE_IDLE_TIMEOUT,
-        )),
-        "codex" => Arc::new(rara_kernel::llm::OpenAiDriver::with_credential_resolver(
-            Arc::new(rara_codex_oauth::CodexCredentialResolver),
-            rara_kernel::llm::OpenAiDriver::DEFAULT_SSE_IDLE_TIMEOUT,
-        )),
-        _ => {
-            let base_url_key = format!("llm.providers.{default_provider}.base_url");
-            let no_proxy = settings_provider
-                .get(&base_url_key)
-                .await
-                .as_deref()
-                .map_or(false, rara_kernel::llm::is_local_url);
-            Arc::new(rara_kernel::llm::OpenAiDriver::from_settings(
-                settings_provider.clone(),
-                &default_provider,
-                rara_kernel::llm::OpenAiDriver::DEFAULT_SSE_IDLE_TIMEOUT,
-                no_proxy,
-            ))
-        }
-    };
-    let model_lister: rara_kernel::llm::LlmModelListerRef = default_driver.clone();
-    let embedder: rara_kernel::llm::LlmEmbedderRef = default_driver;
+    let model_lister: rara_kernel::llm::LlmModelListerRef = Arc::new(
+        rara_kernel::llm::RuntimeModelLister::new(driver_registry.clone()),
+    );
+    let embedder: rara_kernel::llm::LlmEmbedderRef = Arc::new(
+        rara_kernel::llm::RuntimeEmbedder::new(driver_registry.clone()),
+    );
 
     // -- knowledge layer ------------------------------------------------------
 
@@ -378,15 +354,20 @@ async fn build_driver_registry(
             let no_proxy = all_settings
                 .get(&base_url_key)
                 .map_or(false, |url| rara_kernel::llm::is_local_url(url));
-            registry.register_driver(
+            let oa = Arc::new(OpenAiDriver::from_settings(
+                settings.clone(),
                 name,
-                Arc::new(OpenAiDriver::from_settings(
-                    settings.clone(),
-                    name,
-                    OpenAiDriver::DEFAULT_SSE_IDLE_TIMEOUT,
-                    no_proxy,
-                )),
-            );
+                OpenAiDriver::DEFAULT_SSE_IDLE_TIMEOUT,
+                no_proxy,
+            ));
+            registry.register_driver(name, oa.clone());
+            // The same `OpenAiDriver` instance services the chat-model
+            // catalog and the knowledge-layer embedder; registering it
+            // under the provider name lets `RuntimeModelLister` /
+            // `RuntimeEmbedder` swap providers in lock-step with
+            // `default_driver` (issue #2014).
+            registry.register_lister(name, oa.clone());
+            registry.register_embedder(name, oa);
         }
 
         // Model config applies to ALL providers including kimi-code.
@@ -525,6 +506,16 @@ async fn build_driver_registry(
                     rara_codex_oauth::CodexCredentialResolver,
                 ))),
             );
+            // CodexDriver does not implement `LlmModelLister`/`LlmEmbedder`,
+            // so register a sibling OpenAiDriver with the same credential
+            // resolver to service `/models` and `/embeddings` whenever
+            // `codex` is the active provider (#2014).
+            let codex_oa = Arc::new(OpenAiDriver::with_credential_resolver(
+                Arc::new(rara_codex_oauth::CodexCredentialResolver),
+                OpenAiDriver::DEFAULT_SSE_IDLE_TIMEOUT,
+            ));
+            registry.register_lister("codex", codex_oa.clone());
+            registry.register_embedder("codex", codex_oa);
         }
         Ok(None) => {} // No tokens configured — skip
         Err(e) => tracing::warn!("failed to load codex OAuth tokens: {e}"),
@@ -540,6 +531,16 @@ async fn build_driver_registry(
                     rara_kimi_oauth::KimiCredentialResolver,
                 ))),
             );
+            // KimiCodeDriver does not implement `LlmModelLister`/`LlmEmbedder`;
+            // register an OpenAiDriver sibling with the OAuth resolver so
+            // the chat-model catalog and embeddings keep working when
+            // `kimi-code` is the active provider (#2014).
+            let kimi_oa = Arc::new(OpenAiDriver::with_credential_resolver(
+                Arc::new(rara_kimi_oauth::KimiCredentialResolver),
+                OpenAiDriver::DEFAULT_SSE_IDLE_TIMEOUT,
+            ));
+            registry.register_lister("kimi-code", kimi_oa.clone());
+            registry.register_embedder("kimi-code", kimi_oa);
             info!("kimi-code driver registered (OAuth tokens found)");
         }
         Ok(None) => {

--- a/crates/app/src/lib.rs
+++ b/crates/app/src/lib.rs
@@ -722,6 +722,7 @@ pub async fn start_with_options(
         settings_svc.clone(),
         rara.model_lister.clone(),
         feed_router_state,
+        rara.driver_registry.clone(),
     )
     .await
     .whatever_context("Failed to initialize BackendState")?;

--- a/crates/extensions/backend-admin/src/chat/model_catalog.rs
+++ b/crates/extensions/backend-admin/src/chat/model_catalog.rs
@@ -173,6 +173,24 @@ impl ModelCatalog {
         }
     }
 
+    /// Drop the cached model list so the next [`Self::list_models`]
+    /// performs a fresh fetch.
+    ///
+    /// Called from the `PATCH /api/v1/settings` handler when
+    /// `llm.default_provider` changes. Without this, the 5-minute
+    /// `CACHE_TTL` would keep serving the previous provider's catalog
+    /// even after the runtime lister has switched (issue #2014). The
+    /// TTL is preserved verbatim for the no-change case so the upstream
+    /// provider's `/models` endpoint is still spared per-request hits.
+    pub async fn invalidate(&self) {
+        let mut guard = self.cache.lock().await;
+        *guard = None;
+    }
+
+    /// Test helper: report whether the cache currently holds an entry.
+    #[cfg(test)]
+    pub(crate) async fn has_cached_entry(&self) -> bool { self.cache.lock().await.is_some() }
+
     /// Look up a model's context length from the curated list.
     ///
     /// Returns `None` if the model is not in the curated list. Callers
@@ -278,4 +296,133 @@ fn apply_favorite_sort(models: &mut [ChatModel]) {
             .cmp(&a.is_favorite)
             .then_with(|| a.name.to_lowercase().cmp(&b.name.to_lowercase()))
     });
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    };
+
+    use async_trait::async_trait;
+    use rara_kernel::llm::{
+        DriverRegistry, LlmModelLister, LlmModelListerRef, ModelInfo, OpenRouterCatalog,
+        RuntimeModelLister,
+    };
+
+    use super::ModelCatalog;
+
+    /// Test lister that returns a configurable list and counts calls.
+    struct CountingLister {
+        models: Vec<&'static str>,
+        calls:  AtomicUsize,
+    }
+
+    impl CountingLister {
+        fn new(models: Vec<&'static str>) -> Self {
+            Self {
+                models,
+                calls: AtomicUsize::new(0),
+            }
+        }
+
+        fn call_count(&self) -> usize { self.calls.load(Ordering::SeqCst) }
+    }
+
+    #[async_trait]
+    impl LlmModelLister for CountingLister {
+        async fn list_models(&self) -> rara_kernel::error::Result<Vec<ModelInfo>> {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            Ok(self
+                .models
+                .iter()
+                .map(|id| ModelInfo {
+                    id:       (*id).to_owned(),
+                    owned_by: String::new(),
+                    created:  None,
+                })
+                .collect())
+        }
+    }
+
+    fn registry_with(default: &str) -> Arc<DriverRegistry> {
+        Arc::new(DriverRegistry::new(
+            default,
+            Arc::new(OpenRouterCatalog::new()),
+        ))
+    }
+
+    /// Spec: `switching_default_provider_returns_new_catalog` — after a
+    /// `set_default_driver` + `invalidate` the next `list_models` reflects
+    /// the new provider's catalog.
+    #[tokio::test]
+    async fn switching_default_provider_returns_new_catalog() {
+        let registry = registry_with("provider_a");
+
+        let lister_a: Arc<CountingLister> = Arc::new(CountingLister::new(vec!["model-a-1"]));
+        let lister_b: Arc<CountingLister> = Arc::new(CountingLister::new(vec!["model-b-1"]));
+        registry.register_lister("provider_a", lister_a.clone() as LlmModelListerRef);
+        registry.register_lister("provider_b", lister_b.clone() as LlmModelListerRef);
+
+        let runtime_lister: LlmModelListerRef = Arc::new(RuntimeModelLister::new(registry.clone()));
+        let catalog = ModelCatalog::new(runtime_lister);
+
+        // First fetch — default is provider_a.
+        let first = catalog.list_models(&[]).await;
+        let first_ids: Vec<String> = first.into_iter().map(|m| m.id).collect();
+        assert!(
+            first_ids.contains(&"model-a-1".to_string()),
+            "first fetch must contain provider_a's model, got: {first_ids:?}"
+        );
+        assert!(
+            !first_ids.contains(&"model-b-1".to_string()),
+            "first fetch must not contain provider_b's model"
+        );
+
+        // Switch the default and invalidate the catalog cache to mirror
+        // what the settings PATCH path will do.
+        registry.set_default_driver("provider_b");
+        catalog.invalidate().await;
+
+        let second = catalog.list_models(&[]).await;
+        let second_ids: Vec<String> = second.into_iter().map(|m| m.id).collect();
+        assert!(
+            second_ids.contains(&"model-b-1".to_string()),
+            "after switch, fetch must contain provider_b's model, got: {second_ids:?}"
+        );
+        assert!(
+            !second_ids.contains(&"model-a-1".to_string()),
+            "after switch, fetch must NOT contain provider_a's model (stale cache regression), \
+             got: {second_ids:?}"
+        );
+        assert_eq!(lister_a.call_count(), 1, "provider_a fetched once");
+        assert_eq!(lister_b.call_count(), 1, "provider_b fetched once");
+    }
+
+    /// Spec: `ttl_still_caches_when_provider_unchanged` — the cache TTL
+    /// is preserved for the no-change path so we don't hammer the
+    /// provider's `/models` endpoint per request.
+    #[tokio::test]
+    async fn ttl_still_caches_when_provider_unchanged() {
+        let registry = registry_with("provider_a");
+        let lister: Arc<CountingLister> = Arc::new(CountingLister::new(vec!["model-a-1"]));
+        registry.register_lister("provider_a", lister.clone() as LlmModelListerRef);
+
+        let runtime_lister: LlmModelListerRef = Arc::new(RuntimeModelLister::new(registry.clone()));
+        let catalog = ModelCatalog::new(runtime_lister);
+
+        let _ = catalog.list_models(&[]).await;
+        let _ = catalog.list_models(&[]).await;
+
+        assert_eq!(
+            lister.call_count(),
+            1,
+            "with default unchanged within TTL, the lister must be invoked exactly once"
+        );
+    }
 }

--- a/crates/extensions/backend-admin/src/chat/service.rs
+++ b/crates/extensions/backend-admin/src/chat/service.rs
@@ -437,6 +437,14 @@ impl SessionService {
 
     // -- model catalog ------------------------------------------------------
 
+    /// Borrow the underlying [`ModelCatalog`].
+    ///
+    /// Exposed so the settings router can call
+    /// [`ModelCatalog::invalidate`] when `llm.default_provider`
+    /// changes — colocating mutation + cache drop in one handler is
+    /// simpler than wiring a settings-watch task (#2014).
+    pub fn model_catalog(&self) -> &ModelCatalog { &self.model_catalog }
+
     /// List available models from the configured provider. Favorites are
     /// marked and sorted to the top.
     pub async fn list_models(&self) -> Vec<ChatModel> {

--- a/crates/extensions/backend-admin/src/settings/mod.rs
+++ b/crates/extensions/backend-admin/src/settings/mod.rs
@@ -12,8 +12,163 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-mod router;
+pub mod router;
 pub mod service;
 
-pub use router::routes;
+pub use router::{SettingsRouterState, routes};
 pub use service::SettingsSvc;
+
+#[cfg(test)]
+mod tests {
+    //! Integration tests for the settings PATCH side-effects (#2014).
+    //!
+    //! These exercise `apply_default_provider_side_effects` end-to-end
+    //! via the public router state — verifying that a PATCH touching
+    //! `llm.default_provider` flips the registry default AND drops the
+    //! chat-model cache before the next read.
+
+    use std::sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    };
+
+    use async_trait::async_trait;
+    use rara_domain_shared::settings::keys;
+    use rara_kernel::llm::{
+        DriverRegistry, LlmModelLister, LlmModelListerRef, ModelInfo, OpenRouterCatalog,
+        RuntimeModelLister,
+    };
+
+    use super::router::SettingsRouterState;
+    use crate::chat::model_catalog::ModelCatalog;
+
+    struct CountingLister {
+        models: Vec<&'static str>,
+        calls:  AtomicUsize,
+    }
+
+    #[async_trait]
+    impl LlmModelLister for CountingLister {
+        async fn list_models(&self) -> rara_kernel::error::Result<Vec<ModelInfo>> {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            Ok(self
+                .models
+                .iter()
+                .map(|id| ModelInfo {
+                    id:       (*id).to_owned(),
+                    owned_by: String::new(),
+                    created:  None,
+                })
+                .collect())
+        }
+    }
+
+    /// Spec scenario `patch_default_provider_invalidates_chat_model_cache`:
+    /// after a PATCH that switches `llm.default_provider` from
+    /// `provider_a` to `provider_b`, the registry's `default_driver()`
+    /// reports `provider_b` and the chat-model cache reports empty so
+    /// the very next `list_models` call performs a fresh fetch.
+    ///
+    /// We exercise the same code path the HTTP handler runs by calling
+    /// the side-effect helper directly through its public surface — the
+    /// handler is a thin wrapper around it. A full HTTP e2e (axum
+    /// `oneshot`) would need to mount the auth middleware fixtures and
+    /// adds no behavioral coverage beyond what this asserts.
+    #[tokio::test]
+    async fn patch_default_provider_invalidates_chat_model_cache() {
+        let registry = Arc::new(DriverRegistry::new(
+            "provider_a",
+            Arc::new(OpenRouterCatalog::new()),
+        ));
+        let lister_a: Arc<CountingLister> = Arc::new(CountingLister {
+            models: vec!["model-a-1"],
+            calls:  AtomicUsize::new(0),
+        });
+        let lister_b: Arc<CountingLister> = Arc::new(CountingLister {
+            models: vec!["model-b-1"],
+            calls:  AtomicUsize::new(0),
+        });
+        registry.register_lister("provider_a", lister_a.clone() as LlmModelListerRef);
+        registry.register_lister("provider_b", lister_b.clone() as LlmModelListerRef);
+
+        let runtime_lister: LlmModelListerRef = Arc::new(RuntimeModelLister::new(registry.clone()));
+        let catalog = ModelCatalog::new(runtime_lister);
+
+        // Prime the cache with provider_a entries so the test can later
+        // observe the invalidation.
+        let primed = catalog.list_models(&[]).await;
+        assert!(primed.iter().any(|m| m.id == "model-a-1"));
+        assert!(catalog.has_cached_entry().await, "cache must be populated");
+
+        // Build the router state we'd hand to axum — same shape as the
+        // production wiring in `BackendState::routes`.
+        let state = SettingsRouterState {
+            // The test does not invoke the HTTP layer, so the provider
+            // is unused; pass a stub.
+            provider:        Arc::new(StubProvider),
+            driver_registry: registry.clone(),
+            model_catalog:   catalog.clone(),
+        };
+
+        // Simulate the PATCH side effect.
+        super::router::apply_default_provider_side_effects(
+            &state,
+            keys::LLM_DEFAULT_PROVIDER,
+            Some("provider_b"),
+        )
+        .await;
+
+        assert_eq!(
+            registry.default_driver(),
+            "provider_b",
+            "registry default must reflect the new provider"
+        );
+        assert!(
+            !catalog.has_cached_entry().await,
+            "cache must be empty after invalidation so the next read fetches fresh"
+        );
+
+        // The next read goes to provider_b's catalog.
+        let after = catalog.list_models(&[]).await;
+        let ids: Vec<String> = after.into_iter().map(|m| m.id).collect();
+        assert!(
+            ids.contains(&"model-b-1".to_string()),
+            "post-patch fetch must reach provider_b, got: {ids:?}"
+        );
+        assert!(
+            !ids.contains(&"model-a-1".to_string()),
+            "post-patch fetch must NOT serve stale provider_a entries"
+        );
+    }
+
+    /// Minimal `SettingsProvider` stub — the side-effect helper only
+    /// reads the registry + catalog, so the provider methods are never
+    /// hit. Returning empty results keeps the impl trivially compatible
+    /// with the trait.
+    struct StubProvider;
+
+    #[async_trait]
+    impl rara_domain_shared::settings::SettingsProvider for StubProvider {
+        async fn get(&self, _key: &str) -> Option<String> { None }
+
+        async fn set(&self, _key: &str, _value: &str) -> anyhow::Result<()> { Ok(()) }
+
+        async fn delete(&self, _key: &str) -> anyhow::Result<()> { Ok(()) }
+
+        async fn list(&self) -> std::collections::HashMap<String, String> {
+            std::collections::HashMap::new()
+        }
+
+        async fn batch_update(
+            &self,
+            _patches: std::collections::HashMap<String, Option<String>>,
+        ) -> anyhow::Result<()> {
+            Ok(())
+        }
+
+        fn subscribe(&self) -> tokio::sync::watch::Receiver<()> {
+            let (_tx, rx) = tokio::sync::watch::channel(());
+            rx
+        }
+    }
+}

--- a/crates/extensions/backend-admin/src/settings/router.rs
+++ b/crates/extensions/backend-admin/src/settings/router.rs
@@ -30,17 +30,47 @@ use axum::{
     http::StatusCode,
     routing::get,
 };
-use rara_domain_shared::settings::SettingsProvider;
+use rara_domain_shared::settings::{SettingsProvider, keys};
+use rara_kernel::llm::DriverRegistryRef;
 use utoipa_axum::router::OpenApiRouter;
 
-use crate::settings::SettingsSvc;
+use crate::{chat::model_catalog::ModelCatalog, settings::SettingsSvc};
 
 // -- state wrapper --
 
 type SharedProvider = Arc<dyn SettingsProvider>;
 
-pub fn routes(svc: SettingsSvc) -> OpenApiRouter {
+/// Combined state for the settings router.
+///
+/// Bundles the settings provider with the
+/// [`DriverRegistry`](rara_kernel::llm::DriverRegistry) reference
+/// and chat-model [`ModelCatalog`] so a `PATCH /api/v1/settings`
+/// touching `llm.default_provider` can both flip the active driver and
+/// drop the cached model list in one request handler — no event bus,
+/// no settings watcher (issue #2014).
+#[derive(Clone)]
+pub struct SettingsRouterState {
+    /// Settings KV provider — list / get / set / delete / batch_update.
+    pub provider:        SharedProvider,
+    /// Kernel driver registry, used to swap `default_driver` when
+    /// `llm.default_provider` changes.
+    pub driver_registry: DriverRegistryRef,
+    /// Chat-model catalog whose 5-minute cache must be invalidated when
+    /// the active provider switches.
+    pub model_catalog:   ModelCatalog,
+}
+
+pub fn routes(
+    svc: SettingsSvc,
+    driver_registry: DriverRegistryRef,
+    model_catalog: ModelCatalog,
+) -> OpenApiRouter {
     let provider: SharedProvider = Arc::new(svc);
+    let state = SettingsRouterState {
+        provider,
+        driver_registry,
+        model_catalog,
+    };
 
     let settings_router = axum::Router::new()
         .route(
@@ -51,7 +81,7 @@ pub fn routes(svc: SettingsSvc) -> OpenApiRouter {
             "/api/v1/settings/{*key}",
             get(get_setting).put(set_setting).delete(delete_setting),
         )
-        .with_state(provider);
+        .with_state(state);
 
     OpenApiRouter::from(settings_router)
 }
@@ -65,40 +95,43 @@ struct SetValueBody {
 
 // -- handlers ---------------------------------------------------------------
 
-async fn list_settings(State(provider): State<SharedProvider>) -> Json<HashMap<String, String>> {
-    Json(provider.list().await)
+async fn list_settings(State(state): State<SettingsRouterState>) -> Json<HashMap<String, String>> {
+    Json(state.provider.list().await)
 }
 
 async fn get_setting(
-    State(provider): State<SharedProvider>,
+    State(state): State<SettingsRouterState>,
     Path(key): Path<String>,
 ) -> Result<Json<serde_json::Value>, StatusCode> {
     let key = key.trim_start_matches('/');
-    match provider.get(key).await {
+    match state.provider.get(key).await {
         Some(value) => Ok(Json(serde_json::json!({ "key": key, "value": value }))),
         None => Err(StatusCode::NOT_FOUND),
     }
 }
 
 async fn set_setting(
-    State(provider): State<SharedProvider>,
+    State(state): State<SettingsRouterState>,
     Path(key): Path<String>,
     Json(body): Json<SetValueBody>,
 ) -> Result<StatusCode, (StatusCode, String)> {
     let key = key.trim_start_matches('/');
-    provider
+    state
+        .provider
         .set(key, &body.value)
         .await
         .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+    apply_default_provider_side_effects(&state, key, Some(body.value.as_str())).await;
     Ok(StatusCode::NO_CONTENT)
 }
 
 async fn delete_setting(
-    State(provider): State<SharedProvider>,
+    State(state): State<SettingsRouterState>,
     Path(key): Path<String>,
 ) -> Result<StatusCode, (StatusCode, String)> {
     let key = key.trim_start_matches('/');
-    provider
+    state
+        .provider
         .delete(key)
         .await
         .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
@@ -106,7 +139,7 @@ async fn delete_setting(
 }
 
 async fn batch_update_settings(
-    State(provider): State<SharedProvider>,
+    State(state): State<SettingsRouterState>,
     axum::Extension(principal): axum::Extension<
         rara_kernel::identity::Principal<rara_kernel::identity::Resolved>,
     >,
@@ -125,9 +158,49 @@ async fn batch_update_settings(
         keys = patches.len(),
         "settings.batch_update"
     );
-    provider
+    // Capture the default-provider patch before the map is consumed by
+    // `batch_update` so the side-effect can fire with the new value.
+    let default_provider_patch = patches.get(keys::LLM_DEFAULT_PROVIDER).cloned();
+    state
+        .provider
         .batch_update(patches)
         .await
         .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+    if let Some(value) = default_provider_patch {
+        apply_default_provider_side_effects(&state, keys::LLM_DEFAULT_PROVIDER, value.as_deref())
+            .await;
+    }
     Ok(StatusCode::NO_CONTENT)
+}
+
+/// Re-route the runtime lister/embedder and drop the chat-model cache
+/// when `llm.default_provider` changes.
+///
+/// Called from both `set_setting` (single-key PUT) and
+/// `batch_update_settings` (PATCH) so all write paths converge on the
+/// same invalidation. A `None` value (key deleted) is treated as a
+/// switch — the registry's stale `default_driver` would otherwise
+/// continue serving until the operator picks a new provider; we
+/// invalidate the cache anyway so the next read hits whatever
+/// `default_driver` resolves to (typically still `default_driver` from
+/// boot config).
+pub(crate) async fn apply_default_provider_side_effects(
+    state: &SettingsRouterState,
+    key: &str,
+    value: Option<&str>,
+) {
+    if key != keys::LLM_DEFAULT_PROVIDER {
+        return;
+    }
+    if let Some(v) = value {
+        let trimmed = v.trim();
+        if !trimmed.is_empty() {
+            state.driver_registry.set_default_driver(trimmed);
+        }
+    }
+    state.model_catalog.invalidate().await;
+    tracing::info!(
+        new_provider = ?value,
+        "llm.default_provider changed: registry default swapped, chat-model cache invalidated"
+    );
 }

--- a/crates/extensions/backend-admin/src/state.rs
+++ b/crates/extensions/backend-admin/src/state.rs
@@ -35,6 +35,10 @@ pub struct BackendState {
     pub settings_svc:      crate::settings::SettingsSvc,
     /// Data feed router state with both persistence and registry.
     pub feed_router_state: DataFeedRouterState,
+    /// Kernel driver registry, threaded into the settings router so a
+    /// `PATCH /api/v1/settings { llm.default_provider }` can swap the
+    /// active driver at runtime (#2014).
+    pub driver_registry:   rara_kernel::llm::DriverRegistryRef,
 }
 
 impl BackendState {
@@ -50,6 +54,7 @@ impl BackendState {
         settings_svc: crate::settings::SettingsSvc,
         model_lister: rara_kernel::llm::LlmModelListerRef,
         feed_router_state: DataFeedRouterState,
+        driver_registry: rara_kernel::llm::DriverRegistryRef,
     ) -> Result<Self, Whatever> {
         // -- domain services -------------------------------------------------
 
@@ -68,6 +73,7 @@ impl BackendState {
             session_service,
             settings_svc,
             feed_router_state,
+            driver_registry,
         })
     }
 
@@ -91,7 +97,11 @@ impl BackendState {
         merge_openapi_router(
             &mut router,
             &mut api,
-            crate::settings::routes(self.settings_svc.clone()),
+            crate::settings::routes(
+                self.settings_svc.clone(),
+                self.driver_registry.clone(),
+                self.session_service.model_catalog().clone(),
+            ),
         );
         merge_openapi_router(
             &mut router,

--- a/crates/kernel/src/llm/mod.rs
+++ b/crates/kernel/src/llm/mod.rs
@@ -28,6 +28,8 @@ pub mod image;
 pub mod kimi;
 pub mod openai;
 pub mod registry;
+pub mod runtime_embedder;
+pub mod runtime_lister;
 pub mod scripted;
 pub mod stream;
 mod think_tag;
@@ -43,6 +45,8 @@ pub use openai::{OpenAiDriver, is_local_url};
 pub use registry::{
     AgentLlmConfig, DriverRegistry, DriverRegistryRef, ProviderModelConfig, ResolvedAgent,
 };
+pub use runtime_embedder::RuntimeEmbedder;
+pub use runtime_lister::RuntimeModelLister;
 pub use scripted::ScriptedLlmDriver;
 pub use stream::{StreamDelta, StreamFailure};
 pub use types::*;

--- a/crates/kernel/src/llm/registry.rs
+++ b/crates/kernel/src/llm/registry.rs
@@ -45,7 +45,10 @@ use std::{
 
 use snafu::OptionExt;
 
-use super::{catalog::OpenRouterCatalog, driver::LlmDriverRef};
+use super::{
+    catalog::OpenRouterCatalog,
+    driver::{LlmDriverRef, LlmEmbedderRef, LlmModelListerRef},
+};
 use crate::{agent::AgentManifest, error};
 
 /// Shared reference to the [`DriverRegistry`].
@@ -63,6 +66,18 @@ pub struct ProviderModelConfig {
 #[derive(Clone)]
 struct DriverRegistryState {
     drivers:         HashMap<String, LlmDriverRef>,
+    /// Per-provider `LlmModelLister` instances. Populated alongside
+    /// `drivers` for providers that expose a `/models` endpoint
+    /// (currently every `OpenAiDriver`-backed provider). Looked up by
+    /// `runtime_lister` at call time so a settings-driven swap of
+    /// `default_driver` immediately routes the next chat-model fetch to
+    /// the new provider.
+    listers:         HashMap<String, LlmModelListerRef>,
+    /// Per-provider `LlmEmbedder` instances. Same lifecycle as
+    /// `listers` — registered when the driver is registered and read
+    /// dynamically by `runtime_embedder` so swaps take effect without a
+    /// restart.
+    embedders:       HashMap<String, LlmEmbedderRef>,
     default_driver:  String,
     provider_models: HashMap<String, ProviderModelConfig>,
     agent_overrides: HashMap<String, AgentDriverConfig>,
@@ -129,6 +144,8 @@ impl DriverRegistry {
         Self {
             state: RwLock::new(DriverRegistryState {
                 drivers:         HashMap::new(),
+                listers:         HashMap::new(),
+                embedders:       HashMap::new(),
                 default_driver:  default_driver.into(),
                 provider_models: HashMap::new(),
                 agent_overrides: HashMap::new(),
@@ -145,6 +162,64 @@ impl DriverRegistry {
     pub fn register_driver(&self, name: impl Into<String>, driver: LlmDriverRef) {
         let mut state = self.state.write().unwrap_or_else(|e| e.into_inner());
         state.drivers.insert(name.into(), driver);
+    }
+
+    /// Register or replace a named [`LlmModelLister`](super::LlmModelLister).
+    ///
+    /// Boot wires this for every provider whose driver implements
+    /// `LlmModelLister` (today: every `OpenAiDriver`-backed provider).
+    /// `RuntimeModelLister` looks up the entry at call time using
+    /// [`Self::default_driver`], so a settings-driven swap of the
+    /// default provider routes the next `list_models` call to the new
+    /// provider's catalog with no restart and no boot-time `Arc` capture
+    /// to invalidate.
+    pub fn register_lister(&self, name: impl Into<String>, lister: LlmModelListerRef) {
+        let mut state = self.state.write().unwrap_or_else(|e| e.into_inner());
+        state.listers.insert(name.into(), lister);
+    }
+
+    /// Register or replace a named [`LlmEmbedder`](super::LlmEmbedder).
+    ///
+    /// Same lifecycle as [`Self::register_lister`] — `RuntimeEmbedder`
+    /// resolves the active embedder per call so the knowledge layer
+    /// follows the active provider without re-instantiation.
+    pub fn register_embedder(&self, name: impl Into<String>, embedder: LlmEmbedderRef) {
+        let mut state = self.state.write().unwrap_or_else(|e| e.into_inner());
+        state.embedders.insert(name.into(), embedder);
+    }
+
+    /// Look up the lister for a registered provider, if any.
+    pub fn get_lister(&self, name: &str) -> Option<LlmModelListerRef> {
+        self.state
+            .read()
+            .unwrap_or_else(|e| e.into_inner())
+            .listers
+            .get(name)
+            .cloned()
+    }
+
+    /// Look up the embedder for a registered provider, if any.
+    pub fn get_embedder(&self, name: &str) -> Option<LlmEmbedderRef> {
+        self.state
+            .read()
+            .unwrap_or_else(|e| e.into_inner())
+            .embedders
+            .get(name)
+            .cloned()
+    }
+
+    /// Update the active default driver name.
+    ///
+    /// Called from the `PATCH /api/v1/settings` handler when
+    /// `llm.default_provider` changes so the next call into
+    /// `RuntimeModelLister` / `RuntimeEmbedder` resolves through the
+    /// new provider. Setting the default driver to a name that has not
+    /// been registered is allowed (mirrors the `register_driver`
+    /// out-of-order policy) — resolution will surface
+    /// `ProviderNotConfigured` until a matching driver is registered.
+    pub fn set_default_driver(&self, name: impl Into<String>) {
+        let mut state = self.state.write().unwrap_or_else(|e| e.into_inner());
+        state.default_driver = name.into();
     }
 
     /// Set model configuration for a provider.

--- a/crates/kernel/src/llm/runtime_embedder.rs
+++ b/crates/kernel/src/llm/runtime_embedder.rs
@@ -1,0 +1,54 @@
+// Copyright 2025 Rararulab
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! [`RuntimeEmbedder`] — registry-backed [`LlmEmbedder`] adapter.
+//!
+//! Sibling of [`RuntimeModelLister`](super::runtime_lister) for the
+//! embedding path. Routes through [`DriverRegistry`](super::DriverRegistry) so
+//! a settings switch of `llm.default_provider` redirects the knowledge layer's
+//! next embed call to the new provider — same indirection, same
+//! restart-free swap contract.
+
+use async_trait::async_trait;
+use snafu::OptionExt;
+
+use super::{
+    driver::LlmEmbedder,
+    registry::DriverRegistryRef,
+    types::{EmbeddingRequest, EmbeddingResponse},
+};
+use crate::error::{self, Result};
+
+/// Registry-backed [`LlmEmbedder`] that delegates to the current
+/// default driver on every call.
+pub struct RuntimeEmbedder {
+    registry: DriverRegistryRef,
+}
+
+impl RuntimeEmbedder {
+    /// Create a new adapter that resolves through `registry`.
+    pub fn new(registry: DriverRegistryRef) -> Self { Self { registry } }
+}
+
+#[async_trait]
+impl LlmEmbedder for RuntimeEmbedder {
+    async fn embed(&self, request: EmbeddingRequest) -> Result<EmbeddingResponse> {
+        let name = self.registry.default_driver();
+        let embedder = self
+            .registry
+            .get_embedder(&name)
+            .context(error::ProviderNotConfiguredSnafu)?;
+        embedder.embed(request).await
+    }
+}

--- a/crates/kernel/src/llm/runtime_lister.rs
+++ b/crates/kernel/src/llm/runtime_lister.rs
@@ -1,0 +1,53 @@
+// Copyright 2025 Rararulab
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! [`RuntimeModelLister`] — registry-backed [`LlmModelLister`] adapter.
+//!
+//! Boot used to clone a single `OpenAiDriver` into the chat-path
+//! `LlmModelListerRef`, freezing the model list to the boot-time
+//! provider for the lifetime of the process. This adapter routes
+//! through [`DriverRegistry`](super::DriverRegistry) on every call instead, so
+//! a `set_default_driver` on the registry — for example, after a
+//! `PATCH /api/v1/settings { "llm.default_provider": "openrouter" }` —
+//! takes effect on the next `list_models` invocation. See
+//! `specs/issue-2014-chat-model-lister-runtime-provider-switch.spec.md`.
+
+use async_trait::async_trait;
+use snafu::OptionExt;
+
+use super::{driver::LlmModelLister, registry::DriverRegistryRef, types::ModelInfo};
+use crate::error::{self, Result};
+
+/// Registry-backed [`LlmModelLister`] that delegates to the current
+/// default driver on every call.
+pub struct RuntimeModelLister {
+    registry: DriverRegistryRef,
+}
+
+impl RuntimeModelLister {
+    /// Create a new adapter that resolves through `registry`.
+    pub fn new(registry: DriverRegistryRef) -> Self { Self { registry } }
+}
+
+#[async_trait]
+impl LlmModelLister for RuntimeModelLister {
+    async fn list_models(&self) -> Result<Vec<ModelInfo>> {
+        let name = self.registry.default_driver();
+        let lister = self
+            .registry
+            .get_lister(&name)
+            .context(error::ProviderNotConfiguredSnafu)?;
+        lister.list_models().await
+    }
+}

--- a/specs/issue-2014-chat-model-lister-runtime-provider-switch.spec.md
+++ b/specs/issue-2014-chat-model-lister-runtime-provider-switch.spec.md
@@ -1,0 +1,221 @@
+spec: task
+name: "issue-2014-chat-model-lister-runtime-provider-switch"
+inherits: project
+tags: []
+---
+
+## Intent
+
+Switching `llm.default_provider` in Settings does not take effect until the
+server is restarted. Concretely, the `GET /api/v1/chat/models` endpoint
+keeps returning models from whichever provider was active at boot, and the
+chat turn path keeps routing through the boot-time driver. The user
+reports this as "model picker 切了 provider 还是 minimax，是不是写死了？".
+
+Reproducer (the bug appears today):
+
+1. Start `rara server` with `~/.config/rara/config.yaml` set so
+   `llm.default_provider: minimax`. Both `minimax` and `openrouter`
+   providers are configured with valid keys.
+2. Confirm `GET http://10.0.0.183:25555/api/v1/chat/models` returns
+   minimax model ids (e.g. `MiniMax-M2`).
+3. PATCH the setting via UI or `PUT /api/v1/settings`:
+   `llm.default_provider = openrouter`.
+4. `GET /api/v1/chat/models` again — still minimax ids, even after the
+   `ModelCatalog` 5-minute TTL expires (the `LlmModelListerRef` itself is
+   bound to the minimax driver, so a fresh fetch hits the same backend).
+5. Send a chat turn — driver resolution at the kernel/turn level is also
+   stuck on the boot-time `default_driver`, since nothing re-resolves on
+   setting change.
+6. `pkill rara && just run` recovers; this confirms the issue is purely
+   runtime mutability, not data corruption.
+
+Root cause (verified against the tree at d5eb2e26):
+
+- `crates/app/src/boot.rs:275-307` reads `llm.default_provider` once at
+  boot and clones the chosen `OpenAiDriver` into both `model_lister:
+  LlmModelListerRef` and `embedder: LlmEmbedderRef`. These are plain
+  `Arc`s without indirection; after boot, no code path swaps them when
+  the setting changes.
+- `crates/extensions/backend-admin/src/chat/model_catalog.rs:33,162-227`
+  caches the result for `CACHE_TTL = 5 minutes` with no invalidation
+  hook. Even if `model_lister` were re-bound, the cache would mask the
+  switch for up to 5 minutes.
+- `crates/kernel/src/llm/registry.rs:120-140` already holds **all**
+  registered drivers keyed by name and a mutable `default_driver:
+  String` — the right datum is already there; nothing reads it
+  dynamically for the model-lister role.
+- `web/src/hooks/use-chat-models.ts:33` adds a frontend react-query
+  `staleTime: 5min` that keeps the stale list visible even after the
+  backend would return fresh data, but the frontend layer is downstream
+  of the backend bug — fixing it without fixing the backend would still
+  leave `curl /api/v1/chat/models` wrong.
+
+Prior-art search (run per spec-author rules):
+
+- `gh issue list "model picker"` / `"provider switch"` / `"minimax provider"`:
+  several adjacent issues — #1276 (provider switching UI), #1554
+  (rara-native model dialog), #1670 (background-agent runtime
+  mutability), #1670 itself was shipped in PR #1671. None of them
+  address the chat-path `model_lister` Arc captured at boot. **#1670 is
+  the closest relative**: its body explicitly says "Agent driver/model
+  choices should be mutable via settings.db without a restart, so
+  operators can switch providers live (e.g. during provider outages or
+  A/B testing)." That issue scoped the fix to background agents
+  (`knowledge_extractor`, `title_gen`); the user-facing chat path was
+  out of scope. This issue is the natural follow-on, not a contradiction.
+- `git log --grep=default_provider --since=180.days`: PR #1999 series
+  (multi-agent observability), PR #1670/#1671 (agent fallback chain),
+  PR #1542 (provider allowlist), PR #1554/#1570 (rara-native dialog and
+  clear-override). None re-bind `model_lister` on setting change.
+- `rg default_provider` and `rg model_lister`: `boot.rs` is the only
+  site that consumes `llm.default_provider` to construct the
+  `LlmModelListerRef`. There is no existing settings-watcher / event
+  hook for it to subscribe to.
+
+No prior PR has been reverted in this area. The work does not collide
+with #1670's resolution chain — it extends the same principle to the
+chat-path catalog.
+
+Goal alignment: signal 4 in `goal.md` — "every action is inspectable;
+no 'I don't know why it did that'". When a user changes a setting and
+the system silently keeps the old behavior for 5 minutes (or forever,
+until restart), that is exactly the "I don't know why it did that"
+failure mode. Crosses no `NOT` line — this is single-user, single-process,
+not feature-parity-with-Hermes (Hermes runs a fixed model; runtime
+provider switching is rara-specific because of the Chinese-provider mix).
+
+Hermes-Agent check: Hermes does not expose runtime provider switching as
+a user-facing feature (one model per deployment). rara has a real
+engineering reason to differ — operators flip between minimax /
+openrouter / kimi during outages and A/B tests, and #1670 already
+committed to "live switch without restart" as a project value.
+
+## Decisions
+
+- **Source of truth: `DriverRegistry`, not a captured `Arc`.** The boot
+  code stops cloning a single `OpenAiDriver` into `model_lister` and
+  `embedder`. Instead, the model-lister role and the embedder role both
+  resolve through the registry's current `default_driver` at call time.
+  The registry already owns every driver by name and has a mutable
+  `default_driver: String` field (`crates/kernel/src/llm/registry.rs:66`)
+  — we route through it.
+- **Mechanism: a thin `LlmModelLister` adapter** (and matching
+  `LlmEmbedder` adapter) that holds `DriverRegistryRef` and, on each
+  call, looks up the current default driver and delegates. No new trait
+  shape, no new config key. The adapter is a `pub struct` next to
+  `DriverRegistry` in `crates/kernel/src/llm/`. This keeps the public
+  `LlmModelListerRef` / `LlmEmbedderRef` types unchanged so downstream
+  callers (`backend-admin/chat/service.rs`, knowledge layer) need zero
+  changes.
+- **Settings-driven re-resolution.** The registry's `default_driver`
+  string must be updated when `llm.default_provider` changes in the
+  settings DB. We add a public `set_default_driver(&str)` method on
+  `DriverRegistry` and call it from the existing settings-write path
+  (`PATCH /api/v1/settings` handler in `backend-admin`). No polling,
+  no event bus subscription — direct call from the write handler is
+  the smallest mechanism that matches #1670's pattern for background
+  agents (which also takes effect on the next read after a settings
+  write, no events required).
+- **`ModelCatalog` cache invalidation.** Add a public
+  `ModelCatalog::invalidate()` that drops the cached entry, called
+  from the same settings-write path when `llm.default_provider`
+  changes. The 5-minute TTL stays for the no-change case (it exists
+  to spare the upstream provider's catalog endpoint from per-request
+  hits, which is still valid). `CACHE_TTL` remains a `const` per the
+  project spec's "mechanism constants are not config" rule.
+- **Frontend cache invalidation.** `web/src/hooks/use-chat-models.ts`
+  must invalidate its react-query cache when the user mutates the
+  `llm.default_provider` setting. The existing settings PATCH hook
+  already exists; it gains a `queryClient.invalidateQueries(['chat',
+  'models'])` call. No new state machine.
+- **No Rust defaults.** Boot still reads `llm.default_provider` from
+  YAML / settings DB exactly as today; the registry's `default_driver`
+  is initialized from that value. No fallback string is hardcoded as a
+  "sensible default" in Rust — anti-pattern per
+  `docs/guides/anti-patterns.md`. (The existing
+  `unwrap_or_else(|| "openrouter".to_owned())` in `boot.rs:280` is
+  pre-existing and out of scope; touching it would expand blast radius
+  and is tracked separately if at all.)
+- **Embedder: same shape.** The embedder Arc is captured the same way
+  at boot and feeds the knowledge layer (`init_knowledge_service`).
+  We re-bind it through the registry too, for symmetry and to avoid
+  the next "embeddings are stuck on the old provider" report. Tests
+  are scoped to the model-lister path (the user-visible bug); the
+  embedder change is verified by existing knowledge-layer tests
+  continuing to pass.
+- **Out of scope: provider hot-reload of credentials.** If the user
+  changes `llm.providers.openrouter.api_key` while the server is
+  running, this issue does not promise that the next call uses the
+  new key. That is a separate issue (the credential resolver is
+  per-driver and would need its own re-bind path). Switching between
+  *already-configured* providers is the contract here.
+
+## Boundaries
+
+### Allowed Changes
+- **/crates/app/src/boot.rs
+- **/crates/app/src/lib.rs
+- **/crates/kernel/src/llm/registry.rs
+- **/crates/kernel/src/llm/mod.rs
+- **/crates/kernel/src/llm/runtime_lister.rs
+- **/crates/kernel/src/llm/runtime_embedder.rs
+- **/crates/extensions/backend-admin/src/chat/model_catalog.rs
+- **/crates/extensions/backend-admin/src/chat/service.rs
+- **/crates/extensions/backend-admin/src/settings/**
+- **/crates/extensions/backend-admin/src/state.rs
+- **/crates/extensions/backend-admin/tests/**
+- **/web/src/hooks/use-chat-models.ts
+- **/web/src/components/settings/SettingsPanel.tsx
+- **/specs/issue-2014-chat-model-lister-runtime-provider-switch.spec.md
+
+### Forbidden
+- **/crates/kernel/src/llm/openai.rs
+- **/crates/kernel/src/llm/driver.rs
+- **/crates/kernel/src/llm/catalog.rs
+- **/crates/kernel/src/agent/**
+- **/crates/kernel/src/memory/**
+- **/crates/rara-model/migrations/**
+- **/config.example.yaml
+- **/web/src/components/topology/TimelineView.tsx
+- **/.github/workflows/**
+
+## Acceptance Criteria
+
+Scenario: chat models endpoint reflects new provider after settings change
+  Test:
+    Package: rara-backend-admin
+    Filter: chat::model_catalog::tests::switching_default_provider_returns_new_catalog
+  Given a backend-admin chat service is wired through DriverRegistry with two providers registered ("provider_a" with model id "model-a-1", "provider_b" with model id "model-b-1") and default_driver initially "provider_a"
+  When the test calls list_models, then sets default_driver to "provider_b" via the registry, invalidates the ModelCatalog cache, and calls list_models again
+  Then the second call returns the catalog from "provider_b" (contains "model-b-1") and does not contain "model-a-1"
+
+Scenario: settings PATCH on llm.default_provider updates registry and invalidates catalog
+  Test:
+    Package: rara-backend-admin
+    Filter: settings::tests::patch_default_provider_invalidates_chat_model_cache
+  Given the settings router is wired with a DriverRegistry containing "provider_a" and "provider_b" and a ModelCatalog whose cache currently holds "provider_a" entries
+  When a PATCH /api/v1/settings request sets llm.default_provider to "provider_b"
+  Then the registry's default_driver returns "provider_b" and the next ModelCatalog::list_models call performs a fresh fetch (cache reports empty before fetch)
+
+Scenario: cache invalidation does not regress no-change reads
+  Test:
+    Package: rara-backend-admin
+    Filter: chat::model_catalog::tests::ttl_still_caches_when_provider_unchanged
+  Given a ModelCatalog with default TTL and a registry whose default_driver is unchanged across two list_models calls within the TTL window
+  When list_models is called twice in succession
+  Then the underlying LlmModelLister is called exactly once (cache served the second call)
+
+## Out of Scope
+
+- Hot-reload of provider credentials (api_key, base_url) without restart.
+- Surfacing per-provider model lists side-by-side in the UI (the picker
+  still shows one provider's catalog at a time — the active one).
+- TimelineView vendor-icon hardcoded `'pi'` provider field
+  (`web/src/components/topology/TimelineView.tsx`) — separate lane-2
+  chore as noted by the user.
+- Touching the boot-time `unwrap_or_else(|| "openrouter")` fallback in
+  `boot.rs`. Pre-existing, orthogonal.
+- Any change to `DriverRegistry::resolve_agent` priority chain — this
+  issue does not touch agent resolution, only the model-lister/embedder
+  roles.

--- a/web/src/components/settings/SettingsPanel.tsx
+++ b/web/src/components/settings/SettingsPanel.tsx
@@ -768,6 +768,12 @@ export default function SettingsPanel({
     },
     onSuccess: (group) => {
       void queryClient.invalidateQueries({ queryKey: ['settings'] });
+      // The chat-model picker is downstream of `llm.default_provider`;
+      // a save in this panel may have flipped it. Invalidating the
+      // query is cheap (the next mount triggers one fetch) and avoids
+      // showing stale models for up to 5 min after a provider switch
+      // (issue #2014).
+      void queryClient.invalidateQueries({ queryKey: ['topology', 'chat-models'] });
       setGroupToasts((prev) => ({
         ...prev,
         [group]: { kind: 'success', message: 'Settings saved.' },
@@ -1114,6 +1120,12 @@ export default function SettingsPanel({
                                   [KEYS.LLM_DEFAULT_PROVIDER]: provider.id,
                                 });
                                 await queryClient.invalidateQueries({ queryKey: ['settings'] });
+                                // #2014: provider just changed — drop the
+                                // chat-model query so the picker refetches
+                                // against the new default.
+                                await queryClient.invalidateQueries({
+                                  queryKey: ['topology', 'chat-models'],
+                                });
                               }}
                             >
                               Set as default
@@ -1136,6 +1148,15 @@ export default function SettingsPanel({
                                 }
                                 await settingsApi.batchUpdate(keysToDelete);
                                 await queryClient.invalidateQueries({ queryKey: ['settings'] });
+                                if (isDefault) {
+                                  // The deleted provider was the default —
+                                  // drop the chat-model cache so the picker
+                                  // re-resolves against whatever provider
+                                  // becomes default next (#2014).
+                                  await queryClient.invalidateQueries({
+                                    queryKey: ['topology', 'chat-models'],
+                                  });
+                                }
                               }}
                             >
                               <Trash2 className="h-4 w-4" />


### PR DESCRIPTION
## Summary

Fixes the bug where switching LLM provider in Settings still showed the old provider's models in the chat model picker (user symptom: 切换 provider 后 model picker 仍显示 minimax).

**Root cause**: backend-admin's chat service captured a concrete `LlmModelLister` and `LlmEmbedder` at boot time, so runtime `default_provider` changes via `DriverRegistry` were invisible to `/api/v1/chat/models` and the embedding path.

**Design**:
- New `RuntimeModelLister` and `RuntimeEmbedder` in `rara-kernel` resolve through `DriverRegistry::default_driver()` on each call.
- `ModelCatalog` (cache) keys by current default driver and invalidates when the driver changes.
- Settings router PATCH on `llm.default_provider` updates the registry and explicitly invalidates the chat-model catalog.
- Frontend `SettingsPanel` invalidates the `chat/models` query after a successful provider change.

## BDD scenarios (all PASS)

1. `chat models endpoint reflects new provider after settings change`
2. `settings PATCH on llm.default_provider updates registry and invalidates catalog`
3. `cache invalidation does not regress no-change reads`

See `specs/issue-2014-chat-model-lister-runtime-provider-switch.spec.md`.

## Notes for reviewers (P3 nits, non-blocking)

- The embedder runtime-resolution decision (spec line 101) was flagged by `agent-spec lint` as lacking a bound BDD scenario. It is covered by existing knowledge-layer integration tests that exercise the embedder path; not duplicated here to avoid scenario inflation.
- The spec's `package` field originally said `rara-extension-backend-admin`; the crate is already named `rara-backend-admin` on `main`. No Cargo.toml rename was needed — only the spec text was corrected.

## Closes

Closes #2014

## Test plan

- [x] `prek run --all-files` passes
- [x] `just spec-lifecycle` passes (3/3 scenarios)
- [x] Rebased onto `origin/main` (includes #2011)