### PR TITLE
ci: restore real CI as the merge gate (GitHub-hosted runners + required checks) (#2166)

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -6,9 +6,10 @@
 # Any future RUSTFLAGS additions go here, NOT in `.github/workflows/*.yml`
 # `env:` blocks.
 
-# Linux CI runners (`arc-runner-set`) have `mold` baked into the image
-# (#1942) but rustc was never told to use it — so every link step fell
-# back to GNU ld. This stanza closes that gap.
+# Linux x64 CI jobs install `mold` + `clang` explicitly (GitHub-hosted
+# images do not bake them; the old `arc-runner-set` image did, #1942 —
+# fleet retired, see #2166). This stanza tells rustc to actually link
+# with mold instead of falling back to GNU ld.
 #
 # Target-scoped: macOS dev machines see no change (mold doesn't run on
 # Darwin). `linker = "clang"` is the canonical mold invocation per
@@ -16,3 +17,8 @@
 [target.x86_64-unknown-linux-gnu]
 linker = "clang"
 rustflags = ["-C", "link-arg=-fuse-ld=mold", "-D", "warnings"]
+
+# Linux arm64 CI jobs (`ubuntu-24.04-arm`) keep warnings-as-errors but use
+# the default linker — no mold on the arm64 leg today.
+[target.aarch64-unknown-linux-gnu]
+rustflags = ["-D", "warnings"]

--- a/.claude/workflows/rara-dev.js
+++ b/.claude/workflows/rara-dev.js
@@ -34,7 +34,7 @@ export const meta = {
     { title: 'Implement', detail: 'one implementer per issue: worktree + code + quality gate + local commit' },
     { title: 'Verify', detail: 'fresh-context verifier (S3, harness/roles/verifier.md): clean-state gate + cold boot + hostile probes; FAIL -> one repair round -> escalate' },
     { title: 'Review', detail: 'reviewer <-> implementer loop until APPROVE (max 3 rounds), before push; fix commits invalidate the verify verdict and trigger a one-shot re-verify' },
-    { title: 'Ship', detail: 'push + gh pr create (verification report path in PR body) + gh signoff (runner down) / gh pr checks --watch; stops before merge' },
+    { title: 'Ship', detail: 'push + gh pr create (verification report path in PR body) + gh pr checks --watch (real CI gate); stops before merge' },
   ],
 }
 
@@ -49,15 +49,29 @@ const MAX_REVIEW_ROUNDS = 3
 // FAIL -> one structured repair dispatch -> re-verify -> still FAIL -> stop and
 // escalate to human. Distinct from the review loop's 3-round cap above.
 const MAX_VERIFY_REPAIR_ROUNDS = 1
-// 'signoff' (default — self-hosted runner is down): ship pushes + opens the PR +
-//   runs `gh signoff`. main's only required check is `signoff`, and the LOCAL
-//   quality gate (prek/cargo/bun) from the implement stage is the green signal,
-//   so signing off makes the PR mergeable without the remote runner.
-// 'watch': self-hosted runner healthy — ship runs `gh pr checks --watch`, requires green CI.
-// 'skip': no GitHub-level gate at all (signoff uninstalled) — ship stops after PR creation;
+// 'watch' (default — real CI on GitHub-hosted runners, #2166): ship runs
+//   `gh pr checks --watch` and requires the required checks (Rust Success /
+//   Lint Success) to go green.
+// 'signoff': EMERGENCY OVERRIDE ONLY (e.g. GitHub-hosted runner outage) —
+//   ship pushes + opens the PR + runs `gh signoff` instead of watching CI.
+//   Requires branch protection to have been temporarily flipped back to
+//   ["signoff"] per the procedure in docs/guides/workflow.md. Explicit
+//   opt-in via args.ci; never the default.
+// 'skip': no GitHub-level gate at all — ship stops after PR creation;
 //   the implement-stage local gate is the only verification.
-// Flip the default back to 'watch' when the self-hosted runner recovers.
-const CI_MODE = (args && typeof args === 'object' && args.ci) ? args.ci : 'signoff'
+const CI_MODE = (args && typeof args === 'object' && args.ci) ? args.ci : 'watch'
+if (!['watch', 'signoff', 'skip'].includes(CI_MODE)) {
+  throw new Error(`rara-dev: unknown ci mode ${JSON.stringify(CI_MODE)} — expected 'watch', 'signoff', or 'skip'.`)
+}
+if (CI_MODE === 'signoff') {
+  log('⚠️  CI_MODE=signoff — EMERGENCY OVERRIDE. Real CI (gh pr checks --watch) is being bypassed; ' +
+      'this is only valid during a GitHub-hosted runner outage with branch protection flipped to ' +
+      '["signoff"] per docs/guides/workflow.md. If CI is healthy, drop the ci arg and use watch.')
+}
+if (CI_MODE === 'skip') {
+  log('⚠️  CI_MODE=skip — NO GitHub-level gate at all (no CI watch, no signoff). The implement-stage ' +
+      "local quality gate is the only verification; merging is entirely the user's call.")
+}
 
 // ---- schemas --------------------------------------------------------------
 
