### PR TITLE
feat(kernel,web): user-message-appended topology event (#2063)

### DIFF
--- a/crates/channels/src/web.rs
+++ b/crates/channels/src/web.rs
@@ -274,6 +274,26 @@ pub enum WebEvent {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         forked_at_anchor: Option<String>,
     },
+    /// A user message was appended to the session's main tape, immediately
+    /// before the agent loop spawn. Mirrors
+    /// [`StreamEvent::UserMessageAppended`]. Lets the topology UI render
+    /// the user bubble from the same channel as every other turn artefact
+    /// instead of an FE-side optimistic bridge (#2063). Mita directives
+    /// and tape-append failures emit nothing.
+    ///
+    /// `seq` is the position-based chat seq — the same value the
+    /// `/api/v1/chat/sessions/{key}/messages` REST endpoint returns for
+    /// this entry — so FE dedupe can key on a single integer regardless
+    /// of which path (history refetch or live frame) delivered the
+    /// bubble.
+    ///
+    /// [`StreamEvent::UserMessageAppended`]: rara_kernel::io::StreamEvent::UserMessageAppended
+    UserMessageAppended {
+        parent_session: String,
+        seq:            i64,
+        content:        serde_json::Value,
+        created_at:     jiff::Timestamp,
+    },
     /// A new entry was appended to the session's tape. Emitted on the
     /// persistent per-session WS in two situations:
     ///
@@ -480,6 +500,17 @@ pub(crate) fn stream_event_to_web_event(event: StreamEvent) -> Option<WebEvent> 
             forked_from,
             child_tape,
             forked_at_anchor,
+        }),
+        StreamEvent::UserMessageAppended {
+            parent_session,
+            seq,
+            content,
+            created_at,
+        } => Some(WebEvent::UserMessageAppended {
+            parent_session: parent_session.to_string(),
+            seq,
+            content,
+            created_at,
         }),
     }
 }
@@ -1162,6 +1193,54 @@ mod tests {
             stream_event_to_web_event(event),
             Some(WebEvent::TextDelta { text }) if text == "hello"
         ));
+    }
+
+    #[test]
+    fn web_event_user_message_appended_round_trip() {
+        use rara_kernel::session::SessionKey;
+        use serde_json::json;
+
+        let session = SessionKey::new();
+        let created_at = "2026-01-01T00:00:00Z"
+            .parse::<jiff::Timestamp>()
+            .expect("parse timestamp");
+        let content = json!("hello world");
+
+        let event = StreamEvent::UserMessageAppended {
+            parent_session: session,
+            seq: 7,
+            content: content.clone(),
+            created_at,
+        };
+
+        let mapped =
+            stream_event_to_web_event(event).expect("UserMessageAppended must forward to WebEvent");
+        match &mapped {
+            WebEvent::UserMessageAppended {
+                parent_session,
+                seq,
+                content: c,
+                created_at: ts,
+            } => {
+                assert_eq!(
+                    parent_session,
+                    &session.to_string(),
+                    "parent_session preserved"
+                );
+                assert_eq!(*seq, 7, "seq preserved");
+                assert_eq!(*c, content, "content preserved");
+                assert_eq!(*ts, created_at, "created_at preserved");
+            }
+            other => panic!("expected WebEvent::UserMessageAppended, got {other:?}"),
+        }
+
+        // Wire-format guard: the FE consumer keys on the snake_case
+        // variant tag — locking it down here so a future serde rename
+        // can't silently break the topology timeline (#2063).
+        let json_value = serde_json::to_value(&mapped).expect("serialize");
+        assert_eq!(json_value["type"], "user_message_appended");
+        assert_eq!(json_value["seq"], 7);
+        assert_eq!(json_value["content"], json!("hello world"));
     }
 
     #[test]

--- a/crates/cmd/src/chat/mod.rs
+++ b/crates/cmd/src/chat/mod.rs
@@ -1063,7 +1063,8 @@ fn stream_event_to_cli_event(event: StreamEvent) -> Option<CliEvent> {
         // CLI rendering is a separate downstream spec.
         StreamEvent::SubagentSpawned { .. }
         | StreamEvent::SubagentDone { .. }
-        | StreamEvent::TapeForked { .. } => return None,
+        | StreamEvent::TapeForked { .. }
+        | StreamEvent::UserMessageAppended { .. } => return None,
     })
 }
 

--- a/crates/kernel/src/io.rs
+++ b/crates/kernel/src/io.rs
@@ -1202,6 +1202,33 @@ pub enum StreamEvent {
         /// distinction explicit on the wire).
         forked_at_anchor: Option<String>,
     },
+    /// A non-Mita-directive user message has been appended to the session's
+    /// main tape, immediately before the agent loop spawns.
+    ///
+    /// Emitted by `Kernel::handle_inbound_to_session` (Phase 5) on the
+    /// session's bus right after `TapeService::append_message` returns Ok.
+    /// Lets live topology subscribers render the user bubble from the same
+    /// channel as every other turn artefact, retiring the front-end
+    /// optimistic-bubble path (#2063). Mita directives and tape-append
+    /// failures emit nothing.
+    ///
+    /// `seq` matches the `ChatMessage.seq` produced by the `/messages`
+    /// REST endpoint for the same tape entry — i.e. the position-based
+    /// counter walked by `tap_entries_to_chat_messages` — so frontend
+    /// dedupe can key on a single integer regardless of which path
+    /// (history refetch or live frame) delivered the bubble.
+    UserMessageAppended {
+        /// Session that owns the tape the entry was appended to.
+        parent_session: SessionKey,
+        /// Position-based chat seq matching the REST `/messages` endpoint.
+        seq:            i64,
+        /// Persisted entry payload's `content` field — text-only as a
+        /// JSON string, multimodal as the structured passthrough exactly
+        /// as written to tape.
+        content:        serde_json::Value,
+        /// Persisted tape entry timestamp (`TapEntry.timestamp`).
+        created_at:     jiff::Timestamp,
+    },
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/kernel/src/kernel.rs
+++ b/crates/kernel/src/kernel.rs
@@ -2383,18 +2383,40 @@ impl Kernel {
             };
             let tape_payload = serde_json::json!({
                 "role": "user",
-                "content": tape_content,
+                "content": tape_content.clone(),
             });
-            if let Err(e) = &self
+            match self
                 .tape_service
-                .append_message(
+                .append_message_with_chat_seq(
                     &tape_name,
                     tape_payload,
                     Some(serde_json::json!({"rara_turn_id": msg.id.to_string()})),
                 )
                 .await
             {
-                warn!(%e, "failed to persist user message to tape");
+                Ok((entry, chat_seq)) => {
+                    // Echo the tape persistence on the session topology bus
+                    // so live subscribers (web TimelineView) render the user
+                    // bubble from the same channel as every other turn
+                    // artefact — see #2063 for the FE optimistic-bubble bug
+                    // this collapses. Emitted synchronously, before the
+                    // agent loop spawn, so subscribers see the user bubble
+                    // before any text_delta / tape_forked frame for the
+                    // turn. Failure cases (the `Err` arm below) emit
+                    // nothing — the spec binds emit-on-success only.
+                    self.io.stream_hub().emit_to_session_bus(
+                        &session_key,
+                        crate::io::StreamEvent::UserMessageAppended {
+                            parent_session: session_key,
+                            seq:            chat_seq,
+                            content:        tape_content,
+                            created_at:     entry.timestamp,
+                        },
+                    );
+                }
+                Err(e) => {
+                    warn!(%e, "failed to persist user message to tape");
+                }
             }
         }
 

--- a/crates/kernel/src/memory/service.rs
+++ b/crates/kernel/src/memory/service.rs
@@ -382,10 +382,53 @@ impl TapeService {
         payload: Value,
         metadata: Option<Value>,
     ) -> TapResult<TapEntry> {
-        let outcome = self
-            .store
-            .append(tape_name, TapEntryKind::Message, payload, metadata)
+        let (entry, _seq) = self
+            .append_message_inner(tape_name, payload, metadata, false)
             .await?;
+        Ok(entry)
+    }
+
+    /// Append a message entry and additionally surface the position-based
+    /// chat seq the `/messages` REST endpoint will return for it.
+    ///
+    /// Used by `Kernel::handle_inbound_to_session` to emit
+    /// `StreamEvent::UserMessageAppended` carrying the same seq the
+    /// frontend will see when it refetches history (#2063), removing the
+    /// need for an FE-side optimistic-bubble bridge keyed on a different
+    /// id space. The seq computation is atomic with the append (runs in
+    /// the same tape-IO worker call) so no concurrent append can shift
+    /// the counter between persistence and emission.
+    pub async fn append_message_with_chat_seq(
+        &self,
+        tape_name: &str,
+        payload: Value,
+        metadata: Option<Value>,
+    ) -> TapResult<(TapEntry, i64)> {
+        self.append_message_inner(tape_name, payload, metadata, true)
+            .await
+    }
+
+    /// Shared body of [`Self::append_message`] and
+    /// [`Self::append_message_with_chat_seq`]. `with_chat_seq=true`
+    /// dispatches the worker call that also walks for the chat seq.
+    async fn append_message_inner(
+        &self,
+        tape_name: &str,
+        payload: Value,
+        metadata: Option<Value>,
+        with_chat_seq: bool,
+    ) -> TapResult<(TapEntry, i64)> {
+        let (outcome, seq) = if with_chat_seq {
+            self.store
+                .append_with_chat_seq(tape_name, TapEntryKind::Message, payload, metadata)
+                .await?
+        } else {
+            let outcome = self
+                .store
+                .append(tape_name, TapEntryKind::Message, payload, metadata)
+                .await?;
+            (outcome, 0)
+        };
         let entry = outcome.entry.clone();
         self.record_append(tape_name, &outcome).await;
 
@@ -420,7 +463,7 @@ impl TapeService {
             }
         }
 
-        Ok(entry)
+        Ok((entry, seq))
     }
 
     /// Append a tool-call entry.

--- a/crates/kernel/src/memory/store.rs
+++ b/crates/kernel/src/memory/store.rs
@@ -753,6 +753,43 @@ impl WorkerState {
             })
     }
 
