### PR TITLE
fix(web): render assistant responses without bubble chrome

### DIFF
--- a/web/src/components/topology/__tests__/RaraTurnCard.test.tsx
+++ b/web/src/components/topology/__tests__/RaraTurnCard.test.tsx
@@ -135,6 +135,17 @@ describe('RaraTurnCard — trace + cascade affordances', () => {
     expect((response as HTMLElement).style.maxHeight).toBe('');
   });
 
+  it('RaraTurnCard__assistant_response_renders_as_page_flow_not_message_bubble', () => {
+    const { container } = renderCard(makeTurn({ text: 'final assistant text' }));
+
+    const response = container.querySelector('[data-search-root="response"]');
+    expect(response).not.toBeNull();
+    expect(response).toHaveClass('px-0');
+    expect(response).toHaveClass('py-1');
+    expect(response?.closest('.shadow-minimal')).toBeNull();
+    expect(response?.closest('.rounded-\\[8px\\]')).toBeNull();
+  });
+
   it('RaraTurnCard__trace_modal_opens_with_fetched_content', async () => {
     fetchExecutionTraceMock.mockResolvedValue({
       duration_secs: 1.23,

--- a/web/src/vendor/craft-ui/components/chat/TurnCard.tsx
+++ b/web/src/vendor/craft-ui/components/chat/TurnCard.tsx
@@ -2417,6 +2417,7 @@ export function ResponseCard({
 
   const isCompleted = !isStreaming
   const isBuffering = isStreaming && !bufferDecision.shouldShow
+  const isPageFlowResponse = variant === 'response' && responseOverflowMode === 'page'
   const responseContentStyle = responseOverflowMode === 'contained'
     ? {
         maxHeight: MAX_HEIGHT,
@@ -2430,6 +2431,12 @@ export function ResponseCard({
   const responseContentOverflowClass = responseOverflowMode === 'contained'
     ? 'overflow-y-auto scrollbar-hover'
     : 'overflow-visible'
+  const responseContentClass = isPageFlowResponse
+    ? 'px-0 py-1 text-sm'
+    : 'pl-[22px] pr-[16px] py-3 text-sm'
+  const streamingResponseContentClass = isPageFlowResponse
+    ? 'px-0 py-1 text-sm'
+    : 'pl-[22px] pr-4 py-3 text-sm'
 
   // While buffering, return null - TurnCard will show a subtle indicator instead
   if (isBuffering) {
@@ -2442,9 +2449,12 @@ export function ResponseCard({
 
     return (
       <>
-        <div className="bg-background shadow-minimal rounded-[8px] overflow-hidden relative group">
+        <div className={cn(
+          "relative group",
+          !isPageFlowResponse && "bg-background shadow-minimal rounded-[8px] overflow-hidden"
+        )}>
           {/* Fullscreen button - desktop only; compact mode keeps message chrome minimal */}
-          {!compactMode && (
+          {!isPageFlowResponse && !compactMode && (
           <button
             onClick={() => setIsFullscreen(true)}
             className={cn(
@@ -2479,7 +2489,7 @@ export function ResponseCard({
             data-search-root="response"
             onMouseDown={handleSelectionPointerDown}
             onMouseUp={handleTextSelection}
-            className={cn("pl-[22px] pr-[16px] py-3 text-sm", responseContentOverflowClass)}
+            className={cn(responseContentClass, responseContentOverflowClass)}
             style={responseContentStyle}
           >
             <div ref={contentLayerRef} className="relative">
@@ -2495,7 +2505,7 @@ export function ResponseCard({
           </div>
 
           {/* Footer with actions - hidden in compact mode */}
-          {!compactMode && (
+          {!isPageFlowResponse && !compactMode && (
             <div className={cn(
               "pl-4 pr-2.5 py-2 border-t border-border/30 flex items-center justify-between bg-muted/20",
               SIZE_CONFIG.fontSize
@@ -2589,7 +2599,10 @@ export function ResponseCard({
   // Streaming response - show throttled content with spinner
   return (
     <>
-      <div className="bg-background shadow-minimal rounded-[8px] overflow-hidden group">
+      <div className={cn(
+        "group",
+        !isPageFlowResponse && "bg-background shadow-minimal rounded-[8px] overflow-hidden"
+      )}>
         {/* Content area - uses displayedText (throttled) for performance */}
         {/* Content area: internal scroll by default, page-flow when requested by host UI. */}
         <div
@@ -2597,7 +2610,7 @@ export function ResponseCard({
           data-search-root="response"
           onMouseDown={handleSelectionPointerDown}
           onMouseUp={handleTextSelection}
-          className={cn("pl-[22px] pr-4 py-3 text-sm", responseContentOverflowClass)}
+          className={cn(streamingResponseContentClass, responseContentOverflowClass)}
           style={responseContentStyle}
         >
           <div ref={contentLayerRef} className="relative">
@@ -2613,7 +2626,7 @@ export function ResponseCard({
         </div>
 
         {/* Footer - hidden in compact mode */}
-        {!compactMode && (
+        {!isPageFlowResponse && !compactMode && (
           <div className={cn("px-4 py-2 border-t border-border/30 flex items-center bg-muted/20", SIZE_CONFIG.fontSize)}>
             <div className="flex items-center gap-2 text-muted-foreground">
               <Spinner className={SIZE_CONFIG.spinnerSize} />


### PR DESCRIPTION
## Summary
- make page-flow assistant responses render without the response card background, shadow, rounded corners, or footer chrome
- keep plan responses and contained response mode as card surfaces
- add a RaraTurnCard regression test that rejects the message-bubble wrapper

## Verification
- npm run test -- src/components/topology/__tests__/RaraTurnCard.test.tsx
- npm run typecheck
- npm run build
- git diff --check

Note: local browser startup reached the login dialog on http://127.0.0.1:5175, but the currently running backend still rejected the new CORS origin until it is restarted with the merged config/code.