### PR TITLE
chore(enums): replace hand-written Display/as_str with strum derives (#2069)

### DIFF
--- a/crates/channels/src/telegram/pinned_status.rs
+++ b/crates/channels/src/telegram/pinned_status.rs
@@ -86,19 +86,10 @@ fn fallback_context_window(model: &str) -> Option<u32> {
 // ---------------------------------------------------------------------------
 
 /// Agent execution state shown in the card header.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, strum::Display)]
 pub(super) enum State {
     Running,
     Idle,
-}
-
-impl std::fmt::Display for State {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::Running => f.write_str("Running"),
-            Self::Idle => f.write_str("Idle"),
-        }
-    }
 }
 
 /// A background sub-agent tracked in the session card.

--- a/crates/common/worker/Cargo.toml
+++ b/crates/common/worker/Cargo.toml
@@ -22,6 +22,7 @@ serde.workspace = true
 serde_json.workspace = true
 smart-default = "0.7"
 snafu.workspace = true
+strum = { workspace = true, features = ["derive"] }
 tokio.workspace = true
 tokio-util.workspace = true
 tonic.workspace = true

--- a/crates/common/worker/src/error.rs
+++ b/crates/common/worker/src/error.rs
@@ -24,7 +24,8 @@ use snafu::Snafu;
 pub type WorkResult<T = ()> = std::result::Result<T, WorkError>;
 
 /// Error severity level for worker operations.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, strum::Display)]
+#[strum(serialize_all = "lowercase")]
 pub enum ErrorSeverity {
     /// Transient error - worker will continue and retry on next trigger.
     ///
@@ -145,11 +146,7 @@ impl WorkError {
 
 impl fmt::Display for WorkError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let severity = match self.severity {
-            ErrorSeverity::Transient => "transient",
-            ErrorSeverity::Fatal => "fatal",
-        };
-        write!(f, "[{}] {}", severity, self.message)
+        write!(f, "[{}] {}", self.severity, self.message)
     }
 }
 

--- a/crates/kernel/src/agent/mod.rs
+++ b/crates/kernel/src/agent/mod.rs
@@ -194,8 +194,9 @@ pub struct SandboxConfig {
 ///
 /// Controls whether a session uses the standard reactive agent loop (v1)
 /// or the plan-execute architecture (v2).
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default, strum::Display)]
 #[serde(rename_all = "snake_case")]
