### PR TITLE
fix(ci): pass path-filter result into reusable gate workflows so required contexts always materialize (#2179)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,8 +21,13 @@ permissions:
 # This workflow routes the merge gate: branch protection requires the
 # `Rust / Rust Success` and `Lint / Lint Success` check contexts produced
 # by the reusable workflows called below. It intentionally has NO
-# workflow-level `paths:` filter — it must trigger on every PR so that
-# skipped gate jobs still report and satisfy the required checks (#2166).
+# workflow-level `paths:` filter, and the `rust:`/`lint:` caller jobs
+# always run: a skipped caller job never materializes the called
+# workflow's check runs, so the required contexts would stay forever
+# pending and the PR would be perma-BLOCKED (#2179). Instead the path
+# filter result is passed down as the `run` input; the called workflows
+# skip their work legs internally and their aggregate jobs report
+# success-via-legitimate-skip when `run` is false (#2166, #2179).
 jobs:
   changes:
     name: Detect Changes
@@ -73,14 +78,16 @@ jobs:
   lint:
     name: Lint
     needs: changes
-    if: ${{ needs.changes.outputs.rust == 'true' || github.event_name == 'push' }}
     uses: ./.github/workflows/lint.yml
+    with:
+      run: ${{ needs.changes.outputs.rust == 'true' || github.event_name == 'push' }}
 
   rust:
     name: Rust
     needs: changes
-    if: ${{ needs.changes.outputs.rust == 'true' || github.event_name == 'push' }}
     uses: ./.github/workflows/rust.yml
+    with:
+      run: ${{ needs.changes.outputs.rust == 'true' || github.event_name == 'push' }}
 
   # Verifies changed lane-1 Task Contracts: `agent-spec lint` scores the
   # spec, `agent-spec lifecycle` binds its BDD scenarios to real tests.

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,6 +2,15 @@ name: Lint
 
 on:
   workflow_call:
+    inputs:
+      # Whether the work legs should actually run. The caller (ci.yml)
+      # always invokes this workflow — even for diffs that touch no rust
+      # paths — because a skipped caller job never materializes the
+      # `Lint / Lint Success` required check (#2179). When false, the
+      # work legs skip and `lint-success` reports success-via-skip.
+      run:
+        required: true
+        type: boolean
 
 concurrency:
   group: lint-${{ github.event.pull_request.number || github.sha }}
@@ -23,6 +32,7 @@ permissions:
 jobs:
   rust-format:
     name: Rust Format
+    if: ${{ inputs.run }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -42,6 +52,7 @@ jobs:
 
   proto-lint:
     name: Protocol Buffer Lint
+    if: ${{ inputs.run }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -63,6 +74,7 @@ jobs:
 
   devtool-checks:
     name: Devtool Checks
+    if: ${{ inputs.run }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -95,14 +107,26 @@ jobs:
     steps:
       - name: Check all lint jobs status
         env:
+          RUN: ${{ inputs.run }}
           RUST_FORMAT_RESULT: ${{ needs.rust-format.result }}
           PROTO_LINT_RESULT: ${{ needs.proto-lint.result }}
           DEVTOOL_CHECKS_RESULT: ${{ needs.devtool-checks.result }}
         run: |
-          if [[ "$RUST_FORMAT_RESULT" != "success" || \
-                "$PROTO_LINT_RESULT" != "success" || \
-                "$DEVTOOL_CHECKS_RESULT" != "success" ]]; then
-            echo "One or more lint jobs failed"
+          # A leg satisfies the gate when it succeeded, or when it was
+          # legitimately skipped (invoked with run=false: the diff
+          # touched no rust paths). `failure`, `cancelled`, or a skip
+          # while run=true (broken `if:`, cancelled upstream) must NOT
+          # satisfy the required check (#2166 hard rule, #2179).
+          leg_ok() {
+            [[ "$1" == "success" || ( "$1" == "skipped" && "$RUN" != "true" ) ]]
+          }
+          echo "run:            $RUN"
+          echo "rust-format:    $RUST_FORMAT_RESULT"
+          echo "proto-lint:     $PROTO_LINT_RESULT"
+          echo "devtool-checks: $DEVTOOL_CHECKS_RESULT"
+          if ! leg_ok "$RUST_FORMAT_RESULT" || ! leg_ok "$PROTO_LINT_RESULT" || \
+             ! leg_ok "$DEVTOOL_CHECKS_RESULT"; then
+            echo "One or more lint jobs failed or skipped unexpectedly"
             exit 1
           fi
-          echo "All lint jobs passed successfully"
+          echo "All lint jobs passed (or were legitimately skipped)"

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -2,6 +2,15 @@ name: Rust
 
 on:
   workflow_call:
+    inputs:
+      # Whether the work legs should actually run. The caller (ci.yml)
+      # always invokes this workflow — even for diffs that touch no rust
+      # paths — because a skipped caller job never materializes the
+      # `Rust / Rust Success` required check (#2179). When false, the
+      # work legs skip and `rust-success` reports success-via-skip.
+      run:
+        required: true
+        type: boolean
 
 concurrency:
   group: rust-${{ github.event.pull_request.number || github.sha }}
@@ -48,6 +57,7 @@ permissions:
 jobs:
   clippy:
     name: Clippy (${{ matrix.arch }})
+    if: ${{ inputs.run }}
     runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
@@ -80,6 +90,7 @@ jobs:
 
   test:
     name: Test (${{ matrix.arch }})
+    if: ${{ inputs.run }}
     runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
@@ -126,6 +137,7 @@ jobs:
 
   docs:
     name: Documentation (${{ matrix.arch }})
+    if: ${{ inputs.run }}
     runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
@@ -175,17 +187,26 @@ jobs:
     steps:
       - name: Check all Rust jobs status
         env:
+          RUN: ${{ inputs.run }}
           CLIPPY_RESULT: ${{ needs.clippy.result }}
           TEST_RESULT: ${{ needs.test.result }}
           DOCS_RESULT: ${{ needs.docs.result }}
         run: |
-          if [[ "$CLIPPY_RESULT" != "success" || \
-                "$TEST_RESULT" != "success" || \
-                "$DOCS_RESULT" != "success" ]]; then
-            echo "One or more Rust jobs failed"
-            echo "  clippy: $CLIPPY_RESULT"
-            echo "  test:   $TEST_RESULT"
-            echo "  docs:   $DOCS_RESULT"
+          # A leg satisfies the gate when it succeeded, or when it was
+          # legitimately skipped (invoked with run=false: the diff
+          # touched no rust paths). `failure`, `cancelled`, or a skip
+          # while run=true (broken `if:`, cancelled upstream) must NOT
+          # satisfy the required check (#2166 hard rule, #2179).
+          leg_ok() {
+            [[ "$1" == "success" || ( "$1" == "skipped" && "$RUN" != "true" ) ]]
+          }
+          echo "run:    $RUN"
+          echo "clippy: $CLIPPY_RESULT"
+          echo "test:   $TEST_RESULT"
+          echo "docs:   $DOCS_RESULT"
+          if ! leg_ok "$CLIPPY_RESULT" || ! leg_ok "$TEST_RESULT" || \
+             ! leg_ok "$DOCS_RESULT"; then
+            echo "One or more Rust jobs failed or skipped unexpectedly"
             exit 1
           fi
-          echo "All Rust jobs passed successfully"
+          echo "All Rust jobs passed (or were legitimately skipped)"


### PR DESCRIPTION
## Summary

A skipped caller job never materializes the called workflow's check runs, so on path-skipped PRs the required contexts `Rust / Rust Success` and `Lint / Lint Success` were never created — every docs/workflow/web-only PR sat at `mergeStateStatus: BLOCKED` (first live hit: PR #2177).

This moves the skip decision inside the reusable workflows:

- **ci.yml**: `rust:`/`lint:` caller jobs always run; the path-filter result is passed down as a required boolean `run` input (`${{ needs.changes.outputs.rust == 'true' || github.event_name == 'push' }}`, push semantics preserved). The factually-wrong gate-shape comment from #2166 (lines 21–25) is corrected.
- **rust.yml / lint.yml**: declare the `run` input; every work leg gains `if: inputs.run`; the `if: always()` aggregates (`rust-success` / `lint-success`) accept `success`, accept `skipped` only when `run=false`, and fail on `failure` / `cancelled` / unexpected-skip — preserving the #2166 hard rule.

Branch protection contexts and all job names are unchanged — no protection PATCH needed.

## Verification

**Verification: PASS — verification/report.md (base 84a60361, head a303c85b)**

- `actionlint` on all three workflows: zero findings, exit 0.
- Exhaustive local execution of the aggregate `leg_ok` logic (the exact bash shipped in the workflows):

  | RUN | result | verdict |
  |-----|--------|---------|
  | true | success | OK |
  | true | skipped | FAIL (unexpected skip) |
  | true | failure | FAIL |
  | true | cancelled | FAIL |
  | false | success | OK |
  | false | skipped | OK (legitimate skip) |
  | false | failure | FAIL |
  | false | cancelled | FAIL |

- Non-issues re-verified: no `secrets` in any of the three files; called-workflow concurrency groups key on PR number/SHA (unaffected); `release-pr` (`success || skipped`) still accepted on push; ci.yml is the only caller of rust.yml/lint.yml, so the new required input breaks no other invocation.
- **Acceptance 1 is self-testing**: this PR touches `ci.yml`/`rust.yml`/`lint.yml`, which are in the `rust` path filter — the full real gates (Rust + Lint, both arches) run on this very PR.

## Residual (fail-closed, acceptable)

If the `changes` (Detect Changes) job itself fails, the caller jobs — and therefore the required contexts — still never materialize and the PR blocks. This is inherent to the spec'd shape and fail-closed: a broken path filter blocks merges rather than waving them through.

## Follow-up forecast

`docs/guides/workflow.md:316` still carries the stale "skipped gate jobs satisfy required checks" claim. That gets a separate docs-only issue after this merges — which conveniently doubles as the first live test of this fix (a docs-only PR must now go green via legitimate skip).

## Unblocks

- PR #2177 (workflow-only, currently BLOCKED) — rebase/re-run after merge.
- All future docs-only / web-only / workflow-only PRs of the same class (any diff outside the `rust` path filter).

## Type of change

Bug fix (`bug`) / CI (`ci`)

## Component

`ci`

## Closes

Closes #2179

## Test plan

- [x] `actionlint` clean on all three workflows
- [x] Aggregate gate logic exhaustively truth-tabled locally
- [x] Full real gates run on this PR itself (acceptance 1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
