### PR TITLE
refactor(kernel): collapse 4 endpoint mappings, remove dead EndpointRegistry (#2108)

### DIFF
--- a/crates/app/src/tools/send_file.rs
+++ b/crates/app/src/tools/send_file.rs
@@ -109,13 +109,14 @@ impl ToolExecute for SendFileTool {
             .map(|s| s.to_string());
 
         // Web sessions don't receive the OutboundEnvelope via the standard
-        // adapter fanout (see `binding_to_endpoint` in kernel/src/io.rs —
-        // Web returns `None` because chat_id == session_key). Emit the
-        // bytes on the stream instead so the browser can render the file
-        // inline next to the send-file tool call. Other channels already
-        // render the attachment through their own adapter and would
-        // double-render if they observed this event, so we scope it to
-        // Web origins.
+        // adapter fanout (see `Endpoint::try_from(&ChannelBinding)` in
+        // kernel/src/io.rs — Web is rejected with
+        // `BindingConversionError::StreamHubFanout` because
+        // chat_id == session_key). Emit the bytes on the stream instead so
+        // the browser can render the file inline next to the send-file tool
+        // call. Other channels already render the attachment through their
+        // own adapter and would double-render if they observed this event,
+        // so we scope it to Web origins.
         let is_web_origin = matches!(
             context.origin_endpoint.as_ref().map(|e| e.channel_type),
             Some(ChannelType::Web)

--- a/crates/channels/src/web.rs
+++ b/crates/channels/src/web.rs
@@ -65,10 +65,9 @@ use rara_kernel::{
     },
     error::KernelError,
     handle::KernelHandle,
-    identity::UserId,
     io::{
-        EgressError, Endpoint, EndpointAddress, EndpointRegistry, InteractionType,
-        PlatformOutbound, RawPlatformMessage, ReplyContext, StreamEvent, StreamHub,
+        EgressError, Endpoint, EndpointAddress, InteractionType, PlatformOutbound,
+        RawPlatformMessage, ReplyContext, StreamEvent, StreamHub,
     },
     security::{ApprovalRequest, ApprovalResponse},
     session::SessionKey,
@@ -534,19 +533,17 @@ pub struct WebAdapter {
     /// Phase, outbound replies from `ChannelAdapter::send`). Kernel stream
     /// events bypass this map — they flow directly from
     /// [`StreamHub::subscribe_session_events`] into each WS/SSE task.
-    adapter_events:    Arc<DashMap<SessionKey, broadcast::Sender<WebEvent>>>,
+    adapter_events: Arc<DashMap<SessionKey, broadcast::Sender<WebEvent>>>,
     /// KernelHandle for dispatching inbound messages (set during `start`).
-    sink:              Arc<RwLock<Option<KernelHandle>>>,
+    sink:           Arc<RwLock<Option<KernelHandle>>>,
     /// StreamHub for subscribing to real-time token deltas.
-    stream_hub:        Arc<RwLock<Option<Arc<StreamHub>>>>,
-    /// EndpointRegistry for tracking connected users (set during startup).
-    endpoint_registry: Arc<RwLock<Option<Arc<EndpointRegistry>>>>,
+    stream_hub:     Arc<RwLock<Option<Arc<StreamHub>>>>,
     /// Owner token for verifying WebSocket auth tokens.
     ///
     /// Always present: the boot layer (`rara_app::validate_owner_auth`)
     /// guarantees a non-empty token before constructing the adapter, so
     /// the WS handler always enforces auth.
-    owner_token:       String,
+    owner_token:    String,
     /// Authenticated owner's kernel `user_id`.
     ///
     /// After the owner-token check, this is the identity attached to
@@ -554,20 +551,20 @@ pub struct WebAdapter {
     /// field is ignored — auth establishes "you are the owner", so the
     /// server, not the client, names the identity. Validated at boot by
     /// `rara_app::validate_owner_auth` to match a configured user.
-    owner_user_id:     String,
+    owner_user_id:  String,
     /// Shutdown signal sender.
-    shutdown_tx:       watch::Sender<bool>,
+    shutdown_tx:    watch::Sender<bool>,
     /// Shutdown signal receiver (cloneable).
-    shutdown_rx:       watch::Receiver<bool>,
+    shutdown_rx:    watch::Receiver<bool>,
     /// Optional STT service for transcribing voice messages to text.
-    stt_service:       Option<rara_stt::SttService>,
+    stt_service:    Option<rara_stt::SttService>,
     /// Per-session ring buffer for "important" `WebEvent`s. Adapter
     /// publishes matching [`ReplyBuffer::should_buffer`] are appended so
     /// that a later WS / SSE reconnect can drain them and recover
     /// task-completion replies that fired while no listener was attached
     /// (issue #1804). The buffer is always wired in production — see the
     /// `web_reply_buffer` module for why this is a mechanism, not a knob.
-    reply_buffer:      Arc<ReplyBuffer>,
+    reply_buffer:   Arc<ReplyBuffer>,
 }
 
 impl WebAdapter {
@@ -589,7 +586,6 @@ impl WebAdapter {
             adapter_events: Arc::new(DashMap::new()),
             sink: Arc::new(RwLock::new(None)),
             stream_hub: Arc::new(RwLock::new(None)),
-            endpoint_registry: Arc::new(RwLock::new(None)),
             owner_token,
             owner_user_id,
             shutdown_tx,
@@ -623,15 +619,14 @@ impl WebAdapter {
     /// ```
     pub fn router(&self) -> Router {
         let state = WebAdapterState {
-            adapter_events:    Arc::clone(&self.adapter_events),
-            sink:              Arc::clone(&self.sink),
-            stream_hub:        Arc::clone(&self.stream_hub),
-            endpoint_registry: Arc::clone(&self.endpoint_registry),
-            owner_token:       self.owner_token.clone(),
-            owner_user_id:     self.owner_user_id.clone(),
-            shutdown_rx:       self.shutdown_rx.clone(),
-            stt_service:       self.stt_service.clone(),
-            reply_buffer:      self.reply_buffer.clone(),
+            adapter_events: Arc::clone(&self.adapter_events),
+            sink:           Arc::clone(&self.sink),
+            stream_hub:     Arc::clone(&self.stream_hub),
+            owner_token:    self.owner_token.clone(),
+            owner_user_id:  self.owner_user_id.clone(),
+            shutdown_rx:    self.shutdown_rx.clone(),
+            stt_service:    self.stt_service.clone(),
+            reply_buffer:   self.reply_buffer.clone(),
         };
 
         Router::new()
@@ -880,19 +875,18 @@ fn decision_str(decision: rara_kernel::security::ApprovalDecision) -> &'static s
 /// handler) can mount on the same state without duplicating fields.
 #[derive(Clone)]
 pub(crate) struct WebAdapterState {
-    pub(crate) adapter_events:    Arc<DashMap<SessionKey, broadcast::Sender<WebEvent>>>,
-    pub(crate) sink:              Arc<RwLock<Option<KernelHandle>>>,
-    pub(crate) stream_hub:        Arc<RwLock<Option<Arc<StreamHub>>>>,
-    pub(crate) endpoint_registry: Arc<RwLock<Option<Arc<EndpointRegistry>>>>,
-    pub(crate) owner_token:       String,
+    pub(crate) adapter_events: Arc<DashMap<SessionKey, broadcast::Sender<WebEvent>>>,
+    pub(crate) sink:           Arc<RwLock<Option<KernelHandle>>>,
+    pub(crate) stream_hub:     Arc<RwLock<Option<Arc<StreamHub>>>>,
+    pub(crate) owner_token:    String,
     /// Authenticated owner identity — see [`WebAdapter::owner_user_id`].
     /// Used after auth passes to stamp inbound messages with a
     /// server-trusted user id instead of trusting client input.
-    pub(crate) owner_user_id:     String,
-    pub(crate) shutdown_rx:       watch::Receiver<bool>,
-    pub(crate) stt_service:       Option<rara_stt::SttService>,
+    pub(crate) owner_user_id:  String,
+    pub(crate) shutdown_rx:    watch::Receiver<bool>,
+    pub(crate) stt_service:    Option<rara_stt::SttService>,
     /// Always-on per-session ring buffer; see [`WebAdapter::reply_buffer`].
-    pub(crate) reply_buffer:      Arc<ReplyBuffer>,
+    pub(crate) reply_buffer:   Arc<ReplyBuffer>,
 }
 
 // ---------------------------------------------------------------------------
@@ -918,48 +912,6 @@ pub(crate) fn bearer_token_from_headers(headers: &axum::http::HeaderMap) -> Opti
         .strip_prefix("Bearer ")
         .or_else(|| raw.strip_prefix("bearer "))?;
     (!token.is_empty()).then_some(token)
-}
-
-/// Build a Web endpoint and its associated UserId for endpoint registration.
-///
-/// The `UserId` format matches the app identity resolver (`"web:{user_id}"`).
-fn web_endpoint_for(session_key: &str) -> Endpoint {
-    Endpoint {
-        channel_type: ChannelType::Web,
-        address:      EndpointAddress::Web {
-            connection_id: session_key.to_owned(),
-        },
-    }
-}
-
-/// Compute the UserId matching what the identity resolver returns.
-///
-/// For authenticated web users, the `user_id` is the real kernel username
-/// (extracted from JWT), so no prefix is needed.
-fn web_user_id(user_id: &str) -> UserId { UserId(user_id.to_string()) }
-
-/// Register a web endpoint in the registry (if available).
-pub(crate) async fn register_endpoint(
-    registry: &RwLock<Option<Arc<EndpointRegistry>>>,
-    user_id: &str,
-    session_key: &str,
-) {
-    let guard = registry.read().await;
-    if let Some(ref reg) = *guard {
-        reg.register(&web_user_id(user_id), web_endpoint_for(session_key));
-    }
-}
-
-/// Unregister a web endpoint from the registry (if available).
-pub(crate) async fn unregister_endpoint(
-    registry: &RwLock<Option<Arc<EndpointRegistry>>>,
-    user_id: &str,
-    session_key: &str,
-) {
-    let guard = registry.read().await;
-    if let Some(ref reg) = *guard {
-        reg.unregister(&web_user_id(user_id), &web_endpoint_for(session_key));
-    }
 }
 
 // ---------------------------------------------------------------------------
@@ -1101,7 +1053,6 @@ impl ChannelAdapter for WebAdapter {
 
     async fn start(&self, handle: KernelHandle) -> Result<(), KernelError> {
         *self.stream_hub.write().await = Some(handle.stream_hub().clone());
-        *self.endpoint_registry.write().await = Some(handle.endpoint_registry().clone());
 
         // Subscribe to approval events and fan them out to the originating
         // session's adapter bus so the browser learns about

--- a/crates/channels/src/web_session.rs
+++ b/crates/channels/src/web_session.rs
@@ -119,7 +119,7 @@ fn session_ws_keepalive_interval() -> Duration {
 
 use crate::web::{
     WebAdapter, WebAdapterState, WebEvent, bearer_token_from_headers, build_raw_platform_message,
-    register_endpoint, stream_event_to_web_event, transcribe_audio_blocks, unregister_endpoint,
+    stream_event_to_web_event, transcribe_audio_blocks,
 };
 
 /// Query parameters for the persistent session WS endpoint.
@@ -235,13 +235,6 @@ async fn handle_session_ws(
     state: WebAdapterState,
 ) {
     let (mut ws_tx, mut ws_rx) = socket.split();
-
-    register_endpoint(
-        &state.endpoint_registry,
-        &state.owner_user_id,
-        &session_key_str,
-    )
-    .await;
 
     let (ws_event_tx, mut ws_event_rx) = mpsc::unbounded_channel::<WebEvent>();
 
@@ -640,12 +633,6 @@ async fn handle_session_ws(
     stream_forwarder.abort();
     notification_forwarder.abort();
 
-    unregister_endpoint(
-        &state.endpoint_registry,
-        &state.owner_user_id,
-        &session_key_str,
-    )
-    .await;
     info!(session_key = %session_key_str, "persistent session WS closed");
 }
 

--- a/crates/cmd/src/chat/mod.rs
+++ b/crates/cmd/src/chat/mod.rs
@@ -30,10 +30,7 @@ use rara_kernel::{
     },
     handle::KernelHandle,
     identity::UserId,
-    io::{
-        Endpoint, EndpointAddress, InteractionType, RawPlatformMessage,
-        ReplyContext as IoReplyContext, StreamEvent,
-    },
+    io::{InteractionType, RawPlatformMessage, ReplyContext as IoReplyContext, StreamEvent},
     security::ApprovalDecision,
     session::{ChannelBinding, SessionEntry, SessionIndex, SessionKey},
 };
@@ -95,7 +92,6 @@ impl ChatArgs {
             Some(handle) => handle,
             None => whatever!("kernel handle not available"),
         };
-        let endpoint_registry = kernel_handle.endpoint_registry().clone();
         let stream_hub = kernel_handle.stream_hub().clone();
 
         let session_alias = self.session.clone();
@@ -109,19 +105,10 @@ impl ChatArgs {
         } else {
             self.user_id.clone()
         };
-        let resolved_user_id = cli_kernel_user_id(&user_id);
         let resolved_session_id =
             get_or_create_cli_session(kernel_handle.session_index().as_ref(), &session_alias)
                 .await
                 .whatever_context("Failed to resolve CLI chat session")?;
-
-        let cli_endpoint = Endpoint {
-            channel_type: ChannelType::Cli,
-            address:      EndpointAddress::Cli {
-                session_id: session_alias.clone(),
-            },
-        };
-        endpoint_registry.register(&resolved_user_id, cli_endpoint);
 
         let (session_tx, session_rx) = tokio::sync::watch::channel(resolved_session_id);
         spawn_stream_forwarder(adapter, stream_hub, session_rx);

--- a/crates/kernel/src/handle.rs
+++ b/crates/kernel/src/handle.rs
@@ -29,8 +29,8 @@ use crate::{
     event::{KernelEventEnvelope, Syscall},
     identity::Principal,
     io::{
-        AgentHandle, Endpoint, EndpointRegistryRef, IOError, IOSubsystem, InboundMessage,
-        PipeReader, PipeWriter, RawPlatformMessage, StreamHubRef,
+        AgentHandle, Endpoint, IOError, IOSubsystem, InboundMessage, PipeReader, PipeWriter,
+        RawPlatformMessage, StreamHubRef,
     },
     kernel::{KernelConfig, SettingsRef},
     kv::KvScope,
@@ -394,10 +394,6 @@ impl KernelHandle {
     /// Access the ephemeral stream hub (WebAdapter needs this for token
     /// deltas).
     pub fn stream_hub(&self) -> &StreamHubRef { self.io.stream_hub() }
-
-    /// Access the endpoint registry (WebAdapter needs this for connection
-    /// tracking).
-    pub fn endpoint_registry(&self) -> &EndpointRegistryRef { self.io.endpoint_registry() }
 
     /// Access the session index for session and channel binding lookups.
     pub fn session_index(&self) -> &Arc<dyn SessionIndex> { self.io.session_index() }

--- a/crates/kernel/src/io.rs
+++ b/crates/kernel/src/io.rs
@@ -34,7 +34,7 @@
 //! ```
 
 use std::{
-    collections::{HashMap, HashSet},
+    collections::HashMap,
     sync::{Arc, Mutex},
 };
 
@@ -298,36 +298,15 @@ impl InboundMessage {
         if let Some(ref ep) = self.origin_endpoint_override {
             return Some(ep.clone());
         }
-        match self.source.channel_type {
-            ChannelType::Telegram => {
-                let chat_id = self.source.platform_chat_id.as_ref()?.parse::<i64>().ok()?;
-                let thread_id = self
-                    .reply_context
-                    .as_ref()
-                    .and_then(|rc| rc.thread_id.as_deref())
-                    .and_then(|t| t.parse::<i64>().ok());
-                Some(Endpoint {
-                    channel_type: ChannelType::Telegram,
-                    address:      EndpointAddress::Telegram { chat_id, thread_id },
-                })
-            }
-            ChannelType::Wechat => {
-                let user_id = self.source.platform_chat_id.clone()?;
-                Some(Endpoint {
-                    channel_type: ChannelType::Wechat,
-                    address:      EndpointAddress::Wechat { user_id },
-                })
-            }
-            ChannelType::Web => {
-                let connection_id = self.source.platform_chat_id.clone()?;
-                Some(Endpoint {
-                    channel_type: ChannelType::Web,
-                    address:      EndpointAddress::Web { connection_id },
-                })
-            }
-            // Internal / Api / Proactive have no external peer to address.
-            _ => None,
-        }
+        let thread_id = self
+            .reply_context
+            .as_ref()
+            .and_then(|rc| rc.thread_id.as_deref());
+        endpoint_from_raw_parts(
+            self.source.channel_type,
+            self.source.platform_chat_id.as_deref(),
+            thread_id,
+        )
     }
 }
 
@@ -1707,15 +1686,31 @@ pub enum EndpointAddress {
     },
 }
 
-/// Derive an [`Endpoint`] from inbound routing data carried in
-/// `platform_chat_id`.
+// ---------------------------------------------------------------------------
+// Endpoint construction — single canonical mapping
+// ---------------------------------------------------------------------------
+//
+// All `(channel_type, chat_id, thread_id) → Endpoint` conversions in the
+// kernel funnel through [`endpoint_from_raw_parts`]. Adding a new channel
+// means adding exactly one arm here; the egress-binding entry
+// (`impl TryFrom<&ChannelBinding> for Endpoint`) and the inbound ingress
+// path (`InboundMessage::origin_endpoint`, `IOSubsystem::resolve` auto-
+// register) both delegate to this function. Historical context: before this
+// was unified, four near-duplicate match blocks lived in this file and
+// silently disagreed on what counted as deliverable (see issue #2108).
+
+/// Build a deliverable [`Endpoint`] from raw ingress parts.
 ///
-/// Used by [`IOSubsystem::resolve`] to auto-register the originating endpoint
-/// for channels whose address is fully determined by the raw platform message
-/// (Telegram, WeChat, CLI, Web — the Web adapter writes its `connection_id`
-/// into `platform_chat_id` at WS/SSE ingress). Returns `None` for `Internal`,
-/// `Api`, and `Proactive`, which have no external peer to address.
-fn derive_endpoint(
+/// Returns `None` for channels with no external peer to address
+/// (`Internal`, `Api`, `Proactive`) or when `platform_chat_id` is missing.
+/// Telegram chat ids that fail to parse as `i64` also yield `None`.
+///
+/// This is the single canonical conversion: every callsite that builds an
+/// `Endpoint` from raw `(channel_type, chat_id, thread_id)` parts routes
+/// through here. The egress path goes through
+/// [`Endpoint::try_from(&ChannelBinding)`](Endpoint), which filters
+/// self-fanout channels (Web, CLI) before delegating here.
+fn endpoint_from_raw_parts(
     channel_type: ChannelType,
     platform_chat_id: Option<&str>,
     thread_id: Option<&str>,
@@ -1745,60 +1740,66 @@ fn derive_endpoint(
     })
 }
 
-// ---------------------------------------------------------------------------
-// EndpointRegistry
-// ---------------------------------------------------------------------------
-
-/// Tracks per-user active endpoints.
+/// Reason a [`ChannelBinding`](crate::session::ChannelBinding) cannot be
+/// converted to a deliverable [`Endpoint`].
 ///
-/// Thread-safe via `DashMap`. Adapters register endpoints when a user
-/// connects and unregister when they disconnect.
-#[derive(Default)]
-pub struct EndpointRegistry {
-    connections: DashMap<UserId, HashSet<Endpoint>>,
+/// Egress callers map this to "skip this binding"; it exists so the
+/// [`TryFrom`] impl carries a real error type instead of `()`.
+#[derive(Debug, Snafu)]
+pub enum BindingConversionError {
+    /// The channel routes outbound replies through [`StreamHub`] rather
+    /// than via [`ChannelAdapter`](crate::channel::adapter::ChannelAdapter),
+    /// so building an `Endpoint` here would double-deliver. Applies to
+    /// `Web` and `Cli` bindings, which are self-referential
+    /// (`chat_id == session_key`).
+    #[snafu(display("channel {channel_type:?} fans out via StreamHub, not adapter egress"))]
+    StreamHubFanout { channel_type: ChannelType },
+
+    /// The binding's raw fields could not be parsed into a valid endpoint
+    /// (e.g. a Telegram chat id that is not an `i64`).
+    #[snafu(display("binding fields could not be parsed into endpoint for {channel_type:?}"))]
+    Malformed { channel_type: ChannelType },
+
+    /// The channel type has no external peer to address
+    /// (`Internal`, `Api`, `Proactive`).
+    #[snafu(display("channel {channel_type:?} has no external peer"))]
+    NoExternalPeer { channel_type: ChannelType },
 }
 
-impl EndpointRegistry {
-    /// Create an empty registry.
-    pub fn new() -> Self {
-        Self {
-            connections: DashMap::new(),
-        }
-    }
+impl TryFrom<&crate::session::ChannelBinding> for Endpoint {
+    type Error = BindingConversionError;
 
-    /// Register an endpoint for a user.
-    pub fn register(&self, user: &UserId, endpoint: Endpoint) {
-        self.connections
-            .entry(user.clone())
-            .or_default()
-            .insert(endpoint);
-    }
-
-    /// Unregister an endpoint for a user.
-    pub fn unregister(&self, user: &UserId, endpoint: &Endpoint) {
-        if let Some(mut endpoints) = self.connections.get_mut(user) {
-            endpoints.remove(endpoint);
-            if endpoints.is_empty() {
-                drop(endpoints);
-                self.connections.remove(user);
+    /// Build a deliverable [`Endpoint`] from a session-scoped channel
+    /// binding.
+    ///
+    /// Web and CLI bindings are rejected with
+    /// [`BindingConversionError::StreamHubFanout`] because those adapters
+    /// fan out via [`StreamHub`] rather than
+    /// [`ChannelAdapter`](crate::channel::adapter::ChannelAdapter);
+    /// returning an endpoint here would double-deliver. All other channels
+    /// delegate to the private `endpoint_from_raw_parts` helper — the
+    /// single match arm per channel lives there.
+    fn try_from(binding: &crate::session::ChannelBinding) -> Result<Self, Self::Error> {
+        match binding.channel_type {
+            ChannelType::Web | ChannelType::Cli => StreamHubFanoutSnafu {
+                channel_type: binding.channel_type,
             }
+            .fail(),
+            ChannelType::Api | ChannelType::Internal | ChannelType::Proactive => {
+                NoExternalPeerSnafu {
+                    channel_type: binding.channel_type,
+                }
+                .fail()
+            }
+            ChannelType::Telegram | ChannelType::Wechat => endpoint_from_raw_parts(
+                binding.channel_type,
+                Some(&binding.chat_id),
+                binding.thread_id.as_deref(),
+            )
+            .ok_or(BindingConversionError::Malformed {
+                channel_type: binding.channel_type,
+            }),
         }
-    }
-
-    /// Get all active endpoints for a user.
-    fn get_endpoints(&self, user: &UserId) -> Vec<Endpoint> {
-        self.connections
-            .get(user)
-            .map(|set| set.iter().cloned().collect())
-            .unwrap_or_default()
-    }
-
-    /// Check whether a user has any active endpoints.
-    fn is_online(&self, user: &UserId) -> bool {
-        self.connections
-            .get(user)
-            .map(|set| !set.is_empty())
-            .unwrap_or(false)
     }
 }
 
@@ -1870,9 +1871,6 @@ pub enum EgressError {
 /// Shared reference to a
 /// [`ChannelAdapter`](crate::channel::adapter::ChannelAdapter).
 pub type ChannelAdapterRef = crate::channel::adapter::ChannelAdapterRef;
-
-/// Shared reference to the [`EndpointRegistry`].
-pub type EndpointRegistryRef = Arc<EndpointRegistry>;
 
 // ---------------------------------------------------------------------------
 // IngressRateLimiter
@@ -1992,7 +1990,6 @@ pub struct IOSubsystem {
     /// so contention is effectively zero. `std::sync::RwLock` keeps this
     /// usable from non-async call sites.
     adapters:                std::sync::RwLock<HashMap<ChannelType, ChannelAdapterRef>>,
-    endpoint_registry:       EndpointRegistryRef,
     /// Telegram channel ID for agent-initiated notifications.
     notification_channel_id: Option<i64>,
     rate_limiter:            IngressRateLimiter,
@@ -2001,9 +1998,9 @@ pub struct IOSubsystem {
 impl IOSubsystem {
     /// Create a new I/O subsystem.
     ///
-    /// Internally creates a [`StreamHub`] and [`EndpointRegistry`].
-    /// Call [`register_adapter`](Self::register_adapter) to add egress
-    /// adapters before passing to the kernel.
+    /// Internally creates a [`StreamHub`]. Call
+    /// [`register_adapter`](Self::register_adapter) to add egress adapters
+    /// before passing to the kernel.
     pub fn new(
         identity_resolver: IdentityResolverRef,
         session_index: Arc<dyn SessionIndex>,
@@ -2015,7 +2012,6 @@ impl IOSubsystem {
             session_index,
             stream_hub: Arc::new(StreamHub::new(STREAM_HUB_BROADCAST_CAPACITY)),
             adapters: std::sync::RwLock::new(HashMap::new()),
-            endpoint_registry: Arc::new(EndpointRegistry::new()),
             notification_channel_id,
             rate_limiter: IngressRateLimiter::new(max_ingress_per_minute),
         }
@@ -2097,21 +2093,13 @@ impl IOSubsystem {
             None => None,
         };
 
-        // 4. Auto-register the originating endpoint.
+        // 4. Build InboundMessage with optional session_key.
         //
-        // Why: only the Web adapter has an explicit connection lifecycle
-        // (WS/SSE open/close) and registers itself there. Telegram, WeChat,
-        // and CLI have no equivalent signal — without this, outbound fan-out
-        // via `deliver_to_endpoints()` cannot find them and cross-channel
-        // delivery (e.g. web → tg) silently drops. `HashSet` insert is
-        // idempotent, so re-registering on every message is safe.
-        if let Some(endpoint) =
-            derive_endpoint(raw.channel_type, raw.platform_chat_id.as_deref(), thread_id)
-        {
-            self.endpoint_registry.register(&user_id, endpoint);
-        }
-
-        // 5. Build InboundMessage with optional session_key
+        // No per-user endpoint registration happens here: egress fanout
+        // routes via session-scoped `ChannelBinding`s in
+        // [`Self::deliver_to_endpoints`] (and per-message
+        // `origin_endpoint`), so a parallel per-user index would be
+        // dead state. See issue #2108.
         let msg = InboundMessage::unresolved(
             MessageId::new(),
             ChannelSource {
@@ -2224,47 +2212,6 @@ impl IOSubsystem {
         );
     }
 
-    /// Register egress endpoint for stateless channels (e.g. Telegram).
-    ///
-    /// Connection-oriented channels (Web) register on WS/SSE connect.
-    /// Stateless channels have no persistent connection, so we register on
-    /// every inbound message (idempotent — EndpointRegistry uses a HashSet).
-    pub fn register_stateless_endpoint(&self, msg: &InboundMessage) {
-        let endpoint = match msg.source.channel_type {
-            ChannelType::Telegram => {
-                let chat_id_str = msg.source.platform_chat_id.as_ref();
-                let chat_id = chat_id_str.and_then(|s| s.parse::<i64>().ok());
-                let thread_id = msg
-                    .reply_context
-                    .as_ref()
-                    .and_then(|rc| rc.thread_id.as_deref())
-                    .and_then(|t| t.parse::<i64>().ok());
-                chat_id.map(|id| Endpoint {
-                    channel_type: ChannelType::Telegram,
-                    address:      EndpointAddress::Telegram {
-                        chat_id: id,
-                        thread_id,
-                    },
-                })
-            }
-            ChannelType::Wechat => msg
-                .source
-                .platform_chat_id
-                .as_ref()
-                .map(|user_id| Endpoint {
-                    channel_type: ChannelType::Wechat,
-                    address:      EndpointAddress::Wechat {
-                        user_id: user_id.clone(),
-                    },
-                }),
-            _ => return,
-        };
-        let Some(endpoint) = endpoint else {
-            return;
-        };
-        self.endpoint_registry.register(&msg.user, endpoint);
-    }
-
     /// Propagate a session title change to the channel layer (e.g.
     /// rename the Telegram forum topic). Silent no-op if the session
     /// has no channel binding or the adapter does not implement rename.
@@ -2325,9 +2272,6 @@ impl IOSubsystem {
     /// Access the stream hub.
     pub fn stream_hub(&self) -> &StreamHubRef { &self.stream_hub }
 
-    /// Access the endpoint registry.
-    pub fn endpoint_registry(&self) -> &EndpointRegistryRef { &self.endpoint_registry }
-
     /// Access the identity resolver (platform id → kernel `UserId`).
     pub fn identity_resolver(&self) -> &IdentityResolverRef { &self.identity_resolver }
 
@@ -2359,8 +2303,8 @@ impl IOSubsystem {
                 .await
             {
                 Ok(bindings) => bindings
-                    .into_iter()
-                    .filter_map(binding_to_endpoint)
+                    .iter()
+                    .filter_map(|b| Endpoint::try_from(b).ok())
                     .collect(),
                 Err(e) => {
                     tracing::warn!(
@@ -2435,40 +2379,6 @@ impl IOSubsystem {
             }
         });
         futures::future::join_all(futs).await;
-    }
-}
-
-/// Convert a [`ChannelBinding`](crate::session::ChannelBinding) into a
-/// deliverable [`Endpoint`].
-///
-/// Only channels that accept platform-level delivery via
-/// [`ChannelAdapter`](crate::channel::adapter::ChannelAdapter) are mapped.
-/// Web and CLI bindings are self-referential (`chat_id == session_key`) —
-/// their adapters fan out through [`StreamHub`] rather than
-/// `deliver_to_endpoints`, so routing them here would double-deliver.
-/// Returning `None` for those variants keeps the fanout list
-/// adapter-compatible without relying on downstream routing filters.
-fn binding_to_endpoint(binding: crate::session::ChannelBinding) -> Option<Endpoint> {
-    match binding.channel_type {
-        ChannelType::Telegram => {
-            let chat_id = binding.chat_id.parse::<i64>().ok()?;
-            let thread_id = binding.thread_id.and_then(|t| t.parse::<i64>().ok());
-            Some(Endpoint {
-                channel_type: ChannelType::Telegram,
-                address:      EndpointAddress::Telegram { chat_id, thread_id },
-            })
-        }
-        ChannelType::Wechat => Some(Endpoint {
-            channel_type: ChannelType::Wechat,
-            address:      EndpointAddress::Wechat {
-                user_id: binding.chat_id,
-            },
-        }),
-        ChannelType::Web
-        | ChannelType::Cli
-        | ChannelType::Api
-        | ChannelType::Internal
-        | ChannelType::Proactive => None,
     }
 }
 
@@ -2656,7 +2566,7 @@ mod delivery_routing_tests {
             created_at:   now,
             updated_at:   now,
         };
-        let ep = binding_to_endpoint(binding).expect("telegram binding maps");
+        let ep = Endpoint::try_from(&binding).expect("telegram binding maps");
         assert_eq!(
             ep,
             Endpoint {
@@ -2684,7 +2594,7 @@ mod delivery_routing_tests {
             created_at:   now,
             updated_at:   now,
         };
-        assert!(binding_to_endpoint(binding).is_none());
+        assert!(Endpoint::try_from(&binding).is_err());
     }
 
     #[test]
@@ -2698,7 +2608,7 @@ mod delivery_routing_tests {
             created_at:   now,
             updated_at:   now,
         };
-        assert!(binding_to_endpoint(binding).is_none());
+        assert!(Endpoint::try_from(&binding).is_err());
     }
 }
 
@@ -3211,11 +3121,12 @@ mod inbound_message_tests {
     }
 
     #[test]
-    fn derive_endpoint_web_uses_connection_id() {
-        // `derive_endpoint` is the IOSubsystem path: the Web adapter
-        // ingests a connection_id via `platform_chat_id`, and we must
-        // construct a matching Web endpoint for registry auto-register.
-        let endpoint = derive_endpoint(ChannelType::Web, Some("conn-xyz"), None);
+    fn endpoint_from_raw_parts_web_uses_connection_id() {
+        // The Web adapter ingests a connection_id via `platform_chat_id`;
+        // the unified raw-parts conversion must round-trip it into a Web
+        // endpoint so `origin_endpoint` can route replies back to the
+        // originating WS.
+        let endpoint = endpoint_from_raw_parts(ChannelType::Web, Some("conn-xyz"), None);
         assert_eq!(
             endpoint,
             Some(Endpoint {
@@ -3228,9 +3139,56 @@ mod inbound_message_tests {
     }
 
     #[test]
-    fn derive_endpoint_web_without_chat_id_returns_none() {
+    fn endpoint_from_raw_parts_web_without_chat_id_returns_none() {
         // Without a connection_id we cannot build a Web endpoint.
-        assert!(derive_endpoint(ChannelType::Web, None, None).is_none());
+        assert!(endpoint_from_raw_parts(ChannelType::Web, None, None).is_none());
+    }
+
+    #[test]
+    fn endpoint_from_raw_parts_cli_uses_session_id() {
+        // CLI raw-parts conversion mirrors Web: the chat_id slot carries
+        // the CLI session alias.
+        let endpoint = endpoint_from_raw_parts(ChannelType::Cli, Some("cli-1"), None);
+        assert_eq!(
+            endpoint,
+            Some(Endpoint {
+                channel_type: ChannelType::Cli,
+                address:      EndpointAddress::Cli {
+                    session_id: "cli-1".to_string(),
+                },
+            })
+        );
+    }
+
+    #[test]
+    fn endpoint_from_raw_parts_telegram_parses_thread_id() {
+        let endpoint = endpoint_from_raw_parts(ChannelType::Telegram, Some("-100"), Some("42"));
+        assert_eq!(
+            endpoint,
+            Some(Endpoint {
+                channel_type: ChannelType::Telegram,
+                address:      EndpointAddress::Telegram {
+                    chat_id:   -100,
+                    thread_id: Some(42),
+                },
+            })
+        );
+    }
+
+    #[test]
+    fn endpoint_from_raw_parts_telegram_rejects_malformed_chat_id() {
+        // Telegram chat ids that are not parseable as i64 yield None — the
+        // single canonical mapping must not silently produce a malformed
+        // endpoint.
+        assert!(endpoint_from_raw_parts(ChannelType::Telegram, Some("nope"), None).is_none());
+    }
+
+    #[test]
+    fn endpoint_from_raw_parts_internal_returns_none() {
+        // Internal / Api / Proactive have no external peer to address.
+        assert!(endpoint_from_raw_parts(ChannelType::Internal, Some("x"), None).is_none());
+        assert!(endpoint_from_raw_parts(ChannelType::Api, Some("x"), None).is_none());
+        assert!(endpoint_from_raw_parts(ChannelType::Proactive, Some("x"), None).is_none());
     }
 
     #[test]

--- a/crates/kernel/src/io.rs
+++ b/crates/kernel/src/io.rs
@@ -1098,8 +1098,10 @@ pub enum StreamEvent {
     /// Emitted alongside an outbound envelope when the delivery target is a
     /// channel that does not receive the envelope through the standard
     /// adapter fanout (currently the Web UI, whose bindings are
-    /// self-referential and skipped by
-    /// [`binding_to_endpoint`](crate::io::IOSubsystem)). Channel adapters
+    /// self-referential and rejected by
+    /// [`Endpoint::try_from(&ChannelBinding)`](crate::io::Endpoint) with
+    /// `BindingConversionError::StreamHubFanout` — Web fans out through
+    /// [`StreamHub`] rather than `deliver_to_endpoints`). Channel adapters
     /// that already deliver the envelope via `ChannelAdapter::send` (e.g.
     /// Telegram) ignore this event to avoid double-rendering.
     Attachment {

--- a/crates/kernel/src/kernel.rs
+++ b/crates/kernel/src/kernel.rs
@@ -32,7 +32,7 @@
 //!   ├── NotificationBus
 //!   ├── SecuritySubsystem (auth + authz + approval + guard)
 //!   ├── shared_kv (cross-agent KV)
-//!   ├── StreamHub + IngressPipeline + EndpointRegistry
+//!   ├── StreamHub + IngressPipeline
 //!   └── ShardedEventQueue (single-queue or multi-shard mode)
 //! ```
 //!
@@ -1510,8 +1510,6 @@ impl Kernel {
 
         let user = msg.user.clone();
 
-        self.io.register_stateless_endpoint(&msg);
-
         let origin_endpoint = msg.origin_endpoint();
 
         // ----- Path 1: ID addressing (agent-to-agent) -----
@@ -1748,8 +1746,6 @@ impl Kernel {
                 session.key
             }
         };
-
-        self.io.register_stateless_endpoint(&msg);
 
         // Populate session_key for downstream code.
         let msg = msg.resolve(session_id.clone());


### PR DESCRIPTION
## Summary

Lane-2 refactor consolidating 4 near-duplicate `(channel_type, chat_id, thread_id) → Endpoint` mappings into one canonical entry and removing the dead `EndpointRegistry` egress state.

**Before:** four match-arm-per-channel sites scattered across `crates/kernel/src/io.rs`:
- `InboundMessage::origin_endpoint()` 
- `derive_endpoint()` standalone
- `IOSubsystem::register_stateless_endpoint()`
- `binding_to_endpoint()`

Each handled Telegram / WeChat / Web / CLI differently. New channel = miss one site = silent cross-channel drop (#1731, #1849 class).

**After:** one canonical helper `endpoint_from_raw_parts()` (one match arm per channel), plus `TryFrom<&ChannelBinding> for Endpoint` for the egress filter ("Web/CLI fan out via StreamHub"). `EndpointRegistry` deleted across `crates/`, `web/`, `extension/` (verified by grep returning zero hits).

## Decisions surfaced

1. **`TryFrom<&ChannelBinding>` + free helper** (not `enum EndpointSource`) — idiomatic Rust, no private enum just to host one method. The Web/CLI self-referential filter lives in exactly ONE place: the `TryFrom` head.

2. **Typed `BindingConversionError` snafu enum** (`StreamHubFanout` / `Malformed` / `NoExternalPeer`) instead of `Option<Endpoint>`. Reviewer (a83785b56e09cfe03) explicitly weighed this against speculative-abstraction concerns and approved: the three variants encode genuinely distinct rejection causes (intentional routing skip vs wire-format bug vs class-of-channel invariant), not a "morally Option" pattern. snafu over `Option` is project style when the rejection reason carries info.

3. **`register_stateless_endpoint` deleted outright** (not no-op'd) per anti-patterns.md "Do NOT use noop trait implementations".

4. **AGENT.md untouched** — `crates/kernel/AGENT.md` and `crates/channels/AGENT.md` had zero pre-existing mentions of `EndpointRegistry` or the four-mapping pattern. Historical context lives in the new comment block at `io.rs:1696-1708` pointing back to this issue.

5. **`cmd/src/chat/mod.rs` `resolved_user_id` deleted** — became dead after the registry call site was removed.

## F-invariants (PR #2117) preserved

- `IOSubsystem.adapters: RwLock<HashMap>` — preserved
- `register_adapter(&self, ...)` — preserved  
- `spawn_telegram_config_reloader` — untouched

## Test plan

- [x] `cargo check --workspace --all-targets`
- [x] `cargo +nightly fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings`
- [x] `RUSTDOCFLAGS="-D warnings" cargo +nightly doc --workspace --no-deps --document-private-items`
- [x] `prek run --all-files`
- [x] `cargo test -p rara-kernel --lib io::` — 35 passed
- [x] `cargo test -p rara-channels` — 147 passed
- [x] `cargo test -p rara-app` — 97 passed
- [x] `cargo test -p rara-cli` — 90 passed

Diff: 6 files, +190 / −315 (net −125 LOC) + 1 docs fixup commit (+10/-12).

Closes #2108
Closes #1805
Closes #1806