### PR TITLE
chore(web): add global left nav rail and slim top bar (#2059)

### DIFF
--- a/web/src/components/shell/NavRail.tsx
+++ b/web/src/components/shell/NavRail.tsx
@@ -23,15 +23,7 @@ import { Button } from '@/components/ui/button';
 import { useServerStatus } from '@/hooks/use-server-status';
 import { cn } from '@/lib/utils';
 
-/**
- * localStorage key for the rail's collapsed preference.
- *
- * Intentionally distinct from `rara.topology.sidebarCollapsed` — that key
- * governs the per-page sessions sidebar inside `Chat.tsx` and is a
- * user-data contract; the rail is a separate global concern. Mixing them
- * would silently force the rail and the sessions column into the same
- * collapse state on first load after upgrade.
- */
+/** localStorage key for the rail's collapsed preference; distinct from `rara.topology.sidebarCollapsed` (per-page sessions sidebar). */
 const RAIL_COLLAPSED_STORAGE_KEY = 'rara.shell.navRailCollapsed';
 
 const RAIL_WIDTH_EXPANDED = 208;

--- a/web/src/components/shell/NavRail.tsx
+++ b/web/src/components/shell/NavRail.tsx
@@ -1,0 +1,239 @@
+/*
+ * Copyright 2025 Rararulab
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { BookOpen, MessageSquare, PanelLeft, PanelLeftClose, Settings } from 'lucide-react';
+import { useEffect, useState } from 'react';
+import { NavLink } from 'react-router';
+
+import { useSettingsModal } from '@/components/settings/SettingsModalProvider';
+import { Button } from '@/components/ui/button';
+import { useServerStatus } from '@/hooks/use-server-status';
+import { cn } from '@/lib/utils';
+
+/**
+ * localStorage key for the rail's collapsed preference.
+ *
+ * Intentionally distinct from `rara.topology.sidebarCollapsed` — that key
+ * governs the per-page sessions sidebar inside `Chat.tsx` and is a
+ * user-data contract; the rail is a separate global concern. Mixing them
+ * would silently force the rail and the sessions column into the same
+ * collapse state on first load after upgrade.
+ */
+const RAIL_COLLAPSED_STORAGE_KEY = 'rara.shell.navRailCollapsed';
+
+const RAIL_WIDTH_EXPANDED = 208;
+const RAIL_WIDTH_COLLAPSED = 56;
+
+interface NavItem {
+  to: string;
+  label: string;
+  icon: React.ComponentType<{ className?: string }>;
+  /** Match nested paths (e.g. `/chat/:rootSessionKey`) under the same item. */
+  matchPrefix?: boolean;
+}
+
+const NAV_ITEMS: readonly NavItem[] = [
+  { to: '/chat', label: 'Chat', icon: MessageSquare, matchPrefix: true },
+  { to: '/docs', label: 'Docs', icon: BookOpen },
+];
+
+function readCollapsed(): boolean {
+  try {
+    return window.localStorage.getItem(RAIL_COLLAPSED_STORAGE_KEY) === 'true';
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Persistent global nav rail rendered by `DashboardLayout`.
+ *
+ * Layout — top: brand. Middle: route entries. Bottom: Settings + a
+ * single connection-status dot. The rail is collapsible; collapsed
+ * state shows icons only and persists in localStorage under
+ * `rara.shell.navRailCollapsed`.
+ */
+export default function NavRail() {
+  const { openSettings } = useSettingsModal();
+  const [collapsed, setCollapsed] = useState<boolean>(readCollapsed);
+
+  useEffect(() => {
+    try {
+      window.localStorage.setItem(RAIL_COLLAPSED_STORAGE_KEY, collapsed ? 'true' : 'false');
+    } catch {
+      // Storage may be unavailable (private browsing); the toggle still
+      // works in-memory for the rest of the session.
+    }
+  }, [collapsed]);
+
+  return (
+    <aside
+      // Width transitions only; main column has min-w-0 so it absorbs
+      // the delta without re-flowing children mid-animation.
+      className="hidden shrink-0 flex-col border-r border-border/40 bg-background/30 backdrop-blur-sm transition-[width] duration-200 ease-out md:flex"
+      style={{ width: collapsed ? RAIL_WIDTH_COLLAPSED : RAIL_WIDTH_EXPANDED }}
+      aria-label="Global navigation"
+    >
+      {/* Brand spot */}
+      <div
+        className={cn(
+          'flex h-12 shrink-0 items-center border-b border-border/40 px-3',
+          collapsed && 'justify-center px-0',
+        )}
+      >
+        {collapsed ? (
+          <div className="flex h-7 w-7 items-center justify-center rounded-md bg-foreground/90 text-[12px] font-semibold leading-none tracking-tight text-background">
+            r
+          </div>
+        ) : (
+          <span className="text-[15px] font-semibold leading-none tracking-tight text-foreground">
+            rara
+          </span>
+        )}
+      </div>
+
+      {/* Nav items */}
+      <nav className="flex flex-1 flex-col gap-0.5 overflow-y-auto p-2">
+        {NAV_ITEMS.map((item) => (
+          <RailNavLink key={item.to} item={item} collapsed={collapsed} />
+        ))}
+      </nav>
+
+      {/* Bottom strip — Settings + status dot + collapse toggle */}
+      <div
+        className={cn(
+          'flex shrink-0 flex-col gap-1 border-t border-border/40 p-2',
+          collapsed && 'items-center',
+        )}
+      >
+        <RailButton
+          icon={Settings}
+          label="Settings"
+          collapsed={collapsed}
+          onClick={() => openSettings()}
+        />
+        <div
+          className={cn(
+            'flex items-center',
+            collapsed ? 'justify-center px-1.5 py-1.5' : 'gap-2 px-2 py-1.5',
+          )}
+        >
+          <ConnectionDot />
+          {!collapsed && <ConnectionLabel />}
+        </div>
+        <Button
+          variant="ghost"
+          size="icon"
+          className={cn(
+            'h-7 w-7 self-end text-muted-foreground transition-transform hover:text-foreground active:scale-[0.96]',
+            collapsed && 'self-center',
+          )}
+          onClick={() => setCollapsed((v) => !v)}
+          aria-label={collapsed ? 'Expand navigation' : 'Collapse navigation'}
+          title={collapsed ? 'Expand navigation' : 'Collapse navigation'}
+        >
+          {collapsed ? <PanelLeft className="h-4 w-4" /> : <PanelLeftClose className="h-4 w-4" />}
+        </Button>
+      </div>
+    </aside>
+  );
+}
+
+function RailNavLink({ item, collapsed }: { item: NavItem; collapsed: boolean }) {
+  const Icon = item.icon;
+  return (
+    <NavLink
+      to={item.to}
+      end={!item.matchPrefix}
+      className={({ isActive }) =>
+        cn(
+          'group flex items-center gap-2 rounded-md px-2 py-1.5 text-sm transition-colors',
+          'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1',
+          'hover:bg-foreground/5',
+          isActive
+            ? 'bg-foreground/8 text-foreground'
+            : 'text-muted-foreground hover:text-foreground',
+          collapsed && 'justify-center px-0',
+        )
+      }
+      title={collapsed ? item.label : undefined}
+      aria-label={collapsed ? item.label : undefined}
+    >
+      <Icon className="h-4 w-4 shrink-0" />
+      {!collapsed && <span className="truncate">{item.label}</span>}
+    </NavLink>
+  );
+}
+
+function RailButton({
+  icon: Icon,
+  label,
+  collapsed,
+  onClick,
+}: {
+  icon: React.ComponentType<{ className?: string }>;
+  label: string;
+  collapsed: boolean;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={cn(
+        'group flex items-center gap-2 rounded-md px-2 py-1.5 text-sm text-muted-foreground transition-colors',
+        'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1',
+        'hover:bg-foreground/5 hover:text-foreground',
+        collapsed && 'justify-center px-0',
+      )}
+      title={collapsed ? label : undefined}
+      aria-label={collapsed ? label : undefined}
+    >
+      <Icon className="h-4 w-4 shrink-0" />
+      {!collapsed && <span className="truncate">{label}</span>}
+    </button>
+  );
+}
+
+function ConnectionDot() {
+  const { isOnline, isChecking } = useServerStatus();
+  const tooltip = isChecking ? 'Checking…' : isOnline ? 'Connected' : 'Disconnected';
+  return (
+    <span
+      className={cn(
+        'inline-block h-2 w-2 rounded-full transition-colors',
+        isChecking ? 'bg-muted-foreground/50' : isOnline ? 'bg-green-500' : 'bg-red-500',
+      )}
+      title={tooltip}
+      aria-label={`Backend: ${tooltip}`}
+      role="status"
+    />
+  );
+}
+
+function ConnectionLabel() {
+  const { isOnline, isChecking } = useServerStatus();
+  // Rail-only label — kept terse so the rail width can stay slim. The
+  // top bar no longer carries the "Connected" word per the #2059
+  // restructure; this label is the only place it survives, gated to the
+  // expanded rail.
+  if (isChecking) {
+    return <span className="text-xs text-muted-foreground/70">Checking…</span>;
+  }
+  return (
+    <span className="text-xs text-muted-foreground">{isOnline ? 'Connected' : 'Disconnected'}</span>
+  );
+}

--- a/web/src/components/shell/PageStatusContext.tsx
+++ b/web/src/components/shell/PageStatusContext.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react';
+import { createContext, useContext, useEffect, useMemo, useState } from 'react';
 
 /**
  * Coarse live-indicator state surfaced by a page to the slim top bar.
@@ -58,18 +58,13 @@ export function usePageStatus(): PageLiveStatus | null {
  */
 export function usePublishPageStatus(status: PageLiveStatus | null): void {
   const { setStatus } = useContext(PageStatusContext);
-  // Stable setter via useCallback so the effect below only fires when the
-  // status itself changes, not on every parent render.
-  const publish = useCallback(
-    (next: PageLiveStatus | null) => {
-      setStatus(next);
-    },
-    [setStatus],
-  );
+  // `setStatus` is React's `useState` setter — already referentially
+  // stable across renders — so the effect re-runs only when `status`
+  // actually changes.
   useEffect(() => {
-    publish(status);
+    setStatus(status);
     return () => {
-      publish(null);
+      setStatus(null);
     };
-  }, [publish, status]);
+  }, [setStatus, status]);
 }

--- a/web/src/components/shell/PageStatusContext.tsx
+++ b/web/src/components/shell/PageStatusContext.tsx
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2025 Rararulab
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react';
+
+/**
+ * Coarse live-indicator state surfaced by a page to the slim top bar.
+ *
+ * `null` = no indicator (route doesn't show one, or the page isn't
+ * actively subscribed). Pages that own a long-lived subscription (today
+ * only `Chat.tsx`) publish their state here so the layout can render a
+ * single "live" pill without re-opening the WebSocket — re-subscribing
+ * from the layout would double the WS load and could race with the
+ * page's own reconnect logic.
+ */
+export type PageLiveStatus = 'idle' | 'connecting' | 'live' | 'reconnecting' | 'closed';
+
+interface PageStatusContextValue {
+  status: PageLiveStatus | null;
+  setStatus: (next: PageLiveStatus | null) => void;
+}
+
+const PageStatusContext = createContext<PageStatusContextValue>({
+  status: null,
+  setStatus: () => {},
+});
+
+/** Provider mounted near the layout root so any descendant page can publish. */
+export function PageStatusProvider({ children }: { children: React.ReactNode }) {
+  const [status, setStatus] = useState<PageLiveStatus | null>(null);
+  const value = useMemo<PageStatusContextValue>(() => ({ status, setStatus }), [status]);
+  return <PageStatusContext.Provider value={value}>{children}</PageStatusContext.Provider>;
+}
+
+/** Read-only access for the layout / top bar. */
+export function usePageStatus(): PageLiveStatus | null {
+  return useContext(PageStatusContext).status;
+}
+
+/**
+ * Page-side hook: publish a live status while mounted, clear on unmount.
+ *
+ * Pass `null` when the page knows it has no session to report on so the
+ * top bar collapses the indicator instead of showing a stale value.
+ */
+export function usePublishPageStatus(status: PageLiveStatus | null): void {
+  const { setStatus } = useContext(PageStatusContext);
+  // Stable setter via useCallback so the effect below only fires when the
+  // status itself changes, not on every parent render.
+  const publish = useCallback(
+    (next: PageLiveStatus | null) => {
+      setStatus(next);
+    },
+    [setStatus],
+  );
+  useEffect(() => {
+    publish(status);
+    return () => {
+      publish(null);
+    };
+  }, [publish, status]);
+}

--- a/web/src/components/topology/SessionPicker.tsx
+++ b/web/src/components/topology/SessionPicker.tsx
@@ -15,7 +15,7 @@
  */
 
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import { Archive, ArchiveRestore, EyeOff, Plus, RefreshCw } from 'lucide-react';
+import { Archive, ArchiveRestore, EyeOff, PanelLeftClose, Plus, RefreshCw } from 'lucide-react';
 import { useCallback, useEffect, useState } from 'react';
 
 import { api } from '@/api/client';
@@ -77,6 +77,13 @@ export interface SessionPickerProps {
    * uses this to auto-redirect `/topology` → `/topology/{key}`.
    */
   onAutoSelect?: (key: string) => void;
+  /**
+   * Optional collapse handler. When provided, the action row renders an
+   * extra icon button that hides the entire sessions sidebar. Lives in
+   * the picker (not the page) so it shares the action row's geometry —
+   * a floating overlay button used to overlap the `+` action button.
+   */
+  onCollapse?: () => void;
 }
 
 /**
@@ -90,7 +97,12 @@ export interface SessionPickerProps {
  * archive / unarchive button (disabled on the active session so the
  * post-archive "what now?" question never surfaces).
  */
-export function SessionPicker({ activeSessionKey, onSelect, onAutoSelect }: SessionPickerProps) {
+export function SessionPicker({
+  activeSessionKey,
+  onSelect,
+  onAutoSelect,
+  onCollapse,
+}: SessionPickerProps) {
   const queryClient = useQueryClient();
   const [showArchived, setShowArchived] = useState<boolean>(readShowArchived);
 
@@ -200,6 +212,18 @@ export function SessionPicker({ activeSessionKey, onSelect, onAutoSelect }: Sess
           >
             <Plus className="h-3.5 w-3.5" />
           </Button>
+          {onCollapse && (
+            <Button
+              size="icon"
+              variant="ghost"
+              className="h-6 w-6 transition-transform active:scale-[0.96]"
+              title="Hide sessions"
+              aria-label="Hide sessions"
+              onClick={onCollapse}
+            >
+              <PanelLeftClose className="h-3.5 w-3.5" />
+            </Button>
+          )}
         </div>
       </div>
 

--- a/web/src/layouts/DashboardLayout.tsx
+++ b/web/src/layouts/DashboardLayout.tsx
@@ -15,16 +15,18 @@
  */
 
 import { useQuery } from '@tanstack/react-query';
-import { MessageSquare, Settings } from 'lucide-react';
-import { useState } from 'react';
-import { Outlet, useLocation, useNavigate } from 'react-router';
+import { useMemo, useState } from 'react';
+import { Outlet, useLocation } from 'react-router';
 
 import { settingsApi } from '@/api/client';
 import OnboardingModal, { isOnboardingDismissed } from '@/components/OnboardingModal';
-import { useSettingsModal } from '@/components/settings/SettingsModalProvider';
+import NavRail from '@/components/shell/NavRail';
+import {
+  PageStatusProvider,
+  usePageStatus,
+  type PageLiveStatus,
+} from '@/components/shell/PageStatusContext';
 import ThemeToggle from '@/components/ThemeToggle';
-import { Button } from '@/components/ui/button';
-import { useServerStatus } from '@/hooks/use-server-status';
 import { cn } from '@/lib/utils';
 
 /** Routes that need zero padding in the main content area. */
@@ -42,6 +44,35 @@ const SETTINGS_KEYS = {
   ollamaBaseUrl: 'llm.providers.ollama.base_url',
   codexEnabled: 'llm.providers.codex.enabled',
 } as const;
+
+/**
+ * Per-route metadata consumed by the slim top bar. Keyed by pathname
+ * pattern; the longest-matching prefix wins. Kept as a lookup table
+ * rather than `<Route handle>` because the app still uses the legacy
+ * `BrowserRouter` (not the data router required by `useMatches()`),
+ * and a one-table indirection is smaller than the migration.
+ */
+interface RouteHandle {
+  title: string;
+  showLiveIndicator?: boolean;
+}
+
+const ROUTE_HANDLES: ReadonlyArray<{ test: (path: string) => boolean; handle: RouteHandle }> = [
+  // Order matters: first match wins. `/chat` covers `/chat`, `/chat/:key`,
+  // and the index route (`/`) which renders `<Chat />`.
+  {
+    test: (p) => p === '/' || p === '/chat' || p.startsWith('/chat/'),
+    handle: { title: 'Chat', showLiveIndicator: true },
+  },
+  { test: (p) => p === '/docs' || p.startsWith('/docs/'), handle: { title: 'Documentation' } },
+];
+
+function resolveHandle(pathname: string): RouteHandle | null {
+  for (const entry of ROUTE_HANDLES) {
+    if (entry.test(pathname)) return entry.handle;
+  }
+  return null;
+}
 
 function hasConfiguredLlmProvider(settings: Record<string, string> | undefined): boolean {
   if (!settings) {
@@ -72,22 +103,68 @@ function hasConfiguredLlmProvider(settings: Record<string, string> | undefined):
   }
 }
 
-/** Small dot + label showing live backend connectivity. */
-function ConnectionStatus() {
-  const { isOnline, isChecking } = useServerStatus();
-  if (isChecking) return null;
+/**
+ * Tiny live-state pill rendered next to the page title in the top bar
+ * when the current route opts in via `handle.showLiveIndicator`. Reads
+ * the page-published status (see `PageStatusContext`) — never opens its
+ * own subscription, because the page already owns one.
+ */
+function LiveIndicator({ status }: { status: PageLiveStatus | null }) {
+  if (!status) return null;
+
+  const variants: Record<PageLiveStatus, { dot: string; text: string; label: string }> = {
+    idle: { dot: 'bg-muted-foreground/50', text: 'text-muted-foreground', label: 'idle' },
+    connecting: {
+      dot: 'bg-amber-500 animate-pulse',
+      text: 'text-amber-600 dark:text-amber-400',
+      label: 'connecting',
+    },
+    live: {
+      dot: 'bg-emerald-500',
+      text: 'text-emerald-600 dark:text-emerald-400',
+      label: 'live',
+    },
+    reconnecting: {
+      dot: 'bg-amber-500 animate-pulse',
+      text: 'text-amber-600 dark:text-amber-400',
+      label: 'reconnecting',
+    },
+    closed: { dot: 'bg-red-500', text: 'text-red-600 dark:text-red-400', label: 'closed' },
+  };
+  const v = variants[status];
   return (
-    <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
-      <div className={cn('h-2 w-2 rounded-full', isOnline ? 'bg-green-500' : 'bg-red-500')} />
-      <span>{isOnline ? 'Connected' : 'Disconnected'}</span>
+    <span className={cn('inline-flex items-center gap-1.5 text-[11px]', v.text)}>
+      <span className={cn('h-1.5 w-1.5 rounded-full', v.dot)} />
+      {v.label}
+    </span>
+  );
+}
+
+/** Slim top bar — page title (left) + theme toggle (right). */
+function TopBar() {
+  const { pathname } = useLocation();
+  const status = usePageStatus();
+  const handle = useMemo(() => resolveHandle(pathname), [pathname]);
+
+  return (
+    <div className="flex h-10 shrink-0 items-center justify-between gap-2 border-b border-border/40 bg-background/30 px-4 backdrop-blur-sm">
+      <div className="flex min-w-0 items-center gap-2">
+        {handle?.title && (
+          <h1 className="truncate text-sm font-medium text-foreground [text-wrap:balance]">
+            {handle.title}
+          </h1>
+        )}
+        {handle?.showLiveIndicator && <LiveIndicator status={status} />}
+      </div>
+      <div className="flex items-center">
+        <ThemeToggle />
+      </div>
     </div>
   );
 }
 
 export default function DashboardLayout() {
   const location = useLocation();
-  const navigate = useNavigate();
-  const { openSettings } = useSettingsModal();
   const isFullBleed =
     FULL_BLEED_ROUTES.has(location.pathname) ||
     FULL_BLEED_PREFIXES.some((p) => location.pathname.startsWith(p));
@@ -107,50 +184,31 @@ export default function DashboardLayout() {
   };
 
   return (
-    <div className="rara-admin flex h-screen bg-transparent">
-      {shouldShowOnboarding && (
-        <OnboardingModal
-          open={onboardingOpen}
-          onDismiss={handleOnboardingDismiss}
-          showLlmProviderPrompt={!hasConfiguredLlmProvider(settingsQuery.data)}
-        />
-      )}
-
-      <main
-        className={cn(
-          'relative flex min-w-0 flex-1 flex-col',
-          isFullBleed ? 'overflow-hidden' : 'overflow-auto',
+    <PageStatusProvider>
+      <div className="rara-admin flex h-screen bg-transparent">
+        {shouldShowOnboarding && (
+          <OnboardingModal
+            open={onboardingOpen}
+            onDismiss={handleOnboardingDismiss}
+            showLlmProviderPrompt={!hasConfiguredLlmProvider(settingsQuery.data)}
+          />
         )}
-      >
-        {/* Top bar */}
-        <div className="flex shrink-0 items-center justify-end gap-2 border-b border-border/40 bg-background/30 px-4 py-1.5 backdrop-blur-sm">
-          <ConnectionStatus />
-          <div className="mx-1 h-4 w-px bg-border/60" />
-          <Button
-            variant="ghost"
-            size="sm"
-            className="h-7 gap-1.5 text-xs text-muted-foreground transition-transform hover:text-foreground active:scale-[0.96]"
-            onClick={() => navigate('/chat')}
-          >
-            <MessageSquare className="h-3.5 w-3.5" />
-            Chat
-          </Button>
-          <Button
-            variant="ghost"
-            size="sm"
-            className="h-7 gap-1.5 text-xs text-muted-foreground transition-transform hover:text-foreground active:scale-[0.96]"
-            onClick={() => openSettings()}
-          >
-            <Settings className="h-3.5 w-3.5" />
-            Settings
-          </Button>
-          <ThemeToggle />
-        </div>
 
-        <div className={cn('flex-1 min-h-0', isFullBleed ? 'p-2 md:p-3' : 'p-4 md:p-6')}>
-          <Outlet />
-        </div>
-      </main>
-    </div>
+        <NavRail />
+
+        <main
+          className={cn(
+            'relative flex min-w-0 flex-1 flex-col',
+            isFullBleed ? 'overflow-hidden' : 'overflow-auto',
+          )}
+        >
+          <TopBar />
+
+          <div className={cn('flex-1 min-h-0', isFullBleed ? 'p-2 md:p-3' : 'p-4 md:p-6')}>
+            <Outlet />
+          </div>
+        </main>
+      </div>
+    </PageStatusProvider>
   );
 }

--- a/web/src/layouts/DashboardLayout.tsx
+++ b/web/src/layouts/DashboardLayout.tsx
@@ -46,11 +46,16 @@ const SETTINGS_KEYS = {
 } as const;
 
 /**
- * Per-route metadata consumed by the slim top bar. Keyed by pathname
- * pattern; the longest-matching prefix wins. Kept as a lookup table
- * rather than `<Route handle>` because the app still uses the legacy
- * `BrowserRouter` (not the data router required by `useMatches()`),
- * and a one-table indirection is smaller than the migration.
+ * Per-route metadata consumed by the slim top bar. Iterated in
+ * declaration order; the first matching predicate wins, so list more
+ * specific patterns before broader ones.
+ *
+ * Kept as a lookup table rather than `<Route handle>` + `useMatches()`
+ * because the app still mounts a plain `BrowserRouter` from
+ * `react-router` (see `App.tsx`). `useMatches()` is a data-router
+ * primitive — calling it under `BrowserRouter` throws — and a small
+ * pathname → handle table is smaller than migrating the whole router
+ * topology to `createBrowserRouter` for a top-bar title.
  */
 interface RouteHandle {
   title: string;
@@ -58,13 +63,21 @@ interface RouteHandle {
 }
 
 const ROUTE_HANDLES: ReadonlyArray<{ test: (path: string) => boolean; handle: RouteHandle }> = [
-  // Order matters: first match wins. `/chat` covers `/chat`, `/chat/:key`,
-  // and the index route (`/`) which renders `<Chat />`.
+  // First match wins; declaration order matters. The list MUST cover
+  // every layout-mounted route in `App.tsx` — there is no fallback
+  // entry, so a missed route renders an empty top-bar title. Keep this
+  // list aligned with the `<Route>` children of `<DashboardLayout />`.
+  //
+  // `/chat` covers `/chat`, `/chat/:rootSessionKey`, and the index
+  // route (`/`) which also renders `<Chat />`.
   {
     test: (p) => p === '/' || p === '/chat' || p.startsWith('/chat/'),
     handle: { title: 'Chat', showLiveIndicator: true },
   },
   { test: (p) => p === '/docs' || p.startsWith('/docs/'), handle: { title: 'Documentation' } },
+  // `/topology` and `/topology/:key` are pure redirects to `/chat` (see
+  // `App.tsx`); they never render under this layout, so they
+  // deliberately have no entry here.
 ];
 
 function resolveHandle(pathname: string): RouteHandle | null {

--- a/web/src/pages/AGENT.md
+++ b/web/src/pages/AGENT.md
@@ -24,8 +24,16 @@ single route under `DashboardLayout`.
 - The index route MUST resolve to a real component, not a redirect — the
   router treats `index` as a sibling of named routes, and a `Navigate`
   inside the layout would re-mount on every navigation.
-- Pages are layout consumers. They MUST NOT render their own top-bar /
-  sidebar; that work belongs to `DashboardLayout`.
+- Pages are layout consumers. They MUST NOT render their own top-bar or
+  global nav rail; that work belongs to `DashboardLayout` and
+  `@/components/shell/NavRail`. The page title is surfaced to the slim
+  top bar via the route's `handle: { title, showLiveIndicator? }`
+  metadata read by `DashboardLayout` through `useMatches()` (#2059); a
+  page that owns a long-lived subscription publishes its live state via
+  `usePublishPageStatus` (see `@/components/shell/PageStatusContext`)
+  instead of opening a second WebSocket from the layout. Per-page
+  internal columns (e.g. `Chat.tsx`'s sessions sidebar) are still the
+  page's own concern — the rule only forbids re-rendering app chrome.
 
 ## What NOT To Do
 

--- a/web/src/pages/AGENT.md
+++ b/web/src/pages/AGENT.md
@@ -27,9 +27,13 @@ single route under `DashboardLayout`.
 - Pages are layout consumers. They MUST NOT render their own top-bar or
   global nav rail; that work belongs to `DashboardLayout` and
   `@/components/shell/NavRail`. The page title is surfaced to the slim
-  top bar via the route's `handle: { title, showLiveIndicator? }`
-  metadata read by `DashboardLayout` through `useMatches()` (#2059); a
-  page that owns a long-lived subscription publishes its live state via
+  top bar via the `ROUTE_HANDLES` pathname → `{ title,
+showLiveIndicator? }` lookup table in `DashboardLayout.tsx` (#2059) —
+  add a new entry there when you mount a new top-level route. The table
+  is used in place of `<Route handle>` + `useMatches()` because
+  `App.tsx` still mounts a plain `BrowserRouter`, and `useMatches()`
+  only works under the data router (`createBrowserRouter`). A page that
+  owns a long-lived subscription publishes its live state via
   `usePublishPageStatus` (see `@/components/shell/PageStatusContext`)
   instead of opening a second WebSocket from the layout. Per-page
   internal columns (e.g. `Chat.tsx`'s sessions sidebar) are still the

--- a/web/src/pages/Chat.tsx
+++ b/web/src/pages/Chat.tsx
@@ -15,19 +15,19 @@
  */
 
 import { useQuery } from '@tanstack/react-query';
-import { ArrowLeft, Network, PanelLeft, PanelLeftClose } from 'lucide-react';
+import { ArrowLeft, PanelLeft, PanelLeftClose } from 'lucide-react';
 import { AnimatePresence, motion } from 'motion/react';
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useNavigate, useParams } from 'react-router';
 
 import { api } from '@/api/client';
 import { fetchSessionMessagesBetweenAnchors } from '@/api/sessions';
 import type { ChatMessageData, ChatSession, SessionAnchor } from '@/api/types';
+import { usePublishPageStatus, type PageLiveStatus } from '@/components/shell/PageStatusContext';
 import { SessionAnchorMinimap } from '@/components/topology/SessionAnchorMinimap';
 import { SessionPicker } from '@/components/topology/SessionPicker';
 import { TimelineView } from '@/components/topology/TimelineView';
 import { WorkerInbox } from '@/components/topology/WorkerInbox';
-import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { useTopologySubscription, type TopologyStatus } from '@/hooks/use-topology-subscription';
 
@@ -103,6 +103,16 @@ export default function Chat() {
 
   const subscription = useTopologySubscription(rootSessionKey ?? null);
 
+  // Publish the WS status up to the slim top bar so the layout can show
+  // the live pill without re-subscribing. `null` while no session is
+  // selected — the indicator is not meaningful before a connection is
+  // even attempted.
+  const publishedStatus = useMemo<PageLiveStatus | null>(() => {
+    if (!rootSessionKey) return null;
+    return mapTopologyStatusToPageStatus(subscription.status);
+  }, [rootSessionKey, subscription.status]);
+  usePublishPageStatus(publishedStatus);
+
   // Currently-selected anchor segment (issue #2040). `null` means "no
   // chapter selected" → `TimelineView` falls back to its own
   // `useSessionHistory` fetch (the legacy "last 200" path).
@@ -168,73 +178,6 @@ export default function Chat() {
 
   return (
     <div className="flex h-full min-h-0 flex-col">
-      <header className="flex items-center gap-3 border-b border-border px-3 py-2">
-        {/*
-         * Wrap the chevron in a 40x40 hit-area target (principle #16).
-         * The inner Button stays visually 28x28 so the header doesn't
-         * grow; the surrounding flex centers it inside the larger click
-         * region.
-         */}
-        <span className="-my-1.5 -ml-1 flex h-10 w-10 items-center justify-center">
-          <Button
-            size="icon"
-            variant="ghost"
-            className="h-7 w-7 transition-transform active:scale-[0.96]"
-            aria-label={sidebarCollapsed ? 'Show sidebar' : 'Hide sidebar'}
-            title={sidebarCollapsed ? 'Show sidebar' : 'Hide sidebar'}
-            onClick={() => setSidebarCollapsed((v) => !v)}
-          >
-            {/*
-             * Cross-fade the panel-left / panel-left-close glyph instead
-             * of hard-swapping (principle #7). `mode="wait"` keeps a
-             * single icon mounted at a time so the absolute-position
-             * trick is unnecessary, and `initial={false}` skips the
-             * first-render animation per principle #13.
-             */}
-            <AnimatePresence initial={false} mode="wait">
-              {sidebarCollapsed ? (
-                <motion.span
-                  key="open"
-                  initial={{ opacity: 0, scale: 0.25, filter: 'blur(4px)' }}
-                  animate={{ opacity: 1, scale: 1, filter: 'blur(0px)' }}
-                  exit={{ opacity: 0, scale: 0.25, filter: 'blur(4px)' }}
-                  transition={SPRING}
-                  className="flex"
-                >
-                  <PanelLeft className="h-4 w-4" />
-                </motion.span>
-              ) : (
-                <motion.span
-                  key="close"
-                  initial={{ opacity: 0, scale: 0.25, filter: 'blur(4px)' }}
-                  animate={{ opacity: 1, scale: 1, filter: 'blur(0px)' }}
-                  exit={{ opacity: 0, scale: 0.25, filter: 'blur(4px)' }}
-                  transition={SPRING}
-                  className="flex"
-                >
-                  <PanelLeftClose className="h-4 w-4" />
-                </motion.span>
-              )}
-            </AnimatePresence>
-          </Button>
-        </span>
-        <Network className="h-4 w-4 text-muted-foreground" />
-        {/*
-         * `text-wrap: balance` per principle #10 — even on a one-word
-         * title it costs nothing and keeps any future i18n balanced.
-         */}
-        <h1 className="text-sm font-medium [text-wrap:balance]">Chat</h1>
-        <div className="ml-auto">
-          {rootSessionKey ? (
-            <StatusPill status={subscription.status} />
-          ) : (
-            <Badge variant="outline" className="text-[10px]">
-              no session
-            </Badge>
-          )}
-        </div>
-      </header>
-
       <div className="flex flex-1 min-h-0">
         {/*
          * Sidebar collapse uses a spring on `width` (interruptible per
@@ -251,7 +194,24 @@ export default function Chat() {
               transition={SPRING}
               className="hidden shrink-0 overflow-hidden border-r border-border md:block"
             >
-              <div className="w-[280px]">
+              <div className="relative h-full w-[280px]">
+                {/*
+                 * Per-page sessions-column collapse affordance. Floats
+                 * over the picker's own header (no extra row of chrome
+                 * stacked on top). The toggle used to live in the
+                 * page-level chrome before #2059 moved app chrome into
+                 * the global rail.
+                 */}
+                <Button
+                  size="icon"
+                  variant="ghost"
+                  className="absolute right-1.5 top-1.5 z-10 h-7 w-7 text-muted-foreground transition-transform hover:text-foreground active:scale-[0.96]"
+                  aria-label="Hide sessions"
+                  title="Hide sessions"
+                  onClick={() => setSidebarCollapsed(true)}
+                >
+                  <PanelLeftClose className="h-4 w-4" />
+                </Button>
                 <SessionPicker
                   activeSessionKey={rootSessionKey ?? null}
                   onSelect={selectSession}
@@ -272,6 +232,20 @@ export default function Chat() {
           transition={{ ...SPRING, delay: 0.1 }}
           className="flex flex-1 min-w-0 min-h-0 flex-col p-3"
         >
+          {sidebarCollapsed && (
+            <div className="mb-2 hidden md:flex">
+              <Button
+                size="icon"
+                variant="ghost"
+                className="h-7 w-7 transition-transform active:scale-[0.96]"
+                aria-label="Show sessions"
+                title="Show sessions"
+                onClick={() => setSidebarCollapsed(false)}
+              >
+                <PanelLeft className="h-4 w-4" />
+              </Button>
+            </div>
+          )}
           {rootSessionKey ? (
             <div className="flex flex-1 min-h-0 flex-col gap-2">
               {viewChild && (
@@ -341,42 +315,24 @@ export default function Chat() {
   );
 }
 
-function StatusPill({ status }: { status: TopologyStatus }) {
+/**
+ * Map the per-session WS status to the coarse `PageLiveStatus` consumed
+ * by the slim top bar. The granular `attempt` / `delayMs` info on
+ * `reconnecting` and the `reason` on `closed` are intentionally dropped —
+ * the layout-level pill only carries a single-word state (#2059); pages
+ * that need the detail can render their own badge inline.
+ */
+function mapTopologyStatusToPageStatus(status: TopologyStatus): PageLiveStatus {
   switch (status.kind) {
     case 'idle':
-      return (
-        <Badge variant="outline" className="text-[10px]">
-          idle
-        </Badge>
-      );
+      return 'idle';
     case 'connecting':
-      return (
-        <Badge variant="outline" className="text-[10px]">
-          connecting…
-        </Badge>
-      );
+      return 'connecting';
     case 'open':
-      return (
-        <Badge
-          variant="outline"
-          className="border-emerald-500/40 text-[10px] text-emerald-600 dark:text-emerald-400"
-        >
-          live
-        </Badge>
-      );
+      return 'live';
     case 'reconnecting':
-      // Tabular-nums on the attempt counter + delay (#9) so the badge
-      // doesn't shimmy as the numerals tick up.
-      return (
-        <Badge variant="outline" className="text-[10px] tabular-nums">
-          reconnect #{status.attempt} ({Math.round(status.delayMs / 1000)}s)
-        </Badge>
-      );
+      return 'reconnecting';
     case 'closed':
-      return (
-        <Badge variant="destructive" className="text-[10px]">
-          closed: {status.reason.replace(/_/g, ' ')}
-        </Badge>
-      );
+      return 'closed';
   }
 }

--- a/web/src/pages/Chat.tsx
+++ b/web/src/pages/Chat.tsx
@@ -15,7 +15,7 @@
  */
 
 import { useQuery } from '@tanstack/react-query';
-import { ArrowLeft, PanelLeft, PanelLeftClose } from 'lucide-react';
+import { ArrowLeft, PanelLeft } from 'lucide-react';
 import { AnimatePresence, motion } from 'motion/react';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useNavigate, useParams } from 'react-router';
@@ -194,28 +194,19 @@ export default function Chat() {
               transition={SPRING}
               className="hidden shrink-0 overflow-hidden border-r border-border md:block"
             >
-              <div className="relative h-full w-[280px]">
+              <div className="h-full w-[280px]">
                 {/*
-                 * Per-page sessions-column collapse affordance. Floats
-                 * over the picker's own header (no extra row of chrome
-                 * stacked on top). The toggle used to live in the
-                 * page-level chrome before #2059 moved app chrome into
-                 * the global rail.
+                 * The sessions-column collapse affordance lives inside
+                 * the picker's action row (`onCollapse`) so it shares
+                 * geometry with the picker's other actions. A floating
+                 * overlay button used to overlap the `+` button — see
+                 * the #2059 follow-up review.
                  */}
-                <Button
-                  size="icon"
-                  variant="ghost"
-                  className="absolute right-1.5 top-1.5 z-10 h-7 w-7 text-muted-foreground transition-transform hover:text-foreground active:scale-[0.96]"
-                  aria-label="Hide sessions"
-                  title="Hide sessions"
-                  onClick={() => setSidebarCollapsed(true)}
-                >
-                  <PanelLeftClose className="h-4 w-4" />
-                </Button>
                 <SessionPicker
                   activeSessionKey={rootSessionKey ?? null}
                   onSelect={selectSession}
                   onAutoSelect={selectSession}
+                  onCollapse={() => setSidebarCollapsed(true)}
                 />
               </div>
             </motion.aside>

--- a/web/src/pages/__tests__/Chat.test.tsx
+++ b/web/src/pages/__tests__/Chat.test.tsx
@@ -73,8 +73,22 @@ import Chat from '../Chat';
 // thin markers so the assertions can target the picker's presence in
 // the DOM without spinning up react-query, the WS, or the editor.
 
+// The real `SessionPicker` exposes its sidebar-collapse affordance via the
+// `onCollapse` prop (issue-2059 moved the collapse button into the picker's
+// action row). The stub forwards that callback as a button so the layout
+// tests below can simulate the user collapsing the sidebar without
+// pulling in the picker's full DOM.
 vi.mock('@/components/topology/SessionPicker', () => ({
-  SessionPicker: () => <div data-testid="session-picker">picker</div>,
+  SessionPicker: ({ onCollapse }: { onCollapse?: () => void }) => (
+    <div data-testid="session-picker">
+      picker
+      {onCollapse && (
+        <button type="button" aria-label="Hide sidebar" onClick={onCollapse}>
+          Hide sidebar
+        </button>
+      )}
+    </div>
+  ),
 }));
 
 vi.mock('@/components/topology/TimelineView', () => ({
@@ -151,7 +165,7 @@ describe('Chat — collapsible sidebar (issue-2022)', () => {
     // animation a tick to complete before asserting absence.
     await waitForElementToBeRemoved(() => screen.queryByTestId('session-picker'));
     // Toggle button now reflects the collapsed state.
-    expect(screen.getByRole('button', { name: 'Show sidebar' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Show sessions' })).toBeInTheDocument();
   });
 
   it('toggle_restores_session_picker', () => {
@@ -161,7 +175,7 @@ describe('Chat — collapsible sidebar (issue-2022)', () => {
 
     expect(screen.queryByTestId('session-picker')).not.toBeInTheDocument();
 
-    fireEvent.click(screen.getByRole('button', { name: 'Show sidebar' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Show sessions' }));
 
     expect(screen.getByTestId('session-picker')).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Hide sidebar' })).toBeInTheDocument();
@@ -181,7 +195,7 @@ describe('Chat — collapsible sidebar (issue-2022)', () => {
     render(<Chat />);
 
     expect(screen.queryByTestId('session-picker')).not.toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Show sidebar' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Show sessions' })).toBeInTheDocument();
   });
 
   it('default_state_is_expanded', () => {


### PR DESCRIPTION
## Summary

- Replace the double-decker header (global top bar + Chat-page sub-header) with a craft-style global left rail + a single slim top bar.
- New `NavRail` (collapsible, persisted under new `rara.shell.navRailCollapsed` key): brand at top, Chat + Docs nav with active-route highlight, Settings entry + connection-status dot pinned to the bottom.
- Slim top bar: `[page title + live indicator on /chat] … [theme toggle]`. No more "Connected" text, no more Chat/Settings buttons in the bar.
- Chat-page sub-header (`Chat.tsx` ~lines 167–236) removed; title + live indicator surfaced via `PageStatusContext` (page is the WS owner, layout is a passive consumer — single subscription).
- Sessions-column collapse toggle moved into `SessionPicker`'s existing action row (4th icon) via a new optional `onCollapse` prop.

Refs `vendor/header.png` (before) and `vendor/craft.png` (target).

Closes #2059

## Test plan

- [x] `bun run build` clean
- [x] ESLint clean
- [x] Local dev: rail expanded / collapsed, /chat top bar with live pill, /docs top bar (no live pill), Settings modal opens from rail, theme toggle works, connection dot reflects status
- [x] localStorage keys verified separate: `rara.shell.navRailCollapsed` (rail) vs `rara.topology.sidebarCollapsed` (per-page sessions sidebar)
- [x] No double WS subscription (`useTopologySubscription` mounted exactly once in `Chat.tsx`)
- [x] Reviewer APPROVE