### PR TITLE
feat(web): surface fleet tasks in the worker inbox (#2197)

### DIFF
--- a/specs/issue-2197-fleet-inbox-ui.spec.md
+++ b/specs/issue-2197-fleet-inbox-ui.spec.md
@@ -1,0 +1,149 @@
+spec: task
+name: "issue-2197-fleet-inbox-ui"
+inherits: project
+tags: []
+---
+
+## Intent
+
+After issues 2194 and 2195, rara can dispatch a fleet task and record its
+result contract — but the only way to see any of it is `curl` against the
+read API or `sqlite3` against the DB. The existing worker inbox
+(`web/src/components/topology/WorkerInbox.tsx`, landed in PR 2003) renders
+only in-process child sessions; out-of-process fleet workers are invisible
+in the UI.
+
+Reproducer for the failure mode:
+
+1. The user dispatches a coding task via chat and switches to the rara web
+   UI to watch it.
+2. The worker inbox right rail shows nothing — the fleet task is not a
+   child session, so no card appears while it runs.
+3. Observed bad outcome: the task completes with a branch, PR URL, and
+   cost, and the UI never shows any of it; the user falls back to asking
+   rara "how is that task going?" — the exact regression of goal signal 2
+   — or to reading the DB by hand.
+
+This issue renders fleet tasks in the existing worker-inbox surface (the
+hybrid main-timeline + right-rail-inbox direction already decided for
+multi-agent UI): a fleet section in the inbox listing dispatched tasks
+with live status, and, for terminal tasks, the result contract — branch,
+PR link, token usage, cost. Data comes from polling issue 2195's read API.
+
+Goal alignment: signal 4 ("every action is inspectable" — dispatched work
+becomes visible, not a black box) and signal 2 ("the user stops asking").
+NOT lines: display-only — no new task producers, no multi-user surface,
+rara stays the orchestrator. Hermes parity: not applicable — UI for a
+rara-specific subsystem.
+
+Prior art reviewed (raw):
+
+- Issue 1999 / PR 2003 — multi-agent observability UI: `WorkerInbox.tsx`,
+  `WorkerCard.tsx`, `TimelineView.tsx` under `web/src/components/topology/`
+  (see its AGENT.md), hooks `use-session-timeline.ts` /
+  `use-topology-subscription.ts`. The fleet section extends this surface
+  instead of adding a new page — the hybrid timeline+inbox direction is a
+  recorded decision.
+- Issue 2022 (`specs/issue-2022-topology-collapsible-sidebar.spec.md`) —
+  the lane-1 FE precedent: vitest selectors under
+  `web/src/pages/__tests__/` binding BDD scenarios to component tests.
+- `web/package.json` — vitest is already wired (`bun run test`); no new
+  dependencies are needed or allowed.
+- `gh issue list --search "inbox fleet ui"` — nothing beyond the fleet
+  series (issues 2194, 2195, 2196). No prior decision reversed.
+
+## Decisions
+
+- **Placement**: a fleet-tasks section inside the existing worker inbox
+  right rail — a sibling list to the child-session workers, not a new
+  page. New components live in `web/src/components/topology/` (e.g.
+  `FleetTaskCard.tsx`), following `WorkerCard.tsx` conventions (status
+  badge styling, card layout).
+- **Data**: a `use-fleet-tasks` hook in `web/src/hooks/` polling
+  `GET /api/v1/fleet/tasks` on an interval, following the data-fetch
+  conventions of the existing hooks. Polling only — no WebSocket plumbing
+  in this issue (recorded as out of scope in issue 2195; revisit if
+  polling proves laggy).
+- **Card content**: agent type, truncated prompt (CJK-safe truncation —
+  use code-point/grapheme-aware truncation, never byte slicing; issue 2138
+  is the standing reminder), status badge for
+  queued/running/succeeded/failed/lost, relative created/completed time.
+  Terminal cards additionally render: branch name, PR URL as an external
+  link, token usage, and cost. Failed/lost cards surface the error text.
+- **Empty state**: when the API returns no tasks, the fleet section
+  renders nothing (no empty-shell noise in the rail).
+- **API client**: typed fetch added beside the existing API client code in
+  `web/src/api/`, matching issue 2195's response shape (which never
+  includes `callback_token`).
+- **Tests**: vitest component tests under
+  `web/src/components/topology/__tests__/FleetTasks.test.tsx`, mocking the
+  HTTP layer — so this issue's BDD binding runs without a live backend,
+  keeping the PR independently verifiable while the runtime path depends
+  on issue 2195 being merged.
+- **Quality gate**: frontend lane — `bun run build` + ESLint + vitest;
+  before/after screenshots against the local stack once 2195 is available.
+
+## Boundaries
+
+### Allowed Changes
+- web/src/components/topology/**
+- **/web/src/components/topology/**
+- web/src/hooks/**
+- **/web/src/hooks/**
+- web/src/api/**
+- **/web/src/api/**
+- specs/issue-2197-fleet-inbox-ui.spec.md
+- **/specs/issue-2197-fleet-inbox-ui.spec.md
+
+### Forbidden
+- web/package.json
+- web/bun.lock
+- web/vite.config.ts
+- crates/**
+- config.example.yaml
+- .github/workflows/**
+
+## Completion Criteria
+
+Scenario: fleet tasks from the API render in the worker inbox
+  Test: web/src/components/topology/__tests__/FleetTasks.test.tsx::renders_fleet_tasks_from_api
+  Given the fleet tasks API is mocked to return one running and one succeeded task
+  When the worker inbox renders
+  Then both tasks appear as cards with their agent type and status badge
+
+Scenario: a terminal task shows the result contract
+  Test: web/src/components/topology/__tests__/FleetTasks.test.tsx::terminal_task_shows_pr_link_and_cost
+  Given a succeeded task with branch, pr_url, token usage, and cost_usd
+  When its card renders
+  Then the branch name, a link pointing at pr_url, and the formatted token/cost figures are visible
+
+Scenario: a failed task surfaces its error
+  Test: web/src/components/topology/__tests__/FleetTasks.test.tsx::failed_task_shows_error
+  Given a failed task with a non-empty error field
+  When its card renders
+  Then the failed badge and the error text are visible
+
+Scenario: the fleet section is absent when there are no tasks
+  Test: web/src/components/topology/__tests__/FleetTasks.test.tsx::hides_fleet_section_when_empty
+  Given the fleet tasks API is mocked to return an empty list
+  When the worker inbox renders
+  Then no fleet section heading or card is rendered
+
+Scenario: a CJK prompt is truncated without breaking characters
+  Test: web/src/components/topology/__tests__/FleetTasks.test.tsx::cjk_prompt_truncates_safely
+  Given a task whose prompt is a long CJK string
+  When its card renders
+  Then the truncated prompt renders valid characters with no replacement glyphs
+
+## Out of Scope
+
+- Live push updates over the per-session WebSocket — polling first;
+  follow-up issue if needed.
+- Dispatching or cancelling tasks from the UI — the only producer is the
+  agent's `fleet_dispatch` tool.
+- Main-timeline rendering of the completion summary — that arrives
+  through the normal chat stream via issue 2195's session event and needs
+  no dedicated UI work here.
+- Backend changes of any kind — if the read API shape needs adjustment,
+  that is a follow-up on the backend, not a `crates/**` edit in this PR.
+- Filtering, pagination, or a dedicated fleet history page.

--- a/web/src/api/fleet.ts
+++ b/web/src/api/fleet.ts
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2025 Rararulab
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Typed client for the fleet task read API (`GET /api/v1/fleet/tasks`,
+ * issue 2195). The wire shape mirrors the `fleet_tasks` record defined in
+ * issue 2194's migration, minus `callback_token` — the read API never
+ * exposes the per-task webhook secret.
+ */
+
+import { api } from './client';
+
+/** Lifecycle states of a fleet task — TEXT wire form of the backend's
+ *  `FleetTaskStatus` enum (issue 2194). */
+export type FleetTaskStatus = 'queued' | 'running' | 'succeeded' | 'failed' | 'lost';
+
+/** Statuses after which the result contract fields are populated. */
+export const TERMINAL_STATUSES: readonly FleetTaskStatus[] = ['succeeded', 'failed', 'lost'];
+
+/**
+ * One dispatched fleet task. Result-contract fields (`branch`,
+ * `commit_sha`, `pr_url`, token counts, `cost_usd`, `error`, `exit_code`)
+ * are `null` until the task reaches a terminal status.
+ */
+export interface FleetTask {
+  id: string;
+  agent_type: string;
+  status: FleetTaskStatus;
+  backend: string;
+  prompt: string;
+  repo_url: string;
+  session_key: string | null;
+  branch: string | null;
+  commit_sha: string | null;
+  pr_url: string | null;
+  input_tokens: number | null;
+  output_tokens: number | null;
+  cost_usd: number | null;
+  error: string | null;
+  exit_code: number | null;
+  created_at: string;
+  started_at: string | null;
+  completed_at: string | null;
+}
+
+/** Fetch every fleet task, newest first (backend orders by `created_at`). */
+export function fetchFleetTasks(options?: { signal?: AbortSignal }): Promise<FleetTask[]> {
+  return api.get<FleetTask[]>('/api/v1/fleet/tasks', options);
+}