+    /// Persist one new entry and, in the same worker call, compute the
+    /// position-based chat seq for the just-appended entry.
+    ///
+    /// "Chat seq" matches the counter
+    /// `extensions/backend-admin::tap_entries_to_chat_messages` walks for
+    /// the `/messages` REST endpoint — see `chat_seq_for_entry_id` for the
+    /// rules. Doing the walk inside the worker (i.e. while we still hold
+    /// the tape file's `&mut` and no concurrent appends can land) is the
+    /// race-free way to surface the chat seq alongside the append: callers
+    /// must not re-read the tape from outside the worker to derive the
+    /// seq, because a concurrent append on the same tape could shift the
+    /// counter under them (#2063 spec, "Where the seq comes from").
+    fn append_with_chat_seq(
+        &mut self,
+        tape: &str,
+        kind: super::TapEntryKind,
+        payload: serde_json::Value,
+        metadata: Option<serde_json::Value>,
+    ) -> TapResult<(AppendOutcome, i64)> {
+        let path = self.tape_path(tape);
+        let file = self
+            .tape_files
+            .entry(tape.to_owned())
+            .or_insert_with(|| TapeFile::new(path));
+        let outcome = file.append(TapEntry {
+            id: 0,
+            kind,
+            payload,
+            timestamp: jiff::Timestamp::now(),
+            metadata,
+        })?;
+        let target_id = outcome.entry.id;
+        let entries = file.read()?;
+        let seq = chat_seq_for_entry_id(&entries, target_id).unwrap_or(0);
+        Ok((outcome, seq))
+    }
+
     /// Rename the active tape into a timestamped archive file.
     fn archive(&mut self, tape: &str) -> TapResult<Option<PathBuf>> {
         let mut file = self.take_tape_file(tape);
@@ -994,11 +1031,97 @@ impl FileTapeStore {
             .await
     }
 
+    /// Append one entry and atomically resolve the position-based chat seq
+    /// of the just-appended entry.
+    ///
+    /// Used by `TapeService::append_message_with_chat_seq` to emit
+    /// `StreamEvent::UserMessageAppended` (#2063) with a seq that matches
+    /// the `/messages` REST endpoint's `ChatMessage.seq`. The walk runs
+    /// inside the worker dispatch so no concurrent append can interleave
+    /// between the append and the seq lookup.
+    pub async fn append_with_chat_seq(
+        &self,
+        tape: &str,
+        kind: super::TapEntryKind,
+        payload: serde_json::Value,
+        metadata: Option<serde_json::Value>,
+    ) -> TapResult<(AppendOutcome, i64)> {
+        let tape = tape.to_owned();
+        self.worker
+            .call(move |state| state.append_with_chat_seq(&tape, kind, payload, metadata))
+            .await
+    }
+
     /// Archive one tape into a timestamped backup file.
     pub async fn archive(&self, tape: &str) -> TapResult<Option<PathBuf>> {
         let tape = tape.to_owned();
         self.worker.call(move |state| state.archive(&tape)).await
     }
+}
+
+/// Compute the position-based chat seq for the entry whose `id ==
+/// target_entry_id`, walking `entries` with the same rules as
+/// `extensions/backend-admin::tap_entries_to_chat_messages`'s seq walker.
+///
+/// Emission rules — kept symmetric with `walk_tape_with_seq` in
+/// `crates/extensions/backend-admin/src/chat/service.rs`:
+///
+/// - `Message` whose payload deserializes as [`crate::llm::Message`]: advances
+///   seq by 1 and is emittable.
+/// - `ToolCall` carrying a `calls` array: advances seq by 1.
+/// - `ToolResult` carrying a `results` array of length N: advances seq by N.
+///   The first result of the just-appended entry takes the post- advance seq
+///   (seq + 1).
+/// - Anything else (other kinds, malformed payloads): no advance.
+///
+/// Returns `None` when no entry with the target id is found, or when the
+/// target entry's payload does not advance the seq under the rules above
+/// (callers emit a topology event only on Message/ToolCall/ToolResult
+/// appends, so this is fine to surface as `None`).
+fn chat_seq_for_entry_id(entries: &[TapEntry], target_entry_id: u64) -> Option<i64> {
+    use serde_json::Value;
+
+    use super::TapEntryKind;
+    let mut seq: i64 = 0;
+    for entry in entries {
+        match entry.kind {
+            TapEntryKind::Message
+                if serde_json::from_value::<crate::llm::Message>(entry.payload.clone()).is_ok() =>
+            {
+                seq += 1;
+                if entry.id == target_entry_id {
+                    return Some(seq);
+                }
+            }
+            TapEntryKind::ToolCall
+                if entry
+                    .payload
+                    .get("calls")
+                    .and_then(Value::as_array)
+                    .is_some() =>
+            {
+                seq += 1;
+                if entry.id == target_entry_id {
+                    return Some(seq);
+                }
+            }
+            TapEntryKind::ToolResult => {
+                if let Some(results) = entry.payload.get("results").and_then(Value::as_array) {
+                    let n = results.len() as i64;
+                    if entry.id == target_entry_id {
+                        // The first result owns seq+1 in
+                        // `tap_entries_to_chat_messages`; the kernel
+                        // emits the topology event for the entry as a
+                        // whole, so return that first-result seq.
+                        return if n > 0 { Some(seq + 1) } else { None };
+                    }
+                    seq += n;
+                }
+            }
+            _ => {}
+        }
+    }
+    None
 }
 
 /// Trim ASCII whitespace around one JSONL record before decoding it.

--- a/crates/kernel/src/trace/builder.rs
+++ b/crates/kernel/src/trace/builder.rs
@@ -272,7 +272,8 @@ impl TraceBuilder {
             | StreamEvent::StreamClosed { .. }
             | StreamEvent::SubagentSpawned { .. }
             | StreamEvent::SubagentDone { .. }
-            | StreamEvent::TapeForked { .. } => {}
+            | StreamEvent::TapeForked { .. }
+            | StreamEvent::UserMessageAppended { .. } => {}
         }
     }
 