@@ -154,12 +168,13 @@ const SHIP_SCHEMA = {
 
 const VARIANT_TYPE = { backend: 'implementer-backend', frontend: 'implementer-frontend', generic: 'implementer' }
 const VARIANT_MD = { backend: 'implementer-backend', frontend: 'implementer-frontend', generic: 'implementer' }
-// In 'signoff' mode the local gate REPLACES the dead workspace CI, so backend
-// runs the full `cargo nextest run --workspace` (what rust.yml gated) instead of
-// just the touched crate — otherwise cross-crate regressions slip through. When
-// the runner is healthy ('watch'), remote CI covers --workspace, so the local
-// gate stays narrow (`cargo test -p <crate>`). Real-LLM e2e (e2e.yml) and the
-// Linux matrix remain CI-only — uncovered during the outage by design.
+// In 'signoff' mode (emergency override during a CI outage) the local gate
+// REPLACES workspace CI, so backend runs the full `cargo nextest run
+// --workspace` (what rust.yml gates) instead of just the touched crate —
+// otherwise cross-crate regressions slip through. In the default 'watch'
+// mode, remote CI covers --workspace, so the local gate stays narrow
+// (`cargo test -p <crate>`). Real-LLM e2e (e2e.yml) and the Linux matrix
+// remain CI-only — uncovered during an outage by design.
 const BACKEND_TEST = CI_MODE === 'signoff'
   ? 'cargo nextest run --workspace (full workspace — replaces the down CI; if nextest is unavailable, cargo test --workspace)'
   : 'cargo test -p <crate>'
@@ -269,7 +284,7 @@ function shipPrompt(issue, impl, verify) {
     CI_MODE === 'watch'
       ? `\`gh pr checks <PR-number> --watch\`. If a check fails, diagnose the root cause, fix in ${wt}, push again (cap genuine-flake reruns at 1). Do NOT mark tests ignored to go green.\n\nSTOP after CI is green. Set ciGreen=true only when all required checks pass.`
       : CI_MODE === 'signoff'
-        ? `The self-hosted runner is DOWN; main's ONLY required check is \`signoff\`. Do NOT run \`gh pr checks --watch\` (it would hang). The local quality gate already passed in the implement stage, so run \`gh signoff\` to sign off the pushed commit — this satisfies the required check and makes the PR mergeable. signoff binds to the commit: if you pushed again after the last gate run, re-run the gate then \`gh signoff\` again.\n\nSTOP after signoff succeeds. Set ciGreen=true (signoff is the green signal) and put "self-hosted runner down; signed off after local gate" in ciSummary.`
+        ? `EMERGENCY OVERRIDE (CI outage): branch protection has been temporarily flipped so main's only required check is \`signoff\` (see docs/guides/workflow.md). Do NOT run \`gh pr checks --watch\` (it would hang). The local quality gate already passed in the implement stage, so run \`gh signoff\` to sign off the pushed commit — this satisfies the required check and makes the PR mergeable. signoff binds to the commit: if you pushed again after the last gate run, re-run the gate then \`gh signoff\` again.\n\nSTOP after signoff succeeds. Set ciGreen=true (signoff is the green signal) and put "CI outage override; signed off after local gate" in ciSummary.`
         : `GitHub CI is UNAVAILABLE and signoff is not required — do NOT run \`gh pr checks --watch\`. Stop after the PR is created. Set ciGreen=false and put "no GitHub gate; local quality gate passed in implement stage" in ciSummary.`
   return `You are rara's implementer shipping issue #${issue.issueNumber} from worktree \`${wt}\`. The verifier PASSED (S3) and the reviewer APPROVED — push is unlocked.
 
@@ -435,7 +450,7 @@ return {
   ready_to_merge: readyToMerge.map((r) => ({ issue: r.issue, pr: r.prNumber, url: r.prUrl, ci: r.ciSummary, verify_report: r.verifyReport ?? null })),
   blocked: blocked.map((r) => ({ issue: r.issue, pr: r.prNumber ?? null, escalated: r.escalated ?? false, reason: r.reason ?? r.ciSummary ?? 'CI not green' })),
   gate: CI_MODE === 'signoff'
-    ? 'STOPPED before merge. Self-hosted runner is DOWN; each ready PR has been `gh signoff`-ed (local quality gate from the implement stage is the green signal), satisfying main\'s only required check. merge-to-main is human gate (a): the parent confirms each PR with the user, then `gh pr merge --squash --delete-branch`, then cleans up the worktree.'
+    ? 'STOPPED before merge. EMERGENCY OVERRIDE mode: each ready PR has been `gh signoff`-ed (local quality gate from the implement stage is the green signal), satisfying the temporarily-flipped required check. Restore the real required checks per docs/guides/workflow.md once the outage ends. merge-to-main is human gate (a): the parent confirms each PR with the user, then `gh pr merge --squash --delete-branch`, then cleans up the worktree.'
     : CI_MODE === 'skip'
       ? 'STOPPED after PR creation. GitHub CI is UNAVAILABLE and signoff not required — the only verification is the LOCAL quality gate (prek/cargo/bun) from the implement stage. merge-to-main is human gate (a); merging without any GitHub gate is entirely the user\'s call.'
       : 'STOPPED before merge. merge-to-main is human gate (a): the parent confirms each PR with the user, then `gh pr merge --squash --delete-branch`, then cleans up the worktree.',

--- a/.github/actions/setup-rara-build/action.yml
+++ b/.github/actions/setup-rara-build/action.yml
@@ -1,0 +1,31 @@
+name: Setup rara build environment
+description: >-
+  System toolchain for building the rara workspace on GitHub-hosted Linux
+  runners. Everything here was either implicitly baked into the retired
+  arc-runner-set image (enumerated from rararulab/github-self-runner's
+  Dockerfile) or arrived as a new build requirement while CI was dead
+  (#2166): diesel headers (libsqlite3-sys / pq-sys), protoc (prost-build
+  via api/build.rs), zig (zlob build.rs — needed unconditionally by
+  crates/app), and mold + clang on x86_64 where `.cargo/config.toml`
+  forces `-fuse-ld=mold`. Use this in every job that compiles the
+  workspace so the tool list cannot drift between copies.
+
+runs:
+  using: composite
+  steps:
+    - name: Install apt packages (diesel, protoc, mold linker)
+      shell: bash
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y --no-install-recommends libsqlite3-dev libpq-dev protobuf-compiler
+        # mold is target-scoped to x86_64-unknown-linux-gnu in
+        # .cargo/config.toml; arm64 legs use the default linker.
+        if [[ "$(uname -m)" == "x86_64" ]]; then
+          sudo apt-get install -y --no-install-recommends mold clang
+        fi
+
+    # Version kept in lockstep with zig-codec-smoke.yml.
+    - name: Install Zig (zlob build dependency)
+      uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2
+      with:
+        version: 0.16.0

--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   add-to-project:
     name: Add to project board
-    runs-on: arc-runner-set
+    runs-on: ubuntu-latest
     steps:
       - name: Add to project
         uses: actions/add-to-project@v2.0.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,12 +101,10 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Install system dependencies (diesel, protoc, mold linker)
-        run: |
-          # protobuf-compiler: spec-lifecycle runs cargo test selectors,
-          # which build the workspace; prost-build needs protoc (#2166).
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends libsqlite3-dev libpq-dev mold clang protobuf-compiler
+      # spec-lifecycle runs cargo test selectors, which build the
+      # workspace — same system toolchain as rust.yml (#2166).
+      - name: Setup rara build environment
+        uses: ./.github/actions/setup-rara-build
 
       - name: Install just
         uses: taiki-e/install-action@c93ccc03e00cd0e08e494f5fd058a6c55a6a1907 # v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,15 +18,22 @@ permissions:
   contents: read
   pull-requests: read
 
+# This workflow routes the merge gate: branch protection requires the
+# `Rust / Rust Success` and `Lint / Lint Success` check contexts produced
+# by the reusable workflows called below. It intentionally has NO
+# workflow-level `paths:` filter — it must trigger on every PR so that
+# skipped gate jobs still report and satisfy the required checks (#2166).
 jobs:
   changes:
     name: Detect Changes
-    runs-on: arc-runner-set
+    runs-on: ubuntu-latest
     outputs:
       rust: ${{ steps.filter.outputs.rust }}
       web: ${{ steps.filter.outputs.web }}
       docs: ${{ steps.filter.outputs.docs }}
       specs: ${{ steps.filter.outputs.specs }}
+      specs_files: ${{ steps.filter.outputs.specs_files }}
+      cargo_deps: ${{ steps.filter.outputs.cargo_deps }}
     steps:
       - name: Checkout code
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
@@ -37,6 +44,7 @@ jobs:
         uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         id: filter
         with:
+          list-files: shell
           filters: |
             rust:
               - 'crates/**'
@@ -57,6 +65,10 @@ jobs:
               - 'README*'
             specs:
               - 'specs/**'
+            cargo_deps:
+              - 'Cargo.toml'
+              - 'Cargo.lock'
+              - 'deny.toml'
 
   lint:
     name: Lint
@@ -69,6 +81,125 @@ jobs:
     needs: changes
     if: ${{ needs.changes.outputs.rust == 'true' || github.event_name == 'push' }}
     uses: ./.github/workflows/rust.yml
+
+  # Verifies changed lane-1 Task Contracts: `agent-spec lint` scores the
+  # spec, `agent-spec lifecycle` binds its BDD scenarios to real tests.
+  # `just spec-selftest` (regression lock for the zero-match false-green,
+  # #2165) runs when the target exists — guarded so this job and the
+  # sibling PR that defines the target can land in either order.
+  agent-spec:
+    name: Agent Spec
+    needs: changes
+    if: ${{ needs.changes.outputs.specs == 'true' }}
+    runs-on: ubuntu-latest
+    env:
+      # Lifecycle runs cargo test selectors — same stub as rust.yml.
+      BOXLITE_DEPS_STUB: "1"
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
+        with:
+          persist-credentials: false
+
+      - name: Install system dependencies (diesel + mold linker)
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends libsqlite3-dev libpq-dev mold clang
+
+      - name: Install just
+        uses: taiki-e/install-action@c93ccc03e00cd0e08e494f5fd058a6c55a6a1907 # v2
+        with:
+          tool: just
+
+      - name: Rust cache
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2.9.1
+
+      # Pinned; upstream is https://github.com/ZhangHanDong/agent-spec
+      # (crates.io). Keep in lockstep with the version `just doctor`
+      # enforces locally (#2165).
+      - name: Install agent-spec
+        run: cargo install --locked agent-spec --version 0.3.0
+
+      - name: Lint + lifecycle changed specs
+        env:
+          CHANGED_SPECS: ${{ needs.changes.outputs.specs_files }}
+        run: |
+          ran=0
+          for spec in $CHANGED_SPECS; do
+            case "$spec" in
+              specs/issue-*.spec.md)
+                [ -f "$spec" ] || continue  # deleted in this diff
+                echo "::group::$spec"
+                just spec-lint "$spec"
+                just spec-lifecycle "$spec"
+                echo "::endgroup::"
+                ran=$((ran + 1))
+                ;;
+            esac
+          done
+          echo "verified $ran task spec(s)"
+
+      - name: Spec gate self-test
+        run: |
+          if just --list | grep -q 'spec-selftest'; then
+            just spec-selftest
+          else
+            echo "just spec-selftest not defined yet (lands with #2165); skipping"
+          fi
+
+  # deny.toml was previously only exercised locally via `just lint` —
+  # orphaned in CI (#2166). Advisory/ban/license sweeps only make sense
+  # when the dependency graph changes, hence the cargo_deps filter.
+  #
+  # TODO(#2166 follow-up): continue-on-error because the baseline fails
+  # today (git sources missing from deny.toml allow-git, bzip2-1.0.6
+  # license, unmaintained-crate advisories — all pre-existing, landed
+  # while CI was dead). Fix the drift, then delete continue-on-error to
+  # make this blocking.
+  cargo-deny:
+    name: Cargo Deny
+    needs: changes
+    if: ${{ needs.changes.outputs.cargo_deps == 'true' }}
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
+        with:
+          persist-credentials: false
+
+      - name: Install cargo-deny
+        uses: taiki-e/install-action@c93ccc03e00cd0e08e494f5fd058a6c55a6a1907 # v2
+        with:
+          tool: cargo-deny
+
+      - name: Check advisories, bans, licenses, sources
+        run: cargo deny check
+
+  # Detects unused dependencies declared in Cargo.toml files.
+  #
+  # TODO(#2166 follow-up): continue-on-error because the workspace has 87
+  # pre-existing findings (`cargo shear` on main). Burn the baseline down
+  # in crates/**, then delete continue-on-error to make this blocking.
+  cargo-shear:
+    name: Cargo Shear
+    needs: changes
+    if: ${{ needs.changes.outputs.cargo_deps == 'true' }}
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
+        with:
+          persist-credentials: false
+
+      - name: Install cargo-shear
+        uses: taiki-e/install-action@c93ccc03e00cd0e08e494f5fd058a6c55a6a1907 # v2
+        with:
+          tool: cargo-shear
+
+      - name: Check for unused dependencies
+        run: cargo shear
 
   release-pr:
     name: Release PR

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,10 +101,12 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Install system dependencies (diesel + mold linker)
+      - name: Install system dependencies (diesel, protoc, mold linker)
         run: |
+          # protobuf-compiler: spec-lifecycle runs cargo test selectors,
+          # which build the workspace; prost-build needs protoc (#2166).
           sudo apt-get update
-          sudo apt-get install -y --no-install-recommends libsqlite3-dev libpq-dev mold clang
+          sudo apt-get install -y --no-install-recommends libsqlite3-dev libpq-dev mold clang protobuf-compiler
 
       - name: Install just
         uses: taiki-e/install-action@c93ccc03e00cd0e08e494f5fd058a6c55a6a1907 # v2

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -36,7 +36,7 @@ permissions:
 jobs:
   changes:
     name: Detect Changes
-    runs-on: arc-runner-set
+    runs-on: ubuntu-latest
     outputs:
       rust: ${{ steps.filter.outputs.rust }}
     steps:
@@ -68,9 +68,9 @@ jobs:
     # push to main (e.g. docs- or specs-only merges). workflow_dispatch
     # always runs so maintainers can trigger ad-hoc.
     if: ${{ needs.changes.outputs.rust == 'true' || github.event_name == 'workflow_dispatch' }}
-    runs-on: arc-runner-set
+    runs-on: ubuntu-latest
     env:
-      # ARC runners can't build native boxlite (meson/ninja/patchelf missing),
+      # CI can't build native boxlite (meson/ninja/patchelf not provisioned),
       # mirroring the rust.yml jobs.
       BOXLITE_DEPS_STUB: "1"
     steps:
@@ -79,10 +79,15 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Install diesel system libraries
+      # mold + clang: `.cargo/config.toml` forces the mold linker for
+      # x86_64-unknown-linux-gnu and GitHub-hosted images do not bake it.
+      - name: Install system dependencies (diesel + mold linker)
         run: |
           sudo apt-get update
-          sudo apt-get install -y --no-install-recommends libsqlite3-dev libpq-dev gettext-base
+          sudo apt-get install -y --no-install-recommends libsqlite3-dev libpq-dev gettext-base mold clang
+
+      - name: Rust cache
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2.9.1
 
       - name: Render rara config from template
         env:
@@ -90,10 +95,10 @@ jobs:
           OPENAI_BASE_URL: ${{ vars.OPENAI_BASE_URL }}
           OPENAI_MODEL: ${{ vars.OPENAI_MODEL }}
         run: |
-          # ARC self-hosted runners ship with a read-only $HOME, so render the
-          # config under $RUNNER_TEMP and steer both `dirs::config_dir()` and
-          # `dirs::data_local_dir()` (used by rara_paths::data_dir) there via
-          # the XDG_* env vars for downstream steps.
+          # Render the config under $RUNNER_TEMP and steer both
+          # `dirs::config_dir()` and `dirs::data_local_dir()` (used by
+          # rara_paths::data_dir) there via the XDG_* env vars for
+          # downstream steps — keeps the job independent of runner $HOME.
           mkdir -p "$RUNNER_TEMP/xdg-config/rara" "$RUNNER_TEMP/xdg-data"
           envsubst < ci/config.template.yaml > "$RUNNER_TEMP/xdg-config/rara/config.yaml"
           {

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -81,10 +81,11 @@ jobs:
 
       # mold + clang: `.cargo/config.toml` forces the mold linker for
       # x86_64-unknown-linux-gnu and GitHub-hosted images do not bake it.
-      - name: Install system dependencies (diesel + mold linker)
+      # protobuf-compiler: prost-build (api/build.rs) needs protoc (#2166).
+      - name: Install system dependencies (diesel, protoc, mold linker)
         run: |
           sudo apt-get update
-          sudo apt-get install -y --no-install-recommends libsqlite3-dev libpq-dev gettext-base mold clang
+          sudo apt-get install -y --no-install-recommends libsqlite3-dev libpq-dev gettext-base mold clang protobuf-compiler
 
       - name: Rust cache
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2.9.1

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -79,13 +79,14 @@ jobs:
         with:
           persist-credentials: false
 
-      # mold + clang: `.cargo/config.toml` forces the mold linker for
-      # x86_64-unknown-linux-gnu and GitHub-hosted images do not bake it.
-      # protobuf-compiler: prost-build (api/build.rs) needs protoc (#2166).
-      - name: Install system dependencies (diesel, protoc, mold linker)
+      # System toolchain (diesel headers, protoc, zig, mold) — see
+      # .github/actions/setup-rara-build/action.yml (#2166).
+      - name: Setup rara build environment
+        uses: ./.github/actions/setup-rara-build
+
+      - name: Install gettext (envsubst for config templating)
         run: |
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends libsqlite3-dev libpq-dev gettext-base mold clang protobuf-compiler
+          sudo apt-get install -y --no-install-recommends gettext-base
 
       - name: Rust cache
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2.9.1

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -31,11 +31,14 @@ jobs:
           persist-credentials: false
 
       # The old arc image baked nightly rustfmt; GitHub-hosted does not.
+      # Date-pinned in lockstep with rust.yml's rustdoc nightly (which is
+      # pinned around a rustc ICE) so both gates use one deterministic
+      # toolchain; unpin together when a fixed nightly ships.
       - name: Install nightly toolchain (rustfmt)
-        run: rustup toolchain install nightly --profile minimal --component rustfmt
+        run: rustup toolchain install nightly-2026-06-19 --profile minimal --component rustfmt
 
       - name: Check formatting
-        run: cargo +nightly fmt --all -- --check
+        run: cargo +nightly-2026-06-19 fmt --all -- --check
 
   proto-lint:
     name: Protocol Buffer Lint

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,27 +17,40 @@ defaults:
 permissions:
   contents: read
 
+# GitHub-hosted runners only — see the note in rust.yml: the self-hosted
+# `arc-runner-set` fleet is gone, and it must not appear in any job the
+# `Lint Success` required check depends on (#2166).
 jobs:
   rust-format:
     name: Rust Format
-    runs-on: arc-runner-set
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
         with:
           persist-credentials: false
+
+      # The old arc image baked nightly rustfmt; GitHub-hosted does not.
+      - name: Install nightly toolchain (rustfmt)
+        run: rustup toolchain install nightly --profile minimal --component rustfmt
 
       - name: Check formatting
         run: cargo +nightly fmt --all -- --check
 
   proto-lint:
     name: Protocol Buffer Lint
-    runs-on: arc-runner-set
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
         with:
           persist-credentials: false
+
+      # The old arc image baked buf; GitHub-hosted does not.
+      - name: Install buf
+        uses: bufbuild/buf-action@fd21066df7214747548607aaa45548ba2b9bc1ff # v1.4.0
+        with:
+          setup_only: true
 
       - name: Buf lint
         run: cd api && buf lint
@@ -47,7 +60,7 @@ jobs:
 
   devtool-checks:
     name: Devtool Checks
-    runs-on: arc-runner-set
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
@@ -68,9 +81,12 @@ jobs:
       - name: Check crate dependency direction
         run: scripts/bin/devtool check-deps
 
+      - name: Check CI runner coverage
+        run: scripts/bin/devtool check-ci-runners
+
   lint-success:
     name: Lint Success
-    runs-on: arc-runner-set
+    runs-on: ubuntu-latest
     needs: [rust-format, proto-lint, devtool-checks]
     if: always()
     steps:

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -11,7 +11,7 @@ jobs:
   # Release unpublished packages (only when release PR is merged).
   release-plz-release:
     name: Release-plz release
-    runs-on: arc-runner-set
+    runs-on: ubuntu-latest
     if: ${{ github.repository_owner == 'rararulab' && github.event_name == 'pull_request' && github.event.pull_request.merged == true && contains(github.event.pull_request.labels.*.name, 'release') }}
     outputs:
       version: ${{ steps.get-version.outputs.version }}

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -10,7 +10,7 @@ permissions:
 jobs:
   release-plz-pr:
     name: Create Release PR
-    runs-on: arc-runner-set
+    runs-on: ubuntu-latest
     if: ${{ github.repository_owner == 'rararulab' && github.ref == 'refs/heads/main' }}
     concurrency:
       group: release-plz-${{ github.ref }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,7 +54,7 @@ on:
 jobs:
   # Run 'cargo dist plan' (or host) to determine what tasks we need to do
   plan:
-    runs-on: "arc-runner-set"
+    runs-on: "ubuntu-latest"
     outputs:
       val: ${{ steps.plan.outputs.manifest }}
       tag: ${{ inputs.tag || github.ref_name }}
@@ -169,7 +169,7 @@ jobs:
     needs:
       - plan
       - build-local-artifacts
-    runs-on: "arc-runner-set"
+    runs-on: "ubuntu-latest"
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       BUILD_MANIFEST_NAME: target/distrib/global-dist-manifest.json
@@ -219,7 +219,7 @@ jobs:
     if: ${{ always() && needs.plan.outputs.publishing == 'true' && (needs.build-global-artifacts.result == 'skipped' || needs.build-global-artifacts.result == 'success') && (needs.build-local-artifacts.result == 'skipped' || needs.build-local-artifacts.result == 'success') }}
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    runs-on: "arc-runner-set"
+    runs-on: "ubuntu-latest"
     outputs:
       val: ${{ steps.host.outputs.manifest }}
     steps:
@@ -279,7 +279,7 @@ jobs:
     needs:
       - plan
       - host
-    runs-on: "arc-runner-set"
+    runs-on: "ubuntu-latest"
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       PLAN: ${{ needs.plan.outputs.val }}
@@ -324,7 +324,7 @@ jobs:
     # still allowing individual publish jobs to skip themselves (for prereleases).
     # "host" however must run to completion, false skipping allowed!
     if: ${{ always() && needs.host.result == 'success' && (needs.publish-homebrew-formula.result == 'skipped' || needs.publish-homebrew-formula.result == 'success') }}
-    runs-on: "arc-runner-set"
+    runs-on: "ubuntu-latest"
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -17,15 +17,16 @@ env:
   CARGO_INCREMENTAL: false
   CARGO_NET_RETRY: 10
   RUSTUP_MAX_RETRIES: 10
-  # Disable the runner image's preset sccache wrapper — no backend is configured,
-  # so `rustc -vV` probes (notably `cargo +nightly doc`) time out trying to start a server.
+  # Kept "" defensively: no sccache backend is configured, and a preset
+  # wrapper would make `rustc -vV` probes (notably `cargo +nightly doc`)
+  # time out trying to start a server.
   RUSTC_WRAPPER: ""
   # boxlite (rara-sandbox dep) builds bubblewrap + libkrun + libkrunfw natively.
-  # All Linux jobs set `BOXLITE_DEPS_STUB: "1"` per-job because the
-  # `arc-runner-set` image lacks meson/ninja/patchelf and cannot run a full
-  # native boxlite build. Real boxlite builds happen only on developer
-  # macOS machines today — see #1842 for the plan to add a CI job once a
-  # stable macOS (or properly-provisioned Linux) runner is available.
+  # Linux jobs set `BOXLITE_DEPS_STUB: "1"` per-job because CI does not
+  # provision the full native boxlite toolchain (meson/ninja/patchelf).
+  # Real boxlite builds happen only on developer macOS machines today —
+  # see #1842 for the plan to add a CI job once a stable macOS (or
+  # properly-provisioned Linux) runner is available.
 
 defaults:
   run:
@@ -34,13 +35,30 @@ defaults:
 permissions:
   contents: read
 
+# All jobs run on GitHub-hosted runners. The self-hosted `arc-runner-set`
+# fleet no longer exists (gone since ~2026-05-08); jobs targeting it queued
+# for 24h and were cancelled by GitHub, so `arc-runner-set` must NOT appear
+# in any job a required check `needs` (#2166). Re-adding an ARC leg once the
+# fleet returns is a follow-up — keep it out of the gate aggregate.
+#
+# `.cargo/config.toml` forces `linker = "clang"` + `-fuse-ld=mold` for
+# x86_64-unknown-linux-gnu, and GitHub-hosted images do not bake mold
+# (the arc image did, #1942) — so the x64 legs install mold + clang
+# explicitly before any cargo invocation.
 jobs:
   clippy:
-    name: Clippy
-    runs-on: arc-runner-set
+    name: Clippy (${{ matrix.arch }})
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: linux-x64
+            runner: ubuntu-latest
+          - arch: linux-arm64
+            runner: ubuntu-24.04-arm
     env:
-      # See top-of-file note: stub native boxlite build — ARC runners
-      # cannot do the real native build today.
+      # See top-of-file note: stub native boxlite build in CI.
       BOXLITE_DEPS_STUB: "1"
     steps:
       - name: Checkout code
@@ -48,20 +66,35 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Install diesel system libraries
+      - name: Install system dependencies (diesel + mold linker)
+        env:
+          MATRIX_ARCH: ${{ matrix.arch }}
         run: |
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends libsqlite3-dev libpq-dev
+          if [[ "$MATRIX_ARCH" == "linux-x64" ]]; then
+            sudo apt-get install -y --no-install-recommends mold clang
+          fi
+
+      - name: Rust cache
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2.9.1
 
       - name: Run clippy
         run: cargo clippy --workspace --all-targets --no-deps -- -D warnings
 
   test:
-    name: Test
-    runs-on: arc-runner-set
+    name: Test (${{ matrix.arch }})
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: linux-x64
+            runner: ubuntu-latest
+          - arch: linux-arm64
+            runner: ubuntu-24.04-arm
     env:
-      # See top-of-file note: stub native boxlite build — ARC runners
-      # cannot do the real native build today.
+      # See top-of-file note: stub native boxlite build in CI.
       BOXLITE_DEPS_STUB: "1"
     steps:
       - name: Checkout code
@@ -69,10 +102,25 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Install diesel system libraries
+      - name: Install system dependencies (diesel + mold linker)
+        env:
+          MATRIX_ARCH: ${{ matrix.arch }}
         run: |
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends libsqlite3-dev libpq-dev
+          if [[ "$MATRIX_ARCH" == "linux-x64" ]]; then
+            sudo apt-get install -y --no-install-recommends mold clang
+          fi
+
+      - name: Rust cache
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2.9.1
+
+      # The old arc image had nextest baked in; GitHub-hosted images do not.
+      # `.config/nextest.toml` profile `ci` exists since #1912.
+      - name: Install cargo-nextest
+        uses: taiki-e/install-action@c93ccc03e00cd0e08e494f5fd058a6c55a6a1907 # v2
+        with:
+          tool: cargo-nextest
 
       - name: Run tests
         run: cargo nextest run --workspace --profile ci
@@ -85,17 +133,39 @@ jobs:
         run: cargo run -p rara-cli -- setup boxlite --check
 
   docs:
-    name: Documentation
-    runs-on: arc-runner-set
+    name: Documentation (${{ matrix.arch }})
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: linux-x64
+            runner: ubuntu-latest
+          - arch: linux-arm64
+            runner: ubuntu-24.04-arm
     env:
-      # See top-of-file note: stub native boxlite build — ARC runners
-      # cannot do the real native build today.
+      # See top-of-file note: stub native boxlite build in CI.
       BOXLITE_DEPS_STUB: "1"
     steps:
       - name: Checkout code
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
         with:
           persist-credentials: false
+
+      - name: Install system dependencies (mold linker)
+        env:
+          MATRIX_ARCH: ${{ matrix.arch }}
+        run: |
+          if [[ "$MATRIX_ARCH" == "linux-x64" ]]; then
+            sudo apt-get update
+            sudo apt-get install -y --no-install-recommends mold clang
+          fi
+
+      - name: Install nightly toolchain (rustdoc)
+        run: rustup toolchain install nightly --profile minimal
+
+      - name: Rust cache
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2.9.1
 
       - name: Generate documentation
         run: cargo +nightly doc --workspace --no-deps --document-private-items
@@ -104,7 +174,7 @@ jobs:
 
   rust-success:
     name: Rust Success
-    runs-on: arc-runner-set
+    runs-on: ubuntu-latest
     needs: [clippy, test, docs]
     if: always()
     steps:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -150,14 +150,20 @@ jobs:
       - name: Setup rara build environment
         uses: ./.github/actions/setup-rara-build
 
+      # Pinned: current latest nightly ICEs while documenting
+      # rara-backend-admin (rustc_trait_selection: "DynCompatible(
+      # futures_core::Stream) should have been handled by fulfillment
+      # already"). nightly-2026-06-19 (the known-good local toolchain)
+      # does not. Unpin back to plain `nightly` once a fixed nightly
+      # ships. Keep in lockstep with lint.yml's rustfmt nightly.
       - name: Install nightly toolchain (rustdoc)
-        run: rustup toolchain install nightly --profile minimal
+        run: rustup toolchain install nightly-2026-06-19 --profile minimal
 
       - name: Rust cache
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2.9.1
 
       - name: Generate documentation
-        run: cargo +nightly doc --workspace --no-deps --document-private-items
+        run: cargo +nightly-2026-06-19 doc --workspace --no-deps --document-private-items
         env:
           RUSTDOCFLAGS: -D warnings
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -66,12 +66,14 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Install system dependencies (diesel + mold linker)
+      - name: Install system dependencies (diesel, protoc, mold linker)
         env:
           MATRIX_ARCH: ${{ matrix.arch }}
         run: |
+          # protobuf-compiler: prost-build (api/build.rs) needs protoc; the
+          # old arc image baked it in, GitHub-hosted images do not (#2166).
           sudo apt-get update
-          sudo apt-get install -y --no-install-recommends libsqlite3-dev libpq-dev
+          sudo apt-get install -y --no-install-recommends libsqlite3-dev libpq-dev protobuf-compiler
           if [[ "$MATRIX_ARCH" == "linux-x64" ]]; then
             sudo apt-get install -y --no-install-recommends mold clang
           fi
@@ -102,12 +104,14 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Install system dependencies (diesel + mold linker)
+      - name: Install system dependencies (diesel, protoc, mold linker)
         env:
           MATRIX_ARCH: ${{ matrix.arch }}
         run: |
+          # protobuf-compiler: prost-build (api/build.rs) needs protoc; the
+          # old arc image baked it in, GitHub-hosted images do not (#2166).
           sudo apt-get update
-          sudo apt-get install -y --no-install-recommends libsqlite3-dev libpq-dev
+          sudo apt-get install -y --no-install-recommends libsqlite3-dev libpq-dev protobuf-compiler
           if [[ "$MATRIX_ARCH" == "linux-x64" ]]; then
             sudo apt-get install -y --no-install-recommends mold clang
           fi
@@ -152,12 +156,15 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Install system dependencies (mold linker)
+      - name: Install system dependencies (diesel, protoc, mold linker)
         env:
           MATRIX_ARCH: ${{ matrix.arch }}
         run: |
+          # protobuf-compiler: prost-build (api/build.rs) needs protoc; the
+          # old arc image baked it in, GitHub-hosted images do not (#2166).
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends libsqlite3-dev libpq-dev protobuf-compiler
           if [[ "$MATRIX_ARCH" == "linux-x64" ]]; then
-            sudo apt-get update
             sudo apt-get install -y --no-install-recommends mold clang
           fi
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -66,17 +66,11 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Install system dependencies (diesel, protoc, mold linker)
-        env:
-          MATRIX_ARCH: ${{ matrix.arch }}
-        run: |
-          # protobuf-compiler: prost-build (api/build.rs) needs protoc; the
-          # old arc image baked it in, GitHub-hosted images do not (#2166).
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends libsqlite3-dev libpq-dev protobuf-compiler
-          if [[ "$MATRIX_ARCH" == "linux-x64" ]]; then
-            sudo apt-get install -y --no-install-recommends mold clang
-          fi
+      # Single source of truth for the system toolchain the retired arc
+      # image implicitly provided (diesel headers, protoc, zig, mold) —
+      # see .github/actions/setup-rara-build/action.yml (#2166).
+      - name: Setup rara build environment
+        uses: ./.github/actions/setup-rara-build
 
       - name: Rust cache
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2.9.1
@@ -104,17 +98,11 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Install system dependencies (diesel, protoc, mold linker)
-        env:
-          MATRIX_ARCH: ${{ matrix.arch }}
-        run: |
-          # protobuf-compiler: prost-build (api/build.rs) needs protoc; the
-          # old arc image baked it in, GitHub-hosted images do not (#2166).
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends libsqlite3-dev libpq-dev protobuf-compiler
-          if [[ "$MATRIX_ARCH" == "linux-x64" ]]; then
-            sudo apt-get install -y --no-install-recommends mold clang
-          fi
+      # Single source of truth for the system toolchain the retired arc
+      # image implicitly provided (diesel headers, protoc, zig, mold) —
+      # see .github/actions/setup-rara-build/action.yml (#2166).
+      - name: Setup rara build environment
+        uses: ./.github/actions/setup-rara-build
 
       - name: Rust cache
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2.9.1
@@ -156,17 +144,11 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Install system dependencies (diesel, protoc, mold linker)
-        env:
-          MATRIX_ARCH: ${{ matrix.arch }}
-        run: |
-          # protobuf-compiler: prost-build (api/build.rs) needs protoc; the
-          # old arc image baked it in, GitHub-hosted images do not (#2166).
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends libsqlite3-dev libpq-dev protobuf-compiler
-          if [[ "$MATRIX_ARCH" == "linux-x64" ]]; then
-            sudo apt-get install -y --no-install-recommends mold clang
-          fi
+      # Single source of truth for the system toolchain the retired arc
+      # image implicitly provided (diesel headers, protoc, zig, mold) —
+      # see .github/actions/setup-rara-build/action.yml (#2166).
+      - name: Setup rara build environment
+        uses: ./.github/actions/setup-rara-build
 
       - name: Install nightly toolchain (rustdoc)
         run: rustup toolchain install nightly --profile minimal

--- a/.github/workflows/web-ci.yml
+++ b/.github/workflows/web-ci.yml
@@ -25,23 +25,24 @@ jobs:
         working-directory: web
     steps:
       - uses: actions/checkout@v4
-      # Node version is pinned via mise.toml at the repo root. See
-      # docs/guides/tooling.md.
+      # Node + bun versions are pinned via mise.toml at the repo root. See
+      # docs/guides/tooling.md. bun is the web/ package manager and script
+      # runner (`web/bun.lock`); never npm — see implementer-frontend.md.
       - uses: jdx/mise-action@v4
       - name: Install dependencies
-        run: npm ci
+        run: bun install --frozen-lockfile
       - name: Typecheck
-        run: npm run typecheck
+        run: bun run typecheck
       - name: Lint
-        run: npm run lint -- --max-warnings=0
+        run: bun run lint --max-warnings=0
       - name: Lint CSS
-        run: npm run lint:css
+        run: bun run lint:css
       - name: Format check
-        run: npm run format:check
+        run: bun run format:check
       - name: Test
-        run: npm run test
+        run: bun run test
       - name: Build
-        run: npm run build
+        run: bun run build
 
   playwright:
     name: Playwright (harness)
@@ -53,13 +54,16 @@ jobs:
       - uses: actions/checkout@v4
       - uses: jdx/mise-action@v4
       - name: Install dependencies
-        run: npm ci
+        run: bun install --frozen-lockfile
       - name: Install Playwright browsers
-        run: npx playwright install --with-deps chromium webkit
+        run: bunx playwright install --with-deps chromium webkit
       - name: Build
-        run: npm run build
+        run: bun run build
+      # No --pass-with-no-tests: the harness suite is non-empty
+      # (web/e2e/data-feeds.spec.ts) and a silently-empty testDir must
+      # fail loudly, not pass (#2166).
       - name: Run Playwright harness suite
-        run: npx playwright test --pass-with-no-tests
+        run: bunx playwright test
       - name: Upload Playwright report
         if: failure()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/zig-codec-smoke.yml
+++ b/.github/workflows/zig-codec-smoke.yml
@@ -8,11 +8,12 @@ name: zig-codec-smoke
 # look at recent runs and answer "does Zig still build on Linux?"
 # without spinning up a runner manually.
 #
-# The linux job runs on `arc-runner-set` so it inherits the clang + mold
-# baseline from `rust.yml`'s runner image. `.cargo/config.toml` forces
-# `linker = "clang"` + `-fuse-ld=mold` for `x86_64-unknown-linux-gnu`
-# (see #2010), and GitHub-hosted `ubuntu-latest` lacks mold, so this job
-# was failing on every PR until switched to the self-hosted runner (#2047).
+# The linux job runs on GitHub-hosted `ubuntu-latest` and installs
+# mold + clang explicitly: `.cargo/config.toml` forces `linker = "clang"`
+# + `-fuse-ld=mold` for `x86_64-unknown-linux-gnu` (see #2010). This
+# deliberately reverses #2047 (which moved the job onto `arc-runner-set`
+# for the baked-in mold baseline) — that fleet no longer exists and jobs
+# targeting it queue for 24h and get cancelled (#2166).
 
 on:
   pull_request:
@@ -33,9 +34,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-latest, arc-runner-set]
+        os: [macos-latest, ubuntu-latest]
     steps:
       - uses: actions/checkout@v4
+
+      - name: Install mold linker (Linux)
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends mold clang
 
       - name: Install Zig 0.16
         uses: mlugg/setup-zig@v2

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -308,7 +308,7 @@ hosting = "github"
 # The installers to generate for each app
 installers = ["shell", "homebrew"]
 # Target platforms to build apps for (Rust target-triple syntax)
-targets = ["aarch64-apple-darwin", "x86_64-unknown-linux-gnu"]
+targets = ["aarch64-apple-darwin", "x86_64-unknown-linux-gnu", "aarch64-unknown-linux-gnu"]
 # The archive format to use for windows builds (defaults .zip)
 windows-archive = ".tar.gz"
 # The archive format to use for non-windows builds (defaults .tar.xz)
@@ -326,11 +326,12 @@ allow-dirty = ["ci"]
 tap = "rararulab/homebrew-tap"
 # Publish jobs to run in CI
 publish-jobs = ["homebrew"]
-# Use self-hosted runners for each target
+# GitHub-hosted runners for each target (arc-runner-set fleet retired, #2166)
 [workspace.metadata.dist.github-custom-runners]
-global = "self-hosted"
+global = "ubuntu-latest"
 aarch64-apple-darwin = "macos"
-x86_64-unknown-linux-gnu = "linux"
+x86_64-unknown-linux-gnu = "ubuntu-latest"
+aarch64-unknown-linux-gnu = "ubuntu-24.04-arm"
 
 # The profile that 'cargo dist' will build with
 [profile.dist]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -333,6 +333,18 @@ aarch64-apple-darwin = "macos"
 x86_64-unknown-linux-gnu = "ubuntu-latest"
 aarch64-unknown-linux-gnu = "ubuntu-24.04-arm"
 
+# System packages cargo-dist installs on Linux runners before building
+# (release.yml's `packages_install` matrix step). GitHub-hosted images
+# lack these; the retired arc image baked them in (#2166). mold/clang:
+# `.cargo/config.toml` forces the mold linker for x86_64 Linux;
+# protobuf-compiler: prost-build (api/build.rs) needs protoc.
+[workspace.metadata.dist.dependencies.apt]
+libsqlite3-dev = '*'
+libpq-dev = '*'
+protobuf-compiler = '*'
+mold = '*'
+clang = '*'
+
 # The profile that 'cargo dist' will build with
 [profile.dist]
 inherits = "release"

--- a/crates/cmd/src/setup/boxlite.rs
+++ b/crates/cmd/src/setup/boxlite.rs
@@ -790,7 +790,7 @@ mod tests {
         // Pinning the current resolved value documents the source-of-truth
         // chain end-to-end: change the sandbox tag → Cargo.lock updates →
         // this const updates → this test updates in lockstep.
-        assert_eq!(BOXLITE_VERSION, "v0.9.4");
+        assert_eq!(BOXLITE_VERSION, "v0.9.5");
     }
 
     #[test]

--- a/crates/rara-sandbox/AGENT.md
+++ b/crates/rara-sandbox/AGENT.md
@@ -83,12 +83,12 @@ Public surface (intentionally minimal, see #1697/#1698):
   that install global subscribers fight the host's `tracing` setup.
 - Do NOT extend `BOXLITE_DEPS_STUB="1"` to the macOS CI job —
   **why:** the stub is scoped to the Linux `clippy` / `test` / `docs`
-  jobs in `.github/workflows/rust.yml` because the `arc-runner-set` image
-  lacks meson/ninja/patchelf. The `sandbox-macos` job intentionally
-  builds boxlite for real so link-time / FFI / `build.rs` regressions in
-  `bubblewrap-sys` and `libkrun-sys` are caught on every PR (#1842). If
-  that job starts failing, fix the underlying build issue — do not
-  re-add the stub on macOS.
+  jobs in `.github/workflows/rust.yml` because CI does not provision the
+  full native boxlite toolchain on every Linux runner. The `sandbox-macos`
+  job intentionally builds boxlite for real so link-time / FFI /
+  `build.rs` regressions in `bubblewrap-sys` and `libkrun-sys` are caught
+  on every PR (#1842). If that job starts failing, fix the underlying
+  build issue — do not re-add the stub on macOS.
 
 ## Network policy fusion
 

--- a/docs/guides/boxlite-runtime.md
+++ b/docs/guides/boxlite-runtime.md
@@ -91,9 +91,9 @@ upstream and `setup boxlite` errors loudly on them.
 
 The Linux `clippy` / `test` / `docs` jobs in
 `.github/workflows/rust.yml` build with `BOXLITE_DEPS_STUB="1"` to avoid
-pulling the full native build chain (meson, ninja, patchelf) onto the
-`arc-runner-set` image. Staging itself is exercised in unit tests via a
-hermetic in-process HTTP fixture — no real network access from CI.
+pulling the full native build chain (meson, ninja, patchelf) onto every
+Linux CI runner. Staging itself is exercised in unit tests via a hermetic
+in-process HTTP fixture — no real network access from CI.
 
 There is no CI job that downloads the real upstream tarball today. The
 self-hosted macOS runner introduced in #1842 was removed in #1916

--- a/docs/guides/workflow.md
+++ b/docs/guides/workflow.md
@@ -310,14 +310,22 @@ still add type + component labels explicitly via `--label`.
 
 Commit message must include `Closes #N` so the issue auto-closes on merge.
 
+CI runs on GitHub-hosted runners (`ubuntu-latest` x64 + `ubuntu-24.04-arm`
+arm64). The required merge-gate checks on `main` are the `ci.yml`-routed
+aggregates **`Rust / Rust Success`** and **`Lint / Lint Success`** — path
+filtering inside `ci.yml` means docs-only PRs satisfy them as `skipped`.
+`web-ci.yml` has a workflow-level `paths:` filter, so its checks are
+deliberately NOT required (they would perma-block non-web PRs).
+
 If a CI check fails: read the failure log, diagnose root cause, fix in
 the worktree, push again. Do not mark tests `#[ignore]` to make CI green.
 For genuine flakes (same test failed recently on `main`):
 `gh run rerun <id> --failed`. Cap reruns at 1.
 
-**Why review-before-push:** CI catches platform issues (Linux ARC runner
-behavior vs your local macOS) and integration regressions. Review catches
-design issues, regression-decision reversals, and scope creep. They don't
+**Why review-before-push:** CI catches platform issues (GitHub-hosted
+Linux runner behavior vs your local macOS) and integration regressions.
+Review catches design issues, regression-decision reversals, and scope
+creep. They don't
 catch the same things, but pushing only after review APPROVE means
 PR-level CI runs on already-reviewed code — no force-pushes after review,
 no PRs lingering with "needs another round of review" comments. The
@@ -337,6 +345,49 @@ Commit subject. `--delete-branch` removes the remote branch; the local
 branch and worktree are removed in step 7.
 
 The parent has standing approval; do not re-ask.
+
+## CI outage: the `signoff` emergency override
+
+`gh signoff` stays installed, but it is **not** part of the normal flow —
+it exists solely as a documented override for a genuine CI outage (e.g.
+GitHub-hosted runners down or the Actions service degraded). Do NOT use
+it because a check is slow or flaky; fix the check instead.
+
+Procedure (requires repo admin):
+
+```bash
+# 0. Confirm the current required checks (should list the real gates):
+gh api repos/rararulab/rara/branches/main/protection/required_status_checks
+
+# 1. OUTAGE: temporarily flip the required checks to signoff-only:
+gh api -X PATCH repos/rararulab/rara/branches/main/protection/required_status_checks \
+  --input - <<'EOF'
+{"checks": [{"context": "signoff"}]}
+EOF
+
+# 2. For each PR: run the full local quality gate, then sign off:
+gh signoff
+
+# 3. RESTORE (mandatory, as soon as CI is healthy again):
+gh api -X PATCH repos/rararulab/rara/branches/main/protection/required_status_checks \
+  --input - <<'EOF'
+{"checks": [{"context": "Rust / Rust Success"}, {"context": "Lint / Lint Success"}]}
+EOF
+```
+
+The gate context strings must match the check-run names GitHub reports
+for `ci.yml` (reusable-workflow checks render as `<caller job> / <job
+name>`). If they ever drift, read the live names off a recent run before
+PATCHing:
+
+```bash
+gh api repos/rararulab/rara/commits/$(git rev-parse origin/main)/check-runs \
+  --jq '.check_runs[].name'
+```
+
+While the override is active, `rara-dev.js` must be invoked with
+`ci: 'signoff'` (explicit opt-in — it logs a loud warning); the default
+`watch` mode would hang waiting for checks that never run.
 
 ## Step 7: Cleanup
 

--- a/docs/src/release.md
+++ b/docs/src/release.md
@@ -28,7 +28,7 @@ release-plz.yml triggers (on PR merge with "release" label)
     ▼
 release.yml (cargo-dist)
   • cargo dist plan --tag=vX.Y.Z
-  • builds binaries: aarch64-apple-darwin (macos runner), x86_64-unknown-linux-gnu (linux runner)
+  • builds binaries: aarch64-apple-darwin (macos runner), x86_64-unknown-linux-gnu (ubuntu-latest), aarch64-unknown-linux-gnu (ubuntu-24.04-arm)
   • uploads artifacts to MinIO S3
   • gh release create vX.Y.Z — creates git tag + GitHub Release with binaries attached
   • pushes Homebrew formula (rara-cli.rb) to rararulab/homebrew-tap

--- a/justfile
+++ b/justfile
@@ -100,9 +100,15 @@ check-agent-md:
     @cd scripts && go build -o bin/devtool ./cmd/devtool/
     @scripts/bin/devtool check-agent-md
 
-[doc("run linting checks (clippy, docs, buf, zizmor, yamllint-rs, cargo-deny, agent-md, check-deps)")]
+[doc("check CI runner coverage (Linux arm64 target + runner wiring)")]
 [group("👆 Code Quality")]
-lint: check-agent-md check-deps
+check-ci-runners:
+    @cd scripts && go build -o bin/devtool ./cmd/devtool/
+    @scripts/bin/devtool check-ci-runners
+
+[doc("run linting checks (clippy, docs, buf, zizmor, yamllint-rs, cargo-deny, agent-md, check-deps, check-ci-runners)")]
+[group("👆 Code Quality")]
+lint: check-agent-md check-deps check-ci-runners
     @echo "🔍 Running clippy..."
     cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings
     @echo "📚 Building documentation..."

--- a/scripts/cmd/devtool/main.go
+++ b/scripts/cmd/devtool/main.go
@@ -7,6 +7,7 @@ import (
 	"os"
 
 	"github.com/rararulab/rara/scripts/internal/agentmd"
+	"github.com/rararulab/rara/scripts/internal/ci"
 	"github.com/rararulab/rara/scripts/internal/deps"
 	"github.com/rararulab/rara/scripts/internal/worktree"
 	"github.com/urfave/cli/v3"
@@ -18,6 +19,7 @@ func main() {
 		Usage: "Unified developer toolkit for rara",
 		Commands: []*cli.Command{
 			agentmd.Cmd(),
+			ci.Cmd(),
 			worktree.Cmd(),
 			deps.Cmd(),
 		},

--- a/scripts/internal/ci/commands.go
+++ b/scripts/internal/ci/commands.go
@@ -1,0 +1,153 @@
+// Package ci enforces repository CI runner invariants.
+package ci
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	toml "github.com/pelletier/go-toml/v2"
+	"github.com/urfave/cli/v3"
+)
+
+const (
+	arm64Runner = "ubuntu-24.04-arm"
+	arm64Target = "aarch64-unknown-linux-gnu"
+
+	// The self-hosted ARC fleet is gone (#2166); any job targeting it
+	// queues for 24h and is cancelled by GitHub. It must never appear in
+	// a workflow that a required merge-gate check depends on.
+	retiredRunner = "arc-runner-set"
+)
+
+// gateWorkflows are the workflows whose jobs feed the required
+// branch-protection checks (Rust Success / Lint Success).
+var gateWorkflows = []string{
+	".github/workflows/ci.yml",
+	".github/workflows/rust.yml",
+	".github/workflows/lint.yml",
+}
+
+// Cmd returns the "check-ci-runners" command.
+func Cmd() *cli.Command {
+	return &cli.Command{
+		Name:  "check-ci-runners",
+		Usage: "Check CI runner coverage for Linux arm64",
+		Action: func(_ context.Context, _ *cli.Command) error {
+			return runCheck()
+		},
+	}
+}
+
+func runCheck() error {
+	root, err := findRepoRoot()
+	if err != nil {
+		return err
+	}
+
+	if err := checkCargoDist(filepath.Join(root, "Cargo.toml")); err != nil {
+		return err
+	}
+	if err := checkContains(filepath.Join(root, ".github/workflows/rust.yml"), []byte(arm64Runner)); err != nil {
+		return err
+	}
+	if err := checkContains(filepath.Join(root, ".cargo/config.toml"), []byte("[target."+arm64Target+"]")); err != nil {
+		return err
+	}
+	for _, wf := range gateWorkflows {
+		if err := checkNotContains(filepath.Join(root, wf), []byte(retiredRunner)); err != nil {
+			return err
+		}
+	}
+
+	fmt.Println("CI runner checks passed.")
+	return nil
+}
+
+func findRepoRoot() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	for {
+		if _, err := os.Stat(filepath.Join(dir, ".git")); err == nil {
+			return dir, nil
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return "", fmt.Errorf("no git repository root found")
+		}
+		dir = parent
+	}
+}
+
+func checkCargoDist(path string) error {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return err
+	}
+
+	var cfg struct {
+		Workspace struct {
+			Metadata struct {
+				Dist struct {
+					Targets             []string          `toml:"targets"`
+					GithubCustomRunners map[string]string `toml:"github-custom-runners"`
+				} `toml:"dist"`
+			} `toml:"metadata"`
+		} `toml:"workspace"`
+	}
+	if err := toml.Unmarshal(data, &cfg); err != nil {
+		return fmt.Errorf("parse %s: %w", path, err)
+	}
+
+	if !containsString(cfg.Workspace.Metadata.Dist.Targets, arm64Target) {
+		return fmt.Errorf("cargo-dist targets must include %s", arm64Target)
+	}
+	if got := cfg.Workspace.Metadata.Dist.GithubCustomRunners[arm64Target]; got != arm64Runner {
+		return fmt.Errorf("cargo-dist runner for %s is %q, want %q", arm64Target, got, arm64Runner)
+	}
+	return nil
+}
+
+func checkContains(path string, needle []byte) error {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return err
+	}
+	if !bytes.Contains(data, needle) {
+		return fmt.Errorf("%s must contain %q", path, needle)
+	}
+	return nil
+}
+
+// checkNotContains fails when any non-comment line of the file references
+// the needle. YAML comment lines are skipped so workflows can still explain
+// WHY the retired runner must not come back.
+func checkNotContains(path string, needle []byte) error {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return err
+	}
+	for _, line := range bytes.Split(data, []byte("\n")) {
+		trimmed := bytes.TrimSpace(line)
+		if len(trimmed) == 0 || trimmed[0] == '#' {
+			continue
+		}
+		if bytes.Contains(trimmed, needle) {
+			return fmt.Errorf("%s must not reference %q (retired runner fleet, see #2166)", path, needle)
+		}
+	}
+	return nil
+}
+
+func containsString(items []string, needle string) bool {
+	for _, item := range items {
+		if item == needle {
+			return true
+		}
+	}
+	return false
+}

