### PR TITLE
feat(web): wire trace + cascade buttons via vendor TurnCard slots (#2023)

### DIFF
--- a/specs/issue-2023-topology-trace-cascade-buttons.spec.md
+++ b/specs/issue-2023-topology-trace-cascade-buttons.spec.md
@@ -1,0 +1,239 @@
+spec: task
+name: "issue-2023-topology-trace-cascade-buttons"
+inherits: project
+tags: [enhancement, ui, web]
+---
+
+## Intent
+
+The topology page renders historical and live assistant turns through the
+vendor `TurnCard` (`web/src/vendor/craft-ui/components/chat/TurnCard.tsx`,
+landed in main via PR 2018), bridged by `RaraTurnCard.tsx`. The vendor
+already exposes the chrome we need: an actions dropdown
+(`TurnCardActionsMenu`, opened by clicking a three-dot trigger in the
+turn header) that surfaces an `onOpenDetails?: () => void` slot, plus an
+`onOpenActivityDetails?: (activity: ActivityItem) => void` slot wired
+into every completed activity row. There is no rara-side wiring on
+either slot today, so neither the per-turn execution trace nor the
+cascade context is reachable from the UI.
+
+The backend still serves the data: `crates/extensions/backend-admin/src/chat/router.rs`
+registers `get_execution_trace` and `get_cascade_trace` (`GET /api/v1/chat/sessions/{key}/trace?seq=<n>`
+and the cascade sibling). `web/src/api/kernel-types.ts` retains
+`ExecutionTrace` and `CascadeTrace` TypeScript types. PR 1826 / commit
+356dd74e shipped the equivalent affordance on the retired `/chat-v2`
+page (the "📊 详情" / "🔍 Cascade" buttons + `ExecutionTraceModal` +
+`CascadeModal`); PR 1833 retired pi-web-ui and removed the modals, the
+client wrappers, and the hooks. This spec rewires the now-existing
+vendor slots to the still-existing backend.
+
+If we do not do this, the following concrete bug appears. Reproducer:
+
+1. Run frontend against the remote backend (`VITE_API_URL=http://10.0.0.183:25555 bun run dev`).
+2. Open the topology page; let history load. Each completed assistant
+   turn renders as a vendor `TurnCard` with text, tool calls, and a
+   header — but the three-dot actions menu does not render (the vendor
+   short-circuits when both `onOpenDetails` and `onOpenMultiFileDiff`
+   are undefined, see `TurnCardActionsMenu.tsx` lines 39-42), and
+   activity rows are not click-through to detail.
+3. The user wants to know which intermediate iterations / token usage /
+   raw tool args produced this reply. There is no path from the UI to
+   the `/api/v1/chat/sessions/{key}/trace?seq=<n>` endpoint that the
+   kernel already serves. The user has to `curl` the API by hand or
+   read remote logs to inspect a turn — exactly the regression
+   `goal.md` signal 4 ("every action inspectable through native eval
+   interfaces") forbids.
+
+This advances goal.md signal 4. It is a legitimate restoration scoped
+to wiring: PR 1826 shipped the buttons, PR 1833 removed them as
+collateral when the entire chat surface was replaced, PR 2018 brought
+in vendor surfaces that already model the same affordance. The risk
+PR 1672 / issue 1672 caught (buttons leaking onto every persisted row
+including intermediate iterations) is structurally gone — the vendor's
+`onOpenDetails` is per-turn and only fires when the turn is complete,
+so per-message leakage cannot recur as long as the rara adapter
+threads `finalSeq` at turn granularity (one seq per turn, not per
+event).
+
+`TurnCardData` (`TurnCard.tsx` lines 29-55) currently has no `seq`
+field. The id is `turn-${seq}` of the first event but the seq itself
+is not threaded through. Wiring the actions menu requires adding a
+`finalSeq: number | null` field to `TurnCardData`, populated by
+`buildTurnsFromHistory` from the persisted assistant row's seq for
+history-sourced turns and from the kernel-assigned seq on the `done`
+frame for live turns. `null` means "no inspect affordance" (live frame
+mid-stream, or any case where the seq is not yet known); the adapter
+leaves `onOpenDetails` undefined in that case and the vendor hides the
+chrome (`TurnCardActionsMenu` lines 39-42).
+
+Prior art surveyed:
+
+- PR 2018 — landed vendor `TurnCard` + `RaraTurnCard` adapter. The
+  adapter (`web/src/components/topology/RaraTurnCard.tsx`) currently
+  leaves `onOpenDetails` and `onOpenActivityDetails` undefined and
+  comments that "rara doesn't yet expose those surfaces" — this spec
+  is the surface.
+- PR 1826 / commit 356dd74e — original buttons on `/chat-v2`. Diff is
+  the modal-content blueprint (what the trace modal showed: iteration
+  count, model, token usage, raw tool args; what the cascade modal
+  showed: the cascade chain). Do not import — files have been
+  deleted; write fresh React modal components inspired by the
+  original layout.
+- PR 1672 — gating bug on chat-v2: buttons leaked onto every persisted
+  assistant row including intermediate iterations. Mitigated
+  structurally by per-turn `finalSeq` threading (vendor's
+  `onOpenDetails` fires once per turn).
+- PR 1798 — consolidated trace pills. Visual reference, not reusable.
+- PR 1611 — alignment fix on the old detail button. Irrelevant given
+  the vendor's three-dot menu owns placement.
+- `web/src/api/kernel-types.ts` retains `ExecutionTrace` /
+  `CascadeTrace` types. Reuse as-is.
+- Backend endpoints exist: `crates/extensions/backend-admin/src/chat/router.rs`
+  registers `get_cascade_trace` and `get_execution_trace`. No backend
+  work needed.
+
+## Decisions
+
+- Add `finalSeq: number | null` to `TurnCardData`. History path
+  populates it from the last persisted assistant row of the turn. Live
+  path leaves it `null` until the kernel emits the `done` frame with
+  the assigned seq, then sets it.
+- The adapter `RaraTurnCard` wires `onOpenDetails` (opens the
+  execution trace modal) only when `turn.finalSeq !== null` and
+  `turn.inFlight === false`. When either is unmet, leave the prop
+  undefined; the vendor hides the three-dot menu entirely
+  (`TurnCardActionsMenu.tsx` lines 39-42). This is the structural
+  equivalent of PR 1826's `metadata.seq !== undefined` gate, lifted
+  to the turn level so PR 1672's per-message footgun cannot recur.
+- The cascade affordance binds to a different surface than the trace.
+  Trace is per-turn (the actions menu's "view turn details" item).
+  Cascade is contextual to a specific tool call — wire it through
+  `onOpenActivityDetails(activity)` so clicking a tool row opens
+  the cascade modal scoped to that turn's `finalSeq` (the vendor
+  already routes activity-row clicks to this prop, see
+  `TurnCard.tsx` lines 3020 and 3043). If the implementer finds
+  `onOpenActivityDetails` does not match the desired UX, they may
+  instead use `renderActionsMenu` to inject a custom dropdown with
+  both items; that decision is deferred to implementation, with
+  rationale recorded in the PR.
+- Modal components (`ExecutionTraceModal.tsx`, `CascadeModal.tsx`)
+  are fresh React under `web/src/components/topology/`. PR 1826 is
+  the layout reference, not an import source.
+- API client wrappers live in `web/src/api/sessions.ts` as
+  `fetchExecutionTrace(sessionKey, seq)` and
+  `fetchCascadeTrace(sessionKey, seq)`. Both return the existing
+  types from `kernel-types.ts`; no new types.
+- One `useTraceFetch` hook keyed on `(sessionKey, seq, kind)`,
+  fetching only on modal open (lazy). No pre-fetch on card render.
+- The vendor `TurnCard.tsx` is **not edited** — all rara-side
+  customisation flows through `RaraTurnCard.tsx`'s prop wiring.
+- **Lifecycle gate**: `agent-spec lifecycle` cannot exercise these
+  scenarios end-to-end yet — issue 2015 (open) tracks the missing
+  vitest adapter for `agent-spec`. The implementer runs the vitest
+  suite directly (`cd web && bun run test`) as the verification
+  signal until 2015 lands. Reviewer may APPROVE on green vitest +
+  manual smoke against the remote backend.
+
+## Boundaries
+
+### Allowed Changes
+- **/web/src/components/topology/RaraTurnCard.tsx
+- **/web/src/components/topology/TurnCard.tsx
+- **/web/src/components/topology/TimelineView.tsx
+- **/web/src/components/topology/ExecutionTraceModal.tsx
+- **/web/src/components/topology/CascadeModal.tsx
+- **/web/src/hooks/use-session-timeline.ts
+- **/web/src/hooks/use-trace-fetch.ts
+- **/web/src/api/sessions.ts
+- **/web/src/components/topology/__tests__/**
+- **/specs/issue-2023-topology-trace-cascade-buttons.spec.md
+
+### Forbidden
+- **/crates/**
+- **/web/src/vendor/**
+- **/web/src/api/kernel-types.ts
+- **/web/src/components/topology/AGENT.md
+
+The crates path is forbidden because the backend endpoints already
+exist and were verified before drafting; if the implementer thinks
+the backend needs changes, that is grounds to escalate to spec-author,
+not silently expand scope. The vendor path is forbidden because
+craft-ui is a vendored upstream — fork-edits make future syncs
+painful and the public prop surface is sufficient for this work.
+`kernel-types.ts` is forbidden because the existing `ExecutionTrace`
+/ `CascadeTrace` types are sufficient — re-deriving them from the
+wire shape would split the contract. `AGENT.md` updates are deferred
+until the modals settle in their final home.
+
+## Completion Criteria
+
+Scenario: Actions menu is wired only when finalSeq is present and the turn has completed
+  Test:
+    Package: web
+    Filter: RaraTurnCard__actions_menu_wired_when_finalSeq_present_and_not_inflight
+  Given a RaraTurnCard rendered with `finalSeq = 42` and `inFlight = false`
+  When the card is rendered
+  Then the vendor's three-dot actions trigger is in the DOM
+    And clicking it reveals the "view turn details" item
+
+Scenario: Actions menu is suppressed on in-flight turns and on turns without a known seq
+  Test:
+    Package: web
+    Filter: RaraTurnCard__actions_menu_suppressed_when_inflight_or_seq_null
+  Given a RaraTurnCard rendered with `inFlight = true` and `finalSeq = null`
+  When the card is rendered
+  Then no actions trigger is in the DOM
+    And no "view turn details" item is reachable
+
+Scenario: Selecting "view turn details" opens a modal that fetches and displays the trace
+  Test:
+    Package: web
+    Filter: RaraTurnCard__trace_modal_opens_with_fetched_content
+  Given a RaraTurnCard with `finalSeq = 42` for session key "sess-abc"
+    And the trace API returns a known ExecutionTrace payload (mocked at the fetch layer)
+  When the user opens the actions menu and selects "view turn details"
+  Then a modal becomes visible
+    And the modal shows content derived from the mocked ExecutionTrace payload (e.g. an iteration count or model name from the fixture)
+
+Scenario: Activating an activity row on a completed turn opens the cascade modal scoped to the turn
+  Test:
+    Package: web
+    Filter: RaraTurnCard__cascade_modal_opens_from_activity_row
+  Given a RaraTurnCard with `finalSeq = 42` for session key "sess-abc" and at least one completed tool activity
+    And the cascade API returns a known CascadeTrace payload (mocked at the fetch layer)
+  When the user clicks the tool activity row
+  Then a modal becomes visible
+    And the modal shows content derived from the mocked CascadeTrace payload
+
+Scenario: Trace fetch failure surfaces an error in the modal instead of crashing the card
+  Test:
+    Package: web
+    Filter: RaraTurnCard__trace_modal_shows_error_on_fetch_failure
+  Given a RaraTurnCard with `finalSeq = 42` for session key "sess-abc"
+    And the trace API rejects with a network error (mocked at the fetch layer)
+  When the user opens the actions menu and selects "view turn details"
+  Then the modal becomes visible
+    And the modal shows an error indicator (not blank, not a thrown exception)
+    And the surrounding TurnCard is still rendered
+
+## Out of Scope
+
+- Backend changes. The trace and cascade endpoints already exist
+  (`crates/extensions/backend-admin/src/chat/router.rs`).
+- Vendor `TurnCard` edits. All rara-side wiring flows through
+  `RaraTurnCard.tsx` props.
+- Modifying `kernel-types.ts` — the existing `ExecutionTrace` /
+  `CascadeTrace` types are reused as-is.
+- Adding inspect affordances to non-turn surfaces (user bubbles, spawn
+  markers, worker cards). Only `RaraTurnCard` is in scope.
+- Pre-fetching trace / cascade on card render. Fetch on modal open only.
+- Visual redesign of the modals beyond what is needed to render the
+  fetched payload legibly. Polish iteration is a follow-up if needed.
+- Building the `agent-spec` vitest adapter — issue 2015 owns that.
+  Verification here is direct vitest + manual smoke.
+- Changing where `finalSeq` is sourced for live turns beyond reading
+  the kernel-assigned seq from the `done` frame. If the live path
+  turns out not to surface seq at all, the implementer should leave
+  live-turn wiring disabled (consistent with PR 1826's "live-only
+  frames stay button-less") and surface that observation, not invent
+  a workaround.

--- a/web/src/api/sessions.ts
+++ b/web/src/api/sessions.ts
@@ -15,6 +15,7 @@
  */
 
 import { api } from './client';
+import type { CascadeTrace, ExecutionTrace } from './kernel-types';
 import type { ChatMessageData } from './types';
 
 /**
@@ -75,4 +76,41 @@ export async function listMessages(
   const params = new URLSearchParams({ limit: String(limit) });
   const path = `/api/v1/chat/sessions/${encodeURIComponent(sessionKey)}/messages?${params.toString()}`;
   return api.get<ChatMessageData[]>(path, options?.signal ? { signal: options.signal } : undefined);
+}
+
+/**
+ * Fetch the per-turn execution trace for a single assistant turn.
+ *
+ * Wraps `GET /api/v1/chat/sessions/{key}/execution-trace?seq={seq}`. The
+ * backend handler (`get_execution_trace` in
+ * `crates/extensions/backend-admin/src/chat/router.rs`) returns the
+ * iteration count, model, token usage, plan steps, and per-tool summary
+ * for the turn whose final assistant tape entry has the given seq.
+ */
+export async function fetchExecutionTrace(
+  sessionKey: string,
+  seq: number,
+  options?: { signal?: AbortSignal },
+): Promise<ExecutionTrace> {
+  const params = new URLSearchParams({ seq: String(seq) });
+  const path = `/api/v1/chat/sessions/${encodeURIComponent(sessionKey)}/execution-trace?${params.toString()}`;
+  return api.get<ExecutionTrace>(path, options?.signal ? { signal: options.signal } : undefined);
+}
+
+/**
+ * Fetch the cascade (think → act → observe) trace for a single assistant turn.
+ *
+ * Wraps `GET /api/v1/chat/sessions/{key}/trace?seq={seq}`. The backend
+ * handler (`get_cascade_trace`) replays the tape between the spawning user
+ * input and the closing `done` frame and returns the structured tick /
+ * entry breakdown rendered by `<CascadeModal>`.
+ */
+export async function fetchCascadeTrace(
+  sessionKey: string,
+  seq: number,
+  options?: { signal?: AbortSignal },
+): Promise<CascadeTrace> {
+  const params = new URLSearchParams({ seq: String(seq) });
+  const path = `/api/v1/chat/sessions/${encodeURIComponent(sessionKey)}/trace?${params.toString()}`;
+  return api.get<CascadeTrace>(path, options?.signal ? { signal: options.signal } : undefined);
 }

--- a/web/src/components/topology/CascadeModal.tsx
+++ b/web/src/components/topology/CascadeModal.tsx
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2025 Rararulab
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { useCascadeTrace } from '@/hooks/use-trace-fetch';
+
+export interface CascadeModalProps {
+  /** Session key whose cascade endpoint we hit. */
+  sessionKey: string;
+  /** Per-turn seq — same key as the execution trace; cascade is scoped to the turn. */
+  seq: number | null;
+  /** Whether the modal is open. */
+  open: boolean;
+  /** Close handler driven by the dialog's onOpenChange. */
+  onOpenChange: (open: boolean) => void;
+}
+
+/**
+ * Cascade (think → act → observe) modal for an assistant turn. Renders
+ * the structured tick / entry breakdown returned by `GET /trace?seq=…`.
+ *
+ * The cascade is per-turn, not per-tool — clicking any tool activity row
+ * within a turn opens the same modal, since the cascade is the right
+ * granularity to inspect a turn's reasoning chain. If we later need
+ * tool-scoped views, that goes on top of this without changing the wire
+ * shape.
+ */
+export function CascadeModal({ sessionKey, seq, open, onOpenChange }: CascadeModalProps) {
+  const { data, isLoading, isError, error } = useCascadeTrace(sessionKey, seq, open);
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-3xl">
+        <DialogHeader>
+          <DialogTitle>Cascade trace</DialogTitle>
+          <DialogDescription>
+            seq {seq ?? '—'} · session <span className="font-mono text-xs">{sessionKey}</span>
+          </DialogDescription>
+        </DialogHeader>
+        <div className="max-h-[60vh] overflow-y-auto text-sm">
+          {isLoading && <div className="text-muted-foreground">Loading…</div>}
+          {isError && (
+            <div role="alert" className="text-destructive">
+              Failed to load cascade: {error instanceof Error ? error.message : String(error)}
+            </div>
+          )}
+          {data && (
+            <div className="space-y-3">
+              <div className="text-xs text-muted-foreground">
+                {data.summary.tick_count} tick(s) · {data.summary.tool_call_count} tool call(s) ·{' '}
+                {data.summary.total_entries} entries
+              </div>
+              {data.ticks.map((tick) => (
+                <section key={tick.index} className="border-l-2 border-muted pl-3">
+                  <h3 className="font-medium mb-1">Tick {tick.index}</h3>
+                  <ul className="space-y-1">
+                    {tick.entries.map((entry) => (
+                      <li key={entry.id} className="text-xs">
+                        <span className="font-mono uppercase text-[10px] text-muted-foreground">
+                          {entry.kind}
+                        </span>{' '}
+                        <span className="whitespace-pre-wrap">{entry.content}</span>
+                      </li>
+                    ))}
+                  </ul>
+                </section>
+              ))}
+            </div>
+          )}
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/web/src/components/topology/ExecutionTraceModal.tsx
+++ b/web/src/components/topology/ExecutionTraceModal.tsx
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2025 Rararulab
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { useExecutionTrace } from '@/hooks/use-trace-fetch';
+
+export interface ExecutionTraceModalProps {
+  /** Session key whose trace endpoint we hit. */
+  sessionKey: string;
+  /** Per-turn seq the trace is keyed on. `null` while the turn is still streaming. */
+  seq: number | null;
+  /** Whether the modal is open. The fetch hook is gated on this so the
+   *  request only fires once the user actually opens the modal. */
+  open: boolean;
+  /** Close handler driven by the dialog's onOpenChange. */
+  onOpenChange: (open: boolean) => void;
+}
+
+/**
+ * Per-turn execution trace modal. Shows iteration count, model, token
+ * usage, and per-tool summary for the assistant turn whose final
+ * persisted seq matches `seq`. Layout is intentionally minimal — the
+ * point is "data that was previously only reachable via curl is now
+ * reachable from the UI" (goal.md signal 4), not visual polish.
+ */
+export function ExecutionTraceModal({
+  sessionKey,
+  seq,
+  open,
+  onOpenChange,
+}: ExecutionTraceModalProps) {
+  const { data, isLoading, isError, error } = useExecutionTrace(sessionKey, seq, open);
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-2xl">
+        <DialogHeader>
+          <DialogTitle>Turn execution trace</DialogTitle>
+          <DialogDescription>
+            seq {seq ?? '—'} · session <span className="font-mono text-xs">{sessionKey}</span>
+          </DialogDescription>
+        </DialogHeader>
+        <div className="max-h-[60vh] overflow-y-auto text-sm">
+          {isLoading && <div className="text-muted-foreground">Loading…</div>}
+          {isError && (
+            <div role="alert" className="text-destructive">
+              Failed to load trace: {error instanceof Error ? error.message : String(error)}
+            </div>
+          )}
+          {data && (
+            <div className="space-y-3">
+              <dl className="grid grid-cols-2 gap-x-4 gap-y-1">
+                <dt className="text-muted-foreground">Model</dt>
+                <dd className="font-mono">{data.model}</dd>
+                <dt className="text-muted-foreground">Iterations</dt>
+                <dd>{data.iterations}</dd>
+                <dt className="text-muted-foreground">Duration</dt>
+                <dd>{data.duration_secs.toFixed(2)}s</dd>
+                <dt className="text-muted-foreground">Input tokens</dt>
+                <dd>{data.input_tokens}</dd>
+                <dt className="text-muted-foreground">Output tokens</dt>
+                <dd>{data.output_tokens}</dd>
+                <dt className="text-muted-foreground">Thinking</dt>
+                <dd>{data.thinking_ms}ms</dd>
+              </dl>
+              {data.turn_rationale && (
+                <section>
+                  <h3 className="font-medium mb-1">Rationale</h3>
+                  <p className="text-muted-foreground whitespace-pre-wrap">{data.turn_rationale}</p>
+                </section>
+              )}
+              {data.thinking_preview && (
+                <section>
+                  <h3 className="font-medium mb-1">Thinking preview</h3>
+                  <p className="text-muted-foreground whitespace-pre-wrap text-xs">
+                    {data.thinking_preview}
+                  </p>
+                </section>
+              )}
+              {data.plan_steps.length > 0 && (
+                <section>
+                  <h3 className="font-medium mb-1">Plan</h3>
+                  <ul className="list-disc pl-5 space-y-0.5">
+                    {data.plan_steps.map((step, i) => (
+                      <li key={i}>{step}</li>
+                    ))}
+                  </ul>
+                </section>
+              )}
+              {data.tools.length > 0 && (
+                <section>
+                  <h3 className="font-medium mb-1">Tools</h3>
+                  <ul className="space-y-1">
+                    {data.tools.map((tool, i) => (
+                      <li key={i} className="text-xs">
+                        <span className="font-mono">{tool.name}</span>
+                        {tool.duration_ms !== null && (
+                          <span className="text-muted-foreground"> · {tool.duration_ms}ms</span>
+                        )}
+                        <span className={tool.success ? 'text-success' : 'text-destructive'}>
+                          {' '}
+                          · {tool.success ? 'ok' : 'failed'}
+                        </span>
+                        {tool.summary && (
+                          <div className="text-muted-foreground pl-4">{tool.summary}</div>
+                        )}
+                        {tool.error && <div className="text-destructive pl-4">{tool.error}</div>}
+                      </li>
+                    ))}
+                  </ul>
+                </section>
+              )}
+            </div>
+          )}
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/web/src/components/topology/RaraTurnCard.tsx
+++ b/web/src/components/topology/RaraTurnCard.tsx
@@ -14,8 +14,10 @@
  * limitations under the License.
  */
 
-import { useMemo } from 'react';
+import { useMemo, useState } from 'react';
 
+import { CascadeModal } from './CascadeModal';
+import { ExecutionTraceModal } from './ExecutionTraceModal';
 import { SpawnMarker } from './SpawnMarker';
 import type { TurnCardData } from './TurnCard';
 
@@ -31,17 +33,27 @@ import type { ActivityItem, ResponseContent } from '~vendor/components/chat/Turn
  * only place that bridges the two — keeping the rest of the topology tree
  * unaware of the vendor surface.
  *
- * Many vendor callbacks (`onAcceptPlan`, `onAddAnnotation`, `onBranch`,
- * `onOpenDetails`, …) are intentionally left undefined; rara doesn't yet
- * expose those surfaces. The vendor handles `undefined` gracefully — any
- * crash on a missing optional is a vendor bug to flag, not something to
- * silently work around.
+ * The trace + cascade affordances are wired through the vendor's
+ * `onOpenDetails` (three-dot actions menu → "view turn details") and
+ * `onOpenActivityDetails` (clicking a completed tool row) slots. Both
+ * slots are left undefined when `turn.finalSeq === null` or
+ * `turn.inFlight === true`, which causes the vendor to suppress the
+ * three-dot trigger entirely (see `TurnCardActionsMenu.tsx` lines 39-42)
+ * and the activity row's hover-affordance (see `TurnCard.tsx` ~line 1030).
+ * That's the structural mitigation for #1672 — affordances cannot leak
+ * onto live or seq-less turns because the props they depend on are not
+ * passed.
  */
 export interface RaraTurnCardProps {
   turn: TurnCardData;
+  /** Session key whose trace endpoints back the modals. */
+  sessionKey: string;
 }
 
-export function RaraTurnCard({ turn }: RaraTurnCardProps) {
+export function RaraTurnCard({ turn, sessionKey }: RaraTurnCardProps) {
+  const [traceOpen, setTraceOpen] = useState(false);
+  const [cascadeOpen, setCascadeOpen] = useState(false);
+
   const activities = useMemo<ActivityItem[]>(() => {
     const items: ActivityItem[] = [];
     // Vendor sorts activities by `timestamp` — only relative ordering
@@ -97,6 +109,19 @@ export function RaraTurnCard({ turn }: RaraTurnCardProps) {
   // forbids passing `undefined` explicitly.
   const responseProps = response ? { response } : {};
 
+  // Affordance gate: the trace / cascade endpoints are keyed on a
+  // persisted seq, so leave the slots undefined for live turns and for
+  // any turn whose seq we have not yet observed.
+  const inspectable = turn.finalSeq !== null && !turn.inFlight;
+  const inspectProps = inspectable
+    ? {
+        onOpenDetails: () => setTraceOpen(true),
+        // Cascade is per-turn, so any activity row opens the same modal.
+        // The vendor passes the activity to the callback; we ignore it.
+        onOpenActivityDetails: () => setCascadeOpen(true),
+      }
+    : {};
+
   return (
     <div className="space-y-2">
       <VendorTurnCard
@@ -105,6 +130,7 @@ export function RaraTurnCard({ turn }: RaraTurnCardProps) {
         {...responseProps}
         isStreaming={turn.inFlight}
         isComplete={!turn.inFlight}
+        {...inspectProps}
       />
       {turn.markers.length > 0 && (
         <div className="space-y-1.5">
@@ -112,6 +138,22 @@ export function RaraTurnCard({ turn }: RaraTurnCardProps) {
             <SpawnMarker key={`${turn.id}-marker-${String(idx)}`} marker={marker} />
           ))}
         </div>
+      )}
+      {inspectable && (
+        <>
+          <ExecutionTraceModal
+            sessionKey={sessionKey}
+            seq={turn.finalSeq}
+            open={traceOpen}
+            onOpenChange={setTraceOpen}
+          />
+          <CascadeModal
+            sessionKey={sessionKey}
+            seq={turn.finalSeq}
+            open={cascadeOpen}
+            onOpenChange={setCascadeOpen}
+          />
+        </>
       )}
     </div>
   );

--- a/web/src/components/topology/TimelineView.tsx
+++ b/web/src/components/topology/TimelineView.tsx
@@ -365,7 +365,7 @@ export function TimelineView({ viewSessionKey, events, promptSessionKey }: Timel
                     </div>
                   ) : (
                     <div key={item.key} data-testid="turn-or-bubble">
-                      <RaraTurnCard turn={item.turn} />
+                      <RaraTurnCard turn={item.turn} sessionKey={viewSessionKey} />
                     </div>
                   ),
                 )

--- a/web/src/components/topology/TurnCard.tsx
+++ b/web/src/components/topology/TurnCard.tsx
@@ -49,6 +49,13 @@ export interface TurnCardData {
    *  (`TopologyEventEntry` carries no per-frame `created_at`) so they are
    *  emitted with `null` and sort to the tail of the unified list. */
   createdAt: number | null;
+  /** Persisted seq used as the lookup key for the trace / cascade endpoints
+   *  (`GET /api/v1/chat/sessions/{key}/execution-trace?seq=<n>` and the
+   *  cascade sibling). `null` means the seq is not yet known — either the
+   *  turn is still streaming or it came from a source that does not surface
+   *  a seq, in which case the inspect affordances stay hidden (per
+   *  `specs/issue-2023-topology-trace-cascade-buttons.spec.md`). */
+  finalSeq: number | null;
 }
 
 export interface TurnToolCall {
@@ -106,6 +113,7 @@ export function buildTurnsFromEvents(
       usage: null,
       inFlight: true,
       createdAt: null,
+      finalSeq: null,
     };
     return current;
   };
@@ -200,6 +208,9 @@ export function buildTurnsFromEvents(
         const turn = current as TurnCardData | null;
         if (turn) {
           turn.inFlight = false;
+          // The kernel-assigned seq on the `done` frame is the per-turn
+          // identifier the trace / cascade endpoints accept.
+          turn.finalSeq = seq;
           turns.push(turn);
           current = null;
         }
@@ -290,6 +301,9 @@ export function buildTurnsFromHistory(messages: ChatMessageData[]): TurnCardData
       usage: null,
       inFlight: false,
       createdAt,
+      // Provisional — overwritten by every assistant row encountered so the
+      // last assistant row of the turn ends up as the lookup seq.
+      finalSeq: seedSeq,
     };
     return current;
   };
@@ -319,6 +333,9 @@ export function buildTurnsFromHistory(messages: ChatMessageData[]): TurnCardData
           break;
         }
         const turn = ensure(msg.seq, parseTs(msg.created_at));
+        // Last assistant row wins — the trace endpoint expects the seq of
+        // the final persisted assistant message in the turn.
+        turn.finalSeq = msg.seq;
         if (text) {
           // Backend may emit multiple assistant tape entries within one
           // logical turn (text + a separate tool_call entry). Concatenate

--- a/web/src/components/topology/__tests__/RaraTurnCard.test.tsx
+++ b/web/src/components/topology/__tests__/RaraTurnCard.test.tsx
@@ -1,0 +1,224 @@
+/*
+ * Copyright 2025 Rararulab
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * BDD bindings for `specs/issue-2023-topology-trace-cascade-buttons.spec.md`.
+ *
+ * Each `it(...)` carries the spec's `Filter:` selector verbatim so
+ * `agent-spec verify` can resolve scenarios to real test functions once
+ * the vitest adapter (issue 2015) lands.
+ */
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { RaraTurnCard } from '../RaraTurnCard';
+import type { TurnCardData } from '../TurnCard';
+
+import '@/i18n';
+
+// Mock the fetch wrappers so the tests exercise the wiring, not the network.
+const fetchExecutionTraceMock = vi.fn();
+const fetchCascadeTraceMock = vi.fn();
+vi.mock('@/api/sessions', () => ({
+  fetchExecutionTrace: (...args: unknown[]) => fetchExecutionTraceMock(...args),
+  fetchCascadeTrace: (...args: unknown[]) => fetchCascadeTraceMock(...args),
+}));
+
+function makeTurn(overrides: Partial<TurnCardData> = {}): TurnCardData {
+  return {
+    id: 'turn-42',
+    text: 'final assistant text',
+    reasoning: '',
+    toolCalls: [
+      {
+        id: 'tool-1',
+        name: 'shell',
+        result: { success: true, preview: 'ok', error: null },
+      },
+    ],
+    markers: [],
+    metrics: null,
+    usage: null,
+    inFlight: false,
+    createdAt: 1_700_000_000_000,
+    finalSeq: 42,
+    ...overrides,
+  };
+}
+
+function renderCard(turn: TurnCardData, sessionKey = 'sess-abc') {
+  // Each test gets a fresh QueryClient so cached results from earlier
+  // scenarios cannot leak into the next one.
+  const qc = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0, staleTime: 0 } },
+  });
+  return render(
+    <QueryClientProvider client={qc}>
+      <RaraTurnCard turn={turn} sessionKey={sessionKey} />
+    </QueryClientProvider>,
+  );
+}
+
+/**
+ * Locate the vendor's three-dot actions trigger. The vendor renders it
+ * as `<div role="button">` containing a lucide `MoreHorizontal` SVG with
+ * `class="lucide-more-horizontal"`. Returning the outer div lets the
+ * test fire a real click.
+ */
+function findActionsTrigger(): HTMLElement | null {
+  // Lucide renamed `MoreHorizontal` → `Ellipsis` while keeping the export
+  // name; the rendered icon class is now `lucide-ellipsis`. Match either
+  // so the test does not break on a vendor-side lucide bump.
+  const icon =
+    document.querySelector('.lucide-ellipsis') || document.querySelector('.lucide-more-horizontal');
+  if (!icon) return null;
+  return icon.closest('[role="button"]');
+}
+
+afterEach(() => {
+  cleanup();
+  fetchExecutionTraceMock.mockReset();
+  fetchCascadeTraceMock.mockReset();
+});
+
+describe('RaraTurnCard — trace + cascade affordances', () => {
+  beforeEach(() => {
+    fetchExecutionTraceMock.mockReset();
+    fetchCascadeTraceMock.mockReset();
+  });
+
+  it('RaraTurnCard__actions_menu_wired_when_finalSeq_present_and_not_inflight', () => {
+    renderCard(makeTurn({ finalSeq: 42, inFlight: false }));
+    const trigger = findActionsTrigger();
+    expect(trigger).not.toBeNull();
+
+    fireEvent.click(trigger as HTMLElement);
+    // The dropdown is rendered to a portal — `screen` queries the whole
+    // document, which covers it.
+    expect(screen.getByText(/view turn details/i)).toBeInTheDocument();
+  });
+
+  it('RaraTurnCard__actions_menu_suppressed_when_inflight_or_seq_null', () => {
+    renderCard(makeTurn({ finalSeq: null, inFlight: true }));
+    expect(findActionsTrigger()).toBeNull();
+    expect(screen.queryByText(/view turn details/i)).toBeNull();
+  });
+
+  it('RaraTurnCard__trace_modal_opens_with_fetched_content', async () => {
+    fetchExecutionTraceMock.mockResolvedValue({
+      duration_secs: 1.23,
+      iterations: 7,
+      model: 'gpt-fixture-v9',
+      input_tokens: 100,
+      output_tokens: 200,
+      thinking_ms: 50,
+      thinking_preview: '',
+      plan_steps: [],
+      tools: [],
+      rara_turn_id: 'turn-42',
+    });
+
+    renderCard(makeTurn({ finalSeq: 42, inFlight: false }));
+    const trigger = findActionsTrigger();
+    expect(trigger).not.toBeNull();
+    fireEvent.click(trigger as HTMLElement);
+    fireEvent.click(screen.getByText(/view turn details/i));
+
+    // The modal renders a `dialog` role; it should appear with the fetched
+    // model name and iteration count from the fixture.
+    const dialog = await screen.findByRole('dialog');
+    await waitFor(() => {
+      expect(within(dialog).getByText('gpt-fixture-v9')).toBeInTheDocument();
+    });
+    expect(within(dialog).getByText('7')).toBeInTheDocument();
+    expect(fetchExecutionTraceMock).toHaveBeenCalledWith(
+      'sess-abc',
+      42,
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    );
+  });
+
+  it('RaraTurnCard__cascade_modal_opens_from_activity_row', async () => {
+    fetchCascadeTraceMock.mockResolvedValue({
+      message_id: 'sess-abc-42',
+      ticks: [
+        {
+          index: 0,
+          entries: [
+            {
+              id: 'cascade.0-aaa-1',
+              kind: 'thought',
+              content: 'cascade-fixture-thought',
+              timestamp: '2026-04-30T00:00:00Z',
+            },
+          ],
+        },
+      ],
+      summary: { tick_count: 1, tool_call_count: 1, total_entries: 1 },
+    });
+
+    renderCard(makeTurn({ finalSeq: 42, inFlight: false }));
+    // Vendor renders activities lazily inside an expandable section —
+    // expand the turn first by clicking the chevron header. The chevron
+    // icon is wrapped inside the toggle button.
+    const chevron = document.querySelector('.lucide-chevron-right');
+    expect(chevron).not.toBeNull();
+    const toggleBtn = (chevron as Element).closest('button');
+    expect(toggleBtn).not.toBeNull();
+    fireEvent.click(toggleBtn as HTMLElement);
+
+    // Now the tool activity row is in the DOM. Clicking the row container
+    // (which has onClick={onOpenDetails && isComplete ? onOpenDetails : …})
+    // fires onOpenActivityDetails. We locate the row via the tool name.
+    const toolNameNode = await screen.findByText('shell');
+    // The clickable container is the row `div` (group/row); walk up until
+    // we find a node with an onClick handler. `closest('div.group\\/row')`
+    // is brittle because Tailwind class names vary; instead, fire on the
+    // text node's parent — React's synthetic event bubbles up to the row
+    // handler regardless.
+    fireEvent.click(toolNameNode);
+
+    const dialog = await screen.findByRole('dialog');
+    await waitFor(() => {
+      expect(within(dialog).getByText(/cascade-fixture-thought/)).toBeInTheDocument();
+    });
+    expect(fetchCascadeTraceMock).toHaveBeenCalledWith(
+      'sess-abc',
+      42,
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    );
+  });
+
+  it('RaraTurnCard__trace_modal_shows_error_on_fetch_failure', async () => {
+    fetchExecutionTraceMock.mockRejectedValue(new Error('network is down'));
+
+    renderCard(makeTurn({ finalSeq: 42, inFlight: false }));
+    const trigger = findActionsTrigger();
+    expect(trigger).not.toBeNull();
+    fireEvent.click(trigger as HTMLElement);
+    fireEvent.click(screen.getByText(/view turn details/i));
+
+    const dialog = await screen.findByRole('dialog');
+    await waitFor(() => {
+      expect(within(dialog).getByRole('alert')).toBeInTheDocument();
+    });
+    expect(within(dialog).getByText(/network is down/i)).toBeInTheDocument();
+    // The card itself is still rendered alongside the modal.
+    expect(screen.getByText('final assistant text')).toBeInTheDocument();
+  });
+});

--- a/web/src/hooks/use-trace-fetch.ts
+++ b/web/src/hooks/use-trace-fetch.ts
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2025 Rararulab
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Lazy fetch hooks for the per-turn execution + cascade traces.
+ *
+ * Both hooks are gated on `enabled` so the network call only fires once
+ * the corresponding modal opens — there is no point pre-fetching for
+ * every rendered turn (the topology page has dozens) when the user only
+ * inspects a few. Caching is per `(sessionKey, seq, kind)` so re-opening
+ * the same modal within the same session reuses the result.
+ */
+
+import { useQuery } from '@tanstack/react-query';
+
+import type { CascadeTrace, ExecutionTrace } from '@/api/kernel-types';
+import { fetchCascadeTrace, fetchExecutionTrace } from '@/api/sessions';
+
+/**
+ * Fetch the execution trace for a `(sessionKey, seq)` pair.
+ *
+ * `enabled` defaults to true; pass `false` when the consuming modal is
+ * closed so we do not run the query while the affordance is unused.
+ */
+export function useExecutionTrace(sessionKey: string, seq: number | null, enabled: boolean) {
+  return useQuery<ExecutionTrace>({
+    queryKey: ['trace', 'execution', sessionKey, seq] as const,
+    queryFn: ({ signal }) => {
+      // `enabled` already guards on `seq !== null`, but TS needs the narrowing.
+      if (seq === null) return Promise.reject(new Error('seq is null'));
+      return fetchExecutionTrace(sessionKey, seq, { signal });
+    },
+    enabled: enabled && seq !== null,
+    // The trace for a completed turn is immutable, so cache aggressively
+    // — re-opening the modal within the session should not re-hit the API.
+    staleTime: Infinity,
+    gcTime: 5 * 60_000,
+    retry: false,
+  });
+}
+
+/** Cascade-trace twin of {@link useExecutionTrace}. */
+export function useCascadeTrace(sessionKey: string, seq: number | null, enabled: boolean) {
+  return useQuery<CascadeTrace>({
+    queryKey: ['trace', 'cascade', sessionKey, seq] as const,
+    queryFn: ({ signal }) => {
+      if (seq === null) return Promise.reject(new Error('seq is null'));
+      return fetchCascadeTrace(sessionKey, seq, { signal });
+    },
+    enabled: enabled && seq !== null,
+    staleTime: Infinity,
+    gcTime: 5 * 60_000,
+    retry: false,
+  });
+}


### PR DESCRIPTION
## Summary

- Wires the existing vendor `TurnCard` slots (`onOpenDetails` / `onOpenActivityDetails`) to two new modal components — `ExecutionTraceModal` + `CascadeModal` — backed by a `useTraceFetch` hook.
- Restores the inspectability surface PR #1826 (commit `356dd74e`) shipped on the retired `/chat-v2` page; backend trace + cascade endpoints (`crates/extensions/backend-admin/src/chat/router.rs`) unchanged.
- Live frames without a finalized seq leave `onOpenDetails` undefined → vendor hides chrome.

## Test plan

- [x] 5/5 BDD scenarios pass on `RaraTurnCard.test.tsx`:
  - actions menu wired when finalSeq present and not in-flight
  - actions menu suppressed when in-flight or seq null
  - trace modal opens with fetched content
  - cascade modal opens from activity row
  - trace modal shows error on fetch failure
- [x] 44/44 vitest full suite pass
- [x] `npm run typecheck` / `lint` / `build` clean
- [x] `prek run --all-files` clean
- [ ] CI green
- [ ] Manual browser smoke deferred — reviewer round was skipped this round due to subscription quota; CI + the falsifier-bound vitest scenarios are the verification.

## Notes

- Spec at `specs/issue-2023-topology-trace-cascade-buttons.spec.md` (lint 100%).
- Commit `ddbf8c7a` lands the spec; commit `c863df11` lands the implementation.
- Subagent reviewer not run pre-push due to quota exhaustion; please review the diff carefully before merge.

Closes #2023

🤖 Generated with [Claude Code](https://claude.com/claude-code)