### PR TITLE
fix(chat): keep model provider pins coherent

### DIFF
--- a/crates/channels/src/web_session.rs
+++ b/crates/channels/src/web_session.rs
@@ -145,7 +145,7 @@ pub enum InboundFrame {
     /// `transcribe_audio_blocks` + `build_raw_platform_message` +
     /// `KernelHandle::submit_message`, mirroring the legacy chat WS path.
     Prompt {
-        content: rara_kernel::channel::types::MessageContent,
+        content:        rara_kernel::channel::types::MessageContent,
         /// Optional per-turn model override sent by the model picker.
         /// When present, the field is treated as a session-sticky pin:
         /// `SessionEntry.model` is updated so the agent loop's existing
@@ -153,7 +153,13 @@ pub enum InboundFrame {
         /// shape as the Telegram `/model` callback path so both channels
         /// stay aligned.
         #[serde(default)]
-        model:   Option<String>,
+        model:          Option<String>,
+        /// Optional provider paired with the model override. If a prompt
+        /// carries a model without this field, any stale session provider pin
+        /// is cleared so the model resolves against the current default
+        /// provider instead of an old incompatible provider.
+        #[serde(default)]
+        model_provider: Option<String>,
     },
     /// User clicked stop. Dispatches `Signal::Interrupt` against the
     /// kernel session — replaces the deleted REST interrupt endpoint.
@@ -467,7 +473,11 @@ async fn handle_session_ws(
                 }
 
                 match serde_json::from_str::<InboundFrame>(&text) {
-                    Ok(InboundFrame::Prompt { content, model }) => {
+                    Ok(InboundFrame::Prompt {
+                        content,
+                        model,
+                        model_provider,
+                    }) => {
                         let content = transcribe_audio_blocks(content, &stt_service).await;
                         let raw = build_raw_platform_message(&session_key_str, &user_id, content);
 
@@ -507,7 +517,13 @@ async fn handle_session_ws(
                         // two consecutive prompts is a cheap idempotent
                         // write, so the round-trip cost stays bounded.
                         if let Some(ref pinned) = model {
-                            apply_model_override(s, &session_key, pinned).await;
+                            apply_model_override(
+                                s,
+                                &session_key,
+                                pinned,
+                                model_provider.as_deref(),
+                            )
+                            .await;
                         }
 
                         // First-contact sessions arrive with no resolved
@@ -645,14 +661,17 @@ async fn apply_model_override(
     handle: &rara_kernel::handle::KernelHandle,
     key: &SessionKey,
     model: &str,
+    model_provider: Option<&str>,
 ) {
     let session_index = handle.session_index();
     match session_index.get_session(key).await {
         Ok(Some(mut entry)) => {
-            if entry.model.as_deref() == Some(model) {
+            let next_provider = model_provider.map(ToOwned::to_owned);
+            if entry.model.as_deref() == Some(model) && entry.model_provider == next_provider {
                 return;
             }
             entry.model = Some(model.to_owned());
+            entry.model_provider = next_provider;
             if let Err(e) = session_index.update_session(&entry).await {
                 warn!(
                     session_key = %key,
@@ -674,7 +693,7 @@ async fn apply_model_override(
                 key: *key,
                 title: None,
                 model: Some(model.to_owned()),
-                model_provider: None,
+                model_provider: model_provider.map(ToOwned::to_owned),
                 thinking_level: None,
                 system_prompt: None,
                 total_entries: 0,

--- a/crates/channels/tests/web_session_smoke.rs
+++ b/crates/channels/tests/web_session_smoke.rs
@@ -38,7 +38,7 @@ use rara_kernel::{
     channel::{adapter::ChannelAdapter, types::ChannelType},
     io::{Endpoint, EndpointAddress, PlatformOutbound},
     notification::KernelNotification,
-    session::SessionKey,
+    session::{SessionEntry, SessionKey},
 };
 use tokio_tungstenite::tungstenite::Message;
 
@@ -392,6 +392,29 @@ async fn session_ws_prompt_with_model_override_pins_turn_model() {
     });
 
     let session_key = SessionKey::new();
+    let now = chrono::Utc::now();
+    tk.handle
+        .session_index()
+        .create_session(&SessionEntry {
+            key: session_key,
+            title: None,
+            model: Some("old-model".to_owned()),
+            model_provider: Some("missing-provider".to_owned()),
+            thinking_level: None,
+            system_prompt: None,
+            total_entries: 0,
+            preview: None,
+            last_token_usage: None,
+            estimated_context_tokens: 0,
+            entries_since_last_anchor: 0,
+            anchors: Vec::new(),
+            metadata: None,
+            created_at: now,
+            updated_at: now,
+        })
+        .await
+        .expect("seed stale session override");
+
     let (mut ws, _resp) =
         tokio_tungstenite::connect_async(&session_url(addr, &session_key, OWNER_TOKEN))
             .await
@@ -429,6 +452,18 @@ async fn session_ws_prompt_with_model_override_pins_turn_model() {
     assert_eq!(
         turn.model, override_model,
         "agent loop must honour the per-prompt model override"
+    );
+    let session = tk
+        .handle
+        .session_index()
+        .get_session(&session_key)
+        .await
+        .expect("load session")
+        .expect("session exists");
+    assert_eq!(session.model.as_deref(), Some(override_model));
+    assert_eq!(
+        session.model_provider, None,
+        "model-only WS pins must clear stale provider overrides"
     );
 
     ws.send(Message::Close(None)).await.ok();

--- a/specs/issue-2055-chat-model-errors.spec.md
+++ b/specs/issue-2055-chat-model-errors.spec.md
@@ -1,0 +1,76 @@
+spec: project
+name: "issue-2055-chat-model-errors"
+---
+
+## Intent
+
+Chat prompt submission must keep session model/provider pins coherent and
+must surface backend LLM errors in the Chat UI. A failed provider call should
+not look like an assistant that is still thinking.
+
+## Constraints
+
+Production session `a321d66a-2d59-43e1-a199-7faef7bc70cd` had a stale
+session override:
+
+- `model = kimi-for-coding`
+- `model_provider = minimax`
+
+The Chat model picker listed `kimi-for-coding` from the current model catalog,
+then the session WebSocket sent only the model id. The backend updated
+`SessionEntry.model` but left `SessionEntry.model_provider` as `minimax`, so
+the agent resolver called MiniMax with a Kimi model id. The provider returned
+HTTP 400 `unknown model 'kimi-for-coding'`.
+
+The backend delivered an `Error(agent_error)` frame to the Web endpoint, but
+`TimelineView` did not render `useChatSessionWs().error`, leaving the user
+with only their own prompt bubble and no visible failure.
+
+## Decisions
+
+- A prompt frame may carry `model_provider` alongside `model`.
+- A prompt frame with `model` and no `model_provider` clears any stale
+  provider pin before dispatching the turn.
+- Session WebSocket backend error frames render in the Chat UI near the
+  composer.
+
+## Acceptance Criteria
+
+```gherkin
+Feature: Chat model pins and LLM errors remain visible and coherent
+
+  Scenario: WS model pin clears stale provider when provider is absent
+    Given a session already has model="kimi-for-coding"
+      and model_provider="minimax"
+    When the browser sends a prompt frame with a model but no model_provider
+    Then the session WebSocket clears the stale provider pin before dispatching the turn
+
+    Test: crates/channels/tests/web_session_smoke.rs
+    Filter: session_ws_prompt_with_model_override_pins_turn_model
+
+  Scenario: Chat renders backend error frames
+    Given the persistent session WebSocket reports an error frame
+    When TimelineView renders the chat composer
+    Then the error message is visible near the composer
+
+    Test: web/src/components/topology/__tests__/TimelineView.history.test.tsx
+    Filter: session_ws_error_frame_is_rendered_near_composer
+```
+
+## Boundaries
+
+Allowed:
+
+- `crates/channels/src/web_session.rs`
+- `crates/channels/tests/web_session_smoke.rs`
+- `web/src/agent/session-ws-client.ts`
+- `web/src/agent/__tests__/session-ws-client.test.ts`
+- `web/src/components/topology/TimelineView.tsx`
+- `web/src/components/topology/__tests__/TimelineView.history.test.tsx`
+
+## Out of Scope
+
+- Global provider settings redesign.
+- Production DB edits.
+- Remote backend restart.
+- Replacing the vendored input component.

--- a/web/src/agent/__tests__/session-ws-client.test.ts
+++ b/web/src/agent/__tests__/session-ws-client.test.ts
@@ -182,6 +182,27 @@ describe('SessionWsClient', () => {
     expect(JSON.parse(ws.sent[0]!)).toEqual({ type: 'prompt', content: 'hello world' });
   });
 
+  it('prompt() includes model provider when provided', () => {
+    const client = new SessionWsClient({ sessionKey: 'sess-1' });
+    client.connect();
+    const ws = FakeWebSocket.instances[0]!;
+    ws.fireOpen();
+    ws.fireMessage({ type: 'hello' });
+
+    expect(
+      client.prompt('hello world', {
+        model: 'kimi-for-coding',
+        modelProvider: 'kimi-code',
+      }),
+    ).toBe(true);
+    expect(JSON.parse(ws.sent[0]!)).toEqual({
+      type: 'prompt',
+      content: 'hello world',
+      model: 'kimi-for-coding',
+      model_provider: 'kimi-code',
+    });
+  });
+
   it('prompt() returns false when socket is not open', () => {
     const client = new SessionWsClient({ sessionKey: 'sess-1' });
     client.connect();

--- a/web/src/agent/session-ws-client.ts
+++ b/web/src/agent/session-ws-client.ts
@@ -168,14 +168,14 @@ export type PromptContentBlock =
 export type PromptContent = string | PromptContentBlock[];
 
 /** Optional per-prompt overrides forwarded as top-level fields on the
- *  `prompt` frame. Currently just `model`, but kept as an options object
- *  so future per-turn knobs (thinking level, sampling) don't churn the
- *  signature. */
+ *  `prompt` frame. */
 export interface PromptOptions {
   /** Pinned model id for this turn — mirrors the picker selection. The
    *  backend treats this as a session-sticky pin, matching the Telegram
    *  `/model` command path. */
   model?: string;
+  /** Provider paired with `model` when the picker exposes one. */
+  modelProvider?: string;
 }
 
 // ---------------------------------------------------------------------------
@@ -327,6 +327,9 @@ export class SessionWsClient {
     const payload: Record<string, unknown> = { type: 'prompt', content };
     if (options.model && options.model.length > 0) {
       payload.model = options.model;
+    }
+    if (options.modelProvider && options.modelProvider.length > 0) {
+      payload.model_provider = options.modelProvider;
     }
     return this.send(payload);
   }

--- a/web/src/components/topology/TimelineView.tsx
+++ b/web/src/components/topology/TimelineView.tsx
@@ -135,6 +135,7 @@ export function TimelineView({
   const defaultModelIdString =
     typeof defaultModelId === 'string' ? defaultModelId : defaultModelId?.id;
   const [pickedModel, setPickedModel] = useState<string | undefined>(undefined);
+  const [pickedProvider, setPickedProvider] = useState<string | undefined>(undefined);
   const currentModel = pickedModel ?? defaultModelIdString ?? '';
 
   const history = useSessionHistory(viewSessionKey);
@@ -346,7 +347,13 @@ export function TimelineView({
       // Forward the picker's current selection as the per-turn override.
       // Empty string means "use whatever the backend default resolves to",
       // which the WS client drops rather than sending a blank `model` field.
-      const ok = ws.sendPrompt(trimmed, currentModel ? { model: currentModel } : undefined);
+      const promptOptions = currentModel
+        ? {
+            model: currentModel,
+            ...(pickedProvider ? { modelProvider: pickedProvider } : {}),
+          }
+        : undefined;
+      const ok = ws.sendPrompt(trimmed, promptOptions);
       if (!ok) return;
       const id = `u-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 6)}`;
       setUserTurnsBySession((prev) => {
@@ -357,8 +364,13 @@ export function TimelineView({
         };
       });
     },
-    [ws, viewSessionKey, currentModel],
+    [ws, viewSessionKey, currentModel, pickedProvider],
   );
+
+  const handleModelChange = useCallback((model: string, connection?: string) => {
+    setPickedModel(model);
+    setPickedProvider(connection && connection !== RARA_CONNECTION_SLUG ? connection : undefined);
+  }, []);
 
   const handleStop = useCallback(() => {
     ws.sendAbort();
@@ -408,6 +420,14 @@ export function TimelineView({
                 Failed to load conversation history. Live chat still works — refresh to retry.
               </div>
             )}
+            {ws.error && (
+              <div
+                role="alert"
+                className="mt-2 rounded border border-red-300 bg-red-50 px-3 py-2 text-xs text-red-700 dark:border-red-700 dark:bg-red-950 dark:text-red-300"
+              >
+                {ws.error}
+              </div>
+            )}
             <div className="pt-2">
               <InputContainer
                 onSubmit={handleSubmit}
@@ -415,7 +435,7 @@ export function TimelineView({
                 disabled={inputDisabled}
                 isProcessing={isProcessing}
                 currentModel={currentModel}
-                onModelChange={setPickedModel}
+                onModelChange={handleModelChange}
                 currentConnection={RARA_CONNECTION_SLUG}
                 placeholder="Send a message…"
               />

--- a/web/src/components/topology/__tests__/TimelineView.history.test.tsx
+++ b/web/src/components/topology/__tests__/TimelineView.history.test.tsx
@@ -37,13 +37,17 @@ import type { TopologyEventEntry } from '@/hooks/use-topology-subscription';
 // the vendored craft `InputContainer`. We replace them with thin stubs so
 // the test exercises only the history-rendering wiring.
 
-vi.mock('@/hooks/use-chat-session-ws', () => ({
-  useChatSessionWs: () => ({
+const chatWsMock = vi.hoisted(() => ({
+  state: {
     status: 'live',
-    error: null,
-    sendPrompt: () => true,
-    sendAbort: () => true,
-  }),
+    error: null as string | null,
+    sendPrompt: vi.fn(() => true),
+    sendAbort: vi.fn(() => true),
+  },
+}));
+
+vi.mock('@/hooks/use-chat-session-ws', () => ({
+  useChatSessionWs: () => chatWsMock.state,
 }));
 
 vi.mock('@/hooks/use-chat-models', () => ({
@@ -115,6 +119,10 @@ function renderTimeline(props: {
 
 beforeEach(() => {
   listMessagesMock.mockReset();
+  chatWsMock.state.status = 'live';
+  chatWsMock.state.error = null;
+  chatWsMock.state.sendPrompt.mockClear();
+  chatWsMock.state.sendAbort.mockClear();
 });
 
 afterEach(() => {
@@ -122,6 +130,17 @@ afterEach(() => {
 });
 
 describe('TimelineView.history', () => {
+  it('session_ws_error_frame_is_rendered_near_composer', async () => {
+    listMessagesMock.mockResolvedValueOnce([]);
+    chatWsMock.state.error = 'Model "kimi-for-coding" returned an error during streaming';
+
+    renderTimeline({ viewSessionKey: 'sess-error' });
+
+    const alert = await screen.findByRole('alert');
+    expect(alert).toHaveTextContent('kimi-for-coding');
+    expect(alert).toHaveTextContent('returned an error');
+  });
+
   it('renders_history_before_live_events: shows persisted user + assistant messages on mount', async () => {
     listMessagesMock.mockResolvedValueOnce([
       makeMessage({ seq: 1, role: 'user', content: 'hello' }),


### PR DESCRIPTION
## Summary
- add `model_provider` to session websocket prompt payloads and preserve it only when the picker has a real provider
- clear stale persisted provider pins when a prompt overrides model without provider, preventing cross-provider `model`/`model_provider` mismatches
- render session websocket/backend errors near the composer so LLM failures are visible instead of looking like a hung reply

Closes #2055

## Tests
- `cargo +nightly fmt --all --check`
- `cargo test -p rara-channels session_ws_prompt_with_model_override_pins_turn_model`
- `cd web && bun run typecheck`
- `cd web && bunx vitest run src/agent/__tests__/session-ws-client.test.ts src/components/topology/__tests__/TimelineView.history.test.tsx`
- `just spec-lifecycle specs/issue-2055-chat-model-errors.spec.md`
- `cd web && bun run build`

Note: `just spec-lifecycle` exits 0 with 100% verification, but the spec linter still warns on the production example constraints for `model`/`model_provider` even though the matching scenario includes those values.