--- a/scripts/internal/ci/commands_test.go
+++ b/scripts/internal/ci/commands_test.go
@@ -1,0 +1,120 @@
+package ci
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	toml "github.com/pelletier/go-toml/v2"
+)
+
+const (
+	repoRoot         = "../../.."
+	linuxArm64Runner = "ubuntu-24.04-arm"
+	linuxArm64Target = "aarch64-unknown-linux-gnu"
+)
+
+func TestCargoDistBuildsLinuxArm64OnArmRunner(t *testing.T) {
+	data := readRepoFile(t, "Cargo.toml")
+
+	var cfg struct {
+		Workspace struct {
+			Metadata struct {
+				Dist struct {
+					Targets             []string          `toml:"targets"`
+					GithubCustomRunners map[string]string `toml:"github-custom-runners"`
+				} `toml:"dist"`
+			} `toml:"metadata"`
+		} `toml:"workspace"`
+	}
+	if err := toml.Unmarshal(data, &cfg); err != nil {
+		t.Fatalf("parse Cargo.toml: %v", err)
+	}
+
+	if !contains(cfg.Workspace.Metadata.Dist.Targets, linuxArm64Target) {
+		t.Fatalf("cargo-dist targets = %v, want %s", cfg.Workspace.Metadata.Dist.Targets, linuxArm64Target)
+	}
+	if got := cfg.Workspace.Metadata.Dist.GithubCustomRunners[linuxArm64Target]; got != linuxArm64Runner {
+		t.Fatalf("custom runner for %s = %q, want %q", linuxArm64Target, got, linuxArm64Runner)
+	}
+}
+
+func TestRustWorkflowRunsOnX64AndArm64Linux(t *testing.T) {
+	data := readRepoFile(t, ".github/workflows/rust.yml")
+
+	text := string(data)
+	if !strings.Contains(text, linuxArm64Runner) {
+		t.Fatalf("rust.yml does not mention runner %q", linuxArm64Runner)
+	}
+	if !strings.Contains(text, "${{ matrix.runner }}") {
+		t.Fatalf("rust.yml should use matrix.runner for Rust jobs")
+	}
+}
+
+func TestArm64LinuxTargetKeepsWarningsAsErrors(t *testing.T) {
+	data := readRepoFile(t, ".cargo/config.toml")
+
+	var cfg map[string]any
+	if err := toml.Unmarshal(data, &cfg); err != nil {
+		t.Fatalf("parse .cargo/config.toml: %v", err)
+	}
+
+	targets, ok := cfg["target"].(map[string]any)
+	if !ok {
+		t.Fatalf(".cargo/config.toml has no [target] table")
+	}
+	target, ok := targets[linuxArm64Target].(map[string]any)
+	if !ok {
+		t.Fatalf(".cargo/config.toml has no [target.%s] table", linuxArm64Target)
+	}
+	flags, ok := target["rustflags"].([]any)
+	if !ok {
+		t.Fatalf("[target.%s] has no rustflags array", linuxArm64Target)
+	}
+	if !containsAny(flags, "-D") || !containsAny(flags, "warnings") {
+		t.Fatalf("[target.%s] rustflags = %v, want -D warnings", linuxArm64Target, flags)
+	}
+}
+
+func readRepoFile(t *testing.T, name string) []byte {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join(repoRoot, name))
+	if err != nil {
+		t.Fatalf("read %s: %v", name, err)
+	}
+	return data
+}
+
+func contains(items []string, needle string) bool {
+	for _, item := range items {
+		if item == needle {
+			return true
+		}
+	}
+	return false
+}
+
+func containsAny(items []any, needle string) bool {
+	for _, item := range items {
+		if s, ok := item.(string); ok && s == needle {
+			return true
+		}
+	}
+	return false
+}
+
+func TestGateWorkflowsDoNotTargetRetiredRunner(t *testing.T) {
+	for _, wf := range gateWorkflows {
+		data := readRepoFile(t, wf)
+		for _, line := range strings.Split(string(data), "\n") {
+			trimmed := strings.TrimSpace(line)
+			if trimmed == "" || strings.HasPrefix(trimmed, "#") {
+				continue // comments may explain why the runner is retired
+			}
+			if strings.Contains(trimmed, retiredRunner) {
+				t.Errorf("%s references retired runner %q — gate jobs would queue forever (#2166)", wf, retiredRunner)
+			}
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Restores a **real merge gate** on `main`. Since 2026-05-08 the self-hosted `arc-runner-set` fleet has not existed: every job targeting it queued for exactly 24h and was cancelled by GitHub's queue timeout (`runnerName: null`, e.g. run 28641349131), so every `ci.yml` run concluded `cancelled` — the last green run was **2026-05-07**. Branch protection required only the self-signed `signoff` check, so clippy/test/doc regressions could (and did — see Known-red below) land on `main` unchecked.

### Per-workflow changes

| Workflow | Change |
|---|---|
| `ci.yml` | `Detect Changes` → `ubuntu-latest` (unblocks the whole DAG); filter gains `specs_files` + `cargo_deps`; new path-filtered jobs: **Agent Spec** (`agent-spec 0.3.0` lint+lifecycle on changed `specs/issue-*.spec.md`; `just spec-selftest` guarded with `just --list | grep` so sibling #2165 can land in either order), **Cargo Deny** and **Cargo Shear** (dependency changes only; `continue-on-error` until the pre-existing baseline drift is fixed — deny: git-source/license/advisory drift; shear: 87 findings) |
| `rust.yml` | clippy/test/docs → 2-leg matrix `ubuntu-latest` (x64) + `ubuntu-24.04-arm` (arm64); **no `arc-runner-set` in anything the gate `needs`**; mold+clang installed on x64 legs (`.cargo/config.toml` stays the rustflags source of truth, #2009); nextest via `taiki-e/install-action`; nightly for rustdoc; `Swatinem/rust-cache`; `Rust Success` → `ubuntu-latest` |
| `lint.yml` | all 4 jobs → `ubuntu-latest`; nightly rustfmt + buf installed explicitly; new `devtool check-ci-runners` step (also enforces "no arc ref in gate workflows", comment-aware) |
| `e2e.yml` / `release.yml` / `release-pr.yml` / `release-plz.yml` / `add-to-project.yml` | `arc-runner-set` → `ubuntu-latest`; e2e adds mold+clang + rust-cache |
| `zig-codec-smoke.yml` | linux leg → `ubuntu-latest` + explicit mold+clang install — **deliberately reverses #2047/#1942** (those relied on the arc image's baked-in mold; the fleet is gone) |
| `web-ci.yml` | npm → bun (`bun install --frozen-lockfile` / `bun run` / `bunx`); `--pass-with-no-tests` removed so an empty Playwright testDir fails loudly |
| `Cargo.toml` + `.cargo/config.toml` | cargo-dist → GitHub-hosted runners; new `aarch64-unknown-linux-gnu` target + `-D warnings` stanza |
| `.claude/workflows/rara-dev.js` | default `CI_MODE` flips `signoff` → `watch`; `signoff`/`skip` log loud warnings; unknown modes throw (now a tracked file) |
| `docs/guides/workflow.md` | documents the required checks + the `signoff` emergency-override PATCH/restore procedure |
| `scripts/internal/ci/` + `justfile` | new `devtool check-ci-runners` (adopted from saved WIP, extended), wired into `just lint` |

### ⚠️ KNOWN RED — pre-existing `main` breakage, not this diff

`Rust / Rust Success` on this PR **will be red until sibling #2167 merges**. `crates/**` and `Cargo.lock` in this diff are byte-identical to `origin/main`; the failures are pre-existing breakage that landed unchecked via #2148 while CI was dead (exactly the failure class this PR fixes):

1. `crates/integrations/mcp/src/client.rs:297` — E0599: rmcp 1.8.0 changed `peer_info()` to return `Option<Arc<_>>`; the `.cloned()` call no longer compiles.
2. `crates/common/telemetry` — otel 0.32 deprecated `GEN_AI_*` semconv constants → `-D warnings` clippy errors.

### ⚠️ KNOWN CONFLICT — sibling #2164

Sibling #2164 (pipeline v2 skeleton) also adds `.claude/workflows/rara-dev.js`. Plan: **#2164 merges first, this branch rebases after.**

## Type of change

CI / Infrastructure → `ci` (+ `chore`)

## Component

`ci`

## Closes

Closes #2166

## Test plan

- [x] `actionlint` clean on all changed workflows (release*.yml shellcheck notes verified pre-existing on the main baseline)
- [x] `zizmor` at exact main baseline (39 findings / 11 high — all pre-existing; new actions SHA-pinned)
- [x] `node --check .claude/workflows/rara-dev.js`
- [x] `go test ./internal/ci/` + `just check-ci-runners` pass
- [x] `prek`: fmt / AGENT.md / web hooks pass; cargo hooks fail **only** on the pre-existing #2167 breakage above
- [ ] First run of this PR is itself the live test of the GitHub-hosted workflows
- [ ] `Rust / Rust Success` green after #2167 merges + rebase

## Post-merge checklist — flip branch protection (repo admin)

Preconditions before PATCHing:
1. Read the live check names off a run of this PR and confirm they render as `Rust / Rust Success` and `Lint / Lint Success`:
   ```bash
   gh api repos/rararulab/rara/commits/<head-sha>/check-runs --jq '.check_runs[].name'
   ```
2. Observe a docs-only PR where the gate jobs report `skipped` and the PR is mergeable (skipped checks satisfy required contexts).

Then flip (currently `contexts: ["signoff"]`):
```bash
gh api -X PATCH repos/rararulab/rara/branches/main/protection/required_status_checks \
  --input - <<'JSON'
{"checks": [{"context": "Rust / Rust Success"}, {"context": "Lint / Lint Success"}]}
JSON
```
`web-ci.yml` checks must NOT become required (workflow-level `paths:` filter would perma-block non-web PRs). `signoff` stays installed as the documented emergency override (procedure + restore command in `docs/guides/workflow.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

### Update: the implicit-toolchain tax (rounds 2–3)

After #2171 unblocked the build graph, two more baked-in tools surfaced one red run at a time: **protoc** (prost-build, `api/build.rs`) and **zig** (`zlob` build.rs — a workspace dep added by #2148 *while CI was dead*, so it had never run in any CI). This whack-a-mole is precisely why the old arc image's implicit toolchain was a liability: nothing in the repo declared what the build needs.

Resolution: the toolset is now **enumerated** (from `rararulab/github-self-runner`'s Dockerfile + workspace build-script requirements) and declared in one place — `.github/actions/setup-rara-build/action.yml` (diesel headers, protoc, zig 0.16, mold+clang on x86_64), used by every workspace-building job. Release builds get the same via `[workspace.metadata.dist.dependencies.apt]`.

Known non-gate red: `smoke macos-latest` (zig-codec-smoke) fails linking the zig staticlib on `macos-latest`/aarch64 — `crates/tape-codec-zig` issue, out of this PR's boundary, no green baseline exists (all arc-era runs were queue-cancelled). Follow-up issue material. The linux smoke leg is green on `ubuntu-latest` + explicit mold.
