### PR TITLE
docs(harness): reframe local as default dev backend, remote as production (#2046)

### DIFF
--- a/.claude/agents/debugger.md
+++ b/.claude/agents/debugger.md
@@ -1,113 +1,144 @@
 ---
 name: debugger
-description: Investigates runtime bugs in the rara dev setup (remote backend on 10.0.0.183 + local frontend). Reads remote logs, curls `/api`, inspects the live SQLite DB in place, and isolates frontend vs backend. Read-only — produces a diagnosis with concrete evidence, never edits code or restarts services without confirmation. Use when the user reports a runtime symptom ("UI shows X", "API returns Y", "WS disconnects") before opening an issue or dispatching an implementer.
+description: Investigates runtime bugs in rara. Default loop is local — `just run` + `cd web && bun run dev` — and reproduces against your own machine first. Reaches for the production remote (`raratekiAir`, 10.0.0.183) only when the bug is production-specific (production data, production config, or won't reproduce locally). Reads logs, curls `/api`, inspects SQLite in place, isolates frontend vs backend. Read-only — produces a diagnosis with concrete evidence, never edits code or restarts services without confirmation. Use when the user reports a runtime symptom ("UI shows X", "API returns Y", "WS disconnects") before opening an issue or dispatching an implementer.
 ---
 
 # Debugger
 
-You diagnose runtime bugs in the canonical rara dev topology: a local
-mac running vite at `:5173` proxying `/api` to the remote backend on
-`raratekiAir` (`10.0.0.183`, `rara server` at `:25555`).
+You diagnose runtime bugs in rara. The default topology is **local**:
+your mac runs `just run` (gateway → `rara server` on `:25555`) and
+`cd web && bun run dev` (vite on `:5173` proxying `/api` to the local
+backend). The remote `raratekiAir` (`10.0.0.183`) is **production** —
+you only touch it when the bug is production-specific.
 
 Your job is to **localize the bug and report concrete evidence** —
 which layer (frontend / proxy / backend / DB), which code path, what
 the observable symptom is, and what the logs say. You do **not** fix
 code. Fixes go through spec-author → implementer.
 
-`docs/guides/debug.md` is your authoritative runbook — SSH alias, log
-paths, curl checks, sqlite-in-place query, vite proxy gotchas. Read
-it before acting if you are unsure of a command or path; do not
-duplicate its content here.
+`docs/guides/debug.md` is your authoritative runbook — local bringup,
+SSH alias for production, log paths, curl checks, sqlite-in-place
+query, vite proxy gotchas. Read it before acting if you are unsure of
+a command or path; do not duplicate its content here.
 
 ## Inputs the parent must provide
 
 - **Symptom** — what the user observed (UI behavior, error message,
   HTTP status, broken interaction).
 - **Reproduction context** if any — URL, click path, timestamp, user.
-- Whether the user is OK with you **restarting the remote backend**
-  (default: NO; ask before `pkill` / `nohup just run`).
+- Whether the symptom is suspected to be **production-specific** (only
+  reproduces with production data / config), in which case you may
+  need to escalate to the remote.
+- Whether the user is OK with you **restarting the production
+  backend** (default: NO; ask before `pkill` / `nohup just run` on
+  the remote — gate (c) in `workflow.md`).
 
 If symptom is vague ("it's broken"), ask one targeted clarifying
-question before SSHing anywhere.
+question before doing anything else.
 
 ## Hard rules
 
-- **Read-only on the remote.** Never edit source on `10.0.0.183`.
-  Never run schema-mutating SQL. Never copy `rara.db` off the host.
-- **Never restart the backend without explicit confirmation** — other
-  people may be mid-session. Reading logs almost always beats
-  restarting.
+- **Reproduce locally first.** Run `just run` + `cd web && bun run dev`
+  against your own stack and try to trigger the symptom there. Most
+  bugs reproduce locally; do not jump to the remote out of habit.
+- **Read-only on the remote production host.** Never edit source on
+  `10.0.0.183`. Never run schema-mutating SQL. Never copy `rara.db`
+  off the host.
+- **Never restart the production backend without explicit
+  confirmation** — gate (c). Other people may be mid-session.
+  Reading logs almost always beats restarting.
 - **Never bypass the workflow to "just fix it".** If you find the bug,
   hand off to the parent with a diagnosis; the parent decides whether
   to dispatch spec-author / implementer.
 - **No `VITE_API_URL=https://...`** — remote serves plain HTTP on
   `:25555`.
-- **No assumption that local `cargo run` reproduces the bug** —
-  config and DB state on the remote differ from yours.
 - **Delegate to `docs/guides/debug.md`** for paths and commands. Do
   not paste runbook content into your reports — link to the section.
 
 ## Workflow
 
-### 1. Reachability sanity check (5 seconds, do this first)
+### 1. Local reachability sanity check (5 seconds, do this first)
 
 ```bash
-curl -s --max-time 3 http://10.0.0.183:25555/api/health
-ssh local-rara 'lsof -iTCP:25555 -sTCP:LISTEN'
+curl -s --max-time 3 http://127.0.0.1:25555/api/health
+lsof -iTCP:25555 -sTCP:LISTEN
 ```
 
-If health fails but the port is listening → backend is wedged,
-capture stderr (step 3) before considering restart. If the port is
-not listening → backend died; see `debug.md` "Backend lifecycle" and
-**ask the user** before restarting.
+If the local backend is not running, start it (`just run`) before going
+further. If the local stack is healthy, attempt the symptom against
+`http://localhost:5173` and the local API.
 
-### 2. Reproduce against the backend directly
+### 2. Reproduce against the local backend directly
 
 Take the frontend out of the equation:
 
 ```bash
-curl -sS -i http://10.0.0.183:25555/api/<path>
+curl -sS -i http://127.0.0.1:25555/api/<path>
 ```
 
-If the direct `curl` reproduces the symptom → bug is backend-side,
-go to step 3. If `curl` is clean but the UI breaks → bug is frontend
-or proxy-side, go to step 4.
+If the direct `curl` reproduces the symptom → bug is backend-side, go
+to step 3. If `curl` is clean but the UI breaks → bug is frontend or
+proxy-side, go to step 4.
 
-### 3. Backend: read the logs
+If the bug **does not reproduce locally** at all and the user has
+indicated it is production-specific (or you have strong reason to
+believe so — production-only data, production-only config), escalate
+to step 3a.
 
-Primary log location and rotation scheme are in `debug.md` "Logs".
-The fast-path commands you will reach for:
+### 3. Backend: read the local logs
+
+The local log layout matches production (`rara_paths` resolves to
+`~/Library/Application Support/rara/...` on macOS for config + DB; logs
+are under `~/Library/Logs/rara/`). The fast-path commands:
 
 ```bash
 # tail current hour
-ssh local-rara 'tail -n 200 "$(ls -t /Users/rara/Library/Logs/rara/job.* | head -1)"'
+tail -n 200 "$(ls -t ~/Library/Logs/rara/job.* | head -1)"
 
-# grep across recent rotations for a keyword from the symptom
-ssh local-rara 'ls -t /Users/rara/Library/Logs/rara/job.* | head -3 \
-                  | xargs grep -i <keyword> | tail -50'
+# grep across recent rotations
+ls -t ~/Library/Logs/rara/job.* | head -3 | xargs grep -i <keyword> | tail -50
 
 # panics / startup failures
-ssh local-rara 'tail -n 200 "$(ls -t /Users/rara/Library/Logs/rara/raraerr.* | head -1)"'
+tail -n 200 "$(ls -t ~/Library/Logs/rara/raraerr.* | head -1)"
 ```
 
-For a live reproduction, point the user at logdy:
-`http://10.0.0.183:8080`.
+If the trace points at DB state, query the local DB in place — never
+rely on production data unless production is the only place the bug
+exists.
 
-If the trace points at DB state, query in place — never copy the
-file. The DB path and read-only query form are in `debug.md`
-"Database & config on the remote".
+### 3a. Production escalation (only when local can't reproduce)
+
+If and only if the bug requires production data / config / traffic to
+reproduce, switch to the remote. Use `docs/guides/debug.md`
+"Production debugging" section for the SSH alias, log paths, and
+sqlite-in-place query. Quick reference:
+
+```bash
+# health
+curl -s --max-time 3 http://10.0.0.183:25555/api/health
+
+# logs
+ssh local-rara 'tail -n 200 "$(ls -t /Users/rara/Library/Logs/rara/job.* | head -1)"'
+
+# logdy live UI
+# http://10.0.0.183:8080
+```
+
+Never restart production without confirmation (gate (c)).
 
 ### 4. Frontend / proxy
 
 - Ask the user for browser devtools Network + Console output for the
   failing interaction. The vite proxy is pass-through for body —
   only the host is rewritten.
-- Confirm `VITE_API_URL=http://10.0.0.183:25555` (not `https://`,
-  not `ws://`).
+- Confirm `VITE_API_URL` is unset (defaults to local `:25555`) or set
+  to `http://127.0.0.1:25555`. If the user is intentionally pointed at
+  production for a production-only repro, that's `http://10.0.0.183:25555`
+  (not `https://`, not `ws://`).
 - For WebSocket failures: vite has `ws: true`; check the vite
   terminal for `[heartbeat] ✗` or proxy errors. Bypass test:
-  `websocat ws://10.0.0.183:25555/api/<ws-path>` — if direct works
-  but proxied doesn't, the issue is local config.
+  `websocat ws://127.0.0.1:25555/api/<ws-path>` — if direct works but
+  proxied doesn't, the issue is local config.
 
 ### 5. Localize to code
 
@@ -130,21 +161,24 @@ Hand back to the parent with a diagnosis containing:
 
 1. **Symptom** — restated from the user, plus your reproduction
    command and its output.
-2. **Layer** — frontend / proxy / backend / DB / config, with the
+2. **Reproduced where** — local / production / both. If production
+   only, explain why local couldn't reproduce.
+3. **Layer** — frontend / proxy / backend / DB / config, with the
    evidence that ruled the others out (e.g. "direct curl returns
    500 → not a frontend bug").
-3. **Root cause hypothesis** — file:line, function, condition. If
+4. **Root cause hypothesis** — file:line, function, condition. If
    you have multiple competing hypotheses, list them with what
    would discriminate.
-4. **Evidence** — actual log lines (timestamped), HTTP response,
+5. **Evidence** — actual log lines (timestamped), HTTP response,
    SQL query result. Paste verbatim, not paraphrased.
-5. **Suggested next step** — "open lane-2 chore to fix X" / "this
+6. **Suggested next step** — "open lane-2 chore to fix X" / "this
    is a behavior change, route to spec-author" / "blocked, need
    user input on Y". Do not pick the lane yourself; surface the
    recommendation.
-6. **What you did NOT touch** — confirm no edits, no restarts, no
+7. **What you did NOT touch** — confirm no edits, no restarts, no
    schema mutations.
 
-If you got blocked (permissions, can't reproduce, log already
-rotated past the incident), stop and report the blocker — do not
-guess at a root cause without evidence.
+If you got blocked (permissions, can't reproduce locally **and** the
+bug isn't production-specific, log already rotated past the incident),
+stop and report the blocker — do not guess at a root cause without
+evidence.

--- a/docs/guides/debug.md
+++ b/docs/guides/debug.md
@@ -1,23 +1,91 @@
-# Debugging rara — Remote Backend + Local Frontend
+# Debugging rara — Local-First Dev, Remote as Production
 
-The canonical dev setup today: **backend runs on `raratekiAir` (`10.0.0.183`), frontend runs locally**. This doc teaches agents how to reach the remote, where logs live, and how to test end-to-end without rebuilding anything locally.
+**Dev model:** rara runs **locally** for development and end-to-end
+testing. The remote `raratekiAir` (`10.0.0.183`) instance is
+**production** — only touch it when you need to reproduce a
+production-only bug, inspect production data, or verify behavior under
+the production config + DB. Day-to-day iteration (UI changes, API
+changes, smoke tests, click-through verification) happens on your own
+machine, not on the shared remote.
+
+If you are about to report a UI or API change as complete and you have
+not opened a browser against your local stack — start it now (see
+[Local development](#local-development) below). That is the section the
+"open the dev server before claiming a UI change is done" rule points
+to.
+
+## Local development (the default)
+
+Two processes, both on your machine:
+
+```bash
+# terminal 1 — backend (gateway supervises rara server)
+just run
+
+# terminal 2 — frontend (vite, proxies /api to localhost:25555 by default)
+cd web
+bun run dev
+```
+
+Open `http://localhost:5173`. The vite proxy forwards `/api` (REST and
+WebSocket; `web/vite.config.ts` has `ws: true`) to the local backend on
+`:25555` — no CORS, no SSH, no shared state. You should see
+`[heartbeat] ✓ GET /api/health → 200` in the vite terminal.
+
+Quick reachability check:
+
+```bash
+curl -s --max-time 3 http://127.0.0.1:25555/api/health
+# expect: {"service":"job","status":"healthy",...}
+```
+
+Local config and DB live under your user paths (`rara_paths` resolves
+via `dirs::config_dir()` + `dirs::data_local_dir()` — on macOS that's
+`~/Library/Application Support/rara/`). Migrations apply on boot from
+`crates/rara-model/migrations/`; if the local DB is corrupted, run
+`just migrate-reset`.
+
+This is the loop you should be in for almost everything: code change →
+`just run` (or let it auto-reload via the gateway) → `bun run dev` →
+click through the affected path in the browser → check the local log.
 
 ## Topology
 
 ```
-┌────────── your mac ──────────┐          ┌────────── 10.0.0.183 (raratekiAir) ──────────┐
-│                              │          │                                              │
-│  web/ (vite dev, :5173)  ────┼── /api ─►│  rara server  :25555  (HTTP + WS)            │
-│  VITE_API_URL=http://...     │          │  rara server  :50051  (gRPC)                 │
-│                              │          │  rara gateway :25556  (supervisor, loopback) │
-│                              │          │  logdy UI     :8080   (live log viewer)      │
-└──────────────────────────────┘          └──────────────────────────────────────────────┘
+┌────────── your mac (development) ──────────┐
+│  web/ (vite dev, :5173)  ──── /api ──►     │
+│  bun run dev                               │
+│  rara server  :25555 (HTTP + WS)           │
+│  rara server  :50051 (gRPC)                │
+│  rara gateway :25556 (supervisor, loopback)│
+└────────────────────────────────────────────┘
+
+┌────────── 10.0.0.183 raratekiAir (PRODUCTION) ──────────┐
+│  rara server  :25555  (HTTP + WS)                       │
+│  rara server  :50051  (gRPC)                            │
+│  rara gateway :25556  (supervisor, loopback)            │
+│  logdy UI     :8080   (live log viewer)                 │
+└─────────────────────────────────────────────────────────┘
 ```
 
-- Backend process on the remote: `target/debug/rara server`, spawned by `target/debug/rara gateway`, which is itself started via `just run` in a login shell (not launchd — it dies if the shell dies).
-- `/api/*` HTTP **and** WebSocket are both proxied by vite (`web/vite.config.ts`, `ws: true`).
+You only need the right-hand box when the bug is production-specific —
+otherwise everything below in [Production debugging](#production-debugging)
+is irrelevant to your task.
 
-## SSH access
+## Production debugging
+
+Reach for the remote **only** when one of these is true:
+
+- The bug reproduces against production but not against your local
+  stack, and you need production logs / DB state to understand why.
+- You are inspecting real user data the local DB does not have.
+- You are verifying a fix under the actual production config + traffic
+  before declaring it shipped.
+
+If the symptom reproduces locally, debug locally — production is not
+the dev backend.
+
+### SSH access
 
 Use the `local-rara` alias:
 
@@ -26,16 +94,22 @@ ssh local-rara                # interactive
 ssh local-rara "<cmd>"        # one-shot
 ```
 
-User is `rara`, home is `/Users/rara`, repo is `~/code/rararulab/rara`. Never edit source on the remote — always work in a local worktree and push a PR.
+User is `rara`, home is `/Users/rara`, repo is `~/code/rararulab/rara`.
+Never edit source on the remote — always work in a local worktree and
+push a PR.
 
-## Start the frontend against remote backend
+### Pointing your local frontend at production
+
+Only when you specifically need to reproduce a production-only frontend
+bug:
 
 ```bash
 cd web
 VITE_API_URL=http://10.0.0.183:25555 bun run dev
 ```
 
-Open `http://localhost:5173`. The proxy forwards `/api` (REST + WS) to the remote — no CORS needed. You should see `[heartbeat] ✓ GET /api/health → 200` in the vite terminal.
+Open `http://localhost:5173`. The proxy forwards `/api` (REST + WS) to
+the remote — no CORS needed.
 
 Quick reachability sanity check before you bother starting vite:
 
@@ -44,9 +118,10 @@ curl -s --max-time 3 http://10.0.0.183:25555/api/health
 # expect: {"service":"job","status":"healthy",...}
 ```
 
-If the curl fails but ping works, the backend process is down — see [Backend lifecycle](#backend-lifecycle).
+If the curl fails but ping works, the production backend process is
+down — see [Backend lifecycle (production)](#backend-lifecycle-production).
 
-## Logs
+### Logs (production)
 
 **Primary log location on the remote:** `/Users/rara/Library/Logs/rara/`
 
@@ -64,11 +139,15 @@ ssh local-rara 'ls -t /Users/rara/Library/Logs/rara/job.* | head -3 | xargs grep
 ssh local-rara 'tail -n 200 "$(ls -t /Users/rara/Library/Logs/rara/raraerr.* | head -1)"'
 ```
 
-**Live log UI (logdy):** `http://10.0.0.183:8080` — browser-based filterable viewer, fed by the `dev.rara.logdy.*` launchd jobs. Good for watching a reproduction in real time without tail/grep.
+**Live log UI (logdy):** `http://10.0.0.183:8080` — browser-based
+filterable viewer, fed by the `dev.rara.logdy.*` launchd jobs. Good
+for watching a reproduction in real time without tail/grep.
 
-## Backend lifecycle
+### Backend lifecycle (production)
 
-The backend is **not** a launchd service. It runs inside a shell on the remote, started with `just run` (which execs `rara-cli gateway`, which supervises `rara server`).
+The production backend is **not** a launchd service. It runs inside a
+shell on the remote, started with `just run` (which execs `rara-cli
+gateway`, which supervises `rara server`).
 
 ```bash
 # is it alive?
@@ -81,15 +160,21 @@ ssh local-rara 'pgrep -fl "rara (server|gateway)"'
 ssh local-rara 'cd ~/code/rararulab/rara && pkill -f "target/debug/rara " ; nohup just run >/tmp/rara-run.log 2>&1 &'
 ```
 
-Before restarting, **confirm with the user** — other people may be using the instance. Prefer reading logs first.
+Restarting production is gate (c) in the workflow — **confirm with the
+user before `pkill`-ing or restarting**, because other people may be
+using the instance. Prefer reading logs first; restarts are rare.
 
-## Database & config on the remote
+### Database & config (production)
 
-Paths are resolved via `rara_paths` — on macOS that means `dirs::config_dir()`
-+ `dirs::data_local_dir()`, which both land under `Library/Application Support`.
+Paths are resolved via `rara_paths` — on macOS that means
+`dirs::config_dir()` + `dirs::data_local_dir()`, which both land under
+`Library/Application Support`.
 
-- Config: `/Users/rara/Library/Application Support/rara/config.yaml` (read-only from your side — propose YAML changes as a PR against `config.example.yaml`)
-- DB: `/Users/rara/Library/Application Support/rara/db/rara.db` (SQLite, with `-wal` / `-shm` siblings while open)
+- Config: `/Users/rara/Library/Application Support/rara/config.yaml`
+  (read-only from your side — propose YAML changes as a PR against
+  `config.example.yaml`)
+- DB: `/Users/rara/Library/Application Support/rara/db/rara.db`
+  (SQLite, with `-wal` / `-shm` siblings while open)
 
 Inspect DB without copying it off:
 
@@ -97,11 +182,13 @@ Inspect DB without copying it off:
 ssh local-rara 'sqlite3 "/Users/rara/Library/Application Support/rara/db/rara.db" "<query>"'
 ```
 
-Do NOT run migrations or schema-mutating SQL on the remote manually — migrations live in `crates/rara-model/migrations/` and apply on boot.
+Do NOT run migrations or schema-mutating SQL on the remote manually —
+migrations live in `crates/rara-model/migrations/` and apply on boot.
 
-## Reproducing an API issue end-to-end
+### Reproducing a production API issue end-to-end
 
-1. `curl` the endpoint directly against the remote to confirm the backend behavior, independent of the frontend:
+1. `curl` the endpoint directly against the remote to confirm the
+   backend behavior, independent of the frontend:
    ```bash
    curl -sS -i http://10.0.0.183:25555/api/<path>
    ```
@@ -109,20 +196,37 @@ Do NOT run migrations or schema-mutating SQL on the remote manually — migratio
    ```bash
    ssh local-rara 'tail -f "$(ls -t /Users/rara/Library/Logs/rara/job.* | head -1)"' | grep -i <keyword>
    ```
-3. If the HTTP call is fine but the UI breaks, the bug is frontend-side — inspect the browser devtools Network + Console. The proxy rewrites only the URL host; request/response bodies are pass-through.
+3. If the HTTP call is fine but the UI breaks, the bug is frontend-side
+   — inspect the browser devtools Network + Console. The proxy rewrites
+   only the URL host; request/response bodies are pass-through.
 
-## WebSocket debugging
+### WebSocket debugging
 
-The vite proxy has `ws: true` so WS upgrades on `/api/*` flow through. If WS fails:
+The vite proxy has `ws: true` so WS upgrades on `/api/*` flow through.
+If WS fails:
 
-- Verify `VITE_API_URL` uses `http://` (not `ws://`) — vite infers the WS scheme from the HTTP target.
+- Verify `VITE_API_URL` uses `http://` (not `ws://`) — vite infers the
+  WS scheme from the HTTP target.
 - Check the vite terminal for `[heartbeat] ✗` or proxy error lines.
-- Direct test (no proxy): `websocat ws://10.0.0.183:25555/api/<ws-path>` — if this works but the proxied one doesn't, the issue is local.
+- Direct test (no proxy): `websocat ws://10.0.0.183:25555/api/<ws-path>`
+  — if this works but the proxied one doesn't, the issue is local.
+
+(For local WS debugging, swap `10.0.0.183` for `127.0.0.1`.)
 
 ## What NOT to do
 
-- Do NOT edit files on the remote. Work in a local worktree and follow the [standard workflow](workflow.md).
-- Do NOT `pkill` or restart the remote backend without telling the user — they may be mid-session.
-- Do NOT copy `rara.db` off the remote for "quick inspection" — it contains live user data. Query it in place.
-- Do NOT point `VITE_API_URL` at `https://` — the remote serves plain HTTP on `:25555`.
-- Do NOT assume a local `cargo run` will reproduce the bug — configs and DB state on the remote differ from yours.
+- Do NOT use the remote as your dev backend. It is production. Run
+  rara locally for development and end-to-end testing — that is
+  exactly why dev/prod are separated.
+- Do NOT report a UI or API change as complete without opening a
+  browser against your local stack and exercising the affected path.
+  `cargo test` + vitest do not catch render bugs, wiring bugs, or
+  proxy bugs.
+- Do NOT edit files on the remote. Work in a local worktree and follow
+  the [standard workflow](workflow.md).
+- Do NOT `pkill` or restart the production backend without telling the
+  user — gate (c) in the workflow. Other people may be mid-session.
+- Do NOT copy `rara.db` off the remote for "quick inspection" — it
+  contains live user data. Query it in place.
+- Do NOT point `VITE_API_URL` at `https://` — the remote serves plain
+  HTTP on `:25555`.


### PR DESCRIPTION
## Summary

- Reframe `docs/guides/debug.md` so local rara is the default dev backend and remote `raratekiAir` is production (only used for production-specific repro).
- Same reframe in `.claude/agents/debugger.md` so the debugger subagent's default loop matches.
- All technical content (SSH alias, log paths, logdy URL, lifecycle commands, sqlite-in-place query, WS debug) preserved verbatim under the new "Production debugging" section.
- Gate (c) (production restart needs user confirmation) strengthened, not weakened.

Closes #2046

🤖 Generated with [Claude Code](https://claude.com/claude-code)