### PR TITLE
fix(web): hide topology scrollbars at idle, fade in on hover (#2021)

### DIFF
--- a/web/src/components/topology/SessionPicker.tsx
+++ b/web/src/components/topology/SessionPicker.tsx
@@ -91,7 +91,7 @@ export function SessionPicker({ activeSessionKey, onSelect, onAutoSelect }: Sess
   }, [activeSessionKey, firstKey, onAutoSelect]);
 
   return (
-    <div className="flex h-full flex-col">
+    <div className="group flex h-full flex-col">
       <div className="flex items-center justify-between border-b border-border px-3 py-2">
         <span className="text-xs font-medium text-muted-foreground">Sessions</span>
         <div className="flex items-center gap-1">
@@ -118,7 +118,7 @@ export function SessionPicker({ activeSessionKey, onSelect, onAutoSelect }: Sess
         </div>
       </div>
 
-      <div className="flex-1 overflow-y-auto">
+      <div className="scrollbar-hover flex-1 overflow-y-auto">
         {sessionsQuery.isLoading ? (
           <SessionPickerEmpty label="Loading sessions…" />
         ) : sessionsQuery.isError ? (

--- a/web/src/components/topology/TapeLineageView.tsx
+++ b/web/src/components/topology/TapeLineageView.tsx
@@ -69,7 +69,7 @@ export function TapeLineageView({ events, activeSessionKey }: TapeLineageViewPro
       </button>
 
       {open && (
-        <div className="border-t border-border p-2">
+        <div className="group border-t border-border p-2">
           {layout.nodes.length === 0 ? (
             <div className="px-1 py-2 text-[11px] text-muted-foreground">
               No forks yet — this session has not anchored a child tape.
@@ -101,7 +101,7 @@ function TapeForestSvg({ layout, activeSessionKey }: TapeForestSvgProps) {
   );
 
   return (
-    <div className="overflow-auto">
+    <div className="scrollbar-hover overflow-auto">
       <svg
         width={layout.width}
         height={layout.height}

--- a/web/src/components/topology/TimelineView.tsx
+++ b/web/src/components/topology/TimelineView.tsx
@@ -350,8 +350,11 @@ export function TimelineView({ viewSessionKey, events, promptSessionKey }: Timel
     <AppShellProvider value={appShellValue}>
       <EscapeInterruptProvider>
         <TooltipPrimitive.Provider delayDuration={300}>
-          <div className="flex flex-1 min-h-0 flex-col">
-            <div ref={scrollRef} className="flex-1 min-h-0 space-y-3 overflow-y-auto pr-1">
+          <div className="group flex flex-1 min-h-0 flex-col">
+            <div
+              ref={scrollRef}
+              className="scrollbar-hover flex-1 min-h-0 space-y-3 overflow-y-auto pr-1"
+            >
               {isEmpty ? (
                 <div className="flex h-full items-center justify-center text-sm text-muted-foreground">
                   Waiting for the next turn on{' '}


### PR DESCRIPTION
## Summary

Scrollbars on the topology pane (TimelineView, SessionPicker, TapeLineageView) were always visible at idle, creating visual noise. Switched to the vendored `.scrollbar-hover` utility (4px overlay, transparent until parent `.group` is hovered) so scroll affordance fades in only when the user is interacting with the pane.

Closes #2021. Reviewer approved.

## Test plan

- [x] Opened topology page; scrollbars are hidden when idle
- [x] On hover, 4px overlay scrollbar fades in
- [x] Screenshots provided in implementer hand-back