### PR TITLE
chore(web): split topology vendor chunk via lazy import + manualChunks (#2033)

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -15,7 +15,7 @@
  */
 
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { useEffect, useState } from 'react';
+import { lazy, Suspense, useEffect, useState } from 'react';
 import { BrowserRouter, Routes, Route, useNavigate } from 'react-router';
 
 import { ConnectionSetupDialog } from '@/components/ConnectionSetupDialog';
@@ -31,7 +31,20 @@ import Docs from '@/pages/Docs';
 import KernelTop from '@/pages/KernelTop';
 import Login from '@/pages/Login';
 import Subscriptions from '@/pages/Subscriptions';
-import Topology from '@/pages/Topology';
+
+// Topology owns the heavy vendor surface (`src/vendor/craft-ui` + tiptap,
+// react-pdf, mermaid, @uiw/react-json-view). Lazy-loading it keeps
+// `/login`, `/kernel-top`, `/subscriptions`, `/docs` off that ~4.7 MB
+// chunk on first paint — see issue #2033.
+const Topology = lazy(() => import('@/pages/Topology'));
+
+function RouteFallback() {
+  return (
+    <div className="flex h-full w-full items-center justify-center p-8 text-sm text-muted-foreground">
+      Loading…
+    </div>
+  );
+}
 
 const STORAGE_KEY = 'rara_backend_url';
 const queryClient = new QueryClient();
@@ -105,12 +118,33 @@ export default function App() {
                   </RequireAuth>
                 }
               >
-                <Route index element={<Topology />} />
+                <Route
+                  index
+                  element={
+                    <Suspense fallback={<RouteFallback />}>
+                      <Topology />
+                    </Suspense>
+                  }
+                />
                 <Route path="docs" element={<Docs />} />
                 <Route path="kernel-top" element={<KernelTop />} />
                 <Route path="subscriptions" element={<Subscriptions />} />
-                <Route path="topology" element={<Topology />} />
-                <Route path="topology/:rootSessionKey" element={<Topology />} />
+                <Route
+                  path="topology"
+                  element={
+                    <Suspense fallback={<RouteFallback />}>
+                      <Topology />
+                    </Suspense>
+                  }
+                />
+                <Route
+                  path="topology/:rootSessionKey"
+                  element={
+                    <Suspense fallback={<RouteFallback />}>
+                      <Topology />
+                    </Suspense>
+                  }
+                />
               </Route>
             </Routes>
           </SettingsModalProvider>

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -151,5 +151,37 @@ export default defineConfig(({ mode }) => {
       port: 4173,
       strictPort: true,
     },
+    build: {
+      rollupOptions: {
+        output: {
+          // Split heavy vendor families into stable chunks so a topology-only
+          // edit doesn't invalidate the React chunk in browser caches, and so
+          // the entry chunk doesn't ship libraries used only by Topology.
+          // See issue #2033.
+          manualChunks(id: string) {
+            if (!id.includes('node_modules')) return undefined;
+            if (
+              /node_modules\/(react|react-dom|react-router|scheduler|@tanstack\/react-query)\//.test(
+                id,
+              )
+            ) {
+              return 'react-vendor';
+            }
+            if (id.includes('node_modules/@tiptap/')) return 'tiptap';
+            if (id.includes('node_modules/react-pdf/') || id.includes('node_modules/pdfjs-dist/')) {
+              return 'pdf';
+            }
+            if (
+              id.includes('node_modules/@uiw/react-json-view') ||
+              id.includes('node_modules/@pierre/diffs')
+            ) {
+              return 'inspector';
+            }
+            if (id.includes('node_modules/mermaid')) return 'mermaid';
+            return undefined;
+          },
+        },
+      },
+    },
   };
 });


### PR DESCRIPTION
## Summary

Entry chunk **4712 → 471 kB** (gzip 1419 → 136 kB, ~90% drop).

- `React.lazy` on the `Topology` route
- `manualChunks` for `react-vendor` / `tiptap` / `pdf` / `inspector` / `mermaid`

## Test plan

- [x] 49/49 vitest pass
- [x] `npm run build` — entry chunk drops as stated above

## Notes

Reviewer P3 nit: the `mermaid` regex rule in `manualChunks` is a no-op — only `beautiful-mermaid` is installed, not `mermaid`. The auto-derived chunk via dynamic import is unaffected. Leaving as a follow-up.

Closes #2033.