### PR TITLE
chore(ci): retire real-LLM e2e — wiremock mock provider over SSE (#2190)

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,21 +1,21 @@
-name: E2E (Real LLM)
+name: E2E (Mock Provider)
 
-# Real-LLM e2e flows (`anchor_checkout_e2e`) against an
-# OpenAI-compatible provider. Triggers on `main` push + manual dispatch only —
-# **not** on pull_request, to avoid burning provider tokens on every push.
-# Maintainer must configure `OPENAI_API_KEY` (secret), `OPENAI_BASE_URL` (var),
-# and `OPENAI_MODEL` (var) in org/repo settings — OpenRouter as of #2178
-# (base_url https://openrouter.ai/api/v1, no trailing slash). A 1-token
-# provider preflight fails the job fast, before the build, when the key or
-# vars are missing/broken.
+# Full-app e2e (`anchor_checkout_e2e`) driving the REAL openai driver stack
+# (HTTP client + auth + SSE stream parsing) against an in-process wiremock
+# OpenAI fake. Deterministic, zero-cost, secret-free — no provider account,
+# no provider secrets or vars anywhere (#2190, retiring the real-LLM lane
+# from #1941 / #2178). Because runs consume no provider tokens, this gates
+# pull requests as well as `main` pushes.
 
 on:
   push:
     branches: [main]
+  pull_request:
+    branches: [main]
   workflow_dispatch:
 
 concurrency:
-  group: e2e-real-llm-${{ github.run_id }}
+  group: e2e-mock-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
 
 env:
@@ -63,12 +63,12 @@ jobs:
               - '.github/workflows/lint.yml'
               - '.github/workflows/e2e.yml'
 
-  real-llm-e2e:
-    name: Real-LLM E2E
+  mock-provider-e2e:
+    name: Mock-Provider E2E
     needs: changes
-    # Skip the real-LLM suite when nothing in the rust bucket changed on a
-    # push to main (e.g. docs- or specs-only merges). workflow_dispatch
-    # always runs so maintainers can trigger ad-hoc.
+    # Skip the e2e suite when nothing in the rust bucket changed (e.g. docs-
+    # or specs-only changes). workflow_dispatch always runs so maintainers
+    # can trigger ad-hoc.
     if: ${{ needs.changes.outputs.rust == 'true' || github.event_name == 'workflow_dispatch' }}
     runs-on: ubuntu-latest
     env:
@@ -81,65 +81,31 @@ jobs:
         with:
           persist-credentials: false
 
-      # Fail fast on provider quota/auth errors BEFORE the ~10-minute build:
-      # a 1-token completion ping surfaces the provider's error body in the
-      # step log within a minute (#2178). The response body carries no
-      # secrets; the API key itself is never echoed.
-      - name: Provider preflight (1-token ping)
-        env:
-          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-          OPENAI_BASE_URL: ${{ vars.OPENAI_BASE_URL }}
-          OPENAI_MODEL: ${{ vars.OPENAI_MODEL }}
-        run: |
-          body="$(mktemp)"
-          status=$(curl -sS --max-time 60 -o "$body" -w "%{http_code}" \
-            -H "Authorization: Bearer ${OPENAI_API_KEY}" \
-            -H "Content-Type: application/json" \
-            -d "{\"model\":\"${OPENAI_MODEL}\",\"messages\":[{\"role\":\"user\",\"content\":\"ping\"}],\"max_tokens\":1}" \
-            "${OPENAI_BASE_URL}/chat/completions")
-          if [ "$status" != "200" ]; then
-            echo "::error::provider preflight failed: HTTP $status from ${OPENAI_BASE_URL} (model ${OPENAI_MODEL})"
-            echo "--- provider response body ---"
-            cat "$body"
-            echo
-            exit 1
-          fi
-          echo "provider preflight OK: HTTP 200 from ${OPENAI_BASE_URL} (model ${OPENAI_MODEL})"
-
       # System toolchain (diesel headers, protoc, zig, mold) — see
       # .github/actions/setup-rara-build/action.yml (#2166).
       - name: Setup rara build environment
         uses: ./.github/actions/setup-rara-build
 
-      - name: Install gettext (envsubst for config templating)
-        run: |
-          sudo apt-get install -y --no-install-recommends gettext-base
-
       - name: Rust cache
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2.9.1
 
-      - name: Render rara config from template
-        env:
-          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-          OPENAI_BASE_URL: ${{ vars.OPENAI_BASE_URL }}
-          OPENAI_MODEL: ${{ vars.OPENAI_MODEL }}
+      - name: Stage CI config (XDG steering)
         run: |
-          # Render the config under $RUNNER_TEMP and steer both
+          # Stage the static CI config under $RUNNER_TEMP and steer both
           # `dirs::config_dir()` and `dirs::data_local_dir()` (used by
-          # rara_paths::data_dir) there via the XDG_* env vars for
-          # downstream steps — keeps the job independent of runner $HOME.
+          # rara_paths) there via the XDG_* env vars — keeps the job
+          # independent of runner $HOME. The mock-provider test is itself
+          # hermetic (it writes its own config under a temp
+          # `rara_paths::set_custom_data_dir`); this staging covers any
+          # other e2e test that boots from the XDG config path.
           mkdir -p "$RUNNER_TEMP/xdg-config/rara" "$RUNNER_TEMP/xdg-data"
-          envsubst < ci/config.template.yaml > "$RUNNER_TEMP/xdg-config/rara/config.yaml"
+          cp ci/config.template.yaml "$RUNNER_TEMP/xdg-config/rara/config.yaml"
           {
             echo "XDG_CONFIG_HOME=$RUNNER_TEMP/xdg-config"
             echo "XDG_DATA_HOME=$RUNNER_TEMP/xdg-data"
           } >> "$GITHUB_ENV"
 
-      - name: Run real-LLM e2e tests
-        env:
-          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-          OPENAI_BASE_URL: ${{ vars.OPENAI_BASE_URL }}
-          OPENAI_MODEL: ${{ vars.OPENAI_MODEL }}
+      - name: Run mock-provider e2e tests
         run: |
           cargo test -p rara-app \
             --test anchor_checkout_e2e \

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -270,6 +270,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3fb67a6e08acf24fdeccbac2cb6ac4305825bd1f117462e0e6f2f193345ad56"
 
 [[package]]
+name = "assert-json-diff"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "async-broadcast"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2028,6 +2038,24 @@ dependencies = [
  "sha2 0.10.9",
  "zeroize",
 ]
+
+[[package]]
+name = "deadpool"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0be2b1d1d6ec8d846f05e137292d0b89133caf95ef33695424c09568bdd39b1b"
+dependencies = [
+ "deadpool-runtime",
+ "lazy_static",
+ "num_cpus",
+ "tokio",
+]
+
+[[package]]
+name = "deadpool-runtime"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
 
 [[package]]
 name = "debugid"
@@ -6584,6 +6612,7 @@ dependencies = [
  "tracing",
  "uuid",
  "walkdir",
+ "wiremock",
  "yunara-store",
  "zlob",
 ]
@@ -10573,6 +10602,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "wiremock"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08db1edfb05d9b3c1542e521aea074442088292f00b5f28e435c714a98f85031"
+dependencies = [
+ "assert-json-diff",
+ "base64 0.22.1",
+ "deadpool",
+ "futures",
+ "http",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "log",
+ "once_cell",
+ "regex",
+ "serde",
+ "serde_json",
+ "tokio",
+ "url",
 ]
 
 [[package]]

--- a/ci/config.template.yaml
+++ b/ci/config.template.yaml
@@ -1,7 +1,9 @@
-# CI config template — rendered at job start via `envsubst` into
-# `$XDG_CONFIG_HOME/rara/config.yaml`. Only `llm.providers.openai.*` references
-# environment variables; the rest is hardcoded CI-safe values so the
-# real-LLM e2e tests have a complete, valid `AppConfig` to load.
+# CI config — copied verbatim at job start to `$XDG_CONFIG_HOME/rara/config.yaml`
+# (no env substitution; every value is a hardcoded CI-safe dummy). The
+# mock-provider e2e test writes its own hermetic config pointing
+# `llm.providers.openai.base_url` at an in-process wiremock server, so the
+# values below are never dialed by CI — they exist so any e2e test booting
+# from the XDG config path has a complete, valid `AppConfig` to load (#2190).
 #
 # See `config.example.yaml` for the canonical reference and field docs.
 
@@ -29,9 +31,11 @@ llm:
   default_provider: "openai"
   providers:
     openai:
-      base_url: "${OPENAI_BASE_URL}"
-      api_key: "${OPENAI_API_KEY}"
-      default_model: "${OPENAI_MODEL}"
+      # Unroutable dummy — tests that need a live provider endpoint must
+      # bring their own (the mock-provider e2e injects a wiremock URL).
+      base_url: "http://127.0.0.1:9"
+      api_key: "ci-dummy-key-not-a-real-secret"
+      default_model: "mock-model"
 
 knowledge:
   embedding_model: "text-embedding-3-small"

--- a/crates/app/Cargo.toml
+++ b/crates/app/Cargo.toml
@@ -89,6 +89,10 @@ rara-kernel = { workspace = true }
 tempfile = { workspace = true }
 tokio = { workspace = true }
 tower = { workspace = true }
+# HTTP-level OpenAI fake for the mock-provider e2e lane ONLY (issue #2190).
+# Do NOT use wiremock in kernel/channels tests — fake the LLM at the trait
+# (`ScriptedLlmDriver`) there; see docs/guides/e2e-style.md "Forbidden".
+wiremock = "0.6"
 
 [lints]
 workspace = true

--- a/crates/app/tests/anchor_checkout_e2e.rs
+++ b/crates/app/tests/anchor_checkout_e2e.rs
@@ -1,5 +1,38 @@
+// Copyright 2025 Rararulab
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Mock-provider driver-stack e2e (issue #2190).
+//!
+//! Boots the full app via `start_with_options()` and drives multi-turn
+//! conversations through the REAL openai driver (HTTP + auth + SSE parsing in
+//! `crates/kernel/src/llm/{openai,stream}.rs`) against an in-process
+//! wiremock OpenAI fake. Deterministic, zero-cost, secret-free — replaces the
+//! retired real-LLM CI lane (#1941 → #2178 → #2190).
+//!
+//! The test is hermetic: it writes its own `config.yaml` under a temp
+//! `rara_paths` custom data dir (the ONLY reliable injection point for the
+//! mock's `base_url` — `ConfigFileSync` seeds the settings store from the
+//! config FILE at boot, so mutating the in-memory `AppConfig` never reaches
+//! the driver's per-request settings lookup).
+
+mod common;
+
 use std::time::Duration;
 
+use common::mock_provider::{
+    self, finish_chunk, reasoning_chunk, text_chunk, tool_call_args_chunk, tool_call_start_chunk,
+};
 use rara_app::{AppConfig, StartOptions, start_with_options};
 use rara_kernel::{
     channel::types::{ChannelType, MessageContent},
@@ -8,9 +41,21 @@ use rara_kernel::{
     memory::{FileTapeStore, TapEntryKind, TapeService},
     session::SessionKey,
 };
+use serde_json::Value;
 use tokio::time::{Instant, sleep};
+use wiremock::MockServer;
 
 const TURN_TIMEOUT_SECS: u64 = 60;
+
+/// Unique content marker inside the workspace note file the scripted tool
+/// call reads — proves real tool output flowed back into the follow-up LLM
+/// request.
+const NOTE_MARKER: &str = "MOCK-NOTE-MARKER-7391";
+
+const TURN1_TEXT: &str = "记住这个数字：42是宇宙的答案。确认你记住了。";
+const TURN2_TEXT: &str =
+    "现在我们讨论一个新话题：Rust的所有权系统。简短解释下 borrow checker 的核心规则。";
+const TURN3_TEXT: &str = "42是什么的答案？只回答数字和含义。";
 
 fn build_test_message(
     session_key: Option<SessionKey>,
@@ -57,21 +102,150 @@ async fn wait_for_turn_count(
     }
 }
 
+/// Write the hermetic test config pointing the openai provider at the mock
+/// server. Required sections mirror `ci/config.template.yaml`.
+fn write_test_config(config_path: &std::path::Path, mock_base_url: &str) {
+    let yaml = format!(
+        r#"http:
+  bind_address: "127.0.0.1:0"
+  cors_allowed_origins:
+    - "http://localhost:5173"
+
+grpc:
+  bind_address: "127.0.0.1:0"
+  server_address: "127.0.0.1:0"
+
+owner_token: "e2e-mock-owner-token-not-a-real-secret"
+owner_user_id: "ryan"
+
+users:
+  - name: "ryan"
+    role: root
+    platforms: []
+
+mita:
+  heartbeat_interval: "30m"
+
+llm:
+  default_provider: "openai"
+  providers:
+    openai:
+      base_url: "{mock_base_url}"
+      api_key: "mock-key-not-a-real-secret"
+      default_model: "mock-model"
+
+knowledge:
+  embedding_model: "mock-embedding"
+  embedding_dimensions: {dims}
+  search_top_k: 5
+  similarity_threshold: 0.85
+"#,
+        dims = mock_provider::EMBEDDING_DIMENSIONS,
+    );
+    std::fs::create_dir_all(
+        config_path
+            .parent()
+            .expect("config path should have a parent"),
+    )
+    .expect("config dir should be creatable");
+    std::fs::write(config_path, yaml).expect("test config should be writable");
+}
+
+/// Script the conversation on the mock server.
+///
+/// Priorities: later turns get numerically lower (= higher) priority because
+/// each turn's request embeds all earlier turns' text in its message history.
+async fn mount_conversation(server: &MockServer, note_path: &str) {
+    // Turn 3 (recall): CJK multi-chunk answer containing the "42" fact.
+    mock_provider::mount_chat_sse(
+        server,
+        TURN3_TEXT,
+        1,
+        &[
+            text_chunk("42是宇宙、生命以及"),
+            text_chunk("一切问题的终极答案。"),
+            finish_chunk("stop"),
+        ],
+    )
+    .await;
+
+    // Turn 2 follow-up (after the read-file tool round): matched on the tool
+    // output marker, which only appears once the tool result is in the
+    // request history.
+    mock_provider::mount_chat_sse(
+        server,
+        NOTE_MARKER,
+        2,
+        &[
+            text_chunk("borrow checker 的核心规则："),
+            text_chunk("同一时刻要么一个可变引用，要么任意多个不可变引用。"),
+            finish_chunk("stop"),
+        ],
+    )
+    .await;
+
+    // Turn 2 (first round): a scripted tool call to `read-file`, with the
+    // JSON arguments split across two SSE chunks to exercise
+    // `ToolCallArgumentsDelta` accumulation in the real driver.
+    let args = serde_json::json!({ "file_path": note_path }).to_string();
+    let (args_head, args_tail) = args.split_at(args.len() / 2);
+    mock_provider::mount_chat_sse(
+        server,
+        TURN2_TEXT,
+        3,
+        &[
+            tool_call_start_chunk("call-mock-1", "read-file"),
+            tool_call_args_chunk(args_head),
+            tool_call_args_chunk(args_tail),
+            finish_chunk("tool_calls"),
+        ],
+    )
+    .await;
+
+    // Turn 1: multi-chunk CJK text + a reasoning delta, streamed through the
+    // real SSE parser.
+    mock_provider::mount_chat_sse(
+        server,
+        "记住这个数字",
+        4,
+        &[
+            reasoning_chunk("用户要求记住一个事实。"),
+            text_chunk("好的，我已经记住了："),
+            text_chunk("42是宇宙的答案。"),
+            finish_chunk("stop"),
+        ],
+    )
+    .await;
+
+    // Background traffic (title_gen, knowledge_extractor, embeddings).
+    mock_provider::mount_fallbacks(server).await;
+}
+
 #[tokio::test]
-#[ignore = "uses the real LLM provider — run with: cargo test -p rara-app --test \
-            anchor_checkout_e2e -- --ignored --nocapture"]
+#[ignore = "full-app-boot e2e (mock provider, no secrets) — runs via e2e.yml; locally: cargo test \
+            -p rara-app --test anchor_checkout_e2e -- --ignored --nocapture"]
 async fn anchor_checkout_roundtrip() {
-    // 1. Setup — load workspace config + start the kernel under test.
+    // 1. Setup — hermetic paths, mock provider, test-authored config.
     common_telemetry::logging::init_default_ut_logging();
-    let workspace_root = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("../..");
-    std::env::set_current_dir(&workspace_root).expect("should switch to workspace root");
+
+    let data_dir = tempfile::tempdir().expect("temp data dir should be creatable");
+    let workspace = tempfile::tempdir().expect("temp workspace should be creatable");
+    // Must run before anything touches rara_paths: steers data_dir AND
+    // config_dir (=> `config_file()`) under the temp dir.
+    rara_paths::set_custom_data_dir(data_dir.path());
+    std::env::set_current_dir(workspace.path()).expect("should switch to temp workspace");
+
+    let note_path = workspace.path().join("mock-note.txt");
+    std::fs::write(&note_path, format!("{NOTE_MARKER}: 关于42的补充说明。\n"))
+        .expect("note file should be writable");
+
+    let server = MockServer::start().await;
+    mount_conversation(&server, note_path.to_str().expect("utf8 temp path")).await;
+    write_test_config(rara_paths::config_file(), &server.uri());
 
     let mut config = AppConfig::new().expect("config should load");
+    // Defend against a portless-injected PORT env rewriting the bind address.
     config.http.bind_address = "127.0.0.1:0".to_string();
-    config.grpc.bind_address = "127.0.0.1:0".to_string();
-    config.grpc.server_address = "127.0.0.1:0".to_string();
-    config.gateway = None;
-    config.telegram = None;
 
     let mut app = start_with_options(config, StartOptions::default())
         .await
@@ -84,12 +258,7 @@ async fn anchor_checkout_roundtrip() {
     // 2. Create session with a verifiable fact
     let principal = Principal::lookup("ryan".to_string());
     let session_key = handle
-        .spawn_named(
-            "rara",
-            "记住这个数字：42是宇宙的答案。确认你记住了。".to_string(),
-            principal.clone(),
-            None,
-        )
+        .spawn_named("rara", TURN1_TEXT.to_string(), principal.clone(), None)
         .await
         .expect("should spawn session");
 
@@ -99,25 +268,50 @@ async fn anchor_checkout_roundtrip() {
     // Verify turn 1 succeeded — print the trace on failure so a failed
     // turn's provider error (carried since #2178) is visible verbatim.
     let traces = handle.get_process_turns(session_key);
+    let turn1 = traces.last().unwrap();
     assert!(
-        traces.last().unwrap().success,
-        "turn 1 should succeed; latest_trace={:?}",
-        traces.last()
+        turn1.success,
+        "turn 1 should succeed; latest_trace={turn1:?}"
+    );
+    // The multi-chunk CJK SSE stream must be reassembled verbatim by the
+    // real driver (stream_chat_completions + StreamAccumulator).
+    let turn1_preview = turn1
+        .iterations
+        .last()
+        .map(|i| i.text_preview.clone())
+        .unwrap_or_default();
+    assert!(
+        turn1_preview.contains("42是宇宙的答案"),
+        "turn 1 preview should carry the scripted CJK content, got: {turn1_preview}"
     );
 
-    // 3. Send another message to build context
+    // 3. Send another message to build context — scripted as a real tool
+    // round: the mock returns a `read-file` tool call, the app executes it,
+    // and the follow-up request carries the tool result back to the mock.
     handle
-        .submit_message(build_test_message(
-            Some(session_key),
-            &chat_id,
-            "现在我们讨论一个新话题：Rust的所有权系统。简短解释下 borrow checker 的核心规则。",
-        ))
+        .submit_message(build_test_message(Some(session_key), &chat_id, TURN2_TEXT))
         .expect("msg 2 should submit");
     wait_for_turn_count(&handle, session_key, 2).await;
 
+    let traces = handle.get_process_turns(session_key);
+    let turn2 = traces.last().unwrap();
+    assert!(
+        turn2.success,
+        "turn 2 should succeed; latest_trace={turn2:?}"
+    );
+    assert_eq!(
+        turn2.total_tool_calls, 1,
+        "turn 2 should execute exactly the scripted read-file call; trace={turn2:?}"
+    );
+    assert_eq!(
+        turn2.iterations.len(),
+        2,
+        "turn 2 should take two LLM iterations (tool call + final answer); trace={turn2:?}"
+    );
+
     // 4. Verify tape has entries and find anchors
     let tape_service = TapeService::new(
-        FileTapeStore::new(rara_paths::memory_dir(), &workspace_root)
+        FileTapeStore::new(rara_paths::memory_dir(), workspace.path())
             .await
             .expect("tape store should open"),
     );
@@ -227,11 +421,7 @@ async fn anchor_checkout_roundtrip() {
 
     // 8. Continue conversation in original session — should still work
     handle
-        .submit_message(build_test_message(
-            Some(session_key),
-            &chat_id,
-            "42是什么的答案？只回答数字和含义。",
-        ))
+        .submit_message(build_test_message(Some(session_key), &chat_id, TURN3_TEXT))
         .expect("recall msg should submit");
     wait_for_turn_count(&handle, session_key, 3).await;
 
@@ -247,12 +437,97 @@ async fn anchor_checkout_roundtrip() {
         .map(|i| i.text_preview.clone())
         .unwrap_or_default();
     eprintln!("recall response: {preview}");
-    // The LLM should remember "42" from the original context
+    // Scripted response — rara-owned assertion (the #1941 model-recall
+    // `contains("42")` assertion is retired; the mock always answers with
+    // the fact).
     assert!(
-        preview.contains("42"),
-        "LLM should recall the fact from original session, got: {preview}"
+        preview.contains("42是宇宙"),
+        "recall preview should carry the scripted answer, got: {preview}"
     );
+
+    // 9. Captured-request assertions — the deterministic replacement for the
+    // old model-behavior check: context assembly through the full app stack
+    // + real driver serialization is what actually recalls "42".
+    let requests = mock_provider::chat_request_bodies(&server).await;
+    assert_request_context(&requests);
 
     eprintln!("E2E anchor checkout test passed!");
     app.shutdown();
+}
+
+/// Post-hoc assertions on the requests the real driver actually sent.
+fn assert_request_context(requests: &[Value]) {
+    // Agent-turn requests are identified structurally: they carry a user
+    // message byte-equal to the turn's input text (see
+    // `mock_provider::user_message_index` for why equality stays unique).
+    let (recall_request, turn3_index) = requests
+        .iter()
+        .rev()
+        .find_map(|r| mock_provider::user_message_index(r, TURN3_TEXT).map(|i| (r, i)))
+        .unwrap_or_else(|| {
+            panic!(
+                "no captured request carries {TURN3_TEXT:?} as a user message; captured {} chat \
+                 requests",
+                requests.len()
+            )
+        });
+
+    // The driver must have requested streaming — proves the SSE path
+    // (`stream_chat_completions`) is what parsed the mock's responses.
+    assert_eq!(
+        recall_request.get("stream"),
+        Some(&Value::Bool(true)),
+        "recall request should be a streaming request"
+    );
+
+    // Context assembly: the recall request must carry the "42" fact from
+    // turn 1 of the same session, EARLIER in the history than the recall
+    // question itself (the question does not contain the fact, so this
+    // cannot pass vacuously).
+    let messages = recall_request
+        .get("messages")
+        .and_then(Value::as_array)
+        .expect("recall request should have messages");
+    let history_has_fact = messages[..turn3_index].iter().any(|m| {
+        m.get("content")
+            .and_then(Value::as_str)
+            .is_some_and(|c| c.contains("42是宇宙的答案"))
+    });
+    assert!(
+        history_has_fact,
+        "recall request history should contain the 42 fact from turn 1; messages={messages:?}"
+    );
+
+    // Tool round: the follow-up request after the scripted read-file call
+    // must carry the tool result (role:"tool", matching id, real file
+    // content) — proves the full tool loop ran over the real wire format.
+    let tool_followup = requests
+        .iter()
+        .find(|r| {
+            r.get("messages")
+                .and_then(Value::as_array)
+                .is_some_and(|msgs| {
+                    msgs.iter().any(|m| {
+                        m.get("role").and_then(Value::as_str) == Some("tool")
+                            && m.get("tool_call_id").and_then(Value::as_str) == Some("call-mock-1")
+                    })
+                })
+        })
+        .expect("a captured request should carry the read-file tool result");
+    let tool_result_has_marker = tool_followup
+        .get("messages")
+        .and_then(Value::as_array)
+        .expect("tool follow-up should have messages")
+        .iter()
+        .filter(|m| m.get("role").and_then(Value::as_str) == Some("tool"))
+        .any(|m| {
+            m.get("content")
+                .and_then(Value::as_str)
+                .is_some_and(|c| c.contains(NOTE_MARKER))
+        });
+    assert!(
+        tool_result_has_marker,
+        "tool result content should contain the note marker {NOTE_MARKER}; \
+         request={tool_followup:?}"
+    );
 }

--- a/crates/app/tests/common/mock_provider.rs
+++ b/crates/app/tests/common/mock_provider.rs
@@ -1,0 +1,203 @@
+// Copyright 2025 Rararulab
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! In-process OpenAI-compatible fake provider (wiremock, streaming SSE).
+//!
+//! Follows the `openai/codex` `codex-rs/core/tests/common/responses.rs`
+//! pattern: canned SSE chat-completion bodies served over a real socket via
+//! `ResponseTemplate::new(200).set_body_raw(body, "text/event-stream")`, with
+//! post-hoc request assertions driven by `MockServer::received_requests()`.
+//!
+//! This exercises the REAL openai driver stack — HTTP client + auth + URL
+//! building (`crates/kernel/src/llm/openai.rs`) and SSE parsing / accumulation
+//! (`stream_chat_completions` + `StreamAccumulator`) — which trait-level DI
+//! (`ScriptedLlmDriver`) deliberately skips. Decision chain:
+//! #1930 → #1941 → #2016 → #2178 → #2190.
+
+use serde_json::{Value, json};
+use wiremock::{
+    Mock, MockServer, Request, ResponseTemplate,
+    matchers::{body_partial_json, body_string_contains, method, path},
+};
+
+/// Request path the real openai driver builds (`openai.rs`:
+/// `format!("{}{}", base_url, "/chat/completions")`). Single definition so a
+/// deliberate shape-break (red/green proof) only needs one edit.
+pub const CHAT_COMPLETIONS_PATH: &str = "/chat/completions";
+
+/// A streamed text delta chunk (Chat Completions SSE shape).
+pub fn text_chunk(text: &str) -> Value {
+    json!({"choices": [{"index": 0, "delta": {"content": text}}]})
+}
+
+/// A streamed reasoning delta chunk (`delta.reasoning_content`).
+pub fn reasoning_chunk(text: &str) -> Value {
+    json!({"choices": [{"index": 0, "delta": {"reasoning_content": text}}]})
+}
+
+/// First chunk of a streamed tool call: carries id + name (index 0).
+pub fn tool_call_start_chunk(id: &str, name: &str) -> Value {
+    json!({"choices": [{"index": 0, "delta": {"tool_calls": [
+        {"index": 0, "id": id, "function": {"name": name, "arguments": ""}}
+    ]}}]})
+}
+
+/// Follow-up chunk carrying a fragment of the tool call's JSON arguments.
+pub fn tool_call_args_chunk(fragment: &str) -> Value {
+    json!({"choices": [{"index": 0, "delta": {"tool_calls": [
+        {"index": 0, "function": {"arguments": fragment}}
+    ]}}]})
+}
+
+/// Final chunk with a `finish_reason` and usage block.
+pub fn finish_chunk(reason: &str) -> Value {
+    json!({
+        "choices": [{"index": 0, "delta": {}, "finish_reason": reason}],
+        "usage": {"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15}
+    })
+}
+
+/// Assemble chunks into an SSE body (`data: {...}` events + `data: [DONE]`).
+fn sse_body(chunks: &[Value]) -> String {
+    let mut body = String::new();
+    for chunk in chunks {
+        body.push_str("data: ");
+        body.push_str(&chunk.to_string());
+        body.push_str("\n\n");
+    }
+    body.push_str("data: [DONE]\n\n");
+    body
+}
+
+/// A 200 `text/event-stream` response streaming the given chunks.
+pub fn sse_response(chunks: &[Value]) -> ResponseTemplate {
+    ResponseTemplate::new(200).set_body_raw(sse_body(chunks), "text/event-stream")
+}
+
+/// Mount a scripted SSE response for `POST /chat/completions` requests whose
+/// body contains `marker`.
+///
+/// Later conversation turns embed earlier turns' text in their request
+/// history, so markers overlap across turns — disambiguate by giving the
+/// LATEST turn the numerically lowest (= highest) `priority`.
+pub async fn mount_chat_sse(server: &MockServer, marker: &str, priority: u8, chunks: &[Value]) {
+    Mock::given(method("POST"))
+        .and(path(CHAT_COMPLETIONS_PATH))
+        .and(body_string_contains(marker))
+        .respond_with(sse_response(chunks))
+        .with_priority(priority)
+        .mount(server)
+        .await;
+}
+
+/// Catch-all mounts for LLM traffic this test does not script per-turn:
+/// background agents (title_gen, knowledge_extractor) and the knowledge
+/// layer's embedder. Mounted at the lowest priority so scripted turn mocks
+/// always win.
+pub async fn mount_fallbacks(server: &MockServer) {
+    // Streaming chat fallback.
+    Mock::given(method("POST"))
+        .and(path(CHAT_COMPLETIONS_PATH))
+        .and(body_partial_json(json!({"stream": true})))
+        .respond_with(sse_response(&[
+            text_chunk("mock background reply"),
+            finish_chunk("stop"),
+        ]))
+        .with_priority(250)
+        .mount(server)
+        .await;
+
+    // Non-streaming chat fallback (`LlmDriver::complete`).
+    Mock::given(method("POST"))
+        .and(path(CHAT_COMPLETIONS_PATH))
+        .and(body_partial_json(json!({"stream": false})))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "id": "cmpl-mock",
+            "object": "chat.completion",
+            "created": 0,
+            "model": "mock-model",
+            "choices": [{
+                "index": 0,
+                "message": {"role": "assistant", "content": "mock background reply"},
+                "finish_reason": "stop"
+            }],
+            "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 1}
+        })))
+        .with_priority(250)
+        .mount(server)
+        .await;
+
+    // Embeddings fallback: one zero-vector per input, dimensions matching the
+    // test config's `knowledge.embedding_dimensions`.
+    Mock::given(method("POST"))
+        .and(path("/embeddings"))
+        .respond_with(embeddings_response)
+        .with_priority(250)
+        .mount(server)
+        .await;
+}
+
+/// Dimensions served by the embeddings fallback — keep in sync with the
+/// `knowledge.embedding_dimensions` value in the test-authored config.
+pub const EMBEDDING_DIMENSIONS: usize = 8;
+
+/// Dynamic responder: echoes one zero-embedding per request input so batch
+/// sizes always line up.
+fn embeddings_response(request: &Request) -> ResponseTemplate {
+    let input_len = serde_json::from_slice::<Value>(&request.body)
+        .ok()
+        .and_then(|body| body.get("input").and_then(|i| i.as_array()).map(Vec::len))
+        .unwrap_or(1);
+    let data: Vec<Value> = (0..input_len)
+        .map(|index| {
+            json!({
+                "object": "embedding",
+                "index": index,
+                "embedding": vec![0.0f32; EMBEDDING_DIMENSIONS]
+            })
+        })
+        .collect();
+    ResponseTemplate::new(200).set_body_json(json!({
+        "object": "list",
+        "data": data,
+        "model": "mock-embedding",
+        "usage": {"prompt_tokens": 1, "total_tokens": 1}
+    }))
+}
+
+/// All captured `POST /chat/completions` request bodies, parsed as JSON, in
+/// arrival order.
+pub async fn chat_request_bodies(server: &MockServer) -> Vec<Value> {
+    server
+        .received_requests()
+        .await
+        .expect("request recording should be enabled")
+        .iter()
+        .filter(|r| r.method.as_str() == "POST" && r.url.path() == CHAT_COMPLETIONS_PATH)
+        .map(|r| serde_json::from_slice(&r.body).expect("chat request body should be JSON"))
+        .collect()
+}
+
+/// Index of the `role: "user"` message whose content EQUALS `text`.
+///
+/// Equality (not `contains`) keeps the lookup unique: background agents
+/// (title_gen, knowledge_extractor) embed conversation text inside larger
+/// prompts, and context assembly appends system-reminder user messages after
+/// the real one — neither is byte-equal to the original turn input.
+pub fn user_message_index(body: &Value, text: &str) -> Option<usize> {
+    body.get("messages")?.as_array()?.iter().position(|m| {
+        m.get("role").and_then(Value::as_str) == Some("user")
+            && m.get("content").and_then(Value::as_str) == Some(text)
+    })
+}

--- a/crates/app/tests/common/mock_provider.rs
+++ b/crates/app/tests/common/mock_provider.rs
@@ -34,34 +34,34 @@ use wiremock::{
 /// Request path the real openai driver builds (`openai.rs`:
 /// `format!("{}{}", base_url, "/chat/completions")`). Single definition so a
 /// deliberate shape-break (red/green proof) only needs one edit.
-pub const CHAT_COMPLETIONS_PATH: &str = "/chat/completions";
+pub(crate) const CHAT_COMPLETIONS_PATH: &str = "/chat/completions";
 
 /// A streamed text delta chunk (Chat Completions SSE shape).
-pub fn text_chunk(text: &str) -> Value {
+pub(crate) fn text_chunk(text: &str) -> Value {
     json!({"choices": [{"index": 0, "delta": {"content": text}}]})
 }
 
 /// A streamed reasoning delta chunk (`delta.reasoning_content`).
-pub fn reasoning_chunk(text: &str) -> Value {
+pub(crate) fn reasoning_chunk(text: &str) -> Value {
     json!({"choices": [{"index": 0, "delta": {"reasoning_content": text}}]})
 }
 
 /// First chunk of a streamed tool call: carries id + name (index 0).
-pub fn tool_call_start_chunk(id: &str, name: &str) -> Value {
+pub(crate) fn tool_call_start_chunk(id: &str, name: &str) -> Value {
     json!({"choices": [{"index": 0, "delta": {"tool_calls": [
         {"index": 0, "id": id, "function": {"name": name, "arguments": ""}}
     ]}}]})
 }
 
 /// Follow-up chunk carrying a fragment of the tool call's JSON arguments.
-pub fn tool_call_args_chunk(fragment: &str) -> Value {
+pub(crate) fn tool_call_args_chunk(fragment: &str) -> Value {
     json!({"choices": [{"index": 0, "delta": {"tool_calls": [
         {"index": 0, "function": {"arguments": fragment}}
     ]}}]})
 }
 
 /// Final chunk with a `finish_reason` and usage block.
-pub fn finish_chunk(reason: &str) -> Value {
+pub(crate) fn finish_chunk(reason: &str) -> Value {
     json!({
         "choices": [{"index": 0, "delta": {}, "finish_reason": reason}],
         "usage": {"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15}
@@ -81,7 +81,7 @@ fn sse_body(chunks: &[Value]) -> String {
 }
 
 /// A 200 `text/event-stream` response streaming the given chunks.
-pub fn sse_response(chunks: &[Value]) -> ResponseTemplate {
+pub(crate) fn sse_response(chunks: &[Value]) -> ResponseTemplate {
     ResponseTemplate::new(200).set_body_raw(sse_body(chunks), "text/event-stream")
 }
 
@@ -91,7 +91,12 @@ pub fn sse_response(chunks: &[Value]) -> ResponseTemplate {
 /// Later conversation turns embed earlier turns' text in their request
 /// history, so markers overlap across turns — disambiguate by giving the
 /// LATEST turn the numerically lowest (= highest) `priority`.
-pub async fn mount_chat_sse(server: &MockServer, marker: &str, priority: u8, chunks: &[Value]) {
+pub(crate) async fn mount_chat_sse(
+    server: &MockServer,
+    marker: &str,
+    priority: u8,
+    chunks: &[Value],
+) {
     Mock::given(method("POST"))
         .and(path(CHAT_COMPLETIONS_PATH))
         .and(body_string_contains(marker))
@@ -105,7 +110,7 @@ pub async fn mount_chat_sse(server: &MockServer, marker: &str, priority: u8, chu
 /// background agents (title_gen, knowledge_extractor) and the knowledge
 /// layer's embedder. Mounted at the lowest priority so scripted turn mocks
 /// always win.
-pub async fn mount_fallbacks(server: &MockServer) {
+pub(crate) async fn mount_fallbacks(server: &MockServer) {
     // Streaming chat fallback.
     Mock::given(method("POST"))
         .and(path(CHAT_COMPLETIONS_PATH))
@@ -150,7 +155,7 @@ pub async fn mount_fallbacks(server: &MockServer) {
 
 /// Dimensions served by the embeddings fallback — keep in sync with the
 /// `knowledge.embedding_dimensions` value in the test-authored config.
-pub const EMBEDDING_DIMENSIONS: usize = 8;
+pub(crate) const EMBEDDING_DIMENSIONS: usize = 8;
 
 /// Dynamic responder: echoes one zero-embedding per request input so batch
 /// sizes always line up.
@@ -178,7 +183,7 @@ fn embeddings_response(request: &Request) -> ResponseTemplate {
 
 /// All captured `POST /chat/completions` request bodies, parsed as JSON, in
 /// arrival order.
-pub async fn chat_request_bodies(server: &MockServer) -> Vec<Value> {
+pub(crate) async fn chat_request_bodies(server: &MockServer) -> Vec<Value> {
     server
         .received_requests()
         .await
@@ -195,7 +200,7 @@ pub async fn chat_request_bodies(server: &MockServer) -> Vec<Value> {
 /// (title_gen, knowledge_extractor) embed conversation text inside larger
 /// prompts, and context assembly appends system-reminder user messages after
 /// the real one — neither is byte-equal to the original turn input.
-pub fn user_message_index(body: &Value, text: &str) -> Option<usize> {
+pub(crate) fn user_message_index(body: &Value, text: &str) -> Option<usize> {
     body.get("messages")?.as_array()?.iter().position(|m| {
         m.get("role").and_then(Value::as_str) == Some("user")
             && m.get("content").and_then(Value::as_str) == Some(text)

--- a/crates/app/tests/common/mod.rs
+++ b/crates/app/tests/common/mod.rs
@@ -19,4 +19,4 @@
 //! driver-stack e2e tests in this crate — kernel-flow tests fake the LLM at
 //! the trait via `ScriptedLlmDriver` (see `docs/guides/e2e-style.md`).
 
-pub mod mock_provider;
+pub(crate) mod mock_provider;

--- a/crates/app/tests/common/mod.rs
+++ b/crates/app/tests/common/mod.rs
@@ -1,0 +1,22 @@
+// Copyright 2025 Rararulab
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Shared helpers for `rara-app` e2e tests.
+//!
+//! `mock_provider` is the wiremock-based OpenAI-compatible fake used by the
+//! mock-provider e2e lane (issue #2190). It is sanctioned ONLY for
+//! driver-stack e2e tests in this crate — kernel-flow tests fake the LLM at
+//! the trait via `ScriptedLlmDriver` (see `docs/guides/e2e-style.md`).
+
+pub mod mock_provider;

--- a/docs/guides/e2e-style.md
+++ b/docs/guides/e2e-style.md
@@ -1,9 +1,10 @@
 # E2E Test Style — What rara's End-to-End Tests Look Like
 
 rara is an HTTP-served, in-process Rust agent. Its end-to-end behavior is
-testable in pure Rust — no separate binary, no HTTP fakes, no language
-runtime spin-up. This guide codifies what an e2e test *is* in this repo,
-which lane it belongs in, and what it must (and must not) assert.
+testable in pure Rust — no separate binary, no language runtime spin-up,
+and no HTTP fakes outside the one sanctioned driver-stack lane (lane 3).
+This guide codifies what an e2e test *is* in this repo, which lane it
+belongs in, and what it must (and must not) assert.
 
 If you are touching `crates/{app,kernel,channels,acp,sandbox}/src/`, the
 diff almost certainly needs an e2e in this style. Read the lanes first;
@@ -59,26 +60,47 @@ Anchors:
   contract example: one scripted turn, assert `TurnTrace.iterations`
   has length one and the preview matches.
 
-### Lane 3 — Real LLM flows (runs on `main` push only, never on PRs)
+### Lane 3 — Mock-provider driver-stack e2e (runs on PRs and `main`)
 
-Anything whose assertion depends on a real model's output (instruction
-following, tool selection, reasoning quality) is `#[ignore]`'d by default
-and runs only via `.github/workflows/e2e.yml` on push to `main`. This
-lane is **not** expanded by ordinary feature work. If you find yourself
-wanting to add a real-LLM test from a feature PR, stop — the assertion
-you are writing probably belongs in lane 1 or lane 2 instead.
+Full app boot via `start_with_options()` + the **real openai driver over
+HTTP** against a local in-process wiremock OpenAI fake serving scripted
+SSE chat completions. This is the only lane that exercises what lane 2's
+trait-level DI deliberately skips: HTTP client construction, auth
+headers, URL building (`crates/kernel/src/llm/openai.rs`), and SSE
+stream parsing / idle timeout / stream-close salvage
+(`stream_chat_completions` + `StreamAccumulator`). Assertions are
+rara-owned: `TurnTrace` shape, tape state, and post-hoc assertions on
+the **captured requests** the driver actually sent (context assembly,
+tool-result round-trips, `stream: true`).
 
-Anchors: `crates/app/tests/run_code_session.rs` (real LLM + boxlite
-runtime), the `e2e.yml` workflow, the decision in issue #1941 / PR #1943.
+The tests are `#[ignore]`'d (full-app boot is too heavy for the ordinary
+`cargo nextest run --workspace` gate) and run via
+`.github/workflows/e2e.yml` (`E2E (Mock Provider)`) on pull requests and
+`main` pushes — deterministic, zero-cost, secret-free.
+
+**Real-model-behavior assertions no longer run in CI at all** (#2190,
+user decision: no real provider key, for cost). Tests that need a live
+model (e.g. `crates/app/tests/run_code_session.rs`, real LLM + boxlite)
+stay `#[ignore]`'d and are manual/local only, for humans with their own
+key. If you find yourself wanting to add a real-LLM assertion from a
+feature PR, stop — the assertion you are writing belongs in lane 1 or
+lane 2 instead.
+
+Anchors: `crates/app/tests/anchor_checkout_e2e.rs`, the shared fake in
+`crates/app/tests/common/mock_provider.rs` (modeled on `openai/codex`
+`codex-rs/core/tests/common/responses.rs`), the `e2e.yml` workflow.
+Decision chain: #1930 → #1941 → #2016 → #2178 → #2190.
 
 ## Lane decision rule
 
 > Does the assertion read meaningfully when the LLM returns a
 > deterministic canned response? If yes → lane 1 or 2 (lane 1 if no LLM
-> at all is needed). If the assertion only makes sense with a real
-> model — e.g. "the model picks the read_file tool" or "the response
-> contains an explanation" — that's lane 3, and almost always the wrong
-> assertion to be making in a feature PR.
+> at all is needed); lane 3 only when the **wire itself** is the test
+> target — driver HTTP/SSE behavior or full-app-boot integration. If the
+> assertion only makes sense with a real model — e.g. "the model picks
+> the read_file tool" or "the response contains an explanation" — it has
+> no CI lane at all (#2190): keep it manual/local, and it is almost
+> always the wrong assertion to be making in the first place.
 
 PR #1941 is the cautionary tale: a real-LLM e2e was added whose
 assertions (`saw_anchor`, `read_file_calls >= 9`) tested the model's
@@ -110,9 +132,11 @@ bus.
 ### When `#[ignore]` is allowed
 
 Only when the test depends on an external resource the PR-time runner
-cannot provide:
+cannot provide, or boots the full app:
 
-- A real LLM provider (lane 3).
+- Full app boot via `start_with_options()` (lane 3) — too heavy for the
+  ordinary workspace test gate; runs in `e2e.yml` via `-- --ignored`.
+- A real LLM provider (manual/local only since #2190).
 - The `boxlite` runtime files (see
   `crates/app/tests/run_code_session.rs`).
 
@@ -121,19 +145,32 @@ tests that need a temp directory. Fix the underlying cause.
 
 ## Forbidden
 
-- `wiremock`, `mockito`, or any HTTP-fake crate. The kernel's LLM
-  surface is a Rust trait — fake it at the trait, not at the wire.
-  Decision chain: issue #1930 / PR #1933.
+- `wiremock`, `mockito`, or any HTTP-fake crate **outside the lane-3
+  driver-stack e2e** (`rara-app` dev-dependency, used by
+  `crates/app/tests/anchor_checkout_e2e.rs` + its
+  `tests/common/mock_provider.rs` helper). Everywhere else the kernel's
+  LLM surface is a Rust trait — fake it at the trait, not at the wire.
+
+  **Decision reversal, explicit (#2190):** #1930 / PR #1933 banned
+  wiremock entirely because "CI is gaining a real LLM API key" made
+  HTTP fakes redundant. That premise was revoked on 2026-07-05 (user
+  decision: no real key in CI, for cost) — with no real key, the wire
+  path (`openai.rs` HTTP + SSE parsing) has **zero** CI coverage unless
+  an HTTP fake provides it. The carve-out is narrow: wiremock is
+  sanctioned ONLY where the wire is the test target; kernel/channels
+  tests keep the trait-DI rule. Decision chain:
+  #1930 → #1941 → #2016 → #2178 → #2190.
 - Resurrecting `crates/app/tests/e2e_scripted.rs` or any equivalent
   flow-suite that wires `ScriptedLlmDriver` through the full app stack.
   The keep-list for `ScriptedLlmDriver` is narrow kernel-loop scenarios,
-  not flow suites. Decision chain: issue #1930 / PR #1933.
+  not flow suites. Decision chain: issue #1930 / PR #1933 (unchanged by
+  #2190).
 - New top-level e2e crates or test harnesses. Reuse `KernelTestHarness`
   (`TestKernelBuilder`) and `start_with_options()` exclusively.
-- Asserting on real-model behavior in a PR-time test (the PR #1941
-  pattern). If your assertion only makes sense for a real model, the
-  test belongs in `e2e.yml` and almost certainly should not be added at
-  all.
+- Asserting on real-model behavior in any CI test (the PR #1941
+  pattern). Since #2190 no CI job talks to a real model; such an
+  assertion is deterministic-canned-response-meaningless and almost
+  certainly should not be added at all.
 
 ## Pairing with workflow.md
 


### PR DESCRIPTION
## Summary

Retires real LLM providers from CI entirely (user decision, for cost). `anchor_checkout_e2e` now boots the full app and drives the **real openai driver stack** (HTTP client + auth + URL building in `crates/kernel/src/llm/openai.rs`, SSE parsing/accumulation in `stream_chat_completions` + `StreamAccumulator`) against an in-process **wiremock OpenAI fake** serving scripted streaming SSE — the `openai/codex` `codex-rs/core/tests/common/responses.rs` pattern. Deterministic, zero-cost, secret-free, so `E2E (Mock Provider)` now also gates pull requests (this PR's run is its first live PR-triggered execution).

- `crates/app/tests/common/mock_provider.rs` (new): SSE chunk builders, priority-ordered content-matched mounts, background-traffic fallbacks (title_gen / knowledge_extractor / embeddings), captured-request helpers. `wiremock` is a dev-dep of `rara-app` ONLY.
- `anchor_checkout_e2e.rs`: hermetic (writes its own `config.yaml` under a temp `rara_paths::set_custom_data_dir` — `ConfigFileSync` seeds settings from the config FILE, so the test-authored file is the only safe injection point for the mock `base_url`; the test no longer touches the developer's real config/DB). Scripts a genuine `read-file` tool round with split argument deltas and multi-chunk CJK content. The #1941 model-recall `preview.contains("42")` assertion is replaced by rara-owned captured-request assertions (context assembly, tool-result round-trip, `stream: true`).
- `e2e.yml`: renamed `E2E (Mock Provider)`, provider preflight + all provider secrets/vars removed (`rg -n "OPENAI_" .github/workflows/e2e.yml` → no matches), envsubst/gettext dropped, `pull_request` trigger added.
- `ci/config.template.yaml`: hardcoded CI-safe dummies, copied verbatim.
- `docs/guides/e2e-style.md`: lane 3 redefined; Forbidden section carve-out (see reversal below).

## Verification

Verification: PASS — verification/report.md (base 6572c23e, head 6e823f19)

Red/green evidence (each mutation applied temporarily, observed red, reverted, re-observed green):

- **Mutation 1 — request-shape break**: mock path changed to `/v1/chat/completions` → driver's real `POST /chat/completions` gets 404 → test FAILS with the #2183 provider trace verbatim: `success: false, error: Some("provider: agent execution failed: Model \"mock-model\" returned an error during streaming: non-retryable error: HTTP 404 Not Found")`. A scripted HTTP 500 for turn 1 likewise fails with the 500 body surfaced in the trace.
- **Mutation 2 — assertion-needle corruption**: context-assertion needle changed `42是宇宙的答案` → `43是宇宙的答案` → captured-request context assertion fails (anchor_checkout_e2e.rs:496, `recall request history should contain the 42 fact from turn 1`), with the full captured request dumped — proving the assertion reads real driver-serialized wire content (system prompt, turn-1 fact, assistant `tool_calls`, `role:"tool"` result with the note marker, recall question).
- **Dead-proxy run**: running with an unreachable proxy configured proves zero network egress beyond loopback — the suite consumes no provider tokens and reaches no external host.
- **Hermetic mtime check**: the developer's real config/DB files are untouched after a run (mtimes unchanged) — the test lives entirely in temp dirs via `rara_paths::set_custom_data_dir`.

SSE genuinely exercised: multi-chunk CJK deltas, a reasoning delta, tool-call arguments split across two chunks; captured requests show `"stream": true`; turn-2 trace asserts exactly 2 LLM iterations / 1 tool call.

## Decision reversal (#1930) — must travel with the squash

**This PR reverses part of #1930 / PR #1933, explicitly and narrowly.**

The flip-flop chain:

- **#1930 / PR #1933** dropped the scripted-LLM e2e suites **and all wiremock usage**; `docs/guides/e2e-style.md` "Forbidden" said: "`wiremock`, `mockito`, or any HTTP-fake crate. The kernel's LLM surface is a Rust trait — fake it at the trait, not at the wire." Rationale at the time, quoted from #1930: "CI is gaining a real LLM API key, so the scripted-LLM e2e suites and HTTP wiremocks no longer earn their keep."
- **#1941 / PR #1943** added the real-LLM `e2e.yml` job (and became the cautionary tale about model-behavior assertions).
- **#2016 / PR #2024** dropped real-LLM soak coupling, added scripted lane-2 coverage.
- **#2178 / PR #2183** switched MiniMax → OpenRouter + preflight + failed-turn traces — blocked on a human org-secret step that never happened; every rust push to `main` since 2026-07-04 had a red e2e canary.

**Reversal rationale:** #1930's premise — "CI is gaining a real LLM API key" — was **revoked by user decision on 2026-07-05, for cost** ("我们放弃真实的llm调用，成本问题，真要实现的话，我们用fake的mock"). With no real key, the wire-level driver stack (`openai.rs` HTTP + `stream.rs`/`stream_chat_completions` SSE parsing) has **zero** CI coverage unless an HTTP fake provides it. The reversal is narrow: wiremock is sanctioned **only** for the driver-stack e2e lane (`crates/app/tests/anchor_checkout_e2e.rs` + its `tests/common/mock_provider.rs` helper, dev-dep of `rara-app` only). "Fake it at the trait, not at the wire" remains the rule for kernel/channels tests — there the wire is not the test target; here it is. Resurrecting `e2e_scripted.rs`-style flow suites stays forbidden. Decision chain: #1930 → #1941 → #2016 → #2178 → #2190.

## Notes

- **The #2178 human-only org-secret step (fund an OpenRouter key, set `OPENAI_API_KEY`/`OPENAI_BASE_URL`/`OPENAI_MODEL` org vars) is CANCELLED, not pending.** No provider account or secret is needed anywhere.
- **Known residue:** `docs/guides/workflow.md:192` still describes lane 3 as "real LLM in e2e.yml" — outside this issue's Boundaries; a follow-up issue is being filed in parallel.
- e2e lane for this diff: the diff touches only `crates/app/tests/**` (no `src/`), and the changed test IS the lane-3 e2e itself.

## Type of change

CI / Infrastructure — `ci` (+ `chore`)

## Component

`ci`

## Closes

Closes #2190

## Test plan

- [x] `prek run --all-files` green (check / nightly fmt / clippy `-D warnings` / doc)
- [x] `cargo nextest run -p rara-app` — 97 passed, 2 skipped
- [x] `cargo test -p rara-app --test anchor_checkout_e2e -- --ignored` green locally (~4s)
- [x] `cargo deny check` + `cargo shear` clean (new dev-dep tree)
- [x] `actionlint .github/workflows/e2e.yml` clean
- [x] Red/green mutations (see Verification)

🤖 Generated with [Claude Code](https://claude.com/claude-code)