### PR TITLE
chore(clippy): fix clippy 1.97 toolchain-drift lints (#2220)

### DIFF
--- a/crates/common/telemetry/src/logging.rs
+++ b/crates/common/telemetry/src/logging.rs
@@ -551,7 +551,7 @@ pub fn init_global_logging(
                 .unwrap_or_else(|e| {
                     panic!(
                         "initializing rolling file appender at {} failed: {}",
-                        &opts.dir, e
+                        opts.dir, e
                     )
                 });
             let (writer, guard) = tracing_appender::non_blocking(rolling_appender);
@@ -588,7 +588,7 @@ pub fn init_global_logging(
                 .unwrap_or_else(|e| {
                     panic!(
                         "initializing rolling file appender at {} failed: {}",
-                        &opts.dir, e
+                        opts.dir, e
                     )
                 });
             let (writer, guard) = tracing_appender::non_blocking(rolling_appender);

--- a/crates/kernel/src/cascade.rs
+++ b/crates/kernel/src/cascade.rs
@@ -645,7 +645,7 @@ mod tests {
         assert_eq!(trace.summary.tool_call_count, 1);
         // First tick: user + assistant(empty skipped) + action + observation
         // Second tick: assistant thought
-        assert!(trace.ticks[1].entries[0].kind == CascadeEntryKind::Thought);
+        assert_eq!(trace.ticks[1].entries[0].kind, CascadeEntryKind::Thought);
     }
 
     #[test]

--- a/crates/kernel/src/llm/codex.rs
+++ b/crates/kernel/src/llm/codex.rs
@@ -192,7 +192,7 @@ mod tests {
         let body = build_responses_request(&request, ApiFormat::Responses);
         assert!(body.get("max_output_tokens").is_none());
         assert!(body.get("parallel_tool_calls").is_none());
-        assert!(body["tools"].as_array().expect("tools array").len() == 1);
+        assert_eq!(body["tools"].as_array().expect("tools array").len(), 1);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

CI runners upgraded to **clippy 1.97.0** (`rustc 1.97.0 2d8144b78 2026-07-07`).
The workspace enables `clippy::all` + `pedantic` + `nursery` at `warn` and CI
runs `-D warnings`, so two newly-added 1.97 lints become hard errors and
red-board **every open PR** on `Rust / Clippy` and `Lint / Lint Ratchet`.

Two lints, one root cause (the 1.96→1.97 bump). Machine-applicable, no
behavior change:

1. `useless_borrows_in_formatting` — `crates/common/telemetry/src/logging.rs`
   (lines 554 + 591): drop the redundant `&` on `opts.dir` in two `panic!`
   args. Formatting `&T` and `T` are equivalent. (Line 550's `.build(&opts.dir)`
   is intentionally left untouched — that `&` is required.)
2. `manual_assert_eq` — `crates/kernel/src/cascade.rs:648` and
   `crates/kernel/src/llm/codex.rs:195`: `assert!(a == b)` → `assert_eq!(a, b)`
   in two test assertions.

### Why two crates, not just telemetry

The original diagnosis was telemetry-only. That is **necessary but not
sufficient**: clippy compiles in dependency order and **aborts at
`common-telemetry` (a low-level dep) before reaching downstream crates**, so
the CI log only ever showed `useless_borrows_in_formatting`. Reproducing with
a locally-installed clippy 1.97.0 proves that once telemetry is fixed, clippy
proceeds and fails on the two `manual_assert_eq` sites. A full `--no-deps`
inventory on 1.97 confirms these four are the **complete** blast radius —
fixing telemetry alone would leave `Rust / Clippy` red.

## Type of change

Maintenance — `chore`

## Component

`ci` (toolchain-drift lint fix spanning `common-telemetry` + `rara-kernel`)

## Closes

Closes #2220

## Test plan

- [x] `cargo +1.97.0 clippy --workspace --all-targets --all-features --no-deps -- -D warnings` exits **0** (exact CI toolchain, reproduced locally)
- [x] `cargo check --workspace --all-targets` passes
- [x] `cargo +nightly fmt --all -- --check` passes
- [x] `prek run --all-files` passes (all hooks)
- [x] `cargo test -p rara-kernel --lib` — the two changed assertions pass; the only failure is a pre-existing global-state ordering flake (`test_kernel_builder_redirect_is_idempotent`, `set_custom_config_dir called after config_dir was initialized`) unrelated to this diff (passes in isolation; main CI is green)

Lane-2 chore: pure lint fix, no new tests.