### PR TITLE
feat(memory): explain() API to trace which memory items shaped a turn (#2113)

### DIFF
--- a/crates/app/src/boot.rs
+++ b/crates/app/src/boot.rs
@@ -461,10 +461,14 @@ pub(crate) async fn boot(
 
     // -- knowledge layer ------------------------------------------------------
 
-    let knowledge_service =
-        init_knowledge_service(diesel_pools.clone(), settings_provider.as_ref(), embedder)
-            .await
-            .whatever_context("Failed to initialize knowledge layer")?;
+    let knowledge_service = init_knowledge_service(
+        diesel_pools.clone(),
+        settings_provider.as_ref(),
+        embedder,
+        Arc::new(tape_service.clone()),
+    )
+    .await
+    .whatever_context("Failed to initialize knowledge layer")?;
 
     info!("Boot completed");
 
@@ -1052,6 +1056,7 @@ async fn init_knowledge_service(
     pools: yunara_store::diesel_pool::DieselSqlitePools,
     settings: &dyn rara_domain_shared::settings::SettingsProvider,
     embedder: rara_kernel::llm::LlmEmbedderRef,
+    tape_service: Arc<rara_kernel::memory::TapeService>,
 ) -> anyhow::Result<rara_kernel::memory::knowledge::KnowledgeServiceRef> {
     use rara_domain_shared::settings::keys;
     use rara_kernel::memory::knowledge::{EmbeddingService, KnowledgeConfig, KnowledgeService};
@@ -1096,6 +1101,7 @@ async fn init_knowledge_service(
         pools,
         embedding_svc,
         config,
+        tape_service,
     }))
 }
 

--- a/crates/kernel/src/memory/knowledge/service.rs
+++ b/crates/kernel/src/memory/knowledge/service.rs
@@ -16,10 +16,14 @@
 
 use std::sync::Arc;
 
+use snafu::ResultExt;
 use yunara_store::diesel_pool::DieselSqlitePools;
 
 use super::{EmbeddingService, KnowledgeConfig, outcome::OutcomeKind};
-use crate::error::Result;
+use crate::{
+    error::Result,
+    memory::{TapEntryKind, TapeService},
+};
 
 /// Bundles the knowledge layer's runtime dependencies into a single handle
 /// that can be shared across the kernel.
