### PR TITLE
chore(deps): bump diesel-async and pyroscope (#2065)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -158,7 +158,7 @@ crossbeam-queue = "0.3"
 crossterm = "0.28"
 derive_more = { version = "2.0", features = ["full"] }
 diesel = { version = "2.3", features = ["sqlite", "chrono", "uuid", "serde_json", "r2d2", "returning_clauses_for_sqlite_3_35"] }
-diesel-async = { version = "0.8", features = ["sqlite", "bb8"] }
+diesel-async = { version = "0.9", features = ["sqlite", "bb8"] }
 diesel_migrations = { version = "2.3", features = ["sqlite"] }
 dirs = "^6"
 eventsource-stream = "0.2"
@@ -190,8 +190,7 @@ opendal = { version = "0.52", features = ["services-fs", "services-memory"] }
 parking_lot = "0.12"
 prost = "^0.14"
 protobuf = "^3.7"
-pyroscope = "0.5"
-pyroscope_pprofrs = "0.2"
+pyroscope = "2.0"
 rand = "0.10"
 rapidfuzz = "0.5"
 ratatui = { version = "0.29", features = ["crossterm"] }

--- a/crates/common/telemetry/AGENT.md
+++ b/crates/common/telemetry/AGENT.md
@@ -42,6 +42,6 @@ Telemetry utilities — logging initialization, tracing subscriber setup (with o
 
 ## Dependencies
 
-**Upstream:** `tracing`, `tracing-subscriber`, `tracing-appender`, `opentelemetry` (optional OTLP), `pyroscope` + `pyroscope_pprofrs` (continuous profiling).
+**Upstream:** `tracing`, `tracing-subscriber`, `tracing-appender`, `opentelemetry` (optional OTLP), `pyroscope` with the `backend-pprof-rs` feature (continuous profiling — the pprof backend ships in-tree as of `pyroscope` 2.0, so the standalone `pyroscope_pprofrs` crate is no longer used).
 
 **Downstream:** `crates/cmd` (initializes logging at startup).

--- a/crates/common/telemetry/Cargo.toml
+++ b/crates/common/telemetry/Cargo.toml
@@ -26,8 +26,7 @@ opentelemetry-appender-tracing = { version = "0.31.0" }
 opentelemetry-otlp = { version = "0.31.0", features = ["trace", "metrics", "logs", "grpc-tonic", "http-proto", "reqwest-blocking-client"] }
 opentelemetry-semantic-conventions = { version = "0.31.0", features = ["semconv_experimental"] }
 opentelemetry_sdk = { version = "0.31.0", features = ["rt-tokio", "trace", "metrics", "logs"] }
-pyroscope = { workspace = true }
-pyroscope_pprofrs = { workspace = true }
+pyroscope = { workspace = true, features = ["backend-pprof-rs"] }
 # Pinned to 0.12 to match opentelemetry-http 0.31's reqwest dep — the
 # `HttpClient` trait impl is only visible for the version that crate links
 # against. Workspace reqwest is 0.13.

--- a/crates/common/telemetry/src/profiling.rs
+++ b/crates/common/telemetry/src/profiling.rs
@@ -31,8 +31,11 @@
 //! stalls or tokio mutex contention — for those, use `tokio-console`
 //! (separate feature flag, tracked as a future chore).
 
-use pyroscope::{PyroscopeAgent, pyroscope::PyroscopeAgentRunning};
-use pyroscope_pprofrs::{PprofConfig, pprof_backend};
+use pyroscope::{
+    PyroscopeAgent,
+    backend::{BackendConfig, PprofConfig, pprof_backend},
+    pyroscope::{PyroscopeAgentBuilder, PyroscopeAgentRunning},
+};
 use serde::{Deserialize, Serialize};
 use snafu::{ResultExt, Snafu};
 
@@ -121,17 +124,33 @@ pub fn init_pyroscope(
         return Ok(None);
     }
 
-    let pprof = PprofConfig::new().sample_rate(cfg.sample_rate);
+    let pprof = PprofConfig {
+        sample_rate: cfg.sample_rate,
+    };
     // `tags` is a Vec<(&str, &str)>, so build owned strings up-front and
     // borrow into the call. Pyroscope copies them internally.
     let tags: Vec<(&str, &str)> =
         vec![("env", env), ("host", host), ("build_commit", build_commit)];
 
-    let agent = PyroscopeAgent::builder(&cfg.endpoint, &cfg.application_name)
-        .backend(pprof_backend(pprof))
-        .tags(tags)
-        .build()
-        .context(BuildAgentSnafu)?;
+    // pyroscope 2.0 absorbed the pprof-rs backend behind the
+    // `backend-pprof-rs` feature (the standalone `pyroscope_pprofrs`
+    // crate is dead — last published against pyroscope 0.5.7). It also
+    // dropped the `PyroscopeAgent::builder` shortcut, so we go through
+    // `PyroscopeAgentBuilder::new` and supply sample_rate + spy
+    // identity (name + version) up-front. We report ourselves as
+    // `pyroscope-rs` (the canonical Rust spy name) at our crate version
+    // so the server can disambiguate uploads.
+    let agent: PyroscopeAgent<_> = PyroscopeAgentBuilder::new(
+        &cfg.endpoint,
+        &cfg.application_name,
+        cfg.sample_rate,
+        "pyroscope-rs",
+        env!("CARGO_PKG_VERSION"),
+        pprof_backend(pprof, BackendConfig::default()),
+    )
+    .tags(tags)
+    .build()
+    .context(BuildAgentSnafu)?;
 
     let running = agent.start().context(StartAgentSnafu)?;
     tracing::info!(

--- a/crates/common/telemetry/src/profiling.rs
+++ b/crates/common/telemetry/src/profiling.rs
@@ -14,9 +14,10 @@
 
 //! Continuous CPU profiling via [Pyroscope](https://github.com/grafana/pyroscope).
 //!
-//! Wraps `pyroscope` + `pyroscope_pprofrs` so the `rara-cli` bootstrap can
-//! turn profiling on/off from YAML config without dragging the underlying
-//! crates into every binary.
+//! Wraps the `pyroscope` crate (with its `backend-pprof-rs` feature, which
+//! absorbs what used to be the standalone `pyroscope_pprofrs` crate) so the
+//! `rara-cli` bootstrap can turn profiling on/off from YAML config without
+//! dragging the underlying crate into every binary.
 //!
 //! ## Cardinality contract
 //!

--- a/crates/common/yunara-store/src/kv.rs
+++ b/crates/common/yunara-store/src/kv.rs
@@ -16,7 +16,7 @@ use std::collections::HashMap;
 
 use bon::Builder;
 use diesel::{ExpressionMethods, QueryDsl, upsert::excluded};
-use diesel_async::{RunQueryDsl, scoped_futures::ScopedFutureExt};
+use diesel_async::RunQueryDsl;
 use rara_model::schema::kv_table;
 use serde::{Serialize, de::DeserializeOwned};
 use snafu::ResultExt;
@@ -116,20 +116,17 @@ impl KVStore {
 
         let mut conn = self.pools.writer.get().await.context(DieselPoolRunSnafu)?;
         use diesel_async::AsyncConnection;
-        conn.transaction::<_, diesel::result::Error, _>(|tx| {
-            async move {
-                for (key, value_json) in &serialized_pairs {
-                    diesel::insert_into(kv_table::table)
-                        .values((kv_table::key.eq(key), kv_table::value.eq(value_json)))
-                        .on_conflict(kv_table::key)
-                        .do_update()
-                        .set(kv_table::value.eq(excluded(kv_table::value)))
-                        .execute(tx)
-                        .await?;
-                }
-                Ok(())
+        conn.transaction::<_, diesel::result::Error, _>(async |tx| {
+            for (key, value_json) in &serialized_pairs {
+                diesel::insert_into(kv_table::table)
+                    .values((kv_table::key.eq(key), kv_table::value.eq(value_json)))
+                    .on_conflict(kv_table::key)
+                    .do_update()
+                    .set(kv_table::value.eq(excluded(kv_table::value)))
+                    .execute(tx)
+                    .await?;
             }
-            .scope_boxed()
+            Ok(())
         })
         .await
         .context(DieselSnafu)?;

--- a/crates/kernel/src/memory/fts/mod.rs
+++ b/crates/kernel/src/memory/fts/mod.rs
@@ -10,7 +10,7 @@
 mod repo;
 mod tokenizer;
 
-use diesel_async::{AsyncConnection, RunQueryDsl, scoped_futures::ScopedFutureExt};
+use diesel_async::{AsyncConnection, RunQueryDsl};
 use serde_json::Value;
 use snafu::ResultExt;
 pub(crate) use tokenizer::warmup as warmup_tokenizer;
@@ -101,50 +101,45 @@ impl TapeFts {
         // open transaction back to the pool whenever an inner step
         // returned `Err`, which produced "cannot start a transaction
         // within a transaction" on the next checkout (#1843).
+        let tape_name_owned = tape_name.to_owned();
+        let session_key_owned = session_key.to_owned();
         let count = conn
-            .transaction::<_, diesel::result::Error, _>(|conn| {
-                let tape_name = tape_name.to_owned();
-                let session_key = session_key.to_owned();
-                let segmented = segmented.clone();
-                async move {
-                    use diesel::{
-                        ExpressionMethods,
-                        sql_types::{BigInt, Text},
-                        upsert::excluded,
-                    };
-                    use rara_model::schema::tape_fts_meta;
+            .transaction::<_, diesel::result::Error, _>(async |conn| {
+                use diesel::{
+                    ExpressionMethods,
+                    sql_types::{BigInt, Text},
+                    upsert::excluded,
+                };
+                use rara_model::schema::tape_fts_meta;
 
-                    let mut count = 0usize;
-                    for (entry_id, kind_str, content) in &segmented {
-                        diesel::sql_query(
-                            "INSERT INTO tape_fts (content, tape_name, entry_kind, entry_id, \
-                             session_key) VALUES (?, ?, ?, ?, ?)",
-                        )
-                        .bind::<Text, _>(content)
-                        .bind::<Text, _>(&tape_name)
-                        .bind::<Text, _>(kind_str)
-                        .bind::<BigInt, _>(*entry_id as i64)
-                        .bind::<Text, _>(&session_key)
-                        .execute(&mut *conn)
-                        .await?;
-                        count += 1;
-                    }
-                    diesel::insert_into(tape_fts_meta::table)
-                        .values((
-                            tape_fts_meta::tape_name.eq(&tape_name),
-                            tape_fts_meta::last_indexed_id.eq(max_id as i32),
-                        ))
-                        .on_conflict(tape_fts_meta::tape_name)
-                        .do_update()
-                        .set(
-                            tape_fts_meta::last_indexed_id
-                                .eq(excluded(tape_fts_meta::last_indexed_id)),
-                        )
-                        .execute(conn)
-                        .await?;
-                    Ok(count)
+                let mut count = 0usize;
+                for (entry_id, kind_str, content) in &segmented {
+                    diesel::sql_query(
+                        "INSERT INTO tape_fts (content, tape_name, entry_kind, entry_id, \
+                         session_key) VALUES (?, ?, ?, ?, ?)",
+                    )
+                    .bind::<Text, _>(content)
+                    .bind::<Text, _>(&tape_name_owned)
+                    .bind::<Text, _>(kind_str)
+                    .bind::<BigInt, _>(*entry_id as i64)
+                    .bind::<Text, _>(&session_key_owned)
+                    .execute(&mut *conn)
+                    .await?;
+                    count += 1;
                 }
-                .scope_boxed()
+                diesel::insert_into(tape_fts_meta::table)
+                    .values((
+                        tape_fts_meta::tape_name.eq(&tape_name_owned),
+                        tape_fts_meta::last_indexed_id.eq(max_id as i32),
+                    ))
+                    .on_conflict(tape_fts_meta::tape_name)
+                    .do_update()
+                    .set(
+                        tape_fts_meta::last_indexed_id.eq(excluded(tape_fts_meta::last_indexed_id)),
+                    )
+                    .execute(conn)
+                    .await?;
+                Ok(count)
             })
             .await
             .context(DieselSnafu)?;

--- a/crates/sessions/src/sqlite_index.rs
+++ b/crates/sessions/src/sqlite_index.rs
@@ -314,7 +314,7 @@ impl SessionIndex for SqliteSessionIndex {
         key: &SessionKey,
         derived: &SessionDerivedState,
     ) -> Result<(), SessionError> {
-        use diesel_async::{AsyncConnection, scoped_futures::ScopedFutureExt};
+        use diesel_async::AsyncConnection;
 
         let anchors_json = serde_json::to_string(&derived.anchors).context(JsonSnafu)?;
         let updated_at = derived.updated_at.to_rfc3339();
@@ -329,37 +329,34 @@ impl SessionIndex for SqliteSessionIndex {
         // Wrap both UPDATEs in a single transaction so a concurrent
         // `update_session` (PATCH /sessions) cannot slip a write between
         // the derived-state UPDATE and the conditional preview UPDATE.
-        conn.transaction::<_, diesel::result::Error, _>(|tx| {
-            async move {
-                diesel::update(sessions::table.filter(sessions::key.eq(&key_str)))
-                    .set((
-                        sessions::total_entries.eq(total_entries),
-                        sessions::last_token_usage.eq(last_token_usage),
-                        sessions::estimated_context_tokens.eq(estimated_context_tokens),
-                        sessions::entries_since_last_anchor.eq(entries_since_last_anchor),
-                        sessions::anchors_json.eq(&anchors_json),
-                        sessions::updated_at.eq(&updated_at),
-                    ))
-                    .execute(tx)
-                    .await?;
+        conn.transaction::<_, diesel::result::Error, _>(async |tx| {
+            diesel::update(sessions::table.filter(sessions::key.eq(&key_str)))
+                .set((
+                    sessions::total_entries.eq(total_entries),
+                    sessions::last_token_usage.eq(last_token_usage),
+                    sessions::estimated_context_tokens.eq(estimated_context_tokens),
+                    sessions::entries_since_last_anchor.eq(entries_since_last_anchor),
+                    sessions::anchors_json.eq(&anchors_json),
+                    sessions::updated_at.eq(&updated_at),
+                ))
+                .execute(tx)
+                .await?;
 
-                // Preview is "what this conversation started as" — only
-                // set it when the row currently has none. A second
-                // UPDATE keeps the contract simple at the cost of one
-                // extra statement on the (very rare) preview-write path.
-                if let Some(preview) = &preview {
-                    diesel::update(
-                        sessions::table
-                            .filter(sessions::key.eq(&key_str))
-                            .filter(sessions::preview.is_null()),
-                    )
-                    .set(sessions::preview.eq(preview))
-                    .execute(tx)
-                    .await?;
-                }
-                Ok(())
+            // Preview is "what this conversation started as" — only
+            // set it when the row currently has none. A second
+            // UPDATE keeps the contract simple at the cost of one
+            // extra statement on the (very rare) preview-write path.
+            if let Some(preview) = &preview {
+                diesel::update(
+                    sessions::table
+                        .filter(sessions::key.eq(&key_str))
+                        .filter(sessions::preview.is_null()),
+                )
+                .set(sessions::preview.eq(preview))
+                .execute(tx)
+                .await?;
             }
-            .scope_boxed()
+            Ok(())
         })
         .await
         .map_err(map_diesel_err)?;


### PR DESCRIPTION
## Summary

Replaces dependabot PRs #2027 and #1919 with a single bundled bump.
`keyring` 3 → 4 was descoped — see #2066 (4.0 is no longer a library).

- `diesel-async` 0.8 → 0.9
- `pyroscope` 0.5 → 2.0
- dropped `pyroscope_pprofrs` (the standalone crate is abandoned —
  latest 0.2.10 still pins `pyroscope = "0.5.7"`); pprof backend
  now comes from the `pyroscope` crate's `backend-pprof-rs` feature

## API migrations

**pyroscope 2.0** — `PyroscopeAgent::builder(url, app)` shortcut
removed; replaced with `PyroscopeAgentBuilder::new(url, app, sample_rate,
spy_name, spy_version, backend)`. `pprof_backend` signature is now
`(PprofConfig, BackendConfig)`. `PprofConfig` is a public-field struct.
`init_pyroscope()` public signature, snafu error variants, agent guard
semantics, and YAML config keys are all unchanged.

**diesel-async 0.9** — `scoped_futures` removed. Transaction calls
migrated from `|c| async move { … }.scope_boxed()` to
`async |c| { … }` at three sites (`yunara-store/src/kv.rs`,
`sessions/src/sqlite_index.rs`, `kernel/src/memory/fts/mod.rs`). In
`fts/mod.rs` two borrowed shorts were hoisted to owned locals outside
the transaction closure — functionally identical.

## Test plan
- [x] `cargo check --workspace --all-targets`
- [x] `cargo +nightly fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings`
- [x] `prek run --all-files`
- [x] `cargo test --workspace`

Closes #2065