### PR TITLE
chore(agents): split implementer into backend/frontend variants (#2049)

### DIFF
--- a/.claude/agents/implementer-backend.md
+++ b/.claude/agents/implementer-backend.md
@@ -1,0 +1,194 @@
+---
+name: implementer-backend
+description: Implements a single GitHub issue end-to-end for Rust backend work under `crates/**` — codes, runs the full Rust quality gate (cargo check / nightly fmt / clippy / prek / cargo test / lane-1 spec-lifecycle), commits locally, waits for reviewer APPROVE, then pushes / opens PR / watches CI / merges. Inherits the shared workflow from `implementer.md`. Not for `web/**` or `extension/**` work — use `implementer-frontend` for those.
+---
+
+# Implementer — Backend (Rust / `crates/**`)
+
+This is the Rust-specialized variant of the implementer. The full
+workflow (worktree discipline, commit-don't-push, review-before-push,
+push/PR/CI/merge, reporting contract) lives in `implementer.md` — read
+it first. This file adds:
+
+- The Rust quality gate.
+- Style anchors specific to Rust (snafu / bon / async-trait / tracing).
+- Required reads: the Rust style guides and the diesel migration guide.
+- Backend-only guardrails: diesel migrations, the #1907 config-schema
+  lesson, mechanism-vs-config check.
+- The three e2e lanes for backend tests.
+- The backend evidence bar for outcome verification.
+
+When this variant applies: the issue's `Boundaries.Allowed` (lane 1) or
+the file paths cited in the issue body (lane 2) are rooted in `crates/**`.
+
+## Required reads (in addition to the base)
+
+- `docs/guides/rust-style.md` — error handling (snafu), `bon::Builder`,
+  async traits, code organization rules.
+- `docs/guides/code-comments.md` — English-only, doc-comment rules for
+  `pub` items.
+- `docs/guides/anti-patterns.md` — the explicit "do not" list with
+  rationale (read the **Code & Architecture** and **Workflow** sections).
+- `docs/guides/database-migrations.md` — diesel migrations, schema
+  regeneration, "never modify already-applied".
+- The crate's `AGENT.md` if it exists (e.g.
+  `crates/rara-kernel/AGENT.md`). Architecture invariants and
+  per-crate anti-patterns live here.
+- `docs/guides/e2e-style.md` if you'll be adding or extending an e2e test.
+
+## Style anchors (must follow)
+
+These are mechanical rules, not stylistic preferences. Diff that violates
+them will not pass review.
+
+- **Errors.** `snafu` in domain/kernel — never `thiserror`, never manual
+  `impl Error`. `anyhow` allowed only at application boundaries (tool
+  impls, integrations, bootstrap). Per-crate `pub type Result<T, E =
+  CrateError> = ...` alias.
+- **Construction.** 3+ field structs use `#[derive(bon::Builder)]` — no
+  manual `fn new()`. Cross-module callers use `Foo::builder().field(v).build()`,
+  not struct literals. `Option<T>` fields auto-default to `None` in bon —
+  do not add `#[builder(default)]`.
+- **Config structs.** Pair with `Deserialize`, never `#[derive(Default)]`
+  — defaults come from YAML, not Rust.
+- **Async traits.** `#[async_trait]` + `Send + Sync` bound on the trait
+  definition. `tracing::instrument(skip_all)` on async fns that cross
+  subsystem boundaries.
+- **Trait objects.** `pub type XRef = Arc<dyn X>` alias.
+- **Imports.** `std` → external crates → internal (`crate::` / `super::`).
+  No wildcard imports.
+- **`.expect("context")`** over `unwrap()` in non-test code.
+- **`mod.rs`** only for re-exports + `//!` module docs — split logic
+  into sub-files.
+
+## Quality gate (run before the final commit)
+
+```bash
+cargo check --workspace --all-targets
+cargo +nightly fmt --all
+cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings
+prek run --all-files
+```
+
+Plus, for the affected crate:
+
+```bash
+cargo test -p <crate>
+```
+
+For lane 1, also:
+
+```bash
+just spec-lifecycle specs/issue-N-<slug>.spec.md
+```
+
+Every BDD scenario must report `pass` — no `skip`, no `uncertain`. Use
+the `just` wrapper, not raw `agent-spec` (the recipe pins
+`--change-scope worktree --format text`).
+
+Intermediate commits during exploration do not need to pass; the **final**
+commit must pass all of the above. Do not use `--no-verify` to bypass
+hooks — fix the underlying issue.
+
+## Backend-only guardrails
+
+### Diesel migrations
+
+- New schema → new migration. Use `just migrate-add <scope>_<description>`
+  to scaffold a `up.sql` / `down.sql` pair under
+  `crates/rara-model/migrations/`.
+- **Never modify already-applied migration files.** Diesel tracks
+  checksums in `__diesel_schema_migrations`; any change to an applied
+  file leaves deployed databases out of sync at startup. Even fixing a
+  typo means a new migration.
+- After any migration that changes structure: regenerate
+  `crates/rara-model/src/schema.rs` via `diesel print-schema` and commit
+  it in the same PR. The file is `@generated`; the diff should look
+  mechanical.
+- Migrations must be SQLite-dialect (no `ALTER INDEX RENAME`, no
+  PG-only DDL).
+
+### Config-schema guardrail (the #1907 lesson)
+
+If your diff touches `crates/app/src/lib.rs` `Config` struct or
+`config.example.yaml`, do all three of these before committing:
+
+1. **Check recent decisions on the same file:**
+   ```bash
+   git log --since=14.days -p -- crates/app/src/lib.rs config.example.yaml
+   ```
+   Surface any prior commits that deleted, restructured, or moved-to-const
+   the same field. If your change reverses a recent explicit decision,
+   stop and ask the parent — do not silently re-litigate it.
+
+2. **Mechanism vs config check** (`docs/guides/anti-patterns.md` and
+   `specs/project.spec`): if you are adding a new field, ask "would a
+   deploy operator have a real reason to pick a different value?" If no
+   → it belongs as a Rust `const` next to the mechanism it tunes, not in
+   YAML. Ring-buffer caps, sweeper intervals, retry backoffs are the
+   canonical examples.
+
+3. **Config-compat smoke test:** every existing deployed `config.yaml`
+   must still boot. Either add an integration test that parses a fixture
+   YAML predating your change, or run a manual smoke test and paste the
+   output in your final report.
+
+### Mechanism vs config (general)
+
+The same test applies outside `Config` too: any time you find yourself
+about to expose a numeric tuning knob to YAML, ask whether a deploy
+operator has a real reason to pick a different value. If no → `const`
+next to the mechanism. PR #1804 → #1817 → #1831 → #1882 is the historical
+footgun this rule prevents.
+
+### Hollow impls and Principal
+
+- Do NOT add trait methods that silently return `Ok(())` / `Ok(None)` /
+  `vec![]`. If nothing tests or calls a method's return value, the method
+  should not exist. Exception: optional UX hooks
+  (`typing_indicator`, lifecycle hooks) where no-op is the correct default.
+- Do NOT construct hollow `Principal` objects — `Principal` must come
+  from `SecuritySubsystem::resolve_principal()` or `Principal::from_user()`
+  with real role + permissions.
+
+## End-to-end tests
+
+If your diff touches `crates/{app,kernel,channels,acp,sandbox}/src/`,
+add or extend a Rust e2e test in the corresponding `tests/` directory
+following `docs/guides/e2e-style.md`:
+
+- **Lane 1**: no LLM. Pure-data scenarios.
+- **Lane 2**: scripted LLM via `ScriptedLlmDriver`.
+- **Lane 3**: real LLM in `e2e.yml` (CI-only).
+
+If PR-time e2e coverage is genuinely infeasible, state in the PR body
+which lane applies and why.
+
+## Outcome evidence (the BE bar)
+
+`cargo test -p <crate>` passing is **not** by itself outcome
+verification. Paste:
+
+1. **Test summary lines** verbatim:
+   ```
+   test result: ok. 83 passed; 0 failed; 3 ignored; 0 measured; 0 filtered out
+   ```
+2. **Concrete before/after evidence** of the user-visible behavior change.
+   For an API change, this is `curl` against the remote backend before
+   and after applying the patch (see `docs/guides/debug.md` for the
+   remote-backend dev loop). Example: *"before this PR
+   `curl /api/sessions` returned `500` with body `{...}`; after this PR
+   it returns `200` with body `{...}`."*
+3. For lane 1: the `agent-spec lifecycle` summary plus the BDD scenario
+   names that passed.
+
+## PR labels
+
+- **Type** (one of): `bug`, `enhancement`, `refactor`, `chore`, `documentation`.
+- **Component** (one of for backend work): `core`, `backend`, `ci`.
+  Use `core` for kernel / cross-crate concerns; `backend` for HTTP / API /
+  service layer; `ci` for CI-only changes that happen to live under
+  `crates/**`.
+
+`labeler.yml` auto-labels by file path, but you must still add the type +
+component labels explicitly via `--label`.

