### PR TITLE
chore(spec): upgrade agent-spec 0.3.0 + kill zero-match false-green (#2165)

### DIFF
--- a/init.sh
+++ b/init.sh
@@ -60,6 +60,20 @@ else
     fail "prek not found — install: brew install prek"
 fi
 
+# agent-spec powers the lane-1 BDD gate (just spec-lint / spec-lifecycle /
+# spec-selftest). Minimum version pinned here — versions below it carry the
+# zero-match false-green documented in issue #2165 / PR #2038.
+AGENT_SPEC_MIN_VERSION="0.3.0"
+if agent_spec_version=$(agent-spec --version 2>/dev/null | awk '{print $2}') && [ -n "$agent_spec_version" ]; then
+    if [ "$(printf '%s\n%s\n' "$AGENT_SPEC_MIN_VERSION" "$agent_spec_version" | sort -V | head -1)" = "$AGENT_SPEC_MIN_VERSION" ]; then
+        ok "agent-spec: ${agent_spec_version} (>= ${AGENT_SPEC_MIN_VERSION})"
+    else
+        fail "agent-spec ${agent_spec_version} < ${AGENT_SPEC_MIN_VERSION} — upgrade: cargo install agent-spec --version ${AGENT_SPEC_MIN_VERSION} --locked --force"
+    fi
+else
+    fail "agent-spec not found — install: cargo install agent-spec --version ${AGENT_SPEC_MIN_VERSION} --locked"
+fi
+
 # mise is warn-only: it pins the non-Rust toolchain (node/bun/go/just/gh) for
 # parity with CI, but rustup-only contributors working on pure Rust changes
 # can still pass this check. See docs/guides/tooling.md.

--- a/justfile
+++ b/justfile
@@ -402,11 +402,34 @@ spec-init slug:
 spec-lint spec:
     @agent-spec lint {{spec}} --min-score 0.7
 
-# Run lint + verify + report against the current worktree.
+# Run lint + verify + report against the current worktree. Routes through the
+# zero-match guard: a Test selector that resolves to zero tests is a FAIL even
+# when agent-spec itself reports green (issue #2165 / PR #2038 false-green).
 [doc("verify a task spec against this worktree: just spec-lifecycle specs/issue-N-<slug>.spec.md")]
 [group("📝 Spec")]
 spec-lifecycle spec:
-    @agent-spec lifecycle {{spec}} --code . --change-scope worktree --format text
+    @./scripts/spec-lifecycle-guard.sh {{spec}}
+
+# Regression lock for the zero-match false-green: the lifecycle gate must
+# REJECT specs/fixtures/zero-match.spec.md. If this goes red, the false-green
+# class has returned (upstream regression or guard removal).
+[doc("assert the lifecycle gate rejects the zero-match fixture")]
+[group("📝 Spec")]
+spec-selftest:
+    #!/usr/bin/env bash
+    set -uo pipefail
+    if ./scripts/spec-lifecycle-guard.sh specs/fixtures/zero-match.spec.md; then
+        echo "spec-selftest: FAIL — zero-match fixture passed the lifecycle gate (false-green is back)"
+        exit 1
+    fi
+    echo "spec-selftest: OK — lifecycle gate rejected the zero-match fixture"
+
+# Check that every Test: selector in specs/issue-*.spec.md still resolves to
+# at least one real test (spec drift). Skips specs/fixtures/ by construction.
+[doc("sweep task specs for Test: selectors that no longer resolve")]
+[group("📝 Spec")]
+spec-drift-sweep:
+    @./scripts/spec-drift-sweep.sh
 
 # Render the agent-facing contract view (Intent + Decisions + Boundaries + Acceptance).
 [doc("render the contract view of a spec: just spec-contract specs/issue-N-<slug>.spec.md")]

--- a/justfile
+++ b/justfile
@@ -418,11 +418,16 @@ spec-lifecycle spec:
 spec-selftest:
     #!/usr/bin/env bash
     set -uo pipefail
-    if ./scripts/spec-lifecycle-guard.sh specs/fixtures/zero-match.spec.md; then
-        echo "spec-selftest: FAIL — zero-match fixture passed the lifecycle gate (false-green is back)"
-        exit 1
-    fi
-    echo "spec-selftest: OK — lifecycle gate rejected the zero-match fixture"
+    # Only guard exit 1 (verification failure) counts as "fixture rejected".
+    # Exit 0 means the false-green is back; exit 2 means the gate could not
+    # even run (agent-spec/jq missing, malformed report) — both are failures.
+    ./scripts/spec-lifecycle-guard.sh specs/fixtures/zero-match.spec.md
+    rc=$?
+    case "$rc" in
+        1) echo "spec-selftest: OK — lifecycle gate rejected the zero-match fixture (exit 1)" ;;
+        0) echo "spec-selftest: FAIL — zero-match fixture passed the lifecycle gate (false-green is back)"; exit 1 ;;
+        *) echo "spec-selftest: FAIL — guard could not run the gate (infra error, exit ${rc})"; exit 1 ;;
+    esac
 
 # Check that every Test: selector in specs/issue-*.spec.md still resolves to
 # at least one real test (spec drift). Skips specs/fixtures/ by construction.

