### PR TITLE
chore(web): comment why SpawnMarker renders outside vendor TurnCard (#2030)

### DIFF
--- a/web/src/components/topology/RaraTurnCard.tsx
+++ b/web/src/components/topology/RaraTurnCard.tsx
@@ -132,6 +132,10 @@ export function RaraTurnCard({ turn, sessionKey }: RaraTurnCardProps) {
         isComplete={!turn.inFlight}
         {...inspectProps}
       />
+      {/* Spawn markers render as siblings, not inside VendorTurnCard:
+          the vendor's `activities[]` is a discriminated union of
+          thinking | tool, and there is no `children` / footer slot.
+          Sibling layout is the only non-fork option. */}
       {turn.markers.length > 0 && (
         <div className="space-y-1.5">
           {turn.markers.map((marker, idx) => (


### PR DESCRIPTION
## Summary

Adds a 4-line JSX comment above the `SpawnMarker` block in `RaraTurnCard.tsx` explaining why the marker renders as a sibling of the vendor `TurnCard` rather than inline within it: the vendor component exposes no inline slot for per-turn decoration, so we render alongside it.

Captures the P3 finding from PR #2018's reviewer pass — future readers will hit the same "why is this outside the card?" question, and the answer should live next to the code.

## Test plan

- [x] Comment-only change, zero behavior change
- [x] `cd web && npm run build` passes locally
- [x] Reviewer pre-push skipped (lane-2 chore, comment-only)

Closes #2030