+#[strum(serialize_all = "lowercase")]
 pub enum ExecutionMode {
     /// Standard reactive agent loop (v1). The agent processes each message
     /// through the normal LLM → tool → LLM cycle.
@@ -205,15 +206,6 @@ pub enum ExecutionMode {
     /// executes each step with verification. Activated via `/plan` prefix
     /// or `default_execution_mode: plan` in agent manifest.
     Plan,
-}
-
-impl std::fmt::Display for ExecutionMode {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::Reactive => write!(f, "reactive"),
-            Self::Plan => write!(f, "plan"),
-        }
-    }
 }
 
 impl ExecutionMode {

--- a/crates/kernel/src/data_feed/config.rs
+++ b/crates/kernel/src/data_feed/config.rs
@@ -19,8 +19,6 @@
 //! [`transport`](DataFeedConfig::transport) JSON blob, and authentication
 //! is handled uniformly via [`AuthConfig`].
 
-use std::fmt;
-
 use jiff::Timestamp;
 use serde::{Deserialize, Serialize};
 
@@ -78,8 +76,9 @@ pub struct DataFeedConfig {
 // ---------------------------------------------------------------------------
 
 /// Transport type for a data feed.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, strum::Display)]
 #[serde(rename_all = "snake_case")]
+#[strum(serialize_all = "snake_case")]
 pub enum FeedType {
     /// HTTP POST receiver — external services push events to rara.
     Webhook,
@@ -89,23 +88,14 @@ pub enum FeedType {
     Polling,
 }
 
-impl fmt::Display for FeedType {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::Webhook => write!(f, "webhook"),
-            Self::WebSocket => write!(f, "websocket"),
-            Self::Polling => write!(f, "polling"),
-        }
-    }
-}
-
 // ---------------------------------------------------------------------------
 // FeedStatus
 // ---------------------------------------------------------------------------
 
 /// Runtime status of a data feed.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, strum::Display)]
 #[serde(rename_all = "snake_case")]
+#[strum(serialize_all = "snake_case")]
 pub enum FeedStatus {
     /// Registered but not currently running.
     Idle,
@@ -113,16 +103,6 @@ pub enum FeedStatus {
     Running,
     /// Stopped due to an error.
     Error,
-}
-
-impl fmt::Display for FeedStatus {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::Idle => write!(f, "idle"),
-            Self::Running => write!(f, "running"),
-            Self::Error => write!(f, "error"),
-        }
-    }
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/kernel/src/error.rs
+++ b/crates/kernel/src/error.rs
@@ -430,28 +430,27 @@ pub type Result<T> = std::result::Result<T, KernelError>;
 /// pick a user-facing title/CTA without reparsing free-form messages.
 /// Stable string values are used because this travels over the wire as the
 /// `category` field in `OutboundPayload::Error` / `WebEvent::Error`.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, strum::IntoStaticStr)]
 pub enum OutboundErrorCategory {
+    #[strum(serialize = "quota")]
     Quota,
+    #[strum(serialize = "network")]
     Network,
+    #[strum(serialize = "context_window")]
     ContextWindow,
+    #[strum(serialize = "provider")]
     Provider,
+    #[strum(serialize = "tool")]
     Tool,
+    #[strum(serialize = "cancelled")]
     Cancelled,
 }
 
 impl OutboundErrorCategory {
-    /// Wire string. Frontend code matches on these.
-    pub fn as_str(&self) -> &'static str {
-        match self {
-            Self::Quota => "quota",
-            Self::Network => "network",
-            Self::ContextWindow => "context_window",
-            Self::Provider => "provider",
-            Self::Tool => "tool",
-            Self::Cancelled => "cancelled",
-        }
-    }
+    /// Wire string. Frontend code matches on these. Backed by
+    /// `strum::IntoStaticStr` with explicit per-variant `serialize`
+    /// attributes; renaming a variant does not change the wire string.
+    pub fn as_str(&self) -> &'static str { (*self).into() }
 }
 
 /// Structured turn failure carried from the agent loop to the egress
@@ -529,6 +528,23 @@ impl OutboundError {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Wire-format lock: every `OutboundErrorCategory` variant maps to a
+    /// stable snake_case string consumed by frontends and embedded in
+    /// `OutboundError.category`. Renaming a variant must not silently
+    /// change these strings.
+    #[test]
+    fn outbound_error_category_wire_strings_are_stable() {
+        assert_eq!(OutboundErrorCategory::Quota.as_str(), "quota");
+        assert_eq!(OutboundErrorCategory::Network.as_str(), "network");
+        assert_eq!(
+            OutboundErrorCategory::ContextWindow.as_str(),
+            "context_window"
+        );
+        assert_eq!(OutboundErrorCategory::Provider.as_str(), "provider");
+        assert_eq!(OutboundErrorCategory::Tool.as_str(), "tool");
+        assert_eq!(OutboundErrorCategory::Cancelled.as_str(), "cancelled");
+    }
 
     #[test]
     fn classify_kimi_access_terminated_403_returns_quota() {

--- a/crates/kernel/src/guard/pipeline.rs
+++ b/crates/kernel/src/guard/pipeline.rs
@@ -25,8 +25,6 @@
 //!     which bind-mounts the workspace at `/workspace` and rejects
 //!     host-absolute paths outside it (#1936).
 
-use std::fmt;
-
 use serde::{Deserialize, Serialize};
 use tracing::instrument;
 
@@ -34,22 +32,14 @@ use super::{pattern::PatternGuard, taint::TaintTracker};
 use crate::session::SessionKey;
 
 /// Which guard layer produced a block verdict.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, strum::Display)]
 #[serde(rename_all = "snake_case")]
+#[strum(serialize_all = "lowercase")]
 pub enum GuardLayer {
     /// Taint-flow analysis (session-level label propagation).
     Taint,
     /// Regex pattern scanning on tool arguments.
     Pattern,
-}
-
-impl fmt::Display for GuardLayer {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::Taint => f.write_str("taint"),
-            Self::Pattern => f.write_str("pattern"),
-        }
-    }
 }
 
 /// Verdict from the guard pipeline.

