### PR TITLE
chore(deps): bump boxlite v0.9.3 → v0.9.4 (#2092)

### DIFF
--- a/crates/cmd/src/setup/boxlite.rs
+++ b/crates/cmd/src/setup/boxlite.rs
@@ -39,7 +39,7 @@ use super::prompt;
 ///
 /// This is a mechanism constant (matches the dependency, not user
 /// preference), not a YAML knob.
-const BOXLITE_VERSION: &str = "v0.9.3";
+const BOXLITE_VERSION: &str = "v0.9.4";
 
 /// Base URL for the upstream boxlite release archive. Appended with
 /// `{version}/boxlite-runtime-{version}-{target}.tar.gz`.

--- a/crates/rara-sandbox/Cargo.toml
+++ b/crates/rara-sandbox/Cargo.toml
@@ -17,7 +17,7 @@ workspace = true
 
 [dependencies]
 bon = { workspace = true }
-boxlite = { git = "https://github.com/boxlite-ai/boxlite", tag = "v0.9.3" }
+boxlite = { git = "https://github.com/boxlite-ai/boxlite", tag = "v0.9.4" }
 futures = { workspace = true }
 serde = { workspace = true }
 snafu = { workspace = true }


### PR DESCRIPTION
## Summary

Patch bump for boxlite: `v0.9.3` → `v0.9.4`. Replaces closed dependabot PR #2089 (which had a stale `v0.8.2` base from before #2088 landed).

Two lines, lockstep:
- `crates/rara-sandbox/Cargo.toml` — git tag
- `crates/cmd/src/setup/boxlite.rs` — `BOXLITE_VERSION` const (a guard test ties these together)

## Test plan

- [x] `prek run --all-files` — check / nightly fmt / clippy / doc all pass
- [x] `cargo test -p rara-sandbox` — 6 pass
- [x] `cargo test -p rara-cli` — 84 pass (guard test enforcing const ↔ Cargo.toml tag included)
- [x] Independent reviewer verified upstream tag `v0.9.4` exists (`45e211fa`) and 30d regression-decision scan clean
- [ ] CI green

Closes #2092