### PR TITLE
chore(deps): burn down cargo-deny + cargo-shear baselines, make CI checks real (#2175)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,21 +160,19 @@ jobs:
             echo "just spec-selftest not defined yet (lands with #2165); skipping"
           fi
 
-  # deny.toml was previously only exercised locally via `just lint` —
-  # orphaned in CI (#2166). Advisory/ban/license sweeps only make sense
+  # Advisory/ban/license/source sweeps against deny.toml. Only makes sense
   # when the dependency graph changes, hence the cargo_deps filter.
   #
-  # TODO(#2166 follow-up): continue-on-error because the baseline fails
-  # today (git sources missing from deny.toml allow-git, bzip2-1.0.6
-  # license, unmaintained-crate advisories — all pre-existing, landed
-  # while CI was dead). Fix the drift, then delete continue-on-error to
-  # make this blocking.
+  # Real (red = fix it) since #2175 burned the baseline down: triaged
+  # advisories are ignored in deny.toml with per-RUSTSEC reasons, git
+  # sources are allow-listed, and the bzip2-1.0.6 license has a scoped
+  # exception. New findings mean new debt — triage them in deny.toml,
+  # do not soften this job back to advisory-only.
   cargo-deny:
     name: Cargo Deny
     needs: changes
     if: ${{ needs.changes.outputs.cargo_deps == 'true' }}
     runs-on: ubuntu-latest
-    continue-on-error: true
     steps:
       - name: Checkout code
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -191,15 +189,15 @@ jobs:
 
   # Detects unused dependencies declared in Cargo.toml files.
   #
-  # TODO(#2166 follow-up): continue-on-error because the workspace has 87
-  # pre-existing findings (`cargo shear` on main). Burn the baseline down
-  # in crates/**, then delete continue-on-error to make this blocking.
+  # Real (red = fix it) since #2175 removed the 80+ finding baseline.
+  # Genuine false positives (codegen-only or pin-activation deps) belong in
+  # a [package.metadata.cargo-shear] ignored list with a justification
+  # comment — see api/Cargo.toml and crates/app/Cargo.toml for the pattern.
   cargo-shear:
     name: Cargo Shear
     needs: changes
     if: ${{ needs.changes.outputs.cargo_deps == 'true' }}
     runs-on: ubuntu-latest
-    continue-on-error: true
     steps:
       - name: Checkout code
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -270,22 +270,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3fb67a6e08acf24fdeccbac2cb6ac4305825bd1f117462e0e6f2f193345ad56"
 
 [[package]]
-name = "astral-tokio-tar"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08648fef353ab39a9d26f909ad53fc4f071be4c91853b78523f5cc3d9e5ebffd"
-dependencies = [
- "futures-core",
- "libc",
- "portable-atomic",
- "rustc-hash",
- "rustix 0.38.44",
- "tokio",
- "tokio-stream",
- "xattr",
-]
-
-[[package]]
 name = "async-broadcast"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -624,25 +608,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "axum-tracing-opentelemetry"
-version = "0.38.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c938150bbecf4b43a24964bea0780f99d538b6654455e45b1784d410f122822"
-dependencies = [
- "axum 0.8.9",
- "futures-core",
- "futures-util",
- "http",
- "opentelemetry",
- "opentelemetry-semantic-conventions",
- "pin-project-lite",
- "tower 0.5.3",
- "tracing",
- "tracing-opentelemetry",
- "tracing-opentelemetry-instrumentation-sdk",
-]
-
-[[package]]
 name = "backon"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -678,7 +643,6 @@ dependencies = [
  "serde",
  "serde_json",
  "tracing",
- "utoipa",
  "uuid",
 ]
 
@@ -862,80 +826,6 @@ dependencies = [
  "futures-io",
  "futures-lite",
  "piper",
-]
-
-[[package]]
-name = "bollard"
-version = "0.20.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee04c4c84f1f811b017f2fbb7dd8815c976e7ca98593de9c1e2afad0f636bff4"
-dependencies = [
- "async-stream",
- "base64 0.22.1",
- "bitflags 2.13.0",
- "bollard-buildkit-proto",
- "bollard-stubs",
- "bytes",
- "futures-core",
- "futures-util",
- "hex",
- "home",
- "http",
- "http-body-util",
- "hyper",
- "hyper-named-pipe",
- "hyper-rustls",
- "hyper-util",
- "hyperlocal",
- "log",
- "num",
- "pin-project-lite",
- "rand 0.9.4",
- "rustls",
- "rustls-native-certs",
- "rustls-pki-types",
- "serde",
- "serde_derive",
- "serde_json",
- "serde_urlencoded",
- "thiserror 2.0.18",
- "time",
- "tokio",
- "tokio-stream",
- "tokio-util",
- "tonic 0.14.6",
- "tower-service",
- "url",
- "winapi",
-]
-
-[[package]]
-name = "bollard-buildkit-proto"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85a885520bf6249ab931a764ffdb87b0ceef48e6e7d807cfdb21b751e086e1ad"
-dependencies = [
- "prost 0.14.4",
- "prost-types 0.14.4",
- "tonic 0.14.6",
- "tonic-prost",
- "ureq",
-]
-
-[[package]]
-name = "bollard-stubs"
-version = "1.52.1-rc.29.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f0a8ca8799131c1837d1282c3f81f31e76ceb0ce426e04a7fe1ccee3287c066"
-dependencies = [
- "base64 0.22.1",
- "bollard-buildkit-proto",
- "bytes",
- "prost 0.14.4",
- "serde",
- "serde_json",
- "serde_repr",
- "time",
 ]
 
 [[package]]
@@ -1443,7 +1333,6 @@ dependencies = [
  "bon",
  "console-subscriber",
  "derive_more 2.1.1",
- "lazy_static",
  "once_cell",
  "opentelemetry",
  "opentelemetry-appender-tracing",
@@ -1459,7 +1348,6 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-appender",
- "tracing-core",
  "tracing-log",
  "tracing-opentelemetry",
  "tracing-subscriber",
@@ -1475,14 +1363,11 @@ dependencies = [
  "croner",
  "derive_more 2.1.1",
  "opentelemetry",
- "serde",
- "serde_json",
  "smart-default",
  "snafu",
  "strum 0.27.2",
  "tokio",
  "tokio-util",
- "tonic 0.14.6",
  "tracing",
  "tracing-subscriber",
  "uuid",
@@ -1705,7 +1590,6 @@ dependencies = [
  "reqwest 0.13.4",
  "serde",
  "snafu",
- "tokio",
  "tracing",
  "validator",
 ]
@@ -2463,17 +2347,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "docker_credential"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29547a1dc60885a552306986316bc9701ba120c1a8db6769fa68691529ad373d"
-dependencies = [
- "base64 0.22.1",
- "serde",
- "serde_json",
-]
-
-[[package]]
 name = "document-features"
 version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2697,16 +2570,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "etcetera"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de48cc4d1c1d97a20fd819def54b890cadde72ed3ad0c614822a0a433361be96"
-dependencies = [
- "cfg-if",
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "euclid"
 version = "0.22.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2788,17 +2651,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
 dependencies = [
  "simd-adler32",
-]
-
-[[package]]
-name = "ferroid"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee93edf3c501f0035bbeffeccfed0b79e14c311f12195ec0e661e114a0f60da4"
-dependencies = [
- "portable-atomic",
- "rand 0.10.2",
- "web-time",
 ]
 
 [[package]]
@@ -3521,15 +3373,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "home"
-version = "0.5.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
-dependencies = [
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "hostname"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3643,21 +3486,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hyper-named-pipe"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73b7d8abf35697b81a825e386fc151e0d503e8cb5fcb93cc8669c376dfd6f278"
-dependencies = [
- "hex",
- "hyper",
- "hyper-util",
- "pin-project-lite",
- "tokio",
- "tower-service",
- "winapi",
-]
-
-[[package]]
 name = "hyper-rustls"
 version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3725,21 +3553,6 @@ dependencies = [
  "tower-service",
  "tracing",
  "windows-registry",
-]
-
-[[package]]
-name = "hyperlocal"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "986c5ce3b994526b3cd75578e62554abd09f0899d6206de48b3e96ab34ccc8c7"
-dependencies = [
- "hex",
- "http-body-util",
- "hyper",
- "hyper-util",
- "pin-project-lite",
- "tokio",
- "tower-service",
 ]
 
 [[package]]
@@ -5743,31 +5556,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "parse-display"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "914a1c2265c98e2446911282c6ac86d8524f495792c38c5bd884f80499c7538a"
-dependencies = [
- "parse-display-derive",
- "regex",
- "regex-syntax",
-]
-
-[[package]]
-name = "parse-display-derive"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ae7800a4c974efd12df917266338e79a7a74415173caf7e70aa0a0707345281"
-dependencies = [
- "proc-macro2",
- "quote",
- "regex",
- "regex-syntax",
- "structmeta",
- "syn 2.0.118",
-]
-
-[[package]]
 name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6376,26 +6164,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "protobuf"
-version = "3.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d65a1d4ddae7d8b5de68153b48f6aa3bba8cb002b243dbdbc55a5afbc98f99f4"
-dependencies = [
- "once_cell",
- "protobuf-support",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "protobuf-support"
-version = "3.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e36c2f31e0a47f9280fb347ef5e461ffcd2c52dd520d8e216b52f93b0b0d7d6"
-dependencies = [
- "thiserror 1.0.69",
-]
-
-[[package]]
 name = "psm"
 version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6744,13 +6512,8 @@ name = "rara-api"
 version = "0.0.1"
 dependencies = [
  "prost 0.14.4",
- "prost-types 0.14.4",
- "protobuf",
  "serde",
- "strum 0.27.2",
- "strum_macros 0.27.2",
  "tonic 0.14.6",
- "tonic-build 0.14.6",
  "tonic-prost",
  "tonic-prost-build",
 ]
@@ -6765,9 +6528,7 @@ dependencies = [
  "base",
  "bon",
  "chrono",
- "common-runtime",
  "common-telemetry",
- "common-worker",
  "config",
  "dashmap",
  "diesel",
@@ -6785,7 +6546,6 @@ dependencies = [
  "lettre",
  "notify",
  "parking_lot",
- "rand 0.10.2",
  "rara-acp",
  "rara-agents",
  "rara-backend-admin",
@@ -6835,41 +6595,28 @@ dependencies = [
  "anyhow",
  "async-trait",
  "axum 0.8.9",
- "base",
- "bon",
  "chrono",
- "common-telemetry",
- "derive_more 2.1.1",
  "diesel",
  "diesel-async",
  "futures",
- "git2 0.21.0",
  "jiff",
- "opentelemetry",
- "rara-channels",
  "rara-domain-shared",
- "rara-git",
  "rara-kernel",
  "rara-mcp",
  "rara-model",
  "rara-paths",
  "rara-sessions",
  "rara-skills",
- "reqwest 0.13.4",
  "serde",
  "serde_json",
  "snafu",
  "strum 0.27.2",
- "strum_macros 0.27.2",
  "tempfile",
- "testcontainers",
- "testcontainers-modules",
  "tokio",
  "tokio-util",
  "tower 0.5.3",
  "tower-http 0.7.0",
  "tracing",
- "tracing-opentelemetry",
  "url",
  "utoipa",
  "utoipa-axum",
@@ -6942,7 +6689,6 @@ name = "rara-cli"
 version = "0.0.1"
 dependencies = [
  "anyhow",
- "async-trait",
  "axum 0.8.9",
  "base64 0.22.1",
  "chrono",
@@ -6956,7 +6702,6 @@ dependencies = [
  "flate2",
  "futures",
  "indexmap 2.14.0",
- "jiff",
  "open",
  "rara-app",
  "rara-channels",
@@ -7008,13 +6753,8 @@ dependencies = [
  "anyhow",
  "async-trait",
  "chrono",
- "derive_more 2.1.1",
  "jiff",
- "serde",
  "tokio",
- "tracing",
- "utoipa",
- "uuid",
 ]
 
 [[package]]
@@ -7036,12 +6776,9 @@ dependencies = [
  "getrandom 0.4.3",
  "git2 0.21.0",
  "rand_core 0.10.1",
- "rara-paths",
  "snafu",
  "ssh-key",
- "tempfile",
  "tokio",
- "tracing",
 ]
 
 [[package]]
@@ -7051,9 +6788,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "axum 0.8.9",
- "backon",
  "base",
- "base64 0.22.1",
  "bb8",
  "bon",
  "chrono",
@@ -7064,13 +6799,11 @@ dependencies = [
  "derive_more 2.1.1",
  "diesel",
  "diesel-async",
- "diesel_migrations",
  "eventsource-stream",
  "futures",
  "hex",
  "hmac 0.13.0",
  "image",
- "indexmap 2.14.0",
  "jieba-rs",
  "jiff",
  "md5",
@@ -7085,7 +6818,6 @@ dependencies = [
  "rara-paths",
  "rara-sessions",
  "rara-soul",
- "rara-stt",
  "rara-tool-macro",
  "regex",
  "reqwest 0.13.4",
@@ -7101,12 +6833,10 @@ dependencies = [
  "subtle",
  "tape-codec-zig",
  "tempfile",
- "test-case",
  "tokio",
  "tokio-util",
  "tower 0.5.3",
  "tracing",
- "tracing-opentelemetry",
  "tracing-subscriber",
  "ulid",
  "unicode-normalization",
@@ -7148,7 +6878,6 @@ version = "0.0.1"
 dependencies = [
  "anyhow",
  "async-trait",
- "axum 0.8.9",
  "base",
  "bon",
  "futures",
@@ -7166,7 +6895,6 @@ dependencies = [
  "sha2 0.11.0",
  "smart-default",
  "snafu",
- "tempfile",
  "tokio",
  "tokio-util",
  "tracing",
@@ -7176,11 +6904,7 @@ dependencies = [
 name = "rara-model"
 version = "0.0.1"
 dependencies = [
- "chrono",
  "diesel",
- "serde",
- "serde_json",
- "uuid",
 ]
 
 [[package]]
@@ -7210,22 +6934,17 @@ version = "0.0.1"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
- "axum-tracing-opentelemetry",
  "base",
  "bon",
  "bytes",
- "common-runtime",
- "derive_more 2.1.1",
  "futures",
  "http",
- "http-body-util",
  "jiff",
  "moka",
  "opentelemetry",
  "opentelemetry_sdk",
  "rara-api",
  "rara-error",
- "reqwest 0.13.4",
  "serde",
  "serde_json",
  "smart-default",
@@ -7238,7 +6957,6 @@ dependencies = [
  "tonic-health",
  "tonic-reflection",
  "tonic-tracing-opentelemetry",
- "tonic-web",
  "tower 0.5.3",
  "tower-http 0.7.0",
  "tracing",
@@ -7273,7 +6991,6 @@ dependencies = [
  "async-trait",
  "base64 0.22.1",
  "bb8",
- "chrono",
  "diesel",
  "diesel-async",
  "dirs 6.0.0",
@@ -7286,7 +7003,6 @@ dependencies = [
  "rara-paths",
  "regex",
  "reqwest 0.13.4",
- "rstest",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -7606,12 +7322,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
-name = "relative-path"
-version = "1.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
-
-[[package]]
 name = "reqsign-core"
 version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7850,35 +7560,6 @@ checksum = "c51c9ae4df8a7fba42103df5c621fa3c37eccf3a3c650879e90fc48b11cc192c"
 dependencies = [
  "hashbrown 0.16.1",
  "thiserror 2.0.18",
-]
-
-[[package]]
-name = "rstest"
-version = "0.26.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5a3193c063baaa2a95a33f03035c8a72b83d97a54916055ba22d35ed3839d49"
-dependencies = [
- "futures-timer",
- "futures-util",
- "rstest_macros",
-]
-
-[[package]]
-name = "rstest_macros"
-version = "0.26.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c845311f0ff7951c5506121a9ad75aec44d083c31583b2ea5a30bcb0b0abba0"
-dependencies = [
- "cfg-if",
- "glob",
- "proc-macro-crate",
- "proc-macro2",
- "quote",
- "regex",
- "relative-path",
- "rustc_version",
- "syn 2.0.118",
- "unicode-ident",
 ]
 
 [[package]]
@@ -8790,29 +8471,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
-name = "structmeta"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e1575d8d40908d70f6fd05537266b90ae71b15dbbe7a8b7dffa2b759306d329"
-dependencies = [
- "proc-macro2",
- "quote",
- "structmeta-derive",
- "syn 2.0.118",
-]
-
-[[package]]
-name = "structmeta-derive"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "152a0b65a590ff6c3da95cabe2353ee04e6167c896b28e3b14478c2636c922fc"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.118",
-]
-
-[[package]]
 name = "strum"
 version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9206,79 +8864,6 @@ dependencies = [
  "wezterm-dynamic",
  "wezterm-input-types",
  "winapi",
-]
-
-[[package]]
-name = "test-case"
-version = "3.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb2550dd13afcd286853192af8601920d959b14c401fcece38071d53bf0768a8"
-dependencies = [
- "test-case-macros",
-]
-
-[[package]]
-name = "test-case-core"
-version = "3.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adcb7fd841cd518e279be3d5a3eb0636409487998a4aff22f3de87b81e88384f"
-dependencies = [
- "cfg-if",
- "proc-macro2",
- "quote",
- "syn 2.0.118",
-]
-
-[[package]]
-name = "test-case-macros"
-version = "3.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c89e72a01ed4c579669add59014b9a524d609c0c88c6a585ce37485879f6ffb"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.118",
- "test-case-core",
-]
-
-[[package]]
-name = "testcontainers"
-version = "0.27.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfd5785b5483672915ed5fe3cddf9f546802779fc1eceff0a6fb7321fac81c1e"
-dependencies = [
- "astral-tokio-tar",
- "async-trait",
- "bollard",
- "bytes",
- "docker_credential",
- "either",
- "etcetera",
- "ferroid",
- "futures",
- "http",
- "itertools 0.14.0",
- "log",
- "memchr",
- "parse-display",
- "pin-project-lite",
- "serde",
- "serde_json",
- "serde_with",
- "thiserror 2.0.18",
- "tokio",
- "tokio-stream",
- "tokio-util",
- "url",
-]
-
-[[package]]
-name = "testcontainers-modules"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5985fde5befe4ffa77a052e035e16c2da86e8bae301baa9f9904ad3c494d357"
-dependencies = [
- "testcontainers",
 ]
 
 [[package]]
@@ -9775,24 +9360,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tonic-web"
-version = "0.14.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5e6a1b6319ca4b61a4c0f0c94d439c8f3ed344cca56fe0df40e1fe4be11380b"
-dependencies = [
- "base64 0.22.1",
- "bytes",
- "http",
- "http-body",
- "pin-project",
- "tokio-stream",
- "tonic 0.14.6",
- "tower-layer",
- "tower-service",
- "tracing",
-]
-
-[[package]]
 name = "tower"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10165,33 +9732,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d49784317cd0d1ee7ec5c716dd598ec5b4483ea832a2dced265471cc0f690ae"
 
 [[package]]
-name = "ureq"
-version = "3.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dea7109cdcd5864d4eeb1b58a1648dc9bf520360d7af16ec26d0a9354bafcfc0"
-dependencies = [
- "base64 0.22.1",
- "log",
- "percent-encoding",
- "rustls",
- "rustls-pki-types",
- "ureq-proto",
- "utf8-zero",
-]
-
-[[package]]
-name = "ureq-proto"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e994ba84b0bd1b1b0cf92878b7ef898a5c1760108fe7b6010327e274917a808c"
-dependencies = [
- "base64 0.22.1",
- "http",
- "httparse",
- "log",
-]
-
-[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10226,12 +9766,6 @@ name = "utf-8"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
-
-[[package]]
-name = "utf8-zero"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8c0a043c9540bae7c578c88f91dda8bd82e59ae27c21baca69c8b191aaf5a6e"
 
 [[package]]
 name = "utf8_iter"
@@ -11136,7 +10670,6 @@ dependencies = [
  "serde",
  "serde_json",
  "snafu",
- "tokio",
  "tracing",
  "uuid",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -152,12 +152,8 @@ members = [
 
 [workspace.dependencies]
 anyhow = "^1.0"
-argon2 = "0.5"
-async-openai = { version = "0.33", features = ["chat-completion"] }
 async-trait = "^0.1"
 axum = "^0.8"
-axum-tracing-opentelemetry = "0.38.0"
-backon = "^1.3"
 base64 = "^0.22"
 bon = "^3.6"
 bytes = "^1.11"
@@ -178,20 +174,16 @@ futures = "^0.3"
 hex = "0.4"
 hmac = "0.13"
 http = "^1"
-hyper = { version = "1", features = ["full"] }
 image = { version = "0.25", default-features = false, features = ["jpeg", "png", "webp", "gif"] }
 indexmap = "2"
 jieba-rs = "0.10"
 jiff = { version = "^0.2", features = ["serde"] }
-jsonwebtoken = "9"
-lazy_static = "^1.4"
 lettre = { version = "0.11", default-features = false, features = [
     "tokio1-rustls-tls",
     "smtp-transport",
     "builder",
     "hostname",
 ] }
-lineark-sdk = "2.0"
 md5 = "0.7"
 moka = { version = "0.12", features = ["future"] }
 notify = "8"
@@ -201,7 +193,6 @@ open = "5"
 opendal = { version = "0.57", features = ["services-fs", "services-memory"] }
 parking_lot = "0.12"
 prost = "^0.14"
-protobuf = "^3.7"
 pyroscope = "2.0"
 rand = "0.10"
 rapidfuzz = "0.5"
@@ -226,13 +217,11 @@ teloxide = { version = "^0.17", features = ["macros"] }
 tokio = { version = "^1.45", features = ["full", "tracing"] }
 tokio-util = "^0.7"
 tonic = "^0.14"
-tonic-build = "^0.14"
 tonic-health = "^0.14"
 tonic-prost = "0.14"
 tonic-prost-build = "0.14"
 tonic-reflection = "^0.14"
 tonic-tracing-opentelemetry = "0.38.0"
-tonic-web = "^0.14"
 tower = "^0.5"
 tower-http = { version = "^0.7", features = ["cors", "timeout", "trace"] }
 tracing = "^0.1"
@@ -249,15 +238,11 @@ validator = "^0.20"
 # Testing
 git2 = "0.21"
 tempfile = "3"
-testcontainers = "0.27"
-testcontainers-modules = { version = "0.15", features = ["postgres", "k3s"] }
 
 # Internal workspace crates (use =version to keep in sync with workspace version)
 base = { path = "crates/common/base" }
 common-runtime = { path = "crates/common/runtime" }
 common-telemetry = { path = "crates/common/telemetry" }
-common-worker = { path = "crates/common/worker" }
-crawl4ai = { path = "crates/common/crawl4ai" }
 
 rara-acp = { path = "crates/rara-acp" }
 rara-agents = { path = "crates/agents" }
@@ -268,12 +253,10 @@ rara-browser = { path = "crates/drivers/browser" }
 rara-stt = { path = "crates/drivers/stt" }
 rara-tts = { path = "crates/drivers/tts" }
 rara-channels = { path = "crates/channels" }
-rara-cli = { path = "crates/cmd" }
 rara-codex-oauth = { path = "crates/integrations/codex-oauth" }
 rara-kimi-oauth = { path = "crates/integrations/kimi-oauth" }
 rara-domain-shared = { path = "crates/domain/shared" }
 rara-error = { path = "crates/common/error" }
-rara-git = { path = "crates/extensions/rara-git" }
 rara-kernel = { path = "crates/kernel" }
 rara-keyring-store = { path = "crates/integrations/keyring-store" }
 rara-mcp = { path = "crates/integrations/mcp" }
@@ -294,7 +277,6 @@ rara-sandbox = { path = "crates/rara-sandbox" }
 # dedicated PR after updating `crates/app/src/tools/{fff_find,fff_grep}.rs`
 # to the new upstream API.
 fff-search = { git = "https://github.com/dmtrKovalenko/fff.nvim", rev = "ea1f9802d7879345f02bef72bcadecd7252b8add", features = ["zlob"] }
-fff-grep = { git = "https://github.com/dmtrKovalenko/fff.nvim", rev = "ea1f9802d7879345f02bef72bcadecd7252b8add" }
 fff-query-parser = { git = "https://github.com/dmtrKovalenko/fff.nvim", rev = "ea1f9802d7879345f02bef72bcadecd7252b8add", default-features = false }
 
 # zlob is a transitive dep of fff-search (feature = "zlob"); declaring it here

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -11,18 +11,18 @@ keywords.workspace = true
 categories.workspace = true
 description = "API definitions and gRPC stubs for rara"
 
+# prost and tonic-prost are referenced only by the `tonic::include_proto!`
+# generated code in OUT_DIR, which cargo-shear cannot see.
+[package.metadata.cargo-shear]
+ignored = ["prost", "tonic-prost"]
+
 [dependencies]
 prost = { workspace = true }
-prost-types = "0.14"
-protobuf = { workspace = true }
 serde = { workspace = true }
-strum = { workspace = true }
-strum_macros = { workspace = true }
 tonic = { workspace = true }
 tonic-prost = { workspace = true }
 
 [build-dependencies]
-tonic-build = { workspace = true }
 tonic-prost-build = { workspace = true }
 
 [lints]

--- a/crates/app/Cargo.toml
+++ b/crates/app/Cargo.toml
@@ -11,6 +11,12 @@ keywords.workspace = true
 categories.workspace = true
 description = "Application orchestration and lifecycle management for rara"
 
+# zlob is deliberately never imported: the dependency edge exists only to
+# activate the workspace-level `=1.5.0` pin on fff-search's transitive zlob
+# (see the note in the workspace `[workspace.dependencies]`).
+[package.metadata.cargo-shear]
+ignored = ["zlob"]
+
 [dependencies]
 anyhow.workspace = true
 async-trait = { workspace = true }
@@ -18,9 +24,7 @@ axum = { workspace = true }
 base = { workspace = true }
 bon = { workspace = true }
 chrono.workspace = true
-common-runtime = { workspace = true }
 common-telemetry = { workspace = true }
-common-worker = { workspace = true }
 config = { workspace = true }
 futures.workspace = true
 glob = "0.3.3"
@@ -32,7 +36,6 @@ jiff.workspace = true
 lettre.workspace = true
 notify = { workspace = true }
 parking_lot.workspace = true
-rand.workspace = true
 rara-acp.workspace = true
 rara-agents.workspace = true
 rara-backend-admin = { workspace = true }
@@ -56,7 +59,7 @@ rara-soul.workspace = true
 rara-tool-macro.workspace = true
 fff-search = { workspace = true }
 fff-query-parser = { workspace = true }
-# Direct dep (not imported) to activate the workspace-level `=1.3.2` pin on
+# Direct dep (not imported) to activate the workspace-level `=1.5.0` pin on
 # this transitive; see the note in the workspace `[dependencies]`.
 zlob = { workspace = true }
 regex.workspace = true

--- a/crates/cmd/Cargo.toml
+++ b/crates/cmd/Cargo.toml
@@ -25,11 +25,9 @@ name = "rara"
 path = "src/main.rs"
 
 [dependencies]
-async-trait.workspace = true
 base64.workspace = true
 chrono.workspace = true
 clap = { workspace = true }
-jiff.workspace = true
 rara-sessions = { workspace = true }
 common-telemetry.workspace = true
 crossterm.workspace = true

--- a/crates/common/base/Cargo.toml
+++ b/crates/common/base/Cargo.toml
@@ -17,7 +17,6 @@ rustix = { workspace = true, features = ["process"] }
 schemars.workspace = true
 serde.workspace = true
 tracing.workspace = true
-utoipa.workspace = true
 uuid.workspace = true
 
 [dev-dependencies]

--- a/crates/common/crawl4ai/Cargo.toml
+++ b/crates/common/crawl4ai/Cargo.toml
@@ -18,8 +18,5 @@ snafu.workspace = true
 tracing.workspace = true
 validator = { workspace = true, features = ["derive"] }
 
-[dev-dependencies]
-tokio = { workspace = true }
-
 [lints]
 workspace = true

--- a/crates/common/telemetry/Cargo.toml
+++ b/crates/common/telemetry/Cargo.toml
@@ -19,7 +19,6 @@ backtrace = "0.3"
 bon = { workspace = true }
 console-subscriber = { version = "0.5", optional = true }
 derive_more = { workspace = true }
-lazy_static = "1.4"
 once_cell = "1.19"
 opentelemetry = { version = "0.32.0", default-features = false, features = ["trace", "metrics", "logs"] }
 opentelemetry-appender-tracing = { version = "0.32.0" }
@@ -39,7 +38,6 @@ snafu.workspace = true
 tokio.workspace = true
 tracing.workspace = true
 tracing-appender = "0.2.3"
-tracing-core = "0.1.32"
 tracing-log = "0.2"
 tracing-opentelemetry = "0.33.0"
 tracing-subscriber = { version = "0.3.18", features = ["env-filter", "json"] }

--- a/crates/common/worker/Cargo.toml
+++ b/crates/common/worker/Cargo.toml
@@ -18,14 +18,11 @@ common-runtime = { workspace = true }
 croner = "3"
 derive_more = { workspace = true }
 opentelemetry = { version = "0.32.0", default-features = false, features = ["metrics"] }
-serde.workspace = true
-serde_json.workspace = true
 smart-default = "0.7"
 snafu.workspace = true
 strum = { workspace = true, features = ["derive"] }
 tokio.workspace = true
 tokio-util.workspace = true
-tonic.workspace = true
 tracing.workspace = true
 uuid = { version = "1", features = ["v4"] }
 

--- a/crates/common/yunara-store/Cargo.toml
+++ b/crates/common/yunara-store/Cargo.toml
@@ -26,6 +26,3 @@ serde_json.workspace = true
 snafu.workspace = true
 tracing.workspace = true
 uuid = { workspace = true }
-
-[dev-dependencies]
-tokio.workspace = true

--- a/crates/domain/shared/Cargo.toml
+++ b/crates/domain/shared/Cargo.toml
@@ -19,13 +19,8 @@ testing = []
 anyhow.workspace = true
 async-trait.workspace = true
 chrono.workspace = true
-derive_more.workspace = true
 jiff.workspace = true
-serde.workspace = true
 tokio = { workspace = true, features = ["sync"] }
-tracing.workspace = true
-utoipa.workspace = true
-uuid = { version = "1", features = ["v4", "serde"] }
 
 [lints]
 workspace = true

--- a/crates/extensions/backend-admin/Cargo.toml
+++ b/crates/extensions/backend-admin/Cargo.toml
@@ -11,24 +11,15 @@ workspace = true
 anyhow = { workspace = true }
 async-trait = { workspace = true }
 axum = { workspace = true, features = ["ws"] }
-base = { workspace = true }
-bon = { workspace = true }
 chrono = { workspace = true }
-derive_more = { workspace = true }
 futures = { workspace = true }
-git2 = { workspace = true }
 jiff = { workspace = true }
-
-opentelemetry = { version = "0.32.0", default-features = false, features = ["trace"] }
-rara-channels = { workspace = true }
 rara-domain-shared = { workspace = true }
-rara-git = { workspace = true }
 rara-kernel = { workspace = true }
 rara-mcp = { workspace = true }
 rara-paths = { workspace = true }
 rara-sessions = { workspace = true }
 rara-skills = { workspace = true }
-reqwest = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 snafu = { workspace = true }
@@ -36,12 +27,10 @@ diesel = { workspace = true }
 diesel-async = { workspace = true }
 rara-model = { workspace = true }
 strum = { workspace = true }
-strum_macros = { workspace = true }
 tokio = { workspace = true, features = ["sync", "fs", "rt"] }
 tokio-util = { workspace = true }
 tower-http = { workspace = true, features = ["cors"] }
 tracing = { workspace = true }
-tracing-opentelemetry = "0.33.0"
 url = { workspace = true }
 utoipa = { workspace = true }
 utoipa-axum = { workspace = true }
@@ -50,10 +39,6 @@ yunara-store = { workspace = true }
 
 [dev-dependencies]
 async-trait = { workspace = true }
-base = { workspace = true }
-common-telemetry = { workspace = true }
 tempfile = { workspace = true }
-testcontainers = { workspace = true }
-testcontainers-modules = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 tower = { workspace = true }

--- a/crates/extensions/rara-git/Cargo.toml
+++ b/crates/extensions/rara-git/Cargo.toml
@@ -12,11 +12,6 @@ workspace = true
 getrandom = { version = "0.4", features = ["sys_rng"] }
 git2 = { workspace = true }
 rand_core = "0.10"
-rara-paths = { workspace = true }
 snafu.workspace = true
 ssh-key = { version = "0.7.0-rc.9", features = ["ed25519", "rand_core"] }
 tokio = { workspace = true }
-tracing.workspace = true
-
-[dev-dependencies]
-tempfile.workspace = true

--- a/crates/integrations/mcp/Cargo.toml
+++ b/crates/integrations/mcp/Cargo.toml
@@ -44,9 +44,5 @@ tokio.workspace = true
 tokio-util.workspace = true
 tracing.workspace = true
 
-[dev-dependencies]
-axum.workspace = true
-tempfile.workspace = true
-
 [lints]
 workspace = true

--- a/crates/kernel/Cargo.toml
+++ b/crates/kernel/Cargo.toml
@@ -23,9 +23,7 @@ zig-codec = ["dep:tape-codec-zig", "tape-codec-zig/zig-codec"]
 anyhow.workspace = true
 async-trait.workspace = true
 axum = { workspace = true }
-backon.workspace = true
 base.workspace = true
-base64.workspace = true
 bon.workspace = true
 chrono.workspace = true
 common-telemetry.workspace = true
@@ -38,7 +36,6 @@ futures.workspace = true
 hex.workspace = true
 hmac.workspace = true
 image.workspace = true
-indexmap.workspace = true
 jieba-rs.workspace = true
 jiff.workspace = true
 md5.workspace = true
@@ -50,7 +47,6 @@ rara-browser.workspace = true
 rara-domain-shared.workspace = true
 rara-paths.workspace = true
 rara-soul.workspace = true
-rara-stt.workspace = true
 rara-tool-macro.workspace = true
 regex.workspace = true
 reqwest.workspace = true
@@ -73,7 +69,6 @@ subtle.workspace = true
 tokio.workspace = true
 tokio-util = { workspace = true }
 tracing.workspace = true
-tracing-opentelemetry = "0.33.0"
 ulid.workspace = true
 unicode-normalization.workspace = true
 urlencoding.workspace = true
@@ -85,14 +80,12 @@ xxhash-rust = { version = "0.8", features = ["xxh3"] }
 async-trait.workspace = true
 chrono.workspace = true
 dashmap = "6"
-diesel_migrations.workspace = true
 rara-domain-shared = { workspace = true, features = ["testing"] }
 rara-kernel = { path = ".", features = ["testing"] }
 rara-model.workspace = true
 rara-sessions.workspace = true
 serde_json.workspace = true
 tempfile.workspace = true
-test-case = "^3"
 tower.workspace = true
 tokio = { workspace = true, features = ["full", "test-util"] }
 tracing-subscriber = { workspace = true }

--- a/crates/rara-model/Cargo.toml
+++ b/crates/rara-model/Cargo.toml
@@ -12,11 +12,7 @@ categories.workspace = true
 description = "Database-layer models and SQL migrations shared across domains"
 
 [dependencies]
-chrono.workspace = true
 diesel = { workspace = true }
-serde.workspace = true
-serde_json.workspace = true
-uuid = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/rara-sandbox/Cargo.toml
+++ b/crates/rara-sandbox/Cargo.toml
@@ -21,7 +21,6 @@ boxlite = { git = "https://github.com/boxlite-ai/boxlite", tag = "v0.9.7" }
 futures = { workspace = true }
 serde = { workspace = true }
 snafu = { workspace = true }
-tokio = { workspace = true }
 tracing = { workspace = true }
 
 [dev-dependencies]

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -16,15 +16,11 @@ async-trait = { workspace = true }
 axum = { workspace = true }
 bon = { workspace = true }
 bytes = { workspace = true }
-derive_more = { workspace = true }
 http = { workspace = true }
 jiff = { workspace = true }
 moka = { workspace = true }
 smart-default = { workspace = true }
-# fastrace = { workspace = true }
-axum-tracing-opentelemetry = { workspace = true }
 base = { workspace = true }
-common-runtime = { workspace = true }
 futures = { workspace = true }
 opentelemetry = { version = "0.32.0", default-features = false, features = ["metrics", "trace"] }
 tracing-opentelemetry = "0.33.0"
@@ -41,16 +37,12 @@ tonic = { workspace = true }
 tonic-health = { workspace = true }
 tonic-reflection = { workspace = true }
 tonic-tracing-opentelemetry = { workspace = true }
-tonic-web = { workspace = true }
 tower = { workspace = true }
 tower-http = { workspace = true }
 tracing = { workspace = true }
-tracing-subscriber = { workspace = true }
 
 [dev-dependencies]
-reqwest = { version = "0.13", features = ["json"] }
 tower = { workspace = true, features = ["util"] }
-http-body-util = "0.1"
 opentelemetry_sdk = { version = "0.32.0", features = ["trace"] }
 tracing-subscriber = { workspace = true }
 

--- a/crates/skills/Cargo.toml
+++ b/crates/skills/Cargo.toml
@@ -17,7 +17,6 @@ workspace = true
 [dependencies]
 async-trait.workspace = true
 base64.workspace = true
-chrono.workspace = true
 dirs.workspace = true
 flate2 = "1"
 fs2 = "0.4"
@@ -46,5 +45,4 @@ url.workspace = true
 zip = "8.2.0"
 
 [dev-dependencies]
-rstest = "0.26"
 tempfile = { workspace = true }

--- a/deny.toml
+++ b/deny.toml
@@ -4,10 +4,19 @@ all-features = true
 [advisories]
 version = 2
 ignore = [
-    "RUSTSEC-2025-0012", # backoff (transitive via async-openai)
-    "RUSTSEC-2024-0384", # instant (transitive via backoff)
     "RUSTSEC-2024-0436", # paste (transitive via utoipa-axum)
-    "RUSTSEC-2025-0134", # rustls-pemfile (transitive via testcontainers/bollard)
+    # Unmaintained transitives we cannot upgrade away from our side (#2175):
+    "RUSTSEC-2025-0056", # adler unmaintained (via boxlite -> qcow2-rs -> miniz_oxide 0.7; fix needs upstream boxlite bump)
+    "RUSTSEC-2024-0375", # atty unmaintained (via boxlite -> qcow2-rs -> env_logger 0.9; std IsTerminal replacement is upstream's call)
+    "RUSTSEC-2025-0141", # bincode unmaintained (via fff-search -> heed and boxlite -> qcow2-rs; alternatives: postcard/bitcode, upstream's call)
+    "RUSTSEC-2026-0173", # proc-macro-error2 unmaintained (via teloxide -> aquamarine, jieba-rs -> include-flate, validator)
+    "RUSTSEC-2020-0163", # term_size unmaintained (via boxlite; terminal_size replacement is upstream's call)
+    # Vulnerabilities with no semver-compatible fix reachable from our side (#2175):
+    # opendal 0.57 (latest release) pins quick-xml ^0.39; the fixes landed in
+    # quick-xml 0.41. Drop both ignores when opendal releases against >=0.41.
+    "RUSTSEC-2026-0194", # quick-xml quadratic duplicate-attribute check (via opendal-core)
+    "RUSTSEC-2026-0195", # quick-xml NsReader memory-exhaustion DoS (via opendal-core)
+    "RUSTSEC-2023-0071", # rsa Marvin timing sidechannel (via opendal-core -> reqsign-core; no fixed rsa release exists upstream)
 ]
 
 [licenses]
@@ -30,6 +39,12 @@ allow = [
     "CDLA-Permissive-2.0",
 ]
 confidence-threshold = 0.8
+
+# bzip2-1.0.6 is the permissive BSD-style bzip2/libbzip2 license. Scoped to
+# the one crate that ships it (via zip -> bzip2) rather than globally allowed.
+exceptions = [
+    { crate = "libbz2-rs-sys", allow = ["bzip2-1.0.6"] },
+]
 
 [licenses.private]
 ignore = true
@@ -91,4 +106,8 @@ unknown-registry = "deny"
 unknown-git = "deny"
 allow-registry = ["https://github.com/rust-lang/crates.io-index"]
 allow-git = [
+    # rara-sandbox microVM backend (#1840); upstream publishes git tags only.
+    "https://github.com/boxlite-ai/boxlite",
+    # fff-search fuzzy file search (#1283); pinned rev, not published to crates.io.
+    "https://github.com/dmtrKovalenko/fff.nvim",
 ]

--- a/justfile
+++ b/justfile
@@ -114,7 +114,7 @@ check-ci-runners:
 lint-ratchet:
     @scripts/lint-ratchet.sh
 
-[doc("run linting checks (clippy, docs, buf, zizmor, yamllint-rs, cargo-deny, agent-md, check-deps, check-ci-runners)")]
+[doc("run linting checks (clippy, docs, buf, zizmor, yamllint-rs, cargo-deny, cargo-shear, agent-md, check-deps, check-ci-runners)")]
 [group("👆 Code Quality")]
 lint: check-agent-md check-deps check-ci-runners
     @echo "🔍 Running clippy..."
@@ -129,6 +129,8 @@ lint: check-agent-md check-deps check-ci-runners
     find .github/workflows -name '*.yml' ! -name 'release.yml' -exec zizmor {} +
     @echo "🔍 Checking dependencies (advisories & bans)..."
     cargo deny check
+    @echo "🔍 Checking for unused dependencies..."
+    cargo shear
     @echo "✅ All linting checks passed!"
 
 [doc("run `fmt` `clippy` `check` `test` at once")]


### PR DESCRIPTION
## Summary

Burns down the cargo-deny + cargo-shear baselines and deletes the two `continue-on-error: true` lines in `ci.yml`, completing the `TODO(#2166 follow-up)` blocks that PR #2170 left behind — the Cargo Deny and Cargo Shear jobs are now real (red = fix it) checks.

**Verification: PASS — verification/report.md (base 086bdb6e, head c3bd820f)**

### Before / after

| Check | Before (branch base) | After |
|---|---|---|
| `cargo deny check` | exit 13 — 18 errors (8 source-not-allowed, 1 license reject, 6 unmaintained, 3 vulnerabilities) | exit 0 |
| `cargo shear` | exit 1 — 87 findings (64 unused deps, 21 unused workspace deps, 2 misplaced) | exit 0 |
| `grep -c "continue-on-error" .github/workflows/ci.yml` | 2 | 0 |

### Decisions

Full per-finding decision tables are in #2175 (implementer hand-off). Condensed:

- **deny sources (8)**: `[sources].allow-git` for `boxlite-ai/boxlite` (#1840) and `dmtrKovalenko/fff.nvim` (#1283), with reason comments.
- **deny license (1)**: scoped `[licenses].exceptions` for `libbz2-rs-sys` (`bzip2-1.0.6`, permissive BSD-style) instead of global allow.
- **deny unmaintained (6)**: per-RUSTSEC ignores with parent-chain reasons — all transitive via boxlite / fff-search / teloxide / jieba-rs / validator, none upgradeable from our side (atty is not our dep, so `std::io::IsTerminal` replacement doesn't apply here).
- **deny vulnerabilities (3)**: quick-xml ×2 (RUSTSEC-2026-0194/0195) fixed only in quick-xml 0.41 while opendal 0.57 — the latest release — pins `^0.39`; ignored with an in-file note to drop both when opendal bumps. rsa Marvin (RUSTSEC-2023-0071) has no fixed upstream release; ignored per standard ecosystem practice.
- **deny stale ignores (3 removed)**: backoff / instant / rustls-pemfile entries no longer matched any crate in the graph.
- **shear (87)**: 81 genuinely unused declarations removed (workspace + per-crate manifests; proven by full check/clippy/nextest with `--all-targets --all-features`), 3 true false positives ignored with justification comments (`api`: `prost` + `tonic-prost` used only by `include_proto!` codegen; `app`: `zlob` pin-activation edge), 3 workspace-level findings resolved by those ignores.
- `justfile`: `cargo shear` added to the `lint` recipe so local `just lint` matches CI.
- Disclosure: fixed a stale comment in `crates/app/Cargo.toml` — the zlob pin note said `=1.3.2` but the workspace pins `=1.5.0`.

### Follow-up candidates (out of scope here)

- (a) `common-worker` is now an orphan workspace member (no member depends on it).
- (b) `POST /api/v1/mcp/servers` validation laxness (surfaced during verification probes).
- (c) `docs/guides/anti-patterns.md` testcontainers rationale needs rewording for the diesel/SQLite era (testcontainers left the dependency graph).

## Type of change

Maintenance (`chore`)

## Component

`core`

## Closes

Closes #2175

## Test plan

- [x] `just test` passes — `cargo nextest run --workspace --all-features`: 1154 passed, 4 skipped
- [x] `just lint` passes — clippy `-D warnings` clean, `cargo deny check` exit 0, `cargo shear` exit 0
- [x] Tested locally — full gate from clean state (`prek run --all-files` all Passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
