### PR TITLE
ci(zig-codec-smoke): pin macos smoke leg to macos-15 (#2187)

### DIFF
--- a/.github/workflows/zig-codec-smoke.yml
+++ b/.github/workflows/zig-codec-smoke.yml
@@ -14,6 +14,17 @@ name: zig-codec-smoke
 # deliberately reverses #2047 (which moved the job onto `arc-runner-set`
 # for the baked-in mold baseline) — that fleet no longer exists and jobs
 # targeting it queue for 24h and get cancelled (#2166).
+#
+# The macos job is pinned to `macos-15` (#2187): the `macos-26-arm64`
+# image (Xcode 26.5 / CLT 26.6) ships a newer ld that hard-errors on
+# zig 0.16's under-padded `compiler_rt.o` archive member ("64-bit
+# mach-o member not 8-byte aligned"), so `macos-latest` fails whenever
+# the alias resolves to macOS 26 (run 28704763601 failed on
+# macos-26-arm64; run 28703902869 passed on macos-15-arm64, 35 minutes
+# apart). Unpin when either a tagged zig release fixes MachO archive
+# member alignment and we adopt it, or the build.rs re-pack of the
+# zig-emitted `.a` (e.g. via `libtool -static`) lands — see the
+# follow-up named in #2187.
 
 on:
   pull_request:
@@ -34,7 +45,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-latest, ubuntu-latest]
+        os: [macos-15, ubuntu-latest]
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 


### PR DESCRIPTION
## Summary

Pin the `zig-codec-smoke` macOS matrix leg from `macos-latest` to `macos-15`, and document the pin rationale + unpin condition in the workflow header.

Root cause (issue #2187): the `macos-26-arm64` image (Xcode 26.5 / CLT 26.6) ships a newer ld that hard-errors on zig 0.16's under-padded `compiler_rt.o` archive member (`64-bit mach-o member 'compiler_rt.o' not 8-byte aligned`), so `macos-latest` fails whenever the alias resolves to macOS 26 — an image-rollout lottery, not a flake (run 28704763601 failed on macos-26-arm64; run 28703902869 passed on macos-15-arm64, 35 minutes apart). Unpin condition: a tagged zig release fixing MachO archive member alignment, or the `build.rs` libtool re-pack follow-up named in #2187.

## Verification

Verification: PASS — verification/report.md (base 086bdb6e, head 3b0b870d)

Fact-check summary: diff is exactly one file (`.github/workflows/zig-codec-smoke.yml`), matrix `macos-latest` → `macos-15` plus header-comment paragraph; `actionlint` exits 0 with no findings; run IDs and image versions cited in the header match the evidence table in #2187; all Forbidden paths (build.rs, zig/**, .cargo/config.toml, Linux leg, other workflows) untouched.

**Post-merge check:** this PR touches the workflow file itself (it is in its own `paths:` glob), so it triggers its own `zig-codec-smoke` run. The first triggered run's `smoke macos-15` job must show `Image: macos-15-arm64` in the Set up job log and pass. Watch that run before/at merge.

## Type of change

CI / Infrastructure (`bug` + `ci`)

## Component

`ci`

## Closes

Closes #2187

## Test plan

- [x] `actionlint .github/workflows/zig-codec-smoke.yml` — exit 0, no findings
- [x] Workflow-only diff; Rust/web pre-commit hooks correctly skipped (no matching files)
- [x] Self-triggering smoke run on this PR must be green on `macos-15` (watched via `gh pr checks --watch`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)