### PR TITLE
fix(web): move data-feeds spec into e2e/harness so the harness suite runs it (#2172)

### DIFF
--- a/.github/workflows/web-ci.yml
+++ b/.github/workflows/web-ci.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Build
         run: bun run build
       # No --pass-with-no-tests: the harness suite is non-empty
-      # (web/e2e/data-feeds.spec.ts) and a silently-empty testDir must
+      # (web/e2e/harness/data-feeds.spec.ts) and a silently-empty testDir must
       # fail loudly, not pass (#2166).
       - name: Run Playwright harness suite
         run: bunx playwright test

--- a/web/e2e/harness/data-feeds.spec.ts
+++ b/web/e2e/harness/data-feeds.spec.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { test, expect } from "@playwright/test";
+import { test, expect } from '@playwright/test';
 
 // ---------------------------------------------------------------------------
 // Types — mirrors web/src/api/data-feeds.ts
@@ -23,12 +23,12 @@ import { test, expect } from "@playwright/test";
 interface DataFeedConfig {
   id: string;
   name: string;
-  feed_type: "webhook" | "websocket" | "polling";
+  feed_type: 'webhook' | 'websocket' | 'polling';
   tags: string[];
   transport: Record<string, unknown>;
   auth: { type: string; [key: string]: unknown } | null;
   enabled: boolean;
-  status: "idle" | "running" | "error";
+  status: 'idle' | 'running' | 'error';
   last_error: string | null;
   created_at: string;
   updated_at: string;
@@ -50,8 +50,7 @@ interface FeedEvent {
 /** Yahoo Finance payload — fetched once in beforeAll, or falls back to static fixture. */
 let yahooPayload: unknown;
 
-const YAHOO_API_URL =
-  "https://query1.finance.yahoo.com/v8/finance/chart/AAPL?interval=1d&range=1d";
+const YAHOO_API_URL = 'https://query1.finance.yahoo.com/v8/finance/chart/AAPL?interval=1d&range=1d';
 
 /** Static fallback when Yahoo Finance API is unreachable. */
 const YAHOO_FALLBACK = {
@@ -59,10 +58,10 @@ const YAHOO_FALLBACK = {
     result: [
       {
         meta: {
-          currency: "USD",
-          symbol: "AAPL",
-          exchangeName: "NMS",
-          fullExchangeName: "NasdaqGS",
+          currency: 'USD',
+          symbol: 'AAPL',
+          exchangeName: 'NMS',
+          fullExchangeName: 'NasdaqGS',
           regularMarketPrice: 195.89,
         },
         timestamp: [1713100200],
@@ -85,27 +84,27 @@ const YAHOO_FALLBACK = {
 
 /** Fake settings that satisfy hasConfiguredLlmProvider so onboarding is skipped. */
 const MOCK_SETTINGS: Record<string, string> = {
-  "llm.default_provider": "openrouter",
-  "llm.providers.openrouter.enabled": "true",
-  "llm.providers.openrouter.api_key": "sk-fake-key-for-e2e",
+  'llm.default_provider': 'openrouter',
+  'llm.providers.openrouter.enabled': 'true',
+  'llm.providers.openrouter.api_key': 'sk-fake-key-for-e2e',
 };
 
 function makeFeed(overrides: Partial<DataFeedConfig> = {}): DataFeedConfig {
   const now = new Date().toISOString();
   return {
-    id: "feed-1",
-    name: "yahoo-aapl",
-    feed_type: "polling",
-    tags: ["stock", "yahoo", "aapl"],
+    id: 'feed-1',
+    name: 'yahoo-aapl',
+    feed_type: 'polling',
+    tags: ['stock', 'yahoo', 'aapl'],
     transport: {
       url: YAHOO_API_URL,
       interval_secs: 60,
       headers: {},
-      method: "GET",
+      method: 'GET',
     },
     auth: null,
     enabled: true,
-    status: "running",
+    status: 'running',
     last_error: null,
     created_at: now,
     updated_at: now,
@@ -115,10 +114,10 @@ function makeFeed(overrides: Partial<DataFeedConfig> = {}): DataFeedConfig {
 
 function makeEvent(overrides: Partial<FeedEvent> = {}): FeedEvent {
   return {
-    id: "evt-1",
-    source_name: "yahoo-aapl",
-    event_type: "poll_response",
-    tags: ["stock", "yahoo", "aapl"],
+    id: 'evt-1',
+    source_name: 'yahoo-aapl',
+    event_type: 'poll_response',
+    tags: ['stock', 'yahoo', 'aapl'],
     payload: yahooPayload,
     received_at: new Date().toISOString(),
     ...overrides,
@@ -132,7 +131,7 @@ function makeEvent(overrides: Partial<FeedEvent> = {}): FeedEvent {
 test.beforeAll(async () => {
   try {
     const res = await fetch(YAHOO_API_URL, {
-      headers: { "User-Agent": "Mozilla/5.0" },
+      headers: { 'User-Agent': 'Mozilla/5.0' },
       signal: AbortSignal.timeout(5_000),
     });
     if (res.ok) {
@@ -161,37 +160,45 @@ test.beforeAll(async () => {
  * Playwright's page.route() then intercepts these before they hit the network.
  */
 async function setupRoutes(
-  page: import("@playwright/test").Page,
+  page: import('@playwright/test').Page,
   state: {
     feeds: DataFeedConfig[];
     events: FeedEvent[];
   },
 ) {
   // Suppress onboarding & connection dialogs via localStorage.
-  // Using the Vite dev server URL keeps resolveUrl() pointing at same origin.
   await page.addInitScript(() => {
-    // Use empty string so resolveUrl returns relative paths that page.route can intercept.
-    // hasCustomBackendUrl() needs a truthy value to suppress ConnectionSetupDialog.
-    localStorage.setItem("rara_backend_url", "http://localhost:5173");
-    localStorage.setItem("onboarding_dismissed", "true");
+    // Point resolveUrl() at the page origin (vite preview or dev server)
+    // so fetches stay same-origin and page.route can intercept them.
+    // hasCustomBackendUrl() needs a non-null value to suppress
+    // ConnectionSetupDialog.
+    localStorage.setItem('rara_backend_url', location.origin);
+    localStorage.setItem('onboarding_dismissed', 'true');
+    // Satisfy the RequireAuth route guard (owner-token login): it reads
+    // both keys straight from localStorage, no network round-trip.
+    localStorage.setItem('access_token', 'e2e-fake-token');
+    localStorage.setItem(
+      'auth_user',
+      JSON.stringify({ user_id: 'owner', role: 'owner', is_admin: true }),
+    );
   });
 
   // Health check.
-  await page.route("**/api/v1/health", (route) =>
-    route.fulfill({ status: 200, json: { status: "ok" } }),
+  await page.route('**/api/v1/health', (route) =>
+    route.fulfill({ status: 200, json: { status: 'ok' } }),
   );
 
   // Settings — return a configured provider so onboarding is suppressed.
-  await page.route("**/api/v1/settings", (route) =>
+  await page.route('**/api/v1/settings', (route) =>
     route.fulfill({ status: 200, json: MOCK_SETTINGS }),
   );
 
   // Data feeds list + create.
-  await page.route("**/api/v1/data-feeds", async (route, request) => {
+  await page.route('**/api/v1/data-feeds', async (route, request) => {
     const method = request.method();
-    if (method === "GET") {
+    if (method === 'GET') {
       await route.fulfill({ json: state.feeds });
-    } else if (method === "POST") {
+    } else if (method === 'POST') {
       const body = request.postDataJSON();
       const now = new Date().toISOString();
       const created: DataFeedConfig = {
@@ -202,7 +209,7 @@ async function setupRoutes(
         transport: body.transport ?? {},
         auth: body.auth ?? null,
         enabled: true,
-        status: "running",
+        status: 'running',
         last_error: null,
         created_at: now,
         updated_at: now,
@@ -215,18 +222,18 @@ async function setupRoutes(
   });
 
   // Toggle feed.
-  await page.route("**/api/v1/data-feeds/*/toggle", async (route, request) => {
-    if (request.method() === "PUT") {
+  await page.route('**/api/v1/data-feeds/*/toggle', async (route, request) => {
+    if (request.method() === 'PUT') {
       const url = request.url();
       const idMatch = url.match(/data-feeds\/([^/]+)\/toggle/);
       const id = idMatch?.[1];
       const feed = state.feeds.find((f) => f.id === id);
       if (feed) {
         feed.enabled = !feed.enabled;
-        feed.status = feed.enabled ? "running" : "idle";
+        feed.status = feed.enabled ? 'running' : 'idle';
         await route.fulfill({ json: feed });
       } else {
-        await route.fulfill({ status: 404, json: { error: "not found" } });
+        await route.fulfill({ status: 404, json: { error: 'not found' } });
       }
     } else {
       await route.continue();
@@ -234,7 +241,7 @@ async function setupRoutes(
   });
 
   // Feed events — must be registered before the single-feed catch-all.
-  await page.route("**/api/v1/data-feeds/*/events*", async (route) => {
+  await page.route('**/api/v1/data-feeds/*/events*', async (route) => {
     await route.fulfill({
       json: {
         events: state.events,
@@ -245,208 +252,195 @@ async function setupRoutes(
   });
 
   // Single feed operations (GET/PUT/DELETE by id).
-  await page.route(
-    /\/api\/v1\/data-feeds\/[^/]+$/,
-    async (route, request) => {
-      const method = request.method();
-      const url = request.url();
-      const idMatch = url.match(/data-feeds\/([^/]+)$/);
-      const id = idMatch?.[1];
+  await page.route(/\/api\/v1\/data-feeds\/[^/]+$/, async (route, request) => {
+    const method = request.method();
+    const url = request.url();
+    const idMatch = url.match(/data-feeds\/([^/]+)$/);
+    const id = idMatch?.[1];
 
-      if (method === "DELETE") {
-        state.feeds = state.feeds.filter((f) => f.id !== id);
-        await route.fulfill({ status: 204 });
-      } else if (method === "PUT") {
-        const feed = state.feeds.find((f) => f.id === id);
-        if (feed) {
-          const body = request.postDataJSON();
-          Object.assign(feed, body, { updated_at: new Date().toISOString() });
-          await route.fulfill({ json: feed });
-        } else {
-          await route.fulfill({ status: 404, json: { error: "not found" } });
-        }
-      } else if (method === "GET") {
-        const feed = state.feeds.find((f) => f.id === id);
-        if (feed) {
-          await route.fulfill({ json: feed });
-        } else {
-          await route.fulfill({ status: 404, json: { error: "not found" } });
-        }
+    if (method === 'DELETE') {
+      state.feeds = state.feeds.filter((f) => f.id !== id);
+      await route.fulfill({ status: 204 });
+    } else if (method === 'PUT') {
+      const feed = state.feeds.find((f) => f.id === id);
+      if (feed) {
+        const body = request.postDataJSON();
+        Object.assign(feed, body, { updated_at: new Date().toISOString() });
+        await route.fulfill({ json: feed });
       } else {
-        await route.continue();
+        await route.fulfill({ status: 404, json: { error: 'not found' } });
       }
-    },
-  );
+    } else if (method === 'GET') {
+      const feed = state.feeds.find((f) => f.id === id);
+      if (feed) {
+        await route.fulfill({ json: feed });
+      } else {
+        await route.fulfill({ status: 404, json: { error: 'not found' } });
+      }
+    } else {
+      await route.continue();
+    }
+  });
 }
 
 /** Navigate directly to the Data Feeds settings tab. */
-async function goToDataFeeds(page: import("@playwright/test").Page) {
-  await page.goto("/settings?section=data-feeds");
-  await page.waitForLoadState("networkidle");
+async function goToDataFeeds(page: import('@playwright/test').Page) {
+  await page.goto('/settings?section=data-feeds');
+  await page.waitForLoadState('networkidle');
 }
 
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
 
-test.describe("Data Feeds Management", () => {
-
+test.describe('Data Feeds Management', () => {
   // -----------------------------------------------------------------------
   // 1. Navigate to Data Feeds tab
   // -----------------------------------------------------------------------
 
-  test("navigate to Data Feeds tab in settings", async ({ page }) => {
+  test('navigate to Data Feeds tab in settings', async ({ page }) => {
     await setupRoutes(page, { feeds: [], events: [] });
-    await page.goto("/settings");
+    await page.goto('/settings');
 
     // Click the Data Feeds sidebar button.
-    const navButton = page.locator("button", { hasText: "Data Feeds" });
+    const navButton = page.locator('button', { hasText: 'Data Feeds' });
     await expect(navButton).toBeVisible({ timeout: 10_000 });
     await navButton.click();
 
     // The Data Feeds panel should render.
-    await expect(
-      page.getByText("External data sources that push events into rara."),
-    ).toBeVisible();
+    await expect(page.getByText('External data sources that push events into rara.')).toBeVisible();
   });
 
   // -----------------------------------------------------------------------
   // 2. Empty state
   // -----------------------------------------------------------------------
 
-  test("shows empty state when no feeds configured", async ({ page }) => {
+  test('shows empty state when no feeds configured', async ({ page }) => {
     await setupRoutes(page, { feeds: [], events: [] });
     await goToDataFeeds(page);
 
-    await expect(
-      page.getByText("No data feeds configured"),
-    ).toBeVisible({ timeout: 10_000 });
-    await expect(page.getByText("Create Feed")).toBeVisible();
+    await expect(page.getByText('No data feeds configured')).toBeVisible({ timeout: 10_000 });
+    await expect(page.getByText('Create Feed')).toBeVisible();
   });
 
   // -----------------------------------------------------------------------
   // 3. Create a polling feed
   // -----------------------------------------------------------------------
 
-  test("create a polling feed", async ({ page }) => {
+  test('create a polling feed', async ({ page }) => {
     await setupRoutes(page, { feeds: [], events: [] });
     await goToDataFeeds(page);
 
     // Click "Create Feed" button in the empty state.
-    await page.getByRole("button", { name: /Create Feed/ }).click();
+    await page.getByRole('button', { name: /Create Feed/ }).click();
 
     // Dialog should open.
-    await expect(page.getByText("New Data Feed")).toBeVisible({ timeout: 5_000 });
+    await expect(page.getByText('New Data Feed')).toBeVisible({ timeout: 5_000 });
 
     // Fill name.
     const nameInput = page.locator('input[placeholder="e.g. github-rara"]');
-    await nameInput.fill("yahoo-aapl");
+    await nameInput.fill('yahoo-aapl');
 
     // Type defaults to Polling — verify it is selected.
-    await expect(page.getByText("Polling")).toBeVisible();
+    await expect(page.getByText('Polling')).toBeVisible();
 
     // Fill URL.
-    const urlInput = page.locator(
-      'input[placeholder="https://api.example.com/data"]',
-    );
+    const urlInput = page.locator('input[placeholder="https://api.example.com/data"]');
     await urlInput.fill(YAHOO_API_URL);
 
     // Fill tags.
     const tagsInput = page.locator('input[placeholder="stock, yahoo, aapl"]');
-    await tagsInput.fill("stock, yahoo, aapl");
+    await tagsInput.fill('stock, yahoo, aapl');
 
     // Click Create.
-    await page.getByRole("button", { name: "Create" }).click();
+    await page.getByRole('button', { name: 'Create' }).click();
 
     // Dialog should close and the feed should appear in the list.
-    await expect(page.getByText("yahoo-aapl")).toBeVisible({ timeout: 5_000 });
+    await expect(page.getByText('yahoo-aapl')).toBeVisible({ timeout: 5_000 });
 
     // Verify status badge shows Running.
-    await expect(page.getByText("Running")).toBeVisible();
+    await expect(page.getByText('Running')).toBeVisible();
   });
 
   // -----------------------------------------------------------------------
   // 4. Feed list renders existing feeds
   // -----------------------------------------------------------------------
 
-  test("feed list renders existing feeds with correct columns", async ({
-    page,
-  }) => {
+  test('feed list renders existing feeds with correct columns', async ({ page }) => {
     const feed = makeFeed();
     await setupRoutes(page, { feeds: [feed], events: [] });
     await goToDataFeeds(page);
 
     // Name column.
-    await expect(page.getByText("yahoo-aapl")).toBeVisible({ timeout: 10_000 });
+    await expect(page.getByText('yahoo-aapl')).toBeVisible({ timeout: 10_000 });
 
     // Type badge.
-    await expect(page.getByText("Polling")).toBeVisible();
+    await expect(page.getByText('Polling')).toBeVisible();
 
     // Status badge.
-    await expect(page.getByText("Running")).toBeVisible();
+    await expect(page.getByText('Running')).toBeVisible();
 
     // Tags.
-    await expect(page.getByText("stock")).toBeVisible();
-    await expect(page.getByText("yahoo", { exact: true })).toBeVisible();
-    await expect(page.getByText("aapl", { exact: true })).toBeVisible();
+    await expect(page.getByText('stock')).toBeVisible();
+    await expect(page.getByText('yahoo', { exact: true })).toBeVisible();
+    await expect(page.getByText('aapl', { exact: true })).toBeVisible();
   });
 
   // -----------------------------------------------------------------------
   // 5. View event history for a feed
   // -----------------------------------------------------------------------
 
-  test("view event history for a feed", async ({ page }) => {
+  test('view event history for a feed', async ({ page }) => {
     const feed = makeFeed();
     const events = [makeEvent()];
     await setupRoutes(page, { feeds: [feed], events });
     await goToDataFeeds(page);
 
     // Click the feed name to navigate to event history.
-    await page.getByText("yahoo-aapl").click();
+    await page.getByText('yahoo-aapl').click();
 
     // Should see the Back button.
-    await expect(
-      page.getByRole("button", { name: "Back" }),
-    ).toBeVisible({ timeout: 5_000 });
+    await expect(page.getByRole('button', { name: 'Back' })).toBeVisible({ timeout: 5_000 });
 
     // Should see the feed info card with name and status.
-    await expect(page.getByText("yahoo-aapl")).toBeVisible();
-    await expect(page.getByText("Running")).toBeVisible();
+    await expect(page.getByText('yahoo-aapl')).toBeVisible();
+    await expect(page.getByText('Running')).toBeVisible();
 
     // Should see event table headers.
-    await expect(page.getByRole("columnheader", { name: "Time" })).toBeVisible();
-    await expect(page.getByRole("columnheader", { name: "Type" })).toBeVisible();
-    await expect(page.getByRole("columnheader", { name: "Size" })).toBeVisible();
+    await expect(page.getByRole('columnheader', { name: 'Time' })).toBeVisible();
+    await expect(page.getByRole('columnheader', { name: 'Type' })).toBeVisible();
+    await expect(page.getByRole('columnheader', { name: 'Size' })).toBeVisible();
 
     // Should see the event type badge.
-    await expect(page.getByText("poll_response")).toBeVisible();
+    await expect(page.getByText('poll_response')).toBeVisible();
   });
 
   // -----------------------------------------------------------------------
   // 6. View event detail with JSON payload
   // -----------------------------------------------------------------------
 
-  test("view event detail with JSON payload", async ({ page }) => {
+  test('view event detail with JSON payload', async ({ page }) => {
     const feed = makeFeed();
     const events = [makeEvent()];
     await setupRoutes(page, { feeds: [feed], events });
     await goToDataFeeds(page);
 
     // Navigate to event history.
-    await page.getByText("yahoo-aapl").click();
-    await expect(
-      page.getByRole("button", { name: "Back" }),
-    ).toBeVisible({ timeout: 5_000 });
+    await page.getByText('yahoo-aapl').click();
+    await expect(page.getByRole('button', { name: 'Back' })).toBeVisible({ timeout: 5_000 });
 
-    // Click the event row to open the detail sheet.
-    const eventRow = page.locator("tr.cursor-pointer").first();
-    await eventRow.click();
+    // Click the event row to open the detail sheet. Target the event-type
+    // badge cell rather than the <tr>: on the 390px mobile viewport the row
+    // is wider than the panel, so the row's center point sits under the
+    // settings sidebar and a raw row click never lands.
+    const eventRow = page.locator('tr.cursor-pointer').first();
+    await eventRow.getByText('poll_response').click();
 
     // The Sheet should open — look for the event ID in the sheet header.
-    await expect(page.getByText("evt-1")).toBeVisible({ timeout: 5_000 });
+    await expect(page.getByText('evt-1')).toBeVisible({ timeout: 5_000 });
 
     // Payload section should show the JsonTree with Yahoo Finance keys.
-    await expect(page.getByText("Payload")).toBeVisible();
+    await expect(page.getByText('Payload')).toBeVisible();
 
     // The JsonTree renders top-level keys visible, nested ones are collapsed.
     // "chart:" and "result:" are visible at their respective nesting levels.
@@ -457,59 +451,55 @@ test.describe("Data Feeds Management", () => {
     await expect(page.getByText(/error.*null/)).toBeVisible();
 
     // Copy button should be present.
-    await expect(page.getByRole("button", { name: "Copy" })).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Copy' })).toBeVisible();
   });
 
   // -----------------------------------------------------------------------
   // 7. Toggle feed enabled/disabled
   // -----------------------------------------------------------------------
 
-  test("toggle feed enabled/disabled", async ({ page }) => {
-    const feed = makeFeed({ enabled: true, status: "running" });
+  test('toggle feed enabled/disabled', async ({ page }) => {
+    const feed = makeFeed({ enabled: true, status: 'running' });
     await setupRoutes(page, { feeds: [feed], events: [] });
     await goToDataFeeds(page);
 
     // Feed should show Running initially.
-    await expect(page.getByText("Running")).toBeVisible({ timeout: 10_000 });
+    await expect(page.getByText('Running')).toBeVisible({ timeout: 10_000 });
 
     // Click the toggle switch.
-    const toggle = page.getByRole("switch");
+    const toggle = page.getByRole('switch');
     await toggle.click();
 
     // After toggle, the status should change to Disabled.
-    await expect(page.getByText("Disabled")).toBeVisible({ timeout: 5_000 });
+    await expect(page.getByText('Disabled')).toBeVisible({ timeout: 5_000 });
   });
 
   // -----------------------------------------------------------------------
   // 8. Delete a feed
   // -----------------------------------------------------------------------
 
-  test("delete a feed", async ({ page }) => {
+  test('delete a feed', async ({ page }) => {
     const feed = makeFeed();
     await setupRoutes(page, { feeds: [feed], events: [] });
     await goToDataFeeds(page);
 
     // Feed should be visible.
-    await expect(page.getByText("yahoo-aapl")).toBeVisible({ timeout: 10_000 });
+    await expect(page.getByText('yahoo-aapl')).toBeVisible({ timeout: 10_000 });
 
     // Click the delete button (Trash2 icon button with destructive styling).
-    const deleteButton = page.locator("button.text-destructive");
+    const deleteButton = page.locator('button.text-destructive');
     await deleteButton.click();
 
     // Confirmation dialog should appear.
-    await expect(page.getByText("Delete Feed")).toBeVisible({ timeout: 5_000 });
-    await expect(
-      page.getByText("This will permanently remove this feed"),
-    ).toBeVisible();
+    await expect(page.getByText('Delete Feed')).toBeVisible({ timeout: 5_000 });
+    await expect(page.getByText('This will permanently remove this feed')).toBeVisible();
 
     // Click the destructive Delete button in the confirmation dialog.
-    const confirmDelete = page
-      .locator('[role="dialog"]')
-      .getByRole("button", { name: "Delete" });
+    const confirmDelete = page.locator('[role="dialog"]').getByRole('button', { name: 'Delete' });
     await confirmDelete.click();
 
     // Feed should disappear and empty state should show.
-    await expect(page.getByText("No data feeds configured")).toBeVisible({
+    await expect(page.getByText('No data feeds configured')).toBeVisible({
       timeout: 5_000,
     });
   });
@@ -518,47 +508,39 @@ test.describe("Data Feeds Management", () => {
   // 9. Navigate back from event history to feed list
   // -----------------------------------------------------------------------
 
-  test("navigate back from event history to feed list", async ({ page }) => {
+  test('navigate back from event history to feed list', async ({ page }) => {
     const feed = makeFeed();
     await setupRoutes(page, { feeds: [feed], events: [makeEvent()] });
     await goToDataFeeds(page);
 
     // Go to event history.
-    await page.getByText("yahoo-aapl").click();
-    await expect(
-      page.getByRole("button", { name: "Back" }),
-    ).toBeVisible({ timeout: 5_000 });
+    await page.getByText('yahoo-aapl').click();
+    await expect(page.getByRole('button', { name: 'Back' })).toBeVisible({ timeout: 5_000 });
 
     // Click Back.
-    await page.getByRole("button", { name: "Back" }).click();
+    await page.getByRole('button', { name: 'Back' }).click();
 
     // Should return to the feed list with the "New Feed" button visible.
-    await expect(
-      page.getByRole("button", { name: "New Feed" }),
-    ).toBeVisible({ timeout: 5_000 });
+    await expect(page.getByRole('button', { name: 'New Feed' })).toBeVisible({ timeout: 5_000 });
 
     // Feed should still be in the list.
-    await expect(page.getByText("yahoo-aapl")).toBeVisible();
+    await expect(page.getByText('yahoo-aapl')).toBeVisible();
   });
 
   // -----------------------------------------------------------------------
   // 10. Event history shows empty state for no events
   // -----------------------------------------------------------------------
 
-  test("event history shows empty state when no events", async ({ page }) => {
+  test('event history shows empty state when no events', async ({ page }) => {
     const feed = makeFeed();
     await setupRoutes(page, { feeds: [feed], events: [] });
     await goToDataFeeds(page);
 
     // Navigate to event history.
-    await page.getByText("yahoo-aapl").click();
-    await expect(
-      page.getByRole("button", { name: "Back" }),
-    ).toBeVisible({ timeout: 5_000 });
+    await page.getByText('yahoo-aapl').click();
+    await expect(page.getByRole('button', { name: 'Back' })).toBeVisible({ timeout: 5_000 });
 
     // Should show "No events in this time range".
-    await expect(
-      page.getByText("No events in this time range"),
-    ).toBeVisible({ timeout: 5_000 });
+    await expect(page.getByText('No events in this time range')).toBeVisible({ timeout: 5_000 });
   });
 });

--- a/web/playwright.config.live.ts
+++ b/web/playwright.config.live.ts
@@ -14,17 +14,16 @@
  * limitations under the License.
  */
 
-// Playwright config for the live-backend e2e suite (data-feeds.spec.ts).
-// Kept separate from the harness suite because
-// these tests hit a real rara backend via `npm run dev` and are not
-// safe to run in CI without fixture coordination. Invoke with
-// `npm run test:e2e:live` locally when the backend is already up.
+// Playwright config for the live (dev-server) e2e run. Unlike the
+// harness config it runs every spec under e2e/ against `npm run dev`,
+// so backend-driven specs are allowed here and are not safe to run in
+// CI without fixture coordination. Invoke with `npm run test:e2e:live`
+// locally when the backend is already up.
 
 import { defineConfig, devices } from '@playwright/test';
 
 export default defineConfig({
   testDir: './e2e',
-  testIgnore: /harness\/.*/,
   fullyParallel: false,
   forbidOnly: !!process.env.CI,
   retries: 0,


### PR DESCRIPTION
## Summary

Fixes the `Playwright (harness)` job failing with `No tests found` on every run since #2170. The harness config's `testMatch` (`/harness\/.*\.spec\.ts$/`) has matched zero files since #2003 deleted the original harness specs; #2170 removed the masking `--pass-with-no-tests` flag, exposing the empty suite. `web/e2e/data-feeds.spec.ts` is fully network-mocked — exactly the harness contract — so it moves under `web/e2e/harness/`.

Changes:

- Move `web/e2e/data-feeds.spec.ts` → `web/e2e/harness/data-feeds.spec.ts` (git mv; the spec has no relative imports).
- Fix the spec so it actually passes against the static preview (`:4173`) and the current app:
  - Seed `access_token` + `auth_user` in the init script — the owner-token `RequireAuth` guard (added after the spec was written) redirected every page to `/login`.
  - Set `rara_backend_url` to `location.origin` instead of hardcoded `:5173` so `resolveUrl()` stays same-origin under both the harness preview (`:4173`) and the live dev server (`:5173`).
  - Click the event-type badge cell instead of the `<tr>` — on the 390px mobile viewport the row overflows the panel and its center point sits under the settings sidebar.
- Remove `testIgnore: /harness\/.*/` from `playwright.config.live.ts` (supersession justification below).
- Fix the stale spec path in the `web-ci.yml` comment left by #2170.

No `--pass-with-no-tests`, no `test.skip`, no product code touched.

## Supersession of #1612's live-config `testIgnore`

#1612 created the harness/live split and added `testIgnore: /harness\/.*/` to `playwright.config.live.ts` so the live run would not re-execute harness specs. Issue #2172's acceptance bullet 3 requires that `bun run test:e2e:live` still resolves `data-feeds.spec.ts` after the move — but with the #1612 ignore in place, moving the only spec under `harness/` leaves the live config resolving **zero** tests (the issue's premise that the live config has "no filter" was factually wrong). Removing the `testIgnore` line is the minimal change that satisfies the acceptance criterion and matches the issue's stated end state ("the live suite still picks the file up"). The boundary that actually matters — backend-driven specs must never join the backend-less harness CI job — remains enforced by `testMatch: /harness\/.*\.spec\.ts$/` in `playwright.config.ts`: a future backend-driven spec dropped at `e2e/` root joins only the opt-in live run, never the harness job.

## Verification

Verification: PASS — verification/report.md (base 84a60361, head b4d1a918)

- Harness suite (exact CI invocation, `bunx playwright test` in `web/`): **30/30 passed** (10 tests × mobile / desktop-1280 / desktop-1920) — run twice, including once on the final committed state after the prettier pre-commit hook reformatted the spec.
- Base-sha transition: on base `84a60361` the harness suite fails with `No tests found`; on head `b4d1a918` it executes and passes 30 tests.
- Live config resolution: `bunx playwright test --config=playwright.config.live.ts --list` → `Total: 10 tests in 1 file` (no live-suite regression, no backend needed).
- Quality gate: `bun run build` (`tsc -b && vite build`) ✓, `bun run typecheck` ✓, `bun run lint` (`eslint .`) ✓.

## Merge sequencing

Merge is sequenced **after** the #2179 gate-shape fix PR (this PR took #2180, so that fix will land under a later number): this PR's Rust/Lint gates will skip and the required contexts won't materialize until #2179 lands — known repo-wide blocker, evidence on PR #2177. Do not merge before that.

Closes #2172

🤖 Generated with [Claude Code](https://claude.com/claude-code)