--- a/scripts/spec-drift-sweep.sh
+++ b/scripts/spec-drift-sweep.sh
@@ -11,7 +11,7 @@
 # Exit code: 0 when every checked selector resolves, 1 otherwise.
 
 set -uo pipefail
-cd "$(dirname "${BASH_SOURCE[0]}")/.."
+cd "$(dirname "${BASH_SOURCE[0]}")/.." || exit 1
 
 DRIFTED=0
 CHECKED=0

--- a/scripts/spec-drift-sweep.sh
+++ b/scripts/spec-drift-sweep.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# spec-drift-sweep.sh — check that every `Test:` selector in
+# specs/issue-*.spec.md still resolves to >=1 test function in the current
+# workspace (spec drift baseline, issue #2165).
+#
+# Skips specs/fixtures/** by construction (the glob below only matches real
+# task specs; fixtures intentionally violate resolution — that is what they
+# test). Selectors with `Package: web` are reported as SKIP: there is no
+# vitest adapter yet (issue #2015).
+#
+# Exit code: 0 when every checked selector resolves, 1 otherwise.
+
+set -uo pipefail
+cd "$(dirname "${BASH_SOURCE[0]}")/.."
+
+DRIFTED=0
+CHECKED=0
+SKIPPED=0
+
+for spec in specs/issue-*.spec.md; do
+    [ -e "$spec" ] || continue
+    # Package/Filter pairs appear in this order under each Test: block.
+    while IFS=$'\t' read -r pkg filter; do
+        [ -n "$pkg" ] && [ -n "$filter" ] || continue
+        if [ "$pkg" = "web" ]; then
+            echo "SKIP   $spec :: $pkg :: $filter (no vitest adapter — issue #2015)"
+            SKIPPED=$((SKIPPED + 1))
+            continue
+        fi
+        CHECKED=$((CHECKED + 1))
+        if out=$(cargo test -p "$pkg" "$filter" -- --list 2>&1); then
+            matches=$(printf '%s\n' "$out" | grep -c ': test$')
+            if [ "${matches:-0}" -gt 0 ]; then
+                echo "OK     $spec :: $pkg :: $filter (${matches} match(es))"
+            else
+                echo "DRIFT  $spec :: $pkg :: $filter (resolves to zero tests)"
+                DRIFTED=$((DRIFTED + 1))
+            fi
+        else
+            echo "DRIFT  $spec :: $pkg :: $filter (cargo test --list failed: unknown package or build error)"
+            DRIFTED=$((DRIFTED + 1))
+        fi
+    done < <(awk '
+        /^[[:space:]]*Package:[[:space:]]*/ { pkg = $2 }
+        /^[[:space:]]*Filter:[[:space:]]*/  { print pkg "\t" $2 }
+    ' "$spec")
+done
+
+echo
+echo "spec-drift-sweep: ${CHECKED} checked, ${DRIFTED} drifted, ${SKIPPED} skipped (web)"
+[ "$DRIFTED" -eq 0 ]

--- a/scripts/spec-lifecycle-guard.sh
+++ b/scripts/spec-lifecycle-guard.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# spec-lifecycle-guard.sh — zero-match guard around `agent-spec lifecycle`.
+#
+# agent-spec (<= 0.3.0) reports a scenario as passed even when the cargo test
+# filter matches ZERO tests ("running 0 tests" / "0 passed; N filtered out").
+# That false-green converts "unverified" into "verified" — see issue #2165 and
+# the verbatim record in PR #2038. Upstream report:
+# https://github.com/ZhangHanDong/agent-spec/issues/4
+#
+# This wrapper runs the lifecycle with JSON output, then inspects the raw
+# runner output captured in each scenario's test evidence. A scenario whose
+# test runs executed zero tests (0 passed AND 0 failed across every
+# `test result:` line) is a FAIL, regardless of agent-spec's own verdict.
+#
+# `just spec-lifecycle` routes through this script; `just spec-selftest`
+# asserts it rejects specs/fixtures/zero-match.spec.md.
+#
+# Usage: scripts/spec-lifecycle-guard.sh <spec-file>
+
+set -uo pipefail
+
+if [ $# -ne 1 ]; then
+    echo "usage: $0 <spec-file>" >&2
+    exit 2
+fi
+SPEC="$1"
+
+for tool in agent-spec jq; do
+    if ! command -v "$tool" >/dev/null 2>&1; then
+        echo "spec-lifecycle-guard: '$tool' not found — run ./init.sh for install hints" >&2
+        exit 2
+    fi
+done
+
+REPORT="$(mktemp)"
+trap 'rm -f "$REPORT"' EXIT
+
+agent-spec lifecycle "$SPEC" --code . --change-scope worktree --format json >"$REPORT"
+LIFECYCLE_EXIT=$?
+
+# Human-readable summary of the JSON report (text format omits runner output,
+# which is exactly what the guard needs — so we run JSON once and render it).
+jq -r '
+  "=== Lifecycle Report (guarded) ===",
+  "Spec: \(.verification.spec_name // "unknown")  stage: \(.stage)  passed: \(.passed)",
+  (.verification.results[]? | "  [\(.verdict | ascii_upcase)] \(.scenario_name)")
+' "$REPORT" || cat "$REPORT"
+
+if [ "$LIFECYCLE_EXIT" -ne 0 ]; then
+    echo "spec-lifecycle-guard: agent-spec lifecycle exited $LIFECYCLE_EXIT" >&2
+    exit "$LIFECYCLE_EXIT"
+fi
+
+# Zero-match detection: for every scenario with test evidence, sum executed
+# tests (passed + failed) across all `test result:` lines in the captured
+# runner stdout. Zero executed tests means the selector resolved to nothing.
+ZERO_MATCH=$(jq -r '
+  [ .verification.results[]?
+    | select([.evidence[]? | select(.type == "test_output")] | length > 0)
+    | { scenario: .scenario_name,
+        executed: ([ .evidence[]?
+                     | select(.type == "test_output")
+                     | .stdout // ""
+                     | scan("(\\d+) passed; (\\d+) failed")
+                     | map(tonumber) | add
+                   ] | add // 0) }
+    | select(.executed == 0)
+    | .scenario
+  ] | .[]
+' "$REPORT")
+
+if [ -n "$ZERO_MATCH" ]; then
+    echo "" >&2
+    echo "spec-lifecycle-guard: FAIL — Test selector(s) matched ZERO tests (0 passed; filtered out):" >&2
+    while IFS= read -r scenario; do
+        [ -n "$scenario" ] && echo "  - $scenario" >&2
+    done <<< "$ZERO_MATCH"
+    echo "Every lane-1 Test: selector must resolve to >=1 real test function — see specs/README.md." >&2
+    exit 1
+fi
+
+echo "spec-lifecycle-guard: OK — every Test selector executed >=1 test"
+exit 0

--- a/scripts/spec-lifecycle-guard.sh
+++ b/scripts/spec-lifecycle-guard.sh
@@ -11,9 +11,18 @@
 # runner output captured in each scenario's test evidence. A scenario whose
 # test runs executed zero tests (0 passed AND 0 failed across every
 # `test result:` line) is a FAIL, regardless of agent-spec's own verdict.
+# The guard fails CLOSED: a report it cannot parse, or one carrying no
+# scenario results at all, is never treated as verified.
+#
+# Exit-code contract:
+#   0 — lifecycle passed AND every Test selector executed >= 1 test
+#   1 — verification failure (lifecycle itself failed, or a selector
+#       matched zero tests)
+#   2 — infra/usage error (bad args; agent-spec or jq missing; report is
+#       malformed JSON or missing .verification.results — schema drift)
 #
 # `just spec-lifecycle` routes through this script; `just spec-selftest`
-# asserts it rejects specs/fixtures/zero-match.spec.md.
+# asserts it rejects specs/fixtures/zero-match.spec.md with exit 1.
 #
 # Usage: scripts/spec-lifecycle-guard.sh <spec-file>
 
@@ -44,17 +53,27 @@ jq -r '
   "=== Lifecycle Report (guarded) ===",
   "Spec: \(.verification.spec_name // "unknown")  stage: \(.stage)  passed: \(.passed)",
   (.verification.results[]? | "  [\(.verdict | ascii_upcase)] \(.scenario_name)")
-' "$REPORT" || cat "$REPORT"
+' "$REPORT" 2>/dev/null || cat "$REPORT"
 
 if [ "$LIFECYCLE_EXIT" -ne 0 ]; then
-    echo "spec-lifecycle-guard: agent-spec lifecycle exited $LIFECYCLE_EXIT" >&2
-    exit "$LIFECYCLE_EXIT"
+    echo "spec-lifecycle-guard: FAIL — agent-spec lifecycle exited $LIFECYCLE_EXIT" >&2
+    exit 1
+fi
+
+# Fail closed on malformed JSON or schema drift: a green lifecycle whose
+# report carries no scenario results verified nothing.
+if ! jq -e '.verification.results | type == "array" and length > 0' "$REPORT" >/dev/null 2>&1; then
+    echo "spec-lifecycle-guard: report is malformed JSON or has no scenario results (.verification.results) — refusing to treat it as verified" >&2
+    exit 2
 fi
 
 # Zero-match detection: for every scenario with test evidence, sum executed
 # tests (passed + failed) across all `test result:` lines in the captured
 # runner stdout. Zero executed tests means the selector resolved to nothing.
-ZERO_MATCH=$(jq -r '
+# Scenarios WITHOUT test_output evidence are skipped on purpose: boundary
+# checks carry none, and web specs produce none until the vitest adapter
+# lands (issue #2015) — do not "fix" this skip into a web-spec breaker.
+if ! ZERO_MATCH=$(jq -r '
   [ .verification.results[]?
     | select([.evidence[]? | select(.type == "test_output")] | length > 0)
     | { scenario: .scenario_name,
@@ -67,7 +86,10 @@ ZERO_MATCH=$(jq -r '
     | select(.executed == 0)
     | .scenario
   ] | .[]
-' "$REPORT")
+' "$REPORT"); then
+    echo "spec-lifecycle-guard: failed to scan the lifecycle report for zero-match evidence (jq error)" >&2
+    exit 2
+fi
 
 if [ -n "$ZERO_MATCH" ]; then
     echo "" >&2

--- a/specs/README.md
+++ b/specs/README.md
@@ -60,10 +60,34 @@ to a real test function that meaningfully verifies the outcome?"**
 If unsure, lane 2 — overhead-on-the-side-of-less. Lane 1's value is the BDD
 binding. Without that binding, lane 1 produces ceremony, not safety.
 
+## Test selectors MUST resolve to real tests
+
+Every lane-1 spec's `Test:` selectors MUST resolve to **at least one real
+test function** in the current codebase. A lifecycle run whose test output
+shows `filtered out` with **0 passed** (cargo ran `0 tests` for that
+selector) is a **FAIL, never a pass** — nothing was executed, so nothing
+was verified.
+
+Background: agent-spec (<= 0.3.0) reports such scenarios as green — the
+zero-match false-green documented in PR #2038 and issue #2165, reported
+upstream. `just spec-lifecycle` therefore routes through
+`scripts/spec-lifecycle-guard.sh`, which inspects the per-scenario runner
+output and exits non-zero on the zero-match signature regardless of
+agent-spec's own verdict. Do not call `agent-spec lifecycle` directly.
+
+Self-check: `just spec-selftest` asserts the gate rejects
+`specs/fixtures/zero-match.spec.md` (a fixture whose selector intentionally
+matches zero tests). If the selftest goes red, the false-green class has
+returned. `just spec-drift-sweep` checks all existing task specs for
+selectors that no longer resolve (spec drift).
+
 ## Naming
 
 - Task spec files: `specs/issue-<N>-<slug>.spec.md`
 - Inherits clause: `inherits: project` (the constraints in `project.spec`)
+- Fixtures for the verification tooling itself: `specs/fixtures/*.spec.md`
+  — intentionally outside the `issue-N-` convention so tooling that globs
+  real task specs never picks them up
 
 ## Project-level constraints
 

--- a/specs/fixtures/zero-match.spec.md
+++ b/specs/fixtures/zero-match.spec.md
@@ -1,0 +1,60 @@
+spec: task
+name: "fixture-zero-match"
+inherits: project
+tags: []
+---
+
+## Intent
+
+This is a **test fixture, not a real task spec**. It exists to prove that
+the spec-lifecycle gate rejects a spec whose `Test:` selector resolves to
+zero test functions (the agent-spec 0.2.7 false-green documented in
+PR 2038 and issue 2165: cargo test prints `0 passed; N filtered out` and
+the lifecycle still exits green).
+
+`just spec-selftest` runs the lifecycle gate against this file and asserts
+a NON-ZERO exit. If this fixture ever passes the gate, the zero-match
+false-green class has returned (upstream regression or guard removal) and
+the selftest goes red.
+
+Reproducer this fixture encodes:
+
+1. A lane-1 spec names a test function that does not exist (typo, or the
+   test was renamed/deleted after the spec was written — spec drift).
+2. `just spec-lifecycle` runs cargo test with that filter.
+3. cargo test reports `0 passed; N filtered out`; nothing was executed,
+   yet the tool reports the scenario as passed.
+
+## Decisions
+
+- The `Filter:` below intentionally names a test function that must never
+  exist anywhere in the workspace. Do NOT "fix" it to point at a real test.
+- This file lives in `specs/fixtures/`, outside the `issue-N-*.spec.md`
+  naming convention, so tooling that globs real task specs must not pick
+  it up.
+- Boundaries allow everything: `just spec-selftest` runs in arbitrarily
+  dirty worktrees, and the selftest must fail on the zero-match class
+  alone — never on an incidental boundary violation.
+
+## Boundaries
+
+### Allowed Changes
+- **
+
+### Forbidden
+- this/path/must/never/exist/**
+
+## Completion Criteria
+
+Scenario: selector intentionally matches zero tests
+  Test:
+    Package: rara-paths
+    Filter: fixture_zero_match_this_test_function_must_never_exist
+  Given a Test selector naming a test function that does not exist in the workspace
+  When the spec lifecycle gate runs cargo test with that filter
+  Then the runner reports zero executed tests and the gate must fail
+
+## Out of Scope
+
+- Everything. This fixture verifies the verification tooling itself; it
+  makes no claim about rara behavior.

--- a/specs/fixtures/zero-match.spec.md
+++ b/specs/fixtures/zero-match.spec.md
@@ -8,7 +8,7 @@ tags: []
 
 This is a **test fixture, not a real task spec**. It exists to prove that
 the spec-lifecycle gate rejects a spec whose `Test:` selector resolves to
-zero test functions (the agent-spec 0.2.7 false-green documented in
+zero test functions (the agent-spec <= 0.3.0 false-green documented in
 PR 2038 and issue 2165: cargo test prints `0 passed; N filtered out` and
 the lifecycle still exits green).
 


### PR DESCRIPTION
## Summary

`agent-spec` (the lane-1 BDD gate behind `just spec-lint` / `just spec-lifecycle`) reports a scenario as **passed** when the cargo test filter matches **zero** tests (`0 passed; N filtered out`) — the false-green documented verbatim in PR #2038. Falsification confirmed the bug **persists in 0.3.0**: `agent-spec lifecycle` exits 0 with `passed=true` while the report's captured runner stdout shows `running 0 tests`. Reported upstream (ZhangHanDong/agent-spec#4, closed as completed same-day; a future follow-up bumps the min version when the fixed release ships). Per the issue Decision, the local guard is unconditional defense-in-depth:

- **Upgrade to agent-spec 0.3.0** — `lifecycle --code . --change-scope worktree` flags parse unchanged; `init.sh` doctor now pins `agent-spec >= 0.3.0` (fatal check, `AGENT_SPEC_MIN_VERSION`).
- **`scripts/spec-lifecycle-guard.sh`** — wraps `agent-spec lifecycle` (JSON output), sums executed tests (passed+failed) per scenario's `test_output` evidence, exits non-zero on zero-match regardless of agent-spec's verdict. Fails CLOSED on malformed JSON / schema drift / missing scenario results. Exit contract: 0 = verified pass, 1 = verification failure, 2 = infra error. `just spec-lifecycle` routes through it.
- **`specs/fixtures/zero-match.spec.md`** — permanent fixture whose selector intentionally resolves to zero tests; **`just spec-selftest`** asserts the gate rejects it with exactly exit 1 (exit 0 = false-green back; exit 2 = gate could not run — both distinct selftest failures). Fixture lives outside the `issue-N-*` naming so task-spec tooling never picks it up.
- **`scripts/spec-drift-sweep.sh`** + `just spec-drift-sweep` — checks every `specs/issue-*.spec.md` `Test:` selector still resolves (skips `specs/fixtures/` by construction; `Package: web` reported SKIP pending the vitest adapter, #2015).
- **`specs/README.md`** — documents the rule: every lane-1 `Test:` selector MUST resolve to >= 1 real test function; `filtered out` with 0 passed is a FAIL, never a pass.

### Deliverable-5 evidence: spec-drift baseline

Full sweep results (81 selectors: 40 OK, 9 true zero-match drift, 32 unverifiable, 34 web SKIP): https://github.com/rararulab/rara/issues/2165#issuecomment-4881100131

### Notes

- **Pre-existing breakage on `main`, unrelated to this PR:** `rara-mcp` fails to compile at `edcca1ca` (`E0599` on `Option<Arc<InitializeResult>>::cloned`, `crates/integrations/mcp/src/client.rs:297`, rmcp 1.8.0 from the #2148 dep sweep) — so `cargo check --workspace --all-targets` / `prek run --all-files` are red on `main` today. Tracked in #2167. This diff touches no Rust/TOML; the commit-scope prek gate is green.
- **CI will not report on this PR** until the runner fleet restoration (#2166) lands — the arc-runner-set fleet is gone repo-wide. The current required check is `signoff`; merge sequencing is coordinated by the parent. Not waiting on queued checks is deliberate.

## Type of change

Maintenance (`chore`) + CI/Infrastructure (`ci`)

## Component

`ci` (verification tooling: justfile, scripts, specs docs, init.sh doctor)

## Closes

Closes #2165

## Test plan

- [x] Falsification: raw `agent-spec lifecycle` on the zero-match fixture → exit 0 / `passed=true` with `"stdout": "...running 0 tests...0 passed..."` in evidence (bug confirmed on 0.3.0)
- [x] `just spec-selftest` → guard exits 1 on the fixture → `spec-selftest: OK` (regression lock)
- [x] Positive control (real selector `rara-server::trace_headers_x_request_id_matches_otel_trace_id`) → guard exit 0
- [x] Fake agent-spec emitting malformed JSON (`{ not json`, exit 0) → guard exit 2 (fail-closed)
- [x] Fake agent-spec emitting valid JSON without `.verification.results` → guard exit 2 (fail-closed)
- [x] PATH without agent-spec → `just spec-selftest` FAILS with distinct infra-error message
- [x] `shellcheck` clean on both scripts; `just --list` parses; `agent-spec lint` on the fixture passes
- [x] `prek` green on the commit scope (no Rust/TOML in diff; cargo hooks correctly skipped)
- [ ] `just test` / repo-wide `prek run --all-files` — red on `main` independent of this PR (rara-mcp breakage, #2167)

🤖 Generated with [Claude Code](https://claude.com/claude-code)