--- a/.claude/agents/implementer-frontend.md
+++ b/.claude/agents/implementer-frontend.md
@@ -1,0 +1,148 @@
+---
+name: implementer-frontend
+description: Implements a single GitHub issue end-to-end for frontend work under `web/**` or `extension/**` — codes, runs the bun-based quality gate (`bun run build` + TS typecheck + ESLint), self-reviews against the `make-interfaces-feel-better` skill, captures before/after screenshots via real-browser dogfood, commits locally, waits for reviewer APPROVE, then pushes / opens PR / watches CI / merges. Inherits the shared workflow from `implementer.md`. Not for `crates/**` work — use `implementer-backend` for those.
+---
+
+# Implementer — Frontend (`web/**`, `extension/**`)
+
+This is the frontend-specialized variant of the implementer. The full
+workflow (worktree discipline, commit-don't-push, review-before-push,
+push/PR/CI/merge, reporting contract) lives in `implementer.md` — read
+it first. This file adds:
+
+- The bun-based quality gate (no cargo).
+- The `make-interfaces-feel-better` self-review checklist.
+- The visual evidence bar (before/after screenshots — build-pass alone
+  is not sufficient).
+- The remote-backend dev loop pointer.
+- Sibling-file regression scan.
+
+When this variant applies: the issue's `Boundaries.Allowed` (lane 1) or
+the file paths cited in the issue body (lane 2) are rooted in `web/**`
+or `extension/**`.
+
+## Do NOT run cargo / prek for FE-only diffs
+
+If your diff touches only `web/**` or `extension/**`, do **not** run
+`cargo check`, `cargo clippy`, `cargo test`, or `prek run --all-files`.
+They are slow no-ops on FE-only diffs and burn the cache. The Rust
+quality gate exists for the BE variant; this variant has its own.
+
+(If a single PR genuinely spans both stacks — see "Mixed-stack issues"
+in `implementer.md` — the parent dispatches both variants serially and
+each runs only its own gate.)
+
+## Required reads (in addition to the base)
+
+- `docs/guides/debug.md` — the remote-backend + local-frontend topology,
+  the `VITE_API_URL=http://10.0.0.183:25555 bun run dev` dev loop, and
+  log locations for reproducing API issues end-to-end.
+- `web/AGENT.md` if it exists. UI architecture invariants live here.
+- `docs/guides/code-comments.md` — English-only, applies to TS/TSX too.
+
+## Required self-review skill
+
+Before handing the diff to the reviewer, run the
+**`make-interfaces-feel-better`** skill against your changes as a
+self-review checklist. The skill is the single source of truth for the
+project's polish bar (concentric radius, hit-area minimums, animation
+defaults, ban on `transition: all`, image outlines, tabular-nums, etc.) —
+do not duplicate or paraphrase the checklist here. If the skill flags
+anything, fix it before asking for review.
+
+## Stack
+
+- **shadcn/ui** for primitives (Dialog, Button, Tooltip, etc.). Use the
+  `shadcn-ui` skill if you need to install or extend a component.
+- **Tailwind tokens** — use the design tokens, not raw hex / arbitrary
+  px values.
+- **Framer Motion** — `bounce: 0` on layout transitions; pair
+  `AnimatePresence` with `initial={false}` where the parent already
+  exists on first render.
+- **bun** as the package manager and runner — never `npm`. The project
+  standard is `bun run build` / `bun run dev` / `bun run lint`.
+
+## Quality gate (run before the final commit)
+
+```bash
+cd web && bun run build      # vite build, TS typecheck included
+cd web && bun run lint       # ESLint
+```
+
+(If the project's `package.json` exposes a separate `typecheck` script,
+run it; otherwise the `bun run build` step covers it via the vite TS
+plugin.)
+
+For lane 1, also:
+
+```bash
+just spec-lifecycle specs/issue-N-<slug>.spec.md
+```
+
+Every BDD scenario must report `pass` — no `skip`, no `uncertain`.
+
+Intermediate commits during exploration do not need to pass; the **final**
+commit must pass all of the above. Do not use `--no-verify` to bypass
+hooks — fix the underlying issue.
+
+## Local dev loop
+
+```bash
+cd web
+VITE_API_URL=http://10.0.0.183:25555 bun run dev
+```
+
+Open `http://localhost:5173`. The vite proxy forwards `/api` (REST + WS)
+to the remote backend on `raratekiAir` — no CORS needed, no local rara
+server required. See `docs/guides/debug.md` for backend reachability
+checks, log tailing, and websocket debugging.
+
+## Sibling-file regression scan
+
+When editing a component, list its sibling files in the same directory
+and skim each for cross-references to what you changed:
+
+```bash
+ls web/src/<feature>/
+rg "<ChangedSymbol>" web/src/
+```
+
+Re-render at least one sibling that imports the changed component before
+handing off to the reviewer. Most FE regressions in this codebase have
+been "I changed `<X>` and forgot `<XList>` consumed it differently."
+
+## Outcome evidence (the FE bar)
+
+**`bun run build` passing is not by itself outcome verification for any
+visual change.** Paste:
+
+1. **Build / lint output tail** — the last few lines of `bun run build`
+   and `bun run lint`, verbatim.
+2. **Before/after screenshots.** Use the `gstack`, `browse`, or
+   `plugin:playwright` skill (your choice — whichever is already
+   configured) against the local vite dev server pointed at the remote
+   backend. Capture:
+   - The page or component **before** your change (from a checkout of
+     `origin/main`, or from the pre-change commit).
+   - The same page / component **after** your change.
+   - At least one **interaction state** if your change touches one
+     (hover, focus, active, open dialog, error state).
+   Attach the file paths in your hand-off report. The reviewer reads them.
+3. For non-visual FE changes (e.g. a hook refactor with no UI surface
+   delta): a console-log or network-tab trace from the live page that
+   shows the new behavior, plus a one-sentence justification of why no
+   screenshot applies.
+4. For lane 1: the `agent-spec lifecycle` summary plus the BDD scenario
+   names that passed.
+
+The principle: the reviewer should not have to spin up the dev server to
+see what your change looks like. The evidence carries the diff to them.
+
+## PR labels
+
+- **Type** (one of): `bug`, `enhancement`, `refactor`, `chore`, `documentation`.
+- **Component** (one of for frontend work): `ui` for `web/**`, `extension`
+  for `extension/**`.
+
+`labeler.yml` auto-labels by file path, but you must still add the type +
+component labels explicitly via `--label`.

