### PR TITLE
refactor(channels): TelegramAdapter bon::Builder, drop set_*_handlers setters (#2109)

### DIFF
--- a/crates/app/src/lib.rs
+++ b/crates/app/src/lib.rs
@@ -749,7 +749,11 @@ pub async fn start_with_options(
     );
     let web_router = web_adapter.router();
 
-    let telegram_adapter = match try_build_telegram(
+    // Build the Telegram bot + config precursor up front. The adapter itself
+    // is constructed later (after `KernelHandle` is available and command
+    // handlers can be built), since command/callback handlers are now a
+    // **required** builder field on `TelegramAdapter` (#2109).
+    let telegram_precursor = match try_build_telegram_precursor(
         &backend.settings_svc,
         rara.user_question_manager.clone(),
         stt_service,
@@ -757,16 +761,16 @@ pub async fn start_with_options(
     )
     .await
     {
-        Ok(Some(adapter)) => {
-            info!("Telegram adapter built");
-            Some(adapter)
+        Ok(Some(p)) => {
+            info!("Telegram precursor resolved (bot built, settings polled)");
+            Some(p)
         }
         Ok(None) => {
             info!("Telegram not configured (bot_token unset in settings), skipping");
             None
         }
         Err(e) => {
-            warn!(error = %e, "Failed to build Telegram adapter, skipping");
+            warn!(error = %e, "Failed to resolve Telegram precursor, skipping");
             None
         }
     };
@@ -791,15 +795,13 @@ pub async fn start_with_options(
         .get(rara_domain_shared::settings::keys::TELEGRAM_NOTIFICATION_CHANNEL_ID)
         .await
         .and_then(|s| s.parse::<i64>().ok());
-    let mut io = rara_kernel::io::IOSubsystem::new(
+    let io = rara_kernel::io::IOSubsystem::new(
         rara.identity_resolver.clone(),
         rara.session_index.clone(),
         notification_channel_id,
         config.max_ingress_per_minute,
     );
-    if let Some(ref tg) = telegram_adapter {
-        io.register_adapter(ChannelType::Telegram, tg.clone() as Arc<dyn ChannelAdapter>);
-    }
+    // Telegram is registered after `KernelHandle` is available; see below.
     if let Some(ref wc) = wechat_adapter {
         io.register_adapter(ChannelType::Wechat, wc.clone() as Arc<dyn ChannelAdapter>);
     }
@@ -1126,7 +1128,7 @@ pub async fn start_with_options(
             BasicCommandHandler, DebugCommandHandler, McpCommandHandler, RenameCommandHandler,
             SessionCommandHandler, StatusCommandHandler, StopCommandHandler, TapeCommandHandler,
         };
-        let tg_bot = telegram_adapter.as_ref().map(|a| a.bot());
+        let tg_bot = telegram_precursor.as_ref().map(|p| p.bot.clone());
         let session_handler =
             std::sync::Arc::new(SessionCommandHandler::new(bot_client.clone(), tg_bot));
         let stop_handler = std::sync::Arc::new(StopCommandHandler::new(
@@ -1168,37 +1170,77 @@ pub async fn start_with_options(
         ]
     };
 
-    if let Some(ref tg_adapter) = telegram_adapter {
-        tg_adapter.set_command_handlers(command_handlers.clone());
+    // Build callback handlers for inline keyboard interactions. Built
+    // unconditionally so both the (Telegram) adapter wiring path and the
+    // dead-code path stay symmetric — `vec!` allocation is cheap and the
+    // handlers are also used implicitly by any future channel that
+    // dispatches kernel callbacks.
+    let callback_handlers: Vec<std::sync::Arc<dyn rara_kernel::channel::command::CallbackHandler>> = {
+        use rara_channels::telegram::commands::{
+            ModelSwitchCallbackHandler, SessionDeleteCallbackHandler, SessionDeleteCancelHandler,
+            SessionDeleteConfirmHandler, SessionDetailCallbackHandler,
+            SessionSwitchCallbackHandler, StatusJobsCallbackHandler,
+        };
+        vec![
+            std::sync::Arc::new(SessionSwitchCallbackHandler::new(bot_client.clone())),
+            std::sync::Arc::new(SessionDetailCallbackHandler::new(bot_client.clone())),
+            std::sync::Arc::new(SessionDeleteCallbackHandler::new(bot_client.clone())),
+            std::sync::Arc::new(SessionDeleteConfirmHandler::new(bot_client.clone())),
+            std::sync::Arc::new(SessionDeleteCancelHandler::new()),
+            std::sync::Arc::new(ModelSwitchCallbackHandler::new(bot_client.clone())),
+            std::sync::Arc::new(StatusJobsCallbackHandler::new(kernel_handle.clone())),
+        ]
+    };
 
-        // Register callback handlers for inline keyboard interactions.
-        {
-            use rara_channels::telegram::commands::{
-                ModelSwitchCallbackHandler, SessionDeleteCallbackHandler,
-                SessionDeleteCancelHandler, SessionDeleteConfirmHandler,
-                SessionDetailCallbackHandler, SessionSwitchCallbackHandler,
-                StatusJobsCallbackHandler,
-            };
-            let callback_handlers: Vec<
-                std::sync::Arc<dyn rara_kernel::channel::command::CallbackHandler>,
-            > = vec![
-                std::sync::Arc::new(SessionSwitchCallbackHandler::new(bot_client.clone())),
-                std::sync::Arc::new(SessionDetailCallbackHandler::new(bot_client.clone())),
-                std::sync::Arc::new(SessionDeleteCallbackHandler::new(bot_client.clone())),
-                std::sync::Arc::new(SessionDeleteConfirmHandler::new(bot_client.clone())),
-                std::sync::Arc::new(SessionDeleteCancelHandler::new()),
-                std::sync::Arc::new(ModelSwitchCallbackHandler::new(bot_client.clone())),
-                std::sync::Arc::new(StatusJobsCallbackHandler::new(kernel_handle.clone())),
-            ];
-            tg_adapter.set_callback_handlers(callback_handlers);
-        }
+    // Build the Telegram adapter now that handlers (which depend on
+    // `kernel_handle` and `bot_client`) exist. Construction is compile-time
+    // total: `TelegramAdapter::builder()` requires `command_handlers` and
+    // `callback_handlers`, so dropping either makes `cargo check` fail (no
+    // more silent "/session does nothing" runtime no-op, see #2109).
+    let telegram_adapter: Option<Arc<rara_channels::telegram::TelegramAdapter>> =
+        if let Some(precursor) = telegram_precursor {
+            let TelegramPrecursor {
+                bot,
+                initial_config,
+                settings,
+                user_question_manager,
+                stt_service,
+                tts_service,
+            } = precursor;
+            let adapter = Arc::new(
+                rara_channels::telegram::TelegramAdapter::builder()
+                    .bot(bot)
+                    .allowed_chat_ids(vec![])
+                    .command_handlers(command_handlers.clone())
+                    .callback_handlers(callback_handlers)
+                    .config(initial_config)
+                    .user_question_manager(user_question_manager)
+                    .maybe_stt_service(stt_service)
+                    .maybe_tts_service(tts_service)
+                    .settings(Arc::clone(&settings))
+                    .build(),
+            );
 
-        use rara_kernel::channel::adapter::ChannelAdapter as _;
-        match tg_adapter.start(kernel_handle.clone()).await {
-            Ok(()) => info!("Telegram adapter started"),
-            Err(e) => warn!(error = %e, "Failed to start Telegram adapter"),
-        }
-    }
+            // Register the adapter with the kernel I/O subsystem (deferred
+            // from boot for the same reason — handlers need `KernelHandle`).
+            kernel_handle.io().register_adapter(
+                ChannelType::Telegram,
+                adapter.clone() as Arc<dyn ChannelAdapter>,
+            );
+
+            // Wire settings → TelegramConfig hot-reload now that the
+            // adapter (and its `config_handle`) exists.
+            spawn_telegram_config_reloader(&adapter, settings);
+
+            use rara_kernel::channel::adapter::ChannelAdapter as _;
+            match adapter.start(kernel_handle.clone()).await {
+                Ok(()) => info!("Telegram adapter started"),
+                Err(e) => warn!(error = %e, "Failed to start Telegram adapter"),
+            }
+            Some(adapter)
+        } else {
+            None
+        };
     {
         use rara_kernel::channel::adapter::ChannelAdapter as _;
         match web_adapter.start(kernel_handle.clone()).await {
@@ -1263,23 +1305,33 @@ pub async fn start_with_options(
     Ok(app_handle)
 }
 
-async fn try_build_telegram(
+/// Precursor inputs needed to construct a
+/// [`rara_channels::telegram::TelegramAdapter`] late, after `KernelHandle`
+/// and the command/callback handlers are available.
+///
+/// Decoupling bot + config + service-handle resolution from the adapter
+/// itself is what lets command handlers be a **required** builder field on
+/// `TelegramAdapter` (see #2109): handlers depend on `bot_client` which
+/// depends on `kernel_handle`, so the adapter must be built **after** the
+/// kernel — but its underlying [`teloxide::Bot`] (and the polled
+/// settings) can be built up front, and the handlers can take the bot
+/// directly without going through `adapter.bot()`.
+struct TelegramPrecursor {
+    bot:                   teloxide::Bot,
+    initial_config:        rara_channels::telegram::TelegramConfig,
+    settings:              Arc<dyn rara_domain_shared::settings::SettingsProvider>,
+    user_question_manager: rara_kernel::user_question::UserQuestionManagerRef,
+    stt_service:           Option<rara_stt::SttService>,
+    tts_service:           Option<rara_tts::TtsService>,
+}
+
+async fn try_build_telegram_precursor(
     settings_svc: &rara_backend_admin::settings::SettingsSvc,
     user_question_manager: rara_kernel::user_question::UserQuestionManagerRef,
     stt_service: Option<rara_stt::SttService>,
     tts_service: Option<rara_tts::TtsService>,
-) -> Result<Option<Arc<rara_channels::telegram::TelegramAdapter>>, Whatever> {
+) -> Result<Option<TelegramPrecursor>, Whatever> {
     use rara_domain_shared::settings::{SettingsProvider, keys};
-
-    fn parse_group_policy(raw: Option<String>) -> GroupPolicy {
-        raw.and_then(|s| {
-            s.trim()
-                .parse::<GroupPolicy>()
-                .map_err(|e| warn!(error = %e, "invalid telegram.group_policy, using default"))
-                .ok()
-        })
-        .unwrap_or_default()
-    }
 
     let settings: Arc<dyn SettingsProvider> = Arc::new(settings_svc.clone());
     let token = match settings.get(keys::TELEGRAM_BOT_TOKEN).await {
@@ -1295,6 +1347,9 @@ async fn try_build_telegram(
         info!(proxy = %p, "telegram adapter: using proxy");
     }
 
+    let bot = rara_channels::telegram::build_bot(&token, proxy.as_deref())
+        .whatever_context("failed to build telegram bot")?;
+
     let chat_id: Option<i64> = settings
         .get(keys::TELEGRAM_CHAT_ID)
         .await
@@ -1303,26 +1358,43 @@ async fn try_build_telegram(
         .get(keys::TELEGRAM_ALLOWED_GROUP_CHAT_ID)
         .await
         .and_then(|v| v.parse().ok());
-    let group_policy = parse_group_policy(settings.get(keys::TELEGRAM_GROUP_POLICY).await);
+    let group_policy = parse_telegram_group_policy(settings.get(keys::TELEGRAM_GROUP_POLICY).await);
 
-    let mut tg_config = rara_channels::telegram::TelegramConfig::default();
-    tg_config.primary_chat_id = chat_id;
-    tg_config.allowed_group_chat_id = group_id;
-    tg_config.group_policy = group_policy;
+    let initial_config = rara_channels::telegram::TelegramConfig {
+        primary_chat_id: chat_id,
+        allowed_group_chat_id: group_id,
+        group_policy,
+    };
 
-    let adapter = Arc::new(
-        rara_channels::telegram::TelegramAdapter::with_proxy(
-            &token,
-            vec![],
-            proxy.as_deref(),
-            Arc::clone(&settings),
-        )
-        .whatever_context("failed to build telegram adapter")?
-        .with_config(tg_config)
-        .with_user_question_manager(user_question_manager)
-        .with_stt_service(stt_service)
-        .with_tts_service(tts_service),
-    );
+    Ok(Some(TelegramPrecursor {
+        bot,
+        initial_config,
+        settings,
+        user_question_manager,
+        stt_service,
+        tts_service,
+    }))
+}
+
+fn parse_telegram_group_policy(raw: Option<String>) -> GroupPolicy {
+    raw.and_then(|s| {
+        s.trim()
+            .parse::<GroupPolicy>()
+            .map_err(|e| warn!(error = %e, "invalid telegram.group_policy, using default"))
+            .ok()
+    })
+    .unwrap_or_default()
+}
+
+/// Spawn the settings → `TelegramConfig` hot-reload task. Mirrors the
+/// previous inline `tokio::spawn` in `try_build_telegram`; pulled out so
+/// the call site that builds the adapter via `TelegramAdapter::builder`
+/// can wire it up in one line.
+fn spawn_telegram_config_reloader(
+    adapter: &Arc<rara_channels::telegram::TelegramAdapter>,
+    settings: Arc<dyn rara_domain_shared::settings::SettingsProvider>,
+) {
+    use rara_domain_shared::settings::keys;
 
     let config_handle = adapter.config_handle();
     let mut settings_rx = settings.subscribe();
@@ -1337,15 +1409,13 @@ async fn try_build_telegram(
                 .await
                 .and_then(|v| v.parse().ok());
             let new_group_policy =
-                parse_group_policy(settings.get(keys::TELEGRAM_GROUP_POLICY).await);
+                parse_telegram_group_policy(settings.get(keys::TELEGRAM_GROUP_POLICY).await);
             let mut cfg = config_handle.write().unwrap_or_else(|e| e.into_inner());
             cfg.primary_chat_id = new_chat_id;
             cfg.allowed_group_chat_id = new_group_id;
             cfg.group_policy = new_group_policy;
         }
     });
-
-    Ok(Some(adapter))
 }
 
 async fn try_build_wechat(

--- a/crates/channels/AGENT.md
+++ b/crates/channels/AGENT.md
@@ -29,8 +29,8 @@ Concrete channel adapter implementations for the rara platform — bridges the k
 
 ### Telegram specifics
 
-- Command and callback handlers are set after adapter construction via `set_command_handlers()` / `set_callback_handlers()`.
-- `TelegramConfig` is hot-reloadable via `config_handle()` (returns `Arc<RwLock<TelegramConfig>>`), updated when settings change.
+- `TelegramAdapter` is built via `TelegramAdapter::builder()` (`bon::Builder`). `command_handlers` and `callback_handlers` are **required** fields — dropping either is a `cargo check` error, killing the historical footgun where forgetting `set_command_handlers` left `/session` silently no-op (#2109). The app boot path resolves the apparent construction cycle (handlers need `KernelHandle` → handlers need the adapter's `bot()`) by building the `teloxide::Bot` up front via `build_bot(token, proxy)`, then handing the same `Bot` to both the command handlers and the `TelegramAdapter::builder().bot(...)` call.
+- `TelegramConfig` is hot-reloadable via `config_handle()` (returns `Arc<RwLock<TelegramConfig>>`), updated when settings change. The builder takes a plain `TelegramConfig` value via `.config(...)` and wraps it internally.
 - Proxy support via `HTTPS_PROXY` / `HTTP_PROXY` / `ALL_PROXY` env vars. Uses pinned `reqwest 0.12` for teloxide compatibility.
 
 ## Critical Invariants

--- a/crates/channels/src/telegram/adapter.rs
+++ b/crates/channels/src/telegram/adapter.rs
@@ -1061,25 +1061,27 @@ impl Default for TelegramConfig {
 ///    handled separately via [`ChannelAdapter::send`].
 /// 3. Call [`stop`](ChannelAdapter::stop) to signal the polling loop to exit
 ///    gracefully.
+#[derive(bon::Builder)]
 pub struct TelegramAdapter {
     bot:                   teloxide::Bot,
     allowed_chat_ids:      Vec<i64>,
+    /// Long-poll timeout in seconds. The HTTP client timeout is derived from
+    /// this (poll + 30s).
+    #[builder(default = POLL_TIMEOUT_SECS)]
     polling_timeout:       u32,
-    shutdown_tx:           watch::Sender<bool>,
-    shutdown_rx:           watch::Receiver<bool>,
-    /// Bot username from getMe (set during start).
-    bot_username:          Arc<RwLock<Option<String>>>,
-    /// Registered command handlers for slash commands.
-    command_handlers:      StdRwLock<Vec<Arc<dyn CommandHandler>>>,
-    /// Registered callback handlers for interactive elements.
-    callback_handlers:     StdRwLock<Vec<Arc<dyn CallbackHandler>>>,
+    /// Registered command handlers for slash commands. Required at
+    /// construction — empty handlers in production is always a bug (see
+    /// #2109 and the `start()` "no commands registered" warning path).
+    command_handlers:      Vec<Arc<dyn CommandHandler>>,
+    /// Registered callback handlers for interactive elements. Required at
+    /// construction for the same reason as `command_handlers`.
+    callback_handlers:     Vec<Arc<dyn CallbackHandler>>,
     /// Runtime-updatable configuration (primary chat ID, allowed group chat
-    /// ID).
+    /// ID). Wrapped in `Arc<StdRwLock<…>>` so external callers can hot-reload
+    /// via [`config_handle`](Self::config_handle); pass a plain
+    /// [`TelegramConfig`] to the builder.
+    #[builder(with = |c: TelegramConfig| Arc::new(StdRwLock::new(c)))]
     config:                Arc<StdRwLock<TelegramConfig>>,
-    /// StreamHub for subscribing to real-time token deltas.
-    stream_hub:            Arc<RwLock<Option<StreamHubRef>>>,
-    /// Per-chat active streaming state, keyed by `chat_id`.
-    active_streams:        Arc<DashMap<i64, StreamingMessage>>,
     /// User question manager for the ask-user tool — when set, the adapter
     /// subscribes to new questions and resolves them via reply-to messages.
     user_question_manager: Option<UserQuestionManagerRef>,
@@ -1087,183 +1089,42 @@ pub struct TelegramAdapter {
     stt_service:           Option<rara_stt::SttService>,
     /// Optional TTS service for synthesizing voice replies.
     tts_service:           Option<rara_tts::TtsService>,
-    /// Chat IDs whose most recent inbound message was a voice note.
-    /// Checked at egress to decide whether to reply with a voice note.
-    voice_chat_ids:        Arc<DashSet<i64>>,
     /// Settings provider for persisting pinned message IDs across restarts.
     settings:              Arc<dyn SettingsProvider>,
+
+    // -- Internally-initialized state (not part of the builder API) -----------
+    #[builder(skip = {
+        let (tx, _rx) = watch::channel(false);
+        tx
+    })]
+    shutdown_tx:    watch::Sender<bool>,
+    /// Bot username from getMe (set during start).
+    #[builder(skip = Arc::new(RwLock::new(None)))]
+    bot_username:   Arc<RwLock<Option<String>>>,
+    /// StreamHub for subscribing to real-time token deltas.
+    #[builder(skip = Arc::new(RwLock::new(None)))]
+    stream_hub:     Arc<RwLock<Option<StreamHubRef>>>,
+    /// Per-chat active streaming state, keyed by `chat_id`.
+    #[builder(skip = Arc::new(DashMap::new()))]
+    active_streams: Arc<DashMap<i64, StreamingMessage>>,
+    /// Chat IDs whose most recent inbound message was a voice note.
+    /// Checked at egress to decide whether to reply with a voice note.
+    #[builder(skip = Arc::new(DashSet::new()))]
+    voice_chat_ids: Arc<DashSet<i64>>,
     /// Per-chat + global rate limiter for outbound Telegram API calls. All
     /// `sendMessage`, `editMessageText`, `sendPhoto`, `sendVoice`, and
     /// `sendChatAction` call sites must `.acquire(chat_id)` first (see
     /// `AGENT.md` invariants).
-    rate_limiter:          Arc<super::rate_limit::ChatRateLimiter>,
+    #[builder(skip = Arc::new(super::rate_limit::ChatRateLimiter::new()))]
+    rate_limiter:   Arc<super::rate_limit::ChatRateLimiter>,
 }
 
 impl TelegramAdapter {
-    /// Create a new Telegram adapter.
-    ///
-    /// # Arguments
-    ///
-    /// - `bot` — a configured [`teloxide::Bot`] instance
-    /// - `allowed_chat_ids` — list of Telegram chat IDs that are permitted to
-    ///   interact with the adapter. Pass an empty vec to allow all chats.
-    pub fn new(
-        bot: teloxide::Bot,
-        allowed_chat_ids: Vec<i64>,
-        settings: Arc<dyn SettingsProvider>,
-    ) -> Self {
-        let (shutdown_tx, shutdown_rx) = watch::channel(false);
-        Self {
-            bot,
-            allowed_chat_ids,
-            polling_timeout: POLL_TIMEOUT_SECS,
-            shutdown_tx,
-            shutdown_rx,
-            bot_username: Arc::new(RwLock::new(None)),
-            command_handlers: StdRwLock::new(Vec::new()),
-            callback_handlers: StdRwLock::new(Vec::new()),
-            config: Arc::new(StdRwLock::new(TelegramConfig::default())),
-            stream_hub: Arc::new(RwLock::new(None)),
-            active_streams: Arc::new(DashMap::new()),
-            user_question_manager: None,
-            stt_service: None,
-            tts_service: None,
-            voice_chat_ids: Arc::new(DashSet::new()),
-            settings,
-            rate_limiter: Arc::new(super::rate_limit::ChatRateLimiter::new()),
-        }
-    }
-
-    /// Build a [`teloxide::Bot`] with an optional proxy, then wrap it in an
-    /// adapter.
-    ///
-    /// The proxy URL is passed to [`reqwest012::Proxy::all`] (supports
-    /// `http://`, `https://`, `socks5://`).
-    pub fn with_proxy(
-        token: &str,
-        allowed_chat_ids: Vec<i64>,
-        proxy: Option<&str>,
-        settings: Arc<dyn SettingsProvider>,
-    ) -> Result<Self, anyhow::Error> {
-        let bot = build_bot(token, proxy)?;
-        Ok(Self::new(bot, allowed_chat_ids, settings))
-    }
-
-    /// Create a new Telegram adapter with a custom polling timeout.
-    #[must_use]
-    pub fn with_polling_timeout(mut self, timeout_secs: u32) -> Self {
-        self.polling_timeout = timeout_secs;
-        self
-    }
-
-    /// Register command handlers (builder pattern — must be called before `Arc`
-    /// wrapping).
-    #[must_use]
-    pub fn with_command_handlers(self, handlers: Vec<Arc<dyn CommandHandler>>) -> Self {
-        *self
-            .command_handlers
-            .write()
-            .unwrap_or_else(|e| e.into_inner()) = handlers;
-        self
-    }
-
-    /// Replace command handlers at runtime (works through `&self` /
-    /// `Arc<Self>`).
-    pub fn set_command_handlers(&self, handlers: Vec<Arc<dyn CommandHandler>>) {
-        *self
-            .command_handlers
-            .write()
-            .unwrap_or_else(|e| e.into_inner()) = handlers;
-    }
-
-    /// Register callback handlers (builder pattern — must be called before
-    /// `Arc` wrapping).
-    #[must_use]
-    pub fn with_callback_handlers(self, handlers: Vec<Arc<dyn CallbackHandler>>) -> Self {
-        *self
-            .callback_handlers
-            .write()
-            .unwrap_or_else(|e| e.into_inner()) = handlers;
-        self
-    }
-
-    /// Replace callback handlers at runtime (works through `&self` /
-    /// `Arc<Self>`).
-    pub fn set_callback_handlers(&self, handlers: Vec<Arc<dyn CallbackHandler>>) {
-        *self
-            .callback_handlers
-            .write()
-            .unwrap_or_else(|e| e.into_inner()) = handlers;
-    }
-
     /// Return a clone of the underlying [`teloxide::Bot`] handle.
     ///
     /// Used by command handlers that need to call Telegram APIs directly
     /// (e.g. deleting forum topics on `/clear`).
     pub fn bot(&self) -> teloxide::Bot { self.bot.clone() }
-
-    /// Set the primary chat ID for privileged commands.
-    ///
-    /// Commands like `/search` and `/jd` are restricted to this chat only.
-    /// This is a convenience builder that mutates the internal config.
-    #[must_use]
-    pub fn with_primary_chat_id(self, id: i64) -> Self {
-        {
-            let mut cfg = self.config.write().unwrap_or_else(|e| e.into_inner());
-            cfg.primary_chat_id = Some(id);
-        }
-        self
-    }
-
-    /// Set the allowed group chat ID.
-    ///
-    /// When set, only the specified group is authorized for group-chat
-    /// interactions. Messages from other groups receive an "unauthorized"
-    /// response and are not dispatched further.
-    /// This is a convenience builder that mutates the internal config.
-    #[must_use]
-    pub fn with_allowed_group_chat_id(self, id: i64) -> Self {
-        {
-            let mut cfg = self.config.write().unwrap_or_else(|e| e.into_inner());
-            cfg.allowed_group_chat_id = Some(id);
-        }
-        self
-    }
-
-    /// Set the full runtime config.
-    ///
-    /// Replaces the current config with the provided one.
-    #[must_use]
-    pub fn with_config(self, config: TelegramConfig) -> Self {
-        {
-            let mut cfg = self.config.write().unwrap_or_else(|e| e.into_inner());
-            *cfg = config;
-        }
-        self
-    }
-
-    /// Attach a [`UserQuestionManager`](rara_kernel::user_question::UserQuestionManager)
-    /// so the adapter can render agent questions and resolve them via
-    /// reply-to messages.
-    #[must_use]
-    pub fn with_user_question_manager(mut self, mgr: UserQuestionManagerRef) -> Self {
-        self.user_question_manager = Some(mgr);
-        self
-    }
-
-    /// Attach an STT service for voice message transcription.
-    #[must_use]
-    pub fn with_stt_service(mut self, stt: Option<rara_stt::SttService>) -> Self {
-        self.stt_service = stt;
-        self
-    }
-
-    /// Attach a TTS service for synthesizing voice replies.
-    #[must_use]
-    pub fn with_tts_service(mut self, tts: Option<rara_tts::TtsService>) -> Self {
-        self.tts_service = tts;
-        self
-    }
 
     /// Return a shared handle to the runtime config.
     ///
@@ -1650,23 +1511,15 @@ impl ChannelAdapter for TelegramAdapter {
         let bot = self.bot.clone();
         let allowed_chat_ids = self.allowed_chat_ids.clone();
         let polling_timeout = self.polling_timeout;
-        let mut shutdown_rx = self.shutdown_rx.clone();
+        let mut shutdown_rx = self.shutdown_tx.subscribe();
         let bot_username = Arc::clone(&self.bot_username);
         let config = Arc::clone(&self.config);
         let stream_hub = Arc::clone(&self.stream_hub);
         let active_streams = Arc::clone(&self.active_streams);
-        let command_handlers: Arc<[Arc<dyn CommandHandler>]> = self
-            .command_handlers
-            .read()
-            .unwrap_or_else(|e| e.into_inner())
-            .clone()
-            .into();
-        let callback_handlers: Arc<[Arc<dyn CallbackHandler>]> = self
-            .callback_handlers
-            .read()
-            .unwrap_or_else(|e| e.into_inner())
-            .clone()
-            .into();
+        let command_handlers: Arc<[Arc<dyn CommandHandler>]> =
+            Arc::from(self.command_handlers.clone());
+        let callback_handlers: Arc<[Arc<dyn CallbackHandler>]> =
+            Arc::from(self.callback_handlers.clone());
         let stt_service = self.stt_service.clone();
         let voice_chat_ids = Arc::clone(&self.voice_chat_ids);
         let settings = Arc::clone(&self.settings);
@@ -1699,7 +1552,7 @@ impl ChannelAdapter for TelegramAdapter {
             let approval_config = Arc::clone(&self.config);
             let approval_session_index = Arc::clone(handle.session_index());
             let approval_rate_limiter = Arc::clone(&self.rate_limiter);
-            let mut approval_shutdown = self.shutdown_rx.clone();
+            let mut approval_shutdown = self.shutdown_tx.subscribe();
             tokio::spawn(async move {
                 approval_listener(
                     approval_bot,
@@ -1722,7 +1575,7 @@ impl ChannelAdapter for TelegramAdapter {
             let question_config = Arc::clone(&self.config);
             let question_mgr = Arc::clone(mgr);
             let question_rate_limiter = Arc::clone(&self.rate_limiter);
-            let mut question_shutdown = self.shutdown_rx.clone();
+            let mut question_shutdown = self.shutdown_tx.subscribe();
             tokio::spawn(async move {
                 question_listener(
                     question_bot,

--- a/crates/kernel/src/io.rs
+++ b/crates/kernel/src/io.rs
@@ -1983,7 +1983,15 @@ pub struct IOSubsystem {
     identity_resolver:       IdentityResolverRef,
     session_index:           Arc<dyn SessionIndex>,
     stream_hub:              StreamHubRef,
-    adapters:                HashMap<ChannelType, ChannelAdapterRef>,
+    /// Egress adapters keyed by channel type. `RwLock` allows late registration
+    /// through `&self` so call sites that only have `Arc<IOSubsystem>` (e.g.
+    /// after `Kernel::start`) can wire in adapters whose own construction
+    /// depends on `KernelHandle` (e.g. Telegram, whose command handlers need
+    /// `bot_client = KernelBotServiceClient::new(.., kernel_handle, ..)`).
+    /// Reads happen on every outbound egress path and inserts only at boot —
+    /// so contention is effectively zero. `std::sync::RwLock` keeps this
+    /// usable from non-async call sites.
+    adapters:                std::sync::RwLock<HashMap<ChannelType, ChannelAdapterRef>>,
     endpoint_registry:       EndpointRegistryRef,
     /// Telegram channel ID for agent-initiated notifications.
     notification_channel_id: Option<i64>,
@@ -2006,7 +2014,7 @@ impl IOSubsystem {
             identity_resolver,
             session_index,
             stream_hub: Arc::new(StreamHub::new(STREAM_HUB_BROADCAST_CAPACITY)),
-            adapters: HashMap::new(),
+            adapters: std::sync::RwLock::new(HashMap::new()),
             endpoint_registry: Arc::new(EndpointRegistry::new()),
             notification_channel_id,
             rate_limiter: IngressRateLimiter::new(max_ingress_per_minute),
@@ -2136,9 +2144,16 @@ impl IOSubsystem {
 
     /// Register an egress adapter for a channel type.
     ///
-    /// Must be called **before** passing to the kernel.
-    pub fn register_adapter(&mut self, channel_type: ChannelType, adapter: ChannelAdapterRef) {
-        self.adapters.insert(channel_type, adapter);
+    /// May be called either at boot (before the subsystem is wrapped in `Arc`
+    /// and handed to `Kernel::builder`) or post-start through `Arc<Self>` —
+    /// the latter is needed by adapters whose own construction depends on a
+    /// running `KernelHandle` (e.g. Telegram). Last writer wins per channel
+    /// type. Lock poisoning is recovered via `into_inner`.
+    pub fn register_adapter(&self, channel_type: ChannelType, adapter: ChannelAdapterRef) {
+        self.adapters
+            .write()
+            .unwrap_or_else(|e| e.into_inner())
+            .insert(channel_type, adapter);
     }
 
     /// Spawn a deliver task so that egress I/O (Telegram API, WebSocket
@@ -2174,7 +2189,13 @@ impl IOSubsystem {
             tracing::warn!("send_notification: no notification_channel_id configured, dropping");
             return;
         };
-        let Some(adapter) = self.adapters.get(&ChannelType::Telegram).cloned() else {
+        let Some(adapter) = self
+            .adapters
+            .read()
+            .unwrap_or_else(|e| e.into_inner())
+            .get(&ChannelType::Telegram)
+            .cloned()
+        else {
             tracing::warn!("send_notification: no Telegram adapter registered, dropping");
             return;
         };
@@ -2275,7 +2296,13 @@ impl IOSubsystem {
             return;
         }
         for binding in &bindings {
-            let Some(adapter) = self.adapters.get(&binding.channel_type).cloned() else {
+            let Some(adapter) = self
+                .adapters
+                .read()
+                .unwrap_or_else(|e| e.into_inner())
+                .get(&binding.channel_type)
+                .cloned()
+            else {
                 continue;
             };
             if let Err(e) = adapter.rename_session_label(binding, title).await {
@@ -2356,7 +2383,11 @@ impl IOSubsystem {
         };
         tracing::info!(
             targets = targets.len(),
-            adapters = self.adapters.len(),
+            adapters = self
+                .adapters
+                .read()
+                .unwrap_or_else(|e| e.into_inner())
+                .len(),
             has_origin = envelope.origin_endpoint.is_some(),
             routing = ?envelope.routing,
             payload = %payload_variant,
@@ -2368,7 +2399,12 @@ impl IOSubsystem {
         // copy work for nothing.
         let outbound = envelope.to_platform_outbound();
         let futs = targets.into_iter().map(|endpoint| {
-            let adapter = self.adapters.get(&endpoint.channel_type).cloned();
+            let adapter = self
+                .adapters
+                .read()
+                .unwrap_or_else(|e| e.into_inner())
+                .get(&endpoint.channel_type)
+                .cloned();
             let outbound = outbound.clone();
             async move {
                 if let Some(adapter) = adapter {


### PR DESCRIPTION
## Summary

Lane-2 refactor migrating `TelegramAdapter` from post-construction mutate-setter pattern (`set_command_handlers()`, `set_callback_handlers()`, plus 11 other `with_*` chains) to `bon::Builder`. Drops 13 setter / chain methods.

**Reproducer the issue protects against** — now compile-time forbidden:

```
$ sed -i 's/\.command_handlers(...)//' crates/app/src/lib.rs
$ cargo check -p rara-app
error[E0277]: the member `Unset<command_handlers>` was not set
```

Pre-PR this compiled clean and left `/session` silently no-op.

## Decisions surfaced

**Boundary stretch (kernel/io.rs):** the construction-order unflattening (handlers need `KernelHandle` ⇒ adapter built post-`kernel.start()` ⇒ late registration through `Arc<IOSubsystem>` needs `&self`) required:

- `IOSubsystem.adapters: HashMap<...>` → `std::sync::RwLock<HashMap<...>>`
- `register_adapter(&mut self, ...)` → `register_adapter(&self, ...)`
- 5 read sites updated

The issue's `Boundaries.Forbidden` listed `crates/kernel/**` with rider *"ChannelAdapter / CommandHandler / CallbackHandler traits do not change"*. Trait surfaces are genuinely unchanged. The alternative — a setter on `IOSubsystem` — recreates exactly the anti-pattern this PR removes. Reviewer (a14f0838) approved this as P2 with explicit reasoning.

`std::sync::RwLock` (not `tokio::sync::RwLock`) — critical section is one `HashMap::insert/get`, no `.await` ever held across a guard.

**Construction order in `crates/app/src/lib.rs`:** split `try_build_telegram` into `try_build_telegram_precursor` (returns `TelegramPrecursor { bot, initial_config, … }` early in boot) + late adapter construction via `TelegramAdapter::builder()...build()` after `kernel.start()`. Late `IOSubsystem` registration via `kernel_handle.io().register_adapter(...)`.

## Invariants preserved (spot-checked in review)

- `ChatRateLimiter::acquire(chat_id)` on every outbound (3 sites)
- `reqwest 0.12` pin
- `config_handle()` returns `Arc<RwLock<TelegramConfig>>`
- `bot()` accessor
- All `ChannelAdapter` trait methods unchanged
- Shutdown semantics (watch::Sender::subscribe equivalent to retained Receiver)
- Hot-reload via new `spawn_telegram_config_reloader` — identical semantics to prior inline `tokio::spawn`

## Test plan

- [x] `cargo check --workspace --all-targets`
- [x] `cargo +nightly fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings`
- [x] `RUSTDOCFLAGS="-D warnings" cargo +nightly doc --workspace --no-deps --document-private-items`
- [x] `prek run --all-files`
- [x] `cargo test -p rara-channels` — 10 passed
- [x] `cargo test -p rara-app` — 92 passed
- [x] `cargo test -p rara-kernel --lib` — 536 passed (2 pre-existing flakes unrelated, verified on main)

Diff: 4 files, +233 / −274 (net −41).

Closes #2109