### PR TITLE
chore(deps): batch dep upgrades (opendal, sysinfo, boxlite, gh actions) (#2086)

### DIFF
--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: arc-runner-set
     steps:
       - name: Add to project
-        uses: actions/add-to-project@v1.0.2
+        uses: actions/add-to-project@v2.0.0
         with:
           project-url: https://github.com/orgs/rararulab/projects/1
           github-token: ${{ secrets.ADD_TO_PROJECT_TOKEN }}

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -29,7 +29,7 @@ jobs:
           rm -rf bin/
           git clean -fdX
       - name: Run release-plz
-        uses: release-plz/action@52440b50d383aa252927de395c8b2c1e0a9cf8e9 # v0.5
+        uses: release-plz/action@4a08fbe6cb1bb0e4d066058e6efcf50f352db236 # v0.5.129
         with:
           command: release
         env:

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -27,7 +27,7 @@ jobs:
           rm -rf bin/
           git clean -fdX
       - name: Run release-plz
-        uses: release-plz/action@52440b50d383aa252927de395c8b2c1e0a9cf8e9 # v0.5
+        uses: release-plz/action@4a08fbe6cb1bb0e4d066058e6efcf50f352db236 # v0.5.129
         with:
           command: release-pr
         env:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -186,7 +186,7 @@ notify = "8"
 oauth2 = "5"
 once_cell = "^1.20"
 open = "5"
-opendal = { version = "0.52", features = ["services-fs", "services-memory"] }
+opendal = { version = "0.56", features = ["services-fs", "services-memory"] }
 parking_lot = "0.12"
 prost = "^0.14"
 protobuf = "^3.7"
@@ -209,7 +209,7 @@ snafu = "^0.9"
 strum = "^0.27"
 strum_macros = "^0.27"
 subtle = "2"
-sysinfo = "0.38"
+sysinfo = "0.39"
 teloxide = { version = "^0.17", features = ["macros"] }
 tokio = { version = "^1.45", features = ["full", "tracing"] }
 tokio-util = "^0.7"

--- a/crates/cmd/src/setup/boxlite.rs
+++ b/crates/cmd/src/setup/boxlite.rs
@@ -39,7 +39,7 @@ use super::prompt;
 ///
 /// This is a mechanism constant (matches the dependency, not user
 /// preference), not a YAML knob.
-const BOXLITE_VERSION: &str = "v0.8.2";
+const BOXLITE_VERSION: &str = "v0.9.3";
 
 /// Base URL for the upstream boxlite release archive. Appended with
 /// `{version}/boxlite-runtime-{version}-{target}.tar.gz`.

--- a/crates/rara-sandbox/Cargo.toml
+++ b/crates/rara-sandbox/Cargo.toml
@@ -17,7 +17,7 @@ workspace = true
 
 [dependencies]
 bon = { workspace = true }
-boxlite = { git = "https://github.com/boxlite-ai/boxlite", tag = "v0.8.2" }
+boxlite = { git = "https://github.com/boxlite-ai/boxlite", tag = "v0.9.3" }
 futures = { workspace = true }
 serde = { workspace = true }
 snafu = { workspace = true }


### PR DESCRIPTION
## Summary

Replaces 11 closed dependabot PRs (#2074, #2075, #2077, #2078, #2079, #2080, #2081, #2082, #2083, #2084, #2085) with one batched upgrade so workspace CI runs once instead of 11×.

## Upgraded

- `opendal` `0.52` → `0.56` (workspace)
- `sysinfo` `0.38` → `0.39` (workspace)
- `boxlite` git tag `v0.8.2` → `v0.9.3` (`crates/rara-sandbox`) + `BOXLITE_VERSION` const in `crates/cmd/src/setup/boxlite.rs` (paired via a guard test)
- `release-plz/action` `v0.5.126` → `v0.5.129` (SHA + comment, in both `release-pr.yml` and `release-plz.yml`)
- `actions/add-to-project` `v1.0.2` → `v2.0.0`

## Deferred (drop-on-infeasible per #2086)

- **`keyring ^3.6 → ^4.0`** — `keyring 4.0` was repackaged into `keyring-core` + per-platform backend crates; the `[features]` table our `crates/integrations/keyring-store` wrapper depends on (`crypto-rust`, `apple-native`, `linux-native-async-persistent`, `tokio`) is gone. Real refactor required, not a few-line adapter — file as its own issue.
- **`opentelemetry` family `0.31 → 0.32`** — `tracing-opentelemetry 0.32.1`, `axum-tracing-opentelemetry 0.33.1`, `tonic-tracing-opentelemetry 0.32.2` (all latest) still pin `opentelemetry ^0.31`. Bumping our 5 otel crates would produce a dual-version dep graph and break `TraceContextExt`-using call sites. Re-batch once the ecosystem catches up.

## Test plan

- [x] `prek run --all-files` — check / nightly fmt / clippy / doc all pass
- [x] `cargo test --workspace` — 537 pass; one pre-existing flake in `rara-kernel::testing::tests::test_kernel_builder_redirect_is_idempotent` reproduces on `origin/main` (test-ordering issue with a global `set_custom_config_dir`), unrelated to this diff
- [x] Independent reviewer verified `release-plz/action v0.5.129` SHA matches `gh api repos/release-plz/action/git/refs/tags/v0.5.129`
- [x] Independent reviewer verified `actions/add-to-project v2.0.0` only changes Node runtime (no input breakage; we only pass `project-url` + `github-token`)
- [ ] CI green

Closes #2086