### PR TITLE
fix(ci): install mdbook-mermaid in web.yml docs deploy (#2184)

### DIFF
--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -29,10 +29,10 @@ jobs:
         with:
           fetch-depth: false
           persist-credentials: false
-      - name: Install mdbook
+      - name: Install mdbook and mdbook-mermaid
         uses: taiki-e/install-action@c93ccc03e00cd0e08e494f5fd058a6c55a6a1907 # v2
         with:
-          tool: mdbook
+          tool: mdbook,mdbook-mermaid
       - name: Build mdbook
         run: mdbook build docs
 


### PR DESCRIPTION
## Summary

`docs/book.toml` declares the mermaid preprocessor (`command = "mdbook-mermaid"`), but the `ubuntu-latest` runner introduced by PR #2177 only installed `mdbook`, so the "Build mdbook" step failed with `ERROR The command 'mdbook-mermaid' wasn't found`. This extends the existing `taiki-e/install-action` step to `tool: mdbook,mdbook-mermaid` (the action's documented comma-separated multi-tool syntax). Pinned action SHA unchanged; `docs/book.toml` untouched (the `optional = true` alternative was rejected in the issue as masking).

Closes #2184

## Verification

**Verification: PASS — verification/report.md**

- `actionlint .github/workflows/web.yml` — clean, exit 0.
- Local end-to-end build with the exact CI command: `mdbook build docs` succeeds (mdbook v0.5.2 + mdbook-mermaid 0.17.0) with mermaid assets emitted into `docs/book`.
- Upstream `manifests/mdbook-mermaid.json` confirmed present in `taiki-e/install-action` at the pinned SHA, so the action installs a prebuilt binary (cargo-binstall fallback built in).
- Rebase onto `origin/main` (after #2183 landed) was content-identical — zero overlap with the intervening commit.

## Post-merge acceptance

The real acceptance criterion (carried over from issue #2173): after merge, `gh workflow run web.yml` on `main` must be **fully green**, including the "Deploy to GitHub Pages" step pushing to `gh-pages`, with no missing-preprocessor error in the "Build mdbook" step log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)