--- a/crates/kernel/tests/user_message_appended_topology_event.rs
+++ b/crates/kernel/tests/user_message_appended_topology_event.rs
@@ -1,0 +1,509 @@
+// Copyright 2025 Rararulab
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Integration tests for `StreamEvent::UserMessageAppended` (issue #2063).
+//!
+//! Three scenarios mapped to the spec's BDD acceptance criteria:
+//!
+//! - `kernel_emits_user_message_appended_after_tape_append` — non-Mita user
+//!   message → exactly one `UserMessageAppended` whose `seq` / `content` /
+//!   `created_at` match the persisted tape entry, ordered before any
+//!   `TapeForked` for the same turn.
+//! - `kernel_does_not_emit_user_message_appended_for_mita_directive` —
+//!   `metadata.mita_directive=true` → zero `UserMessageAppended` events.
+//! - `kernel_user_message_appended_seq_matches_rest_messages_endpoint` — the
+//!   `seq` carried by the event equals the seq the
+//!   `tap_entries_to_chat_messages` walker (REST `/messages`) produces for the
+//!   same entry. Catches drift between the two seq derivations.
+
+use std::{collections::HashMap, path::PathBuf, sync::Once, time::Duration};
+
+use rara_kernel::{
+    channel::types::{ChannelType, MessageContent},
+    identity::{Principal, UserId},
+    io::{ChannelSource, InboundMessage, MessageId, StreamEvent},
+    memory::{TapEntry, TapEntryKind},
+    session::SessionKey,
+    testing::{TestKernelBuilder, scripted_response},
+};
+use serde_json::{Value, json};
+use tokio::sync::broadcast::error::{RecvError, TryRecvError};
+
+/// Override `rara_paths` to a stable per-process temp dir — same reasoning
+/// as `subagent_topology_events::init_test_env`.
+fn init_test_env() {
+    static ROOT: std::sync::OnceLock<PathBuf> = std::sync::OnceLock::new();
+    static INIT: Once = Once::new();
+    let root = ROOT.get_or_init(|| {
+        std::env::temp_dir().join(format!("rara-kernel-uma-test-{}", std::process::id()))
+    });
+    INIT.call_once(move || {
+        let data = root.join("rara_data");
+        let config = root.join("rara_config");
+        std::fs::create_dir_all(&data).expect("create test data dir");
+        std::fs::create_dir_all(&config).expect("create test config dir");
+        rara_paths::set_custom_data_dir(&data);
+        rara_paths::set_custom_config_dir(&config);
+    });
+}
+
+/// Drain whatever events are queued on the receiver right now.
+fn drain_now(rx: &mut tokio::sync::broadcast::Receiver<StreamEvent>) -> Vec<StreamEvent> {
+    let mut out = Vec::new();
+    loop {
+        match rx.try_recv() {
+            Ok(ev) => out.push(ev),
+            Err(TryRecvError::Empty) | Err(TryRecvError::Closed) => return out,
+            Err(TryRecvError::Lagged(_)) => continue,
+        }
+    }
+}
+
+/// Wait up to `timeout` for an event matching `pred`. Returns the matched
+/// event or `None` on timeout.
+async fn wait_for<F>(
+    rx: &mut tokio::sync::broadcast::Receiver<StreamEvent>,
+    timeout: Duration,
+    mut pred: F,
+) -> Option<StreamEvent>
+where
+    F: FnMut(&StreamEvent) -> bool,
+{
+    tokio::time::timeout(timeout, async {
+        loop {
+            match rx.recv().await {
+                Ok(ev) if pred(&ev) => return Some(ev),
+                Ok(_) => continue,
+                Err(RecvError::Lagged(_)) => continue,
+                Err(RecvError::Closed) => return None,
+            }
+        }
+    })
+    .await
+    .ok()
+    .flatten()
+}
+
+/// Walk a tape with the same per-result seq rules
+/// `tap_entries_to_chat_messages` uses, returning the seq of the entry
+/// whose id matches `target_id` (Message-only — sufficient for this test
+/// since we only assert against user-message entries).
+fn rest_chat_seq_for_entry_id(entries: &[TapEntry], target_id: u64) -> Option<i64> {
+    let mut seq: i64 = 0;
+    for entry in entries {
+        match entry.kind {
+            TapEntryKind::Message
+                if serde_json::from_value::<rara_kernel::llm::Message>(entry.payload.clone())
+                    .is_ok() =>
+            {
+                seq += 1;
+                if entry.id == target_id {
+                    return Some(seq);
+                }
+            }
+            TapEntryKind::ToolCall
+                if entry
+                    .payload
+                    .get("calls")
+                    .and_then(Value::as_array)
+                    .is_some() =>
+            {
+                seq += 1;
+            }
+            TapEntryKind::ToolResult => {
+                if let Some(results) = entry.payload.get("results").and_then(Value::as_array) {
+                    seq += results.len() as i64;
+                }
+            }
+            _ => {}
+        }
+    }
+    None
+}
+
+// ---------------------------------------------------------------------------
+// Scenario 1: emit-on-success
+// ---------------------------------------------------------------------------
+
+/// Submitting a non-Mita user message produces exactly one
+/// `UserMessageAppended` on the session bus, ordered before any
+/// `TapeForked` for the same turn, with `seq` / `content` / `created_at`
+/// matching the persisted tape entry.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn kernel_emits_user_message_appended_after_tape_append() {
+    init_test_env();
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let tk = TestKernelBuilder::new(tmp.path())
+        .responses(vec![scripted_response("ok")])
+        .build()
+        .await;
+
+    let session_key = SessionKey::new();
+    let mut rx = tk
+        .handle
+        .stream_hub()
+        .subscribe_session_events(&session_key);
+
+    let principal = Principal::lookup("test");
+    let manifest = tk
+        .handle
+        .agent_registry()
+        .get("test-agent")
+        .expect("test-agent manifest registered");
+    let returned_key = tk
+        .handle
+        .spawn_with_input(
+            manifest,
+            "hello world".to_string(),
+            principal,
+            None,
+            Some(session_key),
+        )
+        .await
+        .expect("spawn agent");
+    assert_eq!(returned_key, session_key);
+
+    let event = wait_for(&mut rx, Duration::from_secs(10), |ev| {
+        matches!(ev, StreamEvent::UserMessageAppended { .. })
+    })
+    .await
+    .expect("UserMessageAppended not received within 10s");
+
+    match event {
+        StreamEvent::UserMessageAppended {
+            parent_session,
+            seq,
+            content,
+            created_at,
+        } => {
+            assert_eq!(parent_session, session_key, "parent_session must match");
+            assert!(seq >= 1, "seq must be a positive chat-seq, got {seq}");
+            // Content was sent as plain text — should round-trip as a JSON
+            // string per kernel.rs Phase 5 serialisation rules.
+            assert_eq!(
+                content,
+                json!("hello world"),
+                "content must mirror the persisted tape payload"
+            );
+
+            // Cross-check: the persisted tape's user entry carries the
+            // same timestamp and seq.
+            let tape_name = session_key.to_string();
+            let entries = tk
+                .handle
+                .tape()
+                .store()
+                .read(&tape_name)
+                .await
+                .expect("read tape")
+                .expect("tape exists");
+            let user_entry = entries
+                .iter()
+                .find(|e| {
+                    matches!(e.kind, TapEntryKind::Message)
+                        && e.payload
+                            .get("role")
+                            .and_then(|v| v.as_str())
+                            .map(|s| s == "user")
+                            .unwrap_or(false)
+                })
+                .expect("a user message entry must exist on tape");
+            assert_eq!(
+                created_at, user_entry.timestamp,
+                "created_at must equal the persisted tape entry timestamp"
+            );
+            let rest_seq = rest_chat_seq_for_entry_id(&entries, user_entry.id)
+                .expect("REST walker must find seq for the user entry");
+            assert_eq!(
+                seq, rest_seq,
+                "seq carried on the topology event must match the REST /messages seq for the same \
+                 entry"
+            );
+        }
+        other => panic!("expected UserMessageAppended, got {other:?}"),
+    }
+
+    // Exactly one UserMessageAppended for this single submit — drain
+    // the rest of the buffer and verify no second instance arrives.
+    let leftover = drain_now(&mut rx);
+    let extra: Vec<_> = leftover
+        .iter()
+        .filter(|ev| matches!(ev, StreamEvent::UserMessageAppended { .. }))
+        .collect();
+    assert!(
+        extra.is_empty(),
+        "expected exactly one UserMessageAppended, got an extra: {extra:?}"
+    );
+
+    tk.shutdown();
+}
+
+// ---------------------------------------------------------------------------
+// Scenario 2: Mita directive does NOT emit
+// ---------------------------------------------------------------------------
+
+/// A message with `metadata.mita_directive=true` is recorded as an
+/// `Event` entry on the tape (mita-directive bookkeeping) and must NOT
+/// emit a `UserMessageAppended` on the topology bus.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn kernel_does_not_emit_user_message_appended_for_mita_directive() {
+    init_test_env();
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let tk = TestKernelBuilder::new(tmp.path())
+        .responses(vec![scripted_response("ok"), scripted_response("ok2")])
+        .build()
+        .await;
+
+    // Spawn an initial session so the directive has a target process.
+    let session_key = SessionKey::new();
+    let principal = Principal::lookup("test");
+    let manifest = tk
+        .handle
+        .agent_registry()
+        .get("test-agent")
+        .expect("test-agent manifest registered");
+    let returned_key = tk
+        .handle
+        .spawn_with_input(
+            manifest,
+            "first turn".to_string(),
+            principal.clone(),
+            None,
+            Some(session_key),
+        )
+        .await
+        .expect("spawn agent");
+    assert_eq!(returned_key, session_key);
+
+    // Subscribe AFTER the spawn so we observe events emitted by the
+    // forthcoming Mita-directive delivery (we explicitly DO NOT care
+    // about the spawn's own UserMessageAppended frame here).
+    let mut rx = tk
+        .handle
+        .stream_hub()
+        .subscribe_session_events(&session_key);
+
+    // Wait for the initial spawn turn to settle so the next deliver hits
+    // an idle process — otherwise it gets buffered and skipped under
+    // active-turn semantics.
+    tokio::time::sleep(Duration::from_millis(500)).await;
+    drain_now(&mut rx);
+
+    // Construct an InboundMessage with `mita_directive=true` and route
+    // it through the kernel's standard ingress.
+    let mut metadata: HashMap<String, Value> = HashMap::new();
+    metadata.insert("mita_directive".to_owned(), json!(true));
+    let inbound = InboundMessage::unresolved(
+        MessageId::new(),
+        ChannelSource {
+            channel_type:        ChannelType::Internal,
+            platform_message_id: None,
+            platform_user_id:    "test".to_owned(),
+            platform_chat_id:    None,
+        },
+        UserId("test".to_owned()),
+        Some(session_key),
+        None,
+        MessageContent::Text("mita please re-enter".to_owned()),
+        None,
+        jiff::Timestamp::now(),
+        metadata,
+    );
+    tk.handle.deliver_internal(inbound).await;
+
+    // Give the kernel a generous moment to process the directive.
+    tokio::time::sleep(Duration::from_millis(800)).await;
+
+    let events = drain_now(&mut rx);
+    let bad: Vec<_> = events
+        .iter()
+        .filter(|ev| matches!(ev, StreamEvent::UserMessageAppended { .. }))
+        .collect();
+    assert!(
+        bad.is_empty(),
+        "Mita directive must NOT emit UserMessageAppended, got: {bad:?}"
+    );
+
+    tk.shutdown();
+}
+
+// ---------------------------------------------------------------------------
+// Scenario 2b: tape append failure does NOT emit
+// ---------------------------------------------------------------------------
+
+/// When `TapeService::append_message_with_chat_seq` fails (here: tape
+/// directory made read-only after kernel boot so the lazy file `open`
+/// returns `EACCES`), the kernel must NOT emit a `UserMessageAppended`
+/// event. Spec scenario "Kernel does not emit UserMessageAppended when
+/// tape append fails" — emit-on-success-only.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn kernel_does_not_emit_user_message_appended_on_tape_failure() {
+    use std::os::unix::fs::PermissionsExt;
+
+    init_test_env();
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let tk = TestKernelBuilder::new(tmp.path())
+        .responses(vec![scripted_response("ok")])
+        .build()
+        .await;
+
+    // The tape root is created at `<tmp>/tapes/tapes` during boot
+    // (`TestKernelBuilder` passes `<tmp>/tapes` as the FileTapeStore home,
+    // and `WorkerState::new` then nests another `tapes/` under it). Strip
+    // write perms so the next lazy `OpenOptions::create(true)` returns
+    // EACCES, forcing the kernel's `match append_message_with_chat_seq`
+    // arm to hit `Err` and skip the topology emit.
+    let tape_root = tmp.path().join("tapes").join("tapes");
+    let mut perms = std::fs::metadata(&tape_root)
+        .expect("read tape dir metadata")
+        .permissions();
+    perms.set_mode(0o555);
+    std::fs::set_permissions(&tape_root, perms).expect("chmod tape dir read-only");
+
+    let session_key = SessionKey::new();
+    let mut rx = tk
+        .handle
+        .stream_hub()
+        .subscribe_session_events(&session_key);
+
+    let principal = Principal::lookup("test");
+    let manifest = tk
+        .handle
+        .agent_registry()
+        .get("test-agent")
+        .expect("test-agent manifest registered");
+    // spawn_with_input may itself surface the tape failure — that's
+    // acceptable; what matters is that the topology bus carries no
+    // UserMessageAppended frame for this submit.
+    let _ = tk
+        .handle
+        .spawn_with_input(
+            manifest,
+            "this append must fail".to_string(),
+            principal,
+            None,
+            Some(session_key),
+        )
+        .await;
+
+    // Give the kernel a generous moment to attempt the append + emit.
+    tokio::time::sleep(Duration::from_millis(800)).await;
+
+    let events = drain_now(&mut rx);
+    let bad: Vec<_> = events
+        .iter()
+        .filter(|ev| matches!(ev, StreamEvent::UserMessageAppended { .. }))
+        .collect();
+    assert!(
+        bad.is_empty(),
+        "tape-append failure must NOT emit UserMessageAppended, got: {bad:?}"
+    );
+
+    // Restore perms so tempdir cleanup can drop the directory.
+    let mut perms = std::fs::metadata(&tape_root)
+        .expect("re-read tape dir metadata")
+        .permissions();
+    perms.set_mode(0o755);
+    std::fs::set_permissions(&tape_root, perms).expect("chmod tape dir restore");
+
+    tk.shutdown();
+}
+
+// ---------------------------------------------------------------------------
+// Scenario 3: seq matches the REST endpoint walker (drift guard)
+// ---------------------------------------------------------------------------
+
+/// The chat seq on the topology event must equal the seq the
+/// `/messages` REST walker produces for the same entry, even after the
+/// tape has acquired non-Message entries (Anchor / Event) that the
+/// position-based walker skips.
+///
+/// This is the explicit drift guard required by the spec's "Where the
+/// seq comes from" decision: the topology event's seq must match the
+/// REST endpoint's seq for the same tape entry, full stop.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn kernel_user_message_appended_seq_matches_rest_messages_endpoint() {
+    init_test_env();
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let tk = TestKernelBuilder::new(tmp.path())
+        .responses(vec![scripted_response("ok")])
+        .build()
+        .await;
+
+    let session_key = SessionKey::new();
+    let mut rx = tk
+        .handle
+        .stream_hub()
+        .subscribe_session_events(&session_key);
+
+    let principal = Principal::lookup("test");
+    let manifest = tk
+        .handle
+        .agent_registry()
+        .get("test-agent")
+        .expect("test-agent manifest registered");
+    let _ = tk
+        .handle
+        .spawn_with_input(
+            manifest,
+            "drift guard prompt".to_string(),
+            principal,
+            None,
+            Some(session_key),
+        )
+        .await
+        .expect("spawn agent");
+
+    let event = wait_for(&mut rx, Duration::from_secs(10), |ev| {
+        matches!(ev, StreamEvent::UserMessageAppended { .. })
+    })
+    .await
+    .expect("UserMessageAppended not received within 10s");
+
+    let StreamEvent::UserMessageAppended {
+        seq: emitted_seq, ..
+    } = event
+    else {
+        unreachable!("filtered above");
+    };
+
+    let tape_name = session_key.to_string();
+    let entries = tk
+        .handle
+        .tape()
+        .store()
+        .read(&tape_name)
+        .await
+        .expect("read tape")
+        .expect("tape exists");
+    let user_entry = entries
+        .iter()
+        .find(|e| {
+            matches!(e.kind, TapEntryKind::Message)
+                && e.payload
+                    .get("role")
+                    .and_then(|v| v.as_str())
+                    .map(|s| s == "user")
+                    .unwrap_or(false)
+        })
+        .expect("user entry must exist on tape");
+    let rest_seq = rest_chat_seq_for_entry_id(&entries, user_entry.id)
+        .expect("REST walker must find seq for the user entry");
+    assert_eq!(
+        emitted_seq, rest_seq,
+        "topology event seq must equal REST /messages seq for the same tape entry — drift detected"
+    );
+
+    tk.shutdown();
+}

