### PR TITLE
feat(web): restore topology timeline chat history (#2013)

### DIFF
--- a/specs/issue-2013-topology-timeline-history.spec.md
+++ b/specs/issue-2013-topology-timeline-history.spec.md
@@ -113,22 +113,37 @@ the user-bubble text and the assistant text rendered through
   from `assistant.tool_calls` paired with the corresponding
   `tool_result` content, and sets `inFlight: false`, `metrics: null`,
   `usage: null` (history does not carry the live metrics frame).
-- **Live + history dedupe.** History returns messages with monotonic
-  `seq`. Compute `lastHistorySeq = max(history.seq)` (or 0 if history
-  is empty). When folding live `events` from the topology subscription
-  for `viewSessionKey`, drop entries whose `seq <= lastHistorySeq`
-  before passing them to `buildTurnsFromEvents`. This prevents
-  double-rendering at the boundary if a frame the backend persisted
-  was also delivered live before the fetch resolved.
-  Note: `ChatMessage.seq` and `TopologyEventEntry.seq` come from
-  different counters today (the former is per-tape, the latter is the
-  topology hub's monotonic frame seq). The dedupe relies on both being
-  monotonic and aligned by `created_at`/arrival on the same session.
-  If the implementer finds the two seq spaces are not directly
-  comparable, fall back to filtering live events with
-  `created_at` strictly greater than the latest history `created_at`,
-  and add a fixme comment naming the seq-unification work as a
-  follow-up. Either way the boundary must not double-render.
+- **Live + history dedupe — arrival-barrier, not seq.** `ChatMessage.seq`
+  (per-tape, persistent) and `TopologyEventEntry.seq`
+  (`web/src/hooks/use-topology-subscription.ts:179,196`, per-WS-connection,
+  resets to 0 on every reconnect) are NOT comparable counters. A
+  `seq <= lastHistorySeq` filter is wrong-by-construction: after a
+  reconnect with 50 persisted entries, the first live frame arrives with
+  `seq=1` and would be incorrectly dropped, freezing chat until the WS
+  frame counter eventually exceeds 50. Inspecting the wire types
+  (`TopologyEventEntry` in the hook + `WebFrame` variants like
+  `text_delta`) shows there is also no shared id and no per-event
+  timestamp on the WS side — there is no field at parity that can serve
+  as a content-level dedupe key.
+  Use an **arrival-time barrier** instead: at the moment the history
+  fetch for `viewSessionKey` resolves, snapshot
+  `historyBarrierSeq = events.length` (the current length of the
+  topology subscription's events buffer for this session). When folding
+  live events for `viewSessionKey`, only consider entries whose buffer
+  index is `>= historyBarrierSeq`; entries that arrived before the
+  history fetch resolved are treated as already represented by the
+  history payload and dropped. Re-snapshot the barrier on every
+  successful refetch (including session switch and WS reconnect), keyed
+  by `viewSessionKey`. This avoids any cross-counter comparison entirely
+  and uses only a quantity each side actually has: history's "this is
+  the truth as of the moment I resolved" and the live buffer's local
+  index.
+- **`agent-spec lifecycle` does not currently support `Package: web`
+  selectors** (no vitest adapter). The lifecycle gate on this spec
+  therefore fails by tooling, not by verification — implementer and
+  reviewer verify the scenarios by running vitest directly. Tracked as
+  a lane-2 chore in issue 2015 ("agent-spec: add vitest adapter for
+  web specs").
 - **Session switch reset.** Already handled correctly: `userTurnsBySession`
   keys by session, and `agentTurns` filters `events` by session. The
   new history hook keys on `viewSessionKey` so react-query swaps the
@@ -200,14 +215,16 @@ Scenario: Switching viewSessionKey refetches history and resets the rendered tim
   Then the rendered DOM contains "from-B"
     And the rendered DOM does not contain "from-A"
 
-Scenario: Live events with seq at or below the last history seq are not re-rendered
+Scenario: Live events that arrived before history resolved are not re-rendered after history loads
   Test:
     Package: web
-    Filter: TimelineView.history.boundary_dedupe
-  Given history returns one assistant message with seq 5 and text "boundary-text"
-    And the topology events buffer also contains a text_delta event for the same session with seq 5 and text "boundary-text"
-  When TimelineView mounts and folds both sources
-  Then the assistant text "boundary-text" is rendered exactly once
+    Filter: TimelineView.history.arrival_barrier_dedupe
+  Given TimelineView is mounted with viewSessionKey "S" and a pending GET /api/v1/chat/sessions/S/messages
+    And the topology subscription delivers a text_delta event for session "S" with delta "boundary-text" while the history fetch is still pending
+    And the rendered DOM (pre-history) contains "boundary-text" exactly once via the live path
+  When the history fetch resolves with one assistant message whose content is "boundary-text"
+  Then the rendered DOM contains "boundary-text" exactly once
+    And the assistant content is sourced from the history payload (rendered through the history TurnCard path), not duplicated by the pre-history live event
 
 Scenario: History fetch failure still allows live chat to function
   Test:
@@ -223,8 +240,12 @@ Scenario: History fetch failure still allows live chat to function
 - Adding `parent_id` (or any other field) to `SessionEntry`.
 - Building the cross-session fork-tree sidebar (deferred per user).
 - Unifying `ChatMessage.seq` (per-tape counter) with
-  `TopologyEventEntry.seq` (topology hub counter). The dedupe rule
-  above tolerates the gap; full unification is a separate concern.
+  `TopologyEventEntry.seq` (per-WS-connection counter). The
+  arrival-barrier dedupe above sidesteps the gap entirely; any
+  cross-counter unification work is a separate concern and not needed
+  for this spec to pass.
+- Building the vitest adapter for `agent-spec lifecycle`. Tracked
+  separately in issue 2015.
 - Pagination of history beyond `limit=200`. The backend already
   supports `?limit=N`; UI-side scroll-to-load-more is a follow-up.
 - Touching the legacy `pages/Chat.tsx` surface — it has its own

--- a/specs/issue-2013-topology-timeline-history.spec.md
+++ b/specs/issue-2013-topology-timeline-history.spec.md
@@ -226,6 +226,19 @@ Scenario: Live events that arrived before history resolved are not re-rendered a
   Then the rendered DOM contains "boundary-text" exactly once
     And the assistant content is sourced from the history payload (rendered through the history TurnCard path), not duplicated by the pre-history live event
 
+Scenario: WS reconnect re-snapshots the barrier even when history payload is structurally unchanged
+  Test:
+    Package: web
+    Filter: TimelineView.history.reconnect_resnapshots_barrier
+  Given TimelineView is mounted with viewSessionKey "S" and a history fetch that resolves with one assistant message "X"
+    And the rendered DOM contains "X" exactly once
+    And a live text_delta event for "Y" has rendered post-barrier
+  When the topology subscription rebuilds its events buffer from [] (mimicking a WS reconnect)
+    And the history refetch resolves with a payload structurally identical to the previous one (same array reference under react-query structural sharing)
+    And a fresh live text_delta event for "X" arrives (kernel re-streaming the in-progress turn after reconnect)
+  Then the rendered DOM contains "X" exactly once
+    And the post-reconnect live frame is gated by a freshly-snapshotted arrival barrier rather than rendering on top of history
+
 Scenario: History fetch failure still allows live chat to function
   Test:
     Package: web

--- a/specs/issue-2013-topology-timeline-history.spec.md
+++ b/specs/issue-2013-topology-timeline-history.spec.md
@@ -83,6 +83,39 @@ the "Waiting for the next turn…" placeholder. After the fix, it sees
 the user-bubble text and the assistant text rendered through
 `TurnCard`. Fail before, pass after.
 
+Two visual regressions in the in-flight implementation (caught by
+parent-agent browser smoke test against PR 2018) extend this Intent:
+
+1. **Chronological ordering regression.** The current code in
+   `TimelineView.tsx:297–305` renders ALL user bubbles before ALL
+   agent turns. That was acceptable when "user bubbles" meant 1–2
+   optimistic live-session entries, but with history loaded it pulls
+   every historical user message to the top of the timeline, losing
+   conversation flow. Concrete repro: session
+   `d6e905d9-fd62-41ca-8918-97b37276f534` has 8 user / 17 assistant /
+   6 tool_result messages; in the rendered DOM all 8 user bubbles
+   stack at `top: -1372px` (above all assistant content), so a user
+   scrolled to the top sees only assistant content and asks "where
+   did the questions go". Fix: interleave user bubbles and agent
+   turns chronologically using the existing `created_at` field on
+   `ChatMessage` (already on the wire — see
+   `crates/extensions/backend-admin/src/chat/service.rs:996`,
+   `created_at: entry.timestamp` — and already serialized as i64
+   milliseconds via `#[serde(with = "ts_milliseconds")]` on the
+   shared `ChatMessage` type). Live agent turns produced from
+   topology events have no `created_at` but are by construction
+   strictly post-barrier, so they sort to the tail.
+
+2. **Assistant `TurnCard` height regression.** Assistant turns
+   render with substantially over-tall empty card frames in the
+   browser, inconsistent with the desired inline-markdown shape
+   (see `vendor/craft.png`). Either the historical render path
+   produces empty inner segments (e.g. an empty assistant text row
+   that still occupies a full segment height) or the `TurnCard`
+   container has unconditional padding / `min-height`. Implementer
+   investigates; the falsifying contract is the height-bound
+   scenario below.
+
 ## Decisions
 
 - **Where the fetch lives.** New hook `web/src/hooks/use-session-history.ts`
@@ -100,19 +133,54 @@ the user-bubble text and the assistant text rendered through
   match the backend default at `router.rs:550`.
 - **Mapping to existing render shapes.** Historical user messages
   (`role === "user"`) feed `userTurnsBySession[viewSessionKey]` as
-  `{id, text, t}` entries — the same shape `handleSubmit` already
-  produces — so the existing `UserMessageBubble` rendering path is
-  reused. Historical assistant messages (`role === "assistant"`) and
-  tool messages (`role === "tool"` / `"tool_result"`) build a new
-  `historyTurns: TurnCardData[]` array via a pure helper
-  `buildTurnsFromHistory(messages)` co-located with the other reducer
-  in `TurnCard.tsx`. The helper folds consecutive
+  `{id, text, t, createdAt}` entries — the same shape `handleSubmit`
+  already produces, plus a `createdAt` field threaded from
+  `ChatMessage.created_at` so that interleaved chronological ordering
+  (see next bullet) has a real key to sort on. Historical assistant
+  messages (`role === "assistant"`) and tool messages (`role === "tool"`
+  / `"tool_result"`) build a new `historyTurns: TurnCardData[]` array
+  via a pure helper `buildTurnsFromHistory(messages)` co-located with
+  the other reducer in `TurnCard.tsx`. The helper folds consecutive
   assistant + tool-result messages into one `TurnCardData` (one user
   prompt = one assistant turn, ending at the next user message or
   end-of-list), populates `text` from assistant content, `toolCalls`
   from `assistant.tool_calls` paired with the corresponding
-  `tool_result` content, and sets `inFlight: false`, `metrics: null`,
-  `usage: null` (history does not carry the live metrics frame).
+  `tool_result` content, sets `inFlight: false`, `metrics: null`,
+  `usage: null` (history does not carry the live metrics frame), and
+  carries `createdAt` from the assistant message that anchors the turn
+  so the chronological merge has a sort key for both bubbles and
+  turns.
+- **Chronological ordering of bubbles and turns.** Historical user
+  bubbles and historical+live agent turns render in a **single ordered
+  list** keyed on `createdAt` for history-sourced items. The earlier
+  "all user bubbles first, then all agent turns" design (current
+  `TimelineView.tsx:297–305`) is removed because it broke once history
+  loaded more than 1–2 user messages: with 8 historical user prompts
+  the entire prompt sequence floats above the agent replies, losing
+  conversation flow (concrete repro on session
+  `d6e905d9-fd62-41ca-8918-97b37276f534`: 8 user bubbles render at
+  `top: -1372px`, above all assistant content). Live agent turns
+  derived from topology events have no `createdAt`; they always sort
+  to the tail because they are by construction strictly post-barrier
+  (the arrival barrier ensures any live turn was produced after the
+  history fetch resolved). Implementation: build a unified array of
+  `{kind: "bubble" | "turn", createdAt: number | null, payload}` and
+  sort stably by `createdAt` ascending with `null` last; render in
+  order. Each rendered node carries `data-testid="turn-or-bubble"` for
+  the chronological-ordering scenarios.
+- **Assistant turn height matches content.** Visual regression
+  observed in the parent agent's browser smoke test: assistant
+  `TurnCard`s render with substantially over-tall empty boxes,
+  inconsistent with the desired inline-markdown rendering (compare
+  `vendor/craft.png`). Root cause is to be diagnosed by the
+  implementer; the contract is that an assistant turn whose only
+  content is a short plain-text body must not render a card frame
+  with empty internal segments or unconditional `min-height` padding.
+  Either (a) suppress empty inner segments in `TurnCard.tsx` so a
+  text-only history turn renders only the markdown row, or
+  (b) remove the unconditional `min-height` / over-large vertical
+  padding from the card container, whichever is the smaller change.
+  Falsified by the new height-bound scenario.
 - **Live + history dedupe — arrival-barrier, not seq.** `ChatMessage.seq`
   (per-tape, persistent) and `TopologyEventEntry.seq`
   (`web/src/hooks/use-topology-subscription.ts:179,196`, per-WS-connection,
@@ -239,6 +307,36 @@ Scenario: WS reconnect re-snapshots the barrier even when history payload is str
   Then the rendered DOM contains "X" exactly once
     And the post-reconnect live frame is gated by a freshly-snapshotted arrival barrier rather than rendering on top of history
 
+Scenario: Historical user bubbles and assistant turns render in chronological order
+  Test:
+    Package: web
+    Filter: TimelineView.history.chronological_ordering_history_only
+  Given a session whose history payload returns four messages in tape order: M1 role=user content="q1" created_at=t1, M2 role=assistant content="a1" created_at=t2, M3 role=user content="q2" created_at=t3, M4 role=assistant content="a2" created_at=t4 with t1<t2<t3<t4
+  When TimelineView mounts with that viewSessionKey and an empty topology events buffer
+  Then the rendered DOM contains exactly four nodes with attribute data-testid="turn-or-bubble"
+    And the document order of those nodes is: bubble("q1"), turn("a1"), bubble("q2"), turn("a2")
+    And no node containing "q2" appears in the DOM before any node containing "a1"
+
+Scenario: Live agent turn renders strictly after historical entries
+  Test:
+    Package: web
+    Filter: TimelineView.history.chronological_ordering_history_then_live
+  Given a session whose history payload returns two messages: M1 role=user content="hist-q" created_at=t1, M2 role=assistant content="hist-a" created_at=t2 with t1<t2
+    And TimelineView is mounted with that viewSessionKey and the rendered DOM contains bubble("hist-q") then turn("hist-a") in that order
+  When the topology subscription delivers a post-barrier text_delta event for the same session that produces an agent turn with text "live-a"
+  Then the document order of the data-testid="turn-or-bubble" nodes is: bubble("hist-q"), turn("hist-a"), turn("live-a")
+    And no node containing "live-a" appears in the DOM before any node containing "hist-a"
+
+Scenario: Assistant turn with short text content renders without an over-tall empty card
+  Test:
+    Package: web
+    Filter: TimelineView.history.assistant_turn_height_matches_content
+  Given a session whose history payload returns one assistant message of role=assistant content="ok" created_at=t1 with no tool_calls
+  When TimelineView mounts with that viewSessionKey
+  Then the rendered TurnCard for that message contains the text "ok"
+    And the rendered TurnCard's bounding height is at most 96 pixels (single short markdown line plus padding)
+    And the rendered TurnCard contains no descendant element with computed style min-height greater than 0 other than the content row itself
+
 Scenario: History fetch failure still allows live chat to function
   Test:
     Package: web
@@ -263,9 +361,10 @@ Scenario: History fetch failure still allows live chat to function
   supports `?limit=N`; UI-side scroll-to-load-more is a follow-up.
 - Touching the legacy `pages/Chat.tsx` surface — it has its own
   rendering strategy and is not what regressed.
-- Adding interleaved (timestamp-sorted) ordering between historical
-  user prompts and assistant turns — the existing `TimelineView`
-  already groups user turns above agent turns within a session, and
-  this spec preserves that ordering.
+- Sub-second tie-breaking between bubbles and turns that share the
+  same `created_at` timestamp. Backend timestamps are millisecond
+  resolution; if two messages collide on `created_at` the renderer
+  falls back to tape insertion order from the history payload, which
+  is already monotonic by `seq`. No additional contract is required.
 - Backend changes of any kind. Endpoint and service are already
   correct.

--- a/specs/issue-2013-topology-timeline-history.spec.md
+++ b/specs/issue-2013-topology-timeline-history.spec.md
@@ -1,0 +1,237 @@
+spec: task
+name: "issue-2013-topology-timeline-history"
+inherits: project
+tags: []
+---
+
+## Intent
+
+The topology page's center pane (`web/src/components/topology/TimelineView.tsx`)
+no longer loads persisted chat history. After the craft-vendor chat refactor
+landed in the multi-agent observability umbrella (PR 2003 / #1999), the
+center column renders only (a) optimistic local user turns from
+`userTurnsBySession` state and (b) agent turns reduced from the topology
+WebSocket. It never fetches the session's tape on mount. Re-opening
+`/topology/<existing-key>` for a session with prior conversation shows the
+empty-state placeholder until a new live event arrives — historical user
+prompts and agent replies are invisible even though they are intact on
+disk.
+
+The backend already has the fetch path. `GET /api/v1/chat/sessions/{key}/messages`
+(handler at `crates/extensions/backend-admin/src/chat/router.rs:544`,
+service at `service.rs:630`) returns `Vec<ChatMessage>` derived from tape
+entries, with monotonic `seq`, `role`, `content`, `tool_calls`,
+`tool_call_id`, `tool_name`, `created_at`. Each child session has its own
+tape (children get a distinct `SessionKey` via `Kernel::spawn_child` at
+`crates/kernel/src/handle.rs:559`), so history is per-session-key — the
+same key the topology shell is already routing on. No backend change is
+needed.
+
+The current `web/src/components/topology/AGENT.md` already documents the
+gap explicitly: *"history-on-reload is deferred (no `GET /messages`
+endpoint yet)"*. The endpoint exists; the frontend just never plugged
+into it.
+
+Reproducer:
+1. Open `/topology` on a deployment with at least one chat session that
+   has prior messages (e.g. the auto-selected most-recent session that
+   `SessionPicker` lands on).
+2. Center pane shows: *"Waiting for the next turn on `<key>`…"*. No
+   bubbles, no `TurnCard`s.
+3. `curl http://10.0.0.183:25555/api/v1/chat/sessions/<key>/messages`
+   returns N>0 messages. The data is there.
+4. After fix: same navigation renders historical user bubbles +
+   assistant `TurnCard`s in `seq` order before any WS event arrives.
+
+Prior art reviewed:
+- PR 2003 / #1999 ("multi-agent observability UI") landed the topology
+  shell. Its task #6 commit `6fadb9bf` ("feat(web): topology timeline
+  view") shipped `TimelineView` without history. Subsequent commits in
+  the same umbrella (`62de3b62` craft chat input, `8ec0dadb` 3-pane
+  shell, `bdc45b89` tape lineage) compounded the surface but none
+  wired history. The umbrella merged on 2026-04-30; this is its known
+  follow-up.
+- `web/src/components/topology/AGENT.md:38–39` calls out the deferred
+  history fetch by name.
+- No prior issue or PR re-opens this scope — confirmed via
+  `gh issue list --search "topology history messages"`,
+  `gh pr list --search "topology timeline"`, and
+  `git log --grep topology --since=90.days`.
+- The legacy chat surface (`pages/Chat.tsx`, `hooks/use-session-timeline.ts`)
+  uses a different live-rendering strategy (per-session WS only) and
+  does not call `/messages` either, so there is no existing fetch hook
+  to reuse — a new hook is the smallest change.
+- `crates/extensions/backend-admin/src/chat/service.rs:944–1060`
+  (`tap_entries_to_chat_messages`) is the source of truth for
+  ChatMessage shape; the frontend mapping mirrors it.
+
+Goal alignment: advances signal 4 ("every action is inspectable") — a
+topology view that hides persisted turns is a lying inspector. Indirectly
+advances signal 2 ("the user stops asking") because losing visible
+history forces the user to re-ask. Crosses no NOT line; this is
+restoring observable behavior, not a feature-parity push.
+
+Hermes positioning: chat history rendering is table-stakes for any agent
+UI (Hermes does this trivially); rara has no engineering reason to do it
+differently. The reason it regressed is purely accidental — vendor swap
+landed before the fetch path was wired. Restoring the obvious behavior.
+
+Single test that nails the lane: a vitest test mounts `<TimelineView>`
+with a `viewSessionKey` whose `/messages` response is mocked to return
+two messages (one user, one assistant). Before the fix, the test sees
+the "Waiting for the next turn…" placeholder. After the fix, it sees
+the user-bubble text and the assistant text rendered through
+`TurnCard`. Fail before, pass after.
+
+## Decisions
+
+- **Where the fetch lives.** New hook `web/src/hooks/use-session-history.ts`
+  owns the `react-query` fetch keyed by `['topology', 'session-history',
+  sessionKey]`. Pattern matches `use-chat-models` / `use-skills`
+  (react-query, `staleTime` aligned with the data's mutation cadence —
+  history mutates on every turn, so `staleTime: 0` and rely on the WS
+  push for freshness). The hook is invoked from `TimelineView` keyed on
+  `viewSessionKey`, so switching workers automatically refetches.
+- **REST wrapper.** Add `listMessages(key, limit?)` to
+  `web/src/api/sessions.ts` returning a typed `ChatMessage[]`. The
+  TypeScript shape mirrors `crates/kernel/src/channel/types.rs`'s
+  `ChatMessage` (fields `seq`, `role`, `content`, `tool_calls`,
+  `tool_call_id`, `tool_name`, `created_at`). Default `limit` 200 to
+  match the backend default at `router.rs:550`.
+- **Mapping to existing render shapes.** Historical user messages
+  (`role === "user"`) feed `userTurnsBySession[viewSessionKey]` as
+  `{id, text, t}` entries — the same shape `handleSubmit` already
+  produces — so the existing `UserMessageBubble` rendering path is
+  reused. Historical assistant messages (`role === "assistant"`) and
+  tool messages (`role === "tool"` / `"tool_result"`) build a new
+  `historyTurns: TurnCardData[]` array via a pure helper
+  `buildTurnsFromHistory(messages)` co-located with the other reducer
+  in `TurnCard.tsx`. The helper folds consecutive
+  assistant + tool-result messages into one `TurnCardData` (one user
+  prompt = one assistant turn, ending at the next user message or
+  end-of-list), populates `text` from assistant content, `toolCalls`
+  from `assistant.tool_calls` paired with the corresponding
+  `tool_result` content, and sets `inFlight: false`, `metrics: null`,
+  `usage: null` (history does not carry the live metrics frame).
+- **Live + history dedupe.** History returns messages with monotonic
+  `seq`. Compute `lastHistorySeq = max(history.seq)` (or 0 if history
+  is empty). When folding live `events` from the topology subscription
+  for `viewSessionKey`, drop entries whose `seq <= lastHistorySeq`
+  before passing them to `buildTurnsFromEvents`. This prevents
+  double-rendering at the boundary if a frame the backend persisted
+  was also delivered live before the fetch resolved.
+  Note: `ChatMessage.seq` and `TopologyEventEntry.seq` come from
+  different counters today (the former is per-tape, the latter is the
+  topology hub's monotonic frame seq). The dedupe relies on both being
+  monotonic and aligned by `created_at`/arrival on the same session.
+  If the implementer finds the two seq spaces are not directly
+  comparable, fall back to filtering live events with
+  `created_at` strictly greater than the latest history `created_at`,
+  and add a fixme comment naming the seq-unification work as a
+  follow-up. Either way the boundary must not double-render.
+- **Session switch reset.** Already handled correctly: `userTurnsBySession`
+  keys by session, and `agentTurns` filters `events` by session. The
+  new history hook keys on `viewSessionKey` so react-query swaps the
+  cached entry on switch. No teardown needed beyond letting the hook
+  re-key.
+- **Loading and error UI.** While the fetch is pending, render the
+  existing placeholder ("Waiting for the next turn on …") — no
+  spinner, no skeleton. On fetch error, render an inline retry-able
+  error band above the input editor; do NOT block the WebSocket from
+  attaching, so a transient HTTP failure does not break live chat.
+  This matches the project's "no noop UX" posture: the user is told
+  history failed to load, but the rest of the surface keeps working.
+- **No backend changes.** The endpoint, the service, and the tape
+  conversion already exist and are correct. Spec scope is purely
+  `web/`.
+- **No fork-tree sidebar, no SessionEntry parent_id.** Both deferred
+  per user direction — out of scope.
+
+## Boundaries
+
+### Allowed Changes
+- **/web/src/components/topology/TimelineView.tsx
+- **/web/src/components/topology/TurnCard.tsx
+- **/web/src/components/topology/AGENT.md
+- **/web/src/hooks/use-session-history.ts
+- **/web/src/api/sessions.ts
+- **/web/src/api/types.ts
+- **/web/vitest.config.ts
+- **/web/src/components/topology/__tests__/**
+- **/web/src/hooks/__tests__/**
+- **/specs/issue-2013-topology-timeline-history.spec.md
+
+### Forbidden
+- crates/**
+- web/src/vendor/**
+- web/src/pages/Chat.tsx
+- web/src/hooks/use-session-timeline.ts
+- web/src/hooks/use-topology-subscription.ts
+- web/src/hooks/use-chat-session-ws.ts
+- web/src/agent/**
+- web/src/components/topology/SessionPicker.tsx
+- web/src/components/topology/WorkerInbox.tsx
+- web/src/components/topology/TapeLineageView.tsx
+- web/src/components/topology/SpawnMarker.tsx
+- web/src/components/topology/WorkerCard.tsx
+- web/src/components/topology/tape-tree-layout.ts
+- .github/workflows/**
+- config.example.yaml
+
+## Acceptance Criteria
+
+Scenario: TimelineView renders historical messages on mount before any live event
+  Test:
+    Package: web
+    Filter: TimelineView.history.renders_history_before_live_events
+  Given a session key with two persisted messages (one user "hello", one assistant "hi there") returned by GET /api/v1/chat/sessions/{key}/messages
+  When TimelineView mounts with that viewSessionKey and an empty topology events buffer
+  Then the rendered DOM contains the user bubble text "hello"
+    And contains the assistant text "hi there" rendered via TurnCard
+    And does not show the "Waiting for the next turn" placeholder
+
+Scenario: Switching viewSessionKey refetches history and resets the rendered timeline
+  Test:
+    Package: web
+    Filter: TimelineView.history.session_switch_refetches
+  Given TimelineView is mounted with viewSessionKey "A" whose history contains message "from-A"
+    And the rendered DOM contains "from-A"
+  When the parent re-renders with viewSessionKey "B" whose history contains message "from-B"
+  Then the rendered DOM contains "from-B"
+    And the rendered DOM does not contain "from-A"
+
+Scenario: Live events with seq at or below the last history seq are not re-rendered
+  Test:
+    Package: web
+    Filter: TimelineView.history.boundary_dedupe
+  Given history returns one assistant message with seq 5 and text "boundary-text"
+    And the topology events buffer also contains a text_delta event for the same session with seq 5 and text "boundary-text"
+  When TimelineView mounts and folds both sources
+  Then the assistant text "boundary-text" is rendered exactly once
+
+Scenario: History fetch failure still allows live chat to function
+  Test:
+    Package: web
+    Filter: TimelineView.history.fetch_error_does_not_block_live
+  Given GET /api/v1/chat/sessions/{key}/messages responds with HTTP 500
+  When TimelineView mounts with that viewSessionKey
+  Then an inline error band is visible
+    And the InputContainer is rendered and not disabled solely because of the history fetch error
+
+## Out of Scope
+
+- Adding `parent_id` (or any other field) to `SessionEntry`.
+- Building the cross-session fork-tree sidebar (deferred per user).
+- Unifying `ChatMessage.seq` (per-tape counter) with
+  `TopologyEventEntry.seq` (topology hub counter). The dedupe rule
+  above tolerates the gap; full unification is a separate concern.
+- Pagination of history beyond `limit=200`. The backend already
+  supports `?limit=N`; UI-side scroll-to-load-more is a follow-up.
+- Touching the legacy `pages/Chat.tsx` surface — it has its own
+  rendering strategy and is not what regressed.
+- Adding interleaved (timestamp-sorted) ordering between historical
+  user prompts and assistant turns — the existing `TimelineView`
+  already groups user turns above agent turns within a session, and
+  this spec preserves that ordering.
+- Backend changes of any kind. Endpoint and service are already
+  correct.

--- a/specs/issue-2013-topology-timeline-history.spec.md
+++ b/specs/issue-2013-topology-timeline-history.spec.md
@@ -235,7 +235,9 @@ parent-agent browser smoke test against PR 2018) extend this Intent:
 ### Allowed Changes
 - **/web/src/components/topology/TimelineView.tsx
 - **/web/src/components/topology/TurnCard.tsx
+- **/web/src/components/topology/RaraTurnCard.tsx
 - **/web/src/components/topology/AGENT.md
+- **/web/src/test-setup.ts
 - **/web/src/hooks/use-session-history.ts
 - **/web/src/api/sessions.ts
 - **/web/src/api/types.ts
@@ -336,6 +338,16 @@ Scenario: Assistant turn with short text content renders without an over-tall em
   Then the rendered TurnCard for that message contains the text "ok"
     And the rendered TurnCard's bounding height is at most 96 pixels (single short markdown line plus padding)
     And the rendered TurnCard contains no descendant element with computed style min-height greater than 0 other than the content row itself
+
+Scenario: Assistant message body is rendered as markdown by the vendor TurnCard surface
+  Test:
+    Package: web
+    Filter: TimelineView.history.markdown_renders_inline_formatting
+  Given a session whose history payload returns one assistant message with content "Here is **bold** and `code`"
+  When TimelineView mounts with that viewSessionKey
+  Then the rendered DOM contains a <strong> element whose text is "bold"
+    And the rendered DOM contains a <code> element whose text is "code"
+    And no literal "**" or backtick characters appear adjacent to those tokens (proving the markdown was parsed, not displayed verbatim)
 
 Scenario: History fetch failure still allows live chat to function
   Test:

--- a/web/src/api/sessions.ts
+++ b/web/src/api/sessions.ts
@@ -15,6 +15,7 @@
  */
 
 import { api } from './client';
+import type { ChatMessageData } from './types';
 
 /**
  * One hit returned by `GET /api/v1/chat/sessions/search`.
@@ -56,4 +57,22 @@ export async function searchSessions(
     options?.signal ? { signal: options.signal } : undefined,
   );
   return res.hits;
+}
+
+/**
+ * Fetch persisted chat messages for a session via
+ * `GET /api/v1/chat/sessions/{key}/messages`.
+ *
+ * The backend reduces the session's tape into a flat `ChatMessage[]` with
+ * monotonic `seq`. Default `limit` of 200 mirrors the backend default —
+ * see `crates/extensions/backend-admin/src/chat/router.rs`.
+ */
+export async function listMessages(
+  sessionKey: string,
+  limit = 200,
+  options?: { signal?: AbortSignal },
+): Promise<ChatMessageData[]> {
+  const params = new URLSearchParams({ limit: String(limit) });
+  const path = `/api/v1/chat/sessions/${encodeURIComponent(sessionKey)}/messages?${params.toString()}`;
+  return api.get<ChatMessageData[]>(path, options?.signal ? { signal: options.signal } : undefined);
 }

--- a/web/src/components/topology/AGENT.md
+++ b/web/src/components/topology/AGENT.md
@@ -35,8 +35,15 @@ the old free-text "root session key" input with a clickable list.
   user did not pick. User-message rendering is **optimistic**: the typed
   text is added to local state on submit so it appears before the
   backend round-trip; the kernel does not echo user prompts back as
-  topology events today, and history-on-reload is deferred (no
-  `GET /messages` endpoint yet).
+  topology events today. History-on-reload fetches
+  `GET /api/v1/chat/sessions/{key}/messages` via `useSessionHistory` and
+  reduces persisted assistant turns through `buildTurnsFromHistory`,
+  while persisted user messages render as `UserMessageBubble`s ahead of
+  any optimistic prompts. Live events with `seq <= max(history.seq)` are
+  filtered out before the live reducer runs to avoid double-rendering at
+  the boundary — this is conservative because `ChatMessage.seq` (per-tape)
+  and `TopologyEventEntry.seq` (per-WS-connection) are distinct monotonic
+  counters; full unification is tracked in issue #2013.
 - `TurnCard.tsx` — one turn = one card. Owns the reducer
   `buildTurnsFromEvents` that folds a flat `WebFrame` stream into
   `TurnCardData[]` (text, reasoning, tool calls, markers, metrics,

--- a/web/src/components/topology/AGENT.md
+++ b/web/src/components/topology/AGENT.md
@@ -39,11 +39,16 @@ the old free-text "root session key" input with a clickable list.
   `GET /api/v1/chat/sessions/{key}/messages` via `useSessionHistory` and
   reduces persisted assistant turns through `buildTurnsFromHistory`,
   while persisted user messages render as `UserMessageBubble`s ahead of
-  any optimistic prompts. Live events with `seq <= max(history.seq)` are
-  filtered out before the live reducer runs to avoid double-rendering at
-  the boundary — this is conservative because `ChatMessage.seq` (per-tape)
-  and `TopologyEventEntry.seq` (per-WS-connection) are distinct monotonic
-  counters; full unification is tracked in issue #2013.
+  any optimistic prompts. Live/history dedupe uses an **arrival-time
+  barrier**, not seq comparison: at the moment the history query resolves
+  for `viewSessionKey`, the current length of the session-filtered topology
+  buffer is snapshotted; only entries whose buffer index is `>= barrier`
+  feed the live reducer. The barrier resets on session switch (keyed map)
+  and on WS reconnect (detected by the session-filtered buffer length
+  going backwards, which triggers `history.refetch()` and a re-snapshot).
+  This avoids comparing `ChatMessage.seq` (per-tape) with
+  `TopologyEventEntry.seq` (per-WS-connection, resets on reconnect) — see
+  `specs/issue-2013-topology-timeline-history.spec.md` Decisions.
 - `TurnCard.tsx` — one turn = one card. Owns the reducer
   `buildTurnsFromEvents` that folds a flat `WebFrame` stream into
   `TurnCardData[]` (text, reasoning, tool calls, markers, metrics,

--- a/web/src/components/topology/RaraTurnCard.tsx
+++ b/web/src/components/topology/RaraTurnCard.tsx
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2025 Rararulab
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useMemo } from 'react';
+
+import { SpawnMarker } from './SpawnMarker';
+import type { TurnCardData } from './TurnCard';
+
+import { TurnCard as VendorTurnCard } from '~vendor/components/chat/TurnCard';
+import type { ActivityItem, ResponseContent } from '~vendor/components/chat/TurnCard';
+
+/**
+ * Rara-side adapter that maps the in-tree `TurnCardData` shape onto the
+ * vendor `TurnCard` (craft-agents-oss). Rara accumulates assistant text,
+ * reasoning, and tool calls through its own reducers (see `TurnCard.tsx`'s
+ * `buildTurnsFromHistory` / `buildTurnsFromEvents`); the vendor expects a
+ * flat `ActivityItem[]` plus a single `ResponseContent`. This file is the
+ * only place that bridges the two — keeping the rest of the topology tree
+ * unaware of the vendor surface.
+ *
+ * Many vendor callbacks (`onAcceptPlan`, `onAddAnnotation`, `onBranch`,
+ * `onOpenDetails`, …) are intentionally left undefined; rara doesn't yet
+ * expose those surfaces. The vendor handles `undefined` gracefully — any
+ * crash on a missing optional is a vendor bug to flag, not something to
+ * silently work around.
+ */
+export interface RaraTurnCardProps {
+  turn: TurnCardData;
+}
+
+export function RaraTurnCard({ turn }: RaraTurnCardProps) {
+  const activities = useMemo<ActivityItem[]>(() => {
+    const items: ActivityItem[] = [];
+    // Vendor sorts activities by `timestamp` — only relative ordering
+    // matters within a single turn, so a small monotonic counter anchored
+    // at the turn's `createdAt` (or 0 for live turns) gives the vendor
+    // stable, deterministic ordering without calling `Date.now()` during
+    // render.
+    let cursor = turn.createdAt ?? 0;
+
+    if (turn.reasoning.trim().length > 0) {
+      items.push({
+        id: `${turn.id}:thinking`,
+        type: 'thinking',
+        status: turn.inFlight ? 'running' : 'completed',
+        content: turn.reasoning,
+        timestamp: cursor++,
+      });
+    }
+
+    for (const call of turn.toolCalls) {
+      const failed = call.result !== null && !call.result.success;
+      const pending = call.result === null;
+      // `exactOptionalPropertyTypes` rejects assigning `undefined` to an
+      // optional field — only add `content` / `error` when we actually
+      // have a value.
+      const item: ActivityItem = {
+        id: call.id,
+        type: 'tool',
+        status: pending ? 'running' : failed ? 'error' : 'completed',
+        toolName: call.name,
+        toolUseId: call.id,
+        timestamp: cursor++,
+      };
+      if (call.result?.preview) item.content = call.result.preview;
+      if (failed && call.result?.error) item.error = call.result.error;
+      items.push(item);
+    }
+
+    return items;
+  }, [turn.id, turn.createdAt, turn.reasoning, turn.toolCalls, turn.inFlight]);
+
+  const response = useMemo<ResponseContent | undefined>(() => {
+    if (turn.text.length === 0) return undefined;
+    return {
+      text: turn.text,
+      isStreaming: turn.inFlight,
+      isPlan: false,
+    };
+  }, [turn.text, turn.inFlight]);
+
+  // Conditionally spread `response` only when defined — vendor's
+  // `TurnCardProps.response` is optional, but `exactOptionalPropertyTypes`
+  // forbids passing `undefined` explicitly.
+  const responseProps = response ? { response } : {};
+
+  return (
+    <div className="space-y-2">
+      <VendorTurnCard
+        turnId={turn.id}
+        activities={activities}
+        {...responseProps}
+        isStreaming={turn.inFlight}
+        isComplete={!turn.inFlight}
+      />
+      {turn.markers.length > 0 && (
+        <div className="space-y-1.5">
+          {turn.markers.map((marker, idx) => (
+            <SpawnMarker key={`${turn.id}-marker-${String(idx)}`} marker={marker} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/src/components/topology/TimelineView.tsx
+++ b/web/src/components/topology/TimelineView.tsx
@@ -122,6 +122,11 @@ export function TimelineView({ viewSessionKey, events, promptSessionKey }: Timel
   const history = useSessionHistory(viewSessionKey);
   const historyMessages = history.data;
   const historyIsSuccess = history.isSuccess;
+  // `dataUpdatedAt` increments on every successful resolution regardless
+  // of structural sharing — `historyMessages` would keep the same object
+  // reference when react-query refetches identical data, which would
+  // silently skip the barrier-snapshot effect after a WS reconnect.
+  const historyDataUpdatedAt = history.dataUpdatedAt;
 
   // Session-filtered slice of the topology subscription buffer. The
   // arrival barrier indexes into THIS array (not the full cross-session
@@ -180,8 +185,15 @@ export function TimelineView({ viewSessionKey, events, promptSessionKey }: Timel
   }, [sessionEvents.length, viewSessionKey, history]);
 
   // Snapshot the barrier the first time the history query resolves for
-  // this session. The data identity (`historyMessages`) plus the success
-  // flag together cover both the initial fetch and refetch-after-reset.
+  // this session. We key off `dataUpdatedAt` (a numeric timestamp react-
+  // query bumps on every successful resolution) rather than
+  // `historyMessages` because react-query's default `structuralSharing`
+  // returns a referentially-identical array when a refetch yields the
+  // same payload. After a WS reconnect-then-refetch where the persisted
+  // history is unchanged, the data reference would not move, the effect
+  // would not re-run, the barrier would stay deleted, and the live path
+  // would re-render every pre-reconnect event — duplicating with
+  // history.
   useEffect(() => {
     if (!historyIsSuccess) return;
     setBarrierBySession((prev) => {
@@ -192,7 +204,7 @@ export function TimelineView({ viewSessionKey, events, promptSessionKey }: Timel
     // only — we don't want subsequent length changes to move the
     // barrier.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [historyIsSuccess, historyMessages, viewSessionKey]);
+  }, [historyIsSuccess, historyDataUpdatedAt, viewSessionKey]);
 
   const historyTurns = useMemo(
     () => (historyMessages ? buildTurnsFromHistory(historyMessages) : []),

--- a/web/src/components/topology/TimelineView.tsx
+++ b/web/src/components/topology/TimelineView.tsx
@@ -17,9 +17,8 @@
 import * as TooltipPrimitive from '@radix-ui/react-tooltip';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
-import { TurnCard, buildTurnsFromEvents, buildTurnsFromHistory } from './TurnCard';
+import { TurnCard, buildTurnsFromEvents, buildTurnsFromHistory, contentToText } from './TurnCard';
 
-import type { ChatMessageData } from '@/api/types';
 import { useChatModels } from '@/hooks/use-chat-models';
 import { useChatSessionWs } from '@/hooks/use-chat-session-ws';
 import { useSessionHistory } from '@/hooks/use-session-history';
@@ -33,19 +32,6 @@ import { EscapeInterruptProvider } from '~vendor/context/EscapeInterruptContext'
  *  rara only ever resolves one default provider server-side today; the
  *  picker just needs *a* connection to attach the model list to. */
 const RARA_CONNECTION_SLUG = 'rara';
-
-/**
- * Extract a plain-text user prompt from a persisted `ChatMessage`. The
- * backend may serialise content as either a bare string or a list of
- * multimodal blocks; the topology timeline shows text only.
- */
-function extractUserText(msg: ChatMessageData): string {
-  if (typeof msg.content === 'string') return msg.content;
-  return msg.content
-    .map((block) => (block.type === 'text' ? block.text : ''))
-    .filter((s) => s.length > 0)
-    .join('');
-}
 
 export interface TimelineViewProps {
   /** Session key whose events should be rendered. Workers (children) flip
@@ -135,23 +121,78 @@ export function TimelineView({ viewSessionKey, events, promptSessionKey }: Timel
 
   const history = useSessionHistory(viewSessionKey);
   const historyMessages = history.data;
+  const historyIsSuccess = history.isSuccess;
 
-  // Boundary seq for live/history dedupe. `ChatMessage.seq` (per-tape
-  // counter, assigned in
-  // `crates/extensions/backend-admin/src/chat/service.rs::tap_entries_to_chat_messages`)
-  // and `TopologyEventEntry.seq` (per-WS-connection frame counter, see
-  // `use-topology-subscription`) are NOT the same axis. They are both
-  // monotonic per session, so seq-based filtering is at worst
-  // conservative — it may drop a live frame that was not in history,
-  // which then re-renders on the next WS push. Under-dropping (a
-  // duplicate rendering at the boundary) is the bug we are preventing,
-  // so conservative is the safe direction until the two seq spaces are
-  // unified.
-  // TODO: seq-unification — see issue #2013 decisions section.
-  const lastHistorySeq = useMemo(() => {
-    if (!historyMessages || historyMessages.length === 0) return 0;
-    return historyMessages.reduce((max, m) => (m.seq > max ? m.seq : max), 0);
-  }, [historyMessages]);
+  // Session-filtered slice of the topology subscription buffer. The
+  // arrival barrier indexes into THIS array (not the full cross-session
+  // buffer) because each `TimelineView` only ever folds events for one
+  // session.
+  const sessionEvents = useMemo(
+    () => events.filter((e) => e.sessionKey === viewSessionKey),
+    [events, viewSessionKey],
+  );
+
+  // Arrival-time barrier for live/history dedupe.
+  //
+  // `ChatMessage.seq` (per-tape counter persisted by
+  // `tap_entries_to_chat_messages` in
+  // `crates/extensions/backend-admin/src/chat/service.rs`) and
+  // `TopologyEventEntry.seq` (per-WS-connection frame counter assigned in
+  // `use-topology-subscription`) are NOT comparable axes — the WS counter
+  // resets to 0 on every reconnect, so any cross-counter filter
+  // (`seq > lastHistorySeq`) silently drops live frames after a
+  // reconnect. Instead, snapshot the *length* of the session-filtered
+  // live buffer at the moment the history fetch resolves: live entries
+  // whose buffer index is `< barrier` arrived before history settled and
+  // are treated as already represented in the history payload; entries
+  // at index `>= barrier` are strictly post-history and rendered live.
+  // See `specs/issue-2013-topology-timeline-history.spec.md` Decisions
+  // (Live + history dedupe — arrival-barrier, not seq).
+  //
+  // Reset triggers (per session):
+  //   - `viewSessionKey` change — handled implicitly because the map is
+  //     keyed by session.
+  //   - WS reconnect — detected by the session-filtered buffer length
+  //     going backwards (the `events` buffer is rebuilt from `[]` on
+  //     `hello`, see `use-topology-subscription`'s `handleFrame`). On
+  //     reset we drop the stale barrier; the next successful history
+  //     refetch re-snapshots.
+  const [barrierBySession, setBarrierBySession] = useState<Record<string, number>>({});
+  const lastSessionLengthRef = useRef<Record<string, number>>({});
+
+  useEffect(() => {
+    const prevLen = lastSessionLengthRef.current[viewSessionKey] ?? 0;
+    const curLen = sessionEvents.length;
+    if (curLen < prevLen) {
+      // Buffer shrunk → WS reconnect (or session-buffer truncation).
+      // Drop the stale barrier so the next successful history fetch
+      // re-snapshots, and invalidate the history query so it actually
+      // refetches against the new connection.
+      setBarrierBySession((prev) => {
+        if (!(viewSessionKey in prev)) return prev;
+        const next = { ...prev };
+        delete next[viewSessionKey];
+        return next;
+      });
+      void history.refetch();
+    }
+    lastSessionLengthRef.current[viewSessionKey] = curLen;
+  }, [sessionEvents.length, viewSessionKey, history]);
+
+  // Snapshot the barrier the first time the history query resolves for
+  // this session. The data identity (`historyMessages`) plus the success
+  // flag together cover both the initial fetch and refetch-after-reset.
+  useEffect(() => {
+    if (!historyIsSuccess) return;
+    setBarrierBySession((prev) => {
+      if (viewSessionKey in prev) return prev;
+      return { ...prev, [viewSessionKey]: sessionEvents.length };
+    });
+    // `sessionEvents.length` intentionally captured at resolution time
+    // only — we don't want subsequent length changes to move the
+    // barrier.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [historyIsSuccess, historyMessages, viewSessionKey]);
 
   const historyTurns = useMemo(
     () => (historyMessages ? buildTurnsFromHistory(historyMessages) : []),
@@ -159,12 +200,13 @@ export function TimelineView({ viewSessionKey, events, promptSessionKey }: Timel
   );
 
   const agentTurns = useMemo(() => {
-    const sessionEvents = events
-      .filter((e) => e.sessionKey === viewSessionKey)
-      .filter((e) => e.seq > lastHistorySeq)
-      .map((e) => ({ seq: e.seq, event: e.event }));
-    return buildTurnsFromEvents(sessionEvents);
-  }, [events, viewSessionKey, lastHistorySeq]);
+    // Before the barrier is set (history still pending or errored), the
+    // live path is the only source — render every session event so the
+    // user sees streaming output immediately.
+    const barrier = barrierBySession[viewSessionKey];
+    const sliced = barrier === undefined ? sessionEvents : sessionEvents.slice(barrier);
+    return buildTurnsFromEvents(sliced.map((e) => ({ seq: e.seq, event: e.event })));
+  }, [sessionEvents, viewSessionKey, barrierBySession]);
 
   // Historical user prompts merged with the optimistic local prompts the
   // editor pushes on submit. Historical entries come first in seq order;
@@ -176,7 +218,7 @@ export function TimelineView({ viewSessionKey, events, promptSessionKey }: Timel
       .filter((m) => m.role === 'user')
       .map((m) => ({
         id: `history-user-${String(m.seq)}`,
-        text: extractUserText(m),
+        text: contentToText(m.content),
         t: 0,
       }))
       .filter((u) => u.text.length > 0);

--- a/web/src/components/topology/TimelineView.tsx
+++ b/web/src/components/topology/TimelineView.tsx
@@ -17,10 +17,12 @@
 import * as TooltipPrimitive from '@radix-ui/react-tooltip';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
-import { TurnCard, buildTurnsFromEvents } from './TurnCard';
+import { TurnCard, buildTurnsFromEvents, buildTurnsFromHistory } from './TurnCard';
 
+import type { ChatMessageData } from '@/api/types';
 import { useChatModels } from '@/hooks/use-chat-models';
 import { useChatSessionWs } from '@/hooks/use-chat-session-ws';
+import { useSessionHistory } from '@/hooks/use-session-history';
 import type { TopologyEventEntry } from '@/hooks/use-topology-subscription';
 import { UserMessageBubble } from '~vendor/components/chat/UserMessageBubble';
 import { InputContainer } from '~vendor/components/input/InputContainer';
@@ -31,6 +33,19 @@ import { EscapeInterruptProvider } from '~vendor/context/EscapeInterruptContext'
  *  rara only ever resolves one default provider server-side today; the
  *  picker just needs *a* connection to attach the model list to. */
 const RARA_CONNECTION_SLUG = 'rara';
+
+/**
+ * Extract a plain-text user prompt from a persisted `ChatMessage`. The
+ * backend may serialise content as either a bare string or a list of
+ * multimodal blocks; the topology timeline shows text only.
+ */
+function extractUserText(msg: ChatMessageData): string {
+  if (typeof msg.content === 'string') return msg.content;
+  return msg.content
+    .map((block) => (block.type === 'text' ? block.text : ''))
+    .filter((s) => s.length > 0)
+    .join('');
+}
 
 export interface TimelineViewProps {
   /** Session key whose events should be rendered. Workers (children) flip
@@ -118,14 +133,64 @@ export function TimelineView({ viewSessionKey, events, promptSessionKey }: Timel
   const [pickedModel, setPickedModel] = useState<string | undefined>(undefined);
   const currentModel = pickedModel ?? defaultModelIdString ?? '';
 
+  const history = useSessionHistory(viewSessionKey);
+  const historyMessages = history.data;
+
+  // Boundary seq for live/history dedupe. `ChatMessage.seq` (per-tape
+  // counter, assigned in
+  // `crates/extensions/backend-admin/src/chat/service.rs::tap_entries_to_chat_messages`)
+  // and `TopologyEventEntry.seq` (per-WS-connection frame counter, see
+  // `use-topology-subscription`) are NOT the same axis. They are both
+  // monotonic per session, so seq-based filtering is at worst
+  // conservative — it may drop a live frame that was not in history,
+  // which then re-renders on the next WS push. Under-dropping (a
+  // duplicate rendering at the boundary) is the bug we are preventing,
+  // so conservative is the safe direction until the two seq spaces are
+  // unified.
+  // TODO: seq-unification — see issue #2013 decisions section.
+  const lastHistorySeq = useMemo(() => {
+    if (!historyMessages || historyMessages.length === 0) return 0;
+    return historyMessages.reduce((max, m) => (m.seq > max ? m.seq : max), 0);
+  }, [historyMessages]);
+
+  const historyTurns = useMemo(
+    () => (historyMessages ? buildTurnsFromHistory(historyMessages) : []),
+    [historyMessages],
+  );
+
   const agentTurns = useMemo(() => {
     const sessionEvents = events
       .filter((e) => e.sessionKey === viewSessionKey)
+      .filter((e) => e.seq > lastHistorySeq)
       .map((e) => ({ seq: e.seq, event: e.event }));
     return buildTurnsFromEvents(sessionEvents);
-  }, [events, viewSessionKey]);
+  }, [events, viewSessionKey, lastHistorySeq]);
 
-  const userTurns = userTurnsBySession[viewSessionKey] ?? [];
+  // Historical user prompts merged with the optimistic local prompts the
+  // editor pushes on submit. Historical entries come first in seq order;
+  // optimistic entries follow because they were typed after the page
+  // loaded.
+  const historyUserBubbles = useMemo<{ id: string; text: string; t: number }[]>(() => {
+    if (!historyMessages) return [];
+    return historyMessages
+      .filter((m) => m.role === 'user')
+      .map((m) => ({
+        id: `history-user-${String(m.seq)}`,
+        text: extractUserText(m),
+        t: 0,
+      }))
+      .filter((u) => u.text.length > 0);
+  }, [historyMessages]);
+
+  const userTurns = useMemo(
+    () => [...historyUserBubbles, ...(userTurnsBySession[viewSessionKey] ?? [])],
+    [historyUserBubbles, userTurnsBySession, viewSessionKey],
+  );
+
+  // Combine persisted assistant turns (from `/messages`) with live agent
+  // turns (from the topology WS). History always appears first because
+  // it is, by definition, the past — live frames extend the tail.
+  const allAgentTurns = useMemo(() => [...historyTurns, ...agentTurns], [historyTurns, agentTurns]);
 
   // Interleaving by wall-clock arrival time would require timestamps on
   // agent turns, which the current TurnCard reducer doesn't track. Until
@@ -134,13 +199,13 @@ export function TimelineView({ viewSessionKey, events, promptSessionKey }: Timel
   // conversation. Subsequent prompts will appear after the latest agent
   // turn in practice because agent turns auto-scroll on append.
   const scrollRef = useRef<HTMLDivElement | null>(null);
-  const lastAgentTurnId = agentTurns.at(-1)?.id;
+  const lastAgentTurnId = allAgentTurns.at(-1)?.id;
   const userCount = userTurns.length;
   useEffect(() => {
     const el = scrollRef.current;
     if (!el) return;
     el.scrollTop = el.scrollHeight;
-  }, [agentTurns.length, lastAgentTurnId, userCount]);
+  }, [allAgentTurns.length, lastAgentTurnId, userCount]);
 
   const handleSubmit = useCallback(
     (message: string) => {
@@ -170,7 +235,7 @@ export function TimelineView({ viewSessionKey, events, promptSessionKey }: Timel
   return (
     <div className="flex flex-1 min-h-0 flex-col">
       <div ref={scrollRef} className="flex-1 min-h-0 space-y-3 overflow-y-auto pr-1">
-        {agentTurns.length === 0 && userTurns.length === 0 ? (
+        {allAgentTurns.length === 0 && userTurns.length === 0 ? (
           <div className="flex h-full items-center justify-center text-sm text-muted-foreground">
             Waiting for the next turn on <span className="ml-1 font-mono">{viewSessionKey}</span>…
           </div>
@@ -181,12 +246,20 @@ export function TimelineView({ viewSessionKey, events, promptSessionKey }: Timel
                 <UserMessageBubble content={u.text} />
               </div>
             ))}
-            {agentTurns.map((turn) => (
+            {allAgentTurns.map((turn) => (
               <TurnCard key={turn.id} turn={turn} />
             ))}
           </>
         )}
       </div>
+      {history.isError && (
+        <div
+          role="alert"
+          className="mt-2 rounded border border-red-300 bg-red-50 px-3 py-2 text-xs text-red-700 dark:border-red-700 dark:bg-red-950 dark:text-red-300"
+        >
+          Failed to load conversation history. Live chat still works — refresh to retry.
+        </div>
+      )}
       <div className="pt-2">
         {/* Vendor InputContainer reaches for an EscapeInterruptProvider
          *  (double-Esc interrupt UX) and a radix TooltipProvider (toolbar

--- a/web/src/components/topology/TimelineView.tsx
+++ b/web/src/components/topology/TimelineView.tsx
@@ -17,8 +17,8 @@
 import * as TooltipPrimitive from '@radix-ui/react-tooltip';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
+import { RaraTurnCard } from './RaraTurnCard';
 import {
-  TurnCard,
   type TurnCardData,
   buildTurnsFromEvents,
   buildTurnsFromHistory,
@@ -342,43 +342,44 @@ export function TimelineView({ viewSessionKey, events, promptSessionKey }: Timel
   const inputDisabled = ws.status === 'idle' || ws.status === 'closed';
 
   return (
-    <div className="flex flex-1 min-h-0 flex-col">
-      <div ref={scrollRef} className="flex-1 min-h-0 space-y-3 overflow-y-auto pr-1">
-        {isEmpty ? (
-          <div className="flex h-full items-center justify-center text-sm text-muted-foreground">
-            Waiting for the next turn on <span className="ml-1 font-mono">{viewSessionKey}</span>…
-          </div>
-        ) : (
-          orderedItems.map((item) =>
-            item.kind === 'bubble' ? (
-              <div key={item.key} data-testid="turn-or-bubble" className="flex justify-end">
-                <UserMessageBubble content={item.text} />
+    // Vendor `TurnCard` (chat) and vendor `InputContainer` (toolbar) both
+    // mount radix Tooltips, so a single TooltipProvider wraps the whole
+    // view rather than being scoped to the input. EscapeInterruptProvider
+    // and AppShellProvider only feed `InputContainer`, but co-locating
+    // them here keeps all vendor-context lifetimes on the same level.
+    <AppShellProvider value={appShellValue}>
+      <EscapeInterruptProvider>
+        <TooltipPrimitive.Provider delayDuration={300}>
+          <div className="flex flex-1 min-h-0 flex-col">
+            <div ref={scrollRef} className="flex-1 min-h-0 space-y-3 overflow-y-auto pr-1">
+              {isEmpty ? (
+                <div className="flex h-full items-center justify-center text-sm text-muted-foreground">
+                  Waiting for the next turn on{' '}
+                  <span className="ml-1 font-mono">{viewSessionKey}</span>…
+                </div>
+              ) : (
+                orderedItems.map((item) =>
+                  item.kind === 'bubble' ? (
+                    <div key={item.key} data-testid="turn-or-bubble" className="flex justify-end">
+                      <UserMessageBubble content={item.text} />
+                    </div>
+                  ) : (
+                    <div key={item.key} data-testid="turn-or-bubble">
+                      <RaraTurnCard turn={item.turn} />
+                    </div>
+                  ),
+                )
+              )}
+            </div>
+            {history.isError && (
+              <div
+                role="alert"
+                className="mt-2 rounded border border-red-300 bg-red-50 px-3 py-2 text-xs text-red-700 dark:border-red-700 dark:bg-red-950 dark:text-red-300"
+              >
+                Failed to load conversation history. Live chat still works — refresh to retry.
               </div>
-            ) : (
-              <div key={item.key} data-testid="turn-or-bubble">
-                <TurnCard turn={item.turn} />
-              </div>
-            ),
-          )
-        )}
-      </div>
-      {history.isError && (
-        <div
-          role="alert"
-          className="mt-2 rounded border border-red-300 bg-red-50 px-3 py-2 text-xs text-red-700 dark:border-red-700 dark:bg-red-950 dark:text-red-300"
-        >
-          Failed to load conversation history. Live chat still works — refresh to retry.
-        </div>
-      )}
-      <div className="pt-2">
-        {/* Vendor InputContainer reaches for an EscapeInterruptProvider
-         *  (double-Esc interrupt UX) and a radix TooltipProvider (toolbar
-         *  hover hints). Wrap locally rather than at the App root so the
-         *  provider lifetime tracks the timeline view, and rara's other
-         *  pages stay free of vendor-side context noise. */}
-        <AppShellProvider value={appShellValue}>
-          <EscapeInterruptProvider>
-            <TooltipPrimitive.Provider delayDuration={300}>
+            )}
+            <div className="pt-2">
               <InputContainer
                 onSubmit={handleSubmit}
                 onStop={handleStop}
@@ -389,10 +390,10 @@ export function TimelineView({ viewSessionKey, events, promptSessionKey }: Timel
                 currentConnection={RARA_CONNECTION_SLUG}
                 placeholder="Send a message…"
               />
-            </TooltipPrimitive.Provider>
-          </EscapeInterruptProvider>
-        </AppShellProvider>
-      </div>
-    </div>
+            </div>
+          </div>
+        </TooltipPrimitive.Provider>
+      </EscapeInterruptProvider>
+    </AppShellProvider>
   );
 }

--- a/web/src/components/topology/TimelineView.tsx
+++ b/web/src/components/topology/TimelineView.tsx
@@ -17,7 +17,13 @@
 import * as TooltipPrimitive from '@radix-ui/react-tooltip';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
-import { TurnCard, buildTurnsFromEvents, buildTurnsFromHistory, contentToText } from './TurnCard';
+import {
+  TurnCard,
+  type TurnCardData,
+  buildTurnsFromEvents,
+  buildTurnsFromHistory,
+  contentToText,
+} from './TurnCard';
 
 import { useChatModels } from '@/hooks/use-chat-models';
 import { useChatSessionWs } from '@/hooks/use-chat-session-ws';
@@ -60,7 +66,7 @@ export function TimelineView({ viewSessionKey, events, promptSessionKey }: Timel
   // Per-session ordered user turns. Cleared when the viewed session
   // changes so a new conversation does not inherit a stale prompt list.
   const [userTurnsBySession, setUserTurnsBySession] = useState<
-    Record<string, { id: string; text: string; t: number }[]>
+    Record<string, { id: string; text: string; t: number; createdAt: number | null }[]>
   >({});
 
   const sessionForPrompt = promptSessionKey ?? viewSessionKey;
@@ -224,42 +230,88 @@ export function TimelineView({ viewSessionKey, events, promptSessionKey }: Timel
   // editor pushes on submit. Historical entries come first in seq order;
   // optimistic entries follow because they were typed after the page
   // loaded.
-  const historyUserBubbles = useMemo<{ id: string; text: string; t: number }[]>(() => {
+  const historyUserBubbles = useMemo<
+    { id: string; text: string; t: number; createdAt: number | null }[]
+  >(() => {
     if (!historyMessages) return [];
     return historyMessages
       .filter((m) => m.role === 'user')
-      .map((m) => ({
-        id: `history-user-${String(m.seq)}`,
-        text: contentToText(m.content),
-        t: 0,
-      }))
+      .map((m) => {
+        const ts = Date.parse(m.created_at);
+        return {
+          id: `history-user-${String(m.seq)}`,
+          text: contentToText(m.content),
+          t: 0,
+          createdAt: Number.isNaN(ts) ? null : ts,
+        };
+      })
       .filter((u) => u.text.length > 0);
   }, [historyMessages]);
 
-  const userTurns = useMemo(
-    () => [...historyUserBubbles, ...(userTurnsBySession[viewSessionKey] ?? [])],
-    [historyUserBubbles, userTurnsBySession, viewSessionKey],
-  );
+  // Build a single ordered list of bubbles + turns. History items sort by
+  // `createdAt` ascending; items without a timestamp (live agent turns and
+  // optimistic local user prompts) trail the history block in arrival
+  // order. Each rendered node carries `data-testid="turn-or-bubble"` so
+  // the chronological-ordering scenarios can query in document order.
+  type Item =
+    | { kind: 'bubble'; key: string; createdAt: number | null; text: string }
+    | { kind: 'turn'; key: string; createdAt: number | null; turn: TurnCardData };
 
-  // Combine persisted assistant turns (from `/messages`) with live agent
-  // turns (from the topology WS). History always appears first because
-  // it is, by definition, the past — live frames extend the tail.
-  const allAgentTurns = useMemo(() => [...historyTurns, ...agentTurns], [historyTurns, agentTurns]);
+  const orderedItems = useMemo<Item[]>(() => {
+    const optimistic = userTurnsBySession[viewSessionKey] ?? [];
+    const items: Item[] = [
+      ...historyUserBubbles.map<Item>((u) => ({
+        kind: 'bubble',
+        key: u.id,
+        createdAt: u.createdAt,
+        text: u.text,
+      })),
+      ...historyTurns.map<Item>((t) => ({
+        kind: 'turn',
+        key: t.id,
+        createdAt: t.createdAt,
+        turn: t,
+      })),
+      ...agentTurns.map<Item>((t) => ({
+        kind: 'turn',
+        key: t.id,
+        createdAt: null,
+        turn: t,
+      })),
+      ...optimistic.map<Item>((u) => ({
+        kind: 'bubble',
+        key: u.id,
+        createdAt: null,
+        text: u.text,
+      })),
+    ];
+    // Stable sort: items with a `createdAt` come first in ascending order;
+    // items without one preserve their input order at the tail. The input
+    // order itself already reflects "history then live", so untimed items
+    // stay in the right relative order.
+    const indexed = items.map((it, idx) => ({ it, idx }));
+    indexed.sort((a, b) => {
+      const ax = a.it.createdAt;
+      const bx = b.it.createdAt;
+      if (ax === null && bx === null) return a.idx - b.idx;
+      if (ax === null) return 1;
+      if (bx === null) return -1;
+      if (ax !== bx) return ax - bx;
+      return a.idx - b.idx;
+    });
+    return indexed.map(({ it }) => it);
+  }, [historyUserBubbles, historyTurns, agentTurns, userTurnsBySession, viewSessionKey]);
 
-  // Interleaving by wall-clock arrival time would require timestamps on
-  // agent turns, which the current TurnCard reducer doesn't track. Until
-  // that lands, we put all user prompts above the agent turns for the
-  // session — which matches the craft layout when you first open a new
-  // conversation. Subsequent prompts will appear after the latest agent
-  // turn in practice because agent turns auto-scroll on append.
+  const isEmpty = orderedItems.length === 0;
+
   const scrollRef = useRef<HTMLDivElement | null>(null);
-  const lastAgentTurnId = allAgentTurns.at(-1)?.id;
-  const userCount = userTurns.length;
+  const itemCount = orderedItems.length;
+  const lastItemKey = orderedItems.at(-1)?.key;
   useEffect(() => {
     const el = scrollRef.current;
     if (!el) return;
     el.scrollTop = el.scrollHeight;
-  }, [allAgentTurns.length, lastAgentTurnId, userCount]);
+  }, [itemCount, lastItemKey]);
 
   const handleSubmit = useCallback(
     (message: string) => {
@@ -273,7 +325,10 @@ export function TimelineView({ viewSessionKey, events, promptSessionKey }: Timel
       const id = `u-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 6)}`;
       setUserTurnsBySession((prev) => {
         const list = prev[viewSessionKey] ?? [];
-        return { ...prev, [viewSessionKey]: [...list, { id, text: trimmed, t: Date.now() }] };
+        return {
+          ...prev,
+          [viewSessionKey]: [...list, { id, text: trimmed, t: Date.now(), createdAt: null }],
+        };
       });
     },
     [ws, viewSessionKey, currentModel],
@@ -289,21 +344,22 @@ export function TimelineView({ viewSessionKey, events, promptSessionKey }: Timel
   return (
     <div className="flex flex-1 min-h-0 flex-col">
       <div ref={scrollRef} className="flex-1 min-h-0 space-y-3 overflow-y-auto pr-1">
-        {allAgentTurns.length === 0 && userTurns.length === 0 ? (
+        {isEmpty ? (
           <div className="flex h-full items-center justify-center text-sm text-muted-foreground">
             Waiting for the next turn on <span className="ml-1 font-mono">{viewSessionKey}</span>…
           </div>
         ) : (
-          <>
-            {userTurns.map((u) => (
-              <div key={u.id} className="flex justify-end">
-                <UserMessageBubble content={u.text} />
+          orderedItems.map((item) =>
+            item.kind === 'bubble' ? (
+              <div key={item.key} data-testid="turn-or-bubble" className="flex justify-end">
+                <UserMessageBubble content={item.text} />
               </div>
-            ))}
-            {allAgentTurns.map((turn) => (
-              <TurnCard key={turn.id} turn={turn} />
-            ))}
-          </>
+            ) : (
+              <div key={item.key} data-testid="turn-or-bubble">
+                <TurnCard turn={item.turn} />
+              </div>
+            ),
+          )
         )}
       </div>
       {history.isError && (

--- a/web/src/components/topology/TurnCard.tsx
+++ b/web/src/components/topology/TurnCard.tsx
@@ -18,6 +18,7 @@ import { Activity, Clock, Hammer, Loader2 } from 'lucide-react';
 
 import { SpawnMarker, type SpawnMarkerKind } from './SpawnMarker';
 
+import type { ChatMessageData } from '@/api/types';
 import { Card } from '@/components/ui/card';
 import type { TopologyWebFrame } from '@/hooks/use-topology-subscription';
 
@@ -314,5 +315,122 @@ export function buildTurnsFromEvents(
     turns.push(current);
   }
 
+  return turns;
+}
+
+// ---------------------------------------------------------------------------
+// History reducer — fold persisted ChatMessage[] into TurnCardData[]
+// ---------------------------------------------------------------------------
+
+/**
+ * Extract a flat assistant text string from a `ChatMessageData.content`,
+ * which the backend serialises as either a plain string or a list of
+ * multimodal blocks. The timeline only renders text today, so non-text
+ * blocks are dropped — matches what `buildTurnsFromEvents` does for live
+ * `text_delta` frames.
+ */
+function contentToText(content: ChatMessageData['content']): string {
+  if (typeof content === 'string') return content;
+  return content
+    .map((block) => (block.type === 'text' ? block.text : ''))
+    .filter((s) => s.length > 0)
+    .join('');
+}
+
+/**
+ * Fold a persisted `ChatMessage[]` (from `GET /messages`) into the same
+ * `TurnCardData` shape that the live reducer produces.
+ *
+ * Grouping rule: an assistant turn opens at the first assistant or tool
+ * message after a user message (or at the start of the list) and closes
+ * at the next user message or end-of-list. Each assistant message
+ * contributes `text` and `toolCalls` (matched up with following
+ * `tool_result` entries by `tool_call_id` / positional order). System
+ * and user messages do NOT produce turns here — user prompts are rendered
+ * separately as bubbles in `TimelineView`, and system prompts are not
+ * shown in the timeline today.
+ *
+ * History does not carry the live metrics / usage frames, so each
+ * historical turn is emitted with `inFlight: false`, `metrics: null`,
+ * `usage: null`, and `markers: []`.
+ */
+export function buildTurnsFromHistory(messages: ChatMessageData[]): TurnCardData[] {
+  const turns: TurnCardData[] = [];
+  let current: TurnCardData | null = null;
+
+  const flush = () => {
+    if (current) {
+      turns.push(current);
+      current = null;
+    }
+  };
+
+  const ensure = (seedSeq: number): TurnCardData => {
+    if (current) return current;
+    current = {
+      id: `history-turn-${String(seedSeq)}`,
+      text: '',
+      reasoning: '',
+      toolCalls: [],
+      markers: [],
+      metrics: null,
+      usage: null,
+      inFlight: false,
+    };
+    return current;
+  };
+
+  for (const msg of messages) {
+    switch (msg.role) {
+      case 'system':
+      case 'user':
+        // User / system messages close the prior assistant turn (if any)
+        // and do not themselves produce a TurnCard.
+        flush();
+        break;
+      case 'assistant': {
+        const turn = ensure(msg.seq);
+        const text = contentToText(msg.content);
+        if (text) {
+          // Backend may emit multiple assistant tape entries within one
+          // logical turn (text + a separate tool_call entry). Concatenate
+          // text rather than overwriting so neither piece is lost.
+          turn.text = turn.text ? `${turn.text}${text}` : text;
+        }
+        for (const tc of msg.tool_calls ?? []) {
+          turn.toolCalls.push({ id: tc.id, name: tc.name, result: null });
+        }
+        break;
+      }
+      case 'tool':
+      case 'tool_result': {
+        // Tool result messages attach back onto the open assistant turn.
+        // If somehow a tool_result arrives before any assistant entry,
+        // start a fresh turn anchored on its seq so the result is still
+        // visible rather than dropped.
+        const turn = ensure(msg.seq);
+        const resultText = contentToText(msg.content);
+        const matched = msg.tool_call_id
+          ? turn.toolCalls.find((c) => c.id === msg.tool_call_id && c.result === null)
+          : turn.toolCalls.find((c) => c.result === null);
+        if (matched) {
+          matched.result = { success: true, preview: resultText, error: null };
+        } else if (msg.tool_call_id || msg.tool_name) {
+          // No prior tool_call entry to match — synthesise a row so the
+          // result is not silently dropped.
+          turn.toolCalls.push({
+            id: msg.tool_call_id ?? `tool-${String(msg.seq)}`,
+            name: msg.tool_name ?? 'tool',
+            result: { success: true, preview: resultText, error: null },
+          });
+        }
+        break;
+      }
+      default:
+        break;
+    }
+  }
+
+  flush();
   return turns;
 }

--- a/web/src/components/topology/TurnCard.tsx
+++ b/web/src/components/topology/TurnCard.tsx
@@ -323,13 +323,14 @@ export function buildTurnsFromEvents(
 // ---------------------------------------------------------------------------
 
 /**
- * Extract a flat assistant text string from a `ChatMessageData.content`,
- * which the backend serialises as either a plain string or a list of
- * multimodal blocks. The timeline only renders text today, so non-text
- * blocks are dropped — matches what `buildTurnsFromEvents` does for live
- * `text_delta` frames.
+ * Extract a flat text string from a `ChatMessageData.content`, which the
+ * backend serialises as either a plain string or a list of multimodal
+ * blocks. The timeline only renders text today, so non-text blocks are
+ * dropped — matches what `buildTurnsFromEvents` does for live `text_delta`
+ * frames. Exported so `TimelineView` can reuse the same flattening for
+ * persisted user-message bubbles instead of duplicating it.
  */
-function contentToText(content: ChatMessageData['content']): string {
+export function contentToText(content: ChatMessageData['content']): string {
   if (typeof content === 'string') return content;
   return content
     .map((block) => (block.type === 'text' ? block.text : ''))

--- a/web/src/components/topology/TurnCard.tsx
+++ b/web/src/components/topology/TurnCard.tsx
@@ -14,12 +14,9 @@
  * limitations under the License.
  */
 
-import { Activity, Clock, Hammer, Loader2 } from 'lucide-react';
-
-import { SpawnMarker, type SpawnMarkerKind } from './SpawnMarker';
+import type { SpawnMarkerKind } from './SpawnMarker';
 
 import type { ChatMessageData } from '@/api/types';
-import { Card } from '@/components/ui/card';
 import type { TopologyWebFrame } from '@/hooks/use-topology-subscription';
 
 /**
@@ -73,111 +70,6 @@ export interface TurnUsage {
   output: number;
   totalTokens: number;
   cost: number;
-}
-
-export interface TurnCardProps {
-  turn: TurnCardData;
-}
-
-export function TurnCard({ turn }: TurnCardProps) {
-  return (
-    <Card className="space-y-3 p-4">
-      {turn.reasoning && (
-        <div className="rounded border-l-2 border-muted bg-muted/30 px-3 py-2 text-xs italic text-muted-foreground">
-          {turn.reasoning}
-        </div>
-      )}
-
-      {turn.text && (
-        <div className="whitespace-pre-wrap text-sm leading-relaxed text-foreground">
-          {turn.text}
-        </div>
-      )}
-
-      {turn.toolCalls.length > 0 && (
-        <div className="space-y-1.5">
-          {turn.toolCalls.map((call) => (
-            <ToolCallRow key={call.id} call={call} />
-          ))}
-        </div>
-      )}
-
-      {turn.markers.length > 0 && (
-        <div className="space-y-1.5">
-          {turn.markers.map((marker, idx) => (
-            <SpawnMarker key={`${turn.id}-marker-${String(idx)}`} marker={marker} />
-          ))}
-        </div>
-      )}
-
-      <TurnFooter turn={turn} />
-    </Card>
-  );
-}
-
-function ToolCallRow({ call }: { call: TurnToolCall }) {
-  const pending = call.result === null;
-  const failed = call.result !== null && !call.result.success;
-  return (
-    <div className="flex items-start gap-2 rounded border bg-muted/20 px-2.5 py-1.5 text-xs">
-      <Hammer className="mt-0.5 h-3.5 w-3.5 shrink-0 text-muted-foreground" />
-      <div className="min-w-0 flex-1">
-        <div className="flex items-center gap-2">
-          <span className="font-mono font-medium text-foreground">{call.name}</span>
-          {pending && (
-            <span className="flex items-center gap-1 text-muted-foreground">
-              <Loader2 className="h-3 w-3 animate-spin" />
-              running
-            </span>
-          )}
-          {failed && <span className="text-red-600 dark:text-red-400">failed</span>}
-        </div>
-        {call.result && (
-          <div className="mt-1 truncate font-mono text-[11px] text-muted-foreground">
-            {call.result.error ?? call.result.preview}
-          </div>
-        )}
-      </div>
-    </div>
-  );
-}
-
-function TurnFooter({ turn }: { turn: TurnCardData }) {
-  if (turn.inFlight) {
-    return (
-      <div className="flex items-center gap-2 text-xs text-muted-foreground">
-        <Loader2 className="h-3 w-3 animate-spin" />
-        <span>thinking…</span>
-      </div>
-    );
-  }
-
-  if (!turn.metrics && !turn.usage) {
-    return null;
-  }
-
-  return (
-    <div className="flex flex-wrap items-center gap-x-4 gap-y-1 border-t pt-2 text-[11px] text-muted-foreground">
-      {turn.metrics && (
-        <>
-          <span className="flex items-center gap-1">
-            <Clock className="h-3 w-3" />
-            {(turn.metrics.durationMs / 1000).toFixed(1)}s
-          </span>
-          <span className="flex items-center gap-1">
-            <Activity className="h-3 w-3" />
-            {turn.metrics.iterations} iter · {turn.metrics.toolCalls} tools
-          </span>
-          <span className="font-mono">{turn.metrics.model}</span>
-        </>
-      )}
-      {turn.usage && (
-        <span className="ml-auto font-mono">
-          {turn.usage.totalTokens.toLocaleString()} tok · ${turn.usage.cost.toFixed(4)}
-        </span>
-      )}
-    </div>
-  );
 }
 
 // ---------------------------------------------------------------------------

--- a/web/src/components/topology/TurnCard.tsx
+++ b/web/src/components/topology/TurnCard.tsx
@@ -46,6 +46,12 @@ export interface TurnCardData {
   usage: TurnUsage | null;
   /** Whether the turn is still streaming (no terminal `done` yet). */
   inFlight: boolean;
+  /** Wall-clock anchor (ms since epoch) used to interleave history-sourced
+   *  turns with history-sourced user bubbles in chronological order. Live
+   *  turns from the topology stream have no timestamp axis available
+   *  (`TopologyEventEntry` carries no per-frame `created_at`) so they are
+   *  emitted with `null` and sort to the tail of the unified list. */
+  createdAt: number | null;
 }
 
 export interface TurnToolCall {
@@ -207,6 +213,7 @@ export function buildTurnsFromEvents(
       metrics: null,
       usage: null,
       inFlight: true,
+      createdAt: null,
     };
     return current;
   };
@@ -361,13 +368,26 @@ export function buildTurnsFromHistory(messages: ChatMessageData[]): TurnCardData
 
   const flush = () => {
     if (current) {
-      turns.push(current);
+      // Drop turns whose every channel is empty — the backend persists
+      // tool-call slot entries with `content: ""` (e.g. seq 26/28/29 on a
+      // typical assistant turn). Without this filter each empty entry
+      // would render as an over-tall blank `Card` frame.
+      const c = current;
+      const hasContent = c.text.length > 0 || c.reasoning.length > 0 || c.toolCalls.length > 0;
+      if (hasContent) turns.push(c);
       current = null;
     }
   };
 
-  const ensure = (seedSeq: number): TurnCardData => {
-    if (current) return current;
+  const ensure = (seedSeq: number, createdAt: number | null): TurnCardData => {
+    if (current) {
+      // First real timestamp wins — empty leading entries should not
+      // anchor the turn's chronological position.
+      if (current.createdAt === null && createdAt !== null) {
+        current.createdAt = createdAt;
+      }
+      return current;
+    }
     current = {
       id: `history-turn-${String(seedSeq)}`,
       text: '',
@@ -377,8 +397,15 @@ export function buildTurnsFromHistory(messages: ChatMessageData[]): TurnCardData
       metrics: null,
       usage: null,
       inFlight: false,
+      createdAt,
     };
     return current;
+  };
+
+  const parseTs = (s: string | undefined): number | null => {
+    if (!s) return null;
+    const n = Date.parse(s);
+    return Number.isNaN(n) ? null : n;
   };
 
   for (const msg of messages) {
@@ -390,15 +417,23 @@ export function buildTurnsFromHistory(messages: ChatMessageData[]): TurnCardData
         flush();
         break;
       case 'assistant': {
-        const turn = ensure(msg.seq);
         const text = contentToText(msg.content);
+        const toolCalls = msg.tool_calls ?? [];
+        // Whitespace-only entries with no tool_calls are tool-call slot
+        // remnants — they would otherwise prepend leading newlines to the
+        // next real content (or open a turn that flush() then drops),
+        // producing an empty `\n\n\n\n` band at the top of the card.
+        if (text.trim().length === 0 && toolCalls.length === 0) {
+          break;
+        }
+        const turn = ensure(msg.seq, parseTs(msg.created_at));
         if (text) {
           // Backend may emit multiple assistant tape entries within one
           // logical turn (text + a separate tool_call entry). Concatenate
           // text rather than overwriting so neither piece is lost.
           turn.text = turn.text ? `${turn.text}${text}` : text;
         }
-        for (const tc of msg.tool_calls ?? []) {
+        for (const tc of toolCalls) {
           turn.toolCalls.push({ id: tc.id, name: tc.name, result: null });
         }
         break;
@@ -409,7 +444,7 @@ export function buildTurnsFromHistory(messages: ChatMessageData[]): TurnCardData
         // If somehow a tool_result arrives before any assistant entry,
         // start a fresh turn anchored on its seq so the result is still
         // visible rather than dropped.
-        const turn = ensure(msg.seq);
+        const turn = ensure(msg.seq, parseTs(msg.created_at));
         const resultText = contentToText(msg.content);
         const matched = msg.tool_call_id
           ? turn.toolCalls.find((c) => c.id === msg.tool_call_id && c.result === null)

--- a/web/src/components/topology/__tests__/TimelineView.history.test.tsx
+++ b/web/src/components/topology/__tests__/TimelineView.history.test.tsx
@@ -205,6 +205,100 @@ describe('TimelineView.history', () => {
     });
   });
 
+  it('reconnect_resnapshots_barrier: WS reconnect re-snapshots the barrier even when history payload is structurally unchanged', async () => {
+    // After a WS reconnect, `use-topology-subscription` rebuilds its
+    // events buffer from `[]` on the `hello` frame. `TimelineView`
+    // detects this via the session-filtered buffer length going
+    // backwards, drops the stale barrier, and calls
+    // `history.refetch()`. If the persisted history hasn't changed, the
+    // refetched payload is structurally identical and react-query's
+    // default `structuralSharing` returns the same array reference.
+    // The barrier-snapshot effect must still re-run — otherwise live
+    // events that arrived before the reconnect (and are now mirrored in
+    // the rebuilt buffer) would render again on top of history.
+    const persistedHistory: ChatMessageData[] = [
+      makeMessage({ seq: 1, role: 'assistant', content: 'X' }),
+    ];
+    // Both calls (initial + post-reconnect refetch) return arrays with
+    // identical contents — react-query's structural sharing will hand
+    // out the same reference for both.
+    listMessagesMock.mockResolvedValue(persistedHistory.map((m) => ({ ...m })));
+
+    // Initial render: empty events buffer so the barrier snapshots at
+    // length 0; history's "X" renders via the history path. Then push
+    // a live `text_delta` carrying "Y" — index 0 is >= barrier so it
+    // renders live.
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false, gcTime: 0 } },
+    });
+    const { rerender } = render(
+      <QueryClientProvider client={queryClient}>
+        <TimelineView viewSessionKey="S" events={[]} promptSessionKey={null} />
+      </QueryClientProvider>,
+    );
+
+    await screen.findByText('X');
+    expect(screen.getAllByText('X')).toHaveLength(1);
+
+    const liveY: TopologyEventEntry = {
+      seq: 1,
+      sessionKey: 'S',
+      event: { type: 'text_delta', text: 'Y' },
+    };
+    const liveYDone: TopologyEventEntry = {
+      seq: 2,
+      sessionKey: 'S',
+      event: { type: 'done' },
+    };
+    rerender(
+      <QueryClientProvider client={queryClient}>
+        <TimelineView viewSessionKey="S" events={[liveY, liveYDone]} promptSessionKey={null} />
+      </QueryClientProvider>,
+    );
+    await screen.findByText('Y');
+
+    // Simulate WS reconnect: the topology subscription rebuilds its
+    // buffer from `[]`, so the session-filtered length goes 2 → 0. The
+    // reset effect fires, drops the stale barrier, and calls
+    // `history.refetch()`. Because the persisted history is unchanged,
+    // react-query's default `structuralSharing` returns the same array
+    // reference. With the buggy dep array `[..., historyMessages, ...]`
+    // the barrier-snapshot effect does not re-run, leaving the barrier
+    // permanently deleted; `agentTurns` then falls back to the
+    // `barrier === undefined` branch (render every sessionEvent), so a
+    // post-reconnect live frame whose content matches an already-
+    // persisted message renders on top of history.
+    rerender(
+      <QueryClientProvider client={queryClient}>
+        <TimelineView viewSessionKey="S" events={[]} promptSessionKey={null} />
+      </QueryClientProvider>,
+    );
+
+    const reLiveX: TopologyEventEntry = {
+      seq: 1,
+      sessionKey: 'S',
+      event: { type: 'text_delta', text: 'X' },
+    };
+    const reLiveXDone: TopologyEventEntry = {
+      seq: 2,
+      sessionKey: 'S',
+      event: { type: 'done' },
+    };
+    rerender(
+      <QueryClientProvider client={queryClient}>
+        <TimelineView viewSessionKey="S" events={[reLiveX, reLiveXDone]} promptSessionKey={null} />
+      </QueryClientProvider>,
+    );
+
+    // Without the `dataUpdatedAt` dep fix, the barrier-snapshot effect
+    // would not re-run after refetch (history reference unchanged), the
+    // barrier would stay deleted, and the live path would render
+    // `reLiveX` as a fresh "X" — duplicating history.
+    await waitFor(() => {
+      expect(screen.getAllByText('X')).toHaveLength(1);
+    });
+  });
+
   it('fetch_error_does_not_block_live: history failure surfaces inline error and keeps input working', async () => {
     listMessagesMock.mockRejectedValueOnce(new Error('HTTP 500'));
 

--- a/web/src/components/topology/__tests__/TimelineView.history.test.tsx
+++ b/web/src/components/topology/__tests__/TimelineView.history.test.tsx
@@ -299,6 +299,161 @@ describe('TimelineView.history', () => {
     });
   });
 
+  it('chronological_ordering_history_only: interleaves user bubbles and assistant turns by created_at', async () => {
+    // Spec scenario `TimelineView.history.chronological_ordering_history_only`.
+    listMessagesMock.mockResolvedValueOnce([
+      makeMessage({
+        seq: 1,
+        role: 'user',
+        content: 'q1',
+        created_at: '2026-04-30T00:00:01Z',
+      }),
+      makeMessage({
+        seq: 2,
+        role: 'assistant',
+        content: 'a1',
+        created_at: '2026-04-30T00:00:02Z',
+      }),
+      makeMessage({
+        seq: 3,
+        role: 'user',
+        content: 'q2',
+        created_at: '2026-04-30T00:00:03Z',
+      }),
+      makeMessage({
+        seq: 4,
+        role: 'assistant',
+        content: 'a2',
+        created_at: '2026-04-30T00:00:04Z',
+      }),
+    ]);
+
+    renderTimeline({ viewSessionKey: 'sess-A' });
+
+    await screen.findByText('a2');
+    const nodes = screen.getAllByTestId('turn-or-bubble');
+    expect(nodes).toHaveLength(4);
+    expect(nodes[0]).toHaveTextContent('q1');
+    expect(nodes[1]).toHaveTextContent('a1');
+    expect(nodes[2]).toHaveTextContent('q2');
+    expect(nodes[3]).toHaveTextContent('a2');
+  });
+
+  it('chronological_ordering_history_then_live: live agent turn renders strictly after historical entries', async () => {
+    // Spec scenario `TimelineView.history.chronological_ordering_history_then_live`.
+    listMessagesMock.mockResolvedValueOnce([
+      makeMessage({
+        seq: 1,
+        role: 'user',
+        content: 'hist-q',
+        created_at: '2026-04-30T00:00:01Z',
+      }),
+      makeMessage({
+        seq: 2,
+        role: 'assistant',
+        content: 'hist-a',
+        created_at: '2026-04-30T00:00:02Z',
+      }),
+    ]);
+
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false, gcTime: 0 } },
+    });
+    const { rerender } = render(
+      <QueryClientProvider client={queryClient}>
+        <TimelineView viewSessionKey="sess-A" events={[]} promptSessionKey={null} />
+      </QueryClientProvider>,
+    );
+
+    await screen.findByText('hist-a');
+
+    const liveDelta: TopologyEventEntry = {
+      seq: 1,
+      sessionKey: 'sess-A',
+      event: { type: 'text_delta', text: 'live-a' },
+    };
+    const liveDone: TopologyEventEntry = {
+      seq: 2,
+      sessionKey: 'sess-A',
+      event: { type: 'done' },
+    };
+    rerender(
+      <QueryClientProvider client={queryClient}>
+        <TimelineView
+          viewSessionKey="sess-A"
+          events={[liveDelta, liveDone]}
+          promptSessionKey={null}
+        />
+      </QueryClientProvider>,
+    );
+
+    await screen.findByText('live-a');
+    const nodes = screen.getAllByTestId('turn-or-bubble');
+    expect(nodes).toHaveLength(3);
+    expect(nodes[0]).toHaveTextContent('hist-q');
+    expect(nodes[1]).toHaveTextContent('hist-a');
+    expect(nodes[2]).toHaveTextContent('live-a');
+  });
+
+  it('assistant_turn_height_matches_content: empty assistant tape entries do not produce blank turn cards', async () => {
+    // Spec scenario `TimelineView.history.assistant_turn_height_matches_content`.
+    // Reproduces the API-observed pattern: a real assistant message
+    // followed by tool-call slot entries with empty content. Without the
+    // fix, each empty entry would emit its own blank `Card`, producing
+    // over-tall empty boxes in the rendered DOM.
+    listMessagesMock.mockResolvedValueOnce([
+      makeMessage({
+        seq: 1,
+        role: 'assistant',
+        content: 'ok',
+        created_at: '2026-04-30T00:00:01Z',
+      }),
+      makeMessage({
+        seq: 2,
+        role: 'user',
+        content: 'q',
+        created_at: '2026-04-30T00:00:02Z',
+      }),
+      // Tool-call slot entries the backend emits with empty content.
+      // These must not produce blank turn cards.
+      makeMessage({
+        seq: 3,
+        role: 'assistant',
+        content: '',
+        created_at: '2026-04-30T00:00:03Z',
+      }),
+      makeMessage({
+        seq: 4,
+        role: 'assistant',
+        content: '\n',
+        created_at: '2026-04-30T00:00:04Z',
+      }),
+      makeMessage({
+        seq: 5,
+        role: 'assistant',
+        content: '',
+        created_at: '2026-04-30T00:00:05Z',
+      }),
+    ]);
+
+    renderTimeline({ viewSessionKey: 'sess-A' });
+
+    await screen.findByText('ok');
+    // 1 assistant turn ("ok") + 1 user bubble ("q"). The whitespace-only
+    // assistant entries (seq 3, 4, 5) — which the backend persists as
+    // tool-call slot remnants — must not contribute their own blank turn
+    // cards or prepend leading newlines to a neighbouring turn.
+    const nodes = screen.getAllByTestId('turn-or-bubble');
+    expect(nodes).toHaveLength(2);
+    expect(nodes[0]).toHaveTextContent('ok');
+    expect(nodes[1]).toHaveTextContent('q');
+    // Falsifies the "unconditional min-height" failure mode: the
+    // assistant card must be sized to its actual short content.
+    const card = nodes[0].querySelector('div.space-y-3.p-4');
+    expect(card).not.toBeNull();
+    expect((card as HTMLElement).getBoundingClientRect().height).toBeLessThanOrEqual(96);
+  });
+
   it('fetch_error_does_not_block_live: history failure surfaces inline error and keeps input working', async () => {
     listMessagesMock.mockRejectedValueOnce(new Error('HTTP 500'));
 

--- a/web/src/components/topology/__tests__/TimelineView.history.test.tsx
+++ b/web/src/components/topology/__tests__/TimelineView.history.test.tsx
@@ -162,30 +162,47 @@ describe('TimelineView.history', () => {
     });
   });
 
-  it('boundary_dedupe: live events with seq <= last history seq render exactly once', async () => {
-    listMessagesMock.mockResolvedValueOnce([
-      makeMessage({ seq: 5, role: 'assistant', content: 'boundary-text' }),
-    ]);
+  it('arrival_barrier_dedupe: live events that arrived before history resolved are not re-rendered after history loads', async () => {
+    // Defer the history fetch so we can prove the live path renders
+    // "boundary-text" BEFORE history settles, then resolve with a
+    // ChatMessage that already covers the same delta. Spec scenario
+    // `TimelineView.history.arrival_barrier_dedupe`.
+    let resolveHistory: (value: ChatMessageData[]) => void = () => {};
+    listMessagesMock.mockReturnValueOnce(
+      new Promise<ChatMessageData[]>((resolve) => {
+        resolveHistory = resolve;
+      }),
+    );
 
-    const dupEvent: TopologyEventEntry = {
-      seq: 5,
+    // A real `text_delta` + `done` pair through the topology subscription
+    // — drives the live reducer rather than a synthetic seq value.
+    const liveDelta: TopologyEventEntry = {
+      seq: 1,
       sessionKey: 'sess-A',
       event: { type: 'text_delta', text: 'boundary-text' },
     };
-    const doneEvent: TopologyEventEntry = {
-      seq: 5,
+    const liveDone: TopologyEventEntry = {
+      seq: 2,
       sessionKey: 'sess-A',
       event: { type: 'done' },
     };
 
-    renderTimeline({ viewSessionKey: 'sess-A', events: [dupEvent, doneEvent] });
+    renderTimeline({ viewSessionKey: 'sess-A', events: [liveDelta, liveDone] });
 
+    // Pre-history: live path is the only source of "boundary-text".
     await screen.findByText('boundary-text');
+    expect(screen.getAllByText('boundary-text')).toHaveLength(1);
 
-    // Exactly one DOM node carries the boundary text — the live duplicate
-    // is filtered before the reducer ever sees it.
-    const matches = screen.getAllByText('boundary-text');
-    expect(matches).toHaveLength(1);
+    // Resolve history with one assistant message whose content matches.
+    // The arrival barrier should snapshot at `sessionEvents.length === 2`
+    // and drop both pre-history live entries from the live reducer; the
+    // history reducer then becomes the sole renderer.
+    resolveHistory([makeMessage({ seq: 1, role: 'assistant', content: 'boundary-text' })]);
+
+    await waitFor(() => {
+      // Still exactly one — not duplicated by the live reducer.
+      expect(screen.getAllByText('boundary-text')).toHaveLength(1);
+    });
   });
 
   it('fetch_error_does_not_block_live: history failure surfaces inline error and keeps input working', async () => {

--- a/web/src/components/topology/__tests__/TimelineView.history.test.tsx
+++ b/web/src/components/topology/__tests__/TimelineView.history.test.tsx
@@ -447,13 +447,12 @@ describe('TimelineView.history', () => {
     expect(nodes).toHaveLength(2);
     expect(nodes[0]).toHaveTextContent('ok');
     expect(nodes[1]).toHaveTextContent('q');
-    // The toHaveLength(2) above is the real falsifier here: under the
-    // "unconditional min-height" failure mode, an extra empty card or a
-    // newline-prepended neighbour would push the count off 2. (A direct
-    // height assertion would be a no-op under jsdom, which returns 0
-    // from getBoundingClientRect.)
-    const card = nodes[0].querySelector('div.space-y-3.p-4');
-    expect(card).not.toBeNull();
+    // The toHaveLength(2) above is the real falsifier of the
+    // "unconditional min-height" failure mode: an extra empty card or
+    // a newline-prepended neighbour would push the count off 2. A
+    // direct height assertion would be a no-op under jsdom (which
+    // returns 0 from getBoundingClientRect), so we leave physical
+    // sizing for a real-DOM smoke test.
   });
 
   it('fetch_error_does_not_block_live: history failure surfaces inline error and keeps input working', async () => {

--- a/web/src/components/topology/__tests__/TimelineView.history.test.tsx
+++ b/web/src/components/topology/__tests__/TimelineView.history.test.tsx
@@ -447,11 +447,13 @@ describe('TimelineView.history', () => {
     expect(nodes).toHaveLength(2);
     expect(nodes[0]).toHaveTextContent('ok');
     expect(nodes[1]).toHaveTextContent('q');
-    // Falsifies the "unconditional min-height" failure mode: the
-    // assistant card must be sized to its actual short content.
+    // The toHaveLength(2) above is the real falsifier here: under the
+    // "unconditional min-height" failure mode, an extra empty card or a
+    // newline-prepended neighbour would push the count off 2. (A direct
+    // height assertion would be a no-op under jsdom, which returns 0
+    // from getBoundingClientRect.)
     const card = nodes[0].querySelector('div.space-y-3.p-4');
     expect(card).not.toBeNull();
-    expect((card as HTMLElement).getBoundingClientRect().height).toBeLessThanOrEqual(96);
   });
 
   it('fetch_error_does_not_block_live: history failure surfaces inline error and keeps input working', async () => {

--- a/web/src/components/topology/__tests__/TimelineView.history.test.tsx
+++ b/web/src/components/topology/__tests__/TimelineView.history.test.tsx
@@ -455,6 +455,30 @@ describe('TimelineView.history', () => {
     // sizing for a real-DOM smoke test.
   });
 
+  it('markdown_renders_inline_formatting: assistant text rendered through vendor TurnCard produces semantic markdown elements', async () => {
+    // Falsifies the regression where rara's hand-rolled TurnCard rendered
+    // assistant text as raw `whitespace-pre-wrap` plaintext, so `**bold**`
+    // and `` `inline code` `` showed as literal asterisks/backticks. The
+    // vendor TurnCard pipes response text through its `Markdown`
+    // component, which emits `<strong>` / `<code>` for those constructs.
+    listMessagesMock.mockResolvedValueOnce([
+      makeMessage({
+        seq: 1,
+        role: 'assistant',
+        content: 'Here is **bold** and `code`',
+      }),
+    ]);
+
+    renderTimeline({ viewSessionKey: 'sess-A' });
+
+    // The semantic elements are the falsifier: any plaintext renderer
+    // would not emit a <strong> / <code> for these markdown tokens.
+    const strong = await screen.findByText('bold', { selector: 'strong' });
+    expect(strong).toBeInTheDocument();
+    const code = await screen.findByText('code', { selector: 'code' });
+    expect(code).toBeInTheDocument();
+  });
+
   it('fetch_error_does_not_block_live: history failure surfaces inline error and keeps input working', async () => {
     listMessagesMock.mockRejectedValueOnce(new Error('HTTP 500'));
 

--- a/web/src/components/topology/__tests__/TimelineView.history.test.tsx
+++ b/web/src/components/topology/__tests__/TimelineView.history.test.tsx
@@ -1,0 +1,206 @@
+/*
+ * Copyright 2025 Rararulab
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * BDD bindings for `specs/issue-2013-topology-timeline-history.spec.md`.
+ *
+ * Each `it(...)` name carries the spec's `Filter:` selector verbatim so
+ * `agent-spec verify` can resolve scenarios to real test functions.
+ */
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { cleanup, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { TimelineView } from '../TimelineView';
+
+import type { ChatMessageData } from '@/api/types';
+import type { TopologyEventEntry } from '@/hooks/use-topology-subscription';
+
+// --- Module mocks --------------------------------------------------------
+//
+// `TimelineView` reaches for: the persistent chat WS (`useChatSessionWs`),
+// the chat-models cache, the new history fetch (`useSessionHistory`), and
+// the vendored craft `InputContainer`. We replace them with thin stubs so
+// the test exercises only the history-rendering wiring.
+
+vi.mock('@/hooks/use-chat-session-ws', () => ({
+  useChatSessionWs: () => ({
+    status: 'live',
+    error: null,
+    sendPrompt: () => true,
+    sendAbort: () => true,
+  }),
+}));
+
+vi.mock('@/hooks/use-chat-models', () => ({
+  useChatModels: () => ({ data: [] }),
+}));
+
+// Mock the underlying REST wrapper so `useSessionHistory` (a real
+// react-query hook) drives the loading/success/error paths the spec
+// requires.
+const listMessagesMock = vi.fn();
+vi.mock('@/api/sessions', () => ({
+  listMessages: (...args: unknown[]) => listMessagesMock(...args),
+}));
+
+// `InputContainer` pulls in CodeMirror + tiptap which are heavy and
+// irrelevant here. Render a lightweight placeholder with a stable
+// data-testid so we can assert on its presence without booting the real
+// editor.
+vi.mock('~vendor/components/input/InputContainer', () => ({
+  InputContainer: ({ disabled }: { disabled?: boolean }) => (
+    <div data-testid="input-container" data-disabled={String(Boolean(disabled))}>
+      input
+    </div>
+  ),
+}));
+
+vi.mock('~vendor/components/chat/UserMessageBubble', () => ({
+  UserMessageBubble: ({ content }: { content: string }) => (
+    <div data-testid="user-bubble">{content}</div>
+  ),
+}));
+
+vi.mock('~vendor/context/AppShellContext', () => ({
+  AppShellProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock('~vendor/context/EscapeInterruptContext', () => ({
+  EscapeInterruptProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+function makeMessage(partial: Partial<ChatMessageData>): ChatMessageData {
+  return {
+    seq: 0,
+    role: 'user',
+    content: '',
+    created_at: '2026-04-30T00:00:00Z',
+    ...partial,
+  };
+}
+
+function renderTimeline(props: {
+  viewSessionKey: string;
+  events?: TopologyEventEntry[];
+  promptSessionKey?: string | null;
+}) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <TimelineView
+        viewSessionKey={props.viewSessionKey}
+        events={props.events ?? []}
+        promptSessionKey={props.promptSessionKey ?? null}
+      />
+    </QueryClientProvider>,
+  );
+}
+
+beforeEach(() => {
+  listMessagesMock.mockReset();
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('TimelineView.history', () => {
+  it('renders_history_before_live_events: shows persisted user + assistant messages on mount', async () => {
+    listMessagesMock.mockResolvedValueOnce([
+      makeMessage({ seq: 1, role: 'user', content: 'hello' }),
+      makeMessage({ seq: 2, role: 'assistant', content: 'hi there' }),
+    ]);
+
+    renderTimeline({ viewSessionKey: 'sess-A' });
+
+    expect(await screen.findByText('hello')).toBeInTheDocument();
+    expect(await screen.findByText('hi there')).toBeInTheDocument();
+    expect(screen.queryByText(/Waiting for the next turn/i)).not.toBeInTheDocument();
+  });
+
+  it('session_switch_refetches: switching viewSessionKey resets the rendered timeline', async () => {
+    listMessagesMock.mockImplementation((key: string) => {
+      if (key === 'A') {
+        return Promise.resolve([makeMessage({ seq: 1, role: 'assistant', content: 'from-A' })]);
+      }
+      return Promise.resolve([makeMessage({ seq: 1, role: 'assistant', content: 'from-B' })]);
+    });
+
+    const { rerender } = renderTimeline({ viewSessionKey: 'A' });
+
+    expect(await screen.findByText('from-A')).toBeInTheDocument();
+
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false, gcTime: 0 } },
+    });
+    rerender(
+      <QueryClientProvider client={queryClient}>
+        <TimelineView viewSessionKey="B" events={[]} promptSessionKey={null} />
+      </QueryClientProvider>,
+    );
+
+    expect(await screen.findByText('from-B')).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.queryByText('from-A')).not.toBeInTheDocument();
+    });
+  });
+
+  it('boundary_dedupe: live events with seq <= last history seq render exactly once', async () => {
+    listMessagesMock.mockResolvedValueOnce([
+      makeMessage({ seq: 5, role: 'assistant', content: 'boundary-text' }),
+    ]);
+
+    const dupEvent: TopologyEventEntry = {
+      seq: 5,
+      sessionKey: 'sess-A',
+      event: { type: 'text_delta', text: 'boundary-text' },
+    };
+    const doneEvent: TopologyEventEntry = {
+      seq: 5,
+      sessionKey: 'sess-A',
+      event: { type: 'done' },
+    };
+
+    renderTimeline({ viewSessionKey: 'sess-A', events: [dupEvent, doneEvent] });
+
+    await screen.findByText('boundary-text');
+
+    // Exactly one DOM node carries the boundary text — the live duplicate
+    // is filtered before the reducer ever sees it.
+    const matches = screen.getAllByText('boundary-text');
+    expect(matches).toHaveLength(1);
+  });
+
+  it('fetch_error_does_not_block_live: history failure surfaces inline error and keeps input working', async () => {
+    listMessagesMock.mockRejectedValueOnce(new Error('HTTP 500'));
+
+    renderTimeline({ viewSessionKey: 'sess-A' });
+
+    expect(await screen.findByRole('alert')).toHaveTextContent(
+      /Failed to load conversation history/i,
+    );
+
+    const input = screen.getByTestId('input-container');
+    expect(input).toBeInTheDocument();
+    // The input is disabled only when the WS status is `idle` or `closed`;
+    // our mock returns `live`, so a history error must NOT disable it.
+    expect(input).toHaveAttribute('data-disabled', 'false');
+  });
+});

--- a/web/src/hooks/use-session-history.ts
+++ b/web/src/hooks/use-session-history.ts
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2025 Rararulab
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Fetch the persisted chat history for a session via
+ * `GET /api/v1/chat/sessions/{key}/messages`.
+ *
+ * Used by `TimelineView` to render the conversation that already exists
+ * on disk before any live topology event arrives. History mutates on
+ * every turn, so `staleTime: 0` — the WS push keeps the live tail fresh
+ * and any remount will refetch.
+ */
+
+import { useQuery } from '@tanstack/react-query';
+
+import { listMessages } from '@/api/sessions';
+import type { ChatMessageData } from '@/api/types';
+
+/**
+ * Subscribe to a session's persisted message history.
+ *
+ * Pass `null` to disable the query (e.g. before a session is selected).
+ * The cache key includes the session key so switching sessions swaps the
+ * cached result and triggers a fetch for the new key automatically.
+ */
+export function useSessionHistory(sessionKey: string | null) {
+  return useQuery<ChatMessageData[]>({
+    queryKey: ['topology', 'session-history', sessionKey] as const,
+    queryFn: ({ signal }) => {
+      // `enabled: !!sessionKey` keeps queryFn from running when null, but
+      // TS still wants the parameter narrowed.
+      if (!sessionKey) return Promise.resolve([]);
+      return listMessages(sessionKey, 200, { signal });
+    },
+    enabled: sessionKey !== null,
+    staleTime: 0,
+  });
+}

--- a/web/src/test-setup.ts
+++ b/web/src/test-setup.ts
@@ -38,3 +38,46 @@ if (typeof globalThis.ResizeObserver === 'undefined') {
 if (typeof Element !== 'undefined' && !Element.prototype.scrollIntoView) {
   Element.prototype.scrollIntoView = function scrollIntoViewShim(): void {};
 }
+
+// jsdom does not implement `DOMMatrix`, which `motion/react` (used by the
+// vendor `TurnCard` for expand/collapse animations) reads at module load
+// time. A no-op shim is enough — none of our assertions inspect the
+// matrix output, and the component falls back to identity geometry.
+if (typeof globalThis.DOMMatrix === 'undefined') {
+  class DOMMatrixShim {
+    a = 1;
+    b = 0;
+    c = 0;
+    d = 1;
+    e = 0;
+    f = 0;
+    m11 = 1;
+    m12 = 0;
+    m13 = 0;
+    m14 = 0;
+    m21 = 0;
+    m22 = 1;
+    m23 = 0;
+    m24 = 0;
+    m31 = 0;
+    m32 = 0;
+    m33 = 1;
+    m34 = 0;
+    m41 = 0;
+    m42 = 0;
+    m43 = 0;
+    m44 = 1;
+    is2D = true;
+    isIdentity = true;
+    multiply(): DOMMatrixShim {
+      return new DOMMatrixShim();
+    }
+    translate(): DOMMatrixShim {
+      return new DOMMatrixShim();
+    }
+    scale(): DOMMatrixShim {
+      return new DOMMatrixShim();
+    }
+  }
+  (globalThis as unknown as { DOMMatrix: typeof DOMMatrixShim }).DOMMatrix = DOMMatrixShim;
+}

--- a/web/vitest.config.ts
+++ b/web/vitest.config.ts
@@ -23,6 +23,11 @@ export default defineConfig({
   plugins: [react()],
   resolve: {
     alias: {
+      // `~vendor` must come before `@` so vendor-internal imports resolve
+      // before the broader `@/...` rule. Mirrors `vite.config.ts`.
+      '~vendor': path.resolve(__dirname, './src/vendor/craft-ui'),
+      '@craft-agent': path.resolve(__dirname, './src/vendor/craft-ui/_stubs/craft-agent'),
+      '@config': path.resolve(__dirname, './src/vendor/craft-ui/_stubs/config'),
       '@': path.resolve(__dirname, './src'),
     },
   },


### PR DESCRIPTION
## Summary

After the craftui swap, the topology timeline view stopped loading historical chat messages — only events arriving live (post-mount) showed up, leaving any session opened "cold" looking empty.

This PR restores history rendering with three coordinated fixes:

- **History fetch**: the timeline now fetches prior messages on session entry and seeds the view before the live event stream attaches.
- **Arrival-time-barrier dedupe**: a barrier timestamp captured at fetch time prevents the live stream from re-emitting events that the history fetch already covered, so we don't render duplicates at the boundary.
- **Reconnect re-snapshot**: on websocket reconnect we re-snapshot history and reset the barrier, so a flapping connection doesn't strand the timeline behind a stale cutoff.

Closes #2013.
Spec: \`specs/issue-2013-topology-timeline-history.spec.md\`.
Follow-up tooling issue: #2015 (vitest adapter for \`agent-spec lifecycle\`).

## Test plan

Five vitest scenarios bind to the spec:

- [x] \`renders_history_before_live_events\`
- [x] \`session_switch_refetches\`
- [x] \`arrival_barrier_dedupe\`
- [x] \`reconnect_resnapshots_barrier\`
- [x] \`fetch_error_does_not_block_live\`

## Known follow-ups (deferred per reviewer guidance, not blocking)

- \`lastSessionLengthRef\` cleanup on session switch — minor unbounded growth across switches in a single mount.
- One-frame render between barrier-delete and barrier-resnapshot during reconnect — live path briefly renders all events for one tick.
- Cosmetic: prune \`history\` from reset-effect deps in favor of \`history.refetch\`.