### PR TITLE
fix(app): reclaim in-flight-exec sandbox VM at session end (#1866)

### DIFF
--- a/crates/app/src/sandbox.rs
+++ b/crates/app/src/sandbox.rs
@@ -45,7 +45,7 @@
 //! - `run_code` — historical full network access, modelled as `Enabled {
 //!   allow_net: [] }`.
 
-use std::sync::Arc;
+use std::{future::Future, sync::Arc, time::Duration};
 
 use dashmap::DashMap;
 use rara_kernel::session::SessionKey;
@@ -164,10 +164,199 @@ pub fn sandbox_not_configured_error(tool: &str) -> anyhow::Error {
     )
 }
 
+/// Maximum ownership-reacquisition attempts before the reaper gives up.
+///
+/// Mechanism-tuning constant (not YAML — see `docs/guides/anti-patterns.md`
+/// "mechanism-tuning constants are Rust `const`"). Sized, together with
+/// [`RECLAIM_BACKOFF`], to comfortably outlast turn-cancellation propagation:
+/// when a session ends with an exec still in flight, turn cancellation drops
+/// the in-flight `Arc` clone within milliseconds, so a sub-second budget is
+/// ample. See [`reclaim_when_idle`] and #1866.
+pub(crate) const RECLAIM_MAX_ATTEMPTS: u32 = 10;
+
+/// Delay between ownership-reacquisition attempts. See
+/// [`RECLAIM_MAX_ATTEMPTS`].
+pub(crate) const RECLAIM_BACKOFF: Duration = Duration::from_millis(150);
+
+/// Outcome of a [`reclaim_when_idle`] run.
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) enum ReclaimOutcome {
+    /// The last outstanding clone dropped, ownership was reacquired, and the
+    /// `reclaim` callback was invoked exactly once.
+    Reclaimed,
+    /// The retry budget was exhausted while a clone was still outstanding;
+    /// `reclaim` was never invoked. Carries the final observed strong count
+    /// so the caller can escalate (warn) with the residual contention.
+    Exhausted { strong_count: usize },
+}
+
+/// Reacquire sole ownership of an `Arc<Mutex<T>>` once its last outstanding
+/// clone drops, then hand the owned `T` to `reclaim`.
+///
+/// This is the mechanism behind [`SandboxCleanupHook`](crate::tools::run_code)
+/// reclaiming a per-session microVM at session end. `Sandbox::destroy`
+/// consumes `self`, so the reaper must own the `Sandbox` — but when a session
+/// ends with an `exec` still in flight, that exec holds a clone of the `Arc`
+/// for the duration of the call. Turn cancellation drops the in-flight future
+/// (and its clone) moments later, so instead of giving up on the first
+/// `Arc::try_unwrap` we retry with a bounded backoff until the clone clears.
+///
+/// The loop is generic over the payload `T` purely so it can be unit-tested
+/// with a probe type and **no boxlite dependency** (CI has no boxlite runtime).
+/// It never blocks the caller's own progress guarantees: callers run it inside
+/// a detached task so the lifecycle pipeline's per-hook timeout is unaffected.
+///
+/// Returns [`ReclaimOutcome::Reclaimed`] once `reclaim` runs, or
+/// [`ReclaimOutcome::Exhausted`] if the budget runs out while a clone is still
+/// live (a genuinely wedged exec — not the timing window this targets). The
+/// task therefore always terminates.
+pub(crate) async fn reclaim_when_idle<T, F, Fut>(
+    arc: Arc<Mutex<T>>,
+    max_attempts: u32,
+    backoff: Duration,
+    reclaim: F,
+) -> ReclaimOutcome
+where
+    F: FnOnce(T) -> Fut,
+    Fut: Future<Output = ()>,
+{
+    let mut arc = arc;
+    for attempt in 1..=max_attempts {
+        match Arc::try_unwrap(arc) {
+            Ok(mutex) => {
+                reclaim(mutex.into_inner()).await;
+                return ReclaimOutcome::Reclaimed;
+            }
+            Err(returned) => {
+                arc = returned;
+                // Sleep between attempts, but not after the final one — there
+                // is no point waiting once the budget is spent.
+                if attempt < max_attempts {
+                    tokio::time::sleep(backoff).await;
+                }
+            }
+        }
+    }
+    ReclaimOutcome::Exhausted {
+        strong_count: Arc::strong_count(&arc),
+    }
+}
+
 #[cfg(test)]
 mod tests {
+    use std::sync::Mutex as StdMutex;
+
     use super::*;
     use crate::BashSandboxConfig;
+
+    /// Payload for the reclamation tests — stands in for `Sandbox` so the
+    /// mechanism is exercised without a boxlite dependency.
+    struct Probe {
+        id: u32,
+    }
+
+    /// Scenario: reclamation waits for an outstanding clone, then reclaims
+    /// exactly once. Core falsifier for #1866 — the single-shot `try_unwrap`
+    /// would give up here and leak.
+    #[tokio::test]
+    async fn reclaim_waits_for_outstanding_clone_then_reclaims_once() {
+        let arc = Arc::new(Mutex::new(Probe { id: 42 }));
+        let clone = Arc::clone(&arc); // simulated in-flight exec's clone
+        let reclaimed: Arc<StdMutex<Vec<u32>>> = Arc::new(StdMutex::new(Vec::new()));
+
+        // The in-flight task holds its clone across a couple of backoff
+        // cycles, asserts the reaper has NOT reclaimed while contended, then
+        // drops the clone so ownership can be reacquired.
+        let seen = Arc::clone(&reclaimed);
+        let holder = tokio::spawn(async move {
+            tokio::time::sleep(Duration::from_millis(60)).await;
+            assert!(
+                seen.lock().unwrap().is_empty(),
+                "reclaim must not fire while a clone is outstanding"
+            );
+            drop(clone);
+        });
+
+        let record = Arc::clone(&reclaimed);
+        let outcome = reclaim_when_idle(
+            arc,
+            50,
+            Duration::from_millis(10),
+            move |probe: Probe| async move {
+                record.lock().unwrap().push(probe.id);
+            },
+        )
+        .await;
+
+        holder.await.expect("holder task");
+        assert_eq!(outcome, ReclaimOutcome::Reclaimed);
+        assert_eq!(
+            *reclaimed.lock().unwrap(),
+            vec![42],
+            "reclaim must fire exactly once with owned ownership of the Probe"
+        );
+    }
+
+    /// Scenario: reclamation fires promptly (first attempt, no sleeping) when
+    /// no clone is outstanding — the common fast path.
+    #[tokio::test]
+    async fn reclaim_fires_immediately_when_idle() {
+        let arc = Arc::new(Mutex::new(Probe { id: 7 }));
+        let reclaimed: Arc<StdMutex<Vec<u32>>> = Arc::new(StdMutex::new(Vec::new()));
+
+        let record = Arc::clone(&reclaimed);
+        let started = std::time::Instant::now();
+        // A huge backoff is only reachable if the reaper retried — so a fast
+        // return proves it reclaimed on the first attempt without sleeping.
+        let outcome = reclaim_when_idle(
+            arc,
+            3,
+            Duration::from_secs(30),
+            move |probe: Probe| async move {
+                record.lock().unwrap().push(probe.id);
+            },
+        )
+        .await;
+        let elapsed = started.elapsed();
+
+        assert_eq!(outcome, ReclaimOutcome::Reclaimed);
+        assert_eq!(*reclaimed.lock().unwrap(), vec![7]);
+        assert!(
+            elapsed < Duration::from_secs(1),
+            "must reclaim on the first attempt without exhausting the retry budget (elapsed \
+             {elapsed:?})"
+        );
+    }
+
+    /// Scenario: reclamation is bounded when the outstanding clone never
+    /// drops — proves the detached task always terminates and surfaces the
+    /// residual rather than spinning forever or leaking silently.
+    #[tokio::test]
+    async fn reclaim_bounded_when_clone_never_drops() {
+        let arc = Arc::new(Mutex::new(Probe { id: 1 }));
+        let clone = Arc::clone(&arc); // held for the entire run, never dropped
+        let reclaimed: Arc<StdMutex<Vec<u32>>> = Arc::new(StdMutex::new(Vec::new()));
+
+        let record = Arc::clone(&reclaimed);
+        let outcome = reclaim_when_idle(
+            arc,
+            3,
+            Duration::from_millis(5),
+            move |probe: Probe| async move {
+                record.lock().unwrap().push(probe.id);
+            },
+        )
+        .await;
+
+        // Bounded termination with the exhaustion surfaced (the caller warns
+        // on this variant), not a silent swallow or a forever-spin.
+        assert_eq!(outcome, ReclaimOutcome::Exhausted { strong_count: 2 });
+        assert!(
+            reclaimed.lock().unwrap().is_empty(),
+            "reclaim must never fire while the clone is still held"
+        );
+        drop(clone);
+    }
 
     fn cfg(bash: Option<BashSandboxConfig>) -> SandboxToolConfig {
         SandboxToolConfig::builder()

--- a/crates/app/src/tools/run_code.rs
+++ b/crates/app/src/tools/run_code.rs
@@ -43,7 +43,10 @@ use tokio::sync::Mutex;
 pub use crate::sandbox::SandboxMap;
 use crate::{
     SandboxToolConfig,
-    sandbox::{sandbox_for_session, sandbox_not_configured_error},
+    sandbox::{
+        RECLAIM_BACKOFF, RECLAIM_MAX_ATTEMPTS, ReclaimOutcome, reclaim_when_idle,
+        sandbox_for_session, sandbox_not_configured_error,
+    },
 };
 
 /// Input parameters for the `run_code` tool.
@@ -221,29 +224,35 @@ impl LifecycleHook for SandboxCleanupHook {
         };
         let session_key = ctx.session_key;
         // The lifecycle pipeline times each hook out at 5s. `Sandbox::destroy`
-        // can take longer (boxlite tears down the VM), so spawn it
-        // detached — the map entry is already removed, and a leaked box
-        // is preferable to blocking subsequent session teardown.
+        // plus the reclamation retry budget can exceed that, so run it
+        // detached — the map entry is already removed above.
+        //
+        // `destroy` consumes `self`, so the reaper must own the `Sandbox`.
+        // When a session ends with an `exec` still in flight, that exec holds
+        // a clone of the `Arc` for the whole call; the kernel signal pipeline
+        // cancels the turn, dropping the clone moments later. Rather than give
+        // up on the first `try_unwrap` (the leak in #1866), retry acquiring
+        // ownership with a bounded backoff until the clone clears, then
+        // destroy. The loop is bounded, so this task always terminates.
         tokio::spawn(async move {
-            // `destroy` consumes `self`; pull the inner Sandbox out of
-            // the Arc<Mutex<…>>. If another task is still mid-exec we
-            // cannot reclaim ownership — the kernel signal pipeline has
-            // already cancelled the turn but the in-flight clone is
-            // still live, so the VM gets leaked until process exit.
-            // Tracked in #1866.
-            let inner = match Arc::try_unwrap(sandbox) {
-                Ok(mutex) => mutex.into_inner(),
-                Err(arc) => {
-                    tracing::warn!(
-                        session_key = %session_key,
-                        strong_count = Arc::strong_count(&arc),
-                        "sandbox still in use at session end; leaking VM until process exit (see #1866)"
-                    );
-                    return;
-                }
-            };
-            if let Err(e) = inner.destroy().await {
-                tracing::warn!(error = %e, "failed to destroy sandbox on session end");
+            let outcome = reclaim_when_idle(
+                sandbox,
+                RECLAIM_MAX_ATTEMPTS,
+                RECLAIM_BACKOFF,
+                |inner: Sandbox| async move {
+                    if let Err(e) = inner.destroy().await {
+                        tracing::warn!(error = %e, "failed to destroy sandbox on session end");
+                    }
+                },
+            )
+            .await;
+            if let ReclaimOutcome::Exhausted { strong_count } = outcome {
+                tracing::warn!(
+                    session_key = %session_key,
+                    strong_count,
+                    "sandbox still in use after reclaim budget exhausted; VM not reclaimed \
+                     until process exit (see #1866)"
+                );
             }
         });
     }

--- a/specs/issue-1866-sandbox-inflight-exec-reclaim.spec.md
+++ b/specs/issue-1866-sandbox-inflight-exec-reclaim.spec.md
@@ -1,0 +1,198 @@
+spec: task
+name: "issue-1866-sandbox-inflight-exec-reclaim"
+inherits: project
+tags: []
+---
+
+## Intent
+
+`run_code` reuses one boxlite microVM per session, keyed in a
+`SandboxMap` (`Arc<DashMap<SessionKey, Arc<Mutex<Sandbox>>>>`) and destroyed
+by `SandboxCleanupHook::on_session_end`
+(`crates/app/src/tools/run_code.rs`, around line 218). `Sandbox::destroy`
+consumes `self`, so the hook removes the map entry and — inside a detached
+`tokio::spawn` — tries `Arc::try_unwrap` to reclaim ownership. When an
+`exec` is still in flight on another task, that task holds a clone of the
+`Arc` (see `RunCodeTool::run`, which binds `let sandbox = …` and
+`let guard = sandbox.lock().await` for the whole exec), so the strong count
+is still greater than one. `try_unwrap` fails and the reaper immediately
+`return`s. The map entry is already gone, so when the in-flight task later
+drops its clone, nothing is watching — the microVM is never `destroy`ed and
+stays registered in the boxlite runtime, holding host memory and file
+descriptors until the rara process exits. The code comments this leak and
+tags it "issue 1866".
+
+Reproducer for the failure mode:
+
+1. Start rara with a `sandbox:` block configured. In a session, the agent
+   invokes `run_code` to launch a long command (e.g. `sh -c 'sleep 30'`).
+   That exec is now mid-flight, holding the per-session
+   `Arc<Mutex<Sandbox>>` clone and the mutex guard.
+2. While the exec is in flight, the session ends (user closes it, or the
+   turn is cancelled). The kernel fires `on_session_end`
+   (`crates/kernel/src/lifecycle.rs::fire_session_end`, 5s per-hook
+   timeout). The hook removes the map entry and spawns the reaper;
+   `Arc::try_unwrap` fails because `strong_count > 1`; the reaper logs
+   "leaking VM until process exit" and returns.
+3. Moments later the in-flight `run` future is dropped by turn
+   cancellation, releasing its clone — but the reaper already gave up.
+   The boxlite microVM is never reclaimed.
+4. Observed on a long-running instance: repeat across many
+   session-with-in-flight-exec teardowns → zombie microVMs accumulate,
+   host memory and fd usage climb monotonically, and nothing short of a
+   process restart reclaims them.
+
+The fix replaces the single-shot `try_unwrap` with a **bounded-retry
+reclamation** inside the same detached task: the reaper keeps the `Arc`,
+waits for the last outstanding clone to drop (which turn cancellation
+guarantees for the timing window this issue describes), then takes
+ownership and calls `Sandbox::destroy`. Reclamation stays fire-and-forget
+so it never blocks the 5s lifecycle-hook pipeline.
+
+Prior art reviewed (mandatory search):
+
+- Issues / PRs: `gh issue list/pr list --search "sandbox"` and
+  `--search "1866"` — no open PR references issue 1866; it is still open,
+  authored alongside the run_code landing. The sandbox subsystem lands in
+  PR 1840 (`rara-sandbox` crate), PR 1844 (runtime staging), PR 1861
+  (`run_code` tool + the cleanup hook that carries this leak), PR 1946
+  (FS-boundary + network fusion). None of them reclaim an in-flight VM at
+  session end — this is a gap in PR 1861, not a decision being reversed.
+- `git log --all --grep 1866` returns only PR 1861 (the commit that
+  introduced the hook and the "Tracked in #1866" comment).
+- Closest sibling: issue 2097 / PR (closed) — boxlite runtime-dir GC. Same
+  leak *class* (resource accumulation on a long-running install, goal
+  signal 1) but a different surface (on-disk staging dirs vs. in-memory
+  VM handles) and a different owner (`rara-cli setup boxlite` vs. the
+  session lifecycle hook). No overlap in code paths; the lesson carried
+  over is only "reclaim on the boring, already-present trigger."
+- `rg` in `crates/rara-sandbox` shows `Sandbox::destroy(self)` is the only
+  teardown path and `crates/rara-sandbox/AGENT.md` is emphatic about
+  keeping the crate's public surface minimal (no `SandboxBackend` trait,
+  no mock backend, no boxlite re-exports). This spec honors that: the fix
+  lives entirely at the app boundary and does not widen `rara-sandbox`.
+
+Goal alignment: signal 1 ("the process runs for months without
+intervention. Memory does not grow unboundedly, file descriptors do not
+leak"). A leaked microVM per session-with-in-flight-exec is a direct
+violation of that signal on a long-running instance. Crosses no `NOT`
+line — this is single-user local stability hygiene, not feature-parity,
+not multi-user, not a framework surface. Hermes parity is N/A: this is
+internal resource discipline, not a user-facing capability.
+
+## Decisions
+
+- **Root cause is the single-shot `try_unwrap`, not `Sandbox::destroy`.**
+  The in-flight clone is only *transiently* live: turn cancellation drops
+  the `run` future — and with it the clone — shortly after the hook fires.
+  The reaper must wait out that window instead of giving up on the first
+  attempt. This is a root fix (reclaim once contention clears), not a
+  narrowing.
+- **Extract the reclamation loop as a generic, unit-testable helper** in
+  `crates/app/src/sandbox.rs` — e.g.
+  `reclaim_when_idle<T>(arc: Arc<Mutex<T>>, max_attempts, backoff, reclaim)`
+  where `reclaim: FnOnce(T) -> impl Future`. It loops:
+  `Arc::try_unwrap` → on `Ok`, `mutex.into_inner()` and hand the owned `T`
+  to `reclaim`; on `Err(arc)`, keep the returned `Arc`, sleep `backoff`,
+  and retry up to `max_attempts`. Making it generic over the payload lets
+  the mechanism be tested with a probe type and **no boxlite dependency**
+  (CI has no boxlite; the existing sandbox integration tests are
+  `#[ignore]`). `SandboxCleanupHook::on_session_end` calls this helper
+  inside its existing detached `tokio::spawn`, passing a `reclaim` closure
+  that awaits `Sandbox::destroy` and `tracing::warn!`s on error.
+- **Stays fire-and-forget.** The map entry is still removed synchronously
+  before the spawn, and reclamation runs in the detached task — cleanup
+  must not block the 5s per-hook timeout in
+  `LifecycleManager::fire_session_end`
+  (`crates/kernel/src/lifecycle.rs`, line ~237), because
+  `Sandbox::destroy` plus the retry budget can exceed 5s.
+- **Retry cadence is Rust `const`, not YAML.** `max_attempts` and
+  `backoff` are mechanism-tuning constants next to the helper. A deploy
+  operator has no reason to pick a different reclaim cadence
+  (project.spec "Mechanism-tuning constants … are Rust `const`"). This is
+  enforced structurally by the boundary: `config.example.yaml` is
+  forbidden. The hook passes the named consts; the helper takes them as
+  parameters purely so tests can drive a short schedule.
+- **Bounded, never unbounded.** The budget is sized to comfortably outlast
+  turn-cancellation propagation. If the outstanding clone somehow never
+  drops (a genuinely wedged exec/VM — not the timing case this issue
+  targets), the reaper stops after `max_attempts` and emits a loud
+  `tracing::warn!` carrying `session_key` and the final `strong_count`, so
+  the residual is observable and counted rather than a silent forever-spin.
+  The detached task therefore always terminates.
+- **No change to `rara-sandbox`.** `Sandbox::destroy(self)` is unchanged;
+  the minimal-surface invariant in `crates/rara-sandbox/AGENT.md` stands.
+  All ownership choreography happens at the app boundary.
+- **No mock/noop `Sandbox`.** Per `crates/rara-sandbox/AGENT.md` and
+  `docs/guides/anti-patterns.md`, the reclamation test fakes at the caller
+  boundary (a probe payload behind the generic helper), never a hollow
+  `Sandbox` impl.
+
+## Boundaries
+
+### Allowed Changes
+- crates/app/src/tools/run_code.rs
+- **/crates/app/src/tools/run_code.rs
+- crates/app/src/sandbox.rs
+- **/crates/app/src/sandbox.rs
+- crates/app/tests/run_code_session.rs
+- **/crates/app/tests/run_code_session.rs
+- specs/issue-1866-sandbox-inflight-exec-reclaim.spec.md
+- **/specs/issue-1866-sandbox-inflight-exec-reclaim.spec.md
+
+### Forbidden
+- crates/rara-sandbox/**
+- crates/kernel/**
+- config.example.yaml
+- web/**
+- extension/**
+- .github/workflows/**
+
+## Acceptance Criteria
+
+Scenario: reclamation waits for an outstanding clone, then reclaims exactly once
+  Test:
+    Package: rara-app
+    Filter: sandbox::tests::reclaim_waits_for_outstanding_clone_then_reclaims_once
+  Given a shared handle Arc<Mutex<Probe>> with one extra outstanding clone held by a simulated in-flight task, and a reclaim callback that records each invocation
+  When the reaper runs while the clone is briefly held and the clone is then dropped
+  Then the reclaim callback is never invoked while the clone is held
+  And after the clone drops the reclaim callback is invoked exactly once with owned ownership of the Probe
+
+Scenario: reclamation fires promptly when no clone is outstanding
+  Test:
+    Package: rara-app
+    Filter: sandbox::tests::reclaim_fires_immediately_when_idle
+  Given a shared handle with no outstanding clones (strong count is one)
+  When the reaper runs
+  Then the reclaim callback is invoked exactly once on the first attempt without exhausting the retry budget
+
+Scenario: reclamation is bounded when the outstanding clone never drops
+  Test:
+    Package: rara-app
+    Filter: sandbox::tests::reclaim_bounded_when_clone_never_drops
+  Given a shared handle whose outstanding clone is held for the entire run and never dropped, and a small max-attempts budget
+  When the reaper runs to completion
+  Then the reaper terminates after the bounded budget rather than spinning forever
+  And the reclaim callback is never invoked
+  And the exhaustion is surfaced (a warn-level escalation) rather than silently swallowed
+
+## Out of Scope
+
+- **Force-tearing-down a VM while an exec still holds a live handle**
+  (destroy-by-key / boxlite `remove(force=true)` without owning `self`).
+  That would additionally eliminate the pathological "clone never drops"
+  residual, but it requires new `rara-sandbox` surface (a deterministic
+  per-session box name plus a force-remove-by-name path) and reaches into
+  tearing down a VM out from under an in-flight exec — a separate, larger
+  change with its own hazards. Flagged for a follow-up; this issue fixes
+  the timing leak the code comment actually describes.
+- **Cancelling or interrupting the in-flight `exec` itself.** The kernel
+  signal pipeline already cancels the turn; this issue only reclaims the
+  VM after the exec's clone drops.
+- **Real-boxlite end-to-end verification of `destroy`.** That stays in the
+  existing `#[ignore]` integration test
+  (`crates/app/tests/run_code_session.rs`); CI has no boxlite runtime.
+- **Reclamation metrics/accounting beyond a warn log.** Counters or
+  dashboards for reclaim outcomes are a later concern.
+- Any change to `Sandbox::destroy`'s signature or the `SandboxMap` type.


### PR DESCRIPTION
## Summary

`SandboxCleanupHook::on_session_end` reclaimed a per-session boxlite microVM with a single `Arc::try_unwrap`. When an `exec` was still in flight, that task held a clone of the `Arc<Mutex<Sandbox>>`, so the strong count was > 1, `try_unwrap` failed, and the reaper gave up — logging "leaking VM until process exit". The map entry was already removed, so when the in-flight clone dropped moments later (turn cancellation) nothing reclaimed the VM; it held host memory + fds until process exit, accumulating on long-running instances (goal signal 1 violation).

The fix replaces the single-shot `try_unwrap` with a **bounded-retry reclamation** inside the same detached task: the reaper keeps the `Arc`, waits out the brief window until the last clone drops, then takes ownership and calls `Sandbox::destroy`. The loop is extracted as a generic `pub(crate)` helper `reclaim_when_idle<T>` in `crates/app/src/sandbox.rs`, so it is unit-testable with a boxlite-free `Probe` payload (CI has no boxlite). Retry cadence (`RECLAIM_MAX_ATTEMPTS`, `RECLAIM_BACKOFF`) is Rust `const`, not YAML. Stays fire-and-forget so it never blocks the 5s per-hook timeout, and is bounded so the detached task always terminates — on exhaustion it warns with `session_key` + final `strong_count` instead of spinning.

No `rara-sandbox` surface change (respects the crate's minimal-surface AGENT.md invariant). Out of scope (separate follow-up): force-tearing-down a VM out from under a live exec handle.

## Type of change

Bug fix — label `bug`.

## Component

`core`

## Closes

Closes #1866

## Verification

**VERDICT: PASS** (score_authority: verifier — independent, fresh-context re-run from clean state).

- **SHAs verified:** base `b593f58196587cee98fbd5bb025360be81af7fea` → head `837f4fa42724727b133795a1ba2d18aa43717998` (subsequently rebased onto current `main`; code unchanged).
- **Clean-state quality gate — all green:** `cargo check --all --all-targets`, `cargo +nightly fmt --all -- --check`, `cargo clippy -p rara-app --all-targets --all-features --no-deps -- -D warnings`, `cargo test -p rara-app` (98 passed + 2 ignored, 0 failed — the 2 ignored are the `#[ignore]` boxlite integration tests), `prek run --all-files`.
- **spec-lifecycle (lane 1):** `stage: complete passed: true`, guard OK; all **3/3** scenarios PASS and non-vacuous:
  - `reclaim_waits_for_outstanding_clone_then_reclaims_once` — core falsifier (old single-shot `try_unwrap` fails/leaks here; bounded-retry fix passes; pass_to_fail = 0).
  - `reclaim_fires_immediately_when_idle` — fast path, asserts first-attempt reclaim (elapsed < 1s vs a 30s backoff → no retry sleep).
  - `reclaim_bounded_when_clone_never_drops` — asserts `Exhausted { strong_count: 2 }`, reclaim never invoked; proves the detached task always terminates.
- **Hostile probes — all PASS:** 40× concurrent stress (racing hold/drop; reclaim fires exactly once, never while contended), retry-window boundary (clone dropped at the last-attempt boundary, no off-by-one in the `attempt < max_attempts` sleep guard), 64 concurrent reapers (each terminates, no deadlock/double-reclaim), degenerate minimal-budget probe. **pass_to_fail = 0** across the matrix.
- **Not driven (by design):** real boxlite `Sandbox::destroy` teardown — the spec explicitly declares this **out of scope** (CI has no boxlite runtime); it stays in the `#[ignore]` integration test. The ownership-choreography mechanism (`reclaim_when_idle`) is fully driven via the boxlite-free `Probe` payload, exactly the generic-helper design the spec mandated for CI-runnable coverage.

## Test plan

- [x] `cargo test -p rara-app` passes
- [x] `prek run --all-files` (lint) passes
- [x] Verified from clean state by independent verifier