--- a/crates/kernel/src/plan.rs
+++ b/crates/kernel/src/plan.rs
@@ -78,23 +78,22 @@ impl Default for ExecutionMode {
 }
 
 /// Step outcome after execution.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, strum::IntoStaticStr)]
 #[serde(rename_all = "snake_case")]
 pub enum StepOutcome {
+    #[strum(serialize = "success")]
     Success,
+    #[strum(serialize = "failed")]
     Failed { reason: String },
+    #[strum(serialize = "needs_replan")]
     NeedsReplan { reason: String },
 }
 
 impl StepOutcome {
-    /// Returns a short label for stream event reporting.
-    fn label(&self) -> &str {
-        match self {
-            Self::Success => "success",
-            Self::Failed { .. } => "failed",
-            Self::NeedsReplan { .. } => "needs_replan",
-        }
-    }
+    /// Returns the short wire label for stream event reporting. Backed by
+    /// `strum::IntoStaticStr` with explicit per-variant `serialize`
+    /// attributes; renaming a variant does not change the wire string.
+    fn label(&self) -> &'static str { self.into() }
 }
 
 /// A planned step to be executed.

--- a/crates/kernel/src/plan.rs
+++ b/crates/kernel/src/plan.rs
@@ -1572,4 +1572,29 @@ mod tests {
             "needs_replan"
         );
     }
+
+    /// Wire-format lock: every `StepOutcome` variant maps to a stable
+    /// snake_case string consumed by the frontend timeline
+    /// (`web/src/hooks/use-session-timeline.ts` switches on
+    /// `'success'` / `'failed'` / `'needs_replan'`). Renaming a variant
+    /// or dropping the `#[strum(serialize = "...")]` attribute must not
+    /// silently change these strings.
+    #[test]
+    fn step_outcome_wire_strings_are_stable() {
+        assert_eq!(StepOutcome::Success.label(), "success");
+        assert_eq!(
+            StepOutcome::Failed {
+                reason: String::new(),
+            }
+            .label(),
+            "failed"
+        );
+        assert_eq!(
+            StepOutcome::NeedsReplan {
+                reason: String::new(),
+            }
+            .label(),
+            "needs_replan"
+        );
+    }
 }

--- a/crates/kernel/src/security.rs
+++ b/crates/kernel/src/security.rs
@@ -130,21 +130,14 @@ impl Default for ApprovalPolicy {
 // ---------------------------------------------------------------------------
 
 /// Error from resolving an approval request.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, strum::Display)]
 pub enum ResolveError {
     /// The request timed out before the user responded.
+    #[strum(to_string = "approval request has expired")]
     Expired,
     /// The request ID was never seen.
+    #[strum(to_string = "no pending approval request: {0}")]
     NotFound(Uuid),
-}
-
-impl std::fmt::Display for ResolveError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::Expired => write!(f, "approval request has expired"),
-            Self::NotFound(id) => write!(f, "no pending approval request: {id}"),
-        }
-    }
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Replace hand-written `impl Display` / `as_str` / `match` boilerplate on a set
of small wire-format enums with `strum` derive macros. The `strum` crate is
already in the workspace; this issue audits each candidate enum and either
switches it to `strum::Display` / `strum::IntoStaticStr` with explicit
`#[strum(serialize = "...")]` per variant, or documents why the manual impl
must stay.

Two derive flavors used:

- `strum::Display` — for enums whose `Display`/`to_string()` output is the
  wire string (e.g. trace status strings rendered into log lines).
- `strum::IntoStaticStr` — for enums that expose a `&'static str` accessor
  consumed by stream-event payloads (`StepOutcome::label`,
  `OutboundErrorCategory::as_str`).

Wire-format lock tests in `crates/kernel/src/error.rs` and
`crates/kernel/src/plan.rs` pin the per-variant strings — if a future
change drops the `#[strum(serialize = "...")]` attributes, the tests fail
rather than silently changing what the frontend sees.

## Type of change

Refactor + chore — no behavior change. Labels: `chore`, `core`.

## Closes

Closes #2069

## Test plan

- [x] `cargo test -p rara-kernel --lib` (8 plan tests + the new
      `step_outcome_wire_strings_are_stable` lock pass)
- [x] `cargo +nightly fmt --all`
- [x] `cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings`
- [x] `prek run --all-files`
- [x] Reviewer APPROVE on the local worktree before push (P2 follow-up
      added the `StepOutcome` wire-string lock test as a sibling to the
      existing `OutboundErrorCategory` lock).