### PR TITLE
feat(memory): commit_outcome API + confidence-weighted ranking (#2112)

### DIFF
--- a/crates/kernel/src/memory/knowledge/mod.rs
+++ b/crates/kernel/src/memory/knowledge/mod.rs
@@ -26,11 +26,13 @@ pub mod embedding;
 pub mod extractor;
 pub mod items;
 pub mod manifest;
+pub mod outcome;
 pub mod service;
 pub mod tool;
 
 pub use config::KnowledgeConfig;
 pub use embedding::EmbeddingService;
 pub use manifest::{KNOWLEDGE_EXTRACTOR_NAME, knowledge_extractor_manifest};
+pub use outcome::{CONFIDENCE_ALPHA, OutcomeKind, apply_ema};
 pub use service::{KnowledgeService, KnowledgeServiceRef};
-pub use tool::MemoryTool;
+pub use tool::{CONFIDENCE_RANK_WEIGHT, MemoryTool};

--- a/crates/kernel/src/memory/knowledge/outcome.rs
+++ b/crates/kernel/src/memory/knowledge/outcome.rs
@@ -1,0 +1,336 @@
+// Copyright 2025 Rararulab
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Outcome feedback for the knowledge layer.
+//!
+//! Defines [`OutcomeKind`] — the polarity-carrying enum the kernel hands to
+//! [`KnowledgeService::commit_outcome`](super::service::KnowledgeService::commit_outcome) —
+//! and [`apply_ema`], the pure EMA update used to move
+//! `memory_items.confidence` in `[0, 1]` based on accumulated outcomes.
+//!
+//! Keeping the enum + math in this file lets the EMA be unit-tested
+//! without diesel, and gives the persistence path (which lives in
+//! [`KnowledgeService::commit_outcome`](super::service::KnowledgeService::commit_outcome))
+//! one small file to import from rather than reaching into `items.rs`.
+
+use diesel::{ExpressionMethods, QueryDsl, result::OptionalExtension};
+use diesel_async::{AsyncConnection, RunQueryDsl};
+use rara_model::schema::{memory_items, memory_outcomes};
+use snafu::ResultExt;
+use yunara_store::diesel_pool::DieselSqlitePool;
+
+use crate::error::{DieselPoolSnafu, DieselSnafu, Result};
+
+/// EMA learning rate used by [`apply_ema`].
+///
+/// At `α = 0.2`, five outcomes of the same polarity move confidence by
+/// roughly 67 % toward the bound — which matches the "you have to be
+/// wrong a handful of times before rara stops trusting you" intuition
+/// the ranking layer assumes.
+///
+/// This is a mechanism-tuning constant (no operator-relevant right
+/// value), so per the project spec it lives as a `const` next to the
+/// mechanism rather than as a YAML knob.
+pub const CONFIDENCE_ALPHA: f32 = 0.2;
+
+/// Kind of outcome reported against a set of memory items.
+///
+/// The polarity table is:
+///
+/// - [`OutcomeKind::Success`] / [`OutcomeKind::Confirmed`] → positive update
+///   (`c' = c + α (1 − c)`).
+/// - [`OutcomeKind::Failure`] / [`OutcomeKind::Contradicted`] → negative update
+///   (`c' = c − α c`).
+///
+/// Both pairs collapse to two cases in the EMA, but the audit row
+/// preserves the source distinction: `Success` typically comes from
+/// automated tool-result correlation, while `Confirmed` typically comes
+/// from explicit user feedback.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OutcomeKind {
+    /// Tool-result-style positive signal.
+    Success,
+    /// Tool-result-style negative signal.
+    Failure,
+    /// User-feedback-style positive signal.
+    Confirmed,
+    /// User-feedback-style negative signal.
+    Contradicted,
+}
+
+impl OutcomeKind {
+    /// Stable string used both as the `memory_outcomes.outcome_kind`
+    /// column value and as the canonical wire / log representation.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            OutcomeKind::Success => "success",
+            OutcomeKind::Failure => "failure",
+            OutcomeKind::Confirmed => "confirmed",
+            OutcomeKind::Contradicted => "contradicted",
+        }
+    }
+
+    /// Whether this outcome moves confidence up (`true`) or down (`false`).
+    pub fn is_positive(self) -> bool {
+        matches!(self, OutcomeKind::Success | OutcomeKind::Confirmed)
+    }
+}
+
+/// Pure EMA update for a single outcome.
+///
+/// Bounded by construction in `[0, 1]` for any starting `current` in
+/// `[0, 1]`: positive update `c' = c + α(1 − c)` lands in `[c, 1]`;
+/// negative update `c' = c − α c` lands in `[0, c]`. No clamping needed.
+pub fn apply_ema(current: f32, kind: OutcomeKind) -> f32 {
+    if kind.is_positive() {
+        CONFIDENCE_ALPHA.mul_add(1.0 - current, current)
+    } else {
+        CONFIDENCE_ALPHA.mul_add(-current, current)
+    }
+}
+
+/// Write one `memory_outcomes` row per id in `item_ids` and update the
+/// parent `memory_items.confidence` via [`apply_ema`], all in a single
+/// writer transaction.
+///
+/// - Empty `item_ids` is a no-op (returns Ok).
+/// - Ids with no matching `memory_items` row are silently skipped. The
+///   transaction still commits any successful pairs.
+///
+/// The `(write memory_outcomes row, update memory_items.confidence)`
+/// pair is the unit of truth: if only one half lands, the future
+/// `explain()` trace starts lying. Diesel's `transaction()` is the
+/// right boundary; the writer pool already serializes writes.
+pub(super) async fn commit_outcome_inner(
+    writer: &DieselSqlitePool,
+    item_ids: &[i64],
+    kind: OutcomeKind,
+    tape_entry_id: Option<i64>,
+) -> Result<()> {
+    if item_ids.is_empty() {
+        return Ok(());
+    }
+
+    let ids_i32: Vec<i32> = item_ids.iter().map(|&v| v as i32).collect();
+    let tape_entry_id_i32: Option<i32> = tape_entry_id.map(|v| v as i32);
+    let kind_str = kind.as_str();
+
+    let mut conn = writer.get().await.context(DieselPoolSnafu)?;
+    conn.transaction::<_, diesel::result::Error, _>(async |conn| {
+        for id in &ids_i32 {
+            // Read the current confidence. If no row matches, skip — the
+            // outer call still returns Ok per spec.
+            let current: Option<f32> = memory_items::table
+                .filter(memory_items::id.eq(*id))
+                .select(memory_items::confidence)
+                .first::<f32>(&mut *conn)
+                .await
+                .optional()?;
+            let Some(current) = current else {
+                continue;
+            };
+
+            // Insert the audit row.
+            diesel::insert_into(memory_outcomes::table)
+                .values((
+                    memory_outcomes::item_id.eq(*id),
+                    memory_outcomes::outcome_kind.eq(kind_str),
+                    memory_outcomes::tape_entry_id.eq(tape_entry_id_i32),
+                ))
+                .execute(&mut *conn)
+                .await?;
+
+            // Update the parent's confidence.
+            let updated = apply_ema(current, kind);
+            diesel::update(memory_items::table.filter(memory_items::id.eq(*id)))
+                .set(memory_items::confidence.eq(updated))
+                .execute(&mut *conn)
+                .await?;
+        }
+        Ok(())
+    })
+    .await
+    .context(DieselSnafu)?;
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use diesel_async::RunQueryDsl as _;
+    use yunara_store::diesel_pool::DieselSqlitePool;
+
+    use super::*;
+
+    /// Mirrors the DDL bundled into the
+    /// `2026-05-21-000000_memory_confidence_outcomes` migration. The
+    /// shared test pool's bootstrap schema still tracks the
+    /// pre-migration `memory_items` shape, so each test opts in.
+    const ADD_CONFIDENCE_SQL: &str =
+        "ALTER TABLE memory_items ADD COLUMN confidence REAL NOT NULL DEFAULT 1.0";
+    const CREATE_OUTCOMES_SQL: &str =
+        "CREATE TABLE memory_outcomes (id INTEGER PRIMARY KEY AUTOINCREMENT, item_id INTEGER NOT \
+         NULL REFERENCES memory_items(id) ON DELETE CASCADE, outcome_kind TEXT NOT NULL, \
+         tape_entry_id INTEGER, created_at TEXT NOT NULL DEFAULT (datetime('now')))";
+    const CREATE_OUTCOMES_INDEX_SQL: &str =
+        "CREATE INDEX idx_memory_outcomes_item_id ON memory_outcomes(item_id)";
+
+    async fn pool_with_migration() -> DieselSqlitePool {
+        let pools = crate::testing::build_memory_diesel_pools().await;
+        let mut conn = pools.writer.get().await.expect("pool conn");
+        for ddl in [
+            ADD_CONFIDENCE_SQL,
+            CREATE_OUTCOMES_SQL,
+            CREATE_OUTCOMES_INDEX_SQL,
+        ] {
+            diesel::sql_query(ddl)
+                .execute(&mut *conn)
+                .await
+                .expect("apply migration ddl");
+        }
+        drop(conn);
+        pools.writer
+    }
+
+    async fn insert_item_with_confidence(pool: &DieselSqlitePool, confidence: f32) -> i64 {
+        use rara_model::schema::memory_items;
+        let mut conn = pool.get().await.expect("pool conn");
+        let id: Option<i32> = diesel::insert_into(memory_items::table)
+            .values((
+                memory_items::username.eq("alice"),
+                memory_items::content.eq("fact"),
+                memory_items::memory_type.eq("preference"),
+                memory_items::category.eq("ui"),
+                memory_items::confidence.eq(confidence),
+            ))
+            .returning(memory_items::id)
+            .get_result(&mut *conn)
+            .await
+            .expect("insert row");
+        id.map(i64::from).unwrap_or(0)
+    }
+
+    async fn fetch_confidence(pool: &DieselSqlitePool, id: i64) -> f32 {
+        use rara_model::schema::memory_items;
+        let mut conn = pool.get().await.expect("pool conn");
+        memory_items::table
+            .filter(memory_items::id.eq(id as i32))
+            .select(memory_items::confidence)
+            .first::<f32>(&mut *conn)
+            .await
+            .expect("fetch confidence")
+    }
+
+    #[test]
+    fn ema_positive_monotone_toward_one() {
+        let mut c: f32 = 0.5;
+        let mut prev = c;
+        for _ in 0..5 {
+            c = apply_ema(c, OutcomeKind::Confirmed);
+            assert!(c > prev, "must strictly increase: prev={prev} next={c}");
+            assert!(c <= 1.0, "must stay <= 1");
+            assert!(c >= prev, "must stay >= previous (>= starting c)");
+            prev = c;
+        }
+        // Sanity: after five Confirmed updates from 0.5 the value should
+        // be well past 0.8 but still below 1.
+        assert!(c > 0.8 && c < 1.0, "expected (0.8, 1.0), got {c}");
+    }
+
+    #[test]
+    fn ema_negative_monotone_toward_zero() {
+        let mut c: f32 = 0.5;
+        let mut prev = c;
+        for _ in 0..5 {
+            c = apply_ema(c, OutcomeKind::Contradicted);
+            assert!(c < prev, "must strictly decrease: prev={prev} next={c}");
+            assert!(c >= 0.0, "must stay >= 0");
+            assert!(c <= prev, "must stay <= previous (<= starting c)");
+            prev = c;
+        }
+        // Sanity: after five Contradicted updates from 0.5 the value
+        // should be well below 0.2 but still positive.
+        assert!(c > 0.0 && c < 0.2, "expected (0.0, 0.2), got {c}");
+    }
+
+    #[tokio::test]
+    async fn commit_outcome_writes_row_and_updates_confidence() {
+        let pool = pool_with_migration().await;
+        let id = insert_item_with_confidence(&pool, 1.0).await;
+
+        commit_outcome_inner(&pool, &[id], OutcomeKind::Failure, Some(42))
+            .await
+            .expect("commit_outcome ok");
+
+        // Audit row landed with the expected polarity + tape entry id.
+        let mut conn = pool.get().await.expect("pool conn");
+        #[derive(diesel::QueryableByName)]
+        struct Row {
+            #[diesel(sql_type = diesel::sql_types::Text)]
+            outcome_kind:  String,
+            #[diesel(sql_type = diesel::sql_types::Nullable<diesel::sql_types::Integer>)]
+            tape_entry_id: Option<i32>,
+        }
+        let rows: Vec<Row> = diesel::sql_query(
+            "SELECT outcome_kind, tape_entry_id FROM memory_outcomes WHERE item_id = ?",
+        )
+        .bind::<diesel::sql_types::Integer, _>(id as i32)
+        .load(&mut *conn)
+        .await
+        .expect("query outcome row");
+        assert_eq!(rows.len(), 1, "exactly one outcome row");
+        assert_eq!(rows[0].outcome_kind, "failure");
+        assert_eq!(rows[0].tape_entry_id, Some(42));
+        drop(conn);
+
+        // Parent confidence applied the negative EMA: c=1.0, α=0.2 →
+        // 1.0 − 0.2·1.0 = 0.8.
+        let after = fetch_confidence(&pool, id).await;
+        assert!(
+            (after - 0.8).abs() < 1e-6,
+            "expected 0.8 after one Failure, got {after}"
+        );
+    }
+
+    #[tokio::test]
+    async fn commit_outcome_skips_unknown_ids() {
+        let pool = pool_with_migration().await;
+        let valid = insert_item_with_confidence(&pool, 1.0).await;
+        let unknown: i64 = 999_999;
+
+        commit_outcome_inner(&pool, &[valid, unknown], OutcomeKind::Failure, None)
+            .await
+            .expect("commit_outcome returns Ok even with unknown ids");
+
+        // Valid row changed via the same EMA as the previous test.
+        let after = fetch_confidence(&pool, valid).await;
+        assert!(
+            (after - 0.8).abs() < 1e-6,
+            "valid row's confidence must update: got {after}"
+        );
+
+        // No outcome row written for the unknown id.
+        let mut conn = pool.get().await.expect("pool conn");
+        #[derive(diesel::QueryableByName)]
+        struct Count {
+            #[diesel(sql_type = diesel::sql_types::Integer)]
+            n: i32,
+        }
+        let rows: Vec<Count> = diesel::sql_query("SELECT COUNT(*) AS n FROM memory_outcomes")
+            .load(&mut *conn)
+            .await
+            .expect("count outcomes");
+        assert_eq!(rows[0].n, 1, "only the valid id produces an audit row");
+    }
+}