--- a/web/src/components/topology/AGENT.md
+++ b/web/src/components/topology/AGENT.md
@@ -72,11 +72,22 @@ button would be overreach.
 - `WorkerInbox.tsx` — right-rail derived view. The reducer
   `deriveWorkers` folds the same event buffer into one `WorkerInfo`
   per spawned child (status, manifest name, last activity seq, event
-  count). Pure; re-runs via `useMemo`.
+  count). Pure; re-runs via `useMemo`. Below the workers it renders a
+  fleet-tasks section (issue #2197) fed by `@/hooks/use-fleet-tasks`
+  polling `GET /api/v1/fleet/tasks`; the section renders nothing at all
+  when the API returns no tasks (no empty-shell noise in the rail).
 - `WorkerCard.tsx` — clickable card per worker; click swaps the
   `Topology` page's `viewChild` state so the timeline focuses on that
   child. The back-to-root affordance lives in the timeline header, not
   the inbox.
+- `FleetTaskCard.tsx` — read-only card per dispatched fleet task
+  (issue #2197): agent type, code-point-safe truncated prompt, status
+  badge (`queued`/`running`/`succeeded`/`failed`/`lost`); terminal
+  tasks add the result contract (branch, external PR link, token
+  usage, cost) and failed / lost tasks surface the error text. Wire
+  types live in `@/api/fleet` and mirror issue #2194's `fleet_tasks`
+  record minus `callback_token`. Not clickable — fleet tasks are not
+  sessions, so there is no timeline focus to swap to.
 - `SessionAnchorMinimap.tsx` — right-rail vertical anchor minimap
   (issue #2052). Reads `anchors[]` from the session row that `Chat.tsx`
   fetches and renders one row per anchor in append order, day-grouped

--- a/web/src/components/topology/FleetTaskCard.tsx
+++ b/web/src/components/topology/FleetTaskCard.tsx
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2025 Rararulab
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ExternalLink } from 'lucide-react';
+
+import { formatRelativeTime } from './SessionPicker';
+
+import type { FleetTask, FleetTaskStatus } from '@/api/fleet';
+import { cn } from '@/lib/utils';
+
+/**
+ * Max prompt preview length in Unicode code points. Display tuning
+ * constant — lives next to the truncation it tunes.
+ */
+const PROMPT_MAX_POINTS = 80;
+
+/**
+ * Truncate a prompt by code point, never by UTF-16 unit. A naive
+ * `String.slice` counts UTF-16 code units and can split a surrogate pair
+ * (CJK Extension B, emoji), rendering a replacement glyph — the FE
+ * sibling of the byte-slice panic in issue 2138.
+ */
+function truncatePrompt(prompt: string): string {
+  const points = Array.from(prompt);
+  if (points.length <= PROMPT_MAX_POINTS) return prompt;
+  return `${points.slice(0, PROMPT_MAX_POINTS).join('')}…`;
+}
+
+/** Compact token count: `842`, `12.5k`. */
+function formatTokens(count: number): string {
+  if (count < 1000) return `${count}`;
+  return `${(count / 1000).toFixed(1)}k`;
+}
+
+/**
+ * Read-only card for one dispatched fleet task in the worker-inbox rail.
+ * Running cards show agent type, prompt preview, and status; terminal
+ * cards add the result contract (branch, PR link, token usage, cost) and
+ * failed / lost cards surface the error text. Not clickable — the only
+ * interactive element is the external PR link.
+ */
+export function FleetTaskCard({ task }: { task: FleetTask }) {
+  const totalTokens = (task.input_tokens ?? 0) + (task.output_tokens ?? 0);
+  const hasTokens = task.input_tokens !== null || task.output_tokens !== null;
+  const hasResultRow = Boolean(task.branch || task.pr_url) || hasTokens || task.cost_usd !== null;
+  const showError = (task.status === 'failed' || task.status === 'lost') && Boolean(task.error);
+
+  return (
+    <div
+      // Mirrors WorkerCard: `rounded-lg` (8px) + `px-2 py-1.5` keeps the
+      // inner `rounded` (4px) badge concentric.
+      className="flex w-full flex-col gap-1 rounded-lg border border-border bg-card px-2 py-1.5 text-[11px] text-foreground"
+    >
+      <div className="flex items-center justify-between gap-2">
+        <span className="truncate font-medium">{task.agent_type}</span>
+        <StatusBadge status={task.status} />
+      </div>
+      <p className="truncate text-[10px] text-muted-foreground" title={task.prompt}>
+        {truncatePrompt(task.prompt)}
+      </p>
+      {hasResultRow && (
+        // `tabular-nums` so polling refreshes don't reflow the figures.
+        <div className="flex flex-wrap items-center gap-x-2 gap-y-0.5 text-[10px] tabular-nums text-muted-foreground">
+          {task.branch && (
+            <span className="truncate font-mono" title={task.branch}>
+              {task.branch}
+            </span>
+          )}
+          {task.pr_url && (
+            <a
+              href={task.pr_url}
+              target="_blank"
+              rel="noreferrer"
+              // Negative margin + padding grows the tap target (#16)
+              // without shifting the row's visual rhythm.
+              className="-mx-1 -my-1.5 inline-flex shrink-0 items-center gap-0.5 rounded px-1 py-1.5 text-info hover:underline"
+            >
+              PR
+              <ExternalLink className="h-2.5 w-2.5" aria-hidden />
+            </a>
+          )}
+          {hasTokens && <span className="shrink-0">{formatTokens(totalTokens)} tok</span>}
+          {task.cost_usd !== null && <span className="shrink-0">${task.cost_usd.toFixed(2)}</span>}
+        </div>
+      )}
+      {showError && <p className="line-clamp-2 text-[10px] text-destructive">{task.error}</p>}
+      <span className="text-[10px] tabular-nums text-muted-foreground">
+        {task.completed_at
+          ? `completed ${formatRelativeTime(task.completed_at)}`
+          : `created ${formatRelativeTime(task.created_at)}`}
+      </span>
+    </div>
+  );
+}
+
+function StatusBadge({ status }: { status: FleetTaskStatus }) {
+  // Same chip treatment as WorkerCard's badge; `lost` is dimmed
+  // destructive so it reads as failure-adjacent but distinct.
+  const styles: Record<FleetTaskStatus, string> = {
+    queued: 'bg-muted text-muted-foreground',
+    running: 'bg-info text-white',
+    succeeded: 'bg-success text-white',
+    failed: 'bg-destructive text-white',
+    lost: 'bg-destructive/60 text-white',
+  };
+  return (
+    <span
+      className={cn(
+        'shrink-0 rounded px-1.5 py-px text-[9px] font-medium uppercase tracking-wide',
+        styles[status],
+      )}
+    >
+      {status}
+    </span>
+  );
+}

--- a/web/src/components/topology/FleetTaskCard.tsx
+++ b/web/src/components/topology/FleetTaskCard.tsx
@@ -18,6 +18,7 @@ import { ExternalLink } from 'lucide-react';
 
 import { formatRelativeTime } from './SessionPicker';
 
+import { TERMINAL_STATUSES } from '@/api/fleet';
 import type { FleetTask, FleetTaskStatus } from '@/api/fleet';
 import { cn } from '@/lib/utils';
 
@@ -39,10 +40,27 @@ function truncatePrompt(prompt: string): string {
   return `${points.slice(0, PROMPT_MAX_POINTS).join('')}…`;
 }
 
-/** Compact token count: `842`, `12.5k`. */
+/** Compact token count: `842`, `12.5k`, `1.2M`. */
 function formatTokens(count: number): string {
-  if (count < 1000) return `${count}`;
-  return `${(count / 1000).toFixed(1)}k`;
+  if (count >= 1_000_000) return `${(count / 1_000_000).toFixed(1)}M`;
+  if (count >= 1000) return `${(count / 1000).toFixed(1)}k`;
+  return `${count}`;
+}
+
+/**
+ * Validate a result-contract URL before rendering it as a link. The
+ * callback payload is worker/LLM output — an untrusted trust boundary —
+ * so only well-formed http(s) URLs become anchors; anything else
+ * (`javascript:`, `data:`, malformed) falls back to plain text. Do not
+ * rely on React's `javascript:` warning for this.
+ */
+function safeHttpUrl(raw: string): string | null {
+  try {
+    const url = new URL(raw);
+    return url.protocol === 'http:' || url.protocol === 'https:' ? url.href : null;
+  } catch {
+    return null;
+  }
 }
 
 /**
@@ -56,7 +74,10 @@ export function FleetTaskCard({ task }: { task: FleetTask }) {
   const totalTokens = (task.input_tokens ?? 0) + (task.output_tokens ?? 0);
   const hasTokens = task.input_tokens !== null || task.output_tokens !== null;
   const hasResultRow = Boolean(task.branch || task.pr_url) || hasTokens || task.cost_usd !== null;
-  const showError = (task.status === 'failed' || task.status === 'lost') && Boolean(task.error);
+  const prHref = task.pr_url === null ? null : safeHttpUrl(task.pr_url);
+  // Succeeded tasks carry `error: null` per the result contract, so
+  // "terminal with an error" is exactly the failed / lost surface.
+  const showError = TERMINAL_STATUSES.includes(task.status) && Boolean(task.error);
 
   return (
     <div
@@ -79,9 +100,9 @@ export function FleetTaskCard({ task }: { task: FleetTask }) {
               {task.branch}
             </span>
           )}
-          {task.pr_url && (
+          {prHref !== null && (
             <a
-              href={task.pr_url}
+              href={prHref}
               target="_blank"
               rel="noreferrer"
               // Negative margin + padding grows the tap target (#16)
@@ -91,6 +112,12 @@ export function FleetTaskCard({ task }: { task: FleetTask }) {
               PR
               <ExternalLink className="h-2.5 w-2.5" aria-hidden />
             </a>
+          )}
+          {prHref === null && task.pr_url !== null && (
+            // Untrusted / non-http(s) pr_url: show it, never link it.
+            <span className="truncate" title={task.pr_url}>
+              {task.pr_url}
+            </span>
           )}
           {hasTokens && <span className="shrink-0">{formatTokens(totalTokens)} tok</span>}
           {task.cost_usd !== null && <span className="shrink-0">${task.cost_usd.toFixed(2)}</span>}

--- a/web/src/components/topology/SessionPicker.tsx
+++ b/web/src/components/topology/SessionPicker.tsx
@@ -378,9 +378,9 @@ function SessionPickerEmpty({ label, action }: SessionPickerEmptyProps) {
  * falling back to a date for older entries). Pure — no `Intl`
  * RelativeTimeFormat to keep the bundle lean and the output deterministic
  * across locales (the picker is a developer surface, not user-facing
- * copy).
+ * copy). Exported for reuse by the fleet task cards in the same rail.
  */
-function formatRelativeTime(iso: string): string {
+export function formatRelativeTime(iso: string): string {
   const then = Date.parse(iso);
   if (Number.isNaN(then)) return iso;
   const deltaSec = Math.max(0, Math.round((Date.now() - then) / 1000));

--- a/web/src/components/topology/WorkerInbox.tsx
+++ b/web/src/components/topology/WorkerInbox.tsx
@@ -16,8 +16,10 @@
 
 import { useMemo } from 'react';
 
+import { FleetTaskCard } from './FleetTaskCard';
 import { WorkerCard, type WorkerInfo, type WorkerStatus } from './WorkerCard';
 
+import { useFleetTasks } from '@/hooks/use-fleet-tasks';
 import type { TopologyEventEntry } from '@/hooks/use-topology-subscription';
 
 export interface WorkerInboxProps {
@@ -40,6 +42,11 @@ export interface WorkerInboxProps {
  * the topology event buffer, with status, manifest name, last activity
  * seq, and event count. Completed / failed workers are kept visible —
  * the surface is an observation deck, not a job queue.
+ *
+ * Below the in-process workers, a fleet section lists out-of-process
+ * fleet tasks polled from `GET /api/v1/fleet/tasks` (issue 2197). The
+ * section renders nothing at all while there are no tasks — no
+ * empty-shell noise in the rail.
  */
 export function WorkerInbox({
   rootSessionKey,
@@ -48,25 +55,35 @@ export function WorkerInbox({
   onSelectChild,
 }: WorkerInboxProps) {
   const workers = useMemo(() => deriveWorkers(rootSessionKey, events), [rootSessionKey, events]);
-
-  if (workers.length === 0) {
-    return (
-      <div className="rounded border border-dashed border-border px-2 py-3 text-[11px] text-muted-foreground">
-        No workers spawned yet.
-      </div>
-    );
-  }
+  const { data: fleetTasks } = useFleetTasks();
+  const tasks = fleetTasks ?? [];
 
   return (
     <div className="space-y-1.5">
-      {workers.map((worker) => (
-        <WorkerCard
-          key={worker.childSession}
-          worker={worker}
-          active={activeChildSession === worker.childSession}
-          onSelect={onSelectChild}
-        />
-      ))}
+      {workers.length === 0 ? (
+        <div className="rounded border border-dashed border-border px-2 py-3 text-[11px] text-muted-foreground">
+          No workers spawned yet.
+        </div>
+      ) : (
+        workers.map((worker) => (
+          <WorkerCard
+            key={worker.childSession}
+            worker={worker}
+            active={activeChildSession === worker.childSession}
+            onSelect={onSelectChild}
+          />
+        ))
+      )}
+      {tasks.length > 0 && (
+        <section aria-label="Fleet tasks" className="space-y-1.5 pt-1.5">
+          <h3 className="text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
+            Fleet tasks
+          </h3>
+          {tasks.map((task) => (
+            <FleetTaskCard key={task.id} task={task} />
+          ))}
+        </section>
+      )}
     </div>
   );
 }

--- a/web/src/components/topology/__tests__/FleetTasks.test.tsx
+++ b/web/src/components/topology/__tests__/FleetTasks.test.tsx
@@ -154,6 +154,28 @@ describe('FleetTasks — worker-inbox fleet section (issue-2197)', () => {
     expect(screen.getByText('agent exited with code 3: quality gate failed')).toBeInTheDocument();
   });
 
+  // Regression guard beyond the spec scenarios: pr_url comes from the
+  // worker result callback (untrusted LLM/worker output), so non-http(s)
+  // values must never become an anchor.
+  it('unsafe_pr_url_renders_as_plain_text', async () => {
+    apiGetMock.mockResolvedValue([
+      makeTask({
+        id: 't1',
+        status: 'succeeded',
+        pr_url: 'javascript:alert(1)',
+        completed_at: '2026-07-05T01:00:00Z',
+      }),
+    ]);
+
+    renderInbox();
+
+    await waitFor(() => {
+      expect(screen.getByText('javascript:alert(1)')).toBeInTheDocument();
+    });
+    expect(screen.queryByRole('link')).not.toBeInTheDocument();
+    expect(document.querySelector('a')).toBeNull();
+  });
+
   it('hides_fleet_section_when_empty', async () => {
     apiGetMock.mockResolvedValue([]);
 

--- a/web/src/components/topology/__tests__/FleetTasks.test.tsx
+++ b/web/src/components/topology/__tests__/FleetTasks.test.tsx
@@ -1,0 +1,192 @@
+/**
+ * BDD bindings for `specs/issue-2197-fleet-inbox-ui.spec.md`.
+ *
+ * Each `it(...)` name carries the spec's `Test:` selector verbatim so
+ * `agent-spec lifecycle` can resolve scenarios to real test functions.
+ * The HTTP layer is mocked — the read API (issue 2195) is not required
+ * to run these.
+ */
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { cleanup, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { WorkerInbox } from '../WorkerInbox';
+
+import type { FleetTask } from '@/api/fleet';
+
+// --- Mocks -----------------------------------------------------------------
+
+const apiGetMock = vi.fn();
+
+vi.mock('@/api/client', () => ({
+  api: {
+    get: (...args: unknown[]) => apiGetMock(...args),
+  },
+}));
+
+// --- Fixture helpers -------------------------------------------------------
+
+function makeTask(partial: Partial<FleetTask> & { id: string }): FleetTask {
+  return {
+    id: partial.id,
+    agent_type: partial.agent_type ?? 'claude-code',
+    status: partial.status ?? 'running',
+    backend: partial.backend ?? 'local-process',
+    prompt: partial.prompt ?? `task ${partial.id}`,
+    repo_url: partial.repo_url ?? 'https://github.com/rararulab/rara',
+    session_key: partial.session_key ?? null,
+    branch: partial.branch ?? null,
+    commit_sha: partial.commit_sha ?? null,
+    pr_url: partial.pr_url ?? null,
+    input_tokens: partial.input_tokens ?? null,
+    output_tokens: partial.output_tokens ?? null,
+    cost_usd: partial.cost_usd ?? null,
+    error: partial.error ?? null,
+    exit_code: partial.exit_code ?? null,
+    created_at: partial.created_at ?? '2026-07-05T00:00:00Z',
+    started_at: partial.started_at ?? null,
+    completed_at: partial.completed_at ?? null,
+  };
+}
+
+function renderInbox() {
+  const client = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, gcTime: 0, staleTime: 0 },
+    },
+  });
+  return render(
+    <QueryClientProvider client={client}>
+      <WorkerInbox
+        rootSessionKey="root"
+        events={[]}
+        activeChildSession={null}
+        onSelectChild={vi.fn()}
+      />
+    </QueryClientProvider>,
+  );
+}
+
+/** Matches a lone (unpaired) UTF-16 surrogate — the artifact a naive
+ *  `String.slice` truncation leaves behind when it splits a pair. */
+const LONE_SURROGATE = /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/;
+
+// --- Setup -----------------------------------------------------------------
+
+beforeEach(() => {
+  apiGetMock.mockReset();
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+// --- Spec scenarios --------------------------------------------------------
+
+describe('FleetTasks — worker-inbox fleet section (issue-2197)', () => {
+  it('renders_fleet_tasks_from_api', async () => {
+    apiGetMock.mockResolvedValue([
+      makeTask({ id: 't1', agent_type: 'claude-code', status: 'running' }),
+      makeTask({
+        id: 't2',
+        agent_type: 'codex',
+        status: 'succeeded',
+        completed_at: '2026-07-05T01:00:00Z',
+      }),
+    ]);
+
+    renderInbox();
+
+    await waitFor(() => {
+      expect(screen.getByText('Fleet tasks')).toBeInTheDocument();
+    });
+    expect(screen.getByText('claude-code')).toBeInTheDocument();
+    expect(screen.getByText('running')).toBeInTheDocument();
+    expect(screen.getByText('codex')).toBeInTheDocument();
+    expect(screen.getByText('succeeded')).toBeInTheDocument();
+    expect(apiGetMock).toHaveBeenCalledWith('/api/v1/fleet/tasks', expect.anything());
+  });
+
+  it('terminal_task_shows_pr_link_and_cost', async () => {
+    apiGetMock.mockResolvedValue([
+      makeTask({
+        id: 't1',
+        status: 'succeeded',
+        branch: 'issue-42-fix-flake',
+        pr_url: 'https://github.com/rararulab/rara/pull/123',
+        input_tokens: 8000,
+        output_tokens: 4500,
+        cost_usd: 0.42,
+        completed_at: '2026-07-05T01:00:00Z',
+      }),
+    ]);
+
+    renderInbox();
+
+    await waitFor(() => {
+      expect(screen.getByText('issue-42-fix-flake')).toBeInTheDocument();
+    });
+    expect(screen.getByRole('link')).toHaveAttribute(
+      'href',
+      'https://github.com/rararulab/rara/pull/123',
+    );
+    expect(screen.getByText('12.5k tok')).toBeInTheDocument();
+    expect(screen.getByText('$0.42')).toBeInTheDocument();
+  });
+
+  it('failed_task_shows_error', async () => {
+    apiGetMock.mockResolvedValue([
+      makeTask({
+        id: 't1',
+        status: 'failed',
+        error: 'agent exited with code 3: quality gate failed',
+        exit_code: 3,
+        completed_at: '2026-07-05T01:00:00Z',
+      }),
+    ]);
+
+    renderInbox();
+
+    await waitFor(() => {
+      expect(screen.getByText('failed')).toBeInTheDocument();
+    });
+    expect(screen.getByText('agent exited with code 3: quality gate failed')).toBeInTheDocument();
+  });
+
+  it('hides_fleet_section_when_empty', async () => {
+    apiGetMock.mockResolvedValue([]);
+
+    renderInbox();
+
+    await waitFor(() => {
+      expect(apiGetMock).toHaveBeenCalled();
+    });
+    expect(screen.queryByText('Fleet tasks')).not.toBeInTheDocument();
+    expect(screen.queryByRole('region', { name: 'Fleet tasks' })).not.toBeInTheDocument();
+    // The worker empty state is unrelated to fleet tasks and stays.
+    expect(screen.getByText('No workers spawned yet.')).toBeInTheDocument();
+  });
+
+  it('cjk_prompt_truncates_safely', async () => {
+    // 'a' + repeated CJK Extension B char (surrogate pair in UTF-16):
+    // a naive UTF-16 `slice` lands mid-pair and leaves a lone surrogate.
+    const prompt = `a${'𠀋汉字调查报告'.repeat(40)}`;
+    apiGetMock.mockResolvedValue([makeTask({ id: 't1', prompt })]);
+
+    renderInbox();
+
+    await waitFor(() => {
+      expect(screen.getByTitle(prompt)).toBeInTheDocument();
+    });
+    const rendered = screen.getByTitle(prompt).textContent ?? '';
+    expect(rendered.endsWith('…')).toBe(true);
+    const body = rendered.slice(0, -1);
+    expect(body).not.toMatch(LONE_SURROGATE);
+    expect(body).not.toContain('�');
+    // The preview is a true prefix of the original prompt, truncated by
+    // code point.
+    expect(prompt.startsWith(body)).toBe(true);
+    expect(Array.from(body)).toHaveLength(80);
+  });
+});

--- a/web/src/hooks/AGENT.md
+++ b/web/src/hooks/AGENT.md
@@ -9,6 +9,7 @@ Custom React hooks shared across rara web pages.
 Real files in this directory (one line each):
 
 - `loading-hints.ts` — poetic placeholder strings + `randomLoadingHint()`, mirrors the Telegram channel's loading copy so both feel cohesive.
+- `use-fleet-tasks.ts` — react-query poll of `GET /api/v1/fleet/tasks` (10s interval, mechanism constant in the hook) backing the worker-inbox fleet section.
 - `use-local-storage.ts` — typed `useState`-style wrapper over `window.localStorage` with JSON serialization.
 - `use-server-status.ts` — context hook exposing `{ isOnline, isChecking }` for the global server-status banner.
 - `use-session-timeline.ts` — react-query backed timeline state for a kernel session: turns → timeline items, live-state tracking, loading hints.

--- a/web/src/hooks/use-fleet-tasks.ts
+++ b/web/src/hooks/use-fleet-tasks.ts
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2025 Rararulab
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Polled fetch of fleet tasks from `GET /api/v1/fleet/tasks` for the
+ * worker-inbox fleet section. Polling (not WebSocket push) is the
+ * recorded decision for the first slice — see
+ * `specs/issue-2197-fleet-inbox-ui.spec.md` Decisions.
+ */
+
+import { useQuery } from '@tanstack/react-query';
+
+import { fetchFleetTasks } from '@/api/fleet';
+
+const FLEET_TASKS_QUERY_KEY = ['topology', 'fleet-tasks'] as const;
+
+/** Poll interval. Fleet tasks are minutes-long coding jobs, so a 10s
+ *  cadence is responsive without hammering the backend. Mechanism
+ *  constant — stays here, not in YAML (docs/guides/anti-patterns.md). */
+const POLL_MS = 10_000;
+
+/** React-query hook polling the fleet task list. */
+export function useFleetTasks() {
+  return useQuery({
+    queryKey: FLEET_TASKS_QUERY_KEY,
+    queryFn: ({ signal }) => fetchFleetTasks({ signal }),
+    refetchInterval: POLL_MS,
+  });
+}


### PR DESCRIPTION
## Summary

Adds a fleet-tasks section to the existing worker-inbox right rail (PR #2003's surface): a `use-fleet-tasks` react-query hook polls `GET /api/v1/fleet/tasks` (issue #2195's read API) every 10s, and `FleetTaskCard` renders each dispatched task with agent type, code-point-safe truncated prompt (FE sibling of the #2138 byte-slice lesson), status badge (`queued`/`running`/`succeeded`/`failed`/`lost`), and relative time. Terminal tasks add the result contract — branch, external PR link (http(s)-validated before rendering an anchor; untrusted worker/LLM output falls back to plain text), token usage, cost — and failed/lost tasks surface the error text. When the API returns no tasks the section renders nothing at all (no empty-shell noise in the rail).

Wire types (`web/src/api/fleet.ts`) mirror issue #2194's `fleet_tasks` record minus `callback_token` (the read API never exposes it). Display-only: no new producers, no backend edits. Spec: `specs/issue-2197-fleet-inbox-ui.spec.md` (ships in this PR).

## Type of change

New feature — `enhancement`

## Component

`ui`

## Closes

Closes #2197

## Test plan

- [x] `cd web && bun run build` passes (tsc -b + vite)
- [x] `cd web && bun run lint` passes (0 errors)
- [x] `cd web && bun run test` passes — 13 files, 79 tests (6 new: 5 BDD-bound + 1 security regression)
- [x] Tested locally — vite dev + stub backend, before/after screenshots + interaction state captured; 404-degradation probed in-browser

## Verification

Verification: PASS — `.worktrees/issue-2197-fleet-inbox-ui/verification/report.md`

**Lane-1 lifecycle tooling gap (#2015):** `just spec-lifecycle` cannot pass for any `web/**` lane-1 spec today — agent-spec 0.3.0 has no vitest adapter (issue #2015, open), so `Test:` selectors fall through to `cargo test`, match zero tests, and `spec-lifecycle-guard.sh` correctly fails closed. Both selector styles were verified broken (`path::name` here; `Package: web + Filter:` in the #2013 spec). The **Agent Spec CI job on this PR is therefore expected red**; it is not a required check. Equivalent evidence: all 5 spec scenarios bind verbatim to real vitest test functions in `web/src/components/topology/__tests__/FleetTasks.test.tsx` (`renders_fleet_tasks_from_api`, `terminal_task_shows_pr_link_and_cost`, `failed_task_shows_error`, `hides_fleet_section_when_empty`, `cjk_prompt_truncates_safely`), all passing, plus `unsafe_pr_url_renders_as_plain_text` from review.

## Dependencies

#2194 / #2195 are not merged yet — this PR is independently verifiable (BDD scenarios mock the HTTP layer, per the spec's recorded decision). Runtime behavior with the read API absent was probed in-browser: the endpoint 404s, the section stays hidden, and the rail renders normally (graceful degradation). **Follow-up once #2195 lands:** re-verify against the real stack (screenshots/dogfood) and re-confirm the wire shape in `web/src/api/fleet.ts` — any drift is a one-file FE fix.

## E2E lane

FE-only diff (`web/src/**` + spec file); does not touch `crates/{app,kernel,channels,acp,sandbox}/src/`, so no Rust e2e obligation applies. Coverage is carried by the vitest component tests (HTTP layer mocked) and real-browser dogfood against the local vite stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)