@@ -33,6 +37,10 @@ pub struct KnowledgeService {
     pub pools:         DieselSqlitePools,
     pub embedding_svc: Arc<EmbeddingService>,
     pub config:        KnowledgeConfig,
+    /// Tape handle used by [`KnowledgeService::explain`] to read the
+    /// `ContextSources` retrieval trace persisted by
+    /// `MemoryTool::exec_search`. Issue #2113.
+    pub tape_service:  Arc<TapeService>,
 }
 
 impl KnowledgeService {
@@ -57,6 +65,90 @@ impl KnowledgeService {
     ) -> Result<()> {
         super::outcome::commit_outcome_inner(&self.pools.writer, item_ids, kind, tape_entry_id)
             .await
+    }
+
+    /// Recover the memory items that shaped a particular turn's
+    /// context — the read side of issue #2113's retrieval trace.
+    ///
+    /// Walks `tape_name` from `turn_entry_id` forward, collecting any
+    /// [`TapEntryKind::ContextSources`] entries up to (but not
+    /// including) the next non-tool entry — in practice zero or one
+    /// per turn — and returns the live `memory_items` rows paired with
+    /// the weights recorded at retrieval time, in the original
+    /// retrieval-rank order. Ids whose rows have since been deleted
+    /// are silently skipped, matching `commit_outcome`'s policy:
+    /// `explain` is a debugging seam, not a consistency contract.
+    ///
+    /// Returns `Ok(vec![])` when the turn did not consult memory
+    /// (no `ContextSources` entry exists in the window).
+    pub async fn explain(
+        &self,
+        tape_name: &str,
+        turn_entry_id: i64,
+    ) -> Result<Vec<(super::items::MemoryItem, f32)>> {
+        let entries = self
+            .tape_service
+            .entries(tape_name)
+            .await
+            .whatever_context::<_, crate::error::KernelError>("failed to read tape for explain")?;
+
+        // Walk forward from the turn's entry id. The turn window ends
+        // at the next entry that is neither a tool exchange nor a
+        // ContextSources trace — i.e. the next assistant `Message` (or
+        // any other non-tool kind). The starting entry itself is the
+        // user Message that opened the turn, so a `Message` kind at
+        // `turn_entry_id` is included rather than treated as a
+        // terminator.
+        let mut found: Option<&serde_json::Value> = None;
+        let mut started = false;
+        for entry in &entries {
+            if (entry.id as i64) < turn_entry_id {
+                continue;
+            }
+            if !started {
+                started = true;
+                continue;
+            }
+            match entry.kind {
+                TapEntryKind::ContextSources => found = Some(&entry.payload),
+                TapEntryKind::ToolCall | TapEntryKind::ToolResult => {}
+                _ => break,
+            }
+        }
+
+        let Some(payload) = found else {
+            return Ok(Vec::new());
+        };
+
+        let item_ids: Vec<i64> = payload
+            .get("item_ids")
+            .and_then(|v| v.as_array())
+            .map(|arr| arr.iter().filter_map(serde_json::Value::as_i64).collect())
+            .unwrap_or_default();
+        let weights: Vec<f32> = payload
+            .get("weights")
+            .and_then(|v| v.as_array())
+            .map(|arr| {
+                arr.iter()
+                    .filter_map(serde_json::Value::as_f64)
+                    .map(|w| w as f32)
+                    .collect()
+            })
+            .unwrap_or_default();
+        if item_ids.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        // Fetch live rows; drop ids whose rows have been deleted.
+        let live = super::items::get_items_by_ids(&self.pools.reader, &item_ids).await?;
+        let by_id: std::collections::HashMap<i64, super::items::MemoryItem> =
+            live.into_iter().map(|item| (item.id, item)).collect();
+        let result: Vec<(super::items::MemoryItem, f32)> = item_ids
+            .iter()
+            .zip(weights.iter().copied().chain(std::iter::repeat(0.0)))
+            .filter_map(|(id, w)| by_id.get(id).cloned().map(|item| (item, w)))
+            .collect();
+        Ok(result)
     }
 
     /// Resolve source tape entries for memory items that have source
@@ -90,3 +182,211 @@ impl KnowledgeService {
 
 /// Shared reference to the knowledge service.
 pub type KnowledgeServiceRef = Arc<KnowledgeService>;
+
+#[cfg(test)]
+mod tests {
+    use async_trait::async_trait;
+    use diesel::{ExpressionMethods, QueryDsl};
+    use diesel_async::RunQueryDsl;
+    use rara_model::schema::memory_items;
+    use serde_json::json;
+    use yunara_store::diesel_pool::DieselSqlitePool;
+
+    use super::*;
+    use crate::{
+        llm::{EmbeddingRequest, EmbeddingResponse, LlmEmbedder, LlmEmbedderRef},
+        memory::{FileTapeStore, TapEntryKind},
+    };
+
+    const ADD_CONFIDENCE_SQL: &str =
+        "ALTER TABLE memory_items ADD COLUMN confidence REAL NOT NULL DEFAULT 1.0";
+
+    struct NoopEmbedder;
+
+    #[async_trait]
+    impl LlmEmbedder for NoopEmbedder {
+        async fn embed(
+            &self,
+            request: EmbeddingRequest,
+        ) -> crate::error::Result<EmbeddingResponse> {
+            let embeddings = request.input.iter().map(|_| vec![0.0_f32; 1]).collect();
+            Ok(EmbeddingResponse::builder()
+                .embeddings(embeddings)
+                .model("noop".to_string())
+                .build())
+        }
+    }
+
+    async fn insert_item(pool: &DieselSqlitePool, content: &str) -> i64 {
+        let mut conn = pool.get().await.expect("pool conn");
+        let id: Option<i32> = diesel::insert_into(memory_items::table)
+            .values((
+                memory_items::username.eq("alice"),
+                memory_items::content.eq(content),
+                memory_items::memory_type.eq("preference"),
+                memory_items::category.eq("ui"),
+                memory_items::confidence.eq(1.0_f32),
+            ))
+            .returning(memory_items::id)
+            .get_result(&mut *conn)
+            .await
+            .expect("insert row");
+        id.map(i64::from).unwrap_or(0)
+    }
+
+    async fn delete_item(pool: &DieselSqlitePool, id: i64) {
+        let mut conn = pool.get().await.expect("pool conn");
+        diesel::delete(memory_items::table.filter(memory_items::id.eq(id as i32)))
+            .execute(&mut *conn)
+            .await
+            .expect("delete row");
+    }
+
+    async fn build_service() -> (KnowledgeServiceRef, tempfile::TempDir) {
+        let pools = crate::testing::build_memory_diesel_pools().await;
+        {
+            let mut conn = pools.writer.get().await.expect("pool conn");
+            diesel::sql_query(ADD_CONFIDENCE_SQL)
+                .execute(&mut *conn)
+                .await
+                .expect("add confidence column");
+        }
+
+        let config = KnowledgeConfig::builder()
+            .embedding_dimensions(1_usize)
+            .search_top_k(5_usize)
+            .similarity_threshold(0.0_f32)
+            .build();
+        let embedder: LlmEmbedderRef = Arc::new(NoopEmbedder);
+        let index_path = std::env::temp_dir()
+            .join(format!("rara-test-{}", uuid::Uuid::new_v4()))
+            .join("memory.usearch");
+        let embedding_svc = Arc::new(
+            EmbeddingService::with_path(config.clone(), embedder, "noop".to_string(), index_path)
+                .expect("embedding svc"),
+        );
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let store = FileTapeStore::new(dir.path(), dir.path())
+            .await
+            .expect("tape store");
+        let tape_service = Arc::new(TapeService::new(store));
+
+        let svc = Arc::new(KnowledgeService {
+            pools,
+            embedding_svc,
+            config,
+            tape_service,
+        });
+        (svc, dir)
+    }
+
+    /// Scenario: explain returns the memory items recorded for a turn
+    /// in retrieval order (issue #2113).
+    #[tokio::test]
+    async fn explain_returns_items_in_retrieval_order() {
+        let (svc, _dir) = build_service().await;
+
+        let id_a = insert_item(&svc.pools.writer, "alpha").await;
+        let id_b = insert_item(&svc.pools.writer, "beta").await;
+        let id_c = insert_item(&svc.pools.writer, "gamma").await;
+
+        // Seed the tape: a Message entry as the turn opener, then a
+        // ContextSources entry referencing the three items in
+        // retrieval-rank order.
+        let tape_name = "session-explain-order";
+        let msg = svc
+            .tape_service
+            .append_message(tape_name, json!({"role": "user", "content": "hi"}), None)
+            .await
+            .expect("append message");
+        svc.tape_service
+            .store()
+            .append(
+                tape_name,
+                TapEntryKind::ContextSources,
+                json!({
+                    "item_ids": [id_a, id_b, id_c],
+                    "weights": [0.93_f32, 0.81_f32, 0.55_f32],
+                }),
+                None,
+            )
+            .await
+            .expect("append cs");
+
+        let result = svc
+            .explain(tape_name, msg.id as i64)
+            .await
+            .expect("explain ok");
+        let ids: Vec<i64> = result.iter().map(|(item, _)| item.id).collect();
+        let weights: Vec<f32> = result.iter().map(|(_, w)| *w).collect();
+        assert_eq!(ids, vec![id_a, id_b, id_c]);
+        assert_eq!(weights.len(), 3);
+        assert!((weights[0] - 0.93).abs() < 1e-4);
+        assert!((weights[1] - 0.81).abs() < 1e-4);
+        assert!((weights[2] - 0.55).abs() < 1e-4);
+    }
+
+    /// Scenario: explain returns an empty vec when the turn did not
+    /// consult memory (issue #2113).
+    #[tokio::test]
+    async fn explain_returns_empty_for_turn_without_context_sources() {
+        let (svc, _dir) = build_service().await;
+        let tape_name = "session-empty";
+        let msg = svc
+            .tape_service
+            .append_message(tape_name, json!({"role": "user", "content": "hi"}), None)
+            .await
+            .expect("append message");
+        // No ContextSources entry appended.
+        let result = svc
+            .explain(tape_name, msg.id as i64)
+            .await
+            .expect("explain ok");
+        assert!(result.is_empty(), "no context sources => empty vec");
+    }
+
+    /// Scenario: explain skips item ids whose memory_items rows have
+    /// been deleted (issue #2113).
+    #[tokio::test]
+    async fn explain_skips_deleted_item_ids() {
+        let (svc, _dir) = build_service().await;
+
+        let id_a = insert_item(&svc.pools.writer, "alpha").await;
+        let id_b = insert_item(&svc.pools.writer, "beta").await;
+        let id_c = insert_item(&svc.pools.writer, "gamma").await;
+
+        let tape_name = "session-deleted";
+        let msg = svc
+            .tape_service
+            .append_message(tape_name, json!({"role": "user", "content": "hi"}), None)
+            .await
+            .expect("append message");
+        svc.tape_service
+            .store()
+            .append(
+                tape_name,
+                TapEntryKind::ContextSources,
+                json!({
+                    "item_ids": [id_a, id_b, id_c],
+                    "weights": [0.93_f32, 0.81_f32, 0.55_f32],
+                }),
+                None,
+            )
+            .await
+            .expect("append cs");
+
+        // Delete the middle item.
+        delete_item(&svc.pools.writer, id_b).await;
+
+        let result = svc
+            .explain(tape_name, msg.id as i64)
+            .await
+            .expect("explain ok");
+        let ids: Vec<i64> = result.iter().map(|(item, _)| item.id).collect();
+        let weights: Vec<f32> = result.iter().map(|(_, w)| *w).collect();
+        assert_eq!(ids, vec![id_a, id_c], "deleted id dropped, order preserved");
+        assert!((weights[0] - 0.93).abs() < 1e-4);
+        assert!((weights[1] - 0.55).abs() < 1e-4);
+    }
+}

--- a/crates/kernel/src/memory/knowledge/tool.rs
+++ b/crates/kernel/src/memory/knowledge/tool.rs
@@ -29,7 +29,10 @@ use serde_json::{Value, json};
 use yunara_store::diesel_pool::DieselSqlitePools;
 
 use super::{categories, embedding::EmbeddingService, items};
-use crate::tool::{ToolContext, ToolExecute};
+use crate::{
+    memory::{TapEntryKind, TapeService},
+    tool::{ToolContext, ToolExecute},
+};
 
 /// Weight λ in the search-time re-rank `score = -distance + λ · confidence`.
 ///
@@ -56,15 +59,23 @@ pub const CONFIDENCE_RANK_WEIGHT: f32 = 0.5;
 pub struct MemoryTool {
     pools:         DieselSqlitePools,
     embedding_svc: Arc<EmbeddingService>,
+    /// Tape handle used to persist the per-turn retrieval trace
+    /// (`TapEntryKind::ContextSources`). Issue #2113.
+    tape_service:  Arc<TapeService>,
 }
 
 impl MemoryTool {
-    /// Create a new `MemoryTool` with the given pool bundle and embedding
-    /// service.
-    pub fn new(pools: DieselSqlitePools, embedding_svc: Arc<EmbeddingService>) -> Self {
+    /// Create a new `MemoryTool` with the given pool bundle, embedding
+    /// service, and tape handle.
+    pub fn new(
+        pools: DieselSqlitePools,
+        embedding_svc: Arc<EmbeddingService>,
+        tape_service: Arc<TapeService>,
+    ) -> Self {
         Self {
             pools,
             embedding_svc,
+            tape_service,
         }
     }
 }
@@ -95,7 +106,12 @@ impl ToolExecute for MemoryTool {
                 if query.is_empty() {
                     return Ok(json!({"error": "query is required for search action"}));
                 }
-                self.exec_search(username, query).await
+                // The ContextSources retrieval trace attaches to the
+                // tape that names the calling turn — i.e. the session
+                // tape (issue #2113). `SessionKey::to_string` is the
+                // tape-name convention used everywhere in the kernel.
+                let tape_name = context.session_key.to_string();
+                self.exec_search(username, &tape_name, query).await
             }
             "categories" => self.exec_categories(username).await,
             "read_category" => {
@@ -111,7 +127,12 @@ impl ToolExecute for MemoryTool {
 }
 
 impl MemoryTool {
-    async fn exec_search(&self, username: &str, query: &str) -> anyhow::Result<Value> {
+    async fn exec_search(
+        &self,
+        username: &str,
+        tape_name: &str,
+        query: &str,
+    ) -> anyhow::Result<Value> {
         // Embed the query.
         let embeddings = self.embedding_svc.embed(&[query.to_string()]).await?;
         let query_emb = embeddings
@@ -150,6 +171,35 @@ impl MemoryTool {
         // to Equal is safe.
         ranked.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
 
+        // Persist the retrieval trace before returning so a later
+        // `KnowledgeService::explain` call can recover which items
+        // shaped this turn (issue #2113). Weights are `1.0 - distance`
+        // clamped to `[0.0, 1.0]` — distances from the usearch index
+        // are joined back by id; ids missing from the distance table
+        // are skipped above, so every `ranked` row has a known
+        // distance. Empty result sets still emit (with empty arrays)
+        // so `explain` can distinguish "search ran and found nothing"
+        // from "search never ran".
+        let item_ids: Vec<i64> = ranked.iter().map(|(item, _)| item.id).collect();
+        let weights: Vec<f32> = ranked
+            .iter()
+            .map(|(item, _)| {
+                distance_by_id
+                    .get(&item.id)
+                    .map(|d| (1.0_f32 - d).clamp(0.0, 1.0))
+                    .unwrap_or(0.0)
+            })
+            .collect();
+        self.tape_service
+            .store()
+            .append(
+                tape_name,
+                TapEntryKind::ContextSources,
+                json!({ "item_ids": item_ids, "weights": weights }),
+                None,
+            )
+            .await?;
+
         let items_json: Vec<Value> = ranked
             .iter()
             .map(|(item, _)| {
@@ -186,13 +236,75 @@ mod tests {
     use diesel::ExpressionMethods;
     use diesel_async::RunQueryDsl;
     use rara_model::schema::memory_items;
-    use yunara_store::diesel_pool::DieselSqlitePool;
+    use yunara_store::diesel_pool::{DieselSqlitePool, DieselSqlitePools};
 
     use super::*;
-    use crate::llm::{EmbeddingRequest, EmbeddingResponse, LlmEmbedder, LlmEmbedderRef};
+    use crate::{
+        llm::{EmbeddingRequest, EmbeddingResponse, LlmEmbedder, LlmEmbedderRef},
+        memory::FileTapeStore,
+    };
 
     const ADD_CONFIDENCE_SQL: &str =
         "ALTER TABLE memory_items ADD COLUMN confidence REAL NOT NULL DEFAULT 1.0";
+
+    /// Build a temp-dir-backed `TapeService` for tests.
+    async fn temp_tape_service() -> Arc<TapeService> {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let store = FileTapeStore::new(dir.path(), dir.path())
+            .await
+            .expect("tape store");
+        // Leak the tempdir so it outlives the test (cleaned up by OS on
+        // tmp purge). The store keeps its own file handles.
+        std::mem::forget(dir);
+        Arc::new(TapeService::new(store))
+    }
+
+    /// Build a `MemoryTool` with the confidence column applied, a unit
+    /// embedder, a usearch index loaded with the supplied items, and a
+    /// fresh tape service. Returns the tool plus the tape handle and
+    /// pool bundle so individual tests can inspect them.
+    async fn build_tool_with_items(
+        items: &[(&str, f32)],
+    ) -> (MemoryTool, Arc<TapeService>, DieselSqlitePools, Vec<i64>) {
+        let pools = crate::testing::build_memory_diesel_pools().await;
+        {
+            let mut conn = pools.writer.get().await.expect("pool conn");
+            diesel::sql_query(ADD_CONFIDENCE_SQL)
+                .execute(&mut *conn)
+                .await
+                .expect("add confidence column");
+        }
+
+        let config = crate::memory::knowledge::KnowledgeConfig::builder()
+            .embedding_dimensions(1_usize)
+            .search_top_k(5_usize)
+            .similarity_threshold(0.0_f32)
+            .build();
+        let embedder: LlmEmbedderRef = Arc::new(UnitEmbedder);
+        let index_path = std::env::temp_dir()
+            .join(format!("rara-test-{}", uuid::Uuid::new_v4()))
+            .join("memory.usearch");
+        let embedding_svc = crate::memory::knowledge::EmbeddingService::with_path(
+            config,
+            embedder,
+            "unit".to_string(),
+            index_path,
+        )
+        .expect("embedding svc");
+
+        let mut ids = Vec::with_capacity(items.len());
+        for (content, confidence) in items {
+            let id = insert_item_with_confidence(&pools.writer, content, *confidence).await;
+            embedding_svc
+                .add_to_index(id as u64, &[1.0])
+                .expect("index item");
+            ids.push(id);
+        }
+
+        let tape_service = temp_tape_service().await;
+        let tool = MemoryTool::new(pools.clone(), Arc::new(embedding_svc), tape_service.clone());
+        (tool, tape_service, pools, ids)
+    }
 
     /// Embedder that hands back a deterministic single-dim vector. Tests
     /// share the same `[1.0]` query so every item ends up at distance 0
@@ -236,50 +348,16 @@ mod tests {
 
     #[tokio::test]
     async fn search_prefers_high_confidence_on_ties() {
-        // Pool with the confidence column applied.
-        let pools = crate::testing::build_memory_diesel_pools().await;
-        {
-            let mut conn = pools.writer.get().await.expect("pool conn");
-            diesel::sql_query(ADD_CONFIDENCE_SQL)
-                .execute(&mut *conn)
-                .await
-                .expect("add confidence column");
-        }
-
         // Item A: high confidence. Item B: low confidence. Both share
         // the same embedding (`[1.0]`), so usearch returns identical
         // distances and the re-rank must use confidence to order them.
-        let id_high =
-            insert_item_with_confidence(&pools.writer, "high-confidence fact", 0.95).await;
-        let id_low = insert_item_with_confidence(&pools.writer, "low-confidence fact", 0.3).await;
+        let (tool, _tape, _pools, ids) =
+            build_tool_with_items(&[("high-confidence fact", 0.95), ("low-confidence fact", 0.3)])
+                .await;
+        let (id_high, id_low) = (ids[0], ids[1]);
 
-        // EmbeddingService over a unit vector and a temp index path.
-        let config = crate::memory::knowledge::KnowledgeConfig::builder()
-            .embedding_dimensions(1_usize)
-            .search_top_k(5_usize)
-            .similarity_threshold(0.0_f32)
-            .build();
-        let embedder: LlmEmbedderRef = Arc::new(UnitEmbedder);
-        let index_path = std::env::temp_dir()
-            .join(format!("rara-test-{}", uuid::Uuid::new_v4()))
-            .join("memory.usearch");
-        let embedding_svc = crate::memory::knowledge::EmbeddingService::with_path(
-            config,
-            embedder,
-            "unit".to_string(),
-            index_path,
-        )
-        .expect("embedding svc");
-        embedding_svc
-            .add_to_index(id_high as u64, &[1.0])
-            .expect("index A");
-        embedding_svc
-            .add_to_index(id_low as u64, &[1.0])
-            .expect("index B");
-
-        let tool = MemoryTool::new(pools, Arc::new(embedding_svc));
         let value = tool
-            .exec_search("alice", "any query")
+            .exec_search("alice", "session-x", "any query")
             .await
             .expect("exec_search ok");
 
@@ -295,5 +373,91 @@ mod tests {
             "high-confidence item must rank first when distances tie"
         );
         assert_eq!(second_id, id_low);
+    }
+
+    /// Scenario: search emits a ContextSources tape entry with item ids
+    /// and weights (issue #2113).
+    #[tokio::test]
+    async fn search_emits_context_sources_entry() {
+        let (tool, tape, _pools, ids) = build_tool_with_items(&[
+            ("first fact", 0.9),
+            ("second fact", 0.7),
+            ("third fact", 0.5),
+        ])
+        .await;
+
+        let value = tool
+            .exec_search("alice", "session-x", "any query")
+            .await
+            .expect("exec_search ok");
+        let returned_ids: Vec<i64> = value
+            .get("items")
+            .and_then(|v| v.as_array())
+            .expect("items array")
+            .iter()
+            .map(|v| v.get("id").and_then(|x| x.as_i64()).expect("id"))
+            .collect();
+        assert_eq!(returned_ids.len(), 3, "all three items returned");
+
+        let entries = tape.entries("session-x").await.expect("read tape");
+        let cs: Vec<&_> = entries
+            .iter()
+            .filter(|e| e.kind == TapEntryKind::ContextSources)
+            .collect();
+        assert_eq!(cs.len(), 1, "exactly one ContextSources entry");
+        let payload = &cs[0].payload;
+        let item_ids: Vec<i64> = payload
+            .get("item_ids")
+            .and_then(|v| v.as_array())
+            .expect("item_ids array")
+            .iter()
+            .map(|v| v.as_i64().expect("i64"))
+            .collect();
+        let weights = payload
+            .get("weights")
+            .and_then(|v| v.as_array())
+            .expect("weights array");
+        assert_eq!(
+            item_ids, returned_ids,
+            "item_ids preserves retrieval-rank order"
+        );
+        assert_eq!(weights.len(), item_ids.len(), "weights same length as ids");
+        // Sanity: ids are the same set as what we inserted.
+        let mut sorted_actual = item_ids.clone();
+        sorted_actual.sort();
+        let mut sorted_expected = ids.clone();
+        sorted_expected.sort();
+        assert_eq!(sorted_actual, sorted_expected);
+    }
+
+    /// Scenario: search with no matches still emits an empty
+    /// ContextSources entry (issue #2113).
+    #[tokio::test]
+    async fn search_emits_empty_context_sources_when_no_matches() {
+        // No items inserted, no embeddings in the index.
+        let (tool, tape, _pools, _ids) = build_tool_with_items(&[]).await;
+
+        tool.exec_search("alice", "session-x", "any query")
+            .await
+            .expect("exec_search ok");
+
+        let entries = tape.entries("session-x").await.expect("read tape");
+        let cs: Vec<&_> = entries
+            .iter()
+            .filter(|e| e.kind == TapEntryKind::ContextSources)
+            .collect();
+        assert_eq!(cs.len(), 1, "exactly one ContextSources entry");
+        let item_ids = cs[0]
+            .payload
+            .get("item_ids")
+            .and_then(|v| v.as_array())
+            .expect("item_ids array");
+        let weights = cs[0]
+            .payload
+            .get("weights")
+            .and_then(|v| v.as_array())
+            .expect("weights array");
+        assert!(item_ids.is_empty(), "empty item_ids on no-match search");
+        assert!(weights.is_empty(), "empty weights on no-match search");
     }
 }

--- a/crates/kernel/src/memory/mod.rs
+++ b/crates/kernel/src/memory/mod.rs
@@ -230,6 +230,15 @@ pub enum TapEntryKind {
     TaskReport,
     /// External data feed event appended via silent-append delivery.
     FeedEvent,
+    /// Retrieval trace recording which memory items shaped a turn's
+    /// context. Emitted by `MemoryTool::exec_search` once per call with
+    /// payload `{"item_ids": [...], "weights": [...]}` in
+    /// retrieval-rank order. Read back via
+    /// `KnowledgeService::explain` to power post-hoc "why did rara
+    /// think that?" inspection and to feed item ids into
+    /// `commit_outcome`. See
+    /// `specs/issue-2113-memory-explain-context-sources.spec.md`.
+    ContextSources,
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/kernel/src/testing.rs
+++ b/crates/kernel/src/testing.rs
@@ -232,10 +232,18 @@ async fn stub_knowledge_service() -> crate::memory::knowledge::KnowledgeServiceR
     )
     .expect("noop embedding service");
 
+    let tape_dir = std::env::temp_dir().join(format!("rara-test-tape-{}", uuid::Uuid::new_v4()));
+    std::fs::create_dir_all(&tape_dir).expect("tape dir");
+    let store = crate::memory::FileTapeStore::new(&tape_dir, &tape_dir)
+        .await
+        .expect("tape store");
+    let tape_service = Arc::new(crate::memory::TapeService::new(store));
+
     Arc::new(crate::memory::knowledge::KnowledgeService {
         pools: pool,
         embedding_svc: Arc::new(embedding_svc),
         config,
+        tape_service,
     })
 }
 

--- a/specs/issue-2113-memory-explain-context-sources.spec.md
+++ b/specs/issue-2113-memory-explain-context-sources.spec.md
@@ -1,0 +1,234 @@
+spec: task
+name: "issue-2113-memory-explain-context-sources"
+inherits: project
+tags: []
+---
+
+## Intent
+
+Issues 2111 and 2112 give rara a confidence-feedback loop on the
+knowledge layer. The missing third piece — borrowed from AMFS's
+`explain()` — is the *trace from a model turn back to the memory items
+that shaped its context*. Without it, the feedback loop is half-blind:
+when a tool result lands and we want to call `commit_outcome` on "the
+items that fed this turn", we cannot, because we never recorded which
+items were retrieved.
+
+It also breaks goal signal 4 ("every action is inspectable") at
+exactly the layer where opacity hurts the most: the user looks at a
+weird answer and asks "why did rara think that?", and the only path
+today is to re-run the query and hope the retrieval is deterministic.
+
+Reproducer for the failure mode:
+
+1. User asks "what dietary restrictions did I mention?". rara
+   retrieves memory items {17, 42, 88} via embedding similarity,
+   builds an LLM prompt that injects them, the model responds, the
+   tape persists the assistant message.
+2. The user later disputes the answer ("you got 88 wrong").
+3. Today: there is no way to recover from tape what items rara
+   pulled into that turn's context. The retrieval ids exist only in
+   stack frames during the turn; once the function returns they are
+   gone.
+4. Concretely: `commit_outcome(&[?], Contradicted, …)` has no
+   `?` to fill in. We end up either guessing (re-running retrieval
+   and hoping it returns the same set) or doing nothing.
+
+The fix is to persist the retrieval set as part of the tape, then
+expose a thin `KnowledgeService::explain(tape_entry_id) -> Vec<(MemoryItem, f32)>`
+API that reads it back.
+
+Goal alignment: signal 4 ("every action is inspectable" — this is
+literally the inspection seam), and it unblocks the
+"automatic-feedback-from-outcomes" follow-up that closes the loop on
+signals 2 and 5. Crosses no `NOT` line — single-user, inspectable,
+not a framework.
+
+Prior art reviewed (raw):
+
+- `gh issue list --search "explain memory"` — 0 matching issues.
+- `gh pr list --search "context sources memory"` — 0 PRs.
+- `git log --grep=explain --since=180.days` — only unrelated hits
+  (commit messages mentioning the word in prose).
+- `rg -n "ContextSources" crates/` — 0 matches. Greenfield name.
+- `crates/kernel/src/memory/codec.rs` and `crates/kernel/src/memory/`
+  define `TapEntryKind` — confirmed via `context.rs` which matches
+  on `Message | ToolCall | ToolResult | Event | System | Anchor |
+  Note | Summary` (8 variants). Adding a ninth kind is the existing
+  extension mechanism; no novelty in the approach.
+- The retrieval path is centralized in
+  `crates/kernel/src/memory/knowledge/tool.rs::exec_search` and
+  `crates/kernel/src/memory/knowledge/extractor.rs` — finite set of
+  call sites to record from.
+
+## Decisions
+
+- **Depends on issues 2111 and 2112** merged into `main`. The
+  `MemoryItem.confidence` field that `explain()` returns alongside
+  each item lands in 2111; the `commit_outcome` consumer that this
+  trace exists to serve lands in 2112.
+- **New `TapEntryKind::ContextSources`** variant with payload shape:
+  ```
+  { "item_ids": [17, 42, 88], "weights": [0.93, 0.81, 0.55] }
+  ```
+  `weights` are the per-item retrieval scores at the moment of the
+  turn — for the embedding-search path that is
+  `1.0 - distance` clamped to `[0.0, 1.0]`. Why include weights at
+  all and not just ids: future `explain()` callers want a "how much
+  did each item contribute" answer, not just a set; the weight is
+  free at retrieval time and expensive to reconstruct later.
+  Recording it now avoids a second migration when the UI surface
+  needs it.
+- **Per-turn emission contract**: `MemoryTool::exec_search` writes
+  exactly one `ContextSources` tape entry per call, on the **current
+  turn's tape**, before the search results return to the caller.
+  Empty result sets still emit an entry (with empty arrays) so that
+  `explain()` can distinguish "search ran and found nothing" from
+  "search never ran".
+- **Tape selection**: the existing `TapeService` already routes
+  writes; the entry attaches to the same tape the calling turn is
+  appending to. The implementer wires this through the
+  `MemoryTool`'s existing access to the tape service (the tool is
+  already kernel-resident; this is a service-locator decision,
+  not a new dependency). If the tool does not already hold a
+  `TapeService` reference, add it on construction — `MemoryTool` is
+  built inside the kernel, no public API change leaks.
+- **`KnowledgeService::explain` signature**:
+  ```
+  pub async fn explain(
+      &self,
+      tape_name: &str,
+      turn_entry_id: i64,
+  ) -> Result<Vec<(MemoryItem, f32)>>;
+  ```
+  Why two parameters: the kernel uses `(tape_name, entry_id)` as the
+  identity of a tape entry — there is no globally unique
+  `tape_entry_id`. (Verified against the tape store layout:
+  `FileTapeStore` indexes by `(tape_name, entry_id)`.) Returning a
+  pair `(item, weight)` mirrors the persisted shape. Items are
+  returned in the order they appear in the tape entry's
+  `item_ids` array — i.e. retrieval-rank order, not by id — so the
+  caller can show the most-contributing memory first.
+- **Resolution semantics**:
+  - If no `ContextSources` entry exists for `(tape_name, turn_entry_id)`
+    or any entry within the same turn-window, return `Ok(vec![])` —
+    "the turn did not consult memory" is a valid answer.
+    Concretely the implementer walks the tape from
+    `turn_entry_id` forward until the next non-tool entry,
+    collecting `ContextSources` entries; in practice there is
+    zero or one.
+  - If a `ContextSources` entry references an `item_id` that has
+    been deleted since the turn, that id is skipped from the
+    returned vec (no error). Rationale: matching `commit_outcome`'s
+    skip-unknown-ids policy; explain is a debugging seam, not a
+    consistency contract.
+- **Do NOT add a new MCP tool** that exposes `explain` to the LLM.
+  This is an internal Rust API; UI / API surface comes later.
+- **Do NOT auto-call `commit_outcome` from `explain` results.** That
+  wiring is a separate change; this PR is read-only on the
+  confidence column.
+- **`ContextSources` entries are recorded for ALL search calls**
+  (not gated on a config flag). Per project spec, "mechanism
+  defaults are always on"; adding a YAML toggle here is exactly the
+  mechanism-vs-config anti-pattern. The cost is one extra tape
+  append per `MemoryTool::search` action — negligible at JSONL
+  write rates.
+- **`weights` precision**: stored as `f32` after clamp; serialized
+  to JSON via `serde_json` default. No rounding beyond IEEE-754
+  representation. The downstream consumers do not depend on exact
+  values, only ordering.
+
+## Boundaries
+
+### Allowed Changes
+- crates/kernel/src/memory/codec.rs
+- **/crates/kernel/src/memory/codec.rs
+- crates/kernel/src/memory/mod.rs
+- **/crates/kernel/src/memory/mod.rs
+- crates/kernel/src/memory/knowledge/service.rs
+- **/crates/kernel/src/memory/knowledge/service.rs
+- crates/kernel/src/memory/knowledge/tool.rs
+- **/crates/kernel/src/memory/knowledge/tool.rs
+- crates/kernel/src/memory/knowledge/mod.rs
+- **/crates/kernel/src/memory/knowledge/mod.rs
+- crates/kernel/src/testing.rs
+- **/crates/kernel/src/testing.rs
+- crates/app/src/boot.rs
+- **/crates/app/src/boot.rs
+- specs/issue-2113-memory-explain-context-sources.spec.md
+- **/specs/issue-2113-memory-explain-context-sources.spec.md
+
+### Forbidden
+- crates/rara-model/**
+- crates/kernel/src/memory/knowledge/items.rs
+- crates/kernel/src/memory/knowledge/extractor.rs
+- crates/kernel/src/memory/knowledge/embedding.rs
+- crates/kernel/src/memory/knowledge/outcome.rs
+- crates/kernel/src/memory/knowledge/config.rs
+- crates/kernel/src/memory/knowledge/categories.rs
+- crates/kernel/src/memory/context.rs
+- crates/kernel/src/memory/store.rs
+- crates/kernel/src/memory/tree.rs
+- crates/kernel/src/memory/anchors.rs
+- config.example.yaml
+- .github/workflows/**
+- docs/**
+- web/**
+
+## Completion Criteria
+
+Scenario: search emits a ContextSources tape entry with item ids and weights
+  Test:
+    Package: rara-kernel
+    Filter: memory::knowledge::tool::tests::search_emits_context_sources_entry
+  Given a knowledge corpus with three memory items embedded and indexed
+  When MemoryTool::exec_search runs for a query that matches all three
+  Then exactly one ContextSources entry is appended to the active tape, its item_ids array equals the returned ids in order, and its weights array has the same length
+
+Scenario: search with no matches still emits an empty ContextSources entry
+  Test:
+    Package: rara-kernel
+    Filter: memory::knowledge::tool::tests::search_emits_empty_context_sources_when_no_matches
+  Given an empty knowledge corpus
+  When MemoryTool::exec_search runs against any query
+  Then a ContextSources entry exists on the tape with item_ids = [] and weights = []
+
+Scenario: explain returns the memory items recorded for a turn in retrieval order
+  Test:
+    Package: rara-kernel
+    Filter: memory::knowledge::service::tests::explain_returns_items_in_retrieval_order
+  Given a tape with a ContextSources entry referencing memory items {17, 42, 88} with weights {0.93, 0.81, 0.55}
+  When KnowledgeService::explain runs against that tape and the entry id of the turn
+  Then it returns the three MemoryItem rows paired with the weights in the same order
+
+Scenario: explain returns an empty vec when the turn did not consult memory
+  Test:
+    Package: rara-kernel
+    Filter: memory::knowledge::service::tests::explain_returns_empty_for_turn_without_context_sources
+  Given a tape with a Message turn entry but no ContextSources entry following it
+  When KnowledgeService::explain runs against that turn's entry id
+  Then it returns Ok with an empty vec
+
+Scenario: explain skips item ids whose memory_items rows have been deleted
+  Test:
+    Package: rara-kernel
+    Filter: memory::knowledge::service::tests::explain_skips_deleted_item_ids
+  Given a ContextSources entry referencing item ids {17, 42, 88} where item 42 has since been deleted
+  When KnowledgeService::explain runs
+  Then it returns items 17 and 88 only, paired with their original weights, in the original order
+
+## Out of Scope
+
+- Auto-calling `commit_outcome` based on `explain` results.
+- Recording context sources for the `extractor` path (which does its
+  own embedding search) — only the user-visible `MemoryTool::search`
+  path emits in this PR. Extractor-time recording is a separate
+  follow-up; the failure mode there is different (no user-facing
+  turn to attribute back to).
+- Surfacing `explain` over HTTP / MCP / UI. Internal Rust API only.
+- Adding decay-over-time to confidence.
+- A backward-fill of `ContextSources` for historical turns.
+- Changing how `default_tape_context` reconstructs LLM messages —
+  `ContextSources` is non-conversational like `Anchor` / `Note` /
+  `Summary` and is skipped by the existing `_ => {}` arm in
+  `crates/kernel/src/memory/context.rs:46..63`.


### PR DESCRIPTION
## Summary

Adds an `explain()` API to the memory subsystem that traces which memory items shaped a given turn — completing the AMFS-inspired memory trilogy:

- #2111 — schema foundation
- #2112 — `commit_outcome` + ranking
- #2113 — `explain()` (this PR)

Spec: `specs/issue-2113-memory-explain-context-sources.spec.md`

## Review

Reviewer APPROVE on commit 6284ebda — 0 blocking issues, 4 P3 nits deferred.

## CI

The shared CI runner is currently unhealthy; user authorized direct merge after local verification (full quality gate + spec lifecycle green).

Closes #2113