--- a/specs/issue-2063-user-message-appended-event.spec.md
+++ b/specs/issue-2063-user-message-appended-event.spec.md
@@ -1,0 +1,348 @@
+spec: task
+name: "issue-2063-user-message-appended-event"
+inherits: project
+tags: []
+---
+
+## Intent
+
+In the topology TimelineView the same user message renders **twice** for an
+in-flight turn — once at the top of the timeline and once at the tail,
+bracketing the in-flight assistant card and the per-turn `tape_forked`
+marker (see `vendor/ing.png`). The duplicate is structural, not visual:
+`web/src/components/topology/TimelineView.tsx` keeps two parallel,
+unreconciled sources of truth for user messages.
+
+1. **Optimistic path.** `userTurnsBySession` state is pushed in
+   `handleSubmit`, never cleared, entries have `createdAt: null` (and
+   therefore sort to the tail by the chronological merge introduced in
+   PR 2018 / spec issue 2013).
+2. **Persisted path.** `useSessionHistory`
+   (`web/src/hooks/use-session-history.ts`) runs with `staleTime: 0`,
+   refetches on WS reconnect (`TimelineView.tsx:205`) and on window
+   focus, and yields entries with the backend `created_at` timestamp.
+
+Backend (`crates/kernel/src/kernel.rs` Phase 4–5, around lines 2335–2400)
+appends the user message to the main tape **synchronously, pre-fork,
+pre-agent-loop**, so the `GET /api/v1/chat/sessions/{key}/messages`
+endpoint returns the message within milliseconds of submit. Once history
+refetches mid-turn, both paths render the same content: the persisted
+entry sorts to the front by `createdAt`, the optimistic entry sorts to
+the tail (after the in-flight assistant card), bracketing the assistant
+card with two identical bubbles.
+
+The two paths share no common id — optimistic uses a front-end-generated
+`u-${Date.now()}-...`, persisted uses backend `seq`. There is no
+reconciliation point. The `userTurnsBySession` mechanism is itself a
+workaround for a missing kernel echo: today the topology stream carries
+only assistant-side frames (`text_delta`, `tool_call_*`, `subagent_*`,
+`tape_forked`, `turn_metrics`, etc.); the user prompt's persistence is
+visible only via REST. The optimistic path is what filled that gap, and
+it races with `useSessionHistory`.
+
+Reproducer:
+1. Open `/topology/<existing-key>` for a session with prior messages.
+2. Submit a new prompt P. The optimistic bubble appears immediately.
+3. While the assistant is still streaming (text deltas flowing,
+   `tape_forked` already emitted), trigger a history refetch — easiest
+   path is to switch tabs and back (window focus) or wait for the WS
+   reconnect refetch on `TimelineView.tsx:205`.
+4. Observed: bubble(P) at the top of the timeline (persisted, real
+   `created_at`), then the in-flight assistant `TurnCard`, then the
+   per-turn `tape_forked` marker, then bubble(P) again at the tail
+   (optimistic, `createdAt: null`).
+5. After fix: bubble(P) appears exactly once at its correct
+   chronological slot, before, during, and after the in-flight turn.
+   Mid-turn focus/reconnect refetches do not introduce duplicates.
+
+The agreed solution is to **make the kernel echo user-prompt persistence
+on the topology stream** so the FE has a real frame to react to, and
+**remove the optimistic path entirely**. Concretely:
+
+- **Backend.** In Phase 4–5 of `crates/kernel/src/kernel.rs`, right
+  after `tape_service.append_message` returns Ok for the user message
+  (the non-Mita-directive branch around lines 2375–2400) and before the
+  agent-loop spawn, emit a new `StreamEvent::UserMessageAppended`
+  variant on the session topology bus carrying the persisted tape entry
+  identity (`seq` matching the `ChatMessage.seq` produced by
+  `tap_entries_to_chat_messages` in
+  `crates/extensions/backend-admin/src/chat/service.rs`), the
+  multimodal-passthrough `content` matching the persisted shape, and
+  `created_at` matching `entry.timestamp`. Forward through
+  `crates/channels/src/web.rs` (`pub enum WebEvent` at line 99) to a
+  corresponding `WebEvent::UserMessageAppended` so the FE WS subscriber
+  receives it; update `crates/channels/src/web_topology.rs` if the
+  forwarding pipe needs an explicit hand-off (the existing
+  `SubagentSpawned` / `TapeForked` handling at line 288 is the model).
+- **Frontend.** Remove `userTurnsBySession` and the optimistic push from
+  `TimelineView.tsx` entirely. User bubbles come exclusively from
+  (a) `historyUserBubbles` derived from `useSessionHistory` and (b) the
+  new topology event applied to the live `events` buffer. Both keyed on
+  backend `seq` so React/dedupe handles them naturally; the existing
+  arrival barrier in TimelineView already separates "live tail" vs
+  "history block" by event index, so the new event slots into that path
+  without new dedupe machinery. `handleSubmit` no longer pushes a local
+  bubble — the optimistic latency is replaced by the topology
+  round-trip, which on a local kernel append is sub-frame.
+
+Prior art reviewed:
+- PR 2013 / spec `specs/issue-2013-topology-timeline-history.spec.md`
+  (merged 2026 in PR 2018) introduced `userTurnsBySession`, the
+  arrival-barrier dedupe, and the `useSessionHistory` hook with
+  `staleTime: 0`. That spec explicitly chose the arrival-barrier
+  mechanism because `ChatMessage.seq` and `TopologyEventEntry.seq`
+  were not comparable — the user-prompt path had no kernel-side echo
+  to ride on. This issue is the structural follow-up: by adding the
+  echo, we collapse the two-source-of-truth design into one and
+  retire the optimistic workaround. The arrival barrier itself stays
+  (live agent turns still need it); only the optimistic user-bubble
+  branch goes away.
+- Commit `f5f17976 fix(memory): deduplicate user message in LLM
+  context assembly (#101)` is a separate, backend-internal dedup
+  inside `default_tape_context` and not related to the FE rendering
+  duplicate addressed here. Confirmed by reading the message and the
+  surrounding tape-context code path.
+- Commit `8c16d920 feat(web): add optimistic updates for chat message
+  sending` is the original introduction of the optimistic mechanism
+  on the legacy `pages/Chat.tsx` surface — predates the topology
+  surface and is not what we are touching. The legacy chat path is
+  out of scope (forbidden) here.
+- `gh issue list --search "user message duplicate timeline"` and
+  `gh pr list --search "user message duplicate"` returned no other
+  prior occurrences against the topology surface.
+
+Goal alignment: advances `goal.md` signal 4 ("every action is
+inspectable") — a timeline that double-renders the same user prompt
+around the in-flight assistant is a lying inspector. Indirectly
+advances signal 2 ("the user stops asking") because the duplicate
+forces the user to second-guess what was actually sent. Crosses no NOT
+line; this is fixing the inspector, not adding a feature.
+
+Hermes positioning: round-tripping persisted user-message events back
+to the UI is table-stakes for any agent UI; rara has no engineering
+reason to do it differently. The reason rara reached today's state is
+purely the order in which #2003 / #2013 landed (topology shell first,
+history second, with optimistic-only as the bridge). The kernel-side
+echo collapses the bridge into the same channel everything else
+already flows through.
+
+Lane test that nails lane 1: a vitest test mounts `<TimelineView>` with
+a `viewSessionKey`, drives a user submit, has the topology subscription
+deliver a `UserMessageAppended` frame, and **also** has
+`useSessionHistory` refetch mid-turn returning the same persisted
+message. Before the fix, the test sees two DOM nodes whose text equals
+the prompt. After the fix, exactly one. Fail before, pass after.
+
+## Decisions
+
+- **New variant name.** `StreamEvent::UserMessageAppended` (kernel
+  side) and `WebEvent::UserMessageAppended` (web channel side). Both
+  carry `seq: i64`, `content: serde_json::Value` (mirroring the
+  `tape_content` value already produced at
+  `crates/kernel/src/kernel.rs` Phase 5 — text-only as a JSON string,
+  multimodal as the structured passthrough), and `created_at:
+  DateTime<Utc>`. Serialized field name on the wire is
+  `user_message_appended` to match the existing snake_case convention
+  on `WebEvent` (`text_delta`, `tape_forked`, `subagent_spawned`).
+- **Where the kernel emits.** Inside `crates/kernel/src/kernel.rs` in
+  the non-Mita-directive branch of Phase 5, immediately after
+  `tape_service.append_message(...).await` returns Ok and **before**
+  the agent-loop spawn. Emit-on-success only — if the tape append
+  fails (the existing `warn!` branch), no event is emitted. The Mita
+  directive branch is unaffected (Mita directives are not user-visible
+  prompts).
+- **Where the seq comes from.** The append API must surface the
+  persisted entry's `seq` so the event carries the same value the
+  REST endpoint will return. If `tape_service.append_message` does not
+  already return the new entry's seq, extend its return type to do
+  so; the alternative (re-reading the tape tail) is racy. The
+  reviewer must verify the seq the event carries matches the seq
+  `tap_entries_to_chat_messages` produces for the same entry.
+- **Forwarding to WebEvent.** `crates/channels/src/web.rs`'s
+  `From<StreamEvent>` (or the equivalent fan-out switch) maps
+  `StreamEvent::UserMessageAppended` → `WebEvent::UserMessageAppended`
+  with the same fields. `crates/channels/src/web_topology.rs` only
+  needs an explicit branch if the topology forwarding pipe filters
+  events explicitly (mirror the `TapeForked` / `SubagentSpawned`
+  treatment at line 288).
+- **Tape-context exclusion.** The new event is a stream-side echo of a
+  tape entry that **already exists**; it must NOT cause the user
+  message to be appended to the tape a second time, and it must NOT
+  affect `default_tape_context` (the LLM context assembler must not
+  see this event because it consumes the tape, not the stream). Test:
+  the kernel runs as today against the tape; the new emit is purely
+  observational on the stream side.
+- **FE: remove optimistic, source bubbles from history + topology
+  event.** Delete the `userTurnsBySession` state, the corresponding
+  setter call in `handleSubmit`, and the merge that includes optimistic
+  entries in the chronological list at `TimelineView.tsx`. Bubbles for
+  the live tail come from a new derivation that scans the topology
+  events buffer for `UserMessageAppended` frames whose buffer index is
+  `>= historyBarrierSeq`, mapping each into the same `{kind: "bubble",
+  createdAt, payload}` shape the chronological merge already accepts.
+  Bubbles before the barrier come from `historyUserBubbles` exactly as
+  today.
+- **Dedupe key for the merge.** Both history-derived and topology-event-
+  derived bubbles carry the backend `seq` as the React key. If a
+  frame and a history entry collide on `seq` (possible when a
+  history refetch resolves while the live frame is still in the
+  buffer), the merge keeps the history entry and drops the live one
+  (history is canonical). This is a refinement of the existing
+  arrival-barrier policy, not a replacement.
+- **No legacy chat changes.** `web/src/pages/Chat.tsx` and
+  `web/src/hooks/use-chat-session-ws.ts` are out of scope — they have
+  their own optimistic mechanism on a separate surface and are not
+  what regressed.
+- **No protobuf / gRPC changes.** The topology stream is a JSON
+  WebSocket (`/api/v1/chat/sessions/{key}/topology`); the new variant
+  is a `serde::Serialize`-derived enum case. No proto regeneration
+  needed.
+- **Test harness.** The vitest test reuses the existing `MSW`-style
+  mocks under `web/src/**/__tests__` (see
+  `TimelineView.history.test.tsx` for the pattern). No new test
+  framework. Backend-side: a Rust unit / integration test in
+  `crates/kernel/tests/` that drives a single user prompt and
+  asserts the topology stream contains exactly one
+  `UserMessageAppended` event with the expected `seq` / `content` /
+  `created_at`, plus zero duplicates of the same `seq` across the
+  turn.
+
+## Boundaries
+
+### Allowed Changes
+- **/crates/kernel/src/kernel.rs
+- **/crates/kernel/src/io.rs
+- **/crates/kernel/src/memory/**
+- **/crates/kernel/src/trace/builder.rs
+- **/crates/kernel/tests/**
+- **/crates/channels/src/web.rs
+- **/crates/channels/src/web_topology.rs
+- **/crates/channels/tests/**
+- **/crates/cmd/src/chat/mod.rs
+- **/crates/extensions/backend-admin/src/chat/service.rs
+- **/web/src/components/topology/TimelineView.tsx
+- **/web/src/components/topology/AGENT.md
+- **/web/src/components/topology/__tests__/**
+- **/web/src/hooks/use-topology-subscription.ts
+- **/web/src/hooks/__tests__/**
+- **/web/src/api/types.ts
+- **/specs/issue-2063-user-message-appended-event.spec.md
+
+### Forbidden
+- web/src/pages/Chat.tsx
+- web/src/hooks/use-chat-session-ws.ts
+- web/src/hooks/use-session-timeline.ts
+- web/src/vendor/**
+- web/src/agent/**
+- web/src/components/topology/SessionPicker.tsx
+- web/src/components/topology/WorkerInbox.tsx
+- web/src/components/topology/SpawnMarker.tsx
+- web/src/components/topology/WorkerCard.tsx
+- web/src/components/topology/tape-tree-layout.ts
+- crates/kernel/src/agent/**
+- crates/kernel/src/guard/**
+- config.example.yaml
+- .github/workflows/**
+
+## Acceptance Criteria
+
+Scenario: Kernel emits UserMessageAppended on the topology stream after persisting a user message
+  Test:
+    Package: rara-kernel
+    Filter: kernel_emits_user_message_appended_after_tape_append
+  Given a session with an attached topology stream subscriber
+  When a non-Mita-directive user message is delivered through the kernel ingress and Phase 5 of message handling completes successfully
+  Then the topology stream subscriber receives exactly one StreamEvent::UserMessageAppended for that message
+    And the event's seq equals the seq returned by the REST endpoint GET /api/v1/chat/sessions/{key}/messages for the same tape entry
+    And the event's content matches the persisted tape entry content (text-as-string for plain text, multimodal-passthrough JSON for multimodal)
+    And the event's created_at equals the persisted tape entry timestamp
+
+Scenario: Kernel does not emit UserMessageAppended for Mita directives
+  Test:
+    Package: rara-kernel
+    Filter: kernel_does_not_emit_user_message_appended_for_mita_directive
+  Given a session with an attached topology stream subscriber
+  When an inbound message marked with metadata mita_directive=true is delivered through the kernel ingress
+  Then the topology stream subscriber receives zero StreamEvent::UserMessageAppended events for that message
+
+Scenario: Kernel does not emit UserMessageAppended when tape append fails
+  Test:
+    Package: rara-kernel
+    Filter: kernel_does_not_emit_user_message_appended_on_tape_failure
+  Given a session whose tape_service.append_message is configured to return an error
+  When a non-Mita-directive user message is delivered through the kernel ingress
+  Then the topology stream subscriber receives zero StreamEvent::UserMessageAppended events for that message
+
+Scenario: WebEvent variant carries the same fields as the kernel StreamEvent
+  Test:
+    Package: rara-channels
+    Filter: web_event_user_message_appended_round_trip
+  Given a StreamEvent::UserMessageAppended with seq S, content C, and created_at T
+  When the channel layer converts it for the topology WebSocket
+  Then the resulting WebEvent::UserMessageAppended carries seq S, content C, and created_at T
+    And the JSON-serialized field name is user_message_appended
+
+Scenario: TimelineView renders exactly one user bubble for an in-flight turn even when history refetches mid-turn
+  Test:
+    Package: web
+    Filter: TimelineView.user_message_appended.no_duplicate_when_history_refetches_mid_turn
+  Given TimelineView is mounted with a viewSessionKey whose history initially returns []
+    And the user submits prompt "P" via the InputContainer
+    And the topology subscription delivers a UserMessageAppended event for "P" with seq=1
+    And the topology subscription begins delivering text_delta events for the assistant turn
+  When useSessionHistory refetches mid-turn and resolves with one persisted user message of seq=1 content="P"
+  Then the rendered DOM contains exactly one node whose text content equals "P"
+    And that node has document order before any node containing assistant text deltas
+
+Scenario: TimelineView removes the optimistic user-bubble path entirely
+  Test:
+    Package: web
+    Filter: TimelineView.user_message_appended.no_optimistic_state
+  Given TimelineView source has been updated to consume UserMessageAppended events
+  When the rendered tree is inspected after a user submit
+  Then no React state named userTurnsBySession is present in the TimelineView component instance
+    And no user-bubble node is rendered with createdAt=null
+
+Scenario: TimelineView renders a user bubble from the topology event when history is empty and no REST refetch fires
+  Test:
+    Package: web
+    Filter: TimelineView.user_message_appended.bubble_from_topology_event_alone
+  Given TimelineView is mounted with a viewSessionKey whose history returns []
+    And no further history refetch is triggered during the test
+  When the topology subscription delivers a UserMessageAppended event for prompt "Q" with seq=1 created_at=t1
+  Then the rendered DOM contains exactly one node whose text content equals "Q"
+    And that node carries the React key derived from seq=1
+    And that node renders before any subsequent live agent turn
+
+Scenario: WS reconnect mid-turn does not duplicate the user bubble
+  Test:
+    Package: web
+    Filter: TimelineView.user_message_appended.reconnect_does_not_duplicate
+  Given TimelineView is mounted with a viewSessionKey and a UserMessageAppended event for "R" seq=1 has rendered exactly one bubble
+    And an assistant turn is in flight (text_delta events still arriving)
+  When the topology subscription rebuilds its events buffer from [] (mimicking a WS reconnect)
+    And useSessionHistory refetches and resolves with one persisted user message seq=1 content="R"
+    And a fresh UserMessageAppended event for "R" seq=1 arrives on the rebuilt buffer
+  Then the rendered DOM contains exactly one node whose text content equals "R"
+    And the bubble is sourced from the history payload (history takes precedence on seq collision), not from the post-reconnect live frame
+
+## Out of Scope
+
+- Touching the legacy `pages/Chat.tsx` surface or its optimistic
+  message path. That surface has its own rendering strategy and is
+  not where the duplicate appears.
+- Re-litigating the arrival-barrier dedupe for live agent turns.
+  The barrier stays; only the optimistic user-bubble branch is
+  retired.
+- Cross-counter unification of `ChatMessage.seq` and
+  `TopologyEventEntry.seq`. The new event carries the tape `seq`
+  directly; no global renumbering is required.
+- Multimodal-content schema changes. The new event passes through
+  whatever shape the tape entry already carries.
+- Adding a new endpoint for "user message appended" notifications.
+  The existing topology WS is the carrier.
+- FE retry/backoff semantics for missed `UserMessageAppended` frames.
+  The history refetch path remains the safety net; if a frame is
+  lost (network blip), the next history refetch reconciles.
+- Backend pagination, history limit changes, or any other
+  REST-side change.

--- a/web/src/components/topology/AGENT.md
+++ b/web/src/components/topology/AGENT.md
@@ -43,14 +43,17 @@ button would be overreach.
   WebSocket) and pushes plain-text prompts. The editor always sends into
   the **root** session — browsing a worker child via the inbox stays
   observation-only so replies do not get written to a sandbox tape the
-  user did not pick. User-message rendering is **optimistic**: the typed
-  text is added to local state on submit so it appears before the
-  backend round-trip; the kernel does not echo user prompts back as
-  topology events today. History-on-reload fetches
-  `GET /api/v1/chat/sessions/{key}/messages` via `useSessionHistory` and
-  reduces persisted assistant turns through `buildTurnsFromHistory`,
-  while persisted user messages render as `UserMessageBubble`s ahead of
-  any optimistic prompts. Live/history dedupe uses an **arrival-time
+  user did not pick. User-message rendering rides the kernel's
+  `user_message_appended` topology frame (#2063): the kernel emits this
+  synchronously after persisting the user message to the main tape and
+  before the agent loop spawns, so the bubble appears within one WS
+  round-trip of submit — no FE optimistic state. Persisted bubbles come
+  from `useSessionHistory`, live bubbles from the topology event; both
+  are keyed on the backend `seq` so a collision (history refetch races
+  the live frame) dedupes by React key with history canonical. History-
+  on-reload fetches `GET /api/v1/chat/sessions/{key}/messages` via
+  `useSessionHistory` and reduces persisted assistant turns through
+  `buildTurnsFromHistory`. Live/history dedupe uses an **arrival-time
   barrier**, not seq comparison: at the moment the history query resolves
   for `viewSessionKey`, the current length of the session-filtered topology
   buffer is snapshotted; only entries whose buffer index is `>= barrier`

--- a/web/src/components/topology/TimelineView.tsx
+++ b/web/src/components/topology/TimelineView.tsx
@@ -252,7 +252,11 @@ export function TimelineView({
       .map((m) => {
         const ts = Date.parse(m.created_at);
         return {
-          id: `history-user-${String(m.seq)}`,
+          // Source-agnostic React key: collapses with the live-bubble
+          // key below so a mid-turn history refetch swapping a live entry
+          // for the persisted one reconciles as the same node (no
+          // unmount/remount flicker on focus / WS reconnect).
+          id: `user-${String(m.seq)}`,
           seq: m.seq,
           text: contentToText(m.content),
           createdAt: Number.isNaN(ts) ? null : ts,
@@ -279,7 +283,7 @@ export function TimelineView({
       if (text.length === 0) return [];
       return [
         {
-          id: `live-user-${String(ev.seq)}`,
+          id: `user-${String(ev.seq)}`,
           seq: ev.seq,
           text,
           createdAt: Number.isNaN(ts) ? null : ts,

--- a/web/src/components/topology/TimelineView.tsx
+++ b/web/src/components/topology/TimelineView.tsx
@@ -58,16 +58,19 @@ export interface TimelineViewProps {
 
 /**
  * Main-timeline view of an agent's stream of consciousness. Renders user
- * turns (from optimistic local state) and agent turns (from the topology
- * stream) in arrival order, with a craft-style {@link InputContainer}
- * pinned to the bottom of the column.
+ * bubbles and agent turns in chronological order, with a craft-style
+ * {@link InputContainer} pinned to the bottom of the column.
  *
- * Optimistic user-message rendering: when the user submits, the message
- * is pushed into `userTurns` immediately so it shows up in the timeline
- * before the WS round-trip finishes. The kernel does not echo user
- * prompts back as topology events today, so without this the user would
- * see their text vanish into the input box and only an assistant
- * response appear later.
+ * User bubbles come from two sources, both keyed on the backend `seq`:
+ *
+ * 1. `useSessionHistory` for messages already persisted on disk before
+ *    this mount.
+ * 2. The `user_message_appended` topology frame (kernel echo, #2063) for
+ *    in-flight prompts. The kernel emits this synchronously, pre-fork,
+ *    right after the user message is appended to the main tape — so the
+ *    bubble appears within one WS round-trip of submit, replacing the
+ *    old optimistic-state mechanism that fought with mid-turn history
+ *    refetches.
  */
 export function TimelineView({
   viewSessionKey,
@@ -75,12 +78,6 @@ export function TimelineView({
   promptSessionKey,
   segmentMessages,
 }: TimelineViewProps) {
-  // Per-session ordered user turns. Cleared when the viewed session
-  // changes so a new conversation does not inherit a stale prompt list.
-  const [userTurnsBySession, setUserTurnsBySession] = useState<
-    Record<string, { id: string; text: string; t: number; createdAt: number | null }[]>
-  >({});
-
   const sessionForPrompt = promptSessionKey ?? viewSessionKey;
   const ws = useChatSessionWs(sessionForPrompt);
 
@@ -243,12 +240,11 @@ export function TimelineView({
     return buildTurnsFromEvents(sliced.map((e) => ({ seq: e.seq, event: e.event })));
   }, [sessionEvents, viewSessionKey, barrierBySession]);
 
-  // Historical user prompts merged with the optimistic local prompts the
-  // editor pushes on submit. Historical entries come first in seq order;
-  // optimistic entries follow because they were typed after the page
-  // loaded.
+  // Persisted user prompts from the REST history payload. Keyed on the
+  // backend `seq` so a colliding live `user_message_appended` frame
+  // dedupes by React key naturally — history is canonical on collision.
   const historyUserBubbles = useMemo<
-    { id: string; text: string; t: number; createdAt: number | null }[]
+    { id: string; seq: number; text: string; createdAt: number | null }[]
   >(() => {
     if (!historyMessages) return [];
     return historyMessages
@@ -257,27 +253,65 @@ export function TimelineView({
         const ts = Date.parse(m.created_at);
         return {
           id: `history-user-${String(m.seq)}`,
+          seq: m.seq,
           text: contentToText(m.content),
-          t: 0,
           createdAt: Number.isNaN(ts) ? null : ts,
         };
       })
       .filter((u) => u.text.length > 0);
   }, [historyMessages]);
 
-  // Build a single ordered list of bubbles + turns. History items sort by
-  // `createdAt` ascending; items without a timestamp (live agent turns and
-  // optimistic local user prompts) trail the history block in arrival
-  // order. Each rendered node carries `data-testid="turn-or-bubble"` so
-  // the chronological-ordering scenarios can query in document order.
+  // Live user bubbles fold from `user_message_appended` topology frames
+  // that arrived strictly after the history barrier — same arrival-barrier
+  // policy as `agentTurns`, so frames mirrored in the history payload
+  // don't render twice. On `seq` collision with a history bubble, history
+  // wins (the live entry is filtered out below in the merge).
+  const liveUserBubbles = useMemo<
+    { id: string; seq: number; text: string; createdAt: number | null }[]
+  >(() => {
+    const barrier = barrierBySession[viewSessionKey];
+    const sliced = barrier === undefined ? sessionEvents : sessionEvents.slice(barrier);
+    return sliced.flatMap((entry) => {
+      const ev = entry.event;
+      if (ev.type !== 'user_message_appended') return [];
+      const ts = Date.parse(ev.created_at);
+      const text = contentToText(ev.content);
+      if (text.length === 0) return [];
+      return [
+        {
+          id: `live-user-${String(ev.seq)}`,
+          seq: ev.seq,
+          text,
+          createdAt: Number.isNaN(ts) ? null : ts,
+        },
+      ];
+    });
+  }, [sessionEvents, viewSessionKey, barrierBySession]);
+
+  // Build a single ordered list of bubbles + turns. History items and
+  // live user bubbles (which carry the kernel-emitted `created_at`) sort
+  // by `createdAt` ascending; live agent turns have no timestamp and
+  // trail the history block in arrival order. Each rendered node carries
+  // `data-testid="turn-or-bubble"` so chronological-ordering scenarios
+  // can query in document order.
   type Item =
     | { kind: 'bubble'; key: string; createdAt: number | null; text: string }
     | { kind: 'turn'; key: string; createdAt: number | null; turn: TurnCardData };
 
   const orderedItems = useMemo<Item[]>(() => {
-    const optimistic = userTurnsBySession[viewSessionKey] ?? [];
+    // Drop any live bubble whose seq collides with a persisted history
+    // bubble — history is canonical (covers the WS-reconnect-then-refetch
+    // race called out in spec scenario `reconnect_does_not_duplicate`).
+    const historySeqs = new Set(historyUserBubbles.map((u) => u.seq));
+    const liveDeduped = liveUserBubbles.filter((u) => !historySeqs.has(u.seq));
     const items: Item[] = [
       ...historyUserBubbles.map<Item>((u) => ({
+        kind: 'bubble',
+        key: u.id,
+        createdAt: u.createdAt,
+        text: u.text,
+      })),
+      ...liveDeduped.map<Item>((u) => ({
         kind: 'bubble',
         key: u.id,
         createdAt: u.createdAt,
@@ -295,12 +329,6 @@ export function TimelineView({
         createdAt: null,
         turn: t,
       })),
-      ...optimistic.map<Item>((u) => ({
-        kind: 'bubble',
-        key: u.id,
-        createdAt: null,
-        text: u.text,
-      })),
     ];
     // Stable sort: items with a `createdAt` come first in ascending order;
     // items without one preserve their input order at the tail. The input
@@ -317,7 +345,7 @@ export function TimelineView({
       return a.idx - b.idx;
     });
     return indexed.map(({ it }) => it);
-  }, [historyUserBubbles, historyTurns, agentTurns, userTurnsBySession, viewSessionKey]);
+  }, [historyUserBubbles, liveUserBubbles, historyTurns, agentTurns]);
 
   const isEmpty = orderedItems.length === 0;
 
@@ -353,18 +381,12 @@ export function TimelineView({
             ...(pickedProvider ? { modelProvider: pickedProvider } : {}),
           }
         : undefined;
-      const ok = ws.sendPrompt(trimmed, promptOptions);
-      if (!ok) return;
-      const id = `u-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 6)}`;
-      setUserTurnsBySession((prev) => {
-        const list = prev[viewSessionKey] ?? [];
-        return {
-          ...prev,
-          [viewSessionKey]: [...list, { id, text: trimmed, t: Date.now(), createdAt: null }],
-        };
-      });
+      // Bubble rendering now comes exclusively from the
+      // `user_message_appended` topology frame the kernel emits after
+      // persisting the message (#2063) — no optimistic state to clear.
+      ws.sendPrompt(trimmed, promptOptions);
     },
-    [ws, viewSessionKey, currentModel, pickedProvider],
+    [ws, currentModel, pickedProvider],
   );
 
   const handleModelChange = useCallback((model: string, connection?: string) => {

--- a/web/src/components/topology/__tests__/TimelineView.user_message_appended.test.tsx
+++ b/web/src/components/topology/__tests__/TimelineView.user_message_appended.test.tsx
@@ -238,13 +238,70 @@ describe('TimelineView.user_message_appended', () => {
 
     const node = await screen.findByText('Q');
     expect(screen.getAllByText('Q')).toHaveLength(1);
-    // Outer wrapper carries the React key derived from seq=1. RTL does
-    // not expose the React `key` directly, but we can verify the render
-    // is sourced from the live (`live-user-${seq}`) path by checking
-    // it is a `user-bubble` node (via testid). The wrapper around it
-    // has no DOM trace of the key, so the falsifier is "exactly one
-    // node" combined with the bubble actually being present.
+    // Outer wrapper carries the React key derived from seq=1
+    // (`user-${seq}`, source-agnostic since the live and history paths
+    // were unified). RTL does not expose React `key` directly; the
+    // falsifier is "exactly one node" combined with the bubble actually
+    // being present.
     expect(node).toHaveAttribute('data-testid', 'user-bubble');
+  });
+
+  it('unified_key_history_wrapper_survives_late_live_event: a same-seq live event arriving after history does not remount the history wrapper', async () => {
+    // Companion to the FE polish fix that unifies the React key for
+    // live + history user bubbles to `user-${seq}` (was
+    // `live-user-${seq}` / `history-user-${seq}`). This test pins the
+    // observable invariant the unified key is meant to preserve in the
+    // common "history canonical, live arrives later" path: the outer
+    // `data-testid="turn-or-bubble"` wrapper is the SAME DOM node
+    // before and after the late live event lands. Note this scenario
+    // alone does NOT falsify the key change in isolation — the seq
+    // dedupe in `orderedItems` keeps history canonical regardless of
+    // key — but it locks in "no remount on collision", which is the
+    // user-visible promise the unified key reinforces against future
+    // refactors that might shuffle iteration order.
+    listMessagesMock.mockResolvedValueOnce([
+      makeMessage({
+        seq: 7,
+        role: 'user',
+        content: 'K',
+        created_at: '2026-04-30T00:00:01Z',
+      }),
+    ]);
+
+    const sessionKey = 'sess-K';
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false, gcTime: 0 } },
+    });
+
+    const { rerender } = render(
+      <QueryClientProvider client={queryClient}>
+        <TimelineView viewSessionKey={sessionKey} events={[]} promptSessionKey={null} />
+      </QueryClientProvider>,
+    );
+
+    const beforeNode = await screen.findByText('K');
+    const beforeWrapper = beforeNode.closest('[data-testid="turn-or-bubble"]');
+    expect(beforeWrapper).not.toBeNull();
+
+    // Late-arriving live frame at the same seq. With the seq dedupe in
+    // `orderedItems` (history canonical), the live entry is filtered
+    // out. With unified keys (`user-7`), the history wrapper is NOT
+    // unmounted — it stays as the same DOM node.
+    const lateLive = makeUserAppended(sessionKey, 7, 'K', '2026-04-30T00:00:01Z', 1);
+    rerender(
+      <QueryClientProvider client={queryClient}>
+        <TimelineView viewSessionKey={sessionKey} events={[lateLive]} promptSessionKey={null} />
+      </QueryClientProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getAllByText('K')).toHaveLength(1);
+    });
+    const afterNode = screen.getByText('K');
+    const afterWrapper = afterNode.closest('[data-testid="turn-or-bubble"]');
+    // Same DOM node ⇒ React reconciled, no remount, no flicker.
+    expect(afterWrapper).toBe(beforeWrapper);
+    expect(beforeWrapper?.isConnected).toBe(true);
   });
 
   it('reconnect_does_not_duplicate: WS reconnect + history refetch keeps exactly one bubble', async () => {

--- a/web/src/components/topology/__tests__/TimelineView.user_message_appended.test.tsx
+++ b/web/src/components/topology/__tests__/TimelineView.user_message_appended.test.tsx
@@ -1,0 +1,325 @@
+/*
+ * Copyright 2025 Rararulab
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * BDD bindings for the FE-bound scenarios in
+ * `specs/issue-2063-user-message-appended-event.spec.md`.
+ *
+ * Each `it(...)` name carries the spec's `Filter:` suffix verbatim so
+ * `agent-spec verify` can resolve scenarios to real test functions
+ * (group prefix `TimelineView.user_message_appended` from the enclosing
+ * `describe`).
+ */
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { cleanup, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { TimelineView } from '../TimelineView';
+
+import type { ChatMessageData } from '@/api/types';
+import type { TopologyEventEntry } from '@/hooks/use-topology-subscription';
+
+// --- Module mocks --------------------------------------------------------
+
+const chatWsMock = vi.hoisted(() => ({
+  state: {
+    status: 'live',
+    error: null as string | null,
+    sendPrompt: vi.fn(() => true),
+    sendAbort: vi.fn(() => true),
+  },
+}));
+
+vi.mock('@/hooks/use-chat-session-ws', () => ({
+  useChatSessionWs: () => chatWsMock.state,
+}));
+
+vi.mock('@/hooks/use-chat-models', () => ({
+  useChatModels: () => ({ data: [] }),
+}));
+
+const listMessagesMock = vi.fn();
+vi.mock('@/api/sessions', () => ({
+  listMessages: (...args: unknown[]) => listMessagesMock(...args),
+}));
+
+vi.mock('~vendor/components/input/InputContainer', () => ({
+  InputContainer: ({
+    onSubmit,
+    disabled,
+  }: {
+    onSubmit?: (message: string) => void;
+    disabled?: boolean;
+  }) => (
+    <div data-testid="input-container" data-disabled={String(Boolean(disabled))}>
+      <button type="button" data-testid="input-submit" onClick={() => onSubmit?.('P')}>
+        send
+      </button>
+    </div>
+  ),
+}));
+
+vi.mock('~vendor/components/chat/UserMessageBubble', () => ({
+  UserMessageBubble: ({ content }: { content: string }) => (
+    <div data-testid="user-bubble">{content}</div>
+  ),
+}));
+
+vi.mock('~vendor/context/AppShellContext', () => ({
+  AppShellProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock('~vendor/context/EscapeInterruptContext', () => ({
+  EscapeInterruptProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+function makeMessage(partial: Partial<ChatMessageData>): ChatMessageData {
+  return {
+    seq: 0,
+    role: 'user',
+    content: '',
+    created_at: '2026-04-30T00:00:00Z',
+    ...partial,
+  };
+}
+
+function makeUserAppended(
+  sessionKey: string,
+  seq: number,
+  text: string,
+  createdAt = '2026-04-30T00:00:01Z',
+  bufferSeq = seq,
+): TopologyEventEntry {
+  return {
+    seq: bufferSeq,
+    sessionKey,
+    event: {
+      type: 'user_message_appended',
+      parent_session: sessionKey,
+      seq,
+      content: text,
+      created_at: createdAt,
+    },
+  };
+}
+
+function renderTimeline(
+  props: {
+    viewSessionKey: string;
+    events?: TopologyEventEntry[];
+  },
+  client?: QueryClient,
+) {
+  const queryClient =
+    client ??
+    new QueryClient({
+      defaultOptions: { queries: { retry: false, gcTime: 0 } },
+    });
+  return {
+    queryClient,
+    ...render(
+      <QueryClientProvider client={queryClient}>
+        <TimelineView
+          viewSessionKey={props.viewSessionKey}
+          events={props.events ?? []}
+          promptSessionKey={null}
+        />
+      </QueryClientProvider>,
+    ),
+  };
+}
+
+beforeEach(() => {
+  listMessagesMock.mockReset();
+  chatWsMock.state.status = 'live';
+  chatWsMock.state.error = null;
+  chatWsMock.state.sendPrompt.mockClear();
+  chatWsMock.state.sendAbort.mockClear();
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('TimelineView.user_message_appended', () => {
+  it('no_duplicate_when_history_refetches_mid_turn: live frame + history refetch render exactly one bubble', async () => {
+    // History initially returns []; after a refetch, returns the
+    // persisted user message at the same seq the live frame carries.
+    let resolveSecondHistory: (value: ChatMessageData[]) => void = () => {};
+    listMessagesMock.mockResolvedValueOnce([]).mockReturnValueOnce(
+      new Promise<ChatMessageData[]>((resolve) => {
+        resolveSecondHistory = resolve;
+      }),
+    );
+
+    const sessionKey = 'sess-A';
+    const liveBubble = makeUserAppended(sessionKey, 1, 'P');
+    // Render with the live frame already in the events buffer.
+    // `useSessionHistory` resolves with `[]` so the barrier snapshots
+    // at length 1 — the live bubble was already there at history-
+    // resolution time. With the seq-dedupe in `orderedItems` (history
+    // canonical), the post-refetch persisted bubble takes over without
+    // duplicating.
+    const { queryClient } = renderTimeline({
+      viewSessionKey: sessionKey,
+      events: [liveBubble],
+    });
+
+    await screen.findByText('P');
+    expect(screen.getAllByText('P')).toHaveLength(1);
+
+    // Mid-turn refetch (e.g. window focus). Resolve with the persisted
+    // user message at seq=1 — same seq as the live frame. History wins
+    // the seq-collision dedupe, so still exactly one bubble.
+    void queryClient.refetchQueries({
+      queryKey: ['topology', 'session-history', sessionKey],
+    });
+    await waitFor(() => expect(listMessagesMock).toHaveBeenCalledTimes(2));
+    resolveSecondHistory([
+      makeMessage({
+        seq: 1,
+        role: 'user',
+        content: 'P',
+        created_at: '2026-04-30T00:00:01Z',
+      }),
+    ]);
+
+    await waitFor(() => {
+      expect(screen.getAllByText('P')).toHaveLength(1);
+    });
+  });
+
+  it('no_optimistic_state: submitting without any topology event yields zero bubbles', async () => {
+    // The optimistic path is gone — submit through the input must NOT
+    // produce a bubble locally; the bubble has to come from the
+    // topology stream's user_message_appended frame.
+    listMessagesMock.mockResolvedValueOnce([]);
+
+    renderTimeline({ viewSessionKey: 'sess-no-opt', events: [] });
+
+    // Wait for empty render.
+    await screen.findByText(/Waiting for the next turn/i);
+
+    // Click the input's send button (mocked to call onSubmit('P')).
+    screen.getByTestId('input-submit').click();
+
+    // Give React a tick.
+    await new Promise((r) => setTimeout(r, 10));
+
+    // No bubble should appear — the live frame would be the only source.
+    expect(screen.queryByText('P')).not.toBeInTheDocument();
+    // ws.sendPrompt was invoked (the path is otherwise functional).
+    expect(chatWsMock.state.sendPrompt).toHaveBeenCalledWith('P', undefined);
+  });
+
+  it('bubble_from_topology_event_alone: empty history + live frame renders exactly one bubble keyed on seq', async () => {
+    listMessagesMock.mockResolvedValueOnce([]);
+
+    const sessionKey = 'sess-Q';
+    const liveBubble = makeUserAppended(sessionKey, 1, 'Q', '2026-04-30T00:00:05Z');
+    renderTimeline({
+      viewSessionKey: sessionKey,
+      events: [liveBubble],
+    });
+
+    const node = await screen.findByText('Q');
+    expect(screen.getAllByText('Q')).toHaveLength(1);
+    // Outer wrapper carries the React key derived from seq=1. RTL does
+    // not expose the React `key` directly, but we can verify the render
+    // is sourced from the live (`live-user-${seq}`) path by checking
+    // it is a `user-bubble` node (via testid). The wrapper around it
+    // has no DOM trace of the key, so the falsifier is "exactly one
+    // node" combined with the bubble actually being present.
+    expect(node).toHaveAttribute('data-testid', 'user-bubble');
+  });
+
+  it('reconnect_does_not_duplicate: WS reconnect + history refetch keeps exactly one bubble', async () => {
+    const sessionKey = 'sess-R';
+
+    // First history call: empty (so the barrier snapshots at 0 and the
+    // live "R" bubble can flow through). Second call (post-reconnect
+    // refetch): returns the persisted "R" at seq=1.
+    let resolveSecond: (value: ChatMessageData[]) => void = () => {};
+    listMessagesMock.mockResolvedValueOnce([]).mockReturnValueOnce(
+      new Promise<ChatMessageData[]>((resolve) => {
+        resolveSecond = resolve;
+      }),
+    );
+
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false, gcTime: 0 } },
+    });
+
+    // Pre-reconnect: live R bubble + an in-flight assistant text_delta.
+    const liveR = makeUserAppended(sessionKey, 1, 'R', '2026-04-30T00:00:01Z', 1);
+    const liveDelta: TopologyEventEntry = {
+      seq: 2,
+      sessionKey,
+      event: { type: 'text_delta', text: 'streaming-a' },
+    };
+    const { rerender } = render(
+      <QueryClientProvider client={queryClient}>
+        <TimelineView
+          viewSessionKey={sessionKey}
+          events={[liveR, liveDelta]}
+          promptSessionKey={null}
+        />
+      </QueryClientProvider>,
+    );
+
+    await screen.findByText('R');
+    expect(screen.getAllByText('R')).toHaveLength(1);
+    await waitFor(() => expect(listMessagesMock).toHaveBeenCalledTimes(1));
+
+    // Simulate WS reconnect: events buffer rebuilt from []. The
+    // session-filtered length goes 2 → 0; the reset effect drops the
+    // barrier and triggers history.refetch().
+    rerender(
+      <QueryClientProvider client={queryClient}>
+        <TimelineView viewSessionKey={sessionKey} events={[]} promptSessionKey={null} />
+      </QueryClientProvider>,
+    );
+
+    await waitFor(() => expect(listMessagesMock).toHaveBeenCalledTimes(2));
+
+    // Refetch resolves with the persisted R.
+    resolveSecond([
+      makeMessage({
+        seq: 1,
+        role: 'user',
+        content: 'R',
+        created_at: '2026-04-30T00:00:01Z',
+      }),
+    ]);
+
+    // Then a fresh user_message_appended for R seq=1 arrives on the
+    // rebuilt buffer (kernel re-broadcasts on the new connection).
+    const reLiveR = makeUserAppended(sessionKey, 1, 'R', '2026-04-30T00:00:01Z', 1);
+    rerender(
+      <QueryClientProvider client={queryClient}>
+        <TimelineView viewSessionKey={sessionKey} events={[reLiveR]} promptSessionKey={null} />
+      </QueryClientProvider>,
+    );
+
+    // Exactly one R — history takes precedence on seq collision so the
+    // post-reconnect live frame is filtered out (seq dedupe in
+    // orderedItems).
+    await waitFor(() => {
+      expect(screen.getAllByText('R')).toHaveLength(1);
+    });
+  });
+});

--- a/web/src/hooks/use-topology-subscription.ts
+++ b/web/src/hooks/use-topology-subscription.ts
@@ -36,6 +36,7 @@ import { useEffect, useRef, useState } from 'react';
 import { buildWsBaseUrl } from '@/adapters/ws-base-url';
 import type { WebFrame } from '@/agent/session-ws-client';
 import { getAccessToken } from '@/api/client';
+import type { ChatMessageData } from '@/api/types';
 
 // ---------------------------------------------------------------------------
 // Wire frames — server → client (topology endpoint)
@@ -74,6 +75,17 @@ export type TopologyWebFrame =
       forked_from: string;
       child_tape: string;
       forked_at_anchor?: string | null;
+    }
+  | {
+      // Kernel-side echo of a user-message tape append (#2063). `seq` is
+      // the same value the REST `/messages` endpoint would return for
+      // this entry — keying both history and live bubbles on it lets
+      // `TimelineView` retire the old optimistic-bubble state.
+      type: 'user_message_appended';
+      parent_session: string;
+      seq: number;
+      content: ChatMessageData['content'];
+      created_at: string;
     };
 
 /** Descendant entry in the topology `hello` snapshot. */


### PR DESCRIPTION
## Summary

Retires the optimistic user-bubble workaround in `TimelineView` that races with `useSessionHistory` and renders the same prompt twice (once before the in-flight assistant card, once after) on any mid-turn history refetch. Replaces it with a kernel-emitted `UserMessageAppended` topology event that the FE consumes alongside history, deduped on backend `seq`.

- **Kernel** (`crates/kernel/src/io.rs`, `kernel.rs` Phase 5): new `StreamEvent::UserMessageAppended { parent_session, seq, content, created_at }`, emitted on the session bus immediately after `tape_service.append_message_with_chat_seq` (synchronous, pre-fork). Mita directives and tape-failure paths intentionally do NOT emit.
- **Channels** (`crates/channels/src/web.rs`): mirrored as `WebEvent::UserMessageAppended` (wire tag `user_message_appended`).
- **Tape** (`crates/kernel/src/memory/{service,store}.rs`): new `append_message_with_chat_seq` returns the persisted chat-message seq atomically inside the same tape-IO worker turn — no race, no tail re-read. Legacy `append_message` callers skip the seq walk.
- **Web** (`web/src/components/topology/TimelineView.tsx`, `use-topology-subscription.ts`): drops `userTurnsBySession` optimistic state. User bubbles come from history + topology event, deduped on `seq` (history wins on collision per spec). React keys unified as `user-${seq}` so a late history catchup does not remount the bubble.

Spec: `specs/issue-2063-user-message-appended-event.spec.md`.

## Test plan

- [x] `cargo test -p rara-kernel --test user_message_appended_topology_event` — 4 scenarios pass (emit on success, no-emit on Mita directive, no-emit on tape failure, seq matches REST `/messages` endpoint)
- [x] `cargo test -p rara-channels` — round-trip `WebEvent::UserMessageAppended` test passes
- [x] `bun test` (web) — 73/73 pass; 5 new TimelineView scenarios cover all 4 FE-bound BDD scenarios + key continuity
- [x] Backend gate: cargo check / fmt / clippy / doc / prek — all green
- [x] Frontend gate: build / typecheck / lint — all clean
- [x] `just spec-lifecycle` — 5 BE scenarios pass; 4 FE scenarios fail by tooling only (#2015, no vitest adapter — vitest itself passes)
- [x] Real-browser dogfood (local `just run` + `bun run dev`): submit prompt → exactly one user bubble per submit, no bracketing duplicate, in-flight + completed states verified

Closes #2063