### PR TITLE
fix(ci): move web.yml deploy to ubuntu-latest with in-workflow mdbook install (#2173)

### DIFF
--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -23,12 +23,16 @@ concurrency:
 jobs:
   web:
     name: Build and deploy site and docs
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
         with:
           fetch-depth: false
           persist-credentials: false
+      - name: Install mdbook
+        uses: taiki-e/install-action@c93ccc03e00cd0e08e494f5fd058a6c55a6a1907 # v2
+        with:
+          tool: mdbook
       - name: Build mdbook
         run: mdbook build docs
 
@@ -60,7 +64,7 @@ jobs:
 
           git config --global --add safe.directory "$deploy_dir"
 
-          # Publish with git directly so the self-hosted runner does not depend on rsync.
+          # Publish with git directly so the runner does not depend on rsync.
           find "$deploy_dir" -mindepth 1 -maxdepth 1 ! -name '.git' -exec rm -rf {} +
           cp -R docs/book/. "$deploy_dir"/
           touch "$deploy_dir/.nojekyll"


### PR DESCRIPTION
## Summary

Restores the site/docs deploy. `web.yml`'s "Build and deploy site and docs" job ran on `runs-on: self-hosted` (raratekiAir), which has no `mdbook` — every `main` push touching `docs/**` since 2026-05-21 failed with `mdbook: command not found` (exit 127), leaving the GitHub Pages docs site frozen at the 2026-05-01 build.

Changes (`.github/workflows/web.yml` only, per issue Boundaries):

1. `runs-on: self-hosted` → `runs-on: ubuntu-latest` (follows the #2170 GitHub-hosted-runner direction; the job has zero machine-local dependency — it publishes `docs/book/` to `gh-pages` over HTTPS with `GITHUB_TOKEN`).
2. New `Install mdbook` step via `taiki-e/install-action@c93ccc03e00cd0e08e494f5fd058a6c55a6a1907 # v2` with `tool: mdbook` — the exact SHA pin already used for nextest in `rust.yml` / `ci.yml`.
3. The git-based gh-pages publish script is unchanged except its now-stale "self-hosted runner" comment.

## Type of change

Bug fix / CI (`bug` + `ci`)

## Component

`ci`

## Closes

Closes #2173

## Verification

Verification: PASS — verification/report.md (base 84a60361, head 115a1c45)

Key evidence:
- `actionlint .github/workflows/web.yml` → no findings
- Build step run locally (mdbook v0.5.2): `mdbook build docs` → `INFO HTML book written to .../docs/book`, exit 0; `docs/book` is gitignored (no residue in the commit)
- Self-hosted assumption sweep: deploy step uses only `git`, `mktemp`, `find`, `cp`, `bash` — all present on ubuntu-latest; no node/bun involved
- prek hooks: all file-filtered hooks correctly skip a workflow-only diff; commit-msg conventional-commit hook passed

## Post-merge acceptance (REQUIRED before the issue counts as done)

This PR does NOT trigger `web.yml` itself — the workflow is path-filtered to `docs/**` and this diff touches only `.github/workflows/`. The deploy step therefore cannot be exercised pre-merge. After merge:

1. Run `gh workflow run web.yml`.
2. Confirm the FULL job is green end-to-end — `Build mdbook` green on `ubuntu-latest` AND the `Deploy to GitHub Pages` step pushes to `gh-pages` (or prints "No changes to deploy").

Completion is explicitly NOT claimable on build-step green alone.

## Test plan

- [x] `actionlint` clean on the changed workflow
- [x] `mdbook build docs` verified locally (the exact build command the job runs)
- [ ] Post-merge `workflow_dispatch` run green end-to-end (deploy step — see above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)