### PR TITLE
chore(ci): introduce mise for node/bun/go/just/gh (#2115)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -54,6 +54,11 @@ jobs:
         with:
           persist-credentials: false
 
+      # Use mise so the Go version stays in lockstep with mise.toml at the
+      # repo root (matches go.work). See docs/guides/tooling.md.
+      - name: Set up mise toolchain
+        uses: jdx/mise-action@v2
+
       - name: Build devtool
         run: cd scripts && go build -o bin/devtool ./cmd/devtool/
 

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -20,9 +20,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v6
-        with:
-          node-version: 22
+      # Node version pinned via mise.toml at the repo root. See
+      # docs/guides/tooling.md.
+      - uses: jdx/mise-action@v2
       - name: Install dependencies
         working-directory: site
         run: npm ci

--- a/.github/workflows/web-ci.yml
+++ b/.github/workflows/web-ci.yml
@@ -25,11 +25,9 @@ jobs:
         working-directory: web
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v6
-        with:
-          node-version: 22
-          cache: npm
-          cache-dependency-path: web/package-lock.json
+      # Node version is pinned via mise.toml at the repo root. See
+      # docs/guides/tooling.md.
+      - uses: jdx/mise-action@v2
       - name: Install dependencies
         run: npm ci
       - name: Typecheck
@@ -53,11 +51,7 @@ jobs:
         working-directory: web
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v6
-        with:
-          node-version: 22
-          cache: npm
-          cache-dependency-path: web/package-lock.json
+      - uses: jdx/mise-action@v2
       - name: Install dependencies
         run: npm ci
       - name: Install Playwright browsers

--- a/.gitignore
+++ b/.gitignore
@@ -106,3 +106,7 @@ specs/**/timings/*.html
 # Zig build cache (written next to zig/build.zig on every `zig build`)
 .zig-cache/
 zig/zig-out/
+
+# mise per-user override (mise.toml is checked in; *.local.toml is opt-in)
+.mise.local.toml
+mise.local.toml

--- a/docs/guides/tooling.md
+++ b/docs/guides/tooling.md
@@ -1,0 +1,24 @@
+# Non-Rust Toolchain — mise
+
+The non-Rust dev toolchain (Node, Bun, Go, `just`, `gh`) is pinned via
+[mise](https://mise.jdx.dev) in `mise.toml` at the repo root. The same
+`mise.toml` is consumed by `jdx/mise-action@v2` in CI, so local and CI
+versions stay in lockstep.
+
+```bash
+brew install mise              # one-time
+mise install                   # provisions everything in mise.toml
+echo 'eval "$(mise activate zsh)"' >> ~/.zshrc   # one-time shell hook
+```
+
+After activation, `cd`-ing into the repo selects the pinned versions
+automatically; outside the repo your system tools are untouched. `mise`
+is **warn-only** in `./init.sh` — rustup-only contributors working on
+pure Rust changes can skip it.
+
+Rust stays on rustup: `rust-toolchain.toml` pins stable and `cargo +nightly`
+comes from rustup. `prek` (pre-commit) stays on brew and `diesel_cli`
+stays on `cargo install` — mise's cargo backend would recompile both
+from source on every `mise install` for no upside.
+
+See `mise.toml` for the version pins and the rationale comment.

--- a/init.sh
+++ b/init.sh
@@ -60,6 +60,15 @@ else
     fail "prek not found — install: brew install prek"
 fi
 
+# mise is warn-only: it pins the non-Rust toolchain (node/bun/go/just/gh) for
+# parity with CI, but rustup-only contributors working on pure Rust changes
+# can still pass this check. See docs/guides/tooling.md.
+if mise --version >/dev/null 2>&1; then
+    ok "mise: $(mise --version)"
+else
+    warn "mise not found — install: brew install mise (see docs/guides/tooling.md)"
+fi
+
 # ----------------------------------------------------------------------------
 # Workspace — fatal
 # ----------------------------------------------------------------------------

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,25 @@
+## rara dev toolchain — managed by mise (https://mise.jdx.dev)
+##
+## Rust is intentionally NOT here: `rust-toolchain.toml` pins stable, and
+## nightly (for fmt + doc warnings) comes from rustup. mise's rust backend
+## would fight rustup.
+##
+## prek / diesel_cli stay on brew / cargo install — mise's cargo backend
+## compiles from source on every `mise install`, which is slower than the
+## current setup with no upside.
+
+[tools]
+node = "25"           # web/, desktop/, site/ — site/package.json needs >=22.12
+bun  = "latest"       # web/ dev + build
+go   = "1.26"         # go.work + scripts/
+just = "latest"       # justfile runner
+gh   = "latest"       # PR + issue workflow
+
+[env]
+## Match the justfile's defaults so `mise exec` / `mise en` users get the
+## same env as `just`. justfile already loads .env via `set dotenv-load`,
+## so secrets stay there — only put non-secret defaults here.
+RARA__DATABASE__MIGRATION_DIR = "crates/rara-model/migrations"
+
+## Tasks intentionally omitted — `justfile` is the task runner.
+## If you want `mise run X`, add it to justfile and call `just X`.


### PR DESCRIPTION
## Summary
- Adds `mise.toml` at repo root pinning **node 25 / bun latest / go 1.26 / just latest / gh latest** so contributors and CI share one source of truth.
- Wires `jdx/mise-action@v2` into the three workflows that actually install a tool: `lint.yml` (devtool-checks → go), `pages.yml` (site → node), `web-ci.yml` (check + playwright → node). `ci.yml`, `e2e.yml`, `web.yml` left alone — none of them install node/bun/go today, so mise-action would be dead weight.
- `init.sh`: adds a **warn-only** mise check so rustup-only contributors still pass `just doctor`.
- New `docs/guides/tooling.md` — short page, links to https://mise.jdx.dev, not a tutorial.
- `.gitignore`: scopes-out `.mise.local.toml` / `mise.local.toml` (per-user override files).

## Out of scope (intentional)
- **Rust** stays with `rust-toolchain.toml` + `rustup` — mise's rust backend would fight rustup over stable/nightly.
- **prek / diesel_cli** stay on brew / `cargo install` — faster than mise's cargo-from-source backend.
- **No** migration of `web-ci.yml` from `npm ci` to bun — separate decision, not authorized by the spec.

## Prior-art note
Commit d4875266 (~9 weeks ago) removed `setup-go` from `lint.yml` with rationale "runner already has Go pre-installed." This PR re-introduces a Go-setup step there, but with a different rationale: **version pinning via mise.toml**, not just-install. Legitimate supersession, called out for reviewer clarity.

## Test plan
- [ ] CI green on this PR
- [ ] Local: `mise install` succeeds against the new mise.toml (parent agent verified during prototype)
- [ ] Local: `./init.sh` still exits 0 when mise is uninstalled
- [ ] After merge: open new shell with `eval \"\$(mise activate zsh)\"` in ~/.zshrc → `cd` into repo → `node -v` == 25, `go version` == 1.26.x

Closes #2115