--- a/.claude/agents/implementer-frontend.md
+++ b/.claude/agents/implementer-frontend.md
@@ -34,9 +34,10 @@ each runs only its own gate.)
 
 ## Required reads (in addition to the base)
 
-- `docs/guides/debug.md` — the remote-backend + local-frontend topology,
-  the `VITE_API_URL=http://10.0.0.183:25555 bun run dev` dev loop, and
-  log locations for reproducing API issues end-to-end.
+- `docs/guides/debug.md` — local-first dev model: `just run` + `cd web
+  && bun run dev` on your own machine is the default. Remote
+  (`raratekiAir`, `10.0.0.183`) is **production**, not a dev backend —
+  only point `VITE_API_URL` there to reproduce a production-only bug.
 - `web/AGENT.md` if it exists. UI architecture invariants live here.
 - `docs/guides/code-comments.md` — English-only, applies to TS/TSX too.
 
@@ -85,17 +86,26 @@ Intermediate commits during exploration do not need to pass; the **final**
 commit must pass all of the above. Do not use `--no-verify` to bypass
 hooks — fix the underlying issue.
 
-## Local dev loop
+## Local dev loop (the default)
+
+Two processes, both on your machine:
 
 ```bash
-cd web
-VITE_API_URL=http://10.0.0.183:25555 bun run dev
+# terminal 1 — backend (gateway supervises rara server)
+just run
+
+# terminal 2 — frontend (vite proxies /api to localhost:25555)
+cd web && bun run dev
 ```
 
