### PR TITLE
feat(web): collapsible topology sidebar (#2022)

### DIFF
--- a/specs/issue-2022-topology-collapsible-sidebar.spec.md
+++ b/specs/issue-2022-topology-collapsible-sidebar.spec.md
@@ -1,0 +1,164 @@
+spec: task
+name: "issue-2022-topology-collapsible-sidebar"
+inherits: project
+tags: []
+---
+
+## Intent
+
+The topology page (`web/src/pages/Topology.tsx`) renders a fixed
+3-pane shell: `SessionPicker` (left, 280px) | `TimelineView` (centre,
+flex) | `WorkerInbox` + `TapeLineageView` (right, 320px). The left rail
+has no toggle — once `md:` breakpoint is hit, the 280px column is
+permanently parked and the operator cannot reclaim that horizontal
+space for the timeline.
+
+This is a UX affordance for the inspectability surface. On a typical
+1366–1440px laptop, after both rails take 600px and the centre pane
+reserves padding, the timeline ends up with ~700px of usable width.
+Long tool-call output (JSON args, code blocks, reasoning text) wraps
+aggressively or scrolls horizontally inside `TurnCard`. Operators
+reading a trace want to widen the centre column without resizing the
+window.
+
+The desired behaviour mirrors the vendored craft pattern (see
+`vendor/craft.png` and existing `web/src/vendor/craft-ui/components/icons/PanelLeftRounded.tsx`):
+a small icon button in the topology header toggles `SessionPicker`
+visibility; when collapsed the centre + right panes redistribute and
+fill the freed width. The collapsed state should persist across page
+reloads via `localStorage` so the operator does not have to re-toggle
+every time they revisit `/topology`.
+
+Reproducer:
+1. Open `/topology/<key>` at a viewport ≥ 768px (so the `md:` rail is
+   visible).
+2. Inspect the DOM — `SessionPicker` is an `<aside class="hidden w-[280px] shrink-0 border-r border-border md:block">`
+   in `Topology.tsx`. There is no toggle anywhere in the header or
+   surrounding chrome.
+3. The timeline column (`<main class="flex flex-1 min-w-0 min-h-0 flex-col p-3">`)
+   has no way to claim the 280px the picker holds.
+4. After fix: a `PanelLeft` icon button in the topology header toggles
+   the picker; clicking it removes the picker from the DOM (or sets
+   its container to `display:none`) and the centre pane expands. The
+   state survives a page reload.
+
+Prior art reviewed:
+- PR 2003 / #1999 (multi-agent observability UI) landed the 3-pane
+  shell on 2026-04-30 with the picker hard-coded as visible. Its
+  AGENT.md (`web/src/components/topology/AGENT.md`) does not call
+  collapsibility out as deferred — it was simply not in scope.
+- `gh issue list --search "sidebar collapse" --state all` returned 0
+  results. No prior issue tracks this.
+- `gh pr list --search "sidebar"` returned chat-sidebar work
+  (PR 1770, 1626, 1589, 1873, 1886) — none of them touch the topology
+  shell.
+- `git log --grep "sidebar|SessionPicker" --since=180.days` shows the
+  topology picker was introduced by `8ec0dadb` (PR 1999 task) and has
+  not been revisited.
+- The vendored craft-ui already ships `PanelLeftRounded.tsx`,
+  `PanelRightRounded.tsx`, and an `AppShellContext` with `localStorage`
+  helpers (`vendor/craft-ui/lib/electron/local-storage.ts`). The
+  smallest concrete approach reuses the icon and a small `useState` +
+  `useEffect` localStorage pattern locally in `Topology.tsx` rather
+  than wiring through `AppShellContext` (the topology page does not
+  consume the AppShell — adopting it just for one toggle is overreach).
+- The right rail (`WorkerInbox` + `TapeLineageView`) is intentionally
+  out of scope. The user asked about the left sidebar specifically;
+  the right rail already auto-hides at < `lg:` breakpoint so the
+  motivation is weaker.
+
+## Decisions
+
+- **Collapse mechanism: conditional render, not CSS-only.** When
+  collapsed, the `<aside>` is removed from the DOM. The `SessionPicker`
+  owns a 30s react-query refetch interval, but `useQuery` keeps the
+  cache hot across mount/unmount on the same `queryKey`, so re-expanding
+  is instantaneous. Removing the node also lets the flex layout
+  redistribute width without the picker holding a `min-content` floor.
+- **Persistence: `localStorage` key `rara.topology.sidebarCollapsed`,
+  boolean.** Read once on mount via lazy `useState` initializer; write
+  on every change via `useEffect`. Default to `false` (sidebar shown)
+  so a first-time visitor still sees the picker.
+- **Toggle placement: topology header.** A `Button size="icon" variant="ghost"`
+  with `PanelLeft` (or `PanelLeftClose`) from `lucide-react` (already
+  the icon library used elsewhere in the page — `Network`, `ArrowLeft`)
+  sits at the start of the header, before the `Network` icon. Single
+  button, two states: shows `PanelLeftClose` when expanded, `PanelLeft`
+  when collapsed. `aria-label` reflects the action ("Hide sidebar" /
+  "Show sidebar"). `title` matches.
+- **Scope: left sidebar only.** Right rail collapsibility is NOT in
+  this spec. If operators ask later, file a separate issue.
+- **No new constants.** The 280px width and `md:` breakpoint stay as
+  they are. The toggle just controls visibility.
+
+## Boundaries
+
+### Allowed Changes
+
+- **/web/src/pages/Topology.tsx
+- **/web/src/pages/__tests__/Topology.test.tsx
+- **/web/src/components/topology/AGENT.md
+- **/specs/issue-2022-topology-collapsible-sidebar.spec.md
+
+### Forbidden
+
+- `web/src/components/topology/SessionPicker.tsx`
+- `web/src/components/topology/WorkerInbox.tsx`
+- `web/src/components/topology/TapeLineageView.tsx`
+- `web/src/components/topology/TimelineView.tsx`
+- `web/src/vendor/**`
+- `crates/**`
+- `web/src/hooks/**`
+
+## Acceptance Criteria
+
+```gherkin
+Feature: Collapsible left sidebar on the topology page
+
+  Scenario: Toggle hides the SessionPicker from the DOM
+    Given the topology page is rendered at a viewport that shows the left rail
+      And the sidebar is in the default expanded state
+    When the user clicks the sidebar toggle button in the topology header
+    Then the SessionPicker is no longer present in the DOM
+      And the centre timeline column expands to fill the freed width
+    Test: web/src/pages/__tests__/Topology.test.tsx::toggle_hides_session_picker
+
+  Scenario: Toggle restores the SessionPicker
+    Given the topology page is rendered with the sidebar collapsed
+    When the user clicks the sidebar toggle button
+    Then the SessionPicker is mounted and visible again
+    Test: web/src/pages/__tests__/Topology.test.tsx::toggle_restores_session_picker
+
+  Scenario: Collapsed state persists across reloads
+    Given the user has collapsed the sidebar
+    When the topology page is unmounted and remounted
+       (simulating a full page reload backed by the same localStorage)
+    Then the SessionPicker is not rendered on the next mount
+      And the toggle button reflects the collapsed state
+    Test: web/src/pages/__tests__/Topology.test.tsx::collapsed_state_persists
+
+  Scenario: Default state for a first-time visitor is expanded
+    Given localStorage has no entry for the sidebar collapse key
+    When the topology page mounts
+    Then the SessionPicker is rendered
+    Test: web/src/pages/__tests__/Topology.test.tsx::default_state_is_expanded
+
+  Scenario: localStorage access failure falls back to default
+    Given localStorage throws on read (private browsing or disabled storage)
+    When the topology page mounts
+    Then the SessionPicker is rendered (default expanded state)
+      And the page does not crash or surface the error to the user
+    Test: web/src/pages/__tests__/Topology.test.tsx::localstorage_failure_falls_back
+```
+
+## Constraints
+
+- All code comments and identifiers in English.
+- No new dependencies (icon comes from `lucide-react` which the page
+  already imports).
+- The `localStorage` read must be resilient to access errors (private
+  browsing, disabled storage) — fall back to the default `false`
+  rather than throwing.
+- Do not introduce a YAML config knob for the default state — this is
+  a per-user UX preference, not a deployment concern (see
+  `docs/guides/anti-patterns.md` "mechanism constants are not config").

--- a/web/src/components/topology/AGENT.md
+++ b/web/src/components/topology/AGENT.md
@@ -16,6 +16,16 @@ the most-recent session on first load so users never have to paste a
 session UUID — task #9 of #1999 fixed that UX complaint by replacing
 the old free-text "root session key" input with a clickable list.
 
+The topology header carries a `PanelLeft` / `PanelLeftClose` icon button
+(issue #2022) that toggles the left rail by conditionally rendering the
+`<aside>` wrapper around `SessionPicker`. When collapsed the picker is
+removed from the DOM, the centre column reclaims the freed flex width,
+and the preference is mirrored to `localStorage` under
+`rara.topology.sidebarCollapsed` so it survives reloads. The toggle lives
+in `Topology.tsx` rather than threading through `AppShellContext` because
+the topology page does not consume the AppShell — adopting it for one
+button would be overreach.
+
 - `SessionPicker.tsx` — left rail. Lists the most-recently updated
   sessions via `useQuery(['topology', 'chat-sessions'])` against
   `GET /api/v1/chat/sessions?limit=50`, polls every 30s, and exposes

--- a/web/src/pages/Topology.tsx
+++ b/web/src/pages/Topology.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { ArrowLeft, Network } from 'lucide-react';
+import { ArrowLeft, Network, PanelLeft, PanelLeftClose } from 'lucide-react';
 import { useCallback, useEffect, useState } from 'react';
 import { useNavigate, useParams } from 'react-router';
 
@@ -43,6 +43,22 @@ import { useTopologySubscription, type TopologyStatus } from '@/hooks/use-topolo
  * so users never have to paste a session UUID — the UX complaint
  * `#1999` task #9 fixes.
  */
+/** localStorage key for the per-user collapsed-sidebar preference. */
+const SIDEBAR_COLLAPSED_STORAGE_KEY = 'rara.topology.sidebarCollapsed';
+
+/**
+ * Read the persisted collapsed-sidebar preference, swallowing access
+ * errors (private browsing, disabled storage). The default is `false`
+ * so first-time visitors still see the picker.
+ */
+function readSidebarCollapsed(): boolean {
+  try {
+    return window.localStorage.getItem(SIDEBAR_COLLAPSED_STORAGE_KEY) === 'true';
+  } catch {
+    return false;
+  }
+}
+
 export default function Topology() {
   const { rootSessionKey } = useParams<{ rootSessionKey?: string }>();
   const navigate = useNavigate();
@@ -50,6 +66,21 @@ export default function Topology() {
   // session key focuses on that worker. Reset whenever the root changes
   // so a new connection always lands on the root view.
   const [viewChild, setViewChild] = useState<string | null>(null);
+  // Lazy initializer reads localStorage exactly once on mount; the
+  // useEffect below mirrors the React state back to storage on change.
+  const [sidebarCollapsed, setSidebarCollapsed] = useState<boolean>(readSidebarCollapsed);
+
+  useEffect(() => {
+    try {
+      window.localStorage.setItem(
+        SIDEBAR_COLLAPSED_STORAGE_KEY,
+        sidebarCollapsed ? 'true' : 'false',
+      );
+    } catch {
+      // Storage may be unavailable (private browsing, quota); the toggle
+      // still works in-memory for the rest of the session.
+    }
+  }, [sidebarCollapsed]);
 
   const subscription = useTopologySubscription(rootSessionKey ?? null);
 
@@ -67,6 +98,20 @@ export default function Topology() {
   return (
     <div className="flex h-full min-h-0 flex-col">
       <header className="flex items-center gap-3 border-b border-border px-3 py-2">
+        <Button
+          size="icon"
+          variant="ghost"
+          className="h-7 w-7"
+          aria-label={sidebarCollapsed ? 'Show sidebar' : 'Hide sidebar'}
+          title={sidebarCollapsed ? 'Show sidebar' : 'Hide sidebar'}
+          onClick={() => setSidebarCollapsed((v) => !v)}
+        >
+          {sidebarCollapsed ? (
+            <PanelLeft className="h-4 w-4" />
+          ) : (
+            <PanelLeftClose className="h-4 w-4" />
+          )}
+        </Button>
         <Network className="h-4 w-4 text-muted-foreground" />
         <h1 className="text-sm font-medium">Topology</h1>
         <div className="ml-auto">
@@ -81,13 +126,15 @@ export default function Topology() {
       </header>
 
       <div className="flex flex-1 min-h-0">
-        <aside className="hidden w-[280px] shrink-0 border-r border-border md:block">
-          <SessionPicker
-            activeSessionKey={rootSessionKey ?? null}
-            onSelect={selectSession}
-            onAutoSelect={selectSession}
-          />
-        </aside>
+        {!sidebarCollapsed && (
+          <aside className="hidden w-[280px] shrink-0 border-r border-border md:block">
+            <SessionPicker
+              activeSessionKey={rootSessionKey ?? null}
+              onSelect={selectSession}
+              onAutoSelect={selectSession}
+            />
+          </aside>
+        )}
 
         <main className="flex flex-1 min-w-0 min-h-0 flex-col p-3">
           {rootSessionKey ? (

--- a/web/src/pages/__tests__/Topology.test.tsx
+++ b/web/src/pages/__tests__/Topology.test.tsx
@@ -1,0 +1,183 @@
+/*
+ * Copyright 2025 Rararulab
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * BDD bindings for `specs/issue-2022-topology-collapsible-sidebar.spec.md`.
+ *
+ * Each `it(...)` name carries the spec's `Test:` selector verbatim so
+ * `agent-spec verify` can resolve scenarios to real test functions.
+ */
+
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Node 25's experimental built-in `localStorage` shim is enabled by
+// default in jsdom but exposes a hollow `[Object: null prototype] {}` —
+// `setItem` / `getItem` / `removeItem` are missing. Install a minimal
+// in-memory `Storage`-shaped stand-in before importing the component so
+// `readSidebarCollapsed()` and the persistence effect see a working
+// surface. Running Topology tests under jsdom is fine; the shim only
+// needs to support the methods this page calls.
+class MemoryStorage {
+  private store = new Map<string, string>();
+  getItem(key: string): string | null {
+    return this.store.has(key) ? (this.store.get(key) ?? null) : null;
+  }
+  setItem(key: string, value: string): void {
+    this.store.set(key, String(value));
+  }
+  removeItem(key: string): void {
+    this.store.delete(key);
+  }
+  clear(): void {
+    this.store.clear();
+  }
+  key(index: number): string | null {
+    return Array.from(this.store.keys())[index] ?? null;
+  }
+  get length(): number {
+    return this.store.size;
+  }
+}
+Object.defineProperty(window, 'localStorage', {
+  configurable: true,
+  value: new MemoryStorage(),
+});
+
+import Topology from '../Topology';
+
+// --- Module mocks --------------------------------------------------------
+//
+// `Topology` mounts `SessionPicker`, `TimelineView`, `WorkerInbox`,
+// `TapeLineageView`, and the topology WS subscription. The toggle test
+// exercises the layout/grid level only — children are stubbed to thin
+// markers so the assertions can target the picker's presence in the DOM
+// without spinning up react-query, the WS, or the editor.
+
+vi.mock('@/components/topology/SessionPicker', () => ({
+  SessionPicker: () => <div data-testid="session-picker">picker</div>,
+}));
+
+vi.mock('@/components/topology/TimelineView', () => ({
+  TimelineView: () => <div data-testid="timeline-view">timeline</div>,
+}));
+
+vi.mock('@/components/topology/WorkerInbox', () => ({
+  WorkerInbox: () => <div data-testid="worker-inbox">workers</div>,
+}));
+
+vi.mock('@/components/topology/TapeLineageView', () => ({
+  TapeLineageView: () => <div data-testid="tape-lineage">lineage</div>,
+}));
+
+vi.mock('@/hooks/use-topology-subscription', () => ({
+  useTopologySubscription: () => ({
+    status: { kind: 'idle' as const },
+    events: [],
+  }),
+}));
+
+// `react-router`'s `useParams` / `useNavigate` work without a Router only
+// in v7 when not used through context; provide stable stubs to avoid the
+// "useNavigate may be used only in the context of a Router" runtime error.
+vi.mock('react-router', () => ({
+  useParams: () => ({}),
+  useNavigate: () => () => {},
+}));
+
+const STORAGE_KEY = 'rara.topology.sidebarCollapsed';
+
+beforeEach(() => {
+  window.localStorage.removeItem(STORAGE_KEY);
+});
+
+afterEach(() => {
+  cleanup();
+  window.localStorage.removeItem(STORAGE_KEY);
+  vi.restoreAllMocks();
+});
+
+describe('Topology — collapsible sidebar (issue-2022)', () => {
+  it('toggle_hides_session_picker', () => {
+    render(<Topology />);
+
+    // Default expanded: picker is in the DOM.
+    expect(screen.getByTestId('session-picker')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Hide sidebar' }));
+
+    // After toggle: SessionPicker is not present in the DOM (the `<aside>`
+    // wrapper is conditionally rendered, so the centre column owns the
+    // freed flex width).
+    expect(screen.queryByTestId('session-picker')).not.toBeInTheDocument();
+    // Toggle button now reflects the collapsed state.
+    expect(screen.getByRole('button', { name: 'Show sidebar' })).toBeInTheDocument();
+  });
+
+  it('toggle_restores_session_picker', () => {
+    window.localStorage.setItem(STORAGE_KEY, 'true');
+
+    render(<Topology />);
+
+    expect(screen.queryByTestId('session-picker')).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Show sidebar' }));
+
+    expect(screen.getByTestId('session-picker')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Hide sidebar' })).toBeInTheDocument();
+  });
+
+  it('collapsed_state_persists', () => {
+    const { unmount } = render(<Topology />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Hide sidebar' }));
+
+    expect(window.localStorage.getItem(STORAGE_KEY)).toBe('true');
+
+    unmount();
+    cleanup();
+
+    // Simulate a page reload backed by the same localStorage.
+    render(<Topology />);
+
+    expect(screen.queryByTestId('session-picker')).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Show sidebar' })).toBeInTheDocument();
+  });
+
+  it('default_state_is_expanded', () => {
+    expect(window.localStorage.getItem(STORAGE_KEY)).toBeNull();
+
+    render(<Topology />);
+
+    expect(screen.getByTestId('session-picker')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Hide sidebar' })).toBeInTheDocument();
+  });
+
+  it('localstorage_failure_falls_back', () => {
+    // Force `getItem` to throw to simulate private browsing / disabled
+    // storage. The component must fall back to the default expanded
+    // state without surfacing the error.
+    const getItemSpy = vi.spyOn(window.localStorage, 'getItem').mockImplementation(() => {
+      throw new Error('storage disabled');
+    });
+
+    expect(() => render(<Topology />)).not.toThrow();
+
+    expect(screen.getByTestId('session-picker')).toBeInTheDocument();
+
+    getItemSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary

- Topology page header gains a `PanelLeft` / `PanelLeftClose` toggle that hides/shows the `SessionPicker` left rail.
- Collapsed state persists across reloads at `localStorage` key `rara.topology.sidebarCollapsed`.
- Chat pane reclaims the freed width via the existing flex layout; localStorage failures fall back to the expanded default.

## Test plan

- [x] BDD scenarios 5/5 pass: `toggle_hides_session_picker`, `toggle_restores_session_picker`, `collapsed_state_persists`, `default_state_is_expanded`, `localstorage_failure_falls_back`.
- [x] `just spec-lifecycle specs/issue-2022-topology-collapsible-sidebar.spec.md` — 5/5 PASS.
- [x] Typecheck / lint / build / `prek run --all-files` clean.
- [ ] Browser smoke skipped — reviewer confirmed acceptable because the parent layout is flex (not grid), so the vitest DOM assertions cover the failure modes.

Closes #2022. Spec at `specs/issue-2022-topology-collapsible-sidebar.spec.md`.