--- a/crates/kernel/src/memory/knowledge/service.rs
+++ b/crates/kernel/src/memory/knowledge/service.rs
@@ -18,7 +18,8 @@ use std::sync::Arc;
 
 use yunara_store::diesel_pool::DieselSqlitePools;
 
-use super::{EmbeddingService, KnowledgeConfig};
+use super::{EmbeddingService, KnowledgeConfig, outcome::OutcomeKind};
+use crate::error::Result;
 
 /// Bundles the knowledge layer's runtime dependencies into a single handle
 /// that can be shared across the kernel.
@@ -35,6 +36,29 @@ pub struct KnowledgeService {
 }
 
 impl KnowledgeService {
+    /// Record one outcome row per `item_id` and update each item's
+    /// `confidence` via the EMA defined in
+    /// [`super::outcome`].
+    ///
+    /// Both halves of the pair land in a single writer transaction. An
+    /// empty `item_ids` slice is a no-op; unknown ids are silently
+    /// skipped (the call still returns Ok). See the issue 2112 spec
+    /// for the rationale on the skip semantics — memory feedback is a
+    /// debugging seam, not a consistency contract.
+    ///
+    /// `tape_entry_id` is the optional pointer into the tape that
+    /// triggered this outcome; populating it from real LLM turns is
+    /// issue 2113's job.
+    pub async fn commit_outcome(
+        &self,
+        item_ids: &[i64],
+        kind: OutcomeKind,
+        tape_entry_id: Option<i64>,
+    ) -> Result<()> {
+        super::outcome::commit_outcome_inner(&self.pools.writer, item_ids, kind, tape_entry_id)
+            .await
+    }
+
     /// Resolve source tape entries for memory items that have source
     /// references.
     ///

--- a/crates/kernel/src/memory/knowledge/tool.rs
+++ b/crates/kernel/src/memory/knowledge/tool.rs
@@ -31,6 +31,20 @@ use yunara_store::diesel_pool::DieselSqlitePools;
 use super::{categories, embedding::EmbeddingService, items};
 use crate::tool::{ToolContext, ToolExecute};
 
+/// Weight λ in the search-time re-rank `score = -distance + λ · confidence`.
+///
+/// Rationale (see issue 2112 spec): practical usearch cosine distances
+/// cluster in `[0, 0.5]`. A confidence swing of 1.0 (fully trusted vs
+/// fully decayed) shifts the score by 0.5 — enough to beat a typical
+/// distance tie (~0.1) but not enough to drag in semantically
+/// irrelevant matches that already got into the top-K. Items with
+/// `confidence < 0.4` are still surfaced if they are the closest
+/// matches, just demoted below higher-confidence neighbors.
+///
+/// Mechanism-tuning constant (no operator-relevant right value) — lives
+/// here, not in YAML.
+pub const CONFIDENCE_RANK_WEIGHT: f32 = 0.5;
+
 /// LLM-callable tool for querying the Knowledge Layer.
 #[derive(ToolDef)]
 #[tool(
@@ -109,14 +123,36 @@ impl MemoryTool {
 
         // Fetch matching items from SQLite.
         let ids: Vec<i64> = results.iter().map(|(key, _)| *key as i64).collect();
-        let mut matched_items = items::get_items_by_ids(&self.pools.reader, &ids).await?;
+        let matched_items = items::get_items_by_ids(&self.pools.reader, &ids).await?;
 
-        // Filter by username.
-        matched_items.retain(|item| item.username == username);
-
-        let items_json: Vec<Value> = matched_items
+        // Re-rank by `score = -distance + λ · confidence`. Distance comes
+        // from the usearch hits, joined back to items by id; items
+        // without a matching distance shouldn't occur in practice (they
+        // would mean usearch returned an id `get_items_by_ids` didn't),
+        // but if they do we skip them rather than score them with a
+        // fabricated distance.
+        let distance_by_id: std::collections::HashMap<i64, f32> = results
             .iter()
-            .map(|item| {
+            .map(|(key, dist)| (*key as i64, *dist))
+            .collect();
+        let mut ranked: Vec<(super::items::MemoryItem, f32)> = matched_items
+            .into_iter()
+            .filter(|item| item.username == username)
+            .filter_map(|item| {
+                distance_by_id.get(&item.id).map(|d| {
+                    let score = CONFIDENCE_RANK_WEIGHT.mul_add(item.confidence, -d);
+                    (item, score)
+                })
+            })
+            .collect();
+        // Descending by score. NaN should not occur here (f32 from
+        // usearch and a clamped confidence), so a partial_cmp fallback
+        // to Equal is safe.
+        ranked.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
+
+        let items_json: Vec<Value> = ranked
+            .iter()
+            .map(|(item, _)| {
                 json!({
                     "id": item.id,
                     "content": item.content,
@@ -141,5 +177,123 @@ impl MemoryTool {
             Some(content) => Ok(json!({"category": category, "content": content})),
             None => Ok(json!({"error": format!("category \'{category}\' not found")})),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use async_trait::async_trait;
+    use diesel::ExpressionMethods;
+    use diesel_async::RunQueryDsl;
+    use rara_model::schema::memory_items;
+    use yunara_store::diesel_pool::DieselSqlitePool;
+
+    use super::*;
+    use crate::llm::{EmbeddingRequest, EmbeddingResponse, LlmEmbedder, LlmEmbedderRef};
+
+    const ADD_CONFIDENCE_SQL: &str =
+        "ALTER TABLE memory_items ADD COLUMN confidence REAL NOT NULL DEFAULT 1.0";
+
+    /// Embedder that hands back a deterministic single-dim vector. Tests
+    /// share the same `[1.0]` query so every item ends up at distance 0
+    /// — the re-rank is then forced to break the tie via confidence.
+    struct UnitEmbedder;
+
+    #[async_trait]
+    impl LlmEmbedder for UnitEmbedder {
+        async fn embed(
+            &self,
+            request: EmbeddingRequest,
+        ) -> crate::error::Result<EmbeddingResponse> {
+            let embeddings = request.input.iter().map(|_| vec![1.0_f32]).collect();
+            Ok(EmbeddingResponse::builder()
+                .embeddings(embeddings)
+                .model("unit".to_string())
+                .build())
+        }
+    }
+
+    async fn insert_item_with_confidence(
+        pool: &DieselSqlitePool,
+        content: &str,
+        confidence: f32,
+    ) -> i64 {
+        let mut conn = pool.get().await.expect("pool conn");
+        let id: Option<i32> = diesel::insert_into(memory_items::table)
+            .values((
+                memory_items::username.eq("alice"),
+                memory_items::content.eq(content),
+                memory_items::memory_type.eq("preference"),
+                memory_items::category.eq("ui"),
+                memory_items::confidence.eq(confidence),
+            ))
+            .returning(memory_items::id)
+            .get_result(&mut *conn)
+            .await
+            .expect("insert row");
+        id.map(i64::from).unwrap_or(0)
+    }
+
+    #[tokio::test]
+    async fn search_prefers_high_confidence_on_ties() {
+        // Pool with the confidence column applied.
+        let pools = crate::testing::build_memory_diesel_pools().await;
+        {
+            let mut conn = pools.writer.get().await.expect("pool conn");
+            diesel::sql_query(ADD_CONFIDENCE_SQL)
+                .execute(&mut *conn)
+                .await
+                .expect("add confidence column");
+        }
+
+        // Item A: high confidence. Item B: low confidence. Both share
+        // the same embedding (`[1.0]`), so usearch returns identical
+        // distances and the re-rank must use confidence to order them.
+        let id_high =
+            insert_item_with_confidence(&pools.writer, "high-confidence fact", 0.95).await;
+        let id_low = insert_item_with_confidence(&pools.writer, "low-confidence fact", 0.3).await;
+
+        // EmbeddingService over a unit vector and a temp index path.
+        let config = crate::memory::knowledge::KnowledgeConfig::builder()
+            .embedding_dimensions(1_usize)
+            .search_top_k(5_usize)
+            .similarity_threshold(0.0_f32)
+            .build();
+        let embedder: LlmEmbedderRef = Arc::new(UnitEmbedder);
+        let index_path = std::env::temp_dir()
+            .join(format!("rara-test-{}", uuid::Uuid::new_v4()))
+            .join("memory.usearch");
+        let embedding_svc = crate::memory::knowledge::EmbeddingService::with_path(
+            config,
+            embedder,
+            "unit".to_string(),
+            index_path,
+        )
+        .expect("embedding svc");
+        embedding_svc
+            .add_to_index(id_high as u64, &[1.0])
+            .expect("index A");
+        embedding_svc
+            .add_to_index(id_low as u64, &[1.0])
+            .expect("index B");
+
+        let tool = MemoryTool::new(pools, Arc::new(embedding_svc));
+        let value = tool
+            .exec_search("alice", "any query")
+            .await
+            .expect("exec_search ok");
+
+        let items = value
+            .get("items")
+            .and_then(|v| v.as_array())
+            .expect("items array");
+        assert_eq!(items.len(), 2, "both items must come back");
+        let first_id = items[0].get("id").and_then(|v| v.as_i64()).expect("id");
+        let second_id = items[1].get("id").and_then(|v| v.as_i64()).expect("id");
+        assert_eq!(
+            first_id, id_high,
+            "high-confidence item must rank first when distances tie"
+        );
+        assert_eq!(second_id, id_low);
     }
 }

--- a/specs/issue-2112-memory-commit-outcome-ranking.spec.md
+++ b/specs/issue-2112-memory-commit-outcome-ranking.spec.md
@@ -1,0 +1,264 @@
+spec: task
+name: "issue-2112-memory-commit-outcome-ranking"
+inherits: project
+tags: []
+---
+
+## Intent
+
+Issue 2111 lands the storage primitives (`memory_items.confidence`
+defaulting to 1.0; append-only `memory_outcomes` table). This issue
+makes them load-bearing:
+
+1. A typed `OutcomeKind` enum the kernel can hand to a service method.
+2. A `KnowledgeService::commit_outcome(item_ids, kind, tape_entry_id)`
+   that writes one `memory_outcomes` row per item **and** updates the
+   parent `memory_items.confidence` in the same transaction, using an
+   exponential-moving-average update with α = 0.2.
+3. The existing embedding-driven search path in
+   `MemoryTool::exec_search` (which goes
+   `EmbeddingService::search` → `items::get_items_by_ids` → return)
+   gets re-ranked: distance is still the primary signal, but
+   confidence breaks ties and significantly dampens items below ~0.4.
+
+Reproducer for the failure mode this fixes:
+
+1. User says "I prefer dark mode" at T0. Extractor writes row A with
+   confidence = 1.0.
+2. User says "actually I prefer light mode" at T+30d. Extractor writes
+   row B with confidence = 1.0.
+3. Today, `MemoryTool` action `search` with query "user UI preference"
+   embeds the query, asks usearch for top-K, fetches the matching
+   items, and returns them ordered by *insertion order from
+   `get_items_by_ids`* — not even by distance. The agent sees both
+   rows on equal footing.
+4. After this PR: an explicit
+   `commit_outcome(&[A], OutcomeKind::Contradicted, …)` drops row A's
+   confidence to ~0.8 the first time and continues to decay as further
+   contradictions accumulate. The same search now returns B before A,
+   because the ranking is `score = -distance + λ · confidence` with
+   λ chosen so that a confidence delta of 0.5 dominates a typical
+   distance tie.
+
+The α and λ values are mechanism-tuning constants (no operator-relevant
+right answer), so they live as `const` next to the mechanism per
+project spec — not as YAML.
+
+Why EMA at α = 0.2:
+
+- Five outcomes of the same kind move confidence by ~67 % toward the
+  bound, which matches the "you have to be wrong a handful of times
+  before rara stops trusting you" intuition we want.
+- Bounded by construction in `[0, 1]` — `c' = c + α(1 − c)` from any
+  starting point in `[0, 1]` lands in `[c, 1]`; the failure update
+  `c' = c − αc` lands in `[0, c]`. No clamping required.
+- Symmetric: a confirmed → contradicted ping-pong returns confidence
+  to approximately its starting value (EMA is memoryful but not
+  hysteretic).
+- Cheap: one multiply-add per outcome, no history scan.
+
+Why the same transaction:
+
+- The pair `(write memory_outcomes row, update memory_items.confidence)`
+  is the unit of truth. If only one half lands, `explain()` (issue
+  2113) starts lying — either it sees an outcome with no corresponding
+  confidence change, or it sees a confidence change with no audit
+  row. Both states are silently corrupting. Diesel's
+  `transaction()` is the right boundary; the writer pool already
+  serializes writes.
+
+Goal alignment: signals 2 ("the user stops asking"), 4 ("every
+decision is inspectable" — the audit row is the trace), 5 ("memory
+survives time"). Crosses no `NOT` line.
+
+Prior art reviewed (raw):
+
+- `gh issue list --search "commit_outcome"` — 0 issues.
+- `gh pr list --search "OutcomeKind ranking"` — 0 PRs.
+- `git log --grep=commit_outcome` — 0 commits. Greenfield.
+- `rg -n "OutcomeKind" crates/` — 0 matches in the memory subtree.
+  (`StepOutcome` exists in the kernel for tool-call lifecycle but is
+  unrelated; we use a different name to avoid conflation.)
+- Existing search path verified against
+  `crates/kernel/src/memory/knowledge/tool.rs:100..132` —
+  `exec_search` embeds query, calls `EmbeddingService::search`,
+  fetches via `items::get_items_by_ids`, filters by username, returns
+  in arrival order. No existing ranking layer; the re-rank is
+  net-new code, not a replacement.
+- `KnowledgeService` in
+  `crates/kernel/src/memory/knowledge/service.rs` currently bundles
+  `pools`, `embedding_svc`, `config`. Adding `commit_outcome` here is
+  the natural seam — pools for the transaction, no other dep needed.
+
+## Decisions
+
+- **Depends on issue 2111** merged into `main` — the column and
+  table must exist before this PR's code references them.
+- **New file `crates/kernel/src/memory/knowledge/outcome.rs`** —
+  hosts the `OutcomeKind` enum, its serialization, and the
+  pure `apply_ema` helper. Keeping the enum + math in its own file
+  makes it trivial to unit-test the EMA without touching the DB.
+- **`OutcomeKind` enum**:
+  ```
+  pub enum OutcomeKind {
+      Success,
+      Failure,
+      Confirmed,
+      Contradicted,
+  }
+  ```
+  `as_str` returns `"success" | "failure" | "confirmed" |
+  "contradicted"`. The polarity table:
+  - `Success`, `Confirmed` → positive update.
+  - `Failure`, `Contradicted` → negative update.
+  Why both pairs (and not just one): the source of an outcome carries
+  meaning beyond the sign. `Success` typically comes from automated
+  tool-result correlation; `Confirmed` typically comes from explicit
+  user feedback. The audit row preserves this distinction even
+  though the EMA math collapses to two cases.
+- **EMA constants** (mechanism, `const`, NOT YAML):
+  - `pub const CONFIDENCE_ALPHA: f32 = 0.2;`
+  - Update: positive → `c' = c + α(1 − c)`; negative → `c' = c − αc`.
+- **`KnowledgeService::commit_outcome`** signature:
+  ```
+  pub async fn commit_outcome(
+      &self,
+      item_ids: &[i64],
+      kind: OutcomeKind,
+      tape_entry_id: Option<i64>,
+  ) -> Result<()>;
+  ```
+  Semantics: opens one writer transaction; for each `item_id` it
+  (a) inserts a `memory_outcomes` row, (b) reads the current
+  confidence, (c) computes the new value via `apply_ema`, (d) writes
+  it back. Empty `item_ids` slice is a no-op (Ok). Unknown
+  `item_ids` (rows that do not exist) are silently skipped at the
+  inner loop level — the outer call still returns Ok. Rationale:
+  callers (notably future tool-result handlers) should not need to
+  worry about a memory item having been deleted between embed-time
+  and feedback-time; a missing row means "no confidence to update",
+  not a programmer error. This decision is deliberate; a follow-up
+  could surface a count of skipped ids if needed.
+- **Ranking constant**:
+  `pub const CONFIDENCE_RANK_WEIGHT: f32 = 0.5;`
+  Combined score for the re-rank: `score = -distance + λ · confidence`.
+  Items are sorted by `score` descending. Rationale for λ = 0.5:
+  usearch cosine distances are in `[0, 2]`, but practical retrieval
+  distances cluster in `[0, 0.5]`. A confidence swing of 1.0 (fully
+  trusted vs fully decayed) shifts the score by 0.5 — enough to beat
+  a typical distance tiebreak (~0.1) but not enough to drag in
+  semantically irrelevant matches that already got into the top-K.
+  Items with `confidence < 0.4` are still surfaced if they are the
+  closest matches, just demoted below higher-confidence neighbors.
+- **Re-rank location**: inside `MemoryTool::exec_search` in
+  `crates/kernel/src/memory/knowledge/tool.rs`. The existing call
+  chain is `embed → search → get_items_by_ids → filter by username
+  → JSON-serialize`. The re-rank inserts between
+  `get_items_by_ids` and `filter by username`: join the
+  `(id, distance)` tuples from `EmbeddingService::search` with the
+  loaded `MemoryItem`s by id, compute `score`, sort, then proceed.
+  No public API change to the tool action.
+- **Do NOT expose `commit_outcome` to the LLM via the existing
+  `MemoryTool` actions in this PR.** The tool currently exposes
+  `search | categories | read_category`. Adding a `commit_outcome`
+  action means the model can self-attest its own memory's truth,
+  which inverts the feedback loop. The internal Rust API is the
+  only caller in this PR; user-driven and tool-result-driven
+  callers are scoped for a later issue.
+- **Schema reuse**: write `memory_outcomes` via a small private
+  diesel insert in `outcome.rs`. Do NOT add a `NewMemoryOutcome`
+  struct to `items.rs` — that file already has a tight focus on
+  `memory_items` rows and crossing the file boundary is the
+  cleanest cut between issues 2111 and 2112.
+- **No `Default` impl** for `OutcomeKind`. There is no sensible
+  default outcome; every call site must pick one explicitly.
+- **`apply_ema` is pure** (`fn apply_ema(current: f32, kind:
+  OutcomeKind) -> f32`) so the EMA math has a unit-test foothold
+  that does not need diesel or a runtime.
+
+## Boundaries
+
+### Allowed Changes
+- crates/kernel/src/memory/knowledge/outcome.rs
+- **/crates/kernel/src/memory/knowledge/outcome.rs
+- crates/kernel/src/memory/knowledge/mod.rs
+- **/crates/kernel/src/memory/knowledge/mod.rs
+- crates/kernel/src/memory/knowledge/service.rs
+- **/crates/kernel/src/memory/knowledge/service.rs
+- crates/kernel/src/memory/knowledge/tool.rs
+- **/crates/kernel/src/memory/knowledge/tool.rs
+- specs/issue-2112-memory-commit-outcome-ranking.spec.md
+- **/specs/issue-2112-memory-commit-outcome-ranking.spec.md
+
+### Forbidden
+- crates/rara-model/**
+- crates/kernel/src/memory/knowledge/items.rs
+- crates/kernel/src/memory/knowledge/extractor.rs
+- crates/kernel/src/memory/knowledge/embedding.rs
+- crates/kernel/src/memory/knowledge/config.rs
+- crates/kernel/src/memory/knowledge/categories.rs
+- crates/kernel/src/memory/knowledge/manifest.rs
+- crates/kernel/src/memory/context.rs
+- crates/kernel/src/memory/store.rs
+- config.example.yaml
+- .github/workflows/**
+- docs/**
+- web/**
+
+## Completion Criteria
+
+Scenario: apply_ema converges toward 1.0 under positive outcomes
+  Test:
+    Package: rara-kernel
+    Filter: memory::knowledge::outcome::tests::ema_positive_monotone_toward_one
+  Given a starting confidence c in (0, 1) and OutcomeKind::Confirmed
+  When apply_ema runs five times in succession
+  Then the result is strictly increasing each step and stays within [c, 1]
+
+Scenario: apply_ema decays toward 0 under negative outcomes
+  Test:
+    Package: rara-kernel
+    Filter: memory::knowledge::outcome::tests::ema_negative_monotone_toward_zero
+  Given a starting confidence c in (0, 1) and OutcomeKind::Contradicted
+  When apply_ema runs five times in succession
+  Then the result is strictly decreasing each step and stays within [0, c]
+
+Scenario: commit_outcome writes audit row and updates confidence atomically
+  Test:
+    Package: rara-kernel
+    Filter: memory::knowledge::outcome::tests::commit_outcome_writes_row_and_updates_confidence
+  Given a memory_items row with confidence 1.0
+  When KnowledgeService::commit_outcome is called with OutcomeKind::Failure and tape_entry_id Some(42)
+  Then a memory_outcomes row exists with outcome_kind = "failure" and tape_entry_id = 42, and the parent row's confidence equals 0.8
+
+Scenario: commit_outcome skips unknown item ids without erroring
+  Test:
+    Package: rara-kernel
+    Filter: memory::knowledge::outcome::tests::commit_outcome_skips_unknown_ids
+  Given an item_ids slice that contains one valid id and one id with no matching row
+  When KnowledgeService::commit_outcome is called
+  Then it returns Ok and only the valid row's confidence changes
+
+Scenario: search re-ranks higher-confidence items above lower-confidence ones
+  Test:
+    Package: rara-kernel
+    Filter: memory::knowledge::tool::tests::search_prefers_high_confidence_on_ties
+  Given two memory items with near-identical embeddings, where item A has confidence 0.95 and item B has confidence 0.3
+  When MemoryTool::exec_search runs against a query that matches both
+  Then item A appears before item B in the returned items array
+
+## Out of Scope
+
+- Adding the schema (column + table) — that is issue 2111's job.
+- Exposing `commit_outcome` to the LLM as a `MemoryTool` action.
+  Deferred deliberately; we want the loop running internally first.
+- Wiring tool-result success/failure to auto-call `commit_outcome`.
+  The tool-result correlation layer is a separate change.
+- Recording which items contributed to a given turn (the
+  `tape_entry_id` parameter is there, but populating it from real
+  LLM turns is issue 2113's job).
+- Boosting/decay decay-over-time on confidence (a separate signal
+  from outcome-driven feedback).
+- UI surfacing of confidence values.
+- Changing `MemoryItem`'s JSON shape sent to the LLM — the existing
+  search-action response keys stay identical.


### PR DESCRIPTION
## Summary

Implements `commit_outcome` API for memory feedback and confidence-weighted ranking on retrieval.

Spec: `specs/issue-2112-memory-commit-outcome-ranking.spec.md`

Closes #2112

## Notes

- `λ = 0.5` (confidence weight in ranking score) is a mechanism-tuning prior, kept as a Rust `const` next to the mechanism per `docs/guides/anti-patterns.md` (mechanism vs config — a deploy operator has no real reason to pick a different value).
- Reviewer APPROVE on commit `1ccabfb2`, 0 blocking findings.
- CI runner is currently unhealthy; landed via authorized direct merge after full local verification (cargo check / fmt / clippy / prek / `cargo test -p` / `just spec-lifecycle` all green).

## Test plan

- [x] `cargo check --workspace --all-targets`
- [x] `cargo +nightly fmt --all`
- [x] `cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings`
- [x] `prek run --all-files`
- [x] `cargo test -p rara-kernel`
- [x] `just spec-lifecycle specs/issue-2112-memory-commit-outcome-ranking.spec.md` — all BDD scenarios pass