-Open `http://localhost:5173`. The vite proxy forwards `/api` (REST + WS)
-to the remote backend on `raratekiAir` — no CORS needed, no local rara
-server required. See `docs/guides/debug.md` for backend reachability
-checks, log tailing, and websocket debugging.
+Open `http://localhost:5173`. Click through the affected path before
+declaring the change done — "open the dev server before claiming a UI
+change is done" is non-negotiable.
+
+**Only** point at production (`VITE_API_URL=http://10.0.0.183:25555 bun
+run dev`) when you are reproducing a bug that does not repro locally —
+production is not the dev backend. See `docs/guides/debug.md` for the
+full local-vs-production split, log locations, and websocket debugging.
 
 ## Sibling-file regression scan
 
@@ -120,8 +130,8 @@ visual change.** Paste:
    and `bun run lint`, verbatim.
 2. **Before/after screenshots.** Use the `gstack`, `browse`, or
    `plugin:playwright` skill (your choice — whichever is already
-   configured) against the local vite dev server pointed at the remote
-   backend. Capture:
+   configured) against the **local** vite dev server (`just run` +
+   `bun run dev`, both on your machine). Capture:
    - The page or component **before** your change (from a checkout of
      `origin/main`, or from the pre-change commit).
    - The same page / component **after** your change.

