### PR TITLE
fix(web,backend): smooth chat responses and allow loopback dev ports

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -13,11 +13,13 @@
 http:
   bind_address: "127.0.0.1:25555"
   # Browser origins permitted to call `/api/v1/*`. At least one entry is
-  # required — the server refuses to boot with an empty list. Add every host
-  # the Vite dev server is reachable from (localhost plus any LAN IPs used to
-  # open the UI from other devices).
+  # required — the server refuses to boot with an empty list. Loopback
+  # development hosts may use `:*` to allow Vite's fallback ports; LAN IPs and
+  # public hosts must list exact ports.
   cors_allowed_origins:
-    - "http://localhost:5173"
+    - "http://localhost:*"
+    - "http://127.0.0.1:*"
+    - "http://[::1]:*"
     - "http://10.0.0.183:5173"
 
 grpc:

--- a/crates/extensions/backend-admin/Cargo.toml
+++ b/crates/extensions/backend-admin/Cargo.toml
@@ -42,6 +42,7 @@ tokio-util = { workspace = true }
 tower-http = { workspace = true, features = ["cors"] }
 tracing = { workspace = true }
 tracing-opentelemetry = "0.32.0"
+url = { workspace = true }
 utoipa = { workspace = true }
 utoipa-axum = { workspace = true }
 uuid = { workspace = true }

--- a/crates/extensions/backend-admin/src/state.rs
+++ b/crates/extensions/backend-admin/src/state.rs
@@ -21,8 +21,9 @@ use std::sync::Arc;
 
 use axum::http::{HeaderName, HeaderValue, Method, header};
 use snafu::Whatever;
-use tower_http::cors::CorsLayer;
+use tower_http::cors::{AllowOrigin, CorsLayer};
 use tracing::info;
+use url::Url;
 
 use crate::data_feeds::DataFeedRouterState;
 
@@ -187,27 +188,31 @@ impl BackendState {
 /// `Authorization` header) is answered here, before any auth middleware can
 /// reject it with 401.
 ///
-/// Panics when the allow-list is empty or contains an origin that is not a
-/// valid HTTP header value. CORS misconfiguration is a boot-time error: the
-/// frontend cannot reach the API without it, and silent fallback would delay
-/// the failure to first browser request.
+/// Each entry is either an exact origin (`http://localhost:5173`) or a
+/// loopback-only port wildcard (`http://localhost:*`,
+/// `http://127.0.0.1:*`, `http://[::1]:*`). Wildcards are intentionally
+/// restricted to loopback hosts: admin endpoints carry bearer tokens, so LAN
+/// IPs and public domains must keep explicit ports.
+///
+/// Panics when the allow-list is empty, contains an origin that is not a valid
+/// HTTP header value, or uses an unsafe wildcard. CORS misconfiguration is a
+/// boot-time error: the frontend cannot reach the API without it, and silent
+/// fallback would delay the failure to first browser request.
 pub fn build_cors_layer(allowed_origins: &[String]) -> CorsLayer {
     assert!(
         !allowed_origins.is_empty(),
         "http.cors_allowed_origins must list at least one origin — see config.example.yaml",
     );
 
-    let origins: Vec<HeaderValue> = allowed_origins
+    let origins = allowed_origins
         .iter()
-        .map(|origin| {
-            HeaderValue::from_str(origin).unwrap_or_else(|err| {
-                panic!("invalid http.cors_allowed_origins entry {origin:?}: {err}")
-            })
-        })
-        .collect();
+        .map(|origin| parse_cors_origin_config(origin))
+        .collect::<Vec<_>>();
 
     CorsLayer::new()
-        .allow_origin(origins)
+        .allow_origin(AllowOrigin::predicate(move |origin, _parts| {
+            origins.iter().any(|allowed| allowed.matches(origin))
+        }))
         .allow_methods([
             Method::GET,
             Method::POST,
@@ -226,6 +231,110 @@ pub fn build_cors_layer(allowed_origins: &[String]) -> CorsLayer {
             HeaderName::from_static("x-request-id"),
             HeaderName::from_static("traceparent"),
         ])
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+enum CorsOriginConfig {
+    Exact(HeaderValue),
+    LoopbackPortWildcard { scheme: String, host: String },
+}
+
+impl CorsOriginConfig {
+    fn matches(&self, origin: &HeaderValue) -> bool {
+        match self {
+            Self::Exact(expected) => origin == expected,
+            Self::LoopbackPortWildcard { scheme, host } => {
+                origin_matches_loopback_port_wildcard(origin, scheme, host)
+            }
+        }
+    }
+}
+
+fn parse_cors_origin_config(origin: &str) -> CorsOriginConfig {
+    if let Some(pattern) = origin.strip_suffix(":*") {
+        return parse_loopback_port_wildcard(origin, pattern);
+    }
+
+    CorsOriginConfig::Exact(
+        HeaderValue::from_str(origin).unwrap_or_else(|err| {
+            panic!("invalid http.cors_allowed_origins entry {origin:?}: {err}")
+        }),
+    )
+}
+
+fn parse_loopback_port_wildcard(origin: &str, pattern: &str) -> CorsOriginConfig {
+    let url = Url::parse(pattern).unwrap_or_else(|err| {
+        panic!("invalid http.cors_allowed_origins port wildcard {origin:?}: {err}")
+    });
+    assert_origin_url_has_no_path(origin, &url);
+    assert!(
+        matches!(url.scheme(), "http" | "https"),
+        "invalid http.cors_allowed_origins port wildcard {origin:?}: scheme must be http or https",
+    );
+    assert!(
+        url.port().is_none(),
+        "invalid http.cors_allowed_origins port wildcard {origin:?}: wildcard must replace the \
+         port",
+    );
+
+    let host = url.host_str().unwrap_or_else(|| {
+        panic!("invalid http.cors_allowed_origins port wildcard {origin:?}: missing host")
+    });
+    assert!(
+        is_loopback_host(host),
+        "invalid http.cors_allowed_origins port wildcard {origin:?}: only localhost, 127.0.0.1, \
+         and [::1] may use :*",
+    );
+
+    CorsOriginConfig::LoopbackPortWildcard {
+        scheme: url.scheme().to_string(),
+        host:   normalize_loopback_host(host),
+    }
+}
+
+fn origin_matches_loopback_port_wildcard(
+    origin: &HeaderValue,
+    expected_scheme: &str,
+    expected_host: &str,
+) -> bool {
+    let Ok(origin) = origin.to_str() else {
+        return false;
+    };
+    let Ok(url) = Url::parse(origin) else {
+        return false;
+    };
+    if !origin_url_has_no_path(&url) || url.scheme() != expected_scheme || url.port().is_none() {
+        return false;
+    }
+
+    url.host_str()
+        .map(normalize_loopback_host)
+        .is_some_and(|host| host == expected_host)
+}
+
+fn assert_origin_url_has_no_path(origin: &str, url: &Url) {
+    assert!(
+        origin_url_has_no_path(url),
+        "invalid http.cors_allowed_origins entry {origin:?}: origin must not include path, query, \
+         or fragment",
+    );
+}
+
+fn origin_url_has_no_path(url: &Url) -> bool {
+    url.path() == "/" && url.query().is_none() && url.fragment().is_none()
+}
+
+fn normalize_loopback_host(host: &str) -> String {
+    host.trim_start_matches('[')
+        .trim_end_matches(']')
+        .to_ascii_lowercase()
+}
+
+fn is_loopback_host(host: &str) -> bool {
+    matches!(
+        normalize_loopback_host(host).as_str(),
+        "localhost" | "127.0.0.1" | "::1"
+    )
 }
 
 fn merge_openapi_router(
@@ -293,5 +402,88 @@ mod tests {
             vec!["x-request-id".to_string(), "traceparent".to_string()],
             "expose_headers must list exactly x-request-id and traceparent"
         );
+    }
+
+    #[tokio::test]
+    async fn cors_loopback_port_wildcard_allows_dev_server_ports() {
+        let layer = build_cors_layer(&[
+            "http://localhost:*".to_string(),
+            "http://127.0.0.1:*".to_string(),
+            "http://[::1]:*".to_string(),
+        ]);
+        let app = Router::new()
+            .route("/probe", get(|| async { StatusCode::OK }))
+            .layer(layer);
+
+        for origin in [
+            "http://localhost:5173",
+            "http://localhost:5175",
+            "http://127.0.0.1:5175",
+            "http://[::1]:5175",
+        ] {
+            let response = app
+                .clone()
+                .oneshot(
+                    Request::builder()
+                        .method("GET")
+                        .uri("/probe")
+                        .header(header::ORIGIN, origin)
+                        .body(Body::empty())
+                        .unwrap(),
+                )
+                .await
+                .unwrap();
+
+            assert_eq!(
+                response
+                    .headers()
+                    .get(header::ACCESS_CONTROL_ALLOW_ORIGIN)
+                    .and_then(|header| header.to_str().ok()),
+                Some(origin),
+                "loopback wildcard must mirror allowed origin {origin}",
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn cors_loopback_port_wildcard_rejects_other_origins() {
+        let layer = build_cors_layer(&["http://localhost:*".to_string()]);
+        let app = Router::new()
+            .route("/probe", get(|| async { StatusCode::OK }))
+            .layer(layer);
+
+        for origin in [
+            "https://localhost:5175",
+            "http://127.0.0.1:5175",
+            "http://10.0.0.183:5175",
+            "http://localhost",
+        ] {
+            let response = app
+                .clone()
+                .oneshot(
+                    Request::builder()
+                        .method("GET")
+                        .uri("/probe")
+                        .header(header::ORIGIN, origin)
+                        .body(Body::empty())
+                        .unwrap(),
+                )
+                .await
+                .unwrap();
+
+            assert!(
+                response
+                    .headers()
+                    .get(header::ACCESS_CONTROL_ALLOW_ORIGIN)
+                    .is_none(),
+                "origin {origin} must not match http://localhost:*",
+            );
+        }
+    }
+
+    #[test]
+    #[should_panic(expected = "only localhost, 127.0.0.1, and [::1] may use :*")]
+    fn cors_port_wildcard_rejects_non_loopback_hosts() {
+        let _ = build_cors_layer(&["http://10.0.0.183:*".to_string()]);
     }
 }

--- a/crates/server/src/http.rs
+++ b/crates/server/src/http.rs
@@ -153,10 +153,13 @@ pub struct RestServerConfig {
     pub web_port:             Option<u16>,
     /// Explicit CORS allow-list for the admin HTTP surface.
     ///
-    /// Each entry is an origin string (scheme + host + port) permitted to
-    /// call `/api/v1/*` from a browser, e.g. `http://localhost:5173`. An
-    /// empty list is a hard boot-time error — no hardcoded default, no
-    /// silent fallback (see `docs/guides/anti-patterns.md`).
+    /// Each entry is an origin string permitted to call `/api/v1/*` from a
+    /// browser, e.g. `http://localhost:5173`. Loopback development hosts may
+    /// use `:*` (`http://localhost:*`, `http://127.0.0.1:*`,
+    /// `http://[::1]:*`) so Vite fallback ports keep working; LAN IPs and
+    /// public hosts must list exact ports. An empty list is a hard boot-time
+    /// error — no hardcoded default, no silent fallback (see
+    /// `docs/guides/anti-patterns.md`).
     #[serde(default)]
     pub cors_allowed_origins: Vec<String>,
 }

--- a/web/src/components/ThemeToggle.tsx
+++ b/web/src/components/ThemeToggle.tsx
@@ -15,6 +15,7 @@
  */
 
 import { Monitor, Moon, Sun } from 'lucide-react';
+import { AnimatePresence, motion } from 'motion/react';
 
 import { Button } from '@/components/ui/button';
 import { useTheme, type Theme } from '@/hooks/use-theme';
@@ -31,7 +32,12 @@ const LABEL_MAP: Record<Theme, string> = {
   system: 'System theme',
 };
 
-/** Button that cycles through light / dark / system theme modes. */
+/**
+ * Button that cycles through light / dark / system theme modes. The icon
+ * swap uses the polish-checklist contextual-icon transition (#7) — scale
+ * 0.25→1, opacity 0→1, blur 4px→0px — and the trigger gets a press-scale
+ * for tactile feedback (#12).
+ */
 export default function ThemeToggle() {
   const { theme, toggleTheme } = useTheme();
   const Icon = ICON_MAP[theme];
@@ -40,11 +46,27 @@ export default function ThemeToggle() {
     <Button
       variant="ghost"
       size="sm"
-      className="h-7 gap-1.5 text-xs text-muted-foreground hover:text-foreground"
+      className="h-7 gap-1.5 text-xs text-muted-foreground transition-transform hover:text-foreground active:scale-[0.96]"
       onClick={toggleTheme}
       title={LABEL_MAP[theme]}
     >
-      <Icon className="h-3.5 w-3.5" />
+      {/*
+       * `initial={false}` skips the page-load animation (#13) — the
+       * theme is read from storage before mount, so first paint should
+       * not animate.
+       */}
+      <AnimatePresence initial={false} mode="wait">
+        <motion.span
+          key={theme}
+          initial={{ opacity: 0, scale: 0.25, filter: 'blur(4px)' }}
+          animate={{ opacity: 1, scale: 1, filter: 'blur(0px)' }}
+          exit={{ opacity: 0, scale: 0.25, filter: 'blur(4px)' }}
+          transition={{ type: 'spring', duration: 0.3, bounce: 0 }}
+          className="flex"
+        >
+          <Icon className="h-3.5 w-3.5" />
+        </motion.span>
+      </AnimatePresence>
     </Button>
   );
 }

--- a/web/src/components/topology/RaraTurnCard.tsx
+++ b/web/src/components/topology/RaraTurnCard.tsx
@@ -164,6 +164,7 @@ export function RaraTurnCard({ turn, sessionKey }: RaraTurnCardProps) {
         {...responseProps}
         isStreaming={turn.inFlight}
         isComplete={!turn.inFlight}
+        responseOverflowMode="page"
         {...inspectProps}
       />
       {/* Spawn markers render as siblings, not inside VendorTurnCard:

--- a/web/src/components/topology/RaraTurnCardActionsMenu.tsx
+++ b/web/src/components/topology/RaraTurnCardActionsMenu.tsx
@@ -15,6 +15,7 @@
  */
 
 import { ArrowUpRight, MoreHorizontal } from 'lucide-react';
+import { AnimatePresence, motion } from 'motion/react';
 import { useEffect, useRef, useState } from 'react';
 
 /**
@@ -69,14 +70,20 @@ export function RaraTurnCardActionsMenu({ onOpenDetails }: RaraTurnCardActionsMe
   }, [open]);
 
   return (
-    <div ref={containerRef} className="relative shrink-0">
+    // 40x40 hit area (#16): the visible chip stays small, but the
+    // surrounding flex catches the click. `-m-2` reclaims layout space so
+    // the wrapper does not push the turn header.
+    <div ref={containerRef} className="relative -m-2 shrink-0">
       <div
         role="button"
         tabIndex={0}
         aria-haspopup="menu"
         aria-expanded={open}
         className={
-          'p-1 rounded-[6px] transition-opacity bg-background shadow-minimal ' +
+          // Explicit transition list (no `transition: all`, #14) and
+          // press-scale (#12, capped at 0.96).
+          'flex h-10 w-10 items-center justify-center rounded-md ' +
+          'transition-[opacity,transform] active:scale-[0.96] ' +
           'text-muted-foreground/50 hover:text-foreground ' +
           'opacity-0 group-hover:opacity-100 ' +
           'focus:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:opacity-100 ' +
@@ -94,54 +101,73 @@ export function RaraTurnCardActionsMenu({ onOpenDetails }: RaraTurnCardActionsMe
           }
         }}
       >
-        <MoreHorizontal className="w-3 h-3" />
+        {/*
+         * Inner chip: `rounded-md` (6px) inside the surrounding 40px hit
+         * region keeps the visible affordance compact while the click
+         * target is generous. Shadow over border (#3) for depth.
+         */}
+        <span className="flex items-center justify-center rounded-md bg-background p-1 shadow-minimal">
+          <MoreHorizontal className="w-3 h-3" />
+        </span>
       </div>
-      {open && (
-        <div
-          role="menu"
-          tabIndex={-1}
-          className={
-            'absolute right-0 top-full mt-1 z-50 min-w-[12rem] ' +
-            'rounded-md border border-border bg-popover text-popover-foreground shadow-md py-1'
-          }
-          // Stop the parent vendor `<button>` (which wraps the header) from
-          // toggling its expanded state when the user clicks an item.
-          onClick={(event) => event.stopPropagation()}
-        >
-          {/*
-           * Use `<div role="menuitem">` rather than `<button>` here:
-           * vendor wraps the entire turn header in its own `<button>`
-           * (TurnCard.tsx ~line 2940), so a nested `<button>` would
-           * trip React's hydration warning on "button cannot be a
-           * descendant of button". `tabIndex={0}` keeps it keyboard-
-           * focusable; `Enter`/`Space` invoke the same action.
-           */}
-          <div
-            role="menuitem"
-            tabIndex={0}
+      {/*
+       * Animated open/close — spring (bounce 0) on opacity + a small
+       * translateY for a subtle exit per principle #6. `initial={false}`
+       * is fine here because the menu only ever animates after a user
+       * click (it is never present on first paint).
+       */}
+      <AnimatePresence initial={false}>
+        {open && (
+          <motion.div
+            role="menu"
+            tabIndex={-1}
+            initial={{ opacity: 0, y: -2 }}
+            animate={{ opacity: 1, y: 0 }}
+            exit={{ opacity: 0, y: -2 }}
+            transition={{ type: 'spring', duration: 0.3, bounce: 0 }}
             className={
-              'w-full flex items-center gap-2 px-3 py-1.5 text-sm text-left cursor-pointer ' +
-              'hover:bg-accent hover:text-accent-foreground'
+              'absolute right-0 top-full mt-1 z-50 min-w-[12rem] ' +
+              'rounded-md border border-border bg-popover text-popover-foreground shadow-md py-1'
             }
-            onClick={(event) => {
-              event.stopPropagation();
-              setOpen(false);
-              onOpenDetails();
-            }}
-            onKeyDown={(event) => {
-              if (event.key === 'Enter' || event.key === ' ') {
-                event.preventDefault();
+            // Stop the parent vendor `<button>` (which wraps the header) from
+            // toggling its expanded state when the user clicks an item.
+            onClick={(event) => event.stopPropagation()}
+          >
+            {/*
+             * Use `<div role="menuitem">` rather than `<button>` here:
+             * vendor wraps the entire turn header in its own `<button>`
+             * (TurnCard.tsx ~line 2940), so a nested `<button>` would
+             * trip React's hydration warning on "button cannot be a
+             * descendant of button". `tabIndex={0}` keeps it keyboard-
+             * focusable; `Enter`/`Space` invoke the same action.
+             */}
+            <div
+              role="menuitem"
+              tabIndex={0}
+              className={
+                'w-full flex items-center gap-2 px-3 py-1.5 text-sm text-left cursor-pointer ' +
+                'hover:bg-accent hover:text-accent-foreground'
+              }
+              onClick={(event) => {
                 event.stopPropagation();
                 setOpen(false);
                 onOpenDetails();
-              }
-            }}
-          >
-            <ArrowUpRight className="w-3.5 h-3.5" />
-            <span>View turn details</span>
-          </div>
-        </div>
-      )}
+              }}
+              onKeyDown={(event) => {
+                if (event.key === 'Enter' || event.key === ' ') {
+                  event.preventDefault();
+                  event.stopPropagation();
+                  setOpen(false);
+                  onOpenDetails();
+                }
+              }}
+            >
+              <ArrowUpRight className="w-3.5 h-3.5" />
+              <span>View turn details</span>
+            </div>
+          </motion.div>
+        )}
+      </AnimatePresence>
     </div>
   );
 }

--- a/web/src/components/topology/SessionPicker.tsx
+++ b/web/src/components/topology/SessionPicker.tsx
@@ -98,7 +98,7 @@ export function SessionPicker({ activeSessionKey, onSelect, onAutoSelect }: Sess
           <Button
             size="icon"
             variant="ghost"
-            className="h-6 w-6"
+            className="h-6 w-6 transition-transform active:scale-[0.96]"
             title="Refresh"
             onClick={() => void sessionsQuery.refetch()}
             disabled={sessionsQuery.isFetching}
@@ -108,7 +108,7 @@ export function SessionPicker({ activeSessionKey, onSelect, onAutoSelect }: Sess
           <Button
             size="icon"
             variant="ghost"
-            className="h-6 w-6"
+            className="h-6 w-6 transition-transform active:scale-[0.96]"
             title="New session"
             onClick={() => createMutation.mutate()}
             disabled={createMutation.isPending}
@@ -168,14 +168,21 @@ function SessionPickerItem({ session, active, onSelect }: SessionPickerItemProps
         type="button"
         onClick={() => onSelect(session.key)}
         className={cn(
-          'flex w-full flex-col items-start gap-0.5 rounded-md border px-2.5 py-2 text-left transition-colors',
+          // `rounded-lg` on the row + `px-2.5 py-2` padding lands inside
+          // a `rounded-xl` parent container at the standard 4px concentric
+          // delta (principle #1). Press-scale per #12, transition list
+          // explicit per #14 (no `transition: all`).
+          'flex w-full flex-col items-start gap-0.5 rounded-lg border px-2.5 py-2 text-left',
+          'transition-[colors,transform] active:scale-[0.98]',
           active
             ? 'border-accent bg-accent/10 text-foreground'
             : 'border-transparent text-foreground hover:bg-accent/5',
         )}
       >
         <span className="line-clamp-1 text-sm font-medium leading-tight">{title}</span>
-        <span className="text-[11px] text-muted-foreground">{meta}</span>
+        {/* `tabular-nums` (#9) — the message count ticks during a live
+            session and would otherwise reflow the row width. */}
+        <span className="text-[11px] tabular-nums text-muted-foreground">{meta}</span>
       </button>
     </li>
   );

--- a/web/src/components/topology/TimelineView.tsx
+++ b/web/src/components/topology/TimelineView.tsx
@@ -384,7 +384,7 @@ export function TimelineView({
               {isEmpty ? (
                 <div className="flex h-full items-center justify-center text-sm text-muted-foreground">
                   Waiting for the next turn on{' '}
-                  <span className="ml-1 font-mono">{viewSessionKey}</span>…
+                  <span className="ml-1 font-mono tabular-nums">{viewSessionKey}</span>…
                 </div>
               ) : (
                 orderedItems.map((item) =>

--- a/web/src/components/topology/WorkerCard.tsx
+++ b/web/src/components/topology/WorkerCard.tsx
@@ -56,7 +56,12 @@ export function WorkerCard({ worker, active, onSelect }: WorkerCardProps) {
       onClick={() => onSelect(worker.childSession)}
       title={worker.childSession}
       className={cn(
-        'flex w-full flex-col gap-1 rounded border px-2 py-1.5 text-left text-[11px] transition-colors',
+        // `rounded-lg` (8px) + `px-2 py-1.5` padding aligns concentrically
+        // with the inner `rounded` (4px) status badge — principle #1.
+        // Explicit transition list avoids `transition: all` (#14); press
+        // scale per #12.
+        'flex w-full flex-col gap-1 rounded-lg border px-2 py-1.5 text-left text-[11px]',
+        'transition-[colors,transform] active:scale-[0.98]',
         active
           ? 'border-accent bg-accent/10 text-foreground'
           : 'border-border bg-card text-foreground hover:bg-muted/40',
@@ -69,7 +74,9 @@ export function WorkerCard({ worker, active, onSelect }: WorkerCardProps) {
       <span className="truncate font-mono text-[10px] text-muted-foreground">
         {shortenSessionKey(worker.childSession)}
       </span>
-      <div className="flex items-center justify-between gap-2 text-[10px] text-muted-foreground">
+      {/* `tabular-nums` (#9) on the live counters so the seq + event
+          count don't reflow as digits roll over. */}
+      <div className="flex items-center justify-between gap-2 text-[10px] tabular-nums text-muted-foreground">
         <span>{worker.eventCount} events</span>
         <span>
           {worker.lastActivitySeq > 0 ? `last @ #${worker.lastActivitySeq}` : 'no events yet'}

--- a/web/src/components/topology/__tests__/RaraTurnCard.test.tsx
+++ b/web/src/components/topology/__tests__/RaraTurnCard.test.tsx
@@ -121,6 +121,20 @@ describe('RaraTurnCard — trace + cascade affordances', () => {
     expect(screen.queryByText(/view turn details/i)).toBeNull();
   });
 
+  it('RaraTurnCard__assistant_response_uses_timeline_scroll_not_inner_scrollbar', () => {
+    const { container } = renderCard(
+      makeTurn({
+        text: Array.from({ length: 80 }, (_, idx) => `response line ${String(idx + 1)}`).join('\n'),
+      }),
+    );
+
+    const response = container.querySelector('[data-search-root="response"]');
+    expect(response).not.toBeNull();
+    expect(response).not.toHaveClass('overflow-y-auto');
+    expect(response).not.toHaveClass('scrollbar-hover');
+    expect((response as HTMLElement).style.maxHeight).toBe('');
+  });
+
   it('RaraTurnCard__trace_modal_opens_with_fetched_content', async () => {
     fetchExecutionTraceMock.mockResolvedValue({
       duration_secs: 1.23,

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -114,6 +114,15 @@
    * the threshold.
    */
   --muted-foreground: oklch(45% 0 0);
+  /*
+   * Crisper text on macOS Retina (issue #2042 polish pass). The Tailwind
+   * preflight applies `antialiased` to `body`, but stating it on `:root`
+   * makes the intent explicit and survives any future preflight tweak —
+   * this is the load-bearing rule the checklist calls out, not a
+   * cosmetic duplicate.
+   */
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
 }
 
 .dark {

--- a/web/src/layouts/DashboardLayout.tsx
+++ b/web/src/layouts/DashboardLayout.tsx
@@ -129,7 +129,7 @@ export default function DashboardLayout() {
           <Button
             variant="ghost"
             size="sm"
-            className="h-7 gap-1.5 text-xs text-muted-foreground hover:text-foreground"
+            className="h-7 gap-1.5 text-xs text-muted-foreground transition-transform hover:text-foreground active:scale-[0.96]"
             onClick={() => navigate('/chat')}
           >
             <MessageSquare className="h-3.5 w-3.5" />
@@ -138,7 +138,7 @@ export default function DashboardLayout() {
           <Button
             variant="ghost"
             size="sm"
-            className="h-7 gap-1.5 text-xs text-muted-foreground hover:text-foreground"
+            className="h-7 gap-1.5 text-xs text-muted-foreground transition-transform hover:text-foreground active:scale-[0.96]"
             onClick={() => openSettings()}
           >
             <Settings className="h-3.5 w-3.5" />

--- a/web/src/pages/Chat.tsx
+++ b/web/src/pages/Chat.tsx
@@ -16,6 +16,7 @@
 
 import { useQuery } from '@tanstack/react-query';
 import { ArrowLeft, Network, PanelLeft, PanelLeftClose } from 'lucide-react';
+import { AnimatePresence, motion } from 'motion/react';
 import { useCallback, useEffect, useState } from 'react';
 import { useNavigate, useParams } from 'react-router';
 
@@ -57,6 +58,13 @@ import { useTopologySubscription, type TopologyStatus } from '@/hooks/use-topolo
  * existing user's sidebar state on first load after upgrade.
  */
 const SIDEBAR_COLLAPSED_STORAGE_KEY = 'rara.topology.sidebarCollapsed';
+
+/**
+ * Shared spring transition tuned per the polish checklist (#2042) — the
+ * `bounce: 0` constraint is load-bearing: anything above 0 reads as a
+ * cartoon overshoot on a UI surface this dense.
+ */
+const SPRING = { type: 'spring', duration: 0.3, bounce: 0 } as const;
 
 /**
  * Read the persisted collapsed-sidebar preference, swallowing access
@@ -155,22 +163,61 @@ export default function Chat() {
   return (
     <div className="flex h-full min-h-0 flex-col">
       <header className="flex items-center gap-3 border-b border-border px-3 py-2">
-        <Button
-          size="icon"
-          variant="ghost"
-          className="h-7 w-7"
-          aria-label={sidebarCollapsed ? 'Show sidebar' : 'Hide sidebar'}
-          title={sidebarCollapsed ? 'Show sidebar' : 'Hide sidebar'}
-          onClick={() => setSidebarCollapsed((v) => !v)}
-        >
-          {sidebarCollapsed ? (
-            <PanelLeft className="h-4 w-4" />
-          ) : (
-            <PanelLeftClose className="h-4 w-4" />
-          )}
-        </Button>
+        {/*
+         * Wrap the chevron in a 40x40 hit-area target (principle #16).
+         * The inner Button stays visually 28x28 so the header doesn't
+         * grow; the surrounding flex centers it inside the larger click
+         * region.
+         */}
+        <span className="-my-1.5 -ml-1 flex h-10 w-10 items-center justify-center">
+          <Button
+            size="icon"
+            variant="ghost"
+            className="h-7 w-7 transition-transform active:scale-[0.96]"
+            aria-label={sidebarCollapsed ? 'Show sidebar' : 'Hide sidebar'}
+            title={sidebarCollapsed ? 'Show sidebar' : 'Hide sidebar'}
+            onClick={() => setSidebarCollapsed((v) => !v)}
+          >
+            {/*
+             * Cross-fade the panel-left / panel-left-close glyph instead
+             * of hard-swapping (principle #7). `mode="wait"` keeps a
+             * single icon mounted at a time so the absolute-position
+             * trick is unnecessary, and `initial={false}` skips the
+             * first-render animation per principle #13.
+             */}
+            <AnimatePresence initial={false} mode="wait">
+              {sidebarCollapsed ? (
+                <motion.span
+                  key="open"
+                  initial={{ opacity: 0, scale: 0.25, filter: 'blur(4px)' }}
+                  animate={{ opacity: 1, scale: 1, filter: 'blur(0px)' }}
+                  exit={{ opacity: 0, scale: 0.25, filter: 'blur(4px)' }}
+                  transition={SPRING}
+                  className="flex"
+                >
+                  <PanelLeft className="h-4 w-4" />
+                </motion.span>
+              ) : (
+                <motion.span
+                  key="close"
+                  initial={{ opacity: 0, scale: 0.25, filter: 'blur(4px)' }}
+                  animate={{ opacity: 1, scale: 1, filter: 'blur(0px)' }}
+                  exit={{ opacity: 0, scale: 0.25, filter: 'blur(4px)' }}
+                  transition={SPRING}
+                  className="flex"
+                >
+                  <PanelLeftClose className="h-4 w-4" />
+                </motion.span>
+              )}
+            </AnimatePresence>
+          </Button>
+        </span>
         <Network className="h-4 w-4 text-muted-foreground" />
-        <h1 className="text-sm font-medium">Chat</h1>
+        {/*
+         * `text-wrap: balance` per principle #10 — even on a one-word
+         * title it costs nothing and keeps any future i18n balanced.
+         */}
+        <h1 className="text-sm font-medium [text-wrap:balance]">Chat</h1>
         <div className="ml-auto">
           {rootSessionKey ? (
             <StatusPill status={subscription.status} />
@@ -183,17 +230,42 @@ export default function Chat() {
       </header>
 
       <div className="flex flex-1 min-h-0">
-        {!sidebarCollapsed && (
-          <aside className="hidden w-[280px] shrink-0 border-r border-border md:block">
-            <SessionPicker
-              activeSessionKey={rootSessionKey ?? null}
-              onSelect={selectSession}
-              onAutoSelect={selectSession}
-            />
-          </aside>
-        )}
+        {/*
+         * Sidebar collapse uses a spring on `width` (interruptible per
+         * principle #4). `AnimatePresence initial={false}` keeps the
+         * first render quiet — only later toggles animate.
+         */}
+        <AnimatePresence initial={false}>
+          {!sidebarCollapsed && (
+            <motion.aside
+              key="sidebar"
+              initial={{ width: 0, opacity: 0 }}
+              animate={{ width: 280, opacity: 1 }}
+              exit={{ width: 0, opacity: 0 }}
+              transition={SPRING}
+              className="hidden shrink-0 overflow-hidden border-r border-border md:block"
+            >
+              <div className="w-[280px]">
+                <SessionPicker
+                  activeSessionKey={rootSessionKey ?? null}
+                  onSelect={selectSession}
+                  onAutoSelect={selectSession}
+                />
+              </div>
+            </motion.aside>
+          )}
+        </AnimatePresence>
 
-        <main className="flex flex-1 min-w-0 min-h-0 flex-col p-3">
+        {/*
+         * Stagger entrance per principle #5 — main lands ~100ms after
+         * the sidebar so the eye reaches the timeline second.
+         */}
+        <motion.main
+          initial={{ opacity: 0, y: 4 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ ...SPRING, delay: 0.1 }}
+          className="flex flex-1 min-w-0 min-h-0 flex-col p-3"
+        >
           {rootSessionKey ? (
             <div className="flex flex-1 min-h-0 flex-col gap-2">
               {viewChild && (
@@ -201,13 +273,13 @@ export default function Chat() {
                   <Button
                     size="sm"
                     variant="ghost"
-                    className="h-7 px-2 text-xs"
+                    className="h-7 px-2 text-xs transition-transform active:scale-[0.96]"
                     onClick={() => setViewChild(null)}
                   >
                     <ArrowLeft className="mr-1 h-3 w-3" />
                     back to root
                   </Button>
-                  <span className="truncate font-mono text-[11px] text-muted-foreground">
+                  <span className="truncate font-mono text-[11px] tabular-nums text-muted-foreground">
                     viewing {viewChild}
                   </span>
                 </div>
@@ -229,10 +301,17 @@ export default function Chat() {
               Select a session from the left, or create a new one to start observing.
             </div>
           )}
-        </main>
+        </motion.main>
 
         {rootSessionKey && (
-          <aside className="hidden w-[320px] shrink-0 flex-col gap-3 overflow-y-auto border-l border-border p-3 lg:flex">
+          <motion.aside
+            // Right rail enters last (~200ms delay) — staggered with
+            // sidebar + main per principle #5.
+            initial={{ opacity: 0, y: 4 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ ...SPRING, delay: 0.2 }}
+            className="hidden w-[320px] shrink-0 flex-col gap-3 overflow-y-auto border-l border-border p-3 lg:flex"
+          >
             <div>
               <div className="mb-1.5 text-xs font-medium text-muted-foreground">Workers</div>
               <WorkerInbox
@@ -249,7 +328,7 @@ export default function Chat() {
                 activeSessionKey={viewChild ?? rootSessionKey}
               />
             </div>
-          </aside>
+          </motion.aside>
         )}
       </div>
     </div>
@@ -280,8 +359,10 @@ function StatusPill({ status }: { status: TopologyStatus }) {
         </Badge>
       );
     case 'reconnecting':
+      // Tabular-nums on the attempt counter + delay (#9) so the badge
+      // doesn't shimmy as the numerals tick up.
       return (
-        <Badge variant="outline" className="text-[10px]">
+        <Badge variant="outline" className="text-[10px] tabular-nums">
           reconnect #{status.attempt} ({Math.round(status.delayMs / 1000)}s)
         </Badge>
       );

--- a/web/src/pages/__tests__/Chat.test.tsx
+++ b/web/src/pages/__tests__/Chat.test.tsx
@@ -21,7 +21,13 @@
  * `agent-spec verify` can resolve scenarios to real test functions.
  */
 
-import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitForElementToBeRemoved,
+} from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 // Node 25's experimental built-in `localStorage` shim is enabled by
@@ -134,7 +140,7 @@ afterEach(() => {
 });
 
 describe('Chat — collapsible sidebar (issue-2022)', () => {
-  it('toggle_hides_session_picker', () => {
+  it('toggle_hides_session_picker', async () => {
     render(<Chat />);
 
     // Default expanded: picker is in the DOM.
@@ -142,10 +148,11 @@ describe('Chat — collapsible sidebar (issue-2022)', () => {
 
     fireEvent.click(screen.getByRole('button', { name: 'Hide sidebar' }));
 
-    // After toggle: SessionPicker is not present in the DOM (the `<aside>`
-    // wrapper is conditionally rendered, so the centre column owns the
-    // freed flex width).
-    expect(screen.queryByTestId('session-picker')).not.toBeInTheDocument();
+    // After toggle: SessionPicker is removed from the DOM. The
+    // `<aside>` wrapper is wrapped in `AnimatePresence` (issue-2042
+    // polish), so use `waitForElementToBeRemoved` to give the exit
+    // animation a tick to complete before asserting absence.
+    await waitForElementToBeRemoved(() => screen.queryByTestId('session-picker'));
     // Toggle button now reflects the collapsed state.
     expect(screen.getByRole('button', { name: 'Show sidebar' })).toBeInTheDocument();
   });

--- a/web/src/vendor/craft-ui/components/chat/TurnCard.tsx
+++ b/web/src/vendor/craft-ui/components/chat/TurnCard.tsx
@@ -292,6 +292,8 @@ export type OpenAnnotationRequest = {
   nonce: number
 }
 
+export type ResponseOverflowMode = 'contained' | 'page'
+
 export interface TurnCardProps {
   /** Session ID for state persistence (optional in shared context) */
   sessionId?: string
@@ -349,6 +351,8 @@ export interface TurnCardProps {
   animateResponse?: boolean
   /** Hide footers for compact embedding (EditPopover) */
   compactMode?: boolean
+  /** Whether response markdown owns an internal scrollbar or expands into the page scroller. */
+  responseOverflowMode?: ResponseOverflowMode
   /** Callback to branch the session from a specific message */
   onBranch?: (messageId: string, options?: { newPanel?: boolean }) => void
   /** Callback to add an annotation to a response message */
@@ -1412,6 +1416,8 @@ export interface ResponseCardProps {
   showAcceptPlan?: boolean
   /** Hide footer for compact embedding (EditPopover) */
   compactMode?: boolean
+  /** Whether response markdown owns an internal scrollbar or expands into the page scroller. */
+  responseOverflowMode?: ResponseOverflowMode
   /** Callback to branch the session from this response */
   onBranch?: (options?: { newPanel?: boolean }) => void
   /** Callback to add annotation from selected text */
@@ -1661,6 +1667,7 @@ export function ResponseCard({
   isLastResponse = true,
   showAcceptPlan = true,
   compactMode = false,
+  responseOverflowMode = 'contained',
   onBranch,
   onAddAnnotation,
   onRemoveAnnotation,
@@ -2410,13 +2417,26 @@ export function ResponseCard({
 
   const isCompleted = !isStreaming
   const isBuffering = isStreaming && !bufferDecision.shouldShow
+  const responseContentStyle = responseOverflowMode === 'contained'
+    ? {
+        maxHeight: MAX_HEIGHT,
+        // Subtle fade at top and bottom edges (16px) - only in dark mode for better contrast
+        ...(isDarkMode && {
+          maskImage: 'linear-gradient(to bottom, transparent 0%, black 16px, black calc(100% - 16px), transparent 100%)',
+          WebkitMaskImage: 'linear-gradient(to bottom, transparent 0%, black 16px, black calc(100% - 16px), transparent 100%)',
+        }),
+      }
+    : undefined
+  const responseContentOverflowClass = responseOverflowMode === 'contained'
+    ? 'overflow-y-auto scrollbar-hover'
+    : 'overflow-visible'
 
   // While buffering, return null - TurnCard will show a subtle indicator instead
   if (isBuffering) {
     return null
   }
 
-  // Completed response or plan - show with max height and footer
+  // Completed response or plan - show with footer; overflow behavior is caller-owned.
   if (isCompleted || variant === 'plan') {
     const isPlan = variant === 'plan'
 
@@ -2453,21 +2473,14 @@ export function ResponseCard({
             </div>
           )}
 
-          {/* Scrollable content area with subtle fade at edges (dark mode only) */}
+          {/* Content area: internal scroll by default, page-flow when requested by host UI. */}
           <div
             ref={contentRef}
             data-search-root="response"
             onMouseDown={handleSelectionPointerDown}
             onMouseUp={handleTextSelection}
-            className="pl-[22px] pr-[16px] py-3 text-sm overflow-y-auto scrollbar-hover"
-            style={{
-              maxHeight: MAX_HEIGHT,
-              // Subtle fade at top and bottom edges (16px) - only in dark mode for better contrast
-              ...(isDarkMode && {
-                maskImage: 'linear-gradient(to bottom, transparent 0%, black 16px, black calc(100% - 16px), transparent 100%)',
-                WebkitMaskImage: 'linear-gradient(to bottom, transparent 0%, black 16px, black calc(100% - 16px), transparent 100%)',
-              }),
-            }}
+            className={cn("pl-[22px] pr-[16px] py-3 text-sm", responseContentOverflowClass)}
+            style={responseContentStyle}
           >
             <div ref={contentLayerRef} className="relative">
               <Markdown
@@ -2578,21 +2591,14 @@ export function ResponseCard({
     <>
       <div className="bg-background shadow-minimal rounded-[8px] overflow-hidden group">
         {/* Content area - uses displayedText (throttled) for performance */}
-        {/* Subtle fade at top and bottom edges (dark mode only) */}
+        {/* Content area: internal scroll by default, page-flow when requested by host UI. */}
         <div
           ref={contentRef}
           data-search-root="response"
           onMouseDown={handleSelectionPointerDown}
           onMouseUp={handleTextSelection}
-          className="pl-[22px] pr-4 py-3 text-sm overflow-y-auto scrollbar-hover"
-          style={{
-            maxHeight: MAX_HEIGHT,
-            // Subtle fade at top and bottom edges (16px) - only in dark mode for better contrast
-            ...(isDarkMode && {
-              maskImage: 'linear-gradient(to bottom, transparent 0%, black 16px, black calc(100% - 16px), transparent 100%)',
-              WebkitMaskImage: 'linear-gradient(to bottom, transparent 0%, black 16px, black calc(100% - 16px), transparent 100%)',
-            }),
-          }}
+          className={cn("pl-[22px] pr-4 py-3 text-sm", responseContentOverflowClass)}
+          style={responseContentStyle}
         >
           <div ref={contentLayerRef} className="relative">
             <Markdown
@@ -2740,6 +2746,7 @@ export const TurnCard = React.memo(function TurnCard({
   displayMode = 'detailed',
   animateResponse = false,
   compactMode = false,
+  responseOverflowMode = 'contained',
   onBranch,
   onAddAnnotation,
   onRemoveAnnotation,
@@ -3106,6 +3113,7 @@ export const TurnCard = React.memo(function TurnCard({
             onAcceptWithCompact={onAcceptPlanWithCompact}
             isLastResponse={isLastResponse && index === planActivities.length - 1}
             compactMode={compactMode}
+            responseOverflowMode={responseOverflowMode}
             onBranch={onBranch ? (options?: { newPanel?: boolean }) => onBranch(planActivity.messageId ?? planActivity.id, options) : undefined}
             sendMessageKey={sendMessageKey}
             hasActiveFollowUpAnnotations={hasActiveFollowUpAnnotations}
@@ -3145,6 +3153,7 @@ export const TurnCard = React.memo(function TurnCard({
                 onAcceptWithCompact={onAcceptPlanWithCompact}
                 isLastResponse={isLastResponse}
                 compactMode={compactMode}
+                responseOverflowMode={responseOverflowMode}
                 onBranch={onBranch && response.messageId ? (options?: { newPanel?: boolean }) => onBranch(response.messageId!, options) : undefined}
                 sendMessageKey={sendMessageKey}
                 hasActiveFollowUpAnnotations={hasActiveFollowUpAnnotations}
@@ -3177,6 +3186,7 @@ export const TurnCard = React.memo(function TurnCard({
             onAcceptWithCompact={onAcceptPlanWithCompact}
             isLastResponse={isLastResponse}
             compactMode={compactMode}
+            responseOverflowMode={responseOverflowMode}
             onBranch={onBranch && response.messageId ? (options?: { newPanel?: boolean }) => onBranch(response.messageId!, options) : undefined}
             sendMessageKey={sendMessageKey}
             hasActiveFollowUpAnnotations={hasActiveFollowUpAnnotations}
@@ -3206,6 +3216,9 @@ export const TurnCard = React.memo(function TurnCard({
 
   // Re-render if displayMode changed
   if (prev.displayMode !== next.displayMode) return false
+
+  // Re-render if response overflow ownership changed
+  if (prev.responseOverflowMode !== next.responseOverflowMode) return false
 
   // Re-render if annotation interaction mode changed (interactive vs tooltip-only)
   if (prev.annotationInteractionMode !== next.annotationInteractionMode) return false


### PR DESCRIPTION
## Summary
- remove the nested fixed-height response scroller from Chat/TurnCard so long assistant replies use the page flow instead
- polish Chat-side action/menu affordances and related tests in the existing issue-2042 UI scope
- allow loopback CORS port wildcards such as http://localhost:*, http://127.0.0.1:*, and http://[::1]:* while keeping LAN/public origins exact-port only

## Verification
- cargo test -p rara-backend-admin cors_ -- --nocapture
- cargo check -p rara-backend-admin
- cargo +nightly fmt --all -- --check
- npm run typecheck
- npm run build
- npm run test -- src/components/topology/__tests__/RaraTurnCard.test.tsx src/pages/__tests__/Chat.test.tsx

Closes #2042