### PR TITLE
fix(kernel): surface failed turns as traces + OpenRouter e2e provider with preflight (#2178)

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -4,8 +4,10 @@ name: E2E (Real LLM)
 # OpenAI-compatible provider. Triggers on `main` push + manual dispatch only —
 # **not** on pull_request, to avoid burning provider tokens on every push.
 # Maintainer must configure `OPENAI_API_KEY` (secret), `OPENAI_BASE_URL` (var),
-# and `OPENAI_MODEL` (var) in repo settings; without them the job fails fast
-# at config render.
+# and `OPENAI_MODEL` (var) in org/repo settings — OpenRouter as of #2178
+# (base_url https://openrouter.ai/api/v1, no trailing slash). A 1-token
+# provider preflight fails the job fast, before the build, when the key or
+# vars are missing/broken.
 
 on:
   push:
@@ -78,6 +80,31 @@ jobs:
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
         with:
           persist-credentials: false
+
+      # Fail fast on provider quota/auth errors BEFORE the ~10-minute build:
+      # a 1-token completion ping surfaces the provider's error body in the
+      # step log within a minute (#2178). The response body carries no
+      # secrets; the API key itself is never echoed.
+      - name: Provider preflight (1-token ping)
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          OPENAI_BASE_URL: ${{ vars.OPENAI_BASE_URL }}
+          OPENAI_MODEL: ${{ vars.OPENAI_MODEL }}
+        run: |
+          body="$(mktemp)"
+          status=$(curl -sS --max-time 60 -o "$body" -w "%{http_code}" \
+            -H "Authorization: Bearer ${OPENAI_API_KEY}" \
+            -H "Content-Type: application/json" \
+            -d "{\"model\":\"${OPENAI_MODEL}\",\"messages\":[{\"role\":\"user\",\"content\":\"ping\"}],\"max_tokens\":1}" \
+            "${OPENAI_BASE_URL}/chat/completions")
+          if [ "$status" != "200" ]; then
+            echo "::error::provider preflight failed: HTTP $status from ${OPENAI_BASE_URL} (model ${OPENAI_MODEL})"
+            echo "--- provider response body ---"
+            cat "$body"
+            echo
+            exit 1
+          fi
+          echo "provider preflight OK: HTTP 200 from ${OPENAI_BASE_URL} (model ${OPENAI_MODEL})"
 
       # System toolchain (diesel headers, protoc, zig, mold) — see
       # .github/actions/setup-rara-build/action.yml (#2166).

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -83,10 +83,6 @@ llm:
       base_url: "https://api.openai.com/v1"
       api_key: "sk-..."
       default_model: "gpt-4o-mini"
-    minimax:
-      base_url: "https://api.minimax.io/v1"
-      api_key: "mm-..."
-      default_model: "MiniMax-M2.7"
 
 # ---------------------------------------------------------------------------
 # Knowledge layer — long-term memory extraction
@@ -122,8 +118,8 @@ knowledge:
 
 agents:
   rara:
-    driver: minimax
-    model: MiniMax-M2.7
+    driver: openrouter
+    model: anthropic/claude-3.5-sonnet
   knowledge_extractor:
     driver: openai
     model: gpt-4o-mini

--- a/crates/app/tests/anchor_checkout_e2e.rs
+++ b/crates/app/tests/anchor_checkout_e2e.rs
@@ -96,9 +96,14 @@ async fn anchor_checkout_roundtrip() {
     let chat_id = format!("e2e-checkout-{}", uuid::Uuid::new_v4());
     wait_for_turn_count(&handle, session_key, 1).await;
 
-    // Verify turn 1 succeeded
+    // Verify turn 1 succeeded — print the trace on failure so a failed
+    // turn's provider error (carried since #2178) is visible verbatim.
     let traces = handle.get_process_turns(session_key);
-    assert!(traces.last().unwrap().success, "turn 1 should succeed");
+    assert!(
+        traces.last().unwrap().success,
+        "turn 1 should succeed; latest_trace={:?}",
+        traces.last()
+    );
 
     // 3. Send another message to build context
     handle
@@ -232,7 +237,10 @@ async fn anchor_checkout_roundtrip() {
 
     let traces = handle.get_process_turns(session_key);
     let recall_trace = traces.last().unwrap();
-    assert!(recall_trace.success, "recall turn should succeed");
+    assert!(
+        recall_trace.success,
+        "recall turn should succeed; latest_trace={recall_trace:?}"
+    );
     let preview = recall_trace
         .iterations
         .last()

--- a/crates/kernel/src/kernel.rs
+++ b/crates/kernel/src/kernel.rs
@@ -3037,18 +3037,21 @@ impl Kernel {
             .with(&session_key, |p| p.manifest.name.clone())
             .unwrap_or_else(|| "unknown".to_string());
 
+        // Resolved once: consumed by the lifecycle hooks below and by the
+        // failed-turn trace in the Err arm.
+        let model = self
+            .process_table
+            .with(&session_key, |p| {
+                p.manifest.model.clone().unwrap_or_default()
+            })
+            .unwrap_or_default();
+
         // Fire post_turn lifecycle hooks and persist nudge messages.
         {
-            let model = self
-                .process_table
-                .with(&session_key, |p| {
-                    p.manifest.model.clone().unwrap_or_default()
-                })
-                .unwrap_or_default();
             let turn_ctx = crate::lifecycle::TurnContext {
                 session_key,
                 user_text: String::new(),
-                model,
+                model: model.clone(),
             };
             let turn_result = match &result {
                 Ok(turn) => crate::lifecycle::TurnResult {
@@ -3240,6 +3243,34 @@ impl Kernel {
                         success:    false,
                     });
                 });
+
+                // Surface the failure as an information-bearing turn trace so
+                // `get_process_turns` (and the session-turns API behind it)
+                // show the actual provider error instead of nothing. This
+                // complements #1938: that change suppressed the information-
+                // FREE all-zero trace in the agent loop's persistence path;
+                // this trace carries `success=false` plus the error text.
+                // Skipped for user interrupts — the /stop handler already
+                // confirmed, and an error trace would be misleading.
+                if _turn_failed {
+                    self.process_table.push_turn_trace(
+                        session_key,
+                        crate::agent::TurnTrace {
+                            duration_ms:      0,
+                            model:            model.clone(),
+                            input_text:       None,
+                            iterations:       vec![],
+                            final_text_len:   0,
+                            total_tool_calls: 0,
+                            success:          false,
+                            error:            Some(format!(
+                                "{}: {}",
+                                err_details.category, err_details.message
+                            )),
+                            rara_turn_id:     in_reply_to,
+                        },
+                    );
+                }
 
                 // Deliver error — use egress session for routing.
                 // Skip for user-initiated interrupts (the /stop handler

--- a/crates/kernel/tests/failed_turn_trace_e2e.rs
+++ b/crates/kernel/tests/failed_turn_trace_e2e.rs
@@ -1,0 +1,102 @@
+// Copyright 2025 Rararulab
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! E2E regression — a failed turn must yield a visible turn trace (#2178).
+//!
+//! Lane 2 (scripted LLM): the driver is scripted to fail with a provider
+//! error, so the turn errors out before any LLM iteration completes.
+//! Before #2178 the kernel's `handle_turn_completed` Err arm never called
+//! `push_turn_trace`, leaving `get_process_turns` empty — a caller (or the
+//! real-LLM e2e's wait loop) saw `current_turns=0 latest_trace=None` and
+//! had no way to learn the provider error. This test pins the fix: exactly
+//! one `success=false` trace carrying the provider error message.
+//!
+//! Note this is the kernel-boundary complement to #1938, which suppressed
+//! the information-FREE all-zero trace in the agent loop's persistence
+//! path. The trace asserted here is information-BEARING: it exists solely
+//! to carry the error text.
+
+use std::time::Duration;
+
+use rara_kernel::{error::KernelError, identity::Principal, testing::TestKernelBuilder};
+
+/// Marker embedded in the scripted provider error. Deliberately avoids the
+/// kernel's retryable / rate-limit / quota patterns (`429`, `rate limit`,
+/// `usage limit`, ...) so the agent loop fails the turn on the first driver
+/// call instead of entering a recovery iteration.
+const SCRIPTED_ERROR: &str = "scripted provider outage e2178";
+
+/// One scripted `Err` → exactly one recorded turn with `success == false`
+/// and an `error` that carries the provider message.
+///
+/// Fails before the #2178 kernel change by timing out: without the Err-arm
+/// `push_turn_trace`, `get_process_turns` stays empty forever.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn failed_turn_yields_error_bearing_trace() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let tk = TestKernelBuilder::new(tmp.path())
+        .with_results(vec![Err(KernelError::Provider {
+            message: SCRIPTED_ERROR.into(),
+        })])
+        .build()
+        .await;
+
+    // `TurnMetrics` (and thus `TurnWaiter`) only fires for successful turns,
+    // so poll the process table directly, bounded by a generous deadline.
+    let principal = Principal::lookup("test");
+    let session_key = tk
+        .handle
+        .spawn_named("test-agent", "ping".to_string(), principal, None)
+        .await
+        .expect("spawn agent");
+
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(30);
+    let traces = loop {
+        let traces = tk.handle.get_process_turns(session_key);
+        if !traces.is_empty() {
+            break traces;
+        }
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "timed out waiting for the failed turn's trace — the kernel dropped the turn failure \
+             without pushing a turn trace (#2178)"
+        );
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    };
+
+    assert_eq!(traces.len(), 1, "expected exactly one recorded turn");
+    let turn = &traces[0];
+    assert!(!turn.success, "failed turn must record success=false");
+    assert!(
+        turn.iterations.is_empty(),
+        "failure before any completed iteration must not fabricate iteration traces, got: {:?}",
+        turn.iterations
+    );
+    assert_eq!(turn.total_tool_calls, 0, "no tools ran in the failed turn");
+
+    let error = turn
+        .error
+        .as_deref()
+        .expect("failed trace must carry an error message");
+    assert!(
+        error.contains(SCRIPTED_ERROR),
+        "trace error should surface the provider message verbatim, got: {error}"
+    );
+    assert!(
+        error.starts_with("provider:"),
+        "trace error should be prefixed with the outbound error category, got: {error}"
+    );
+
+    tk.shutdown();
+}


### PR DESCRIPTION
## Summary

Deprecates MiniMax as the CI e2e LLM provider (switch to OpenRouter) and folds in the two hardenings from the 2026-07-04 failure diagnosis (run 28701944198), so any future provider failure is cheap to see:

- **kernel**: `handle_turn_completed`'s `Err` arm now pushes a minimal information-bearing `TurnTrace` (`success=false`, `error="<category>: <message>"`, zero iterations) so a failed turn is visible via `get_process_turns` / the session-turns API instead of leaving `latest_trace=None`. Complements #1938 — the agent task's information-FREE empty-trace suppression is untouched; this trace exists solely to carry the error text. Skipped for user interrupts.
- **regression test**: new scripted-LLM test `crates/kernel/tests/failed_turn_trace_e2e.rs` (`ScriptedLlmDriver::new_with_results` with one `Err`) — exactly one `success=false` trace carrying the provider message. Times out without the kernel change.
- **e2e.yml**: 1-token curl preflight against `${OPENAI_BASE_URL}/chat/completions` immediately after checkout — provider quota/auth failures kill the job in under a minute with the provider's error body in the step log, before the ~10-minute build.
- **anchor_checkout_e2e**: success assertions now print the latest trace so a failed turn's provider error lands verbatim in CI logs.
- **config.example.yaml**: minimax provider block removed; `agents.rara` example rebound to `openrouter`.

MiniMax-quirk driver code (`tool_xml.rs`, stream-close salvage, system-role folding) is intentionally untouched — separate cleanup issue per the issue's Boundaries.

## Verification

Verification: PASS — `verification/report.md` (base 84a60361, head 50bf0f85)

Independent verifier evidence summary:
- **Red/green both directions**: regression test fails (times out) against the pre-change kernel and passes with the change; full gate re-run from clean state.
- **Cold-boot drive**: candidate build booted with temp data dir; WS → 401 → session-turns API exercised end-to-end, failed turn visible through `GET /api/v1/kernel/sessions/{key}/turns`.
- **Interrupt probe**: user-interrupted turn pushes NO failure trace (interrupts are not misreported as errors).
- **Preflight key-safety**: preflight step never echoes the API key; only the provider response body is printed.

Note: the branch was rebased onto current `main` after verification because #2181 (CI gate fix) merged; the rebase is content-identical (`git range-diff`: `50bf0f85 = 20c50bb9`), so the verification remains valid for the same diff — only the base moved from 84a60361 to 5185cd67.

## Human-only follow-up (org admin — required before acceptance 1–2 are observable)

The code work here is complete, but the live outcomes — e2e green against OpenRouter, and sub-minute failure on a bad key — can only be observed after an org admin updates the Actions values (placeholders only; no key material in this PR):

```bash
gh variable set OPENAI_BASE_URL --org rararulab --body "https://openrouter.ai/api/v1"
gh variable set OPENAI_MODEL   --org rararulab --body "openai/gpt-4o-mini"
gh secret   set OPENAI_API_KEY --org rararulab --visibility all --body "<OpenRouter API key, sk-or-v1-...>"
# adjust --visibility to match current org policy (all / private / selected)
```

Then: `gh workflow run e2e.yml -R rararulab/rara && gh run watch`.

- [ ] Org admin has set the three values above (human-only)
- [ ] `E2E (Real LLM)` green on `main` against OpenRouter (acceptance 1)
- [ ] Bad-key dispatch fails at preflight in <1 min with provider body visible (acceptance 2)

## Type of change

Bug fix (`bug`)

## Component

`core`

## Closes

Closes #2178

## Test plan

- [x] `cargo nextest run -p rara-kernel` — 623 passed, 1 skipped (includes the new `failed_turn_yields_error_bearing_trace`)
- [x] `cargo nextest run -p rara-app` — 97 passed, 2 skipped
- [x] `prek run --all-files` — check / fmt / clippy / doc / AGENT.md all passed
- [x] Regression binding proven both directions (test times out on pre-change kernel, passes after)
- [x] Independent verifier PASS + reviewer APPROVE (pre-push)

e2e lanes: this PR's own regression coverage is **lane 2** (scripted LLM via `ScriptedLlmDriver`); the real-LLM path (`anchor_checkout_e2e`, lane 3) runs in `e2e.yml` on `main` push and is exactly the workflow hardened here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
