### PR TITLE
ci(smoke): switch linux zig smoke job to arc-runner-set (#2047)

### DIFF
--- a/.github/workflows/zig-codec-smoke.yml
+++ b/.github/workflows/zig-codec-smoke.yml
@@ -7,6 +7,12 @@ name: zig-codec-smoke
 # required CI checks. The job exists so that a future maintainer can
 # look at recent runs and answer "does Zig still build on Linux?"
 # without spinning up a runner manually.
+#
+# The linux job runs on `arc-runner-set` so it inherits the clang + mold
+# baseline from `rust.yml`'s runner image. `.cargo/config.toml` forces
+# `linker = "clang"` + `-fuse-ld=mold` for `x86_64-unknown-linux-gnu`
+# (see #2010), and GitHub-hosted `ubuntu-latest` lacks mold, so this job
+# was failing on every PR until switched to the self-hosted runner (#2047).
 
 on:
   pull_request:
@@ -27,7 +33,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-latest, ubuntu-latest]
+        os: [macos-latest, arc-runner-set]
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
## Summary

- Switch `.github/workflows/zig-codec-smoke.yml` linux matrix leg from `ubuntu-latest` → `arc-runner-set`. macOS leg unchanged.
- Add a why-comment block in the workflow header explaining: PR #2010 added project-wide `.cargo/config.toml` mold flag, GitHub-hosted `ubuntu-latest` lacks mold, hence the failure since 5/1; arc-runner-set bakes mold + clang per #1942.

## Test plan

- [x] YAML well-formed; `arc-runner-set` bare-string matches existing `rust.yml` / `lint.yml` / etc.
- [x] No collateral edits; `.cargo/config.toml` untouched
- [ ] CI run on this PR shows `smoke arc-runner-set` (linux leg) green and `smoke macos-latest` still green

Closes #2047

🤖 Generated with [Claude Code](https://claude.com/claude-code)