### PR TITLE
chore: mechanical cleanup pass — unwrap → expect, CJK comments → English, wildcard import (#2071)

### DIFF
--- a/crates/app/src/gateway/supervisor.rs
+++ b/crates/app/src/gateway/supervisor.rs
@@ -286,7 +286,7 @@ impl SupervisorService {
 
         // Wait for the child to exit, a shutdown signal, or a command.
         tokio::select! {
-            status = self.child.as_mut().unwrap().wait() => {
+            status = self.child.as_mut().expect("child was assigned to self.child immediately above").wait() => {
                 match status {
                     Ok(s) if s.success() => {
                         info!("Agent process exited with status 0");

--- a/crates/app/src/lib.rs
+++ b/crates/app/src/lib.rs
@@ -711,7 +711,7 @@ pub async fn start_with_options(
 
     // TraceService is shared between the kernel (which writes traces at
     // turn end) and the backend session service (which reads them for
-    // the web "📊 详情" button). Create it once here so both sides see
+    // the web "📊 Details" button). Create it once here so both sides see
     // the same underlying pool.
     let trace_service = rara_kernel::trace::TraceService::new(diesel_pools.clone());
 

--- a/crates/channels/src/telegram/adapter.rs
+++ b/crates/channels/src/telegram/adapter.rs
@@ -362,7 +362,7 @@ struct PlanStepState {
 /// [`ExecutionTrace`] and emitted
 /// [`rara_kernel::io::StreamEvent::TraceReady`] carrying the `trace_id`.
 /// This adapter fetches the trace via `TraceService::get` and
-/// edits the Telegram message to a compact summary with an inline "📊 详情"
+/// edits the Telegram message to a compact summary with an inline "📊 Details"
 /// button that toggles the full trace view.
 ///
 /// ## Token semantics (from kernel `UsageUpdate`)
@@ -746,7 +746,7 @@ pub(super) fn format_token_count(tokens: u32) -> String {
 
 /// Render a compact one-line summary for a completed execution trace.
 /// Example: `✅ 45s · ↑12.5k ↓1.2k · thought 9s`
-/// This is the collapsed state shown with the inline "详情" button.
+/// This is the collapsed state shown with the inline "Details" button.
 fn render_compact_summary(trace: &ExecutionTrace) -> String {
     let mut parts = Vec::new();
     parts.push(format_duration_compact(std::time::Duration::from_secs(
@@ -2251,9 +2251,9 @@ async fn handle_tool_call_limit_callback(
 /// Handle a trace show/hide callback query from an inline keyboard button.
 ///
 /// Callback data format: `"trace:{action}:{chat_id}:{msg_id}"`
-/// - `action` = "show" → expand to full trace, button becomes "收起"
+/// - `action` = "show" → expand to full trace, button becomes "Collapse"
 /// - `action` = "hide" → collapse back to compact summary, button becomes
-///   "详情"
+///   "Details"
 ///
 /// Trace data is fetched from [`rara_kernel::trace::TraceService`] (SQLite)
 /// and rendered into Telegram HTML on demand. The callback is always answered
@@ -3250,7 +3250,10 @@ async fn handle_update(
                                             if let Some(url) = btn.url {
                                                 teloxide::types::InlineKeyboardButton::url(
                                                     btn.text,
-                                                    url.parse().unwrap(),
+                                                    url.parse().expect(
+                                                        "button URL string is constructed by \
+                                                         adapter code and is always a valid URL",
+                                                    ),
                                                 )
                                             } else {
                                                 teloxide::types::InlineKeyboardButton::callback(
@@ -3864,7 +3867,13 @@ async fn dispatch_command_result(
                     row.into_iter()
                         .map(|btn| {
                             if let Some(url) = btn.url {
-                                InlineKeyboardButton::url(btn.text, url.parse().unwrap())
+                                InlineKeyboardButton::url(
+                                    btn.text,
+                                    url.parse().expect(
+                                        "button URL string is constructed by adapter code and is \
+                                         always a valid URL",
+                                    ),
+                                )
                             } else {
                                 InlineKeyboardButton::callback(
                                     btn.text,
@@ -4075,7 +4084,7 @@ fn spawn_stream_forwarder(
                                     state.dirty = true;
 
                                     if state.accumulated.len() > STREAM_SPLIT_THRESHOLD {
-                                        // 剥离 LLM 可能泄漏到 content 中的 tool call XML
+                                        // Strip tool-call XML the LLM may have leaked into content.
                                         let cleaned = strip_tool_call_xml(&state.accumulated);
                                         let split_chars = cleaned.chars().count();
                                         let html = crate::telegram::markdown::markdown_to_telegram_html(&cleaned);
@@ -4455,7 +4464,7 @@ fn spawn_stream_forwarder(
                             // Hard-truncated to ~500 chars to bound memory; the
                             // full reasoning stays in the kernel's TurnTrace.
                             // Uses .chars().count() for char-level limit to avoid
-                            // panic on slicing multi-byte UTF-8 (中文, emoji, etc).
+                            // panic on slicing multi-byte UTF-8 (Chinese, emoji, etc).
                             let current_chars = progress.reasoning_preview.chars().count();
                             if current_chars < 500 {
                                 let remaining = 500 - current_chars;
@@ -4579,7 +4588,7 @@ fn spawn_stream_forwarder(
                             let flush_req = {
                                 if let Some(state) = active_streams.get(&chat_id) {
                                     if state.dirty {
-                                        // 剥离 LLM 可能泄漏到 content 中的 tool call XML
+                                        // Strip tool-call XML the LLM may have leaked into content.
                                         let cleaned = strip_tool_call_xml(&state.accumulated);
                                         let html = crate::telegram::markdown::markdown_to_telegram_html(&cleaned);
                                         Some(FlushRequest {
@@ -5157,7 +5166,10 @@ async fn flush_edit(
             }
         }
     } else {
-        let msg_id = *req.message_ids.last().unwrap();
+        let msg_id = *req
+            .message_ids
+            .last()
+            .expect("the is_empty() branch returned above, so message_ids has at least one entry");
         rate_limiter.acquire(chat_id).await;
         match bot
             .edit_message_text(ChatId(chat_id), msg_id, &req.text_html)
@@ -5198,7 +5210,10 @@ fn apply_flush_result(
         match result {
             FlushResult::Sent(msg_id) => {
                 if state.message_ids.last().copied() == Some(MessageId(0)) {
-                    *state.message_ids.last_mut().unwrap() = msg_id;
+                    *state
+                        .message_ids
+                        .last_mut()
+                        .expect("the outer guard checked last() == Some(MessageId(0))") = msg_id;
                 } else {
                     state.message_ids.push(msg_id);
                 }

--- a/crates/cmd/src/login/mod.rs
+++ b/crates/cmd/src/login/mod.rs
@@ -41,7 +41,11 @@ impl LoginCmd {
 }
 
 async fn run_codex_login() -> Result<(), Whatever> {
-    use rara_codex_oauth::*;
+    use rara_codex_oauth::{
+        build_auth_url, exchange_authorization_code, generate_code_challenge,
+        generate_code_verifier, generate_nonce, now_unix, parse_callback_url, save_tokens,
+        validate_state,
+    };
 
     println!("Starting Codex OAuth login...\n");
 

--- a/crates/cmd/src/top/app.rs
+++ b/crates/cmd/src/top/app.rs
@@ -345,7 +345,10 @@ impl App {
             let ss = &mut self.session_state;
 
             // Use uptime_ms to compute the actual start time of this process.
-            let agent_start = now.checked_sub(Duration::from_millis(p.uptime_ms)).unwrap();
+            let agent_start = now.checked_sub(Duration::from_millis(p.uptime_ms)).expect(
+                "agent uptime_ms is reported by the kernel and never exceeds wall time since \
+                 process start",
+            );
 
             let session_view =
                 ss.sessions

--- a/crates/common/base/src/readable_size.rs
+++ b/crates/common/base/src/readable_size.rs
@@ -100,18 +100,20 @@ impl Serialize for ReadableSize {
     {
         let size = self.0;
         let mut buffer = String::new();
+        // SAFETY: writing into a `String` via `fmt::Write` cannot fail —
+        // String's Write impl never returns Err.
         if size == 0 {
-            write!(buffer, "{size}KiB").unwrap();
+            write!(buffer, "{size}KiB").expect("write! into String never fails");
         } else if size.is_multiple_of(PIB) {
-            write!(buffer, "{}PiB", size / PIB).unwrap();
+            write!(buffer, "{}PiB", size / PIB).expect("write! into String never fails");
         } else if size.is_multiple_of(TIB) {
-            write!(buffer, "{}TiB", size / TIB).unwrap();
+            write!(buffer, "{}TiB", size / TIB).expect("write! into String never fails");
         } else if size.is_multiple_of(GIB) {
-            write!(buffer, "{}GiB", size / GIB).unwrap();
+            write!(buffer, "{}GiB", size / GIB).expect("write! into String never fails");
         } else if size.is_multiple_of(MIB) {
-            write!(buffer, "{}MiB", size / MIB).unwrap();
+            write!(buffer, "{}MiB", size / MIB).expect("write! into String never fails");
         } else if size.is_multiple_of(KIB) {
-            write!(buffer, "{}KiB", size / KIB).unwrap();
+            write!(buffer, "{}KiB", size / KIB).expect("write! into String never fails");
         } else {
             return serializer.serialize_u64(size);
         }

--- a/crates/common/telemetry/src/logging.rs
+++ b/crates/common/telemetry/src/logging.rs
@@ -400,7 +400,10 @@ pub fn init_default_ut_logging() {
     static START: Once = Once::new();
 
     START.call_once(|| {
-        let mut g = GLOBAL_UT_LOG_GUARD.as_ref().lock().unwrap();
+        let mut g = GLOBAL_UT_LOG_GUARD
+            .as_ref()
+            .lock()
+            .expect("GLOBAL_UT_LOG_GUARD mutex poisoned by an earlier panic");
 
         let dir =
             env::var("UNITTEST_LOG_DIR").unwrap_or_else(|_| "/tmp/__unittest_logs".to_string());

--- a/crates/common/telemetry/src/tracing_context.rs
+++ b/crates/common/telemetry/src/tracing_context.rs
@@ -95,7 +95,10 @@ impl TracingContext {
     /// Panics if JSON serialization fails (should not happen with valid W3C
     /// context).
     #[must_use]
-    pub fn to_json(&self) -> String { serde_json::to_string(&self.to_w3c()).unwrap() }
+    pub fn to_json(&self) -> String {
+        serde_json::to_string(&self.to_w3c())
+            .expect("W3cTrace is a flat map of String->String and always serializes")
+    }
 
     /// Deserialize from JSON string. Returns empty context on invalid JSON.
     #[must_use]

--- a/crates/common/telemetry/src/tracing_sampler.rs
+++ b/crates/common/telemetry/src/tracing_sampler.rs
@@ -153,7 +153,10 @@ fn sample_based_on_probability(prob: f64, trace_id: TraceId) -> SamplingDecision
         let prob_upper_bound = (prob.max(0.0) * (1u64 << 63) as f64) as u64;
         let bytes = trace_id.to_bytes();
         let (_, low) = bytes.split_at(8);
-        let trace_id_low = u64::from_be_bytes(low.try_into().unwrap());
+        let trace_id_low = u64::from_be_bytes(
+            low.try_into()
+                .expect("split_at(8) on a 16-byte TraceId guarantees the second half is 8 bytes"),
+        );
         let rnd_from_trace_id = trace_id_low >> 1;
 
         if rnd_from_trace_id < prob_upper_bound {

--- a/crates/common/worker/src/builder.rs
+++ b/crates/common/worker/src/builder.rs
@@ -479,7 +479,8 @@ where
             name,
             self.blocking,
             self.eager,
-            self.trigger.unwrap(),
+            self.trigger
+                .expect("typestate guarantees trigger is Some once spawn() is callable"),
             pause_mode,
         )
     }
@@ -501,7 +502,8 @@ where
             name,
             self.blocking,
             self.eager,
-            self.trigger.unwrap(),
+            self.trigger
+                .expect("typestate guarantees trigger is Some once spawn() is callable"),
             pause_mode,
         )
     }
@@ -524,7 +526,8 @@ where
             name,
             self.blocking,
             self.eager,
-            self.trigger.unwrap(),
+            self.trigger
+                .expect("typestate guarantees trigger is Some once spawn() is callable"),
             pause_mode,
         )
     }
@@ -547,7 +550,8 @@ where
             name,
             self.blocking,
             self.eager,
-            self.trigger.unwrap(),
+            self.trigger
+                .expect("typestate guarantees trigger is Some once spawn() is callable"),
             pause_mode,
         )
     }
@@ -570,7 +574,8 @@ where
             name,
             self.blocking,
             self.eager,
-            self.trigger.unwrap(),
+            self.trigger
+                .expect("typestate guarantees trigger is Some once spawn() is callable"),
             pause_mode,
         )
     }
@@ -593,7 +598,8 @@ where
             name,
             self.blocking,
             self.eager,
-            self.trigger.unwrap(),
+            self.trigger
+                .expect("typestate guarantees trigger is Some once spawn() is callable"),
             pause_mode,
         )
     }
@@ -887,7 +893,8 @@ where
             name,
             self.blocking,
             self.eager,
-            self.trigger.unwrap(),
+            self.trigger
+                .expect("typestate guarantees trigger is Some once spawn() is callable"),
             pause_mode,
         )
     }
@@ -907,7 +914,8 @@ where
             name,
             self.blocking,
             self.eager,
-            self.trigger.unwrap(),
+            self.trigger
+                .expect("typestate guarantees trigger is Some once spawn() is callable"),
             pause_mode,
         )
     }
@@ -927,7 +935,8 @@ where
             name,
             self.blocking,
             self.eager,
-            self.trigger.unwrap(),
+            self.trigger
+                .expect("typestate guarantees trigger is Some once spawn() is callable"),
             pause_mode,
         )
     }
@@ -947,7 +956,8 @@ where
             name,
             self.blocking,
             self.eager,
-            self.trigger.unwrap(),
+            self.trigger
+                .expect("typestate guarantees trigger is Some once spawn() is callable"),
             pause_mode,
         )
     }
@@ -967,7 +977,8 @@ where
             name,
             self.blocking,
             self.eager,
-            self.trigger.unwrap(),
+            self.trigger
+                .expect("typestate guarantees trigger is Some once spawn() is callable"),
             pause_mode,
         )
     }
@@ -987,7 +998,8 @@ where
             name,
             self.blocking,
             self.eager,
-            self.trigger.unwrap(),
+            self.trigger
+                .expect("typestate guarantees trigger is Some once spawn() is callable"),
             pause_mode,
         )
     }

--- a/crates/drivers/browser/src/manager.rs
+++ b/crates/drivers/browser/src/manager.rs
@@ -225,7 +225,15 @@ impl BrowserManager {
                 .active
                 .as_ref()
                 .and_then(|id| store.tabs.get(id))
-                .map(|tab| (store.active.clone().unwrap(), tab.page.clone()))
+                .map(|tab| {
+                    (
+                        store
+                            .active
+                            .clone()
+                            .expect("active is Some because and_then(|id| ...) succeeded above"),
+                        tab.page.clone(),
+                    )
+                })
         };
 
         let nav_timeout = Duration::from_secs(self.config.navigate_timeout_secs);

--- a/crates/kernel/src/agent/mod.rs
+++ b/crates/kernel/src/agent/mod.rs
@@ -1775,7 +1775,9 @@ async fn run_agent_loop_inner(
                     if !text.is_empty() {
                         if first_token_at.is_none() {
                             first_token_at = Some(Instant::now());
-                            let ttft = first_token_at.unwrap().duration_since(stream_start);
+                            let ttft = first_token_at
+                                .expect("first_token_at was just assigned Some(..) one line above")
+                                .duration_since(stream_start);
                             iter_span.record("first_token_ms", ttft.as_millis() as u64);
                             // gen_ai.server.time_to_first_token is in seconds
                             // per the OTel GenAI spec.

--- a/crates/kernel/src/kernel.rs
+++ b/crates/kernel/src/kernel.rs
@@ -2148,7 +2148,10 @@ impl Kernel {
         // without invoking the agent loop.
         let raw_text = msg.content.as_text();
         if raw_text.starts_with("/msg_version") {
-            let arg = raw_text.strip_prefix("/msg_version").unwrap().trim();
+            let arg = raw_text
+                .strip_prefix("/msg_version")
+                .expect("starts_with(\"/msg_version\") was checked one line above")
+                .trim();
             let user = msg.user.clone();
             let msg_id = msg.id.clone();
             let origin_endpoint = msg.origin_endpoint().or_else(|| {
@@ -2450,7 +2453,7 @@ impl Kernel {
                             .unwrap_or_else(|| serde_json::json!({}));
                         let images = meta
                             .as_object_mut()
-                            .unwrap()
+                            .expect("meta defaulted to json!({}) above, which is always an object")
                             .entry("images")
                             .or_insert_with(|| serde_json::json!({}));
                         if let Some(images_map) = images.as_object_mut() {
@@ -2821,7 +2824,7 @@ impl Kernel {
                 // -- 7f: Persist execution trace --
                 // Why: Every agent turn — success or failure — gets its trace
                 // persisted to SQLite so that any channel can later retrieve
-                // it (Telegram "📊 详情" inline button, web chat
+                // it (Telegram "📊 Details" inline button, web chat
                 // execution-trace modal). Before #1613 this was TG-adapter
                 // responsibility and only TG turns had rows; now trace
                 // construction + save is a single kernel-owned concern.

--- a/crates/kernel/src/llm/types.rs
+++ b/crates/kernel/src/llm/types.rs
@@ -530,7 +530,7 @@ pub enum LlmProviderFamily {
     OpenRouter,
     Ollama,
     Codex,
-    /// 智谱 BigModel (GLM series).
+    /// Zhipu BigModel (GLM series).
     Glm,
     Unknown,
 }

--- a/crates/kernel/src/schedule.rs
+++ b/crates/kernel/src/schedule.rs
@@ -408,10 +408,10 @@ impl JobWheel {
 
     /// Return the next fire time, or `None` if the wheel is empty.
     pub fn next_deadline(&self) -> Option<jiff::Timestamp> {
-        self.jobs
-            .keys()
-            .next()
-            .map(|(secs, _)| jiff::Timestamp::from_second(*secs).unwrap())
+        self.jobs.keys().next().map(|(secs, _)| {
+            jiff::Timestamp::from_second(*secs)
+                .expect("secs was produced by Timestamp::as_second() and stays in jiff's range")
+        })
     }
 
     /// Pure query: which jobs have expired as of `now`?

--- a/crates/kernel/src/trace/builder.rs
+++ b/crates/kernel/src/trace/builder.rs
@@ -384,7 +384,7 @@ impl Default for TraceBuilder {
 
 /// Append `src` to `dst`, stopping once `dst` reaches `max_chars`.
 ///
-/// Operates on char count (not byte count) so multi-byte UTF-8 (中文, emoji)
+/// Operates on char count (not byte count) so multi-byte UTF-8 (Chinese, emoji)
 /// does not accidentally slice a code point in half. When the cap is hit
 /// mid-append, a horizontal-ellipsis `…` is pushed to signal truncation.
 fn append_capped_chars(dst: &mut String, src: &str, max_chars: usize) {

--- a/crates/skills/src/marketplace.rs
+++ b/crates/skills/src/marketplace.rs
@@ -135,11 +135,19 @@ impl MarketplaceService {
     }
 
     /// List registered marketplace sources.
-    pub fn list_sources(&self) -> Vec<MarketplaceSource> { self.sources.read().unwrap().clone() }
+    pub fn list_sources(&self) -> Vec<MarketplaceSource> {
+        self.sources
+            .read()
+            .expect("sources RwLock poisoned by an earlier panic")
+            .clone()
+    }
 
     /// Register a new marketplace source by `owner/repo`.
     pub fn add_source(&self, repo: &str) -> Result<()> {
-        let mut sources = self.sources.write().unwrap();
+        let mut sources = self
+            .sources
+            .write()
+            .expect("sources RwLock poisoned by an earlier panic");
         if sources.iter().any(|s| s.repo == repo) {
             return Ok(()); // idempotent
         }
@@ -153,9 +161,15 @@ impl MarketplaceService {
 
     /// Remove a marketplace source.
     pub fn remove_source(&self, repo: &str) -> Result<()> {
-        let mut sources = self.sources.write().unwrap();
+        let mut sources = self
+            .sources
+            .write()
+            .expect("sources RwLock poisoned by an earlier panic");
         sources.retain(|s| s.repo != repo);
-        self.cache.write().unwrap().remove(repo);
+        self.cache
+            .write()
+            .expect("cache RwLock poisoned by an earlier panic")
+            .remove(repo);
         save_sources(&self.persist_path, &sources)
     }
 
@@ -166,7 +180,12 @@ impl MarketplaceService {
     /// → base64 decode → parse as MarketplaceIndex → cache.
     pub async fn fetch_index(&self, repo: &str) -> Result<MarketplaceIndex> {
         // Return cached if available.
-        if let Some(idx) = self.cache.read().unwrap().get(repo) {
+        if let Some(idx) = self
+            .cache
+            .read()
+            .expect("cache RwLock poisoned by an earlier panic")
+            .get(repo)
+        {
             return Ok(idx.clone());
         }
 
@@ -209,7 +228,7 @@ impl MarketplaceService {
                 let index = synthetic_index_from_plugin_json(repo, &json_str)?;
                 self.cache
                     .write()
-                    .unwrap()
+                    .expect("cache RwLock poisoned by an earlier panic")
                     .insert(repo.to_string(), index.clone());
                 return Ok(index);
             }
@@ -233,16 +252,26 @@ impl MarketplaceService {
 
         self.cache
             .write()
-            .unwrap()
+            .expect("cache RwLock poisoned by an earlier panic")
             .insert(repo.to_string(), index.clone());
         Ok(index)
     }
 
     /// Clear cached indexes. Next `fetch_index` will re-fetch from GitHub.
-    pub fn clear_cache(&self) { self.cache.write().unwrap().clear(); }
+    pub fn clear_cache(&self) {
+        self.cache
+            .write()
+            .expect("cache RwLock poisoned by an earlier panic")
+            .clear();
+    }
 
     /// Clear cache for a specific marketplace.
-    pub fn clear_cache_for(&self, repo: &str) { self.cache.write().unwrap().remove(repo); }
+    pub fn clear_cache_for(&self, repo: &str) {
+        self.cache
+            .write()
+            .expect("cache RwLock poisoned by an earlier panic")
+            .remove(repo);
+    }
 
     /// Browse all plugins across all (or one) marketplace.
     pub async fn browse(&self, marketplace: Option<&str>) -> Result<Vec<PluginInfo>> {

--- a/crates/skills/src/registry.rs
+++ b/crates/skills/src/registry.rs
@@ -80,22 +80,37 @@ impl InMemoryRegistry {
 
     /// Add a skill directly.
     pub fn insert(&self, meta: SkillMetadata) {
-        self.skills.write().unwrap().insert(meta.name.clone(), meta);
+        self.skills
+            .write()
+            .expect("skills RwLock poisoned by an earlier panic")
+            .insert(meta.name.clone(), meta);
     }
 
     /// List all skill metadata.
     pub fn list_all(&self) -> Vec<SkillMetadata> {
-        self.skills.read().unwrap().values().cloned().collect()
+        self.skills
+            .read()
+            .expect("skills RwLock poisoned by an earlier panic")
+            .values()
+            .cloned()
+            .collect()
     }
 
     /// Get a clone of a skill's metadata by name.
     pub fn get(&self, name: &str) -> Option<SkillMetadata> {
-        self.skills.read().unwrap().get(name).cloned()
+        self.skills
+            .read()
+            .expect("skills RwLock poisoned by an earlier panic")
+            .get(name)
+            .cloned()
     }
 
     /// Remove a skill by name. Returns the removed metadata, if any.
     pub fn remove(&self, name: &str) -> Option<SkillMetadata> {
-        self.skills.write().unwrap().remove(name)
+        self.skills
+            .write()
+            .expect("skills RwLock poisoned by an earlier panic")
+            .remove(name)
     }
 }
 


### PR DESCRIPTION
## Summary

Mechanical cleanup pass aligning the repo with `docs/guides/rust-style.md` and `docs/guides/code-comments.md`. Three categories, no behavior change:

- **`.unwrap()` → informative `.expect("…")`** in non-test code (worker/builder, skills/marketplace, skills/registry, kernel, channels, drivers, common/base, common/telemetry, app)
- **CJK code comments → English** (11 translations across 5 files; 15 retained where surrounding English prose quotes a runtime string emitted by the code itself — translating would make the comment lie about what the code does)
- **`use rara_codex_oauth::*;` → 9 explicit imports** in `crates/cmd/src/login/mod.rs`

## Type of change

Maintenance / refactor — `chore` label.

## Component

`core` + `backend`.

## Closes

Closes #2071

## Test plan

- [x] `cargo check --all --all-targets` ✓
- [x] `cargo +nightly fmt --all -- --check` ✓
- [x] `cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings` ✓
- [x] `prek run --all-files` ✓
- [x] `cargo test -p` on the 9 affected crates: 535 passed (1 pre-existing flake in `rara-kernel::testing::tests::test_kernel_builder_redirect_is_idempotent` unrelated to this diff — same failure on `main`)
- [x] No `Cargo.toml` / `Cargo.lock` / migrations / tests / FE touched
- [x] Reviewer (independent) verified: `expect` messages are informative (no `expect("unwrap")` / `expect("")` / `expect("failed")`), CJK retentions are all legitimate runtime-string quotes, wildcard expansion is exhaustive (all 9 imports used exactly once)

## Audit grep before / after

| Audit | Before (main) | After | Drop |
|---|---|---|---|
| `.unwrap()` in `crates/` (excl. `/tests/`) | 487 | 442 | **−45** |
| `//.*[一-鿿]` in `crates/` (CJK in comments) | 26 | 15 | **−11** |
| `use rara_codex_oauth::*` in `cmd/login/mod.rs` | 1 | 0 | **−1** |