### PR TITLE
refactor(kernel): remove duplicate CommandInfo, orphan PhotoAttachment, redundant session_key fields (#2105)

### DIFF
--- a/crates/kernel/src/agent/mod.rs
+++ b/crates/kernel/src/agent/mod.rs
@@ -3358,7 +3358,7 @@ async fn run_agent_loop_inner(
             let current_limit_id = limit_id_counter;
             let elapsed_secs = turn_start.elapsed().as_secs();
             stream_handle.emit(StreamEvent::ToolCallLimit {
-                session_key: session_key.to_string(),
+                session_key,
                 limit_id: current_limit_id,
                 tool_calls_made,
                 elapsed_secs,
@@ -3395,9 +3395,9 @@ async fn run_agent_loop_inner(
                     // Additive: next limit fires after another full interval.
                     next_limit_at = tool_calls_made + limit_interval;
                     stream_handle.emit(StreamEvent::ToolCallLimitResolved {
-                        session_key: session_key.to_string(),
-                        limit_id:    current_limit_id,
-                        continued:   true,
+                        session_key,
+                        limit_id: current_limit_id,
+                        continued: true,
                     });
                 }
                 _ => {
@@ -3405,9 +3405,9 @@ async fn run_agent_loop_inner(
                     // treated as a graceful stop. NOT max-iteration exhaustion.
                     warn!(tool_calls_made, "agent loop stopped by user or timeout");
                     stream_handle.emit(StreamEvent::ToolCallLimitResolved {
-                        session_key: session_key.to_string(),
-                        limit_id:    current_limit_id,
-                        continued:   false,
+                        session_key,
+                        limit_id: current_limit_id,
+                        continued: false,
                     });
                     stopped_by_limit = true;
                     break;

--- a/crates/kernel/src/channel/types.rs
+++ b/crates/kernel/src/channel/types.rs
@@ -296,42 +296,6 @@ impl ChatMessage {
             created_at:   jiff::Timestamp::now(),
         }
     }
-
-    /// Create a tool-call message representing a tool invocation by the LLM.
-    #[must_use]
-    pub fn tool(
-        tool_call_id: impl Into<String>,
-        name: impl Into<String>,
-        content: impl Into<String>,
-    ) -> Self {
-        Self {
-            seq:          0,
-            role:         MessageRole::Tool,
-            content:      MessageContent::Text(content.into()),
-            tool_calls:   Vec::new(),
-            tool_call_id: Some(tool_call_id.into()),
-            tool_name:    Some(name.into()),
-            created_at:   jiff::Timestamp::now(),
-        }
-    }
-
-    /// Create a tool-result message carrying the output of a tool execution.
-    #[must_use]
-    pub fn tool_result(
-        tool_call_id: impl Into<String>,
-        name: impl Into<String>,
-        content: impl Into<String>,
-    ) -> Self {
-        Self {
-            seq:          0,
-            role:         MessageRole::ToolResult,
-            content:      MessageContent::Text(content.into()),
-            tool_calls:   Vec::new(),
-            tool_call_id: Some(tool_call_id.into()),
-            tool_name:    Some(name.into()),
-            created_at:   jiff::Timestamp::now(),
-        }
-    }
 }
 
 // ---------------------------------------------------------------------------
@@ -464,35 +428,17 @@ pub enum StreamEvent {
     Error { message: String },
     /// Agent loop paused at tool call limit — adapter should prompt user.
     ToolCallLimit {
-        session_key:     String,
+        session_key:     crate::session::SessionKey,
         limit_id:        u64,
         tool_calls_made: usize,
         elapsed_secs:    u64,
     },
     /// Tool call limit resolved by user.
     ToolCallLimitResolved {
-        session_key: String,
+        session_key: crate::session::SessionKey,
         limit_id:    u64,
         continued:   bool,
     },
-}
-
-// ---------------------------------------------------------------------------
-// CommandInfo
-// ---------------------------------------------------------------------------
-
-/// Parsed command extracted from a channel message.
-///
-/// Adapters parse platform-specific command formats (e.g. `/search keywords`)
-/// and populate this struct for routing to command handlers.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct CommandInfo {
-    /// Command name without the leading slash (e.g. "search", "help").
-    pub name: String,
-    /// Raw argument string after the command name.
-    pub args: String,
-    /// The complete raw text including the command prefix.
-    pub raw:  String,
 }
 
 // ---------------------------------------------------------------------------
@@ -507,21 +453,6 @@ pub struct CallbackInfo {
     pub data:       String,
     /// Platform-specific message ID that originated the callback.
     pub message_id: Option<String>,
-}
-
-// ---------------------------------------------------------------------------
-// PhotoAttachment
-// ---------------------------------------------------------------------------
-
-/// An image attachment for outbound messages.
-#[derive(Debug, Clone)]
-pub struct PhotoAttachment {
-    /// Image data as bytes.
-    pub data:      Vec<u8>,
-    /// MIME type (e.g. "image/jpeg", "image/png").
-    pub mime_type: String,
-    /// Optional caption text.
-    pub caption:   Option<String>,
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/kernel/src/io.rs
+++ b/crates/kernel/src/io.rs
@@ -1069,7 +1069,7 @@ pub enum StreamEvent {
     /// callback data so that stale buttons from an earlier limit cannot
     /// accidentally resolve a newer one.
     ToolCallLimit {
-        session_key:     String,
+        session_key:     crate::session::SessionKey,
         /// Monotonic limit instance ID — prevents stale callback resolution.
         limit_id:        u64,
         /// Cumulative tool calls executed so far in this turn.
@@ -1082,7 +1082,7 @@ pub enum StreamEvent {
     /// Informational only — adapters may use this to update UI (e.g. edit
     /// the Telegram inline keyboard message to show the decision).
     ToolCallLimitResolved {
-        session_key: String,
+        session_key: crate::session::SessionKey,
         /// Must match the `limit_id` from the corresponding `ToolCallLimit`.
         limit_id:    u64,
         /// `true` if the user chose to continue; `false` on stop or timeout.

--- a/crates/kernel/src/plan.rs
+++ b/crates/kernel/src/plan.rs
@@ -476,7 +476,7 @@ pub(crate) async fn run_plan_loop(
             let current_limit_id = limit_id_counter;
             let elapsed_secs = start.elapsed().as_secs();
             stream_handle.emit(StreamEvent::ToolCallLimit {
-                session_key: session_key.to_string(),
+                session_key,
                 limit_id: current_limit_id,
                 tool_calls_made: total_tool_calls,
                 elapsed_secs,
@@ -507,9 +507,9 @@ pub(crate) async fn run_plan_loop(
                 Ok(Ok(crate::io::ToolCallLimitDecision::Continue)) => {
                     next_limit_at = total_tool_calls + limit_interval;
                     stream_handle.emit(StreamEvent::ToolCallLimitResolved {
-                        session_key: session_key.to_string(),
-                        limit_id:    current_limit_id,
-                        continued:   true,
+                        session_key,
+                        limit_id: current_limit_id,
+                        continued: true,
                     });
                 }
                 _ => {
@@ -519,9 +519,9 @@ pub(crate) async fn run_plan_loop(
                         "plan loop stopped by user or timeout"
                     );
                     stream_handle.emit(StreamEvent::ToolCallLimitResolved {
-                        session_key: session_key.to_string(),
-                        limit_id:    current_limit_id,
-                        continued:   false,
+                        session_key,
+                        limit_id: current_limit_id,
+                        continued: false,
                     });
                     plan.status = PlanStatus::Failed;
                     break;


### PR DESCRIPTION
## Summary

Lane-2 structural cleanup of `crates/kernel/src/channel/types.rs`. Four deletions + one type strengthening, surfaced during a multi-channel design review.

- Delete duplicate `CommandInfo` (survivor in `channel/command.rs`)
- Delete orphan `PhotoAttachment` (zero callers; egress uses `io::Attachment`)
- Convert `StreamEvent::ToolCallLimit{Resolved}::session_key` from `String` to `crate::session::SessionKey` — applied to **both** `channel/types.rs` and `io.rs` copies for consistency
- **Project lead addendum** (not in #2105 body): delete zero-caller `ChatMessage::tool()` / `tool_result()` constructors. **Preserves** the `MessageRole::Tool` / `MessageRole::ToolResult` enum variants — they are load-bearing for the FE wire contract (`web/src/components/topology/TurnCard.tsx:350-351` branches on both)

## Sub-finding (out of scope, follow-up needed)

`channel::types::StreamEvent` itself is orphan — every emit site and consumer uses `io::StreamEvent`. Confirmed by reviewer: zero external imports of `channel::types::StreamEvent`. Converted both copies in this PR for consistency; will file a separate issue to delete the orphan copy.

## Test plan

- [x] `cargo check --workspace --all-targets`
- [x] `cargo +nightly fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings`
- [x] `RUSTDOCFLAGS="-D warnings" cargo +nightly doc --workspace --no-deps --document-private-items`
- [x] `prek run --all-files`
- [x] `cargo test -p rara-kernel` — 536 passed (2 pre-existing flakes verified on main, unrelated)

Diff: 4 files, +18 / -87.

Closes #2105