### PR TITLE
docs(guides): fix stale real-LLM lane-3 wording after #2190 (#2192)

### DIFF
--- a/.claude/workflows/rara-dev.js
+++ b/.claude/workflows/rara-dev.js
@@ -173,7 +173,7 @@ const VARIANT_MD = { backend: 'implementer-backend', frontend: 'implementer-fron
 // --workspace` (what rust.yml gates) instead of just the touched crate —
 // otherwise cross-crate regressions slip through. In the default 'watch'
 // mode, remote CI covers --workspace, so the local gate stays narrow
-// (`cargo test -p <crate>`). Real-LLM e2e (e2e.yml) and the Linux matrix
+// (`cargo test -p <crate>`). Driver-stack e2e (e2e.yml) and the Linux matrix
 // remain CI-only — uncovered during an outage by design.
 const BACKEND_TEST = CI_MODE === 'signoff'
   ? 'cargo nextest run --workspace (full workspace — replaces the down CI; if nextest is unavailable, cargo test --workspace)'

--- a/docs/guides/workflow.md
+++ b/docs/guides/workflow.md
@@ -189,8 +189,9 @@ Whichever variant is dispatched, it:
 If the diff touches `crates/{app,kernel,channels,acp,sandbox}/src/`, the
 backend variant adds or extends a Rust e2e test in the corresponding
 `tests/` directory following `docs/guides/e2e-style.md` (lane 1 = no LLM,
-lane 2 = scripted LLM via `ScriptedLlmDriver`, lane 3 = real LLM in
-`e2e.yml`). If PR-time e2e coverage is infeasible, state in the PR body
+lane 2 = scripted LLM via `ScriptedLlmDriver`, lane 3 = mock-provider
+driver-stack e2e (wiremock SSE) in `e2e.yml`). If PR-time e2e coverage is
+infeasible, state in the PR body
 which lane applies and why.
 
 See `harness/roles/implementer.md` for the shared base contract,

--- a/harness/roles/implementer-backend.md
+++ b/harness/roles/implementer-backend.md
@@ -154,7 +154,7 @@ following `docs/guides/e2e-style.md`:
 
 - **Lane 1**: no LLM. Pure-data scenarios.
 - **Lane 2**: scripted LLM via `ScriptedLlmDriver`.
-- **Lane 3**: real LLM in `e2e.yml` (CI-only).
+- **Lane 3**: mock-provider driver-stack e2e (wiremock SSE) in `e2e.yml`.
 
 If PR-time e2e coverage is genuinely infeasible, state in the PR body
 which lane applies and why.


### PR DESCRIPTION
## Summary

Issue #2190 retired the real-LLM CI e2e lane: `e2e.yml` now runs a mock-provider driver-stack e2e (real openai driver over HTTP against an in-process wiremock OpenAI fake, scripted SSE). Three harness documents still described lane 3 as "real LLM in `e2e.yml`" — and `docs/guides/workflow.md` is `@`-included into every session's CLAUDE.md, so the stale line actively steered implementer dispatches toward a retired lane. This PR updates the three remaining references to match the rewritten `docs/guides/e2e-style.md`:

- `docs/guides/workflow.md` (~192): lane list in the implementer e2e paragraph
- `harness/roles/implementer-backend.md` (157): Lane 3 bullet
- `.claude/workflows/rara-dev.js` (176): comment-only edit, no behavior change

Cross-ref: #2190 (PR #2191).

## Type of change

Documentation — `documentation`

## Component

`core`

## Closes

Closes #2192

## Test plan

Docs-only diff (no Rust/web surface). Issue Verify commands, run in the worktree:

- `grep -rniE "real[- ]LLM" docs/guides/workflow.md harness/roles/implementer-backend.md .claude/workflows/rara-dev.js` → 0 hits (exit 1)
- Full-tree sweep `grep -rniE "real[- ]LLM" docs/ .claude/ harness/` returns only the 6 documented non-stale exclusions:
  - `docs/guides/e2e-style.md:83` — real LLM + boxlite example (owned by #2190, forbidden here)
  - `docs/guides/e2e-style.md:85` — "wanting to add a real-LLM assertion" guidance
  - `docs/guides/e2e-style.md:105` — PR #1941 cautionary tale
  - `docs/guides/e2e-style.md:139` — "manual/local only since #2190"
  - `docs/guides/e2e-style.md:155` — wiremock rationale narrative
  - `harness/roles/spec-author.md:73` — historical prior-art keyword `real-llm`, not lane guidance
- `grep -n "lane 3" docs/guides/workflow.md harness/roles/implementer-backend.md` shows the mock-provider driver-stack wording consistent with `e2e-style.md` lane-3 section
- `node --check .claude/workflows/rara-dev.js` → pass
- `prek run --files <3 files>` → all hooks correctly skipped (docs-only)
- Reviewer APPROVE (pre-push light round)

🤖 Generated with [Claude Code](https://claude.com/claude-code)