### PR TITLE
feat(cmd): GC stale boxlite runtime sibling dirs after staging (#2097)

### DIFF
--- a/crates/cmd/src/setup/boxlite.rs
+++ b/crates/cmd/src/setup/boxlite.rs
@@ -29,7 +29,7 @@ use std::{
 };
 
 use snafu::{ResultExt, Whatever};
-use tracing::instrument;
+use tracing::{instrument, warn};
 
 use super::prompt;
 
@@ -128,6 +128,7 @@ async fn run_boxlite_setup_with(
 
     if opts.dest.join(COMPLETE_STAMP).is_file() && has_required_files(&opts.dest) {
         prompt::print_ok(&format!("already staged at {}", opts.dest.display()));
+        gc_stale_siblings(&opts.dest);
         return Ok(StageOutcome::Staged {
             dest: opts.dest.clone(),
         });
@@ -152,9 +153,54 @@ async fn run_boxlite_setup_with(
     ))?;
 
     prompt::print_ok(&format!("staged at {}", opts.dest.display()));
+    gc_stale_siblings(&opts.dest);
     Ok(StageOutcome::Staged {
         dest: opts.dest.clone(),
     })
+}
+
+/// Remove every direct sibling subdirectory of `dest` under `dest.parent()`.
+///
+/// `dest` is the per-version staging dir (e.g. `runtimes/v0.9.4/`); the
+/// parent (`runtimes/`) is owned end-to-end by `rara-cli setup boxlite`
+/// and any sibling versioned dir is a stale prior install that bloats
+/// disk usage with no consumer. Stray non-directory entries are left
+/// alone (safer not to delete files we did not put there). Per-sibling
+/// removal failures emit a `tracing::warn!` and continue — the user's
+/// primary outcome (staging the current version) already succeeded.
+fn gc_stale_siblings(dest: &Path) {
+    let (Some(parent), Some(keep)) = (dest.parent(), dest.file_name()) else {
+        return;
+    };
+    let entries = match fs::read_dir(parent) {
+        Ok(entries) => entries,
+        Err(err) => {
+            warn!(
+                parent = %parent.display(),
+                error = %err,
+                "boxlite GC: failed to read runtimes parent; skipping cleanup",
+            );
+            return;
+        }
+    };
+    for entry in entries.flatten() {
+        if entry.file_name() == keep {
+            continue;
+        }
+        // Only reclaim directories — leave stray files alone.
+        let is_dir = entry.file_type().map(|ft| ft.is_dir()).unwrap_or(false);
+        if !is_dir {
+            continue;
+        }
+        let path = entry.path();
+        if let Err(err) = fs::remove_dir_all(&path) {
+            warn!(
+                sibling = %path.display(),
+                error = %err,
+                "boxlite GC: failed to remove stale sibling runtime dir; continuing",
+            );
+        }
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -579,13 +625,23 @@ mod tests {
     // Scenario tests (BDD selectors in spec map to these names).
     // -----------------------------------------------------------------
 
+    /// Build a hermetic `(parent, dest)` pair where `parent` is the
+    /// tempdir that plays the role of `runtimes/` and `dest` is the
+    /// version-keyed subdir inside it. Mirrors production layout so
+    /// `dest.parent()` is owned end-to-end by the test.
+    fn fresh_dest() -> (tempfile::TempDir, PathBuf) {
+        let parent = tempdir().expect("create runtimes parent");
+        let dest = parent.path().join("v-current");
+        (parent, dest)
+    }
+
     #[tokio::test]
     async fn fresh_setup_downloads_and_stages_all_files() {
         let server = FixtureServer::start(build_fixture_tarball(&FixtureContents::default())).await;
-        let dest_dir = tempdir().unwrap();
+        let (_parent, dest) = fresh_dest();
         let opts = SetupOptions {
             url:  server.url.clone(),
-            dest: dest_dir.path().to_path_buf(),
+            dest: dest.clone(),
         };
 
         let outcome = run_boxlite_setup_with(false, &opts)
@@ -593,24 +649,21 @@ mod tests {
             .expect("staging should succeed against the fixture server");
 
         match outcome {
-            StageOutcome::Staged { dest } => assert_eq!(dest, opts.dest),
+            StageOutcome::Staged { dest: got } => assert_eq!(got, opts.dest),
             StageOutcome::CheckOnly { .. } => panic!("expected Staged, got CheckOnly"),
         }
 
         for name in REQUIRED_NAMED_FILES {
-            assert!(
-                dest_dir.path().join(name).is_file(),
-                "missing staged file {name}"
-            );
+            assert!(dest.join(name).is_file(), "missing staged file {name}");
         }
-        let libkrunfw = find_libkrunfw(dest_dir.path()).expect("staged libkrunfw present");
+        let libkrunfw = find_libkrunfw(&dest).expect("staged libkrunfw present");
         #[cfg(target_os = "macos")]
         assert_eq!(libkrunfw, "libkrunfw.5.dylib");
         #[cfg(target_os = "linux")]
         assert_eq!(libkrunfw, "libkrunfw.so.5");
 
         assert!(
-            dest_dir.path().join(COMPLETE_STAMP).is_file(),
+            dest.join(COMPLETE_STAMP).is_file(),
             ".complete stamp must be written"
         );
 
@@ -618,14 +671,10 @@ mod tests {
         {
             use std::os::unix::fs::PermissionsExt;
             for name in EXECUTABLE_FILES {
-                let mode = fs::metadata(dest_dir.path().join(name))
-                    .unwrap()
-                    .permissions()
-                    .mode()
-                    & 0o777;
+                let mode = fs::metadata(dest.join(name)).unwrap().permissions().mode() & 0o777;
                 assert_eq!(mode, 0o755, "{name} should be 0o755");
             }
-            let lib_mode = fs::metadata(dest_dir.path().join(&libkrunfw))
+            let lib_mode = fs::metadata(dest.join(&libkrunfw))
                 .unwrap()
                 .permissions()
                 .mode()
@@ -637,22 +686,23 @@ mod tests {
     #[tokio::test]
     async fn idempotent_skip_when_already_complete() {
         let server = FixtureServer::start(build_fixture_tarball(&FixtureContents::default())).await;
-        let dest_dir = tempdir().unwrap();
+        let (_parent, dest) = fresh_dest();
 
         // Pre-populate destination with a valid staging layout.
+        fs::create_dir_all(&dest).unwrap();
         for name in REQUIRED_NAMED_FILES {
-            fs::write(dest_dir.path().join(name), b"existing").unwrap();
+            fs::write(dest.join(name), b"existing").unwrap();
         }
         #[cfg(target_os = "macos")]
-        fs::write(dest_dir.path().join("libkrunfw.5.dylib"), b"existing").unwrap();
+        fs::write(dest.join("libkrunfw.5.dylib"), b"existing").unwrap();
         #[cfg(target_os = "linux")]
-        fs::write(dest_dir.path().join("libkrunfw.so.5"), b"existing").unwrap();
-        fs::write(dest_dir.path().join(COMPLETE_STAMP), BOXLITE_VERSION).unwrap();
+        fs::write(dest.join("libkrunfw.so.5"), b"existing").unwrap();
+        fs::write(dest.join(COMPLETE_STAMP), BOXLITE_VERSION).unwrap();
 
-        let original_bytes = fs::read(dest_dir.path().join("boxlite-shim")).unwrap();
+        let original_bytes = fs::read(dest.join("boxlite-shim")).unwrap();
         let opts = SetupOptions {
             url:  server.url.clone(),
-            dest: dest_dir.path().to_path_buf(),
+            dest: dest.clone(),
         };
 
         let outcome = run_boxlite_setup_with(false, &opts)
@@ -667,17 +717,17 @@ mod tests {
             "server must not be hit on idempotent run"
         );
         // Existing files are unchanged byte-for-byte.
-        let after_bytes = fs::read(dest_dir.path().join("boxlite-shim")).unwrap();
+        let after_bytes = fs::read(dest.join("boxlite-shim")).unwrap();
         assert_eq!(original_bytes, after_bytes);
     }
 
     #[tokio::test]
     async fn check_only_is_pure_dry_run() {
         let server = FixtureServer::start(build_fixture_tarball(&FixtureContents::default())).await;
-        let dest_dir = tempdir().unwrap();
+        let (_parent, dest) = fresh_dest();
         let opts = SetupOptions {
             url:  server.url.clone(),
-            dest: dest_dir.path().to_path_buf(),
+            dest: dest.clone(),
         };
 
         let outcome = run_boxlite_setup_with(true, &opts)
@@ -685,15 +735,14 @@ mod tests {
             .expect("--check should succeed");
 
         match outcome {
-            StageOutcome::CheckOnly { url, dest } => {
+            StageOutcome::CheckOnly { url, dest: got } => {
                 assert_eq!(url, opts.url);
-                assert_eq!(dest, opts.dest);
+                assert_eq!(got, opts.dest);
             }
             StageOutcome::Staged { .. } => panic!("expected CheckOnly, got Staged"),
         }
         assert_eq!(server.hits.load(Ordering::SeqCst), 0);
-        assert!(!dest_dir.path().join(COMPLETE_STAMP).exists());
-        assert!(fs::read_dir(dest_dir.path()).unwrap().next().is_none());
+        assert!(!dest.exists());
     }
 
     #[tokio::test]
@@ -702,10 +751,10 @@ mod tests {
             include_boxlite_guest: false,
         }))
         .await;
-        let dest_dir = tempdir().unwrap();
+        let (_parent, dest) = fresh_dest();
         let opts = SetupOptions {
             url:  server.url.clone(),
-            dest: dest_dir.path().to_path_buf(),
+            dest: dest.clone(),
         };
 
         let err = run_boxlite_setup_with(false, &opts)
@@ -717,7 +766,7 @@ mod tests {
             "error message must name the missing file, got: {msg}"
         );
         assert!(
-            !dest_dir.path().join(COMPLETE_STAMP).exists(),
+            !dest.join(COMPLETE_STAMP).exists(),
             "no stamp must be written on failure"
         );
     }
@@ -765,12 +814,12 @@ mod tests {
         }
 
         let server = FixtureServer::start(build_fixture_tarball(&FixtureContents::default())).await;
-        let dest_dir = tempdir().unwrap();
+        let (_parent, dest) = fresh_dest();
         let opts = SetupOptions {
             url:  server.url.clone(),
             // Destination intentionally lives inside the scratch dir so
             // any "consulted target/" bug would be visible.
-            dest: dest_dir.path().to_path_buf(),
+            dest: dest.clone(),
         };
 
         run_boxlite_setup_with(false, &opts)
@@ -779,7 +828,7 @@ mod tests {
 
         // Staged content must come from the fixture (real signature),
         // not from `target/` (would be the literal "GARBAGE" payload).
-        let shim = fs::read(dest_dir.path().join("boxlite-shim")).unwrap();
+        let shim = fs::read(dest.join("boxlite-shim")).unwrap();
         assert_ne!(shim, b"GARBAGE", "staged file must not come from target/");
         assert_eq!(server.hits.load(Ordering::SeqCst), 1);
     }
@@ -804,6 +853,198 @@ mod tests {
             assert!(is_libkrunfw_soname("libkrunfw.so.5.0"));
             assert!(!is_libkrunfw_soname("libkrunfw.so"));
             assert!(!is_libkrunfw_soname("libkrunfw.5.dylib"));
+        }
+    }
+
+    // -----------------------------------------------------------------
+    // Runtime-GC scenarios (#2097).
+    //
+    // The pipeline owns `dest.parent()` end-to-end; every stage —
+    // including the idempotent skip path — sweeps stale sibling dirs.
+    // -----------------------------------------------------------------
+
+    /// Build a `runtimes/` parent populated with stale sibling dirs and
+    /// return `(parent, target_dest)` where `target_dest` does not yet
+    /// exist on disk (the staging pipeline will create it).
+    fn runtimes_parent_with_stale_siblings(stale_names: &[&str]) -> (tempfile::TempDir, PathBuf) {
+        let parent = tempdir().expect("create runtimes parent");
+        for name in stale_names {
+            let stale = parent.path().join(name);
+            fs::create_dir_all(&stale).expect("create stale sibling dir");
+            // Drop a file inside so `remove_dir_all` has something to
+            // reclaim (a no-op empty dir would not exercise the recursive
+            // path).
+            fs::write(stale.join("bloat.bin"), b"stale runtime payload").unwrap();
+        }
+        let dest = parent.path().join("v-current");
+        (parent, dest)
+    }
+
+    /// Pre-populate `dest` with a valid staged runtime so the idempotent
+    /// skip path short-circuits.
+    fn prepopulate_valid_staging(dest: &Path) {
+        fs::create_dir_all(dest).unwrap();
+        for name in REQUIRED_NAMED_FILES {
+            fs::write(dest.join(name), b"existing").unwrap();
+        }
+        #[cfg(target_os = "macos")]
+        fs::write(dest.join("libkrunfw.5.dylib"), b"existing").unwrap();
+        #[cfg(target_os = "linux")]
+        fs::write(dest.join("libkrunfw.so.5"), b"existing").unwrap();
+        fs::write(dest.join(COMPLETE_STAMP), BOXLITE_VERSION).unwrap();
+    }
+
+    #[tokio::test]
+    async fn stale_sibling_runtime_dirs_removed_on_fresh_stage() {
+        let server = FixtureServer::start(build_fixture_tarball(&FixtureContents::default())).await;
+        let (parent, dest) = runtimes_parent_with_stale_siblings(&["v0.0.1", "v0.0.2"]);
+        let opts = SetupOptions {
+            url:  server.url.clone(),
+            dest: dest.clone(),
+        };
+
+        run_boxlite_setup_with(false, &opts)
+            .await
+            .expect("fresh stage should succeed");
+
+        assert!(dest.join(COMPLETE_STAMP).is_file(), "stamp must be written");
+        for name in REQUIRED_NAMED_FILES {
+            assert!(dest.join(name).is_file(), "missing staged file {name}");
+        }
+        assert!(
+            !parent.path().join("v0.0.1").exists(),
+            "stale v0.0.1 must be removed"
+        );
+        assert!(
+            !parent.path().join("v0.0.2").exists(),
+            "stale v0.0.2 must be removed"
+        );
+    }
+
+    #[tokio::test]
+    async fn stale_siblings_removed_on_idempotent_skip() {
+        let server = FixtureServer::start(build_fixture_tarball(&FixtureContents::default())).await;
+        let (parent, dest) = runtimes_parent_with_stale_siblings(&["v0.0.1"]);
+        prepopulate_valid_staging(&dest);
+        let original_bytes = fs::read(dest.join("boxlite-shim")).unwrap();
+
+        let opts = SetupOptions {
+            url:  server.url.clone(),
+            dest: dest.clone(),
+        };
+
+        let outcome = run_boxlite_setup_with(false, &opts)
+            .await
+            .expect("idempotent skip should succeed");
+        assert!(matches!(outcome, StageOutcome::Staged { .. }));
+
+        // Skip path: no HTTP traffic.
+        assert_eq!(server.hits.load(Ordering::SeqCst), 0);
+        // Stale sibling reclaimed.
+        assert!(
+            !parent.path().join("v0.0.1").exists(),
+            "stale sibling must be removed on idempotent skip"
+        );
+        // Existing files untouched.
+        let after_bytes = fs::read(dest.join("boxlite-shim")).unwrap();
+        assert_eq!(original_bytes, after_bytes);
+    }
+
+    #[tokio::test]
+    async fn check_mode_does_not_gc_siblings() {
+        let server = FixtureServer::start(build_fixture_tarball(&FixtureContents::default())).await;
+        let (parent, dest) = runtimes_parent_with_stale_siblings(&["v0.0.1"]);
+        let opts = SetupOptions {
+            url:  server.url.clone(),
+            dest: dest.clone(),
+        };
+
+        let outcome = run_boxlite_setup_with(true, &opts)
+            .await
+            .expect("--check should succeed");
+        assert!(matches!(outcome, StageOutcome::CheckOnly { .. }));
+        assert!(
+            parent.path().join("v0.0.1").is_dir(),
+            "--check must leave stale siblings in place"
+        );
+    }
+
+    #[tokio::test]
+    async fn stray_files_in_runtimes_parent_are_preserved() {
+        let server = FixtureServer::start(build_fixture_tarball(&FixtureContents::default())).await;
+        let (parent, dest) = runtimes_parent_with_stale_siblings(&[]);
+        let stray = parent.path().join("README.txt");
+        fs::write(&stray, b"hand-placed note, not ours to delete").unwrap();
+
+        let opts = SetupOptions {
+            url:  server.url.clone(),
+            dest: dest.clone(),
+        };
+
+        run_boxlite_setup_with(false, &opts)
+            .await
+            .expect("staging should succeed alongside a stray file");
+
+        assert!(dest.join(COMPLETE_STAMP).is_file());
+        assert!(
+            stray.is_file(),
+            "stray non-directory entry must be left alone"
+        );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn gc_failure_on_sibling_does_not_fail_setup() {
+        use std::os::unix::fs::PermissionsExt;
+
+        // Skip under root — root bypasses write-bit-cleared dir perms,
+        // so the GC failure we're trying to provoke wouldn't actually
+        // fail. Detected by probing: create a 0o000 dir and see whether
+        // we can still create a file inside it.
+        let probe = tempdir().unwrap();
+        let locked = probe.path().join("locked");
+        fs::create_dir(&locked).unwrap();
+        fs::set_permissions(&locked, fs::Permissions::from_mode(0o000)).unwrap();
+        let bypass_perms = fs::write(locked.join("x"), b"").is_ok();
+        fs::set_permissions(&locked, fs::Permissions::from_mode(0o755)).unwrap();
+        if bypass_perms {
+            eprintln!("skipping: running as root (perms bypassed)");
+            return;
+        }
+
+        let server = FixtureServer::start(build_fixture_tarball(&FixtureContents::default())).await;
+        let (parent, dest) = runtimes_parent_with_stale_siblings(&["v0.0.1"]);
+
+        // Clear the parent's write bit so `remove_dir_all` of the sibling
+        // fails with EACCES. The new `dest` was created *before* we lock
+        // the parent, so staging itself still succeeds (it only mutates
+        // inside `dest`, not the parent's entry list — though we also
+        // pre-create `dest` to keep the test independent of that detail).
+        fs::create_dir_all(&dest).unwrap();
+        let parent_mode = fs::metadata(parent.path()).unwrap().permissions().mode();
+        fs::set_permissions(parent.path(), fs::Permissions::from_mode(0o555)).unwrap();
+
+        let opts = SetupOptions {
+            url:  server.url.clone(),
+            dest: dest.clone(),
+        };
+
+        let outcome = run_boxlite_setup_with(false, &opts).await;
+
+        // Restore perms before any assertion so tempdir cleanup works.
+        fs::set_permissions(parent.path(), fs::Permissions::from_mode(parent_mode)).unwrap();
+
+        let outcome = outcome.expect("staging must succeed even when GC cannot reclaim a sibling");
+        match outcome {
+            StageOutcome::Staged { dest: got } => assert_eq!(got, dest),
+            StageOutcome::CheckOnly { .. } => panic!("expected Staged, got CheckOnly"),
+        }
+        assert!(
+            dest.join(COMPLETE_STAMP).is_file(),
+            "staging must complete its own stamp"
+        );
+        for name in REQUIRED_NAMED_FILES {
+            assert!(dest.join(name).is_file(), "missing staged file {name}");
         }
     }
 }

--- a/specs/issue-2097-boxlite-runtime-gc.spec.md
+++ b/specs/issue-2097-boxlite-runtime-gc.spec.md
@@ -1,0 +1,184 @@
+spec: task
+name: "issue-2097-boxlite-runtime-gc"
+inherits: project
+tags: []
+---
+
+## Intent
+
+`rara-cli setup boxlite` stages the runtime into a version-keyed directory
+under `dirs::data_local_dir()/boxlite/runtimes/{BOXLITE_VERSION}` (see
+`crates/cmd/src/setup/boxlite.rs::staged_runtime_dir`, line 221). The path
+is per-version on purpose — boxlite's own embedded extractor checks the
+`.complete` stamp inside the same per-version directory and skips re-
+extraction. Bumping `BOXLITE_VERSION` correctly *creates* a fresh sibling
+dir.
+
+The gap: the staging pipeline never deletes the *old* sibling
+directories. Each version carries libkrunfw + boxlite-shim + boxlite-guest
++ mke2fs + debugfs (tens of MB per version). Across the recent bump
+cadence (v0.8.2 → v0.9.1 → v0.9.2 → v0.9.3 → v0.9.4 in the last few weeks
+per `gh pr list --search boxlite`), a developer who has updated through
+each release accumulates every prior version's runtime under
+`~/Library/Application Support/boxlite/runtimes/`, with nothing in the
+codebase to ever reclaim them.
+
+Reproducer:
+1. `mkdir -p ~/Library/Application\ Support/boxlite/runtimes/v0.0.1` and
+   drop `~50 MB of arbitrary bytes` inside (mimicking a stale prior
+   version). Repeat for `v0.0.2`. Both directories are siblings of the
+   real `v0.9.4` target.
+2. Run `cargo run -p rara-cli -- setup boxlite` (or invoke
+   `run_boxlite_setup(false)` directly in a test against a tempdir).
+3. Observed: staging into `v0.9.4` succeeds; `ls
+   ~/Library/Application\ Support/boxlite/runtimes/` still shows
+   `v0.0.1/`, `v0.0.2/`, and `v0.9.4/` side-by-side. The two stale dirs
+   are never reclaimed.
+4. Expected: after a successful stage of `v0.9.4`, the only entry under
+   `runtimes/` is `v0.9.4/`. The stale siblings are removed.
+
+Prior art reviewed (mandatory search):
+- Issues: `gh issue list --search "boxlite cleanup|runtime|GC"` returns
+  PR-tracking issues (#1696/#1697/#1698/#1699/#1844 — initial sandbox +
+  staging integration) and #1980/#1984 (self-sufficient `setup boxlite`
+  via release tarball). None mention multi-version GC. No prior issue or
+  PR proposes or rejects runtime-dir cleanup.
+- PRs: `gh pr list --search boxlite` shows the recent bump cadence
+  (#2073/#2076/#2077/#2089/#2093 = v0.8.2 → v0.9.1/2/3/4) plus the
+  staging introduction (#1844) and the self-sufficient setup (#1984).
+  None of them address GC.
+- Commits: `git log --grep=boxlite --since=180.days` confirms the same
+  set; the most recent staging-area change is 793395bc (v0.9.4 bump).
+  No prior decision was made to *retain* old runtime dirs — the absence
+  of GC is an oversight, not a design decision being reversed.
+- `rg "runtimes"` inside `crates/cmd` and `crates/rara-sandbox` shows
+  the only writer of that directory tree is `staged_runtime_dir` itself.
+  There is no other consumer that would care about historical sibling
+  dirs (boxlite reads only its own version-keyed dir).
+
+Goal alignment: signal 1 ("the process runs for months without
+intervention. Memory does not grow unboundedly, file descriptors do not
+leak"). The bug is the disk-leak analogue of an unbounded-growth
+violation — every version bump permanently grows the on-disk footprint
+of a long-running rara install. Crosses no `NOT` line; this is hygiene
+for a single-user local install.
+
+## Decisions
+
+- GC runs at the end of `run_boxlite_setup_with` on **every** successful
+  stage, including the idempotent skip path that returns early when
+  `.complete` already exists. Rationale: a user who ran
+  `rara-cli setup boxlite` *before* the bump (current version staged,
+  no cleanup) and then runs it *again* after the bump expects the second
+  invocation to also be a janitor. Limiting GC to the download path
+  would make `rara-cli setup boxlite` silently useless as a cleanup
+  command in exactly the case the user is most likely to invoke it. The
+  cost of running GC on the skip path is one `read_dir` of the
+  `runtimes/` parent — negligible.
+- GC does NOT run in `--check` mode. `--check` is a pure dry-run by
+  contract (see existing `check_only_is_pure_dry_run` test). Adding a
+  filesystem mutation under `--check` would silently break that
+  contract.
+- The GC scope is exactly `dest.parent()` — i.e. the `runtimes/`
+  directory that holds version-keyed siblings. We do NOT touch anything
+  above it (`boxlite/`) and we do NOT recurse below sibling dirs (we
+  remove each sibling whole via `remove_dir_all`).
+- A "stale sibling" is any direct entry of `dest.parent()` that (a) is a
+  directory, (b) has a different name from `dest.file_name()`. We do
+  NOT try to validate the sibling's contents look like a boxlite
+  runtime, and we do NOT compare its name against any whitelist of
+  "known prior versions". Reasoning: any directory at this path is
+  rara's to manage — the path is wholly owned by `rara-cli setup
+  boxlite`. A non-directory entry (stray file) is left alone; safer to
+  ignore than to delete something we did not put there.
+- GC failures do NOT fail the setup pipeline. If a sibling dir cannot
+  be removed (permissions, file-in-use), log a `tracing::warn!` and
+  continue — staging the new version succeeded, which is the user's
+  primary outcome. The user can re-run later or clean up manually.
+- The GC helper is added as a private function in `setup/boxlite.rs`.
+  No new module, no new file — the cleanup is a 20-line addition next
+  to the staging pipeline it serves.
+- Tests extend the existing hermetic `tempdir()` + `FixtureServer`
+  pattern in `mod tests`. We do NOT add an integration test that touches
+  `dirs::data_local_dir()`.
+
+## Boundaries
+
+### Allowed Changes
+- crates/cmd/src/setup/boxlite.rs
+- **/crates/cmd/src/setup/boxlite.rs
+- specs/issue-2097-boxlite-runtime-gc.spec.md
+- **/specs/issue-2097-boxlite-runtime-gc.spec.md
+
+### Forbidden
+- crates/rara-sandbox/**
+- crates/cmd/src/setup/whisper_install.rs
+- crates/cmd/src/setup/prompt.rs
+- crates/cmd/src/setup/mod.rs
+- crates/app/**
+- crates/paths/**
+- .github/workflows/**
+- docs/guides/boxlite-runtime.md
+
+## Acceptance Criteria
+
+Scenario: stale sibling runtime dirs are removed after a fresh stage
+  Test:
+    Package: rara-cli
+    Filter: setup::boxlite::tests::stale_sibling_runtime_dirs_removed_on_fresh_stage
+  Given the runtimes parent directory holds two stale sibling dirs (v0.0.1, v0.0.2) alongside the target staging dir
+  When run_boxlite_setup_with(false, opts) downloads and stages the current version into the target dir
+  Then the target dir contains the staged files and a .complete stamp
+  And the two stale sibling dirs no longer exist under the runtimes parent
+
+Scenario: stale siblings are also removed on the idempotent skip path
+  Test:
+    Package: rara-cli
+    Filter: setup::boxlite::tests::stale_siblings_removed_on_idempotent_skip
+  Given the target dir already contains a valid staged runtime with a .complete stamp
+  And a stale sibling dir exists alongside it
+  When run_boxlite_setup_with(false, opts) is invoked and short-circuits via the idempotent skip path
+  Then the fixture HTTP server receives zero hits
+  And the stale sibling dir no longer exists under the runtimes parent
+  And the target dir's existing files are unchanged byte-for-byte
+
+Scenario: --check mode performs no GC
+  Test:
+    Package: rara-cli
+    Filter: setup::boxlite::tests::check_mode_does_not_gc_siblings
+  Given the runtimes parent holds a stale sibling dir
+  When run_boxlite_setup_with(true, opts) runs in check-only mode
+  Then the outcome is CheckOnly
+  And the stale sibling dir still exists under the runtimes parent
+
+Scenario: stray non-directory entries in the runtimes parent are left alone
+  Test:
+    Package: rara-cli
+    Filter: setup::boxlite::tests::stray_files_in_runtimes_parent_are_preserved
+  Given the runtimes parent contains a stray regular file alongside the target staging dir
+  When run_boxlite_setup_with(false, opts) stages the current version
+  Then the staging succeeds
+  And the stray regular file still exists under the runtimes parent
+
+Scenario: GC failure on a sibling does not fail the setup pipeline
+  Test:
+    Package: rara-cli
+    Filter: setup::boxlite::tests::gc_failure_on_sibling_does_not_fail_setup
+  Given a stale sibling dir exists alongside the target dir but cannot be removed (e.g. on unix the sibling dir's parent has its write bit cleared)
+  When run_boxlite_setup_with(false, opts) stages the current version
+  Then the outcome is Staged with the target dir
+  And the target dir contains the staged files and a .complete stamp
+
+## Out of Scope
+
+- A `--force` flag, a `setup boxlite --gc` flag, or any new CLI surface.
+- App-startup auto-GC (e.g. running cleanup from `rara-app` boot). The
+  setup command is the right venue; boot is not.
+- Doctor / diagnostic command changes.
+- Touching boxlite's own embedded extractor or the `rara-sandbox` crate.
+- Changing the `staged_runtime_dir()` path layout.
+- Whitelisting / version-history-aware retention (e.g. "keep the last N
+  versions"). Single-user local install — one current version is
+  enough; a user who downgrades can re-run `setup boxlite`.
+- GC for the whisper install path. Out of scope; same pattern can be
+  added there in a follow-up if it has the same disk-leak shape.


### PR DESCRIPTION
## Summary

`rara-cli setup boxlite` now removes stale sibling `runtimes/vX.Y.Z/` directories after a successful stage, so version bumps no longer leak old runtimes (libkrunfw + boxlite-guest etc., several tens of MB per version) on disk.

GC runs on **both** the fresh-download path and the idempotent `.complete`-stamp short-circuit path — so re-running setup after dependabot already staged the new version still reclaims the old ones. `--check` is exempt to preserve its dry-run contract. Per-sibling failures are logged via `tracing::warn!` and do not fail the pipeline.

Spec: `specs/issue-2097-boxlite-runtime-gc.spec.md` (lane 1, 5 BDD scenarios, 100% pass).

## Test plan

- [x] `cargo test -p rara-cli` — 89 passed (5 new scenarios under `setup::boxlite::tests`).
- [x] `just spec-lifecycle specs/issue-2097-boxlite-runtime-gc.spec.md` — 5/5 pass, 0 skip / 0 uncertain.
- [x] Full Rust gate (`cargo check` / `cargo +nightly fmt --check` / `cargo clippy -D warnings` / `prek run --all-files` / doc warnings) — clean.
- [x] Hermetic axum HTTP fixture verifies fresh-stage GC, idempotent-skip GC, --check exemption, stray-file preservation, and GC-failure resilience.

Closes #2097

🤖 Generated with [Claude Code](https://claude.com/claude-code)