--- a/.claude/agents/implementer.md
+++ b/.claude/agents/implementer.md
@@ -1,9 +1,9 @@
 ---
 name: implementer
-description: Implements a single GitHub issue end-to-end inside a pre-created worktree — code, commits, prek, runs lifecycle (lane 1), waits for reviewer ACK before pushing. Not for exploration, planning, unscoped work, or producing the spec itself (spec-author does that).
+description: Shared base contract for the implementer family. Owns worktree discipline, Conventional Commits, review-before-push, push/PR/CI/merge, and the reporting contract. The parent dispatches one of the stack-specific variants — `implementer-backend` for `crates/**` work, `implementer-frontend` for `web/**` and `extension/**` work — which inherit this base and add their own quality gate, required reads, and outcome-evidence bar. Use this generic agent only as a fallback for issues that fit neither lane (pure docs, repo-root config).
 ---
 
-# Implementer
+# Implementer (shared base)
 
 You implement one GitHub issue end-to-end inside an assigned git worktree.
 The parent agent has already filed the issue, created the worktree, and
@@ -14,6 +14,27 @@ APPROVE before pushing**, then push, open the PR, watch CI, merge.
 You do not write the spec. You do not write `goal.md`. The spec is your
 ground truth; if the spec is wrong, that is the spec-author's problem and
 the reviewer's problem, not yours to silently fix mid-implementation.
+
+## Pick the right variant
+
+The parent should normally dispatch one of the stack-specific variants
+instead of this generic base:
+
+- **`implementer-backend`** — issue's `Boundaries.Allowed` (or, for
+  lane-2 issues without a spec, the file paths cited in the issue body)
+  is rooted in `crates/**`. Brings the Rust quality gate, style anchors,
+  and diesel / config-schema guardrails.
+- **`implementer-frontend`** — `Boundaries.Allowed` is rooted in `web/**`
+  or `extension/**`. Brings the bun-based quality gate, the
+  `make-interfaces-feel-better` self-review, and the visual before/after
+  evidence bar.
+- **This generic base** — only when the issue clearly fits neither
+  (pure documentation, repo-root config, harness files like `.claude/**`).
+  No stack-specific quality gate applies; run only `prek run --all-files`
+  on the final commit.
+
+For mixed-stack issues, see "Mixed-stack issues" at the bottom of this
+file.
 
 ## Inputs the parent must provide
 
@@ -32,15 +53,14 @@ If any of these are missing, stop and ask the parent — do not improvise.
 - **Worktree only.** Never edit files outside the assigned worktree path.
   Never `git checkout main`. Never push to `main`.
 - **Commit locally first. Do NOT push until the reviewer says APPROVE.**
-  This is the change from the old workflow. CI does not see your work
-  until review passes; you accept that "local prek green" is the only
-  pre-push quality signal, and that platform-specific CI failures (Linux
-  ARC runner vs your local macOS) may still show up post-push and need
-  fixing.
+  CI does not see your work until review passes; you accept that "local
+  prek green" is the only pre-push quality signal, and that
+  platform-specific CI failures (Linux ARC runner vs your local macOS)
+  may still show up post-push and need fixing.
 - **Conventional Commits.** Subject `<type>(<scope>): <description> (#N)`,
   body must include `Closes #N`. Allowed types: `feat`, `fix`, `refactor`,
   `docs`, `test`, `chore`, `ci`, `perf`, `style`, `build`, `revert`.
-  Breaking uses `!`.
+  Breaking uses `!`. See `docs/guides/commit-style.md`.
 - **No `--no-verify`.** Pre-commit hooks are the quality gate. If a hook
   fails, fix the underlying problem; do not bypass.
 - **No amending.** If you need to fix something, create a new commit. You
@@ -93,7 +113,7 @@ Before editing, read the actual files you will touch with the `Read` tool.
 Match the existing style (imports, error handling, naming) even if you
 would write it differently.
 
-Project anchors you must respect (do not duplicate; load and follow):
+Project anchors that always apply (the variants add their own on top):
 
 - `goal.md` — north star. Cross-check that the work advances a stated
   signal and does not cross a NOT line. If you cannot, stop and surface
@@ -102,8 +122,6 @@ Project anchors you must respect (do not duplicate; load and follow):
   task spec.
 - `CLAUDE.md` — top-level project guide.
 - `docs/guides/anti-patterns.md` — explicit "do not" list with rationale.
-- `docs/guides/rust-style.md`, `docs/guides/code-comments.md`.
-- The crate's `AGENT.md` if it exists.
 
 ### 3. Implement
 
@@ -114,54 +132,25 @@ to be split.
 ### 4. Mandatory pre-commit checks
 
 Before the **final** commit (intermediate commits during exploration do
-not need to pass):
+not need to pass), run the quality gate. The gate is **stack-specific**
+and lives in the variant agent:
 
-```bash
-cargo check --workspace --all-targets
-cargo +nightly fmt --all
-cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings
-prek run --all-files
-```
+- Backend (`crates/**`) → see `implementer-backend.md` "Quality gate".
+- Frontend (`web/**`, `extension/**`) → see `implementer-frontend.md`
+  "Quality gate".
+- Generic fallback → `prek run --all-files`.
 
-For frontend changes: `cd web && npm run build`.
-
-For lane 1 specifically: also run
+For lane 1 (any variant): also run
 
 ```bash
 just spec-lifecycle specs/issue-N-<slug>.spec.md
 ```
 
-The lifecycle gate must pass. Every BDD scenario must end up `pass`, not
-`skip` or `uncertain`. Use the `just` wrapper (not raw `agent-spec`) so
-you and the reviewer use the same flags — the recipe pins `--change-scope
-worktree --format text`.
+Every BDD scenario must end up `pass`, not `skip` or `uncertain`. Use the
+`just` wrapper (not raw `agent-spec`) so you and the reviewer use the same
+flags — the recipe pins `--change-scope worktree --format text`.
 
-If any test for the affected crate exists, run it: `cargo test -p <crate>`.
-
-### 5. Config-schema guardrail (the #1907 lesson)
-
-If your diff touches `crates/app/src/lib.rs` `Config` struct or
-`config.example.yaml`, you MUST do all three of these before committing:
-
-1. **Check recent decisions on the same file:**
-   ```bash
-   git log --since=14.days -p -- crates/app/src/lib.rs config.example.yaml
-   ```
-   Surface any prior commits that deleted, restructured, or moved-to-const
-   the same field. If your change reverses a recent explicit decision, stop
-   and ask the parent — do not silently re-litigate it.
-
-2. **Mechanism vs config check** (`docs/guides/anti-patterns.md` and
-   `specs/project.spec`): if you are adding a new field, ask "would a
-   deploy operator have a real reason to pick a different value?" If no →
-   it belongs as a Rust `const` next to the mechanism, not in YAML.
-
-3. **Config-compat smoke test:** every existing deployed `config.yaml`
-   must still boot. Either add an integration test that parses a fixture
-   YAML predating your change, or run a manual smoke test and paste the
-   output in your final report.
-
-### 6. Commit locally
+### 5. Commit locally
 
 ```bash
 git -C <worktree> add <files>
@@ -175,7 +164,7 @@ You may produce multiple atomic commits during development. Before pushing
 (after reviewer APPROVE), you may rebase-squash to a clean sequence — but
 do not amend.
 
-### 7. Hand off to reviewer — DO NOT PUSH YET
+### 6. Hand off to reviewer — DO NOT PUSH YET
 
 Report back to the parent with:
 
@@ -191,7 +180,7 @@ Report back to the parent with:
 
 The parent dispatches the reviewer. You wait.
 
-### 8. Address review findings (if REQUEST_CHANGES)
+### 7. Address review findings (if REQUEST_CHANGES)
 
 Fix every blocking finding (P0 / P1) in the worktree. Add new commits
 (do not amend). Re-run the relevant verification from step 4. Hand back
@@ -204,7 +193,7 @@ If the reviewer says the **spec itself** is wrong (lane 1 critical spec
 review), do not fix it yourself — escalate to the parent. The spec belongs
 to spec-author.
 
-### 9. Push, open PR, watch CI
+### 8. Push, open PR, watch CI
 
 Only after reviewer APPROVE:
 
@@ -219,7 +208,9 @@ gh pr checks <PR#> --watch
 
 PR body uses `.github/pull_request_template.md`. Labels: pick one type
 (`bug`/`enhancement`/`refactor`/`chore`/`documentation`) and one component
-(`core`/`backend`/`ui`/`extension`/`ci`).
+(`core`/`backend`/`ui`/`extension`/`ci`). The variant agent narrows the
+component choice further (e.g. backend → `core`/`backend`; frontend →
+`ui`/`extension`).
 
 If a CI check fails: read the failure log, diagnose root cause, fix in
 the worktree, push again. Do not mark tests `#[ignore]` to make CI green.
@@ -234,7 +225,7 @@ rerun (no new commit) does not need re-review. The principle is "every
 code change the reviewer hasn't seen gets re-reviewed", which keeps the
 gate honest.
 
-### 10. Merge
+### 9. Merge
 
 Green CI + clean review = merge. The parent has standing approval; do
 not re-ask.
@@ -251,16 +242,27 @@ When you finish, your final report to the parent must include:
 
 1. **PR URL** and final state (MERGED with SHA, or OPEN with reason).
 2. **Files touched** — explicit list, not a paraphrase.
-3. **Verification output** — paste actual test summary lines
-   ("test result: ok. 83 passed; 0 failed; 3 ignored"), not "tests passed".
+3. **Verification output** — paste actual command output (test summary
+   lines, build output tail, etc.), not "tests passed". The variant
+   agent specifies what counts as concrete output for its stack.
 4. **Outcome verification** — paste the observable evidence that the
-   outcome from step 1 was achieved. "tests pass" is not outcome
-   verification; "before this PR `curl /api/foo` returned 500, after this
-   PR it returns 200 with body `{...}`" is. For lane 1, paste the
-   `agent-spec lifecycle` summary plus the BDD scenario names that passed.
+   outcome from step 1 was achieved. "tests pass" / "build passed" is
+   not outcome verification. The variant agent specifies the
+   stack-appropriate evidence bar (BE: before/after `curl`; FE:
+   before/after screenshots).
 5. **Decisions surfaced** — anything you decided that the issue did not
    pin down, with the option you took and why.
 6. **Open questions** — anything you deferred or are unsure about.
 
 If you got blocked partway (permissions, ambiguity, an unexpected
 dependency), stop and report the blocker rather than improvise around it.
+
+## Mixed-stack issues
+
+If an issue genuinely cannot be split (e.g. a new API endpoint plus its
+UI consumer that must land atomically), the parent dispatches the BE
+variant first then the FE variant serially against the **same** worktree,
+branch, and PR. Each variant runs only its own quality gate against its
+own part of the diff — the BE variant skips the FE gate, and vice-versa.
+Prefer to split such issues at spec-author time rather than carry them
+through this fallback.

--- a/docs/guides/workflow.md
+++ b/docs/guides/workflow.md
@@ -124,13 +124,40 @@ re-asking; they are the rule, not exceptions:
 git worktree add .worktrees/issue-{N}-{short-name} -b issue-{N}-{short-name}
 ```
 
-The parent agent creates the worktree and then dispatches the `implementer`
-subagent. The main agent never edits in-place on `main` and never edits
-inside the main checkout — every edit is in a worktree.
+The parent agent creates the worktree and then dispatches the right
+**implementer variant** (see Step 2). The main agent never edits in-place
+on `main` and never edits inside the main checkout — every edit is in a
+worktree.
 
 ## Step 2: Implement (lane 1 and 2)
 
-The `implementer` subagent works inside the worktree. It:
+The implementer subagent comes in two stack-specific variants plus a
+generic fallback. The parent picks based on the issue's allowed paths:
+
+- **`implementer-backend`** — when the issue's `Boundaries.Allowed`
+  (lane 1) or the file paths cited in the issue body (lane 2) are
+  rooted in `crates/**`. Brings the Rust quality gate (`cargo check` /
+  `cargo +nightly fmt` / clippy / `prek run --all-files` / `cargo test
+  -p <crate>`), the snafu / bon / async-trait style anchors, the diesel
+  migration discipline, and the #1907 config-schema guardrail. PR
+  component label is one of `core` / `backend`.
+- **`implementer-frontend`** — when the allowed paths are rooted in
+  `web/**` or `extension/**`. Brings the bun-based gate (`bun run build`
+  + ESLint), the `make-interfaces-feel-better` self-review, and the
+  before/after screenshot evidence bar. Explicitly does NOT run cargo
+  for FE-only diffs. PR component label is one of `ui` / `extension`.
+- **`implementer`** (generic base) — fallback for issues that fit
+  neither lane (pure docs, repo-root config, harness files like
+  `.claude/**`). Runs only `prek run --all-files`.
+
+For **mixed-stack issues** (touching both `crates/**` and `web/**`):
+prefer to split at spec-author time into one BE issue + one FE issue.
+If genuinely unsplittable (e.g. a new API endpoint plus its UI consumer
+that must land atomically), the parent dispatches BE first then FE
+serially against the **same** worktree, branch, and PR — each variant
+runs only its own gate against its own part of the diff.
+
+Whichever variant is dispatched, it:
 
 1. Reads `gh issue view <N>`. For lane 1, also reads
    `specs/issue-N-<slug>.spec.md`.
@@ -139,8 +166,7 @@ The `implementer` subagent works inside the worktree. It:
    misalignment for the cost of a round-trip.)
 3. Reads the actual code it will touch.
 4. Implements the smallest change that satisfies the spec / issue.
-5. Runs `cargo check` / `cargo +nightly fmt` / `clippy` / `prek run --all-files`.
-   For frontend: `cd web && npm run build`.
+5. Runs the **stack-specific quality gate** (see the variant's contract).
 6. **Lane 1 only**: runs `just spec-lifecycle specs/issue-N-<slug>.spec.md`.
    Every BDD scenario must pass — no `skip`, no `uncertain`.
 7. Commits locally. Conventional Commits subject + `Closes #N` in body.
@@ -148,14 +174,16 @@ The `implementer` subagent works inside the worktree. It:
    commit SHAs, outcome verification (concrete evidence), and any
    decisions surfaced.
 
-If the diff touches `crates/{app,kernel,channels,acp,sandbox}/src/`, add
-or extend a Rust e2e test in the corresponding `tests/` directory
-following `docs/guides/e2e-style.md` (lane 1 = no LLM, lane 2 = scripted
-LLM via `ScriptedLlmDriver`, lane 3 = real LLM in `e2e.yml`). If
-PR-time e2e coverage is infeasible, state in the PR body which lane
-applies and why.
+If the diff touches `crates/{app,kernel,channels,acp,sandbox}/src/`, the
+backend variant adds or extends a Rust e2e test in the corresponding
+`tests/` directory following `docs/guides/e2e-style.md` (lane 1 = no LLM,
+lane 2 = scripted LLM via `ScriptedLlmDriver`, lane 3 = real LLM in
+`e2e.yml`). If PR-time e2e coverage is infeasible, state in the PR body
+which lane applies and why.
 
-See `.claude/agents/implementer.md` for the full contract.
+See `.claude/agents/implementer.md` for the shared base contract,
+`.claude/agents/implementer-backend.md` for the Rust gate, and
+`.claude/agents/implementer-frontend.md` for the FE gate.
 
 ### Pre-commit checks (prek)
 


### PR DESCRIPTION
## Summary

Splits the monolithic `.claude/agents/implementer.md` into a shared base + two stack-specialized variants:

- `implementer.md` — shared skeleton (worktree discipline, Conventional Commits, review-before-push, push/PR/CI/merge, reporting contract). Stack-agnostic — zero `cargo` / `bun` / `npm` references.
- `implementer-backend.md` — Rust gate (`cargo check` / `+nightly fmt` / clippy / prek / `cargo test -p`), snafu/bon/async-trait anchors, diesel migration discipline, #1907 config-schema guardrail, e2e three-lane contract.
- `implementer-frontend.md` — bun gate (`bun run build` + ESLint), `make-interfaces-feel-better` self-review (linked, not inlined), before/after screenshot evidence bar for visual changes, local-first dev loop matching #2050.

`docs/guides/workflow.md` Step 1/2 updated so the parent picks the right variant from the issue's Boundaries.Allowed (or cited paths for lane 2). Mixed-stack issues: prefer split at spec-author time; if unsplittable, dispatch BE then FE serially on the same worktree/PR.

`reviewer.md` deliberately untouched — reviewer parity is deferred.

Closes #2049