### PR TITLE
feat(trading): add finance information subscriptions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1846,9 +1846,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -110,6 +110,17 @@ dependencies = [
 
 [[package]]
 name = "ahash"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
+dependencies = [
+ "getrandom 0.2.17",
+ "once_cell",
+ "version_check",
+]
+
+[[package]]
+name = "ahash"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
@@ -277,6 +288,22 @@ checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
 dependencies = [
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "astral-tokio-tar"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08648fef353ab39a9d26f909ad53fc4f071be4c91853b78523f5cc3d9e5ebffd"
+dependencies = [
+ "futures-core",
+ "libc",
+ "portable-atomic",
+ "rustc-hash",
+ "rustix 0.38.44",
+ "tokio",
+ "tokio-stream",
+ "xattr",
 ]
 
 [[package]]
@@ -458,6 +485,15 @@ dependencies = [
  "pin-project-lite",
  "tokio",
  "tungstenite 0.28.0",
+]
+
+[[package]]
+name = "atoi"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f28d99ec8bfea296261ca1af174f24225171fea9664ba9003cbebee704810528"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -784,6 +820,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "bitvec"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddcec3d12c579d40898fe0a9a358a803c23e9c52ca3c425707f81c9436211837"
+dependencies = [
+ "funty",
+ "radium",
+ "tap",
+ "wyz",
+]
+
+[[package]]
 name = "blake3"
 version = "1.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -839,6 +887,80 @@ dependencies = [
 ]
 
 [[package]]
+name = "bollard"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee04c4c84f1f811b017f2fbb7dd8815c976e7ca98593de9c1e2afad0f636bff4"
+dependencies = [
+ "async-stream",
+ "base64 0.22.1",
+ "bitflags 2.13.0",
+ "bollard-buildkit-proto",
+ "bollard-stubs",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "hex",
+ "home",
+ "http",
+ "http-body-util",
+ "hyper",
+ "hyper-named-pipe",
+ "hyper-rustls",
+ "hyper-util",
+ "hyperlocal",
+ "log",
+ "num",
+ "pin-project-lite",
+ "rand 0.9.4",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-pki-types",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "serde_urlencoded",
+ "thiserror 2.0.18",
+ "time",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "tonic 0.14.6",
+ "tower-service",
+ "url",
+ "winapi",
+]
+
+[[package]]
+name = "bollard-buildkit-proto"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85a885520bf6249ab931a764ffdb87b0ceef48e6e7d807cfdb21b751e086e1ad"
+dependencies = [
+ "prost 0.14.4",
+ "prost-types 0.14.4",
+ "tonic 0.14.6",
+ "tonic-prost",
+ "ureq",
+]
+
+[[package]]
+name = "bollard-stubs"
+version = "1.52.1-rc.29.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f0a8ca8799131c1837d1282c3f81f31e76ceb0ce426e04a7fe1ccee3287c066"
+dependencies = [
+ "base64 0.22.1",
+ "bollard-buildkit-proto",
+ "bytes",
+ "prost 0.14.4",
+ "serde",
+ "serde_json",
+ "serde_repr",
+ "time",
+]
+
+[[package]]
 name = "bon"
 version = "3.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -860,6 +982,30 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "borsh"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f3f6da4992df95bbcd9af42a6c7dcb994498fc9048230405f3b36ff7cd3f145"
+dependencies = [
+ "borsh-derive",
+ "bytes",
+ "cfg_aliases",
+]
+
+[[package]]
+name = "borsh-derive"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ae8fb4fb5740e4b2c4884ff95f5f32f5e8479db1e8fd8eb49ddbe09eb09bb7c"
+dependencies = [
+ "once_cell",
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
  "syn 2.0.118",
 ]
 
@@ -985,6 +1131,28 @@ name = "by_address"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "64fa3c856b712db6612c019f14756e64e4bcea13337a6b33b696333a9eaa2d06"
+
+[[package]]
+name = "bytecheck"
+version = "0.6.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23cdc57ce23ac53c931e88a43d06d070a6fd142f2617be5855eb75efc9beb1c2"
+dependencies = [
+ "bytecheck_derive",
+ "ptr_meta",
+ "simdutf8",
+]
+
+[[package]]
+name = "bytecheck_derive"
+version = "0.6.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3db406d29fbcd95542e92559bed4d8ad92636d1ca8b3b72ede10b4bcc010e659"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
 
 [[package]]
 name = "bytecount"
@@ -1603,6 +1771,21 @@ dependencies = [
  "tracing",
  "validator",
 ]
+
+[[package]]
+name = "crc"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5eb8a2a1cd12ab0d987a5d5e825195d372001a4094a0376319d5a0ad71c1ba0d"
+dependencies = [
+ "crc-catalog",
+]
+
+[[package]]
+name = "crc-catalog"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "217698eaf96b4a3f0bc4f3662aaa55bdf913cd54d7204591faa790070c6d0853"
 
 [[package]]
 name = "crc32fast"
@@ -2375,6 +2558,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "docker_credential"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29547a1dc60885a552306986316bc9701ba120c1a8db6769fa68691529ad373d"
+dependencies = [
+ "base64 0.22.1",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "document-features"
 version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2382,6 +2576,12 @@ checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
 dependencies = [
  "litrs",
 ]
+
+[[package]]
+name = "dotenvy"
+version = "0.15.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 
 [[package]]
 name = "downcast-rs"
@@ -2598,6 +2798,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "etcetera"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "136d1b5283a1ab77bd9257427ffd09d8667ced0570b6f938942bc7568ed5b943"
+dependencies = [
+ "cfg-if",
+ "home",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "etcetera"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de48cc4d1c1d97a20fd819def54b890cadde72ed3ad0c614822a0a433361be96"
+dependencies = [
+ "cfg-if",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "euclid"
 version = "0.22.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2682,6 +2903,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "feed-rs"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "369995dae0733f1fe5ab0e3f345f6503a5f384179df5d8da333702031a131cf9"
+dependencies = [
+ "chrono",
+ "mediatype",
+ "quick-xml 0.41.0",
+ "regex",
+ "serde",
+ "serde_json",
+ "siphasher",
+ "url",
+ "uuid",
+]
+
+[[package]]
+name = "ferroid"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee93edf3c501f0035bbeffeccfed0b79e14c311f12195ec0e661e114a0f60da4"
+dependencies = [
+ "portable-atomic",
+ "rand 0.10.2",
+ "web-time",
+]
+
+[[package]]
 name = "fff-grep"
 version = "0.5.2"
 source = "git+https://github.com/dmtrKovalenko/fff.nvim?rev=ea1f9802d7879345f02bef72bcadecd7252b8add#ea1f9802d7879345f02bef72bcadecd7252b8add"
@@ -2703,7 +2952,7 @@ name = "fff-search"
 version = "0.5.2"
 source = "git+https://github.com/dmtrKovalenko/fff.nvim?rev=ea1f9802d7879345f02bef72bcadecd7252b8add#ea1f9802d7879345f02bef72bcadecd7252b8add"
 dependencies = [
- "ahash",
+ "ahash 0.8.12",
  "aho-corasick",
  "bindet",
  "blake3",
@@ -2906,6 +3155,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "funty"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
+
+[[package]]
 name = "fuse-backend-rs"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2965,6 +3220,17 @@ dependencies = [
  "futures-core",
  "futures-task",
  "futures-util",
+]
+
+[[package]]
+name = "futures-intrusive"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d930c203dd0b6ff06e0201a4a2fe9149b43c684fd4420555b26d21b1a02956f"
+dependencies = [
+ "futures-core",
+ "lock_api",
+ "parking_lot",
 ]
 
 [[package]]
@@ -3248,6 +3514,9 @@ name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+dependencies = [
+ "ahash 0.7.8",
+]
 
 [[package]]
 name = "hashbrown"
@@ -3261,6 +3530,8 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
+ "allocator-api2",
+ "equivalent",
  "foldhash 0.1.5",
 ]
 
@@ -3284,6 +3555,15 @@ dependencies = [
  "allocator-api2",
  "equivalent",
  "foldhash 0.2.0",
+]
+
+[[package]]
+name = "hashlink"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
+dependencies = [
+ "hashbrown 0.15.5",
 ]
 
 [[package]]
@@ -3401,6 +3681,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "home"
+version = "0.5.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "hostname"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3514,6 +3803,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-named-pipe"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73b7d8abf35697b81a825e386fc151e0d503e8cb5fcb93cc8669c376dfd6f278"
+dependencies = [
+ "hex",
+ "hyper",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
+ "winapi",
+]
+
+[[package]]
 name = "hyper-rustls"
 version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3526,7 +3830,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots",
+ "webpki-roots 1.0.8",
 ]
 
 [[package]]
@@ -3581,6 +3885,21 @@ dependencies = [
  "tower-service",
  "tracing",
  "windows-registry",
+]
+
+[[package]]
+name = "hyperlocal"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "986c5ce3b994526b3cd75578e62554abd09f0899d6206de48b3e96ab34ccc8c7"
+dependencies = [
+ "hex",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
 ]
 
 [[package]]
@@ -4271,7 +4590,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "url",
- "webpki-roots",
+ "webpki-roots 1.0.8",
 ]
 
 [[package]]
@@ -4363,7 +4682,10 @@ version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c943259e342f1e06ff2da7a83eabdfe7f92ce10262688dbf1895ff0b3e6e4652"
 dependencies = [
+ "bitflags 2.13.0",
  "libc",
+ "plain",
+ "redox_syscall 0.9.0",
 ]
 
 [[package]]
@@ -4547,6 +4869,16 @@ checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "md-5"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
+dependencies = [
+ "cfg-if",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "md-5"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69b6441f590336821bb897fb28fc622898ccceb1d6cea3fde5ea86b090c4de98"
@@ -4568,6 +4900,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2640d335e7273dacdcf51044026139b2e269c3bb0dfc3f8cb3496b85e3f6a42c"
 dependencies = [
  "slab",
+]
+
+[[package]]
+name = "mediatype"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "120fa187be19d9962f0926633453784691731018a2bf936ddb4e29101b79c4a7"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -5276,10 +5617,10 @@ dependencies = [
  "http-body",
  "jiff",
  "log",
- "md-5",
+ "md-5 0.11.0",
  "mea",
  "percent-encoding",
- "quick-xml",
+ "quick-xml 0.39.4",
  "reqsign-core",
  "reqwest 0.13.4",
  "serde",
@@ -5578,9 +5919,34 @@ checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.5.18",
  "smallvec",
  "windows-link",
+]
+
+[[package]]
+name = "parse-display"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "914a1c2265c98e2446911282c6ac86d8524f495792c38c5bd884f80499c7538a"
+dependencies = [
+ "parse-display-derive",
+ "regex",
+ "regex-syntax",
+]
+
+[[package]]
+name = "parse-display-derive"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ae7800a4c974efd12df917266338e79a7a74415173caf7e70aa0a0707345281"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "regex",
+ "regex-syntax",
+ "structmeta",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -5929,6 +6295,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
+name = "plain"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
+
+[[package]]
 name = "png"
 version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6202,6 +6574,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ptr_meta"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0738ccf7ea06b608c10564b31debd4f5bc5e197fc8bfe088f68ae5ce81e7a4f1"
+dependencies = [
+ "ptr_meta_derive",
+]
+
+[[package]]
+name = "ptr_meta_derive"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16b845dbfca988fa33db069c0e230574d15a3088f147a87b64c7589eb662c9ac"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "pulldown-cmark"
 version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6325,6 +6717,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "quick-xml"
+version = "0.41.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
+dependencies = [
+ "encoding_rs",
+ "memchr",
+]
+
+[[package]]
 name = "quinn"
 version = "0.11.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6417,6 +6819,12 @@ dependencies = [
  "parking_lot",
  "scheduled-thread-pool",
 ]
+
+[[package]]
+name = "radium"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "radix_trie"
@@ -6594,9 +7002,11 @@ dependencies = [
  "rara-soul",
  "rara-stt",
  "rara-tool-macro",
+ "rara-trading",
  "rara-tts",
  "regex",
  "reqwest 0.13.4",
+ "rust_decimal",
  "schemars 1.2.1",
  "serde",
  "serde_json",
@@ -6636,6 +7046,7 @@ dependencies = [
  "rara-paths",
  "rara-sessions",
  "rara-skills",
+ "rara-trading",
  "serde",
  "serde_json",
  "snafu",
@@ -7087,6 +7498,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "rara-trading"
+version = "0.0.1"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "feed-rs",
+ "jiff",
+ "rara-kernel",
+ "rara-tool-macro",
+ "reqwest 0.13.4",
+ "rust_decimal",
+ "schemars 1.2.1",
+ "serde",
+ "serde_json",
+ "sqlx-core",
+ "sqlx-postgres",
+ "tempfile",
+ "testcontainers",
+ "tokio",
+ "tokio-util",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
 name = "rara-tts"
 version = "0.0.1"
 dependencies = [
@@ -7262,6 +7698,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5102a6aaa05aa011a238e178e6bca86d2cb56fc9f586d37cb80f5bca6e07759"
+dependencies = [
+ "bitflags 2.13.0",
+]
+
+[[package]]
 name = "redox_users"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7351,6 +7796,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
+name = "rend"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71fe3824f5629716b1589be05dacd749f6aa084c87e00e016714a8cdfccc997c"
+dependencies = [
+ "bytecheck",
+]
+
+[[package]]
 name = "reqsign-core"
 version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7420,7 +7874,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams 0.4.2",
  "web-sys",
- "webpki-roots",
+ "webpki-roots 1.0.8",
 ]
 
 [[package]]
@@ -7490,6 +7944,35 @@ dependencies = [
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rkyv"
+version = "0.7.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2297bf9c81a3f0dc96bc9521370b88f054168c29826a75e89c55ff196e7ed6a1"
+dependencies = [
+ "bitvec",
+ "bytecheck",
+ "bytes",
+ "hashbrown 0.12.3",
+ "ptr_meta",
+ "rend",
+ "rkyv_derive",
+ "seahash",
+ "tinyvec",
+ "uuid",
+]
+
+[[package]]
+name = "rkyv_derive"
+version = "0.7.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84d7b42d4b8d06048d3ac8db0eb31bcb942cbeb709f0b5f2b2ebde398d3038f5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -7600,7 +8083,7 @@ dependencies = [
  "bitflags 2.13.0",
  "fallible-iterator",
  "fallible-streaming-iterator",
- "hashlink",
+ "hashlink 0.11.1",
  "libsqlite3-sys",
  "smallvec",
  "sqlite-wasm-rs",
@@ -7614,6 +8097,23 @@ checksum = "796e8d2b6696392a43bea58116b667fb4c29727dc5abd27d6acf338bb4f688c7"
 dependencies = [
  "cfg-if",
  "ordered-multimap",
+]
+
+[[package]]
+name = "rust_decimal"
+version = "1.42.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be2a24f50780bc85f09cc6ac299bdf1424302742d77221106859c9d8b102126a"
+dependencies = [
+ "arrayvec",
+ "borsh",
+ "bytes",
+ "num-traits",
+ "rand 0.8.6",
+ "rkyv",
+ "serde",
+ "serde_json",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -7821,6 +8321,7 @@ dependencies = [
  "schemars_derive",
  "serde",
  "serde_json",
+ "uuid",
 ]
 
 [[package]]
@@ -7863,6 +8364,12 @@ dependencies = [
  "salsa20",
  "sha2 0.10.9",
 ]
+
+[[package]]
+name = "seahash"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
 
 [[package]]
 name = "sec1"
@@ -8287,6 +8794,9 @@ name = "smallvec"
 version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "smart-default"
@@ -8409,6 +8919,79 @@ dependencies = [
 ]
 
 [[package]]
+name = "sqlx-core"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee6798b1838b6a0f69c007c133b8df5866302197e404e8b6ee8ed3e3a5e68dc6"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "crossbeam-queue",
+ "either",
+ "event-listener",
+ "futures-core",
+ "futures-intrusive",
+ "futures-io",
+ "futures-util",
+ "hashbrown 0.15.5",
+ "hashlink 0.10.0",
+ "indexmap 2.14.0",
+ "log",
+ "memchr",
+ "once_cell",
+ "percent-encoding",
+ "rustls",
+ "serde",
+ "serde_json",
+ "smallvec",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-stream",
+ "tracing",
+ "url",
+ "uuid",
+ "webpki-roots 0.26.11",
+]
+
+[[package]]
+name = "sqlx-postgres"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db58fcd5a53cf07c184b154801ff91347e4c30d17a3562a635ff028ad5deda46"
+dependencies = [
+ "atoi",
+ "base64 0.22.1",
+ "bitflags 2.13.0",
+ "byteorder",
+ "crc",
+ "dotenvy",
+ "etcetera 0.8.0",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "hex",
+ "hkdf",
+ "hmac 0.12.1",
+ "home",
+ "itoa",
+ "log",
+ "md-5 0.10.6",
+ "memchr",
+ "once_cell",
+ "rand 0.8.6",
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
+ "smallvec",
+ "sqlx-core",
+ "stringprep",
+ "thiserror 2.0.18",
+ "tracing",
+ "uuid",
+ "whoami",
+]
+
+[[package]]
 name = "sse-stream"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8494,10 +9077,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
+name = "stringprep"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b4df3d392d81bd458a8a621b8bffbd2302a12ffe288a9d931670948749463b1"
+dependencies = [
+ "unicode-bidi",
+ "unicode-normalization",
+ "unicode-properties",
+]
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "structmeta"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e1575d8d40908d70f6fd05537266b90ae71b15dbbe7a8b7dffa2b759306d329"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "structmeta-derive",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "structmeta-derive"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "152a0b65a590ff6c3da95cabe2353ee04e6167c896b28e3b14478c2636c922fc"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
 
 [[package]]
 name = "strum"
@@ -8694,6 +9311,12 @@ name = "takecell"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20f34339676cdcab560c9a82300c4c2581f68b9369aedf0fae86f2ff9565ff3e"
+
+[[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tape-codec-zig"
@@ -8893,6 +9516,37 @@ dependencies = [
  "wezterm-dynamic",
  "wezterm-input-types",
  "winapi",
+]
+
+[[package]]
+name = "testcontainers"
+version = "0.27.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfd5785b5483672915ed5fe3cddf9f546802779fc1eceff0a6fb7321fac81c1e"
+dependencies = [
+ "astral-tokio-tar",
+ "async-trait",
+ "bollard",
+ "bytes",
+ "docker_credential",
+ "either",
+ "etcetera 0.11.0",
+ "ferroid",
+ "futures",
+ "http",
+ "itertools 0.14.0",
+ "log",
+ "memchr",
+ "parse-display",
+ "pin-project-lite",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "url",
 ]
 
 [[package]]
@@ -9689,6 +10343,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
+name = "unicode-bidi"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9702,6 +10362,12 @@ checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
 dependencies = [
  "tinyvec",
 ]
+
+[[package]]
+name = "unicode-properties"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
 
 [[package]]
 name = "unicode-segmentation"
@@ -9761,6 +10427,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d49784317cd0d1ee7ec5c716dd598ec5b4483ea832a2dced265471cc0f690ae"
 
 [[package]]
+name = "ureq"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dea7109cdcd5864d4eeb1b58a1648dc9bf520360d7af16ec26d0a9354bafcfc0"
+dependencies = [
+ "base64 0.22.1",
+ "log",
+ "percent-encoding",
+ "rustls",
+ "rustls-pki-types",
+ "ureq-proto",
+ "utf8-zero",
+]
+
+[[package]]
+name = "ureq-proto"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e994ba84b0bd1b1b0cf92878b7ef898a5c1760108fe7b6010327e274917a808c"
+dependencies = [
+ "base64 0.22.1",
+ "http",
+ "httparse",
+ "log",
+]
+
+[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9795,6 +10488,12 @@ name = "utf-8"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
+
+[[package]]
+name = "utf8-zero"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8c0a043c9540bae7c578c88f91dda8bd82e59ae27c21baca69c8b191aaf5a6e"
 
 [[package]]
 name = "utf8_iter"
@@ -9979,6 +10678,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
+
+[[package]]
 name = "wasm-bindgen"
 version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9987,6 +10692,7 @@ dependencies = [
  "cfg-if",
  "once_cell",
  "rustversion",
+ "serde",
  "wasm-bindgen-macro",
  "wasm-bindgen-shared",
 ]
@@ -10090,6 +10796,15 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.8",
+]
+
+[[package]]
+name = "webpki-roots"
 version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf85cb06032201fa7c6f829d7db5a7e5aa45bcc0655327713065f6f0576731bf"
@@ -10182,6 +10897,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48d7cd18d4acb58fb3cdfe9ea54e6cd96a4e7d4cc45c56338b236e82dad47248"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "whoami"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d4a4db5077702ca3015d3d02d74974948aba2ad9e12ab7df718ee64ccd7e97d"
+dependencies = [
+ "libredox",
+ "wasite",
 ]
 
 [[package]]
@@ -10640,6 +11365,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
+name = "wyz"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
+dependencies = [
+ "tap",
+]
+
+[[package]]
 name = "xattr"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10673,7 +11407,7 @@ checksum = "631a50d867fafb7093e709d75aaee9e0e0d5deb934021fcea25ac2fe09edc51e"
 dependencies = [
  "arraydeque",
  "encoding_rs",
- "hashlink",
+ "hashlink 0.11.1",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -140,6 +140,7 @@ members = [
     "crates/channels",
     "crates/kernel",
     "crates/extensions/backend-admin",
+    "crates/extensions/rara-trading",
     "crates/extensions/rara-git",
     "crates/soul",
     "crates/rara-sandbox",
@@ -170,6 +171,7 @@ diesel-async = { version = "0.9", features = ["sqlite", "bb8"] }
 diesel_migrations = { version = "2.3", features = ["sqlite"] }
 dirs = "^6"
 eventsource-stream = "0.2"
+feed-rs = "2.3.1"
 futures = "^0.3"
 hex = "0.4"
 hmac = "0.13"
@@ -200,6 +202,7 @@ ratatui = { version = "0.30", features = ["crossterm"] }
 regex = "1"
 reqwest = { version = "^0.13", features = ["form", "json", "multipart", "stream"] }
 rustix = "^1.1"
+rust_decimal = "1"
 rustls = { version = "0.23", default-features = false, features = ["ring", "std"] }
 schemars = "^1.2"
 serde = { version = "^1.0", features = ["derive"] }
@@ -207,6 +210,8 @@ serde_json = "1.0.143"
 serde_yaml = "0.9"
 sha2 = "0.11"
 shadow-rs = "2.0"
+sqlx-core = { version = "0.8.6", default-features = false, features = ["_rt-tokio", "_tls-rustls-ring-webpki", "uuid"] }
+sqlx-postgres = { version = "0.8.6", default-features = false, features = ["uuid"] }
 smart-default = "0.7"
 snafu = "^0.9"
 strum = "^0.27"
@@ -238,6 +243,7 @@ validator = "^0.20"
 # Testing
 git2 = "0.21"
 tempfile = "3"
+testcontainers = "0.27.3"
 
 # Internal workspace crates (use =version to keep in sync with workspace version)
 base = { path = "crates/common/base" }
@@ -266,6 +272,7 @@ rara-server = { path = "crates/server" }
 rara-sessions = { path = "crates/sessions" }
 rara-skills = { path = "crates/skills" }
 rara-soul = { path = "crates/soul" }
+rara-trading = { path = "crates/extensions/rara-trading" }
 rara-sandbox = { path = "crates/rara-sandbox" }
 
 # fff (Fast File Finder) — Cargo git dependencies (not vendored).

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -227,6 +227,34 @@ agents:
 #     sample_rate: 100  # Hz
 
 # ---------------------------------------------------------------------------
+# Data feeds — managed through authenticated /api/v1/data-feeds admin API
+# ---------------------------------------------------------------------------
+#
+# Example RSS/Atom finance source payload:
+#
+# feed_type: rss
+# tags: [finance, macro]
+# transport:
+#   url: "https://trusted-publisher.example/feed.xml"
+#   interval_secs: 300
+#   max_entries_per_poll: 20
+#
+# Example batched market-candle source payload:
+#
+# Production OHLCV history is durable only when RARA_MARKET_DATA_DATABASE_URL
+# points at a TimescaleDB/PostgreSQL database with TimescaleDB installed.
+#
+# feed_type: market_candle
+# tags: [finance, market-data, crypto]
+# transport:
+#   url: "https://trusted-market-data.example/candles/latest"
+#   interval_secs: 60
+#   venue: "binance"
+#   symbols: ["BTCUSDT", "ETHUSDT"]
+#   timeframes: ["15m", "1h"]
+#   max_candles_per_poll: 1000
+
+# ---------------------------------------------------------------------------
 # Optional integrations — remove or leave commented out if unused
 # ---------------------------------------------------------------------------
 

--- a/crates/app/Cargo.toml
+++ b/crates/app/Cargo.toml
@@ -56,6 +56,7 @@ rara-stt = { workspace = true }
 rara-tts = { workspace = true }
 rara-skills.workspace = true
 rara-soul.workspace = true
+rara-trading.workspace = true
 rara-tool-macro.workspace = true
 fff-search = { workspace = true }
 fff-query-parser = { workspace = true }
@@ -64,6 +65,7 @@ fff-query-parser = { workspace = true }
 zlob = { workspace = true }
 regex.workspace = true
 reqwest = { workspace = true }
+rust_decimal.workspace = true
 schemars.workspace = true
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true

--- a/crates/app/src/boot.rs
+++ b/crates/app/src/boot.rs
@@ -250,6 +250,7 @@ pub(crate) async fn boot(
     browser_manager: Option<rara_browser::BrowserManagerRef>,
     sandbox_config: Option<crate::SandboxToolConfig>,
     sandbox_map: crate::tools::SandboxMap,
+    finance_registry: Arc<rara_trading::finance::registry::FinanceSubscriptionRegistry>,
 ) -> Result<BootResult, Whatever> {
     // -- credential store --------------------------------------------------
     let credential_store: rara_keyring_store::KeyringStoreRef =
@@ -401,6 +402,7 @@ pub(crate) async fn boot(
             fff_query_tracker,
             sandbox_config,
             sandbox_map,
+            finance_registry,
         },
     );
 

--- a/crates/app/src/boot.rs
+++ b/crates/app/src/boot.rs
@@ -1029,7 +1029,7 @@ pub(crate) struct McpDynamicToolProvider {
 }
 
 impl McpDynamicToolProvider {
-    pub fn new(manager: rara_mcp::manager::mgr::McpManager) -> Self { Self { manager } }
+    pub(crate) fn new(manager: rara_mcp::manager::mgr::McpManager) -> Self { Self { manager } }
 }
 
 #[async_trait]

--- a/crates/app/src/feed_store.rs
+++ b/crates/app/src/feed_store.rs
@@ -31,13 +31,13 @@ use yunara_store::diesel_pool::DieselSqlitePools;
 ///
 /// Implements [`FeedStore`] using the `data_feed_events` table. Reads use
 /// the reader pool; appends use the single-writer pool.
-pub struct SqliteFeedStore {
+pub(crate) struct SqliteFeedStore {
     pools: DieselSqlitePools,
 }
 
 impl SqliteFeedStore {
     /// Create a new store backed by the given pool bundle.
-    pub fn new(pools: DieselSqlitePools) -> Self { Self { pools } }
+    pub(crate) fn new(pools: DieselSqlitePools) -> Self { Self { pools } }
 }
 
 #[async_trait]
@@ -161,7 +161,7 @@ impl FeedEventRow {
 
 #[cfg(test)]
 #[derive(Default)]
-pub struct InMemoryFeedStore {
+pub(crate) struct InMemoryFeedStore {
     events: tokio::sync::RwLock<Vec<FeedEvent>>,
 }
 

--- a/crates/app/src/feed_store.rs
+++ b/crates/app/src/feed_store.rs
@@ -158,3 +158,41 @@ impl FeedEventRow {
         })
     }
 }
+
+#[cfg(test)]
+#[derive(Default)]
+pub struct InMemoryFeedStore {
+    events: tokio::sync::RwLock<Vec<FeedEvent>>,
+}
+
+#[cfg(test)]
+#[async_trait]
+impl FeedStore for InMemoryFeedStore {
+    async fn append(&self, event: &FeedEvent) -> rara_kernel::Result<()> {
+        let mut events = self.events.write().await;
+        if !events.iter().any(|existing| existing.id == event.id) {
+            events.push(event.clone());
+        }
+        Ok(())
+    }
+
+    async fn query(&self, filter: FeedFilter) -> rara_kernel::Result<Vec<FeedEvent>> {
+        let events = self.events.read().await;
+        Ok(events
+            .iter()
+            .filter(|event| {
+                filter
+                    .source_name
+                    .as_ref()
+                    .is_none_or(|source| source == &event.source_name)
+                    && filter
+                        .since
+                        .as_ref()
+                        .is_none_or(|since| event.received_at >= *since)
+                    && filter.tags.iter().all(|tag| event.tags.contains(tag))
+            })
+            .take(filter.limit)
+            .cloned()
+            .collect())
+    }
+}

--- a/crates/app/src/finance_event.rs
+++ b/crates/app/src/finance_event.rs
@@ -29,13 +29,13 @@ use rust_decimal::Decimal;
 
 /// Outcome counters for feed dispatch.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct FeedDispatchOutcome {
-    pub persisted:         bool,
-    pub finance_decisions: usize,
+pub(crate) struct FeedDispatchOutcome {
+    pub(crate) persisted:         bool,
+    pub(crate) finance_decisions: usize,
 }
 
 #[async_trait]
-pub trait FeedDispatchSink: Send + Sync {
+pub(crate) trait FeedDispatchSink: Send + Sync {
     async fn session_active(&self, session: &SessionKey) -> bool;
     async fn deliver_synthetic(&self, owner: UserId, session: SessionKey, directive: String);
     async fn append_feed_event(&self, session: SessionKey, payload: serde_json::Value);
@@ -43,13 +43,13 @@ pub trait FeedDispatchSink: Send + Sync {
 }
 
 /// Production sink backed by a kernel handle.
-pub struct KernelFeedDispatchSink {
+pub(crate) struct KernelFeedDispatchSink {
     handle: rara_kernel::handle::KernelHandle,
 }
 
 impl KernelFeedDispatchSink {
     #[must_use]
-    pub fn new(handle: rara_kernel::handle::KernelHandle) -> Self { Self { handle } }
+    pub(crate) fn new(handle: rara_kernel::handle::KernelHandle) -> Self { Self { handle } }
 }
 
 #[async_trait]
@@ -86,7 +86,7 @@ impl FeedDispatchSink for KernelFeedDispatchSink {
 }
 
 /// Persist, optionally upsert market data, and dispatch matching subscriptions.
-pub async fn dispatch_feed_event(
+pub(crate) async fn dispatch_feed_event(
     event: &FeedEvent,
     feed_store: &dyn FeedStore,
     market_repo: &dyn MarketDataRepository,
@@ -222,7 +222,7 @@ fn required_str<'a>(event: &'a FeedEvent, field: &str) -> anyhow::Result<&'a str
 }
 
 #[cfg(test)]
-pub struct TestFeedDispatchSink {
+struct TestFeedDispatchSink {
     active:    std::collections::HashSet<SessionKey>,
     synthetic: tokio::sync::RwLock<Vec<String>>,
     silent:    tokio::sync::RwLock<Vec<serde_json::Value>>,
@@ -230,7 +230,7 @@ pub struct TestFeedDispatchSink {
 
 #[cfg(test)]
 impl TestFeedDispatchSink {
-    pub fn new(sessions: impl IntoIterator<Item = SessionKey>) -> Self {
+    fn new(sessions: impl IntoIterator<Item = SessionKey>) -> Self {
         Self {
             active:    sessions.into_iter().collect(),
             synthetic: tokio::sync::RwLock::new(Vec::new()),
@@ -238,11 +238,9 @@ impl TestFeedDispatchSink {
         }
     }
 
-    pub async fn synthetic_turns(&self) -> Vec<String> { self.synthetic.read().await.clone() }
+    async fn synthetic_turns(&self) -> Vec<String> { self.synthetic.read().await.clone() }
 
-    pub async fn silent_appends(&self) -> Vec<serde_json::Value> {
-        self.silent.read().await.clone()
-    }
+    async fn silent_appends(&self) -> Vec<serde_json::Value> { self.silent.read().await.clone() }
 }
 
 #[cfg(test)]

--- a/crates/app/src/finance_event.rs
+++ b/crates/app/src/finance_event.rs
@@ -1,0 +1,469 @@
+// Copyright 2026 Rararulab
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use async_trait::async_trait;
+use rara_kernel::{
+    data_feed::{FeedEvent, FeedStore},
+    identity::UserId,
+    notification::{NotifyAction, Subscription},
+    session::SessionKey,
+};
+use rara_trading::{
+    finance::registry::{
+        FinanceDeliveryAction, FinanceDeliveryDecision, FinanceSubscriptionRegistry,
+    },
+    market_data::{MarketCandle, MarketDataRepository, Timeframe},
+};
+use rust_decimal::Decimal;
+
+/// Outcome counters for feed dispatch.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct FeedDispatchOutcome {
+    pub persisted:         bool,
+    pub finance_decisions: usize,
+}
+
+#[async_trait]
+pub trait FeedDispatchSink: Send + Sync {
+    async fn session_active(&self, session: &SessionKey) -> bool;
+    async fn deliver_synthetic(&self, owner: UserId, session: SessionKey, directive: String);
+    async fn append_feed_event(&self, session: SessionKey, payload: serde_json::Value);
+    async fn generic_matches(&self, _tags: &[String]) -> Vec<Subscription> { Vec::new() }
+}
+
+/// Production sink backed by a kernel handle.
+pub struct KernelFeedDispatchSink {
+    handle: rara_kernel::handle::KernelHandle,
+}
+
+impl KernelFeedDispatchSink {
+    #[must_use]
+    pub fn new(handle: rara_kernel::handle::KernelHandle) -> Self { Self { handle } }
+}
+
+#[async_trait]
+impl FeedDispatchSink for KernelFeedDispatchSink {
+    async fn session_active(&self, session: &SessionKey) -> bool {
+        self.handle.process_table().contains(session)
+    }
+
+    async fn deliver_synthetic(&self, owner: UserId, session: SessionKey, directive: String) {
+        let msg = rara_kernel::io::InboundMessage::synthetic(directive, owner, session);
+        self.handle.deliver_internal(msg).await;
+    }
+
+    async fn append_feed_event(&self, session: SessionKey, payload: serde_json::Value) {
+        let _ = self
+            .handle
+            .tape()
+            .store()
+            .append(
+                &session.to_string(),
+                rara_kernel::memory::TapEntryKind::FeedEvent,
+                payload,
+                None,
+            )
+            .await;
+    }
+
+    async fn generic_matches(&self, tags: &[String]) -> Vec<Subscription> {
+        self.handle
+            .subscription_registry()
+            .match_tags_any_owner(tags)
+            .await
+    }
+}
+
+/// Persist, optionally upsert market data, and dispatch matching subscriptions.
+pub async fn dispatch_feed_event(
+    event: &FeedEvent,
+    feed_store: &dyn FeedStore,
+    market_repo: &dyn MarketDataRepository,
+    finance_registry: &FinanceSubscriptionRegistry,
+    sink: &dyn FeedDispatchSink,
+) -> anyhow::Result<FeedDispatchOutcome> {
+    feed_store.append(event).await?;
+
+    if event.event_type == "market_candle_closed" {
+        let candle = market_candle_from_event(event)?;
+        market_repo.upsert_closed_candle(candle).await?;
+    }
+
+    let event_json = serde_json::to_value(event).unwrap_or_default();
+    let decisions = finance_registry.match_event(event).await;
+    for decision in &decisions {
+        dispatch_finance_decision(event, &event_json, decision, sink).await;
+    }
+
+    dispatch_generic_subscriptions(event, &event_json, sink).await;
+
+    Ok(FeedDispatchOutcome {
+        persisted:         true,
+        finance_decisions: decisions.len(),
+    })
+}
+
+async fn dispatch_finance_decision(
+    event: &FeedEvent,
+    event_json: &serde_json::Value,
+    decision: &FinanceDeliveryDecision,
+    sink: &dyn FeedDispatchSink,
+) {
+    match decision.action {
+        FinanceDeliveryAction::Immediate => {
+            if !sink.session_active(&decision.session_key).await {
+                sink.append_feed_event(decision.session_key, event_json.clone())
+                    .await;
+                return;
+            }
+            sink.deliver_synthetic(
+                decision.owner.clone(),
+                decision.session_key,
+                finance_directive(event),
+            )
+            .await;
+        }
+        FinanceDeliveryAction::Silent => {
+            sink.append_feed_event(decision.session_key, event_json.clone())
+                .await;
+        }
+    }
+}
+
+async fn dispatch_generic_subscriptions(
+    event: &FeedEvent,
+    event_json: &serde_json::Value,
+    sink: &dyn FeedDispatchSink,
+) {
+    for sub in sink.generic_matches(&event.tags).await {
+        match sub.on_receive {
+            NotifyAction::ProactiveTurn => {
+                if !sink.session_active(&sub.subscriber).await {
+                    sink.append_feed_event(sub.subscriber, event_json.clone())
+                        .await;
+                    continue;
+                }
+                let payload_pretty =
+                    serde_json::to_string_pretty(&event.payload).unwrap_or_default();
+                let directive = format!(
+                    "[FeedEvent] source={} type={} tags={:?}\n{}",
+                    event.source_name, event.event_type, event.tags, payload_pretty
+                );
+                sink.deliver_synthetic(sub.owner, sub.subscriber, directive)
+                    .await;
+            }
+            NotifyAction::SilentAppend => {
+                sink.append_feed_event(sub.subscriber, event_json.clone())
+                    .await;
+            }
+        }
+    }
+}
+
+fn finance_directive(event: &FeedEvent) -> String {
+    match event.event_type.as_str() {
+        "market_candle_closed" => format!(
+            "[FinanceMarketUpdate] source={} venue={} symbol={} timeframe={} close_time={} \
+             close={}\nReport the market update factually; do not infer a trade unless the user \
+             asks.",
+            event.source_name,
+            event.payload["venue"].as_str().unwrap_or_default(),
+            event.payload["symbol"].as_str().unwrap_or_default(),
+            event.payload["timeframe"].as_str().unwrap_or_default(),
+            event.payload["close_time"].as_str().unwrap_or_default(),
+            event.payload["close"].as_str().unwrap_or_default(),
+        ),
+        _ => format!(
+            "[FinanceArticle] source={} title={} url={} published_at={}\nSummarize factual \
+             relevance; do not give trade advice unless the user asks.",
+            event.source_name,
+            event.payload["title"].as_str().unwrap_or_default(),
+            event.payload["url"].as_str().unwrap_or_default(),
+            event.payload["published_at"].as_str().unwrap_or_default(),
+        ),
+    }
+}
+
+fn market_candle_from_event(event: &FeedEvent) -> anyhow::Result<MarketCandle> {
+    Ok(MarketCandle {
+        source_name:       event.source_name.clone(),
+        venue:             required_str(event, "venue")?.to_owned(),
+        symbol:            required_str(event, "symbol")?.to_owned(),
+        timeframe:         Timeframe::parse(required_str(event, "timeframe")?)?,
+        open_time:         required_str(event, "open_time")?.parse()?,
+        close_time:        required_str(event, "close_time")?.parse()?,
+        open:              Decimal::from_str_exact(required_str(event, "open")?)?,
+        high:              Decimal::from_str_exact(required_str(event, "high")?)?,
+        low:               Decimal::from_str_exact(required_str(event, "low")?)?,
+        close:             Decimal::from_str_exact(required_str(event, "close")?)?,
+        volume:            Decimal::from_str_exact(required_str(event, "volume")?)?,
+        ingested_at:       event.received_at,
+        provider_sequence: event.payload["provider_sequence"]
+            .as_str()
+            .map(ToOwned::to_owned),
+    })
+}
+
+fn required_str<'a>(event: &'a FeedEvent, field: &str) -> anyhow::Result<&'a str> {
+    event.payload[field]
+        .as_str()
+        .ok_or_else(|| anyhow::anyhow!("market candle event missing string field '{field}'"))
+}
+
+#[cfg(test)]
+pub struct TestFeedDispatchSink {
+    active:    std::collections::HashSet<SessionKey>,
+    synthetic: tokio::sync::RwLock<Vec<String>>,
+    silent:    tokio::sync::RwLock<Vec<serde_json::Value>>,
+}
+
+#[cfg(test)]
+impl TestFeedDispatchSink {
+    pub fn new(sessions: impl IntoIterator<Item = SessionKey>) -> Self {
+        Self {
+            active:    sessions.into_iter().collect(),
+            synthetic: tokio::sync::RwLock::new(Vec::new()),
+            silent:    tokio::sync::RwLock::new(Vec::new()),
+        }
+    }
+
+    pub async fn synthetic_turns(&self) -> Vec<String> { self.synthetic.read().await.clone() }
+
+    pub async fn silent_appends(&self) -> Vec<serde_json::Value> {
+        self.silent.read().await.clone()
+    }
+}
+
+#[cfg(test)]
+#[async_trait]
+impl FeedDispatchSink for TestFeedDispatchSink {
+    async fn session_active(&self, session: &SessionKey) -> bool { self.active.contains(session) }
+
+    async fn deliver_synthetic(&self, _owner: UserId, _session: SessionKey, directive: String) {
+        self.synthetic.write().await.push(directive);
+    }
+
+    async fn append_feed_event(&self, _session: SessionKey, payload: serde_json::Value) {
+        self.silent.write().await.push(payload);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use jiff::Timestamp;
+    use rara_kernel::{
+        data_feed::{FeedEvent, FeedEventId},
+        identity::UserId,
+        session::SessionKey,
+    };
+    use rara_trading::{
+        finance::registry::{
+            FinanceDelivery, FinanceEventKind, FinanceSubscription, FinanceSubscriptionRegistry,
+        },
+        market_data::InMemoryMarketDataRepository,
+    };
+
+    use super::{FeedDispatchOutcome, TestFeedDispatchSink, dispatch_feed_event};
+    use crate::feed_store::InMemoryFeedStore;
+
+    fn ts(value: &str) -> Timestamp { value.parse().expect("timestamp fixture should parse") }
+
+    fn article(title: &str) -> FeedEvent {
+        FeedEvent::builder()
+            .id(FeedEventId::deterministic(title))
+            .source_name("fed-news".to_owned())
+            .event_type("rss_article".to_owned())
+            .tags(vec!["finance".to_owned(), "source:fed-news".to_owned()])
+            .payload(serde_json::json!({
+                "title": title,
+                "summary": "",
+                "url": "https://example.com/article"
+            }))
+            .received_at(ts("2026-07-10T08:30:00Z"))
+            .build()
+    }
+
+    fn candle() -> FeedEvent {
+        FeedEvent::builder()
+            .id(FeedEventId::deterministic(
+                "binance:BTCUSDT:15m:2026-07-10T08:15:00Z",
+            ))
+            .source_name("binance-spot".to_owned())
+            .event_type("market_candle_closed".to_owned())
+            .tags(vec![
+                "finance".to_owned(),
+                "market-data".to_owned(),
+                "venue:binance".to_owned(),
+                "symbol:BTCUSDT".to_owned(),
+                "timeframe:15m".to_owned(),
+            ])
+            .payload(serde_json::json!({
+                "venue": "binance",
+                "symbol": "BTCUSDT",
+                "timeframe": "15m",
+                "open_time": "2026-07-10T08:15:00Z",
+                "close_time": "2026-07-10T08:30:00Z",
+                "open": "61500.12",
+                "high": "61640.00",
+                "low": "61480.50",
+                "close": "61610.30",
+                "volume": "124.551"
+            }))
+            .received_at(ts("2026-07-10T08:30:00Z"))
+            .build()
+    }
+
+    async fn registry_for(sub: FinanceSubscription) -> FinanceSubscriptionRegistry {
+        let tmp = tempfile::tempdir().expect("tempdir should be created");
+        let registry = FinanceSubscriptionRegistry::load(tmp.path().join("subs.json"));
+        registry.upsert(sub).await.unwrap();
+        registry
+    }
+
+    fn article_sub(session: SessionKey, delivery: FinanceDelivery) -> FinanceSubscription {
+        FinanceSubscription {
+            id: uuid::Uuid::new_v4(),
+            owner: UserId("alice".to_owned()),
+            session_key: session,
+            event_kinds: vec![FinanceEventKind::RssArticle],
+            source_names: vec!["fed-news".to_owned()],
+            category_tags: Vec::new(),
+            watch_terms: vec!["BTC".to_owned()],
+            venues: Vec::new(),
+            symbols: Vec::new(),
+            timeframes: Vec::new(),
+            delivery,
+            cooldown_secs: 900,
+            max_immediate_per_hour: 6,
+        }
+    }
+
+    fn candle_sub(session: SessionKey, delivery: FinanceDelivery) -> FinanceSubscription {
+        FinanceSubscription {
+            id: uuid::Uuid::new_v4(),
+            owner: UserId("alice".to_owned()),
+            session_key: session,
+            event_kinds: vec![FinanceEventKind::MarketCandleClosed],
+            source_names: Vec::new(),
+            category_tags: Vec::new(),
+            watch_terms: Vec::new(),
+            venues: vec!["binance".to_owned()],
+            symbols: vec!["BTCUSDT".to_owned()],
+            timeframes: vec!["15m".to_owned()],
+            delivery,
+            cooldown_secs: 900,
+            max_immediate_per_hour: 6,
+        }
+    }
+
+    #[tokio::test]
+    async fn matched_immediate_finance_article_creates_one_synthetic_turn() {
+        let session = SessionKey::new();
+        let sink = TestFeedDispatchSink::new([session]);
+        let outcome = dispatch_feed_event(
+            &article("BTC liquidity note"),
+            &InMemoryFeedStore::default(),
+            &InMemoryMarketDataRepository::default(),
+            &registry_for(article_sub(session, FinanceDelivery::Immediate)).await,
+            &sink,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            outcome,
+            FeedDispatchOutcome {
+                persisted:         true,
+                finance_decisions: 1,
+            }
+        );
+        assert_eq!(sink.synthetic_turns().await.len(), 1);
+        assert!(sink.synthetic_turns().await[0].contains("do not give trade advice"));
+    }
+
+    #[tokio::test]
+    async fn matched_immediate_candle_creates_compact_market_update_turn() {
+        let session = SessionKey::new();
+        let sink = TestFeedDispatchSink::new([session]);
+        dispatch_feed_event(
+            &candle(),
+            &InMemoryFeedStore::default(),
+            &InMemoryMarketDataRepository::default(),
+            &registry_for(candle_sub(session, FinanceDelivery::Immediate)).await,
+            &sink,
+        )
+        .await
+        .unwrap();
+
+        let turns = sink.synthetic_turns().await;
+        assert_eq!(turns.len(), 1);
+        assert!(turns[0].contains("BTCUSDT"));
+        assert!(turns[0].contains("do not infer a trade"));
+    }
+
+    #[tokio::test]
+    async fn closed_candle_is_upserted_before_subscription_delivery() {
+        let session = SessionKey::new();
+        let market_repo = InMemoryMarketDataRepository::default();
+        let sink = TestFeedDispatchSink::new([session]);
+        dispatch_feed_event(
+            &candle(),
+            &InMemoryFeedStore::default(),
+            &market_repo,
+            &registry_for(candle_sub(session, FinanceDelivery::Immediate)).await,
+            &sink,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(market_repo.correction_count().await, 0);
+        assert_eq!(sink.synthetic_turns().await.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn silent_finance_event_appends_to_tape_without_turn() {
+        let session = SessionKey::new();
+        let sink = TestFeedDispatchSink::new([session]);
+        dispatch_feed_event(
+            &article("BTC liquidity note"),
+            &InMemoryFeedStore::default(),
+            &InMemoryMarketDataRepository::default(),
+            &registry_for(article_sub(session, FinanceDelivery::Silent)).await,
+            &sink,
+        )
+        .await
+        .unwrap();
+
+        assert!(sink.synthetic_turns().await.is_empty());
+        assert_eq!(sink.silent_appends().await.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn unmatched_finance_event_does_not_wake_a_session() {
+        let session = SessionKey::new();
+        let sink = TestFeedDispatchSink::new([session]);
+        dispatch_feed_event(
+            &article("rate decision"),
+            &InMemoryFeedStore::default(),
+            &InMemoryMarketDataRepository::default(),
+            &registry_for(article_sub(session, FinanceDelivery::Immediate)).await,
+            &sink,
+        )
+        .await
+        .unwrap();
+
+        assert!(sink.synthetic_turns().await.is_empty());
+        assert!(sink.silent_appends().await.is_empty());
+    }
+}

--- a/crates/app/src/lib.rs
+++ b/crates/app/src/lib.rs
@@ -15,6 +15,7 @@
 mod boot;
 pub use boot::TapeReconciler;
 pub mod config_sync;
+mod finance_event;
 pub mod flatten;
 pub mod gateway;
 // Re-export `rara_kernel::tool` so the `ToolDef` proc macro can resolve
@@ -677,6 +678,11 @@ pub async fn start_with_options(
     // and the `SandboxCleanupHook` registered below removes them when the
     // owning session ends.
     let sandbox_map: crate::tools::SandboxMap = std::sync::Arc::new(dashmap::DashMap::new());
+    let finance_registry = Arc::new(
+        rara_trading::finance::registry::FinanceSubscriptionRegistry::load(
+            rara_paths::data_dir().join("trading/finance-subscriptions.json"),
+        ),
+    );
 
     let rara = crate::boot::boot(
         diesel_pools.clone(),
@@ -686,6 +692,7 @@ pub async fn start_with_options(
         browser_manager,
         config.sandbox.clone(),
         sandbox_map.clone(),
+        finance_registry.clone(),
     )
     .await
     .whatever_context("Failed to boot kernel dependencies")?;
@@ -701,24 +708,6 @@ pub async fn start_with_options(
         crate::feed_store::SqliteFeedStore::new(diesel_pools.clone()),
     );
     let feed_svc = rara_backend_admin::data_feeds::DataFeedSvc::new(diesel_pools.clone());
-
-    // Install the status reporter so runtime transitions (running / idle /
-    // error + last_error) persist back to the `data_feeds` table.
-    feed_registry.set_reporter(Arc::new(
-        rara_backend_admin::data_feeds::SvcStatusReporter::new(feed_svc.clone()),
-    ));
-
-    // Install the status reporter so runtime transitions (running / idle /
-    // error + last_error) persist back to the `data_feeds` table.
-    feed_registry.set_reporter(Arc::new(
-        rara_backend_admin::data_feeds::SvcStatusReporter::new(feed_svc.clone()),
-    ));
-
-    // Install the status reporter so runtime transitions (running / idle /
-    // error + last_error) persist back to the `data_feeds` table.
-    feed_registry.set_reporter(Arc::new(
-        rara_backend_admin::data_feeds::SvcStatusReporter::new(feed_svc.clone()),
-    ));
 
     // Install the status reporter so runtime transitions (running / idle /
     // error + last_error) persist back to the `data_feeds` table.
@@ -947,103 +936,75 @@ pub async fn start_with_options(
         .session_service
         .set_kernel_handle(kernel_handle.clone());
 
+    let market_data_repo: Arc<dyn rara_trading::market_data::MarketDataRepository> =
+        match std::env::var("RARA_MARKET_DATA_DATABASE_URL") {
+            Ok(database_url) if !database_url.trim().is_empty() => {
+                match rara_trading::market_data::TimescaleMarketDataRepository::connect(
+                    &database_url,
+                )
+                .await
+                {
+                    Ok(repo) => {
+                        if let Err(e) = repo.apply_schema().await {
+                            warn!(error = %e, "failed to apply market-data Timescale schema");
+                        }
+                        Arc::new(repo)
+                    }
+                    Err(e) => {
+                        warn!(
+                            error = %e,
+                            "market-data Timescale connection failed; using in-memory repository"
+                        );
+                        Arc::new(rara_trading::market_data::InMemoryMarketDataRepository::default())
+                    }
+                }
+            }
+            _ => {
+                warn!(
+                    "RARA_MARKET_DATA_DATABASE_URL not set; using in-memory market-data repository"
+                );
+                Arc::new(rara_trading::market_data::InMemoryMarketDataRepository::default())
+            }
+        };
+
     // Spawn the feed dispatch task — consumes events from all transports,
-    // persists them to the data_feed_events table, and routes matching events
-    // to subscribing sessions via SubscriptionRegistry.
+    // persists them to the data_feed_events table, upserts closed market
+    // candles, and routes matching generic/finance subscriptions.
     {
         let store = feed_store.clone();
-        let handle = kernel_handle.clone();
+        let sink = crate::finance_event::KernelFeedDispatchSink::new(kernel_handle.clone());
+        let market_data_repo = market_data_repo.clone();
+        let finance_registry = finance_registry.clone();
+        let feed_registry = feed_registry.clone();
         tokio::spawn(async move {
             while let Some(event) = feed_event_rx.recv().await {
-                if let Err(e) = store.append(&event).await {
-                    warn!(
-                        source = %event.source_name,
-                        error = %e,
-                        "failed to persist feed event"
-                    );
+                match crate::finance_event::dispatch_feed_event(
+                    &event,
+                    store.as_ref(),
+                    market_data_repo.as_ref(),
+                    finance_registry.as_ref(),
+                    &sink,
+                )
+                .await
+                {
+                    Ok(outcome) => {
+                        info!(
+                            source = %event.source_name,
+                            event_type = %event.event_type,
+                            finance_decisions = outcome.finance_decisions,
+                            "feed event dispatched"
+                        );
+                    }
+                    Err(e) => {
+                        feed_registry.report_error(&event.source_name, e.to_string());
+                        warn!(
+                            source = %event.source_name,
+                            event_type = %event.event_type,
+                            error = %e,
+                            "failed to dispatch feed event"
+                        );
+                    }
                 }
-
-                // Route to subscribers whose tags overlap with the event.
-                let matched = handle
-                    .subscription_registry()
-                    .match_tags_any_owner(&event.tags)
-                    .await;
-                if matched.is_empty() {
-                    continue;
-                }
-
-                let event_json = serde_json::to_value(&event).unwrap_or_default();
-                let payload_pretty =
-                    serde_json::to_string_pretty(&event.payload).unwrap_or_default();
-
-                use rara_kernel::notification::NotifyAction;
-
-                let futs: Vec<_> = matched
-                    .into_iter()
-                    .map(|sub| {
-                        let handle = handle.clone();
-                        let event_json = event_json.clone();
-                        let payload_pretty = payload_pretty.clone();
-                        let source_name = event.source_name.clone();
-                        let event_type = event.event_type.clone();
-                        let tags = event.tags.clone();
-                        async move {
-                            match sub.on_receive {
-                                NotifyAction::ProactiveTurn => {
-                                    if !handle.process_table().contains(&sub.subscriber) {
-                                        warn!(
-                                            subscriber = %sub.subscriber,
-                                            "feed ProactiveTurn downgraded to SilentAppend: \
-                                             subscriber session not in process table"
-                                        );
-                                        let sub_tape = sub.subscriber.to_string();
-                                        let _ = handle
-                                            .tape()
-                                            .store()
-                                            .append(
-                                                &sub_tape,
-                                                rara_kernel::memory::TapEntryKind::FeedEvent,
-                                                event_json,
-                                                None,
-                                            )
-                                            .await;
-                                        return;
-                                    }
-                                    let directive = format!(
-                                        "[FeedEvent] source={source_name} type={event_type} \
-                                         tags={tags:?}\n{payload_pretty}",
-                                    );
-                                    let msg = rara_kernel::io::InboundMessage::synthetic(
-                                        directive,
-                                        sub.owner.clone(),
-                                        sub.subscriber,
-                                    );
-                                    handle.deliver_internal(msg).await;
-                                }
-                                NotifyAction::SilentAppend => {
-                                    let sub_tape = sub.subscriber.to_string();
-                                    let _ = handle
-                                        .tape()
-                                        .store()
-                                        .append(
-                                            &sub_tape,
-                                            rara_kernel::memory::TapEntryKind::FeedEvent,
-                                            event_json,
-                                            None,
-                                        )
-                                        .await;
-                                }
-                            }
-                        }
-                    })
-                    .collect();
-                futures::future::join_all(futs).await;
-
-                info!(
-                    source = %event.source_name,
-                    event_type = %event.event_type,
-                    "feed event dispatched to subscribers"
-                );
             }
             info!("feed dispatch task stopped (channel closed)");
         });

--- a/crates/app/src/tools/mod.rs
+++ b/crates/app/src/tools/mod.rs
@@ -95,6 +95,9 @@ use mita_update_soul_state::UpdateSoulStateTool;
 use mita_write_skill_draft::WriteSkillDraftTool;
 use mita_write_user_note::MitaWriteUserNoteTool;
 use multi_edit::MultiEditTool;
+use rara_trading::finance::tools::{
+    FinanceListSubscriptionsTool, FinanceSubscribeTool, FinanceUnsubscribeTool,
+};
 use read_file::ReadFileTool;
 use run_code::RunCodeTool;
 pub use run_code::SandboxCleanupHook;
@@ -161,6 +164,8 @@ pub struct ToolDeps {
     pub sandbox_config:        Option<crate::SandboxToolConfig>,
     /// Shared per-session sandbox map; the cleanup hook holds a clone.
     pub sandbox_map:           SandboxMap,
+    /// Finance information subscription registry.
+    pub finance_registry:      Arc<rara_trading::finance::registry::FinanceSubscriptionRegistry>,
 }
 
 /// Result of tool registration, carrying handles needed for post-init wiring.
@@ -285,6 +290,10 @@ pub fn register_all(registry: &mut ToolRegistry, deps: ToolDeps) -> ToolRegistra
         Arc::new(WechatLoginConfirmTool::new()),
         // User interaction
         Arc::new(AskUserTool::new(deps.user_question_manager)),
+        // Finance information subscriptions
+        Arc::new(FinanceSubscribeTool::new(deps.finance_registry.clone())),
+        Arc::new(FinanceUnsubscribeTool::new(deps.finance_registry.clone())),
+        Arc::new(FinanceListSubscriptionsTool::new(deps.finance_registry)),
         // Artifacts (rich-content side panel — deferred tier)
         Arc::new(ArtifactsTool::new(deps.tape_service.clone())),
     ];

--- a/crates/common/telemetry/src/logging.rs
+++ b/crates/common/telemetry/src/logging.rs
@@ -551,7 +551,7 @@ pub fn init_global_logging(
                 .unwrap_or_else(|e| {
                     panic!(
                         "initializing rolling file appender at {} failed: {}",
-                        &opts.dir, e
+                        opts.dir, e
                     )
                 });
             let (writer, guard) = tracing_appender::non_blocking(rolling_appender);
@@ -588,7 +588,7 @@ pub fn init_global_logging(
                 .unwrap_or_else(|e| {
                     panic!(
                         "initializing rolling file appender at {} failed: {}",
-                        &opts.dir, e
+                        opts.dir, e
                     )
                 });
             let (writer, guard) = tracing_appender::non_blocking(rolling_appender);

--- a/crates/extensions/backend-admin/Cargo.toml
+++ b/crates/extensions/backend-admin/Cargo.toml
@@ -20,6 +20,7 @@ rara-mcp = { workspace = true }
 rara-paths = { workspace = true }
 rara-sessions = { workspace = true }
 rara-skills = { workspace = true }
+rara-trading = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 snafu = { workspace = true }

--- a/crates/extensions/backend-admin/src/data_feeds/router.rs
+++ b/crates/extensions/backend-admin/src/data_feeds/router.rs
@@ -156,13 +156,16 @@ struct EventListResponse {
 /// Built-in feed catalog entry plus current materialized state.
 #[derive(Debug, Serialize)]
 struct FeedCatalogEntryResponse {
-    id:          String,
-    name:        String,
-    description: String,
-    feed_type:   FeedType,
-    tags:        Vec<String>,
-    enabled:     bool,
-    feed_id:     Option<String>,
+    id:                     String,
+    name:                   String,
+    description:            String,
+    feed_type:              FeedType,
+    tags:                   Vec<String>,
+    enabled:                bool,
+    feed_id:                Option<String>,
+    requires_configuration: bool,
+    setup_hint:             Option<String>,
+    transport_template:     Option<serde_json::Value>,
 }
 
 // ---------------------------------------------------------------------------
@@ -200,7 +203,15 @@ async fn enable_catalog_feed(
     }
 
     let source = find_catalog_source(&id)?;
+    if !source.can_enable() {
+        return Err(ProblemDetails::bad_request(format!(
+            "catalog source requires configuration before it can be enabled: {id}"
+        )));
+    }
     let feed_name = source.feed_name();
+    let transport = source.transport.clone().ok_or_else(|| {
+        ProblemDetails::bad_request(format!("catalog source has no transport template: {id}"))
+    })?;
     let existing = state
         .svc
         .list_feeds()
@@ -215,7 +226,7 @@ async fn enable_catalog_feed(
             .name(feed_name)
             .feed_type(source.feed_type)
             .tags(source.tags)
-            .transport(source.transport)
+            .transport(transport)
             .maybe_auth(source.auth)
             .enabled(true)
             .status(FeedStatus::Idle)
@@ -230,7 +241,7 @@ async fn enable_catalog_feed(
             .name(feed_name)
             .feed_type(source.feed_type)
             .tags(source.tags)
-            .transport(source.transport)
+            .transport(transport)
             .maybe_auth(source.auth)
             .enabled(true)
             .status(FeedStatus::Idle)
@@ -733,13 +744,16 @@ fn catalog_response(feeds: &[DataFeedConfig]) -> Vec<FeedCatalogEntryResponse> {
             let feed_name = source.feed_name();
             let feed = feeds.iter().find(|feed| feed.name == feed_name);
             FeedCatalogEntryResponse {
-                id:          source.id,
-                name:        source.name,
-                description: source.description,
-                feed_type:   source.feed_type,
-                tags:        source.tags,
-                enabled:     feed.is_some_and(|feed| feed.enabled),
-                feed_id:     feed.map(|feed| feed.id.clone()),
+                id:                     source.id,
+                name:                   source.name,
+                description:            source.description,
+                feed_type:              source.feed_type,
+                tags:                   source.tags,
+                enabled:                feed.is_some_and(|feed| feed.enabled),
+                feed_id:                feed.map(|feed| feed.id.clone()),
+                requires_configuration: source.requires_configuration,
+                setup_hint:             source.setup_hint,
+                transport_template:     source.transport,
             }
         })
         .collect()
@@ -985,6 +999,16 @@ mod tests {
 
         assert!(ids.contains(&"fed-press-releases"));
         assert!(ids.contains(&"sec-press-releases"));
+        assert!(ids.contains(&"binance-market-candles"));
+
+        let binance = entries
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|entry| entry["id"] == "binance-market-candles")
+            .unwrap();
+        assert_eq!(binance["requires_configuration"], true);
+        assert_eq!(binance["feed_type"], "market_candle");
     }
 
     #[tokio::test]
@@ -1015,6 +1039,24 @@ mod tests {
         assert!(feed.tags.contains(&"finance".to_owned()));
         assert!(feed.tags.contains(&"news".to_owned()));
         assert!(feed.tags.contains(&"fed".to_owned()));
+    }
+
+    #[tokio::test]
+    async fn finance_catalog_enable_rejects_provider_preset_without_config() {
+        let app = app_with_user(user_of(Role::Admin)).await;
+        let res = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/v1/data-feeds/catalog/binance-market-candles/enable")
+                    .header("Authorization", "Bearer s3cret")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(res.status(), StatusCode::BAD_REQUEST);
     }
 
     #[tokio::test]

--- a/crates/extensions/backend-admin/src/data_feeds/router.rs
+++ b/crates/extensions/backend-admin/src/data_feeds/router.rs
@@ -26,7 +26,7 @@
 //! | GET    | `/api/v1/data-feeds/{id}/events/{event_id}` | get single event    |
 //!
 //! All mutations synchronise both the database (via [`DataFeedSvc`]) and the
-//! in-memory [`DataFeedRegistry`]. When a polling-type feed is created and
+//! in-memory [`DataFeedRegistry`]. When an active feed is created and
 //! enabled, a background task is spawned automatically.
 
 use std::sync::Arc;
@@ -42,6 +42,7 @@ use rara_kernel::data_feed::{
     DataFeed, DataFeedConfig, DataFeedRegistry, FeedStatus, FeedType, parse_duration_ago,
     polling::PollingSource,
 };
+use rara_trading::feed::{market_candle::MarketCandleSource, rss::RssSource};
 use serde::{Deserialize, Deserializer, Serialize};
 use tokio_util::sync::CancellationToken;
 use tracing::{info, warn};
@@ -451,7 +452,7 @@ async fn get_event(
 
 /// Start a feed source task if the config type supports active operation.
 ///
-/// Polling feeds spawn a background tokio task. Webhook feeds are passive
+/// Active feeds spawn a background tokio task. Webhook feeds are passive
 /// (handled by the webhook axum route). WebSocket feeds are not yet
 /// implemented.
 pub fn start_feed_task(config: &DataFeedConfig, registry: &Arc<DataFeedRegistry>) {
@@ -495,6 +496,78 @@ pub fn start_feed_task(config: &DataFeedConfig, registry: &Arc<DataFeedRegistry>
                     }
                 }
                 info!(feed = %name, "polling feed task stopped");
+            });
+        }
+        FeedType::Rss => {
+            let source = match RssSource::from_config(config) {
+                Ok(source) => source,
+                Err(err) => {
+                    warn!(
+                        feed = %config.name, error = %err,
+                        "failed to create rss source from config"
+                    );
+                    registry.report_error(&config.name, format!("config parse failed: {err}"));
+                    return;
+                }
+            };
+
+            let source = match registry.reporter() {
+                Some(reporter) => source.with_reporter(reporter),
+                None => source,
+            };
+
+            let cancel = CancellationToken::new();
+            registry.set_running(config.name.clone(), cancel.clone());
+
+            let event_tx = registry.event_tx();
+            let name = config.name.clone();
+            let registry = registry.clone();
+
+            tokio::spawn(async move {
+                match source.run(event_tx, cancel).await {
+                    Ok(()) => registry.clear_running(&name),
+                    Err(err) => {
+                        warn!(feed = %name, error = %err, "feed task exited with error");
+                        registry.report_error(&name, err.to_string());
+                    }
+                }
+                info!(feed = %name, "rss feed task stopped");
+            });
+        }
+        FeedType::MarketCandle => {
+            let source = match MarketCandleSource::from_config(config) {
+                Ok(source) => source,
+                Err(err) => {
+                    warn!(
+                        feed = %config.name, error = %err,
+                        "failed to create market candle source from config"
+                    );
+                    registry.report_error(&config.name, format!("config parse failed: {err}"));
+                    return;
+                }
+            };
+
+            let source = match registry.reporter() {
+                Some(reporter) => source.with_reporter(reporter),
+                None => source,
+            };
+
+            let cancel = CancellationToken::new();
+            registry.set_running(config.name.clone(), cancel.clone());
+
+            let event_tx = registry.event_tx();
+            let name = config.name.clone();
+            let registry = registry.clone();
+
+            tokio::spawn(async move {
+                match source.run(event_tx, cancel).await {
+                    Ok(()) => registry.clear_running(&name),
+                    Err(err) => {
+                        warn!(feed = %name, error = %err, "feed task exited with error");
+                        registry.report_error(&name, err.to_string());
+                    }
+                }
+                info!(feed = %name, "market candle feed task stopped");
             });
         }
         FeedType::Webhook => {
@@ -640,5 +713,72 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(res.status(), StatusCode::FORBIDDEN);
+    }
+
+    #[tokio::test]
+    async fn start_feed_task_starts_rss_feed() {
+        let (event_tx, _event_rx) = tokio::sync::mpsc::channel(16);
+        let registry = Arc::new(DataFeedRegistry::new(event_tx));
+        let config = DataFeedConfig::builder()
+            .id("rss-feed-id".to_owned())
+            .name("fed-news".to_owned())
+            .feed_type(FeedType::Rss)
+            .tags(vec!["finance".to_owned()])
+            .transport(serde_json::json!({
+                "url": "https://example.com/feed.xml",
+                "interval_secs": 3600,
+                "max_entries_per_poll": 20
+            }))
+            .enabled(true)
+            .status(FeedStatus::Idle)
+            .created_at(Timestamp::UNIX_EPOCH)
+            .updated_at(Timestamp::UNIX_EPOCH)
+            .build();
+
+        registry
+            .register(config.clone())
+            .expect("test config should register");
+        start_feed_task(&config, &registry);
+
+        assert!(registry.is_running("fed-news"));
+
+        registry
+            .remove("fed-news")
+            .expect("test cleanup should cancel");
+    }
+
+    #[tokio::test]
+    async fn start_feed_task_starts_market_candle_feed() {
+        let (event_tx, _event_rx) = tokio::sync::mpsc::channel(16);
+        let registry = Arc::new(DataFeedRegistry::new(event_tx));
+        let config = DataFeedConfig::builder()
+            .id("market-candle-feed-id".to_owned())
+            .name("binance-spot".to_owned())
+            .feed_type(FeedType::MarketCandle)
+            .tags(vec!["finance".to_owned(), "market-data".to_owned()])
+            .transport(serde_json::json!({
+                "url": "https://market-data.example/candles/latest",
+                "interval_secs": 60,
+                "venue": "binance",
+                "symbols": ["BTCUSDT", "ETHUSDT"],
+                "timeframes": ["15m", "1h"],
+                "max_candles_per_poll": 1000
+            }))
+            .enabled(true)
+            .status(FeedStatus::Idle)
+            .created_at(Timestamp::UNIX_EPOCH)
+            .updated_at(Timestamp::UNIX_EPOCH)
+            .build();
+
+        registry
+            .register(config.clone())
+            .expect("test config should register");
+        start_feed_task(&config, &registry);
+
+        assert!(registry.is_running("binance-spot"));
+
+        registry
+            .remove("binance-spot")
+            .expect("test cleanup should cancel");
     }
 }

--- a/crates/extensions/backend-admin/src/data_feeds/router.rs
+++ b/crates/extensions/backend-admin/src/data_feeds/router.rs
@@ -35,14 +35,18 @@ use axum::{
     Json, Router,
     extract::{Path, Query, State},
     http::StatusCode,
-    routing::{get, put},
+    routing::{get, post, put},
 };
 use jiff::Timestamp;
 use rara_kernel::data_feed::{
     DataFeed, DataFeedConfig, DataFeedRegistry, FeedStatus, FeedType, parse_duration_ago,
     polling::PollingSource,
 };
-use rara_trading::feed::{market_candle::MarketCandleSource, rss::RssSource};
+use rara_trading::feed::{
+    catalog::{DefaultFeedSource, default_finance_feed_sources},
+    market_candle::MarketCandleSource,
+    rss::RssSource,
+};
 use serde::{Deserialize, Deserializer, Serialize};
 use tokio_util::sync::CancellationToken;
 use tracing::{info, warn};
@@ -67,6 +71,15 @@ pub struct DataFeedRouterState {
 pub fn data_feed_routes(state: DataFeedRouterState) -> Router {
     Router::new()
         .route("/api/v1/data-feeds", get(list_feeds).post(create_feed))
+        .route("/api/v1/data-feeds/catalog", get(list_feed_catalog))
+        .route(
+            "/api/v1/data-feeds/catalog/{id}/enable",
+            post(enable_catalog_feed),
+        )
+        .route(
+            "/api/v1/data-feeds/catalog/{id}/disable",
+            post(disable_catalog_feed),
+        )
         .route(
             "/api/v1/data-feeds/{id}",
             get(get_feed)
@@ -140,6 +153,18 @@ struct EventListResponse {
     has_more: bool,
 }
 
+/// Built-in feed catalog entry plus current materialized state.
+#[derive(Debug, Serialize)]
+struct FeedCatalogEntryResponse {
+    id:          String,
+    name:        String,
+    description: String,
+    feed_type:   FeedType,
+    tags:        Vec<String>,
+    enabled:     bool,
+    feed_id:     Option<String>,
+}
+
 // ---------------------------------------------------------------------------
 // Handlers
 // ---------------------------------------------------------------------------
@@ -150,6 +175,124 @@ async fn list_feeds(
 ) -> Result<Json<Vec<DataFeedConfig>>, ProblemDetails> {
     let feeds = state.svc.list_feeds().await?;
     Ok(Json(feeds))
+}
+
+/// `GET /api/v1/data-feeds/catalog` — list built-in finance feed sources.
+async fn list_feed_catalog(
+    State(state): State<DataFeedRouterState>,
+) -> Result<Json<Vec<FeedCatalogEntryResponse>>, ProblemDetails> {
+    let feeds = state.svc.list_feeds().await?;
+    Ok(Json(catalog_response(&feeds)))
+}
+
+/// `POST /api/v1/data-feeds/catalog/{id}/enable` — materialize a default feed.
+async fn enable_catalog_feed(
+    State(state): State<DataFeedRouterState>,
+    axum::Extension(principal): axum::Extension<
+        rara_kernel::identity::Principal<rara_kernel::identity::Resolved>,
+    >,
+    Path(id): Path<String>,
+) -> Result<(StatusCode, Json<DataFeedConfig>), ProblemDetails> {
+    if !principal.is_admin() {
+        return Err(ProblemDetails::forbidden(
+            "enabling data feeds requires admin role",
+        ));
+    }
+
+    let source = find_catalog_source(&id)?;
+    let feed_name = source.feed_name();
+    let existing = state
+        .svc
+        .list_feeds()
+        .await?
+        .into_iter()
+        .find(|feed| feed.name == feed_name);
+
+    let now = Timestamp::now();
+    let (status, config) = if let Some(existing) = existing {
+        let updated = DataFeedConfig::builder()
+            .id(existing.id)
+            .name(feed_name)
+            .feed_type(source.feed_type)
+            .tags(source.tags)
+            .transport(source.transport)
+            .maybe_auth(source.auth)
+            .enabled(true)
+            .status(FeedStatus::Idle)
+            .created_at(existing.created_at)
+            .updated_at(now)
+            .build();
+        state.svc.update_feed(&updated).await?;
+        (StatusCode::OK, updated)
+    } else {
+        let created = DataFeedConfig::builder()
+            .id(Uuid::new_v4().to_string())
+            .name(feed_name)
+            .feed_type(source.feed_type)
+            .tags(source.tags)
+            .transport(source.transport)
+            .maybe_auth(source.auth)
+            .enabled(true)
+            .status(FeedStatus::Idle)
+            .created_at(now)
+            .updated_at(now)
+            .build();
+        state.svc.create_feed(&created).await?;
+        (StatusCode::CREATED, created)
+    };
+
+    sync_registry_and_maybe_start(&config, &state.registry);
+
+    Ok((status, Json(config)))
+}
+
+/// `POST /api/v1/data-feeds/catalog/{id}/disable` — turn off a materialized
+/// built-in feed without deleting its config row.
+async fn disable_catalog_feed(
+    State(state): State<DataFeedRouterState>,
+    axum::Extension(principal): axum::Extension<
+        rara_kernel::identity::Principal<rara_kernel::identity::Resolved>,
+    >,
+    Path(id): Path<String>,
+) -> Result<Json<DataFeedConfig>, ProblemDetails> {
+    if !principal.is_admin() {
+        return Err(ProblemDetails::forbidden(
+            "disabling data feeds requires admin role",
+        ));
+    }
+
+    let source = find_catalog_source(&id)?;
+    let feed_name = source.feed_name();
+    let existing = state
+        .svc
+        .list_feeds()
+        .await?
+        .into_iter()
+        .find(|feed| feed.name == feed_name)
+        .ok_or_else(|| {
+            ProblemDetails::not_found(
+                "Feed Not Found",
+                format!("catalog source is not enabled: {id}"),
+            )
+        })?;
+
+    let updated = DataFeedConfig::builder()
+        .id(existing.id)
+        .name(existing.name)
+        .feed_type(existing.feed_type)
+        .tags(existing.tags)
+        .transport(existing.transport)
+        .maybe_auth(existing.auth)
+        .enabled(false)
+        .status(FeedStatus::Idle)
+        .created_at(existing.created_at)
+        .updated_at(Timestamp::now())
+        .build();
+
+    state.svc.update_feed(&updated).await?;
+    sync_registry_and_maybe_start(&updated, &state.registry);
+
+    Ok(Json(updated))
 }
 
 /// `POST /api/v1/data-feeds` — create a new feed, sync registry, start task.
@@ -583,6 +726,47 @@ pub fn start_feed_task(config: &DataFeedConfig, registry: &Arc<DataFeedRegistry>
     }
 }
 
+fn catalog_response(feeds: &[DataFeedConfig]) -> Vec<FeedCatalogEntryResponse> {
+    default_finance_feed_sources()
+        .into_iter()
+        .map(|source| {
+            let feed_name = source.feed_name();
+            let feed = feeds.iter().find(|feed| feed.name == feed_name);
+            FeedCatalogEntryResponse {
+                id:          source.id,
+                name:        source.name,
+                description: source.description,
+                feed_type:   source.feed_type,
+                tags:        source.tags,
+                enabled:     feed.is_some_and(|feed| feed.enabled),
+                feed_id:     feed.map(|feed| feed.id.clone()),
+            }
+        })
+        .collect()
+}
+
+fn find_catalog_source(id: &str) -> Result<DefaultFeedSource, ProblemDetails> {
+    default_finance_feed_sources()
+        .into_iter()
+        .find(|source| source.id == id)
+        .ok_or_else(|| {
+            ProblemDetails::not_found(
+                "Catalog Source Not Found",
+                format!("no built-in data feed source with id: {id}"),
+            )
+        })
+}
+
+fn sync_registry_and_maybe_start(config: &DataFeedConfig, registry: &Arc<DataFeedRegistry>) {
+    let _ = registry.remove(&config.name);
+    if let Err(e) = registry.register(config.clone()) {
+        warn!(name = %config.name, error = %e, "registry sync failed for catalog feed");
+    }
+    if config.enabled {
+        start_feed_task(config, registry);
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use async_trait::async_trait;
@@ -592,6 +776,7 @@ mod tests {
         http::{Request, StatusCode},
         middleware,
     };
+    use diesel_async::RunQueryDsl;
     use rara_kernel::{
         data_feed::DataFeedRegistry,
         error::Result as KernelResult,
@@ -647,12 +832,50 @@ mod tests {
     /// so the pool is never hit on the 403 path these tests exercise.
     async fn app_with_user(user: KernelUser) -> Router {
         let pools = build_memory_diesel_pools().await;
+        bootstrap_data_feed_schema(&pools).await;
         let svc = DataFeedSvc::new(pools);
         let (event_tx, _event_rx) = tokio::sync::mpsc::channel(16);
         let registry = Arc::new(DataFeedRegistry::new(event_tx));
         let state = DataFeedRouterState { svc, registry };
         let auth = auth_state_direct(user);
         data_feed_routes(state).layer(middleware::from_fn_with_state(auth, auth_layer))
+    }
+
+    async fn bootstrap_data_feed_schema(pools: &yunara_store::diesel_pool::DieselSqlitePools) {
+        let mut conn = pools.writer.get().await.expect("pool conn");
+        for ddl in [
+            "CREATE TABLE data_feeds (
+                id TEXT PRIMARY KEY NOT NULL,
+                name TEXT NOT NULL UNIQUE,
+                feed_type TEXT NOT NULL,
+                tags TEXT NOT NULL DEFAULT '[]',
+                transport TEXT NOT NULL DEFAULT '{}',
+                auth TEXT,
+                enabled INTEGER NOT NULL DEFAULT 1,
+                status TEXT NOT NULL DEFAULT 'idle',
+                last_error TEXT,
+                created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+                updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+            )",
+            "CREATE INDEX idx_data_feeds_name ON data_feeds(name)",
+            "CREATE INDEX idx_data_feeds_type ON data_feeds(feed_type)",
+            "CREATE TABLE data_feed_events (
+                id TEXT PRIMARY KEY NOT NULL,
+                source_name TEXT NOT NULL,
+                event_type TEXT NOT NULL,
+                tags TEXT NOT NULL DEFAULT '[]',
+                payload TEXT NOT NULL DEFAULT '{}',
+                received_at TEXT NOT NULL,
+                created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+            )",
+            "CREATE INDEX idx_data_feed_events_source ON data_feed_events(source_name)",
+            "CREATE INDEX idx_data_feed_events_received ON data_feed_events(received_at)",
+        ] {
+            diesel::sql_query(ddl)
+                .execute(&mut *conn)
+                .await
+                .expect("bootstrap data feed schema");
+        }
     }
 
     #[tokio::test]
@@ -713,6 +936,126 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(res.status(), StatusCode::FORBIDDEN);
+    }
+
+    #[tokio::test]
+    async fn non_admin_cannot_enable_catalog_feed() {
+        let app = app_with_user(user_of(Role::User)).await;
+        let res = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/v1/data-feeds/catalog/fed-press-releases/enable")
+                    .header("Authorization", "Bearer s3cret")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(res.status(), StatusCode::FORBIDDEN);
+    }
+
+    #[tokio::test]
+    async fn finance_catalog_lists_default_sources() {
+        let app = app_with_user(user_of(Role::Admin)).await;
+        let res = app
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri("/api/v1/data-feeds/catalog")
+                    .header("Authorization", "Bearer s3cret")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(res.status(), StatusCode::OK);
+
+        let body = axum::body::to_bytes(res.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let entries: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        let ids = entries
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|entry| entry["id"].as_str().unwrap())
+            .collect::<Vec<_>>();
+
+        assert!(ids.contains(&"fed-press-releases"));
+        assert!(ids.contains(&"sec-press-releases"));
+    }
+
+    #[tokio::test]
+    async fn finance_catalog_enable_creates_enabled_feed() {
+        let app = app_with_user(user_of(Role::Admin)).await;
+        let res = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/v1/data-feeds/catalog/fed-press-releases/enable")
+                    .header("Authorization", "Bearer s3cret")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(res.status(), StatusCode::CREATED);
+
+        let body = axum::body::to_bytes(res.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let feed: DataFeedConfig = serde_json::from_slice(&body).unwrap();
+
+        assert_eq!(feed.name, "finance-fed-press-releases");
+        assert_eq!(feed.feed_type, FeedType::Rss);
+        assert!(feed.enabled);
+        assert!(feed.tags.contains(&"finance".to_owned()));
+        assert!(feed.tags.contains(&"news".to_owned()));
+        assert!(feed.tags.contains(&"fed".to_owned()));
+    }
+
+    #[tokio::test]
+    async fn finance_catalog_disable_turns_existing_feed_off() {
+        let app = app_with_user(user_of(Role::Admin)).await;
+        let enable_res = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/v1/data-feeds/catalog/sec-press-releases/enable")
+                    .header("Authorization", "Bearer s3cret")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(enable_res.status(), StatusCode::CREATED);
+
+        let disable_res = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/v1/data-feeds/catalog/sec-press-releases/disable")
+                    .header("Authorization", "Bearer s3cret")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(disable_res.status(), StatusCode::OK);
+
+        let body = axum::body::to_bytes(disable_res.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let feed: DataFeedConfig = serde_json::from_slice(&body).unwrap();
+
+        assert_eq!(feed.name, "finance-sec-press-releases");
+        assert!(!feed.enabled);
+        assert_eq!(feed.status, FeedStatus::Idle);
     }
 
     #[tokio::test]

--- a/crates/extensions/rara-trading/Cargo.toml
+++ b/crates/extensions/rara-trading/Cargo.toml
@@ -1,0 +1,32 @@
+[package]
+name = "rara-trading"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+description = "Trading and finance data-feed extension for rara"
+
+[lints]
+workspace = true
+
+[dependencies]
+anyhow = { workspace = true }
+async-trait = { workspace = true }
+feed-rs = { workspace = true }
+jiff = { workspace = true }
+rara-kernel = { workspace = true }
+reqwest = { workspace = true }
+rust_decimal = { workspace = true }
+schemars = { workspace = true, features = ["uuid1"] }
+serde = { workspace = true }
+serde_json = { workspace = true }
+sqlx-core = { workspace = true }
+sqlx-postgres = { workspace = true }
+tokio = { workspace = true, features = ["sync", "time"] }
+tokio-util = { workspace = true }
+tracing = { workspace = true }
+uuid = { workspace = true }
+rara-tool-macro = { workspace = true }
+
+[dev-dependencies]
+tempfile = { workspace = true }
+testcontainers = { workspace = true }

--- a/crates/extensions/rara-trading/migrations/0001_market_candles.sql
+++ b/crates/extensions/rara-trading/migrations/0001_market_candles.sql
@@ -1,0 +1,38 @@
+CREATE EXTENSION IF NOT EXISTS timescaledb;
+
+CREATE TABLE IF NOT EXISTS market_candles (
+  source_name TEXT NOT NULL,
+  venue TEXT NOT NULL,
+  symbol TEXT NOT NULL,
+  timeframe TEXT NOT NULL,
+  open_time TIMESTAMPTZ NOT NULL,
+  close_time TIMESTAMPTZ NOT NULL,
+  open NUMERIC NOT NULL,
+  high NUMERIC NOT NULL,
+  low NUMERIC NOT NULL,
+  close NUMERIC NOT NULL,
+  volume NUMERIC NOT NULL,
+  ingested_at TIMESTAMPTZ NOT NULL,
+  provider_sequence TEXT,
+  PRIMARY KEY (source_name, venue, symbol, timeframe, open_time)
+);
+
+SELECT create_hypertable('market_candles', 'open_time', if_not_exists => TRUE);
+
+CREATE INDEX IF NOT EXISTS idx_market_candles_venue_symbol_time
+  ON market_candles(venue, symbol, timeframe, open_time DESC);
+
+CREATE INDEX IF NOT EXISTS idx_market_candles_source_symbol_time
+  ON market_candles(source_name, symbol, timeframe, open_time DESC);
+
+CREATE TABLE IF NOT EXISTS market_candle_corrections (
+  id UUID PRIMARY KEY,
+  source_name TEXT NOT NULL,
+  venue TEXT NOT NULL,
+  symbol TEXT NOT NULL,
+  timeframe TEXT NOT NULL,
+  open_time TIMESTAMPTZ NOT NULL,
+  corrected_at TIMESTAMPTZ NOT NULL,
+  previous_payload JSONB NOT NULL,
+  new_payload JSONB NOT NULL
+);

--- a/crates/extensions/rara-trading/src/feed/catalog.rs
+++ b/crates/extensions/rara-trading/src/feed/catalog.rs
@@ -14,27 +14,31 @@
 
 //! Built-in finance feed source catalog.
 //!
-//! The catalog contains only sources that rara can enable without additional
-//! operator secrets or provider adapters. Market-candle feeds stay manually
-//! configured until an operator supplies a normalized candle endpoint.
+//! The catalog separates sources that can run immediately from provider
+//! presets that need operator credentials or a normalized market-data endpoint.
 
 use rara_kernel::data_feed::{AuthConfig, FeedType};
 use serde::Serialize;
 
 #[derive(Debug, Clone, Serialize)]
 pub struct DefaultFeedSource {
-    pub id:          String,
-    pub name:        String,
-    pub description: String,
-    pub feed_type:   FeedType,
-    pub tags:        Vec<String>,
-    pub transport:   serde_json::Value,
-    pub auth:        Option<AuthConfig>,
+    pub id:                     String,
+    pub name:                   String,
+    pub description:            String,
+    pub feed_type:              FeedType,
+    pub tags:                   Vec<String>,
+    pub transport:              Option<serde_json::Value>,
+    pub auth:                   Option<AuthConfig>,
+    pub requires_configuration: bool,
+    pub setup_hint:             Option<String>,
 }
 
 impl DefaultFeedSource {
     #[must_use]
     pub fn feed_name(&self) -> String { format!("finance-{}", self.id) }
+
+    #[must_use]
+    pub fn can_enable(&self) -> bool { !self.requires_configuration && self.transport.is_some() }
 }
 
 #[must_use]
@@ -74,6 +78,23 @@ pub fn default_finance_feed_sources() -> Vec<DefaultFeedSource> {
             ["finance", "news", "sec", "regulatory"],
             300,
         ),
+        provider_preset(
+            "binance-market-candles",
+            "Binance Market Candles",
+            "Preset for Binance OHLCV ingestion through a normalized candle endpoint.",
+            "binance",
+            ["finance", "market-data", "crypto", "binance"],
+            "Connect a normalized Binance candle endpoint and choose symbols/timeframes before \
+             enabling.",
+        ),
+        provider_preset(
+            "longbridge-market-candles",
+            "Longbridge Market Data",
+            "Preset for Longbridge equities market data through a normalized candle endpoint.",
+            "longbridge",
+            ["finance", "market-data", "equities", "longbridge"],
+            "Connect Longbridge credentials behind a normalized candle endpoint before enabling.",
+        ),
     ]
 }
 
@@ -86,17 +107,48 @@ fn rss_source(
     interval_secs: u64,
 ) -> DefaultFeedSource {
     DefaultFeedSource {
-        id:          id.to_owned(),
-        name:        name.to_owned(),
-        description: description.to_owned(),
-        feed_type:   FeedType::Rss,
-        tags:        tags.into_iter().map(str::to_owned).collect(),
-        transport:   serde_json::json!({
+        id:                     id.to_owned(),
+        name:                   name.to_owned(),
+        description:            description.to_owned(),
+        feed_type:              FeedType::Rss,
+        tags:                   tags.into_iter().map(str::to_owned).collect(),
+        transport:              Some(serde_json::json!({
             "url": url,
             "interval_secs": interval_secs,
             "headers": {},
             "max_entries_per_poll": 50
-        }),
-        auth:        None,
+        })),
+        auth:                   None,
+        requires_configuration: false,
+        setup_hint:             None,
+    }
+}
+
+fn provider_preset(
+    id: &str,
+    name: &str,
+    description: &str,
+    venue: &str,
+    tags: impl IntoIterator<Item = &'static str>,
+    setup_hint: &str,
+) -> DefaultFeedSource {
+    DefaultFeedSource {
+        id:                     id.to_owned(),
+        name:                   name.to_owned(),
+        description:            description.to_owned(),
+        feed_type:              FeedType::MarketCandle,
+        tags:                   tags.into_iter().map(str::to_owned).collect(),
+        transport:              Some(serde_json::json!({
+            "url": "",
+            "interval_secs": 60,
+            "headers": {},
+            "venue": venue,
+            "symbols": [],
+            "timeframes": [],
+            "max_candles_per_poll": 1000
+        })),
+        auth:                   None,
+        requires_configuration: true,
+        setup_hint:             Some(setup_hint.to_owned()),
     }
 }

--- a/crates/extensions/rara-trading/src/feed/catalog.rs
+++ b/crates/extensions/rara-trading/src/feed/catalog.rs
@@ -1,0 +1,102 @@
+// Copyright 2026 Rararulab
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Built-in finance feed source catalog.
+//!
+//! The catalog contains only sources that rara can enable without additional
+//! operator secrets or provider adapters. Market-candle feeds stay manually
+//! configured until an operator supplies a normalized candle endpoint.
+
+use rara_kernel::data_feed::{AuthConfig, FeedType};
+use serde::Serialize;
+
+#[derive(Debug, Clone, Serialize)]
+pub struct DefaultFeedSource {
+    pub id:          String,
+    pub name:        String,
+    pub description: String,
+    pub feed_type:   FeedType,
+    pub tags:        Vec<String>,
+    pub transport:   serde_json::Value,
+    pub auth:        Option<AuthConfig>,
+}
+
+impl DefaultFeedSource {
+    #[must_use]
+    pub fn feed_name(&self) -> String { format!("finance-{}", self.id) }
+}
+
+#[must_use]
+pub fn default_finance_feed_sources() -> Vec<DefaultFeedSource> {
+    vec![
+        rss_source(
+            "fed-press-releases",
+            "Federal Reserve Press Releases",
+            "Official Federal Reserve Board press releases.",
+            "https://www.federalreserve.gov/feeds/press_all.xml",
+            ["finance", "news", "fed", "macro"],
+            300,
+        ),
+        rss_source(
+            "fed-h15-announcements",
+            "Federal Reserve H.15 Announcements",
+            "Announcements for selected interest rates published through the Fed Data Download \
+             Program.",
+            "https://www.federalreserve.gov/feeds/h15.xml",
+            ["finance", "rates", "fed", "macro"],
+            900,
+        ),
+        rss_source(
+            "fed-h10-announcements",
+            "Federal Reserve H.10 Announcements",
+            "Announcements for foreign exchange rates published through the Fed Data Download \
+             Program.",
+            "https://www.federalreserve.gov/feeds/h10.xml",
+            ["finance", "fx", "fed", "macro"],
+            900,
+        ),
+        rss_source(
+            "sec-press-releases",
+            "SEC Press Releases",
+            "Official U.S. Securities and Exchange Commission press releases.",
+            "https://www.sec.gov/news/pressreleases.rss",
+            ["finance", "news", "sec", "regulatory"],
+            300,
+        ),
+    ]
+}
+
+fn rss_source(
+    id: &str,
+    name: &str,
+    description: &str,
+    url: &str,
+    tags: impl IntoIterator<Item = &'static str>,
+    interval_secs: u64,
+) -> DefaultFeedSource {
+    DefaultFeedSource {
+        id:          id.to_owned(),
+        name:        name.to_owned(),
+        description: description.to_owned(),
+        feed_type:   FeedType::Rss,
+        tags:        tags.into_iter().map(str::to_owned).collect(),
+        transport:   serde_json::json!({
+            "url": url,
+            "interval_secs": interval_secs,
+            "headers": {},
+            "max_entries_per_poll": 50
+        }),
+        auth:        None,
+    }
+}

--- a/crates/extensions/rara-trading/src/feed/market_candle.rs
+++ b/crates/extensions/rara-trading/src/feed/market_candle.rs
@@ -1,0 +1,554 @@
+// Copyright 2026 Rararulab
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Config-driven latest market candle data feed.
+//!
+//! This transport fetches an operator-managed normalized candle endpoint and
+//! emits one `market_candle_closed` event per closed bar.
+
+use std::{
+    collections::{HashMap, HashSet},
+    str::FromStr,
+    sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    },
+    time::Duration,
+};
+
+use async_trait::async_trait;
+use jiff::Timestamp;
+use rara_kernel::data_feed::{
+    AuthConfig, DataFeed, DataFeedConfig, FeedEvent, FeedEventId, FeedStatus, StatusReporterRef,
+    polling::apply_request_auth,
+};
+use reqwest::{
+    Url,
+    header::{HeaderName, HeaderValue},
+};
+use rust_decimal::Decimal;
+use serde::Deserialize;
+use tokio::sync::mpsc;
+use tokio_util::sync::CancellationToken;
+use tracing::{debug, info, instrument, warn};
+
+const MAX_CANDLES_PER_POLL: usize = 10_000;
+const MAX_BODY_BYTES: usize = 4 * 1024 * 1024;
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct MarketCandleTransport {
+    pub url:                  String,
+    pub interval_secs:        u64,
+    #[serde(default)]
+    pub headers:              HashMap<String, String>,
+    pub venue:                String,
+    pub symbols:              Vec<String>,
+    pub timeframes:           Vec<String>,
+    pub max_candles_per_poll: usize,
+}
+
+pub struct MarketCandleSource {
+    name:       String,
+    tags:       Vec<String>,
+    transport:  MarketCandleTransport,
+    auth:       Option<AuthConfig>,
+    client:     reqwest::Client,
+    reporter:   Option<StatusReporterRef>,
+    in_error:   Arc<AtomicBool>,
+    symbols:    HashSet<String>,
+    timeframes: HashSet<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct CandleBatch {
+    candles: Vec<RawCandle>,
+}
+
+#[derive(Debug, Deserialize)]
+struct RawCandle {
+    venue:      String,
+    symbol:     String,
+    timeframe:  String,
+    open_time:  String,
+    close_time: String,
+    open:       String,
+    high:       String,
+    low:        String,
+    close:      String,
+    volume:     String,
+    closed:     bool,
+}
+
+struct ParsedCandle {
+    venue:      String,
+    symbol:     String,
+    timeframe:  String,
+    open_time:  String,
+    close_time: String,
+    open:       Decimal,
+    high:       Decimal,
+    low:        Decimal,
+    close:      Decimal,
+    volume:     Decimal,
+}
+
+impl MarketCandleSource {
+    pub fn from_config(config: &DataFeedConfig) -> anyhow::Result<Self> {
+        let transport: MarketCandleTransport = serde_json::from_value(config.transport.clone())?;
+        validate_transport(&transport)?;
+        let client = reqwest::Client::builder()
+            .connect_timeout(Duration::from_secs(10))
+            .timeout(Duration::from_secs(30))
+            .build()?;
+        let symbols = transport.symbols.iter().cloned().collect();
+        let timeframes = transport.timeframes.iter().cloned().collect();
+        Ok(Self {
+            name: config.name.clone(),
+            tags: config.tags.clone(),
+            transport,
+            auth: config.auth.clone(),
+            client,
+            reporter: None,
+            in_error: Arc::new(AtomicBool::new(false)),
+            symbols,
+            timeframes,
+        })
+    }
+
+    #[must_use]
+    pub fn with_reporter(mut self, reporter: StatusReporterRef) -> Self {
+        self.reporter = Some(reporter);
+        self
+    }
+
+    fn build_url(&self) -> anyhow::Result<Url> {
+        let mut url = Url::parse(&self.transport.url)?;
+        if let Some(AuthConfig::Query {
+            ref name,
+            ref value,
+        }) = self.auth
+        {
+            url.query_pairs_mut().append_pair(name, value);
+        }
+        Ok(url)
+    }
+
+    fn record_error(&self, message: String) {
+        let was_in_error = self.in_error.swap(true, Ordering::SeqCst);
+        if was_in_error {
+            debug!(feed = %self.name, error = %message, "market candle fetch failed");
+        } else {
+            warn!(feed = %self.name, error = %message, "market candle fetch failed");
+            if let Some(reporter) = self.reporter.clone() {
+                let name = self.name.clone();
+                tokio::spawn(async move {
+                    reporter
+                        .report(&name, FeedStatus::Error, Some(message))
+                        .await;
+                });
+            }
+        }
+    }
+
+    fn record_success(&self) {
+        if self.in_error.swap(false, Ordering::SeqCst) {
+            info!(feed = %self.name, "market candle feed recovered");
+            if let Some(reporter) = self.reporter.clone() {
+                let name = self.name.clone();
+                tokio::spawn(async move {
+                    reporter.report(&name, FeedStatus::Running, None).await;
+                });
+            }
+        }
+    }
+
+    fn parse_candle_events(&self, body: &[u8]) -> anyhow::Result<Vec<FeedEvent>> {
+        let batch: CandleBatch = serde_json::from_slice(body)?;
+        let received_at = Timestamp::now();
+        let mut events = Vec::new();
+
+        for raw in batch
+            .candles
+            .into_iter()
+            .take(self.transport.max_candles_per_poll)
+        {
+            let Some(candle) = self.parse_raw_candle(raw) else {
+                continue;
+            };
+            let mut tags = self.tags.clone();
+            tags.extend([
+                "finance".to_owned(),
+                "market-data".to_owned(),
+                format!("source:{}", self.name),
+                format!("venue:{}", candle.venue),
+                format!("symbol:{}", candle.symbol),
+                format!("timeframe:{}", candle.timeframe),
+            ]);
+            dedupe_sort(&mut tags);
+
+            let payload = serde_json::json!({
+                "venue": candle.venue,
+                "symbol": candle.symbol,
+                "timeframe": candle.timeframe,
+                "open_time": candle.open_time,
+                "close_time": candle.close_time,
+                "open": candle.open.to_string(),
+                "high": candle.high.to_string(),
+                "low": candle.low.to_string(),
+                "close": candle.close.to_string(),
+                "volume": candle.volume.to_string(),
+            });
+
+            let identity = format!(
+                "{}:{}:{}:{}:{}",
+                self.name,
+                payload["venue"].as_str().unwrap_or_default(),
+                payload["symbol"].as_str().unwrap_or_default(),
+                payload["timeframe"].as_str().unwrap_or_default(),
+                payload["open_time"].as_str().unwrap_or_default()
+            );
+
+            events.push(
+                FeedEvent::builder()
+                    .id(FeedEventId::deterministic(&identity))
+                    .source_name(self.name.clone())
+                    .event_type("market_candle_closed".to_owned())
+                    .tags(tags)
+                    .payload(payload)
+                    .received_at(received_at)
+                    .build(),
+            );
+        }
+
+        Ok(events)
+    }
+
+    fn parse_raw_candle(&self, raw: RawCandle) -> Option<ParsedCandle> {
+        if !raw.closed {
+            return None;
+        }
+        if raw.venue != self.transport.venue {
+            return None;
+        }
+        if !self.symbols.contains(&raw.symbol) || !self.timeframes.contains(&raw.timeframe) {
+            return None;
+        }
+        Some(ParsedCandle {
+            venue:      raw.venue,
+            symbol:     raw.symbol,
+            timeframe:  raw.timeframe,
+            open_time:  raw.open_time,
+            close_time: raw.close_time,
+            open:       Decimal::from_str(&raw.open).ok()?,
+            high:       Decimal::from_str(&raw.high).ok()?,
+            low:        Decimal::from_str(&raw.low).ok()?,
+            close:      Decimal::from_str(&raw.close).ok()?,
+            volume:     Decimal::from_str(&raw.volume).ok()?,
+        })
+    }
+
+    async fn poll_once(&self, tx: &mpsc::Sender<FeedEvent>) -> bool {
+        let url = match self.build_url() {
+            Ok(url) => url,
+            Err(err) => {
+                self.record_error(format!("failed to build market candle URL: {err}"));
+                return true;
+            }
+        };
+
+        let mut request = self.client.get(url);
+        for (key, value) in &self.transport.headers {
+            request = request.header(key.as_str(), value.as_str());
+        }
+        request = apply_request_auth(request, &self.auth);
+
+        let response = match request.send().await {
+            Ok(response) => response,
+            Err(err) => {
+                self.record_error(format!("market candle fetch failed: {err}"));
+                return true;
+            }
+        };
+
+        let status = response.status();
+        if !status.is_success() {
+            self.record_error(format!(
+                "market candle fetch received non-success status: {status}"
+            ));
+            return true;
+        }
+
+        let body = match response.bytes().await {
+            Ok(body) => body,
+            Err(err) => {
+                self.record_error(format!("failed to read market candle body: {err}"));
+                return true;
+            }
+        };
+        if body.len() > MAX_BODY_BYTES {
+            self.record_error(format!(
+                "market candle response exceeded {MAX_BODY_BYTES} bytes"
+            ));
+            return true;
+        }
+
+        let events = match self.parse_candle_events(&body) {
+            Ok(events) => events,
+            Err(err) => {
+                self.record_error(format!("failed to parse market candle response: {err}"));
+                return true;
+            }
+        };
+        for event in events {
+            if tx.send(event).await.is_err() {
+                tracing::info!("event channel closed, stopping market candle loop");
+                return false;
+            }
+        }
+
+        self.record_success();
+        true
+    }
+}
+
+#[async_trait]
+impl DataFeed for MarketCandleSource {
+    fn name(&self) -> &str { &self.name }
+
+    fn tags(&self) -> &[String] { &self.tags }
+
+    #[instrument(skip_all, fields(feed = %self.name))]
+    async fn run(
+        &self,
+        tx: mpsc::Sender<FeedEvent>,
+        cancel: CancellationToken,
+    ) -> anyhow::Result<()> {
+        let interval = Duration::from_secs(self.transport.interval_secs);
+        tracing::info!(
+            url = %self.transport.url,
+            ?interval,
+            "market candle feed started"
+        );
+
+        let mut interval_timer = tokio::time::interval(interval);
+        interval_timer.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+
+        loop {
+            tokio::select! {
+                () = cancel.cancelled() => {
+                    tracing::info!("market candle feed cancelled, shutting down");
+                    break;
+                }
+                _ = interval_timer.tick() => {
+                    if !self.poll_once(&tx).await {
+                        break;
+                    }
+                }
+            }
+        }
+
+        Ok(())
+    }
+}
+
+fn validate_transport(transport: &MarketCandleTransport) -> anyhow::Result<()> {
+    let url = Url::parse(&transport.url)?;
+    anyhow::ensure!(url.scheme() == "https", "market candle URL must use HTTPS");
+    anyhow::ensure!(
+        transport.interval_secs > 0,
+        "market candle interval_secs must be greater than zero"
+    );
+    anyhow::ensure!(
+        !transport.venue.is_empty(),
+        "market candle venue is required"
+    );
+    anyhow::ensure!(
+        !transport.symbols.is_empty(),
+        "market candle symbols must not be empty"
+    );
+    anyhow::ensure!(
+        !transport.timeframes.is_empty(),
+        "market candle timeframes must not be empty"
+    );
+    anyhow::ensure!(
+        transport.max_candles_per_poll > 0,
+        "market candle max_candles_per_poll must be greater than zero"
+    );
+    anyhow::ensure!(
+        transport.max_candles_per_poll <= MAX_CANDLES_PER_POLL,
+        "market candle max_candles_per_poll must be <= {MAX_CANDLES_PER_POLL}"
+    );
+    for (name, value) in &transport.headers {
+        HeaderName::from_bytes(name.as_bytes())?;
+        HeaderValue::from_str(value)?;
+    }
+    Ok(())
+}
+
+fn dedupe_sort(values: &mut Vec<String>) {
+    let mut seen = HashSet::new();
+    values.retain(|value| seen.insert(value.clone()));
+    values.sort();
+}
+
+#[cfg(test)]
+mod tests {
+    use rara_kernel::data_feed::{DataFeedConfig, FeedStatus, FeedType};
+
+    use super::MarketCandleSource;
+
+    fn candle_source() -> MarketCandleSource {
+        let config = DataFeedConfig::builder()
+            .id("candles-test".to_owned())
+            .name("binance-spot".to_owned())
+            .feed_type(FeedType::MarketCandle)
+            .tags(vec!["finance".to_owned(), "crypto".to_owned()])
+            .transport(serde_json::json!({
+                "url": "https://market-data.example/candles/latest",
+                "interval_secs": 60,
+                "venue": "binance",
+                "symbols": ["BTCUSDT", "ETHUSDT"],
+                "timeframes": ["15m", "1h"],
+                "max_candles_per_poll": 1000
+            }))
+            .enabled(true)
+            .status(FeedStatus::Idle)
+            .created_at(jiff::Timestamp::UNIX_EPOCH)
+            .updated_at(jiff::Timestamp::UNIX_EPOCH)
+            .build();
+
+        MarketCandleSource::from_config(&config).expect("market candle config should parse")
+    }
+
+    #[test]
+    fn closed_candles_for_many_symbols_become_batched_events() {
+        let source = candle_source();
+        let events = source
+            .parse_candle_events(
+                br#"{
+  "candles": [
+    {
+      "venue": "binance",
+      "symbol": "BTCUSDT",
+      "timeframe": "15m",
+      "open_time": "2026-07-10T08:15:00Z",
+      "close_time": "2026-07-10T08:30:00Z",
+      "open": "61500.12",
+      "high": "61640.00",
+      "low": "61480.50",
+      "close": "61610.30",
+      "volume": "124.551",
+      "closed": true
+    },
+    {
+      "venue": "binance",
+      "symbol": "ETHUSDT",
+      "timeframe": "15m",
+      "open_time": "2026-07-10T08:15:00Z",
+      "close_time": "2026-07-10T08:30:00Z",
+      "open": "3500.00",
+      "high": "3510.00",
+      "low": "3490.00",
+      "close": "3505.25",
+      "volume": "991.5",
+      "closed": true
+    }
+  ]
+}"#,
+            )
+            .expect("candles should parse");
+
+        assert_eq!(events.len(), 2);
+        let event = &events[0];
+        assert_eq!(event.source_name, "binance-spot");
+        assert_eq!(event.event_type, "market_candle_closed");
+        assert!(event.tags.contains(&"finance".to_owned()));
+        assert!(event.tags.contains(&"market-data".to_owned()));
+        assert!(event.tags.contains(&"source:binance-spot".to_owned()));
+        assert!(event.tags.contains(&"venue:binance".to_owned()));
+        assert!(event.tags.contains(&"symbol:BTCUSDT".to_owned()));
+        assert!(event.tags.contains(&"timeframe:15m".to_owned()));
+        assert_eq!(event.payload["open"], "61500.12");
+        assert_eq!(event.payload["close"], "61610.30");
+        assert_eq!(event.payload["volume"], "124.551");
+    }
+
+    #[test]
+    fn same_candle_has_same_event_id_across_polls() {
+        let source = candle_source();
+        let body = br#"{
+  "candles": [
+    {
+      "venue": "binance",
+      "symbol": "BTCUSDT",
+      "timeframe": "15m",
+      "open_time": "2026-07-10T08:15:00Z",
+      "close_time": "2026-07-10T08:30:00Z",
+      "open": "61500.12",
+      "high": "61640.00",
+      "low": "61480.50",
+      "close": "61610.30",
+      "volume": "124.551",
+      "closed": true
+    }
+  ]
+}"#;
+
+        let first = source.parse_candle_events(body).expect("first parse");
+        let second = source.parse_candle_events(body).expect("second parse");
+
+        assert_eq!(first[0].id, second[0].id);
+    }
+
+    #[test]
+    fn open_or_invalid_decimal_candles_are_not_emitted() {
+        let source = candle_source();
+        let events = source
+            .parse_candle_events(
+                br#"{
+  "candles": [
+    {
+      "venue": "binance",
+      "symbol": "BTCUSDT",
+      "timeframe": "15m",
+      "open_time": "2026-07-10T08:15:00Z",
+      "close_time": "2026-07-10T08:30:00Z",
+      "open": "61500.12",
+      "high": "61640.00",
+      "low": "61480.50",
+      "close": "61610.30",
+      "volume": "124.551",
+      "closed": false
+    },
+    {
+      "venue": "binance",
+      "symbol": "ETHUSDT",
+      "timeframe": "15m",
+      "open_time": "2026-07-10T08:15:00Z",
+      "close_time": "2026-07-10T08:30:00Z",
+      "open": "not-a-decimal",
+      "high": "3510.00",
+      "low": "3490.00",
+      "close": "3505.25",
+      "volume": "991.5",
+      "closed": true
+    }
+  ]
+}"#,
+            )
+            .expect("payload should parse while invalid candles are skipped");
+
+        assert!(events.is_empty());
+    }
+}

--- a/crates/extensions/rara-trading/src/feed/mod.rs
+++ b/crates/extensions/rara-trading/src/feed/mod.rs
@@ -14,5 +14,6 @@
 
 //! Finance-oriented feed sources.
 
+pub mod catalog;
 pub mod market_candle;
 pub mod rss;

--- a/crates/extensions/rara-trading/src/feed/mod.rs
+++ b/crates/extensions/rara-trading/src/feed/mod.rs
@@ -1,0 +1,18 @@
+// Copyright 2026 Rararulab
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Finance-oriented feed sources.
+
+pub mod market_candle;
+pub mod rss;

--- a/crates/extensions/rara-trading/src/feed/rss.rs
+++ b/crates/extensions/rara-trading/src/feed/rss.rs
@@ -1,0 +1,483 @@
+// Copyright 2026 Rararulab
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Config-driven RSS/Atom data feed.
+//!
+//! This transport fetches an operator-configured feed URL and emits one
+//! normalised `rss_article` event per feed item.
+
+use std::{
+    collections::{HashMap, HashSet},
+    sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    },
+    time::Duration,
+};
+
+use async_trait::async_trait;
+use jiff::Timestamp;
+use rara_kernel::data_feed::{
+    AuthConfig, DataFeed, DataFeedConfig, FeedEvent, FeedEventId, FeedStatus, StatusReporterRef,
+    polling::apply_request_auth,
+};
+use reqwest::{
+    Url,
+    header::{HeaderName, HeaderValue},
+};
+use serde::Deserialize;
+use tokio::sync::mpsc;
+use tokio_util::sync::CancellationToken;
+use tracing::{debug, info, instrument, warn};
+
+const MAX_ENTRIES_PER_POLL: usize = 500;
+const MAX_BODY_BYTES: usize = 2 * 1024 * 1024;
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct RssTransport {
+    pub url:                  String,
+    pub interval_secs:        u64,
+    #[serde(default)]
+    pub headers:              HashMap<String, String>,
+    pub max_entries_per_poll: usize,
+}
+
+pub struct RssSource {
+    name:      String,
+    tags:      Vec<String>,
+    transport: RssTransport,
+    auth:      Option<AuthConfig>,
+    client:    reqwest::Client,
+    reporter:  Option<StatusReporterRef>,
+    in_error:  Arc<AtomicBool>,
+}
+
+impl RssSource {
+    pub fn from_config(config: &DataFeedConfig) -> anyhow::Result<Self> {
+        let transport: RssTransport = serde_json::from_value(config.transport.clone())?;
+        validate_transport(&transport)?;
+        let client = reqwest::Client::builder()
+            .connect_timeout(Duration::from_secs(10))
+            .timeout(Duration::from_secs(30))
+            .build()?;
+        Ok(Self {
+            name: config.name.clone(),
+            tags: config.tags.clone(),
+            transport,
+            auth: config.auth.clone(),
+            client,
+            reporter: None,
+            in_error: Arc::new(AtomicBool::new(false)),
+        })
+    }
+
+    #[must_use]
+    pub fn with_reporter(mut self, reporter: StatusReporterRef) -> Self {
+        self.reporter = Some(reporter);
+        self
+    }
+
+    fn build_url(&self) -> anyhow::Result<Url> {
+        let mut url = Url::parse(&self.transport.url)?;
+        if let Some(AuthConfig::Query {
+            ref name,
+            ref value,
+        }) = self.auth
+        {
+            url.query_pairs_mut().append_pair(name, value);
+        }
+        Ok(url)
+    }
+
+    fn record_error(&self, message: String) {
+        let was_in_error = self.in_error.swap(true, Ordering::SeqCst);
+        if was_in_error {
+            debug!(feed = %self.name, error = %message, "rss fetch failed");
+        } else {
+            warn!(feed = %self.name, error = %message, "rss fetch failed");
+            if let Some(reporter) = self.reporter.clone() {
+                let name = self.name.clone();
+                tokio::spawn(async move {
+                    reporter
+                        .report(&name, FeedStatus::Error, Some(message))
+                        .await;
+                });
+            }
+        }
+    }
+
+    fn record_success(&self) {
+        if self.in_error.swap(false, Ordering::SeqCst) {
+            info!(feed = %self.name, "rss feed recovered");
+            if let Some(reporter) = self.reporter.clone() {
+                let name = self.name.clone();
+                tokio::spawn(async move {
+                    reporter.report(&name, FeedStatus::Running, None).await;
+                });
+            }
+        }
+    }
+
+    fn parse_feed_events(&self, body: &[u8]) -> anyhow::Result<Vec<FeedEvent>> {
+        let feed = feed_rs::parser::parse(body)?;
+        let received_at = Timestamp::now();
+        let mut events = Vec::new();
+
+        for entry in feed
+            .entries
+            .into_iter()
+            .take(self.transport.max_entries_per_poll)
+        {
+            let url = entry.links.first().map(|link| link.href.clone());
+            let title = entry.title.map(|text| text.content).unwrap_or_default();
+            let summary = entry.summary.map(|text| text.content).unwrap_or_default();
+            let author = entry
+                .authors
+                .first()
+                .map(|person| person.email.clone().unwrap_or_else(|| person.name.clone()));
+            let published_at = entry.published.map(|published| published.to_rfc3339());
+            let categories: Vec<String> = entry
+                .categories
+                .iter()
+                .map(|category| {
+                    category
+                        .label
+                        .clone()
+                        .unwrap_or_else(|| category.term.clone())
+                })
+                .filter(|category| !category.trim().is_empty())
+                .collect();
+
+            let identity = entry_identity(&entry.id, url.as_deref(), &title, &summary);
+            let mut tags = self.tags.clone();
+            tags.push(format!("source:{}", self.name));
+            for category in &categories {
+                let tag = normalize_tag(category);
+                if !tag.is_empty() {
+                    tags.push(format!("category:{tag}"));
+                }
+            }
+            dedupe_sort(&mut tags);
+
+            let payload = serde_json::json!({
+                "title": title,
+                "url": url,
+                "summary": summary,
+                "author": author,
+                "published_at": published_at,
+                "categories": categories,
+            });
+
+            events.push(
+                FeedEvent::builder()
+                    .id(FeedEventId::deterministic(&format!(
+                        "{}:{identity}",
+                        self.transport.url
+                    )))
+                    .source_name(self.name.clone())
+                    .event_type("rss_article".to_owned())
+                    .tags(tags)
+                    .payload(payload)
+                    .received_at(received_at)
+                    .build(),
+            );
+        }
+
+        Ok(events)
+    }
+
+    async fn poll_once(&self, tx: &mpsc::Sender<FeedEvent>) -> bool {
+        let url = match self.build_url() {
+            Ok(url) => url,
+            Err(err) => {
+                self.record_error(format!("failed to build RSS URL: {err}"));
+                return true;
+            }
+        };
+
+        let mut request = self.client.get(url);
+        for (key, value) in &self.transport.headers {
+            request = request.header(key.as_str(), value.as_str());
+        }
+        request = apply_request_auth(request, &self.auth);
+
+        let response = match request.send().await {
+            Ok(response) => response,
+            Err(err) => {
+                self.record_error(format!("RSS fetch failed: {err}"));
+                return true;
+            }
+        };
+
+        let status = response.status();
+        if !status.is_success() {
+            self.record_error(format!("RSS fetch received non-success status: {status}"));
+            return true;
+        }
+
+        let body = match response.bytes().await {
+            Ok(body) => body,
+            Err(err) => {
+                self.record_error(format!("failed to read RSS response body: {err}"));
+                return true;
+            }
+        };
+        if body.len() > MAX_BODY_BYTES {
+            self.record_error(format!("RSS response exceeded {MAX_BODY_BYTES} bytes"));
+            return true;
+        }
+
+        let events = match self.parse_feed_events(&body) {
+            Ok(events) => events,
+            Err(err) => {
+                self.record_error(format!("failed to parse RSS response: {err}"));
+                return true;
+            }
+        };
+
+        for event in events {
+            if tx.send(event).await.is_err() {
+                tracing::info!("event channel closed, stopping rss loop");
+                return false;
+            }
+        }
+
+        self.record_success();
+        true
+    }
+}
+
+#[async_trait]
+impl DataFeed for RssSource {
+    fn name(&self) -> &str { &self.name }
+
+    fn tags(&self) -> &[String] { &self.tags }
+
+    #[instrument(skip_all, fields(feed = %self.name))]
+    async fn run(
+        &self,
+        tx: mpsc::Sender<FeedEvent>,
+        cancel: CancellationToken,
+    ) -> anyhow::Result<()> {
+        let interval = Duration::from_secs(self.transport.interval_secs);
+        tracing::info!(url = %self.transport.url, ?interval, "rss feed started");
+
+        let mut interval_timer = tokio::time::interval(interval);
+        interval_timer.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+
+        loop {
+            tokio::select! {
+                () = cancel.cancelled() => {
+                    tracing::info!("rss feed cancelled, shutting down");
+                    break;
+                }
+                _ = interval_timer.tick() => {
+                    if !self.poll_once(&tx).await {
+                        break;
+                    }
+                }
+            }
+        }
+
+        Ok(())
+    }
+}
+
+fn validate_transport(transport: &RssTransport) -> anyhow::Result<()> {
+    let url = Url::parse(&transport.url)?;
+    anyhow::ensure!(url.scheme() == "https", "RSS feed URL must use HTTPS");
+    anyhow::ensure!(
+        transport.interval_secs > 0,
+        "RSS interval_secs must be greater than zero"
+    );
+    anyhow::ensure!(
+        transport.max_entries_per_poll > 0,
+        "RSS max_entries_per_poll must be greater than zero"
+    );
+    anyhow::ensure!(
+        transport.max_entries_per_poll <= MAX_ENTRIES_PER_POLL,
+        "RSS max_entries_per_poll must be <= {MAX_ENTRIES_PER_POLL}"
+    );
+    for (name, value) in &transport.headers {
+        HeaderName::from_bytes(name.as_bytes())?;
+        HeaderValue::from_str(value)?;
+    }
+    Ok(())
+}
+
+fn entry_identity(id: &str, url: Option<&str>, title: &str, summary: &str) -> String {
+    let id = id.trim();
+    if !id.is_empty() && !looks_generated_id(id) {
+        return id.to_owned();
+    }
+    if let Some(url) = url.filter(|url| !url.trim().is_empty()) {
+        return url.to_owned();
+    }
+    let content_identity = format!("{}:{}", title.trim(), summary.trim());
+    if content_identity != ":" {
+        return content_identity;
+    }
+    id.to_owned()
+}
+
+fn looks_generated_id(id: &str) -> bool {
+    id.starts_with("urn:uuid:") || uuid::Uuid::parse_str(id).is_ok()
+}
+
+fn normalize_tag(value: &str) -> String {
+    let mut out = String::new();
+    let mut last_dash = false;
+    for ch in value.chars().flat_map(char::to_lowercase) {
+        if ch.is_ascii_alphanumeric() {
+            out.push(ch);
+            last_dash = false;
+        } else if !last_dash && !out.is_empty() {
+            out.push('-');
+            last_dash = true;
+        }
+    }
+    if last_dash {
+        out.pop();
+    }
+    out
+}
+
+fn dedupe_sort(values: &mut Vec<String>) {
+    let mut seen = HashSet::new();
+    values.retain(|value| seen.insert(value.clone()));
+    values.sort();
+}
+
+#[cfg(test)]
+mod tests {
+    use rara_kernel::data_feed::{DataFeedConfig, FeedStatus, FeedType};
+
+    use super::RssSource;
+
+    fn rss_source() -> RssSource {
+        let config = DataFeedConfig::builder()
+            .id("rss-test".to_owned())
+            .name("fed-news".to_owned())
+            .feed_type(FeedType::Rss)
+            .tags(vec!["finance".to_owned(), "macro".to_owned()])
+            .transport(serde_json::json!({
+                "url": "https://example.com/feed.xml",
+                "interval_secs": 300,
+                "max_entries_per_poll": 20
+            }))
+            .enabled(true)
+            .status(FeedStatus::Idle)
+            .created_at(jiff::Timestamp::UNIX_EPOCH)
+            .updated_at(jiff::Timestamp::UNIX_EPOCH)
+            .build();
+
+        RssSource::from_config(&config).expect("rss config should parse")
+    }
+
+    #[test]
+    fn rss_item_becomes_one_normalized_article_event() {
+        let source = rss_source();
+        let events = source
+            .parse_feed_events(
+                br#"<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0">
+  <channel>
+    <title>Fed News</title>
+    <item>
+      <guid>fed-guid-1</guid>
+      <title>Fed holds rates</title>
+      <link>https://example.com/fed-holds-rates</link>
+      <description>Policy summary</description>
+      <author>press@example.com</author>
+      <pubDate>Fri, 10 Jul 2026 08:30:00 GMT</pubDate>
+      <category>Monetary Policy</category>
+    </item>
+  </channel>
+</rss>"#,
+            )
+            .expect("feed should parse");
+
+        assert_eq!(events.len(), 1);
+        let event = &events[0];
+        assert_eq!(event.source_name, "fed-news");
+        assert_eq!(event.event_type, "rss_article");
+        assert!(event.tags.contains(&"finance".to_owned()));
+        assert!(event.tags.contains(&"source:fed-news".to_owned()));
+        assert!(event.tags.contains(&"category:monetary-policy".to_owned()));
+        assert_eq!(event.payload["title"], "Fed holds rates");
+        assert_eq!(event.payload["url"], "https://example.com/fed-holds-rates");
+        assert_eq!(event.payload["summary"], "Policy summary");
+        assert_eq!(event.payload["author"], "press@example.com");
+        assert_eq!(event.payload["categories"][0], "Monetary Policy");
+    }
+
+    #[test]
+    fn same_guid_has_same_event_id_across_polls() {
+        let source = rss_source();
+        let body = br#"<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0">
+  <channel>
+    <title>Fed News</title>
+    <item>
+      <guid>stable-guid</guid>
+      <title>Stable item</title>
+      <link>https://example.com/stable</link>
+    </item>
+  </channel>
+</rss>"#;
+
+        let first = source.parse_feed_events(body).expect("first parse");
+        let second = source.parse_feed_events(body).expect("second parse");
+
+        assert_eq!(first[0].id, second[0].id);
+    }
+
+    #[test]
+    fn missing_guid_uses_link_then_content_fallback() {
+        let source = rss_source();
+        let with_link = br#"<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0">
+  <channel>
+    <title>Fed News</title>
+    <item>
+      <title>Link fallback</title>
+      <link>https://example.com/link-fallback</link>
+    </item>
+  </channel>
+</rss>"#;
+        let content_only = br#"<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0">
+  <channel>
+    <title>Fed News</title>
+    <item>
+      <title>Content fallback</title>
+      <description>No link or guid</description>
+    </item>
+  </channel>
+</rss>"#;
+
+        let link_first = source.parse_feed_events(with_link).expect("link first");
+        let link_second = source.parse_feed_events(with_link).expect("link second");
+        let content_first = source
+            .parse_feed_events(content_only)
+            .expect("content first");
+        let content_second = source
+            .parse_feed_events(content_only)
+            .expect("content second");
+
+        assert_eq!(link_first[0].id, link_second[0].id);
+        assert_eq!(content_first[0].id, content_second[0].id);
+        assert_ne!(link_first[0].id, content_first[0].id);
+    }
+}

--- a/crates/extensions/rara-trading/src/finance/mod.rs
+++ b/crates/extensions/rara-trading/src/finance/mod.rs
@@ -1,0 +1,18 @@
+// Copyright 2026 Rararulab
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Conversation-native finance information subscriptions.
+
+pub mod registry;
+pub mod tools;

--- a/crates/extensions/rara-trading/src/finance/registry.rs
+++ b/crates/extensions/rara-trading/src/finance/registry.rs
@@ -1,0 +1,705 @@
+// Copyright 2026 Rararulab
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::{
+    collections::{HashMap, HashSet},
+    path::PathBuf,
+    sync::{
+        Arc,
+        atomic::{AtomicI64, Ordering},
+    },
+};
+
+use jiff::{SignedDuration, Timestamp};
+use rara_kernel::{
+    data_feed::{FeedEvent, FeedEventId},
+    identity::UserId,
+    session::SessionKey,
+};
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use tokio::sync::RwLock;
+use tracing::warn;
+use uuid::Uuid;
+
+/// Finance event kinds supported by the MVP.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum FinanceEventKind {
+    RssArticle,
+    MarketCandleClosed,
+}
+
+impl FinanceEventKind {
+    fn from_event(event: &FeedEvent) -> Option<Self> {
+        match event.event_type.as_str() {
+            "rss_article" => Some(Self::RssArticle),
+            "market_candle_closed" => Some(Self::MarketCandleClosed),
+            _ => None,
+        }
+    }
+}
+
+/// Requested delivery policy.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum FinanceDelivery {
+    Immediate,
+    Silent,
+}
+
+/// Actual delivery action after budget/cooldown enforcement.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum FinanceDeliveryAction {
+    Immediate,
+    Silent,
+}
+
+/// User subscription to finance information events.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FinanceSubscription {
+    pub id:                     Uuid,
+    pub owner:                  UserId,
+    pub session_key:            SessionKey,
+    pub event_kinds:            Vec<FinanceEventKind>,
+    pub source_names:           Vec<String>,
+    pub category_tags:          Vec<String>,
+    pub watch_terms:            Vec<String>,
+    pub venues:                 Vec<String>,
+    pub symbols:                Vec<String>,
+    pub timeframes:             Vec<String>,
+    pub delivery:               FinanceDelivery,
+    pub cooldown_secs:          u64,
+    pub max_immediate_per_hour: u16,
+}
+
+/// Match decision returned by the registry. Side effects are left to the app.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FinanceDeliveryDecision {
+    pub subscription_id:   Uuid,
+    pub owner:             UserId,
+    pub session_key:       SessionKey,
+    pub event_id:          FeedEventId,
+    pub action:            FinanceDeliveryAction,
+    pub downgraded_reason: Option<String>,
+}
+
+/// Clock abstraction for deterministic budget tests.
+pub trait FinanceClock: Send + Sync {
+    fn now(&self) -> Timestamp;
+}
+
+/// System wall-clock implementation.
+#[derive(Debug, Default)]
+pub struct SystemFinanceClock;
+
+impl FinanceClock for SystemFinanceClock {
+    fn now(&self) -> Timestamp { Timestamp::now() }
+}
+
+/// Manually controlled clock for tests.
+#[derive(Debug)]
+pub struct ManualFinanceClock {
+    seconds: AtomicI64,
+}
+
+impl ManualFinanceClock {
+    pub fn new(now: Timestamp) -> Self {
+        Self {
+            seconds: AtomicI64::new(now.as_second()),
+        }
+    }
+
+    pub fn advance(&self, delta: SignedDuration) {
+        let secs = delta.as_secs();
+        self.seconds.fetch_add(secs, Ordering::SeqCst);
+    }
+}
+
+impl FinanceClock for ManualFinanceClock {
+    fn now(&self) -> Timestamp {
+        Timestamp::from_second(self.seconds.load(Ordering::SeqCst))
+            .expect("manual test clock should stay in timestamp range")
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct DeliveryLedgerEntry {
+    subscription_id: Uuid,
+    event_id:        String,
+    delivered_at:    Timestamp,
+    action:          FinanceDeliveryAction,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+struct PersistedState {
+    subscriptions: Vec<FinanceSubscription>,
+    ledger:        Vec<DeliveryLedgerEntry>,
+}
+
+#[derive(Debug)]
+struct RegistryInner {
+    subscriptions: HashMap<Uuid, FinanceSubscription>,
+    ledger:        Vec<DeliveryLedgerEntry>,
+    path:          PathBuf,
+}
+
+/// JSON-backed finance subscription registry.
+pub struct FinanceSubscriptionRegistry {
+    inner: RwLock<RegistryInner>,
+    clock: Arc<dyn FinanceClock>,
+}
+
+impl FinanceSubscriptionRegistry {
+    /// Load a registry using the system clock.
+    #[must_use]
+    pub fn load(path: PathBuf) -> Self { Self::load_with_clock(path, Arc::new(SystemFinanceClock)) }
+
+    /// Load a registry with an injected clock.
+    #[must_use]
+    pub fn load_with_clock(path: PathBuf, clock: Arc<dyn FinanceClock>) -> Self {
+        let state = match std::fs::read_to_string(&path) {
+            Ok(content) => match serde_json::from_str::<PersistedState>(&content) {
+                Ok(state) => state,
+                Err(err) => {
+                    warn!(error = %err, path = %path.display(), "failed to parse finance subscriptions");
+                    PersistedState::default()
+                }
+            },
+            Err(_) => PersistedState::default(),
+        };
+
+        Self {
+            inner: RwLock::new(RegistryInner {
+                subscriptions: state
+                    .subscriptions
+                    .into_iter()
+                    .map(|subscription| (subscription.id, normalize_subscription(subscription)))
+                    .collect(),
+                ledger: state.ledger,
+                path,
+            }),
+            clock,
+        }
+    }
+
+    /// Insert or replace a subscription, then persist state.
+    pub async fn upsert(&self, subscription: FinanceSubscription) -> anyhow::Result<Uuid> {
+        let subscription = normalize_subscription(subscription);
+        let id = subscription.id;
+        let mut inner = self.inner.write().await;
+        inner.subscriptions.insert(id, subscription);
+        persist(&inner)?;
+        Ok(id)
+    }
+
+    /// Remove a subscription owned by `owner`.
+    pub async fn remove(&self, owner: &UserId, id: Uuid) -> anyhow::Result<bool> {
+        let mut inner = self.inner.write().await;
+        let can_remove = inner
+            .subscriptions
+            .get(&id)
+            .is_some_and(|subscription| &subscription.owner == owner);
+        if !can_remove {
+            return Ok(false);
+        }
+        inner.subscriptions.remove(&id);
+        inner.ledger.retain(|entry| entry.subscription_id != id);
+        persist(&inner)?;
+        Ok(true)
+    }
+
+    /// List subscriptions for one owner.
+    pub async fn list_for_owner(&self, owner: &UserId) -> Vec<FinanceSubscription> {
+        let inner = self.inner.read().await;
+        inner
+            .subscriptions
+            .values()
+            .filter(|subscription| &subscription.owner == owner)
+            .cloned()
+            .collect()
+    }
+
+    /// Match an incoming feed event and record delivery decisions.
+    pub async fn match_event(&self, event: &FeedEvent) -> Vec<FinanceDeliveryDecision> {
+        if !event.tags.iter().any(|tag| tag == "finance") {
+            return Vec::new();
+        }
+        let Some(kind) = FinanceEventKind::from_event(event) else {
+            return Vec::new();
+        };
+
+        let now = self.clock.now();
+        let mut inner = self.inner.write().await;
+        let event_id = event.id.to_string();
+        let mut decisions = Vec::new();
+        let mut new_ledger_entries = Vec::new();
+
+        for subscription in inner.subscriptions.values() {
+            if already_delivered(&inner.ledger, subscription.id, &event_id) {
+                continue;
+            }
+            if !matches_subscription(subscription, kind, event) {
+                continue;
+            }
+
+            let (action, downgraded_reason) = delivery_action(subscription, &inner.ledger, now);
+            decisions.push(FinanceDeliveryDecision {
+                subscription_id: subscription.id,
+                owner: subscription.owner.clone(),
+                session_key: subscription.session_key,
+                event_id: event.id.clone(),
+                action,
+                downgraded_reason: downgraded_reason.clone(),
+            });
+            new_ledger_entries.push(DeliveryLedgerEntry {
+                subscription_id: subscription.id,
+                event_id: event_id.clone(),
+                delivered_at: now,
+                action,
+            });
+        }
+
+        if !new_ledger_entries.is_empty() {
+            inner.ledger.extend(new_ledger_entries);
+            if let Err(err) = persist(&inner) {
+                warn!(error = %err, "failed to persist finance subscription decisions");
+            }
+        }
+
+        decisions
+    }
+}
+
+fn persist(inner: &RegistryInner) -> anyhow::Result<()> {
+    let state = PersistedState {
+        subscriptions: inner.subscriptions.values().cloned().collect(),
+        ledger:        inner.ledger.clone(),
+    };
+    if let Some(parent) = inner.path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    std::fs::write(&inner.path, serde_json::to_string_pretty(&state)?)?;
+    Ok(())
+}
+
+fn already_delivered(
+    ledger: &[DeliveryLedgerEntry],
+    subscription_id: Uuid,
+    event_id: &str,
+) -> bool {
+    ledger
+        .iter()
+        .any(|entry| entry.subscription_id == subscription_id && entry.event_id == event_id)
+}
+
+fn delivery_action(
+    subscription: &FinanceSubscription,
+    ledger: &[DeliveryLedgerEntry],
+    now: Timestamp,
+) -> (FinanceDeliveryAction, Option<String>) {
+    if subscription.delivery == FinanceDelivery::Silent {
+        return (FinanceDeliveryAction::Silent, None);
+    }
+
+    let immediate_entries: Vec<&DeliveryLedgerEntry> = ledger
+        .iter()
+        .filter(|entry| {
+            entry.subscription_id == subscription.id
+                && entry.action == FinanceDeliveryAction::Immediate
+                && now.duration_since(entry.delivered_at) < SignedDuration::from_secs(60 * 60)
+        })
+        .collect();
+
+    if subscription.cooldown_secs > 0
+        && immediate_entries.iter().any(|entry| {
+            now.duration_since(entry.delivered_at)
+                < SignedDuration::from_secs(subscription.cooldown_secs as i64)
+        })
+    {
+        return (FinanceDeliveryAction::Silent, Some("cooldown".to_owned()));
+    }
+
+    if immediate_entries.len() >= usize::from(subscription.max_immediate_per_hour) {
+        return (
+            FinanceDeliveryAction::Silent,
+            Some("hourly_budget".to_owned()),
+        );
+    }
+
+    (FinanceDeliveryAction::Immediate, None)
+}
+
+fn matches_subscription(
+    subscription: &FinanceSubscription,
+    kind: FinanceEventKind,
+    event: &FeedEvent,
+) -> bool {
+    group_matches(&subscription.event_kinds, &kind)
+        && string_group_matches(&subscription.source_names, &event.source_name)
+        && tags_group_matches(&subscription.category_tags, &event.tags)
+        && watch_terms_match(subscription, event)
+        && candle_fields_match(subscription, event)
+}
+
+fn group_matches<T: PartialEq>(values: &[T], actual: &T) -> bool {
+    values.is_empty() || values.iter().any(|value| value == actual)
+}
+
+fn string_group_matches(values: &[String], actual: &str) -> bool {
+    values.is_empty() || values.iter().any(|value| value == actual)
+}
+
+fn tags_group_matches(values: &[String], tags: &[String]) -> bool {
+    values.is_empty()
+        || values
+            .iter()
+            .any(|value| tags.iter().any(|tag| tag == value))
+}
+
+fn watch_terms_match(subscription: &FinanceSubscription, event: &FeedEvent) -> bool {
+    if subscription.watch_terms.is_empty() {
+        return true;
+    }
+    if event.event_type != "rss_article" {
+        return true;
+    }
+    let haystack = normalize_text(&format!(
+        "{} {}",
+        event.payload["title"].as_str().unwrap_or_default(),
+        event.payload["summary"].as_str().unwrap_or_default()
+    ));
+    subscription
+        .watch_terms
+        .iter()
+        .any(|term| haystack.contains(&normalize_text(term)))
+}
+
+fn candle_fields_match(subscription: &FinanceSubscription, event: &FeedEvent) -> bool {
+    if event.event_type != "market_candle_closed" {
+        return true;
+    }
+    let venue = event.payload["venue"].as_str().unwrap_or_default();
+    let symbol = event.payload["symbol"].as_str().unwrap_or_default();
+    let timeframe = event.payload["timeframe"].as_str().unwrap_or_default();
+
+    string_group_matches(&subscription.venues, venue)
+        && string_group_matches(&subscription.symbols, symbol)
+        && string_group_matches(&subscription.timeframes, timeframe)
+}
+
+fn normalize_subscription(mut subscription: FinanceSubscription) -> FinanceSubscription {
+    subscription.source_names = dedupe(subscription.source_names);
+    subscription.category_tags = dedupe(
+        subscription
+            .category_tags
+            .into_iter()
+            .map(|tag| {
+                if tag.starts_with("category:") {
+                    tag
+                } else {
+                    format!("category:{}", normalize_tag(&tag))
+                }
+            })
+            .collect(),
+    );
+    subscription.watch_terms = dedupe(
+        subscription
+            .watch_terms
+            .into_iter()
+            .map(|term| normalize_text(&term))
+            .filter(|term| !term.is_empty())
+            .collect(),
+    );
+    subscription.venues = dedupe(subscription.venues);
+    subscription.symbols = dedupe(subscription.symbols);
+    subscription.timeframes = dedupe(subscription.timeframes);
+    subscription
+}
+
+fn dedupe(mut values: Vec<String>) -> Vec<String> {
+    let mut seen = HashSet::new();
+    values.retain(|value| seen.insert(value.clone()));
+    values
+}
+
+fn normalize_text(value: &str) -> String {
+    value
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ")
+        .chars()
+        .flat_map(char::to_lowercase)
+        .collect()
+}
+
+fn normalize_tag(value: &str) -> String {
+    let mut out = String::new();
+    let mut last_dash = false;
+    for ch in value.chars().flat_map(char::to_lowercase) {
+        if ch.is_ascii_alphanumeric() {
+            out.push(ch);
+            last_dash = false;
+        } else if !last_dash && !out.is_empty() {
+            out.push('-');
+            last_dash = true;
+        }
+    }
+    if last_dash {
+        out.pop();
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use jiff::{SignedDuration, Timestamp};
+    use rara_kernel::{
+        data_feed::{FeedEvent, FeedEventId},
+        identity::UserId,
+        session::SessionKey,
+    };
+    use tempfile::TempDir;
+
+    use super::{
+        FinanceDelivery, FinanceDeliveryAction, FinanceEventKind, FinanceSubscription,
+        FinanceSubscriptionRegistry, ManualFinanceClock,
+    };
+
+    fn ts(value: &str) -> Timestamp { value.parse().expect("timestamp fixture should parse") }
+
+    fn owner() -> UserId { UserId("alice".to_owned()) }
+
+    fn registry(
+        now: Timestamp,
+    ) -> (
+        FinanceSubscriptionRegistry,
+        Arc<ManualFinanceClock>,
+        TempDir,
+    ) {
+        let tmp = tempfile::tempdir().expect("tempdir should be created");
+        let clock = Arc::new(ManualFinanceClock::new(now));
+        let registry = FinanceSubscriptionRegistry::load_with_clock(
+            tmp.path().join("subs.json"),
+            clock.clone(),
+        );
+        (registry, clock, tmp)
+    }
+
+    fn sub(session_key: SessionKey) -> FinanceSubscription {
+        FinanceSubscription {
+            id: uuid::Uuid::new_v4(),
+            owner: owner(),
+            session_key,
+            event_kinds: vec![FinanceEventKind::RssArticle],
+            source_names: vec!["fed-news".to_owned()],
+            category_tags: Vec::new(),
+            watch_terms: vec!["BTC".to_owned()],
+            venues: Vec::new(),
+            symbols: Vec::new(),
+            timeframes: Vec::new(),
+            delivery: FinanceDelivery::Immediate,
+            cooldown_secs: 900,
+            max_immediate_per_hour: 6,
+        }
+    }
+
+    fn article(source: &str, title: &str, summary: &str) -> FeedEvent {
+        FeedEvent::builder()
+            .id(FeedEventId::deterministic(&format!("{source}:{title}")))
+            .source_name(source.to_owned())
+            .event_type("rss_article".to_owned())
+            .tags(vec![
+                "finance".to_owned(),
+                format!("source:{source}"),
+                "category:monetary-policy".to_owned(),
+            ])
+            .payload(serde_json::json!({
+                "title": title,
+                "summary": summary,
+                "url": "https://example.com/article"
+            }))
+            .received_at(ts("2026-07-10T08:30:00Z"))
+            .build()
+    }
+
+    fn candle(symbol: &str, timeframe: &str) -> FeedEvent {
+        FeedEvent::builder()
+            .id(FeedEventId::deterministic(&format!(
+                "binance:{symbol}:{timeframe}"
+            )))
+            .source_name("binance-spot".to_owned())
+            .event_type("market_candle_closed".to_owned())
+            .tags(vec![
+                "finance".to_owned(),
+                "market-data".to_owned(),
+                "venue:binance".to_owned(),
+                format!("symbol:{symbol}"),
+                format!("timeframe:{timeframe}"),
+            ])
+            .payload(serde_json::json!({
+                "venue": "binance",
+                "symbol": symbol,
+                "timeframe": timeframe,
+                "close_time": "2026-07-10T08:30:00Z",
+                "close": "61610.30"
+            }))
+            .received_at(ts("2026-07-10T08:30:00Z"))
+            .build()
+    }
+
+    #[tokio::test]
+    async fn article_source_and_watch_terms_are_anded() {
+        let (registry, _clock, _tmp) = registry(ts("2026-07-10T08:31:00Z"));
+        let session = SessionKey::new();
+        registry.upsert(sub(session)).await.unwrap();
+
+        assert_eq!(
+            registry
+                .match_event(&article("fed-news", "Fed mentions BTC liquidity", ""))
+                .await
+                .len(),
+            1
+        );
+        assert!(
+            registry
+                .match_event(&article("fed-news", "Fed holds rates", ""))
+                .await
+                .is_empty()
+        );
+        assert!(
+            registry
+                .match_event(&article("other-news", "BTC headline", ""))
+                .await
+                .is_empty()
+        );
+    }
+
+    #[tokio::test]
+    async fn candle_symbol_and_timeframe_are_anded() {
+        let (registry, _clock, _tmp) = registry(ts("2026-07-10T08:31:00Z"));
+        let session = SessionKey::new();
+        registry
+            .upsert(FinanceSubscription {
+                id:                     uuid::Uuid::new_v4(),
+                owner:                  owner(),
+                session_key:            session,
+                event_kinds:            vec![FinanceEventKind::MarketCandleClosed],
+                source_names:           Vec::new(),
+                category_tags:          Vec::new(),
+                watch_terms:            Vec::new(),
+                venues:                 vec!["binance".to_owned()],
+                symbols:                vec!["BTCUSDT".to_owned()],
+                timeframes:             vec!["15m".to_owned()],
+                delivery:               FinanceDelivery::Silent,
+                cooldown_secs:          900,
+                max_immediate_per_hour: 6,
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(
+            registry.match_event(&candle("BTCUSDT", "15m")).await.len(),
+            1
+        );
+        assert!(
+            registry
+                .match_event(&candle("ETHUSDT", "15m"))
+                .await
+                .is_empty()
+        );
+        assert!(
+            registry
+                .match_event(&candle("BTCUSDT", "1h"))
+                .await
+                .is_empty()
+        );
+    }
+
+    #[tokio::test]
+    async fn values_inside_filter_groups_are_ored() {
+        let (registry, _clock, _tmp) = registry(ts("2026-07-10T08:31:00Z"));
+        let session = SessionKey::new();
+        registry
+            .upsert(FinanceSubscription {
+                id:                     uuid::Uuid::new_v4(),
+                owner:                  owner(),
+                session_key:            session,
+                event_kinds:            vec![FinanceEventKind::RssArticle],
+                source_names:           vec!["fed-news".to_owned(), "sec-news".to_owned()],
+                category_tags:          Vec::new(),
+                watch_terms:            vec!["BTC".to_owned(), "NVDA".to_owned()],
+                venues:                 Vec::new(),
+                symbols:                Vec::new(),
+                timeframes:             Vec::new(),
+                delivery:               FinanceDelivery::Silent,
+                cooldown_secs:          900,
+                max_immediate_per_hour: 6,
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(
+            registry
+                .match_event(&article("sec-news", "NVDA filing update", ""))
+                .await
+                .len(),
+            1
+        );
+    }
+
+    #[tokio::test]
+    async fn duplicate_event_is_delivered_once_after_reload() {
+        let tmp = tempfile::tempdir().expect("tempdir should be created");
+        let path = tmp.path().join("subs.json");
+        let session = SessionKey::new();
+        let clock = Arc::new(ManualFinanceClock::new(ts("2026-07-10T08:31:00Z")));
+        let registry = FinanceSubscriptionRegistry::load_with_clock(path.clone(), clock.clone());
+        registry.upsert(sub(session)).await.unwrap();
+
+        let event = article("fed-news", "BTC first notice", "");
+        assert_eq!(registry.match_event(&event).await.len(), 1);
+
+        let reloaded = FinanceSubscriptionRegistry::load_with_clock(path, clock);
+        assert!(reloaded.match_event(&event).await.is_empty());
+    }
+
+    #[tokio::test]
+    async fn immediate_budget_downgrades_excess_events_to_silent() {
+        let (registry, clock, _tmp) = registry(ts("2026-07-10T08:00:00Z"));
+        let session = SessionKey::new();
+        let mut subscription = sub(session);
+        subscription.max_immediate_per_hour = 1;
+        subscription.cooldown_secs = 0;
+        registry.upsert(subscription).await.unwrap();
+
+        let first = registry
+            .match_event(&article("fed-news", "BTC first", ""))
+            .await;
+        assert_eq!(first[0].action, FinanceDeliveryAction::Immediate);
+
+        clock.advance(SignedDuration::from_secs(60));
+        let second = registry
+            .match_event(&article("fed-news", "BTC second", ""))
+            .await;
+        assert_eq!(second[0].action, FinanceDeliveryAction::Silent);
+        assert_eq!(
+            second[0].downgraded_reason.as_deref(),
+            Some("hourly_budget")
+        );
+    }
+}

--- a/crates/extensions/rara-trading/src/finance/tools.rs
+++ b/crates/extensions/rara-trading/src/finance/tools.rs
@@ -1,0 +1,408 @@
+// Copyright 2026 Rararulab
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use rara_kernel::{
+    identity::UserId,
+    tool::{ToolContext, ToolExecute},
+};
+use rara_tool_macro::ToolDef;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use super::registry::{
+    FinanceDelivery, FinanceEventKind, FinanceSubscription, FinanceSubscriptionRegistry,
+};
+
+const MAX_SELECTOR_VALUES: usize = 64;
+const MAX_SELECTOR_LEN: usize = 128;
+const DEFAULT_COOLDOWN_SECS: u64 = 900;
+const DEFAULT_MAX_IMMEDIATE_PER_HOUR: u16 = 6;
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct FinanceSubscribeParams {
+    #[serde(default)]
+    pub event_kinds:            Option<Vec<FinanceEventKind>>,
+    #[serde(default)]
+    pub source_names:           Vec<String>,
+    #[serde(default)]
+    pub category_tags:          Vec<String>,
+    #[serde(default)]
+    pub watch_terms:            Vec<String>,
+    #[serde(default)]
+    pub venues:                 Vec<String>,
+    #[serde(default)]
+    pub symbols:                Vec<String>,
+    #[serde(default)]
+    pub timeframes:             Vec<String>,
+    #[serde(default)]
+    pub delivery:               Option<FinanceDelivery>,
+    #[serde(default)]
+    pub cooldown_secs:          Option<u64>,
+    #[serde(default)]
+    pub max_immediate_per_hour: Option<u16>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct FinanceSubscribeResult {
+    pub subscription_id:        Uuid,
+    pub delivery:               FinanceDelivery,
+    pub cooldown_secs:          u64,
+    pub max_immediate_per_hour: u16,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct FinanceUnsubscribeParams {
+    pub subscription_id: Uuid,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct FinanceUnsubscribeResult {
+    pub subscription_id: Uuid,
+    pub removed:         bool,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct FinanceListSubscriptionsParams {}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct FinanceListSubscriptionsResult {
+    pub subscriptions: Vec<FinanceSubscription>,
+}
+
+#[derive(ToolDef)]
+#[tool(
+    name = "finance_subscribe",
+    description = "Subscribe the current conversation to operator-configured finance information \
+                   feeds. Identity and session are always taken from tool context; do not pass \
+                   owner or session fields. Use for RSS/article watch terms and closed market \
+                   candle symbol/timeframe updates. This never places trades.",
+    tier = "deferred"
+)]
+pub struct FinanceSubscribeTool {
+    registry: Arc<FinanceSubscriptionRegistry>,
+}
+
+impl FinanceSubscribeTool {
+    pub fn new(registry: Arc<FinanceSubscriptionRegistry>) -> Self { Self { registry } }
+}
+
+#[async_trait]
+impl ToolExecute for FinanceSubscribeTool {
+    type Output = FinanceSubscribeResult;
+    type Params = FinanceSubscribeParams;
+
+    async fn run(
+        &self,
+        params: FinanceSubscribeParams,
+        context: &ToolContext,
+    ) -> anyhow::Result<FinanceSubscribeResult> {
+        validate_selectors(&params)?;
+        let delivery = params.delivery.unwrap_or(FinanceDelivery::Silent);
+        let cooldown_secs = params.cooldown_secs.unwrap_or(DEFAULT_COOLDOWN_SECS);
+        let max_immediate_per_hour = params
+            .max_immediate_per_hour
+            .unwrap_or(DEFAULT_MAX_IMMEDIATE_PER_HOUR);
+
+        let subscription = FinanceSubscription {
+            id: Uuid::new_v4(),
+            owner: UserId(context.user_id.clone()),
+            session_key: context.session_key,
+            event_kinds: params.event_kinds.unwrap_or_default(),
+            source_names: params.source_names,
+            category_tags: params.category_tags,
+            watch_terms: params.watch_terms,
+            venues: params.venues,
+            symbols: params.symbols,
+            timeframes: params.timeframes,
+            delivery,
+            cooldown_secs,
+            max_immediate_per_hour,
+        };
+        let subscription_id = self.registry.upsert(subscription).await?;
+
+        Ok(FinanceSubscribeResult {
+            subscription_id,
+            delivery,
+            cooldown_secs,
+            max_immediate_per_hour,
+        })
+    }
+}
+
+#[derive(ToolDef)]
+#[tool(
+    name = "finance_unsubscribe",
+    description = "Remove one finance information subscription owned by the current user. The \
+                   current user is taken from tool context; this cannot remove another user's \
+                   subscription.",
+    tier = "deferred"
+)]
+pub struct FinanceUnsubscribeTool {
+    registry: Arc<FinanceSubscriptionRegistry>,
+}
+
+impl FinanceUnsubscribeTool {
+    pub fn new(registry: Arc<FinanceSubscriptionRegistry>) -> Self { Self { registry } }
+}
+
+#[async_trait]
+impl ToolExecute for FinanceUnsubscribeTool {
+    type Output = FinanceUnsubscribeResult;
+    type Params = FinanceUnsubscribeParams;
+
+    async fn run(
+        &self,
+        params: FinanceUnsubscribeParams,
+        context: &ToolContext,
+    ) -> anyhow::Result<FinanceUnsubscribeResult> {
+        let owner = UserId(context.user_id.clone());
+        let removed = self.registry.remove(&owner, params.subscription_id).await?;
+        Ok(FinanceUnsubscribeResult {
+            subscription_id: params.subscription_id,
+            removed,
+        })
+    }
+}
+
+#[derive(ToolDef)]
+#[tool(
+    name = "finance_list_subscriptions",
+    description = "List finance information subscriptions owned by the current user. Identity is \
+                   taken from tool context; there is no owner or session parameter.",
+    tier = "deferred",
+    read_only,
+    concurrency_safe
+)]
+pub struct FinanceListSubscriptionsTool {
+    registry: Arc<FinanceSubscriptionRegistry>,
+}
+
+impl FinanceListSubscriptionsTool {
+    pub fn new(registry: Arc<FinanceSubscriptionRegistry>) -> Self { Self { registry } }
+}
+
+#[async_trait]
+impl ToolExecute for FinanceListSubscriptionsTool {
+    type Output = FinanceListSubscriptionsResult;
+    type Params = FinanceListSubscriptionsParams;
+
+    async fn run(
+        &self,
+        _params: FinanceListSubscriptionsParams,
+        context: &ToolContext,
+    ) -> anyhow::Result<FinanceListSubscriptionsResult> {
+        let owner = UserId(context.user_id.clone());
+        Ok(FinanceListSubscriptionsResult {
+            subscriptions: self.registry.list_for_owner(&owner).await,
+        })
+    }
+}
+
+fn validate_selectors(params: &FinanceSubscribeParams) -> anyhow::Result<()> {
+    if params.source_names.is_empty()
+        && params.category_tags.is_empty()
+        && params.watch_terms.is_empty()
+        && params.venues.is_empty()
+        && params.symbols.is_empty()
+        && params.timeframes.is_empty()
+    {
+        anyhow::bail!(
+            "at least one source/category/watch-term/venue/symbol/timeframe selector is required"
+        );
+    }
+
+    validate_string_group("source_names", &params.source_names)?;
+    validate_string_group("category_tags", &params.category_tags)?;
+    validate_string_group("watch_terms", &params.watch_terms)?;
+    validate_string_group("venues", &params.venues)?;
+    validate_string_group("symbols", &params.symbols)?;
+    validate_string_group("timeframes", &params.timeframes)?;
+
+    if let Some(event_kinds) = &params.event_kinds {
+        anyhow::ensure!(
+            event_kinds.len() <= MAX_SELECTOR_VALUES,
+            "event_kinds has too many values"
+        );
+    }
+    if let Some(max) = params.max_immediate_per_hour {
+        anyhow::ensure!(max <= 60, "max_immediate_per_hour must be <= 60");
+    }
+    if let Some(cooldown) = params.cooldown_secs {
+        anyhow::ensure!(cooldown <= 86_400, "cooldown_secs must be <= 86400");
+    }
+
+    Ok(())
+}
+
+fn validate_string_group(name: &str, values: &[String]) -> anyhow::Result<()> {
+    anyhow::ensure!(
+        values.len() <= MAX_SELECTOR_VALUES,
+        "{name} has too many values"
+    );
+    for value in values {
+        let trimmed = value.trim();
+        anyhow::ensure!(!trimmed.is_empty(), "{name} contains an empty value");
+        anyhow::ensure!(
+            trimmed.chars().count() <= MAX_SELECTOR_LEN,
+            "{name} value is too long"
+        );
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use rara_kernel::{
+        io::MessageId,
+        queue::{ShardedEventQueue, ShardedEventQueueConfig},
+        session::SessionKey,
+        tool::{AgentTool, ToolContext, ToolExecute},
+    };
+
+    use super::{
+        FinanceListSubscriptionsTool, FinanceSubscribeParams, FinanceSubscribeTool,
+        FinanceUnsubscribeParams, FinanceUnsubscribeTool,
+    };
+    use crate::finance::registry::{
+        FinanceDelivery, FinanceEventKind, FinanceSubscriptionRegistry,
+    };
+
+    fn context() -> ToolContext {
+        ToolContext {
+            user_id:               "alice".to_owned(),
+            session_key:           SessionKey::new(),
+            origin_endpoint:       None,
+            origin_user_id:        None,
+            event_queue:           Arc::new(ShardedEventQueue::new(ShardedEventQueueConfig {
+                num_shards:      0,
+                shard_capacity:  1,
+                global_capacity: 16,
+            })),
+            rara_turn_id:          MessageId::new(),
+            context_window_tokens: 0,
+            tool_registry:         None,
+            stream_handle:         None,
+            tool_call_id:          None,
+        }
+    }
+
+    #[tokio::test]
+    async fn subscribe_uses_context_owner_and_session_not_llm_fields() {
+        let tmp = tempfile::tempdir().expect("tempdir should be created");
+        let registry = Arc::new(FinanceSubscriptionRegistry::load(
+            tmp.path().join("subs.json"),
+        ));
+        let tool = FinanceSubscribeTool::new(registry.clone());
+        let ctx = context();
+
+        let result = tool
+            .run(
+                FinanceSubscribeParams {
+                    event_kinds:            Some(vec![FinanceEventKind::RssArticle]),
+                    source_names:           vec!["fed-news".to_owned()],
+                    category_tags:          Vec::new(),
+                    watch_terms:            vec!["BTC".to_owned()],
+                    venues:                 Vec::new(),
+                    symbols:                Vec::new(),
+                    timeframes:             Vec::new(),
+                    delivery:               Some(FinanceDelivery::Immediate),
+                    cooldown_secs:          None,
+                    max_immediate_per_hour: None,
+                },
+                &ctx,
+            )
+            .await
+            .unwrap();
+
+        let subs = registry
+            .list_for_owner(&rara_kernel::identity::UserId("alice".to_owned()))
+            .await;
+        assert_eq!(subs.len(), 1);
+        assert_eq!(subs[0].owner.0, "alice");
+        assert_eq!(subs[0].session_key, ctx.session_key);
+        assert_eq!(subs[0].id, result.subscription_id);
+    }
+
+    #[tokio::test]
+    async fn unsubscribe_cannot_remove_another_users_subscription() {
+        let tmp = tempfile::tempdir().expect("tempdir should be created");
+        let registry = Arc::new(FinanceSubscriptionRegistry::load(
+            tmp.path().join("subs.json"),
+        ));
+        let subscribe = FinanceSubscribeTool::new(registry.clone());
+        let unsubscribe = FinanceUnsubscribeTool::new(registry.clone());
+        let alice = context();
+        let mut bob = context();
+        bob.user_id = "bob".to_owned();
+
+        let result = subscribe
+            .run(
+                FinanceSubscribeParams {
+                    event_kinds:            Some(vec![FinanceEventKind::RssArticle]),
+                    source_names:           vec!["fed-news".to_owned()],
+                    category_tags:          Vec::new(),
+                    watch_terms:            vec!["BTC".to_owned()],
+                    venues:                 Vec::new(),
+                    symbols:                Vec::new(),
+                    timeframes:             Vec::new(),
+                    delivery:               None,
+                    cooldown_secs:          None,
+                    max_immediate_per_hour: None,
+                },
+                &alice,
+            )
+            .await
+            .unwrap();
+
+        let removed = unsubscribe
+            .run(
+                FinanceUnsubscribeParams {
+                    subscription_id: result.subscription_id,
+                },
+                &bob,
+            )
+            .await
+            .unwrap();
+        assert!(!removed.removed);
+        assert_eq!(
+            registry
+                .list_for_owner(&rara_kernel::identity::UserId("alice".to_owned()))
+                .await
+                .len(),
+            1
+        );
+    }
+
+    #[test]
+    fn list_schema_has_no_identity_or_session_parameter() {
+        let tmp = tempfile::tempdir().expect("tempdir should be created");
+        let registry = Arc::new(FinanceSubscriptionRegistry::load(
+            tmp.path().join("subs.json"),
+        ));
+        let tool = FinanceListSubscriptionsTool::new(registry);
+        let schema = tool.parameters_schema();
+        let schema_json = schema.to_string();
+
+        assert!(!schema_json.contains("user_id"));
+        assert!(!schema_json.contains("owner"));
+        assert!(!schema_json.contains("session"));
+        assert!(tool.is_read_only(&serde_json::json!({})));
+    }
+}

--- a/crates/extensions/rara-trading/src/lib.rs
+++ b/crates/extensions/rara-trading/src/lib.rs
@@ -1,0 +1,27 @@
+// Copyright 2026 Rararulab
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Trading and finance extension.
+//!
+//! The kernel `data_feed` module owns the generic event envelope, registry,
+//! store, and subscription machinery. This crate owns finance-specific
+//! ingestion/parsing sources and emits ordinary kernel
+//! [`FeedEvent`](rara_kernel::data_feed::FeedEvent) values.
+
+pub mod feed;
+pub mod finance;
+pub mod market_data;
+
+#[doc(hidden)]
+pub use rara_kernel::tool;

--- a/crates/extensions/rara-trading/src/market_data/mod.rs
+++ b/crates/extensions/rara-trading/src/market_data/mod.rs
@@ -1,0 +1,25 @@
+// Copyright 2026 Rararulab
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Durable OHLCV market-data storage.
+
+pub mod model;
+pub mod repository;
+pub mod timescale;
+
+pub use model::{CandleRangeQuery, MarketCandle, Timeframe};
+pub use repository::{
+    InMemoryMarketDataRepository, MarketDataRepository, MarketDataRepositoryRef, UpsertOutcome,
+};
+pub use timescale::TimescaleMarketDataRepository;

--- a/crates/extensions/rara-trading/src/market_data/model.rs
+++ b/crates/extensions/rara-trading/src/market_data/model.rs
@@ -1,0 +1,134 @@
+// Copyright 2026 Rararulab
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::{fmt, str::FromStr};
+
+use jiff::{SignedDuration, Timestamp};
+use rust_decimal::Decimal;
+use serde::{Deserialize, Serialize};
+
+/// Bar timeframe such as `15m`, `1h`, or `1d`.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
+pub struct Timeframe(String);
+
+impl Timeframe {
+    /// Parse and validate a bar timeframe.
+    pub fn parse(value: impl AsRef<str>) -> anyhow::Result<Self> {
+        let value = value.as_ref().trim();
+        anyhow::ensure!(!value.is_empty(), "timeframe must not be empty");
+        anyhow::ensure!(value.len() >= 2, "timeframe must include amount and unit");
+        let (number, unit) = value.split_at(value.len() - 1);
+        let amount: i64 = number.parse()?;
+        anyhow::ensure!(amount > 0, "timeframe amount must be positive");
+        anyhow::ensure!(
+            matches!(unit, "s" | "m" | "h" | "d"),
+            "timeframe unit must be one of s, m, h, d"
+        );
+        Ok(Self(format!("{amount}{unit}")))
+    }
+
+    /// Return the canonical string representation.
+    #[must_use]
+    pub fn as_str(&self) -> &str { &self.0 }
+
+    /// Return the timeframe step as whole seconds.
+    pub fn step(&self) -> anyhow::Result<SignedDuration> {
+        let (number, unit) = self.0.split_at(self.0.len() - 1);
+        let amount: i64 = number.parse()?;
+        let seconds = match unit {
+            "s" => amount,
+            "m" => amount.saturating_mul(60),
+            "h" => amount.saturating_mul(60 * 60),
+            "d" => amount.saturating_mul(24 * 60 * 60),
+            _ => anyhow::bail!("invalid timeframe unit"),
+        };
+        Ok(SignedDuration::from_secs(seconds))
+    }
+}
+
+impl fmt::Display for Timeframe {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result { f.write_str(&self.0) }
+}
+
+impl FromStr for Timeframe {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> { Self::parse(s) }
+}
+
+/// Durable closed OHLCV candle.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MarketCandle {
+    pub source_name:       String,
+    pub venue:             String,
+    pub symbol:            String,
+    pub timeframe:         Timeframe,
+    pub open_time:         Timestamp,
+    pub close_time:        Timestamp,
+    pub open:              Decimal,
+    pub high:              Decimal,
+    pub low:               Decimal,
+    pub close:             Decimal,
+    pub volume:            Decimal,
+    pub ingested_at:       Timestamp,
+    pub provider_sequence: Option<String>,
+}
+
+impl MarketCandle {
+    /// Return true when the current-row values are identical.
+    #[must_use]
+    pub fn same_current_values(&self, other: &Self) -> bool {
+        self.close_time == other.close_time
+            && self.open == other.open
+            && self.high == other.high
+            && self.low == other.low
+            && self.close == other.close
+            && self.volume == other.volume
+            && self.provider_sequence == other.provider_sequence
+    }
+
+    /// JSON payload used for correction/audit rows.
+    #[must_use]
+    pub fn audit_payload(&self) -> serde_json::Value {
+        serde_json::json!({
+            "source_name": self.source_name,
+            "venue": self.venue,
+            "symbol": self.symbol,
+            "timeframe": self.timeframe.as_str(),
+            "open_time": self.open_time.to_string(),
+            "close_time": self.close_time.to_string(),
+            "open": self.open.to_string(),
+            "high": self.high.to_string(),
+            "low": self.low.to_string(),
+            "close": self.close.to_string(),
+            "volume": self.volume.to_string(),
+            "ingested_at": self.ingested_at.to_string(),
+            "provider_sequence": self.provider_sequence,
+        })
+    }
+}
+
+/// Range query for historical candles.
+#[derive(Debug, Clone)]
+pub struct CandleRangeQuery {
+    pub source_name: Option<String>,
+    pub venue:       String,
+    pub symbol:      String,
+    pub timeframe:   Timeframe,
+    /// Inclusive start open time.
+    pub start:       Timestamp,
+    /// Exclusive end open time.
+    pub end:         Timestamp,
+    pub limit:       usize,
+}

--- a/crates/extensions/rara-trading/src/market_data/repository.rs
+++ b/crates/extensions/rara-trading/src/market_data/repository.rs
@@ -1,0 +1,295 @@
+// Copyright 2026 Rararulab
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::{collections::BTreeMap, sync::Arc};
+
+use async_trait::async_trait;
+use jiff::Timestamp;
+use tokio::sync::RwLock;
+
+use super::model::{CandleRangeQuery, MarketCandle};
+
+/// Result of upserting a closed candle.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum UpsertOutcome {
+    /// No candle existed for this primary key.
+    Inserted,
+    /// Existing row was equivalent for current candle values.
+    DuplicateUnchanged,
+    /// Existing current row differed and was replaced, with an audit record.
+    Corrected,
+}
+
+/// Repository abstraction for durable market-data history.
+#[async_trait]
+pub trait MarketDataRepository: Send + Sync {
+    /// Upsert a closed candle by `(source, venue, symbol, timeframe,
+    /// open_time)`.
+    async fn upsert_closed_candle(&self, candle: MarketCandle) -> anyhow::Result<UpsertOutcome>;
+
+    /// Query ordered candles for a venue/symbol/timeframe range.
+    async fn candles(&self, query: CandleRangeQuery) -> anyhow::Result<Vec<MarketCandle>>;
+
+    /// Return missing open times in `[start, end)` based on the query
+    /// timeframe.
+    async fn missing_open_times(&self, query: CandleRangeQuery) -> anyhow::Result<Vec<Timestamp>>;
+}
+
+/// Shared market-data repository reference.
+pub type MarketDataRepositoryRef = Arc<dyn MarketDataRepository>;
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+struct CandleKey {
+    source_name: String,
+    venue:       String,
+    symbol:      String,
+    timeframe:   String,
+    open_time:   Timestamp,
+}
+
+impl From<&MarketCandle> for CandleKey {
+    fn from(candle: &MarketCandle) -> Self {
+        Self {
+            source_name: candle.source_name.clone(),
+            venue:       candle.venue.clone(),
+            symbol:      candle.symbol.clone(),
+            timeframe:   candle.timeframe.to_string(),
+            open_time:   candle.open_time,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+struct CandleCorrection {
+    previous:     serde_json::Value,
+    new:          serde_json::Value,
+    corrected_at: Timestamp,
+}
+
+/// In-memory repository used by tests and local no-TSDB operation.
+#[derive(Debug, Default)]
+pub struct InMemoryMarketDataRepository {
+    candles:     RwLock<BTreeMap<CandleKey, MarketCandle>>,
+    corrections: RwLock<Vec<CandleCorrection>>,
+}
+
+impl InMemoryMarketDataRepository {
+    /// Number of recorded correction audit rows.
+    pub async fn correction_count(&self) -> usize {
+        let corrections = self.corrections.read().await;
+        let _payload_bytes: usize = corrections
+            .iter()
+            .map(|row| {
+                row.previous.to_string().len()
+                    + row.new.to_string().len()
+                    + row.corrected_at.to_string().len()
+            })
+            .sum();
+        corrections.len()
+    }
+}
+
+#[async_trait]
+impl MarketDataRepository for InMemoryMarketDataRepository {
+    async fn upsert_closed_candle(&self, candle: MarketCandle) -> anyhow::Result<UpsertOutcome> {
+        let key = CandleKey::from(&candle);
+        let mut candles = self.candles.write().await;
+
+        let outcome = match candles.get(&key) {
+            None => {
+                candles.insert(key, candle);
+                UpsertOutcome::Inserted
+            }
+            Some(existing) if existing.same_current_values(&candle) => {
+                UpsertOutcome::DuplicateUnchanged
+            }
+            Some(existing) => {
+                let correction = CandleCorrection {
+                    previous:     existing.audit_payload(),
+                    new:          candle.audit_payload(),
+                    corrected_at: Timestamp::now(),
+                };
+                candles.insert(key, candle);
+                drop(candles);
+                self.corrections.write().await.push(correction);
+                return Ok(UpsertOutcome::Corrected);
+            }
+        };
+
+        Ok(outcome)
+    }
+
+    async fn candles(&self, query: CandleRangeQuery) -> anyhow::Result<Vec<MarketCandle>> {
+        let candles = self.candles.read().await;
+        let mut rows: Vec<MarketCandle> = candles
+            .values()
+            .filter(|candle| matches_query(candle, &query))
+            .cloned()
+            .collect();
+        rows.sort_by_key(|candle| candle.open_time);
+        rows.truncate(query.limit.min(10_000));
+        Ok(rows)
+    }
+
+    async fn missing_open_times(&self, query: CandleRangeQuery) -> anyhow::Result<Vec<Timestamp>> {
+        let rows = self.candles(query.clone()).await?;
+        let present: std::collections::HashSet<Timestamp> =
+            rows.into_iter().map(|row| row.open_time).collect();
+        let step = query.timeframe.step()?;
+        let mut missing = Vec::new();
+        let mut cursor = query.start;
+
+        while cursor < query.end {
+            if !present.contains(&cursor) {
+                missing.push(cursor);
+            }
+            cursor = cursor
+                .checked_add(step)
+                .map_err(|err| anyhow::anyhow!("timeframe addition overflowed: {err}"))?;
+        }
+
+        Ok(missing)
+    }
+}
+
+fn matches_query(candle: &MarketCandle, query: &CandleRangeQuery) -> bool {
+    query
+        .source_name
+        .as_ref()
+        .is_none_or(|source| source == &candle.source_name)
+        && candle.venue == query.venue
+        && candle.symbol == query.symbol
+        && candle.timeframe == query.timeframe
+        && candle.open_time >= query.start
+        && candle.open_time < query.end
+}
+
+#[cfg(test)]
+mod tests {
+    use rust_decimal::Decimal;
+
+    use super::{InMemoryMarketDataRepository, MarketDataRepository, UpsertOutcome};
+    use crate::market_data::{CandleRangeQuery, MarketCandle, Timeframe};
+
+    fn ts(value: &str) -> jiff::Timestamp { value.parse().expect("timestamp fixture should parse") }
+
+    fn dec(value: &str) -> Decimal { value.parse().expect("decimal fixture should parse") }
+
+    fn candle(open_time: &str, close: &str) -> MarketCandle {
+        MarketCandle {
+            source_name:       "binance-spot".to_owned(),
+            venue:             "binance".to_owned(),
+            symbol:            "BTCUSDT".to_owned(),
+            timeframe:         Timeframe::parse("15m").expect("timeframe fixture should parse"),
+            open_time:         ts(open_time),
+            close_time:        ts("2026-07-10T08:30:00Z"),
+            open:              dec("61500.12"),
+            high:              dec("61640.00"),
+            low:               dec("61480.50"),
+            close:             dec(close),
+            volume:            dec("124.551"),
+            ingested_at:       ts("2026-07-10T08:30:01Z"),
+            provider_sequence: None,
+        }
+    }
+
+    fn query() -> CandleRangeQuery {
+        CandleRangeQuery {
+            source_name: Some("binance-spot".to_owned()),
+            venue:       "binance".to_owned(),
+            symbol:      "BTCUSDT".to_owned(),
+            timeframe:   Timeframe::parse("15m").expect("timeframe fixture should parse"),
+            start:       ts("2026-07-10T08:00:00Z"),
+            end:         ts("2026-07-10T08:45:00Z"),
+            limit:       100,
+        }
+    }
+
+    #[tokio::test]
+    async fn upsert_candle_is_idempotent_for_same_primary_key() {
+        let repo = InMemoryMarketDataRepository::default();
+        let candle = candle("2026-07-10T08:15:00Z", "61610.30");
+
+        assert_eq!(
+            repo.upsert_closed_candle(candle.clone()).await.unwrap(),
+            UpsertOutcome::Inserted
+        );
+        assert_eq!(
+            repo.upsert_closed_candle(candle).await.unwrap(),
+            UpsertOutcome::DuplicateUnchanged
+        );
+        assert_eq!(repo.candles(query()).await.unwrap().len(), 1);
+        assert_eq!(repo.correction_count().await, 0);
+    }
+
+    #[tokio::test]
+    async fn corrected_candle_updates_current_row_and_records_audit() {
+        let repo = InMemoryMarketDataRepository::default();
+        repo.upsert_closed_candle(candle("2026-07-10T08:15:00Z", "61610.30"))
+            .await
+            .unwrap();
+
+        assert_eq!(
+            repo.upsert_closed_candle(candle("2026-07-10T08:15:00Z", "61611.00"))
+                .await
+                .unwrap(),
+            UpsertOutcome::Corrected
+        );
+
+        let rows = repo.candles(query()).await.unwrap();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].close, dec("61611.00"));
+        assert_eq!(repo.correction_count().await, 1);
+    }
+
+    #[tokio::test]
+    async fn query_range_returns_ordered_candles_for_symbol_timeframe() {
+        let repo = InMemoryMarketDataRepository::default();
+        repo.upsert_closed_candle(candle("2026-07-10T08:30:00Z", "61700.00"))
+            .await
+            .unwrap();
+        repo.upsert_closed_candle(candle("2026-07-10T08:00:00Z", "61500.00"))
+            .await
+            .unwrap();
+        repo.upsert_closed_candle(candle("2026-07-10T08:15:00Z", "61610.30"))
+            .await
+            .unwrap();
+
+        let rows = repo.candles(query()).await.unwrap();
+        assert_eq!(
+            rows.iter()
+                .map(|row| row.open_time.to_string())
+                .collect::<Vec<_>>(),
+            vec![
+                "2026-07-10T08:00:00Z",
+                "2026-07-10T08:15:00Z",
+                "2026-07-10T08:30:00Z",
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn gap_detection_reports_missing_open_times() {
+        let repo = InMemoryMarketDataRepository::default();
+        repo.upsert_closed_candle(candle("2026-07-10T08:00:00Z", "61500.00"))
+            .await
+            .unwrap();
+        repo.upsert_closed_candle(candle("2026-07-10T08:30:00Z", "61700.00"))
+            .await
+            .unwrap();
+
+        let missing = repo.missing_open_times(query()).await.unwrap();
+        assert_eq!(missing, vec![ts("2026-07-10T08:15:00Z")]);
+    }
+}

--- a/crates/extensions/rara-trading/src/market_data/timescale.rs
+++ b/crates/extensions/rara-trading/src/market_data/timescale.rs
@@ -1,0 +1,294 @@
+// Copyright 2026 Rararulab
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use async_trait::async_trait;
+use jiff::Timestamp;
+use rust_decimal::Decimal;
+use sqlx_core::row::Row;
+use sqlx_postgres::{PgPool, Postgres};
+use uuid::Uuid;
+
+use super::{
+    model::{CandleRangeQuery, MarketCandle, Timeframe},
+    repository::{MarketDataRepository, UpsertOutcome},
+};
+
+/// TimescaleDB/PostgreSQL-backed market-data repository.
+#[derive(Debug, Clone)]
+pub struct TimescaleMarketDataRepository {
+    pool: PgPool,
+}
+
+impl TimescaleMarketDataRepository {
+    /// Connect to PostgreSQL/TimescaleDB.
+    pub async fn connect(database_url: &str) -> anyhow::Result<Self> {
+        let pool = PgPool::connect(database_url).await?;
+        Ok(Self { pool })
+    }
+
+    /// Construct from an existing pool.
+    #[must_use]
+    pub fn new(pool: PgPool) -> Self { Self { pool } }
+
+    /// Apply the MVP schema. Operators can also run the SQL migration directly.
+    pub async fn apply_schema(&self) -> anyhow::Result<()> {
+        for statement in include_str!("../../migrations/0001_market_candles.sql")
+            .split(';')
+            .map(str::trim)
+            .filter(|statement| !statement.is_empty())
+        {
+            sqlx_core::query::query(statement)
+                .execute(&self.pool)
+                .await?;
+        }
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl MarketDataRepository for TimescaleMarketDataRepository {
+    async fn upsert_closed_candle(&self, candle: MarketCandle) -> anyhow::Result<UpsertOutcome> {
+        let mut tx = self.pool.begin().await?;
+        let existing = find_existing(&mut tx, &candle).await?;
+
+        let outcome = match existing {
+            None => {
+                insert_candle(&mut tx, &candle).await?;
+                UpsertOutcome::Inserted
+            }
+            Some(existing) if existing.same_current_values(&candle) => {
+                UpsertOutcome::DuplicateUnchanged
+            }
+            Some(existing) => {
+                sqlx_core::query::query(
+                    r#"
+                    INSERT INTO market_candle_corrections (
+                      id, source_name, venue, symbol, timeframe, open_time,
+                      corrected_at, previous_payload, new_payload
+                    )
+                    VALUES (
+                      $1, $2, $3, $4, $5, $6::timestamptz,
+                      $7::timestamptz, $8::jsonb, $9::jsonb
+                    )
+                    "#,
+                )
+                .bind(Uuid::new_v4())
+                .bind(&candle.source_name)
+                .bind(&candle.venue)
+                .bind(&candle.symbol)
+                .bind(candle.timeframe.as_str())
+                .bind(candle.open_time.to_string())
+                .bind(Timestamp::now().to_string())
+                .bind(existing.audit_payload().to_string())
+                .bind(candle.audit_payload().to_string())
+                .execute(&mut *tx)
+                .await?;
+
+                update_candle(&mut tx, &candle).await?;
+                UpsertOutcome::Corrected
+            }
+        };
+
+        tx.commit().await?;
+        Ok(outcome)
+    }
+
+    async fn candles(&self, query: CandleRangeQuery) -> anyhow::Result<Vec<MarketCandle>> {
+        let limit = i64::try_from(query.limit.min(10_000))?;
+        let rows = sqlx_core::query::query(
+            r#"
+            SELECT
+              source_name, venue, symbol, timeframe,
+              open_time::text AS open_time,
+              close_time::text AS close_time,
+              open::text AS open,
+              high::text AS high,
+              low::text AS low,
+              close::text AS close,
+              volume::text AS volume,
+              ingested_at::text AS ingested_at,
+              provider_sequence
+            FROM market_candles
+            WHERE ($1::text IS NULL OR source_name = $1)
+              AND venue = $2
+              AND symbol = $3
+              AND timeframe = $4
+              AND open_time >= $5::timestamptz
+              AND open_time < $6::timestamptz
+            ORDER BY open_time ASC
+            LIMIT $7
+            "#,
+        )
+        .bind(query.source_name.as_deref())
+        .bind(&query.venue)
+        .bind(&query.symbol)
+        .bind(query.timeframe.as_str())
+        .bind(query.start.to_string())
+        .bind(query.end.to_string())
+        .bind(limit)
+        .fetch_all(&self.pool)
+        .await?;
+
+        rows.into_iter().map(row_to_candle).collect()
+    }
+
+    async fn missing_open_times(&self, query: CandleRangeQuery) -> anyhow::Result<Vec<Timestamp>> {
+        let rows = self.candles(query.clone()).await?;
+        let present: std::collections::HashSet<Timestamp> =
+            rows.into_iter().map(|row| row.open_time).collect();
+        let step = query.timeframe.step()?;
+        let mut missing = Vec::new();
+        let mut cursor = query.start;
+
+        while cursor < query.end {
+            if !present.contains(&cursor) {
+                missing.push(cursor);
+            }
+            cursor = cursor
+                .checked_add(step)
+                .map_err(|err| anyhow::anyhow!("timeframe addition overflowed: {err}"))?;
+        }
+
+        Ok(missing)
+    }
+}
+
+async fn find_existing(
+    tx: &mut sqlx_core::transaction::Transaction<'_, Postgres>,
+    candle: &MarketCandle,
+) -> anyhow::Result<Option<MarketCandle>> {
+    let row = sqlx_core::query::query(
+        r#"
+        SELECT
+          source_name, venue, symbol, timeframe,
+          open_time::text AS open_time,
+          close_time::text AS close_time,
+          open::text AS open,
+          high::text AS high,
+          low::text AS low,
+          close::text AS close,
+          volume::text AS volume,
+          ingested_at::text AS ingested_at,
+          provider_sequence
+        FROM market_candles
+        WHERE source_name = $1
+          AND venue = $2
+          AND symbol = $3
+          AND timeframe = $4
+          AND open_time = $5::timestamptz
+        "#,
+    )
+    .bind(&candle.source_name)
+    .bind(&candle.venue)
+    .bind(&candle.symbol)
+    .bind(candle.timeframe.as_str())
+    .bind(candle.open_time.to_string())
+    .fetch_optional(&mut **tx)
+    .await?;
+
+    row.map(row_to_candle).transpose()
+}
+
+async fn insert_candle(
+    tx: &mut sqlx_core::transaction::Transaction<'_, Postgres>,
+    candle: &MarketCandle,
+) -> anyhow::Result<()> {
+    sqlx_core::query::query(
+        r#"
+        INSERT INTO market_candles (
+          source_name, venue, symbol, timeframe, open_time, close_time,
+          open, high, low, close, volume, ingested_at, provider_sequence
+        )
+        VALUES (
+          $1, $2, $3, $4, $5::timestamptz, $6::timestamptz,
+          $7::numeric, $8::numeric, $9::numeric, $10::numeric, $11::numeric,
+          $12::timestamptz, $13
+        )
+        "#,
+    )
+    .bind(&candle.source_name)
+    .bind(&candle.venue)
+    .bind(&candle.symbol)
+    .bind(candle.timeframe.as_str())
+    .bind(candle.open_time.to_string())
+    .bind(candle.close_time.to_string())
+    .bind(candle.open.to_string())
+    .bind(candle.high.to_string())
+    .bind(candle.low.to_string())
+    .bind(candle.close.to_string())
+    .bind(candle.volume.to_string())
+    .bind(candle.ingested_at.to_string())
+    .bind(&candle.provider_sequence)
+    .execute(&mut **tx)
+    .await?;
+    Ok(())
+}
+
+async fn update_candle(
+    tx: &mut sqlx_core::transaction::Transaction<'_, Postgres>,
+    candle: &MarketCandle,
+) -> anyhow::Result<()> {
+    sqlx_core::query::query(
+        r#"
+        UPDATE market_candles
+        SET close_time = $6::timestamptz,
+            open = $7::numeric,
+            high = $8::numeric,
+            low = $9::numeric,
+            close = $10::numeric,
+            volume = $11::numeric,
+            ingested_at = $12::timestamptz,
+            provider_sequence = $13
+        WHERE source_name = $1
+          AND venue = $2
+          AND symbol = $3
+          AND timeframe = $4
+          AND open_time = $5::timestamptz
+        "#,
+    )
+    .bind(&candle.source_name)
+    .bind(&candle.venue)
+    .bind(&candle.symbol)
+    .bind(candle.timeframe.as_str())
+    .bind(candle.open_time.to_string())
+    .bind(candle.close_time.to_string())
+    .bind(candle.open.to_string())
+    .bind(candle.high.to_string())
+    .bind(candle.low.to_string())
+    .bind(candle.close.to_string())
+    .bind(candle.volume.to_string())
+    .bind(candle.ingested_at.to_string())
+    .bind(&candle.provider_sequence)
+    .execute(&mut **tx)
+    .await?;
+    Ok(())
+}
+
+fn row_to_candle(row: sqlx_postgres::PgRow) -> anyhow::Result<MarketCandle> {
+    Ok(MarketCandle {
+        source_name:       row.try_get("source_name")?,
+        venue:             row.try_get("venue")?,
+        symbol:            row.try_get("symbol")?,
+        timeframe:         Timeframe::parse(row.try_get::<String, _>("timeframe")?)?,
+        open_time:         row.try_get::<String, _>("open_time")?.parse()?,
+        close_time:        row.try_get::<String, _>("close_time")?.parse()?,
+        open:              Decimal::from_str_exact(&row.try_get::<String, _>("open")?)?,
+        high:              Decimal::from_str_exact(&row.try_get::<String, _>("high")?)?,
+        low:               Decimal::from_str_exact(&row.try_get::<String, _>("low")?)?,
+        close:             Decimal::from_str_exact(&row.try_get::<String, _>("close")?)?,
+        volume:            Decimal::from_str_exact(&row.try_get::<String, _>("volume")?)?,
+        ingested_at:       row.try_get::<String, _>("ingested_at")?.parse()?,
+        provider_sequence: row.try_get("provider_sequence")?,
+    })
+}

--- a/crates/extensions/rara-trading/tests/timescale_container.rs
+++ b/crates/extensions/rara-trading/tests/timescale_container.rs
@@ -1,0 +1,105 @@
+// Copyright 2026 Rararulab
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use rara_trading::market_data::{
+    CandleRangeQuery, MarketCandle, MarketDataRepository, Timeframe, TimescaleMarketDataRepository,
+    UpsertOutcome,
+};
+use rust_decimal::Decimal;
+use sqlx_core::row::Row;
+use testcontainers::{
+    GenericImage, ImageExt,
+    core::{IntoContainerPort, WaitFor},
+    runners::AsyncRunner,
+};
+
+#[tokio::test(flavor = "multi_thread")]
+async fn timescale_repository_contract_runs_against_testcontainer() -> anyhow::Result<()> {
+    let container = GenericImage::new("timescale/timescaledb", "2.17.2-pg16")
+        .with_exposed_port(5432.tcp())
+        .with_wait_for(WaitFor::message_on_stderr(
+            "database system is ready to accept connections",
+        ))
+        .with_env_var("POSTGRES_DB", "rara_test")
+        .with_env_var("POSTGRES_USER", "rara")
+        .with_env_var("POSTGRES_PASSWORD", "rara")
+        .start()
+        .await?;
+
+    let port = container.get_host_port_ipv4(5432.tcp()).await?;
+    let database_url = format!("postgres://rara:rara@127.0.0.1:{port}/rara_test");
+    let repo = TimescaleMarketDataRepository::connect(&database_url).await?;
+    repo.apply_schema().await?;
+
+    let first = candle("2026-07-10T08:15:00Z", "61610.30");
+    assert_eq!(
+        repo.upsert_closed_candle(first.clone()).await?,
+        UpsertOutcome::Inserted
+    );
+    assert_eq!(
+        repo.upsert_closed_candle(first).await?,
+        UpsertOutcome::DuplicateUnchanged
+    );
+    assert_eq!(
+        repo.upsert_closed_candle(candle("2026-07-10T08:15:00Z", "61611.00"))
+            .await?,
+        UpsertOutcome::Corrected
+    );
+
+    let rows = repo
+        .candles(CandleRangeQuery {
+            source_name: Some("timescale-container-contract".to_owned()),
+            venue:       "binance".to_owned(),
+            symbol:      "BTCUSDT".to_owned(),
+            timeframe:   Timeframe::parse("15m")?,
+            start:       ts("2026-07-10T08:00:00Z"),
+            end:         ts("2026-07-10T08:45:00Z"),
+            limit:       10,
+        })
+        .await?;
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].close, dec("61611.00"));
+
+    let audit_pool = sqlx_postgres::PgPool::connect(&database_url).await?;
+    let correction_count: i64 =
+        sqlx_core::query::query("SELECT COUNT(*)::bigint AS count FROM market_candle_corrections")
+            .fetch_one(&audit_pool)
+            .await?
+            .try_get("count")?;
+    assert_eq!(correction_count, 1);
+
+    Ok(())
+}
+
+fn ts(value: &str) -> jiff::Timestamp { value.parse().expect("timestamp fixture should parse") }
+
+fn dec(value: &str) -> Decimal { value.parse().expect("decimal fixture should parse") }
+
+fn candle(open_time: &str, close: &str) -> MarketCandle {
+    MarketCandle {
+        source_name:       "timescale-container-contract".to_owned(),
+        venue:             "binance".to_owned(),
+        symbol:            "BTCUSDT".to_owned(),
+        timeframe:         Timeframe::parse("15m").expect("timeframe fixture should parse"),
+        open_time:         ts(open_time),
+        close_time:        ts("2026-07-10T08:30:00Z"),
+        open:              dec("61500.12"),
+        high:              dec("61640.00"),
+        low:               dec("61480.50"),
+        close:             dec(close),
+        volume:            dec("124.551"),
+        ingested_at:       ts("2026-07-10T08:30:01Z"),
+        provider_sequence: None,
+    }
+}

--- a/crates/kernel/src/cascade.rs
+++ b/crates/kernel/src/cascade.rs
@@ -645,7 +645,7 @@ mod tests {
         assert_eq!(trace.summary.tool_call_count, 1);
         // First tick: user + assistant(empty skipped) + action + observation
         // Second tick: assistant thought
-        assert!(trace.ticks[1].entries[0].kind == CascadeEntryKind::Thought);
+        assert_eq!(trace.ticks[1].entries[0].kind, CascadeEntryKind::Thought);
     }
 
     #[test]

--- a/crates/kernel/src/data_feed/config.rs
+++ b/crates/kernel/src/data_feed/config.rs
@@ -86,6 +86,12 @@ pub enum FeedType {
     WebSocket,
     /// Periodic HTTP GET — rara polls an external API at fixed intervals.
     Polling,
+    /// Periodic RSS/Atom/JSON Feed fetch — emits one normalised article event
+    /// per item.
+    Rss,
+    /// Periodic market candle fetch — emits one normalised closed-candle event
+    /// per bar.
+    MarketCandle,
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/kernel/src/llm/codex.rs
+++ b/crates/kernel/src/llm/codex.rs
@@ -192,7 +192,7 @@ mod tests {
         let body = build_responses_request(&request, ApiFormat::Responses);
         assert!(body.get("max_output_tokens").is_none());
         assert!(body.get("parallel_tool_calls").is_none());
-        assert!(body["tools"].as_array().expect("tools array").len() == 1);
+        assert_eq!(body["tools"].as_array().expect("tools array").len(), 1);
     }
 
     #[test]

--- a/docs/guides/finance-subscriptions.md
+++ b/docs/guides/finance-subscriptions.md
@@ -55,19 +55,26 @@ cargo test -p rara-trading --test timescale_container
 
 ## Operator setup
 
-The Settings → Data Feeds panel lists built-in official finance RSS sources
-under "Default finance sources". Enabling one creates or re-enables a
-deterministic data feed named `finance-{catalog_id}`; disabling it turns the
-feed off without deleting the config row. The same catalog is available through
-the authenticated admin API:
+The Settings → Data Feeds panel lists built-in finance sources under "Default
+finance sources":
+
+- official RSS feeds that can be enabled immediately;
+- provider presets such as Binance and Longbridge that prefill a
+  `market_candle` configuration but still require an operator-managed endpoint
+  or credentials.
+
+Enabling a ready source creates or re-enables a deterministic data feed named
+`finance-{catalog_id}`; disabling it turns the feed off without deleting the
+config row. The same catalog is available through the authenticated admin API:
 
 - `GET /api/v1/data-feeds/catalog`
 - `POST /api/v1/data-feeds/catalog/{id}/enable`
 - `POST /api/v1/data-feeds/catalog/{id}/disable`
 
-Built-in sources are limited to feeds that can run without operator secrets or
-provider-specific adapters. Market-candle feeds still require an
-operator-managed normalized endpoint.
+Built-in provider presets are not directly enabled by the catalog API. A direct
+enable attempt returns `400 Bad Request` until the operator supplies a complete
+feed configuration. Market-candle feeds still require an operator-managed
+normalized endpoint.
 
 Custom finance feeds can also be created through the authenticated admin API.
 Example payloads are documented in `config.example.yaml`.

--- a/docs/guides/finance-subscriptions.md
+++ b/docs/guides/finance-subscriptions.md
@@ -12,8 +12,9 @@ generic feed config, lifecycle, event IDs, persistence, and status reporting.
 
 The ingestion path is:
 
-1. An operator creates an authenticated `rss` or `market_candle` data feed
-   through the existing admin data-feed API.
+1. An operator enables a built-in finance RSS source or creates an
+   authenticated `rss` / `market_candle` data feed through the existing admin
+   data-feed API.
 2. The app starts the configured source in the background.
 3. The source emits normalized `FeedEvent`s:
    - `rss_article`
@@ -54,8 +55,22 @@ cargo test -p rara-trading --test timescale_container
 
 ## Operator setup
 
-Create finance feeds through the authenticated admin API. Example payloads are
-also documented in `config.example.yaml`.
+The Settings → Data Feeds panel lists built-in official finance RSS sources
+under "Default finance sources". Enabling one creates or re-enables a
+deterministic data feed named `finance-{catalog_id}`; disabling it turns the
+feed off without deleting the config row. The same catalog is available through
+the authenticated admin API:
+
+- `GET /api/v1/data-feeds/catalog`
+- `POST /api/v1/data-feeds/catalog/{id}/enable`
+- `POST /api/v1/data-feeds/catalog/{id}/disable`
+
+Built-in sources are limited to feeds that can run without operator secrets or
+provider-specific adapters. Market-candle feeds still require an
+operator-managed normalized endpoint.
+
+Custom finance feeds can also be created through the authenticated admin API.
+Example payloads are documented in `config.example.yaml`.
 
 RSS/Atom:
 
@@ -138,7 +153,8 @@ than waking the session.
 
 Use this checklist before considering a deployment ready:
 
-1. Create an authenticated `rss` data feed with tags `["finance", "macro"]`.
+1. Enable a built-in RSS source from Settings → Data Feeds, or create a custom
+   authenticated `rss` data feed with tags `["finance", "macro"]`.
 2. Create an authenticated `market_candle` data feed with tags
    `["finance", "market-data"]`.
 3. Confirm each closed candle is upserted into `market_candles` exactly once

--- a/docs/guides/finance-subscriptions.md
+++ b/docs/guides/finance-subscriptions.md
@@ -1,0 +1,163 @@
+# Finance information subscriptions
+
+This guide covers the first rara trading deliverable: financial information
+subscriptions for RSS/Atom articles and latest closed market candles. It does
+not enable strategy deployment, account access, orders, or execution.
+
+## Runtime model
+
+`rara-trading` provides finance-specific feed transports, a TSDB-backed market
+data repository, and conversation tools. The kernel `data_feed` layer only owns
+generic feed config, lifecycle, event IDs, persistence, and status reporting.
+
+The ingestion path is:
+
+1. An operator creates an authenticated `rss` or `market_candle` data feed
+   through the existing admin data-feed API.
+2. The app starts the configured source in the background.
+3. The source emits normalized `FeedEvent`s:
+   - `rss_article`
+   - `market_candle_closed`
+4. Every event is written to the feed-event store.
+5. Closed candles are also upserted into `MarketDataRepository`.
+6. `FinanceSubscriptionRegistry` matches event metadata against conversation
+   subscriptions and either wakes the session once or appends silently to tape.
+
+The conversation can subscribe to already configured feeds. It cannot add feed
+URLs, provider URLs, credentials, account identifiers, orders, deployments, or
+arbitrary ticker fetches.
+
+## Storage
+
+Feed events are stored in the existing SQLite-backed `data_feed_events` table.
+They are notification facts, not the OHLCV history store.
+
+Closed candles are also stored through `MarketDataRepository`. Production uses
+TimescaleDB/PostgreSQL when `RARA_MARKET_DATA_DATABASE_URL` is set:
+
+```bash
+export RARA_MARKET_DATA_DATABASE_URL='postgres://user:pass@host:5432/rara'
+```
+
+On startup, rara applies the market-candle migration from
+`crates/extensions/rara-trading/migrations/0001_market_candles.sql`. The
+TimescaleDB extension must be installed in the target database. If the variable
+is missing, rara falls back to an in-memory repository, which is suitable only
+for local development because candle history is not durable.
+
+Local Timescale contract tests use testcontainers and do not require a manually
+managed database:
+
+```bash
+cargo test -p rara-trading --test timescale_container
+```
+
+## Operator setup
+
+Create finance feeds through the authenticated admin API. Example payloads are
+also documented in `config.example.yaml`.
+
+RSS/Atom:
+
+```json
+{
+  "name": "fed-news",
+  "feed_type": "rss",
+  "enabled": true,
+  "tags": ["finance", "macro"],
+  "transport": {
+    "url": "https://trusted-publisher.example/feed.xml",
+    "interval_secs": 300,
+    "max_entries_per_poll": 20
+  }
+}
+```
+
+Latest closed candles:
+
+```json
+{
+  "name": "binance-spot",
+  "feed_type": "market_candle",
+  "enabled": true,
+  "tags": ["finance", "market-data", "crypto"],
+  "transport": {
+    "url": "https://trusted-market-data.example/candles/latest",
+    "interval_secs": 60,
+    "venue": "binance",
+    "symbols": ["BTCUSDT", "ETHUSDT"],
+    "timeframes": ["15m", "1h"],
+    "max_candles_per_poll": 1000
+  }
+}
+```
+
+The market-candle endpoint must return normalized JSON with decimal strings.
+Only `closed: true` bars are emitted. In-progress bars are ignored in the MVP.
+
+## Conversation tools
+
+The app registers three deferred tools:
+
+- `finance_subscribe`
+- `finance_unsubscribe`
+- `finance_list_subscriptions`
+
+Identity and session routing are always taken from `ToolContext`. The tool
+schema has no `owner` or `session` parameter, so an agent cannot subscribe or
+unsubscribe on behalf of another user by passing forged IDs.
+
+Example article subscription:
+
+```json
+{
+  "event_kinds": ["rss_article"],
+  "source_names": ["fed-news"],
+  "watch_terms": ["BTC", "NVDA", "Federal Reserve"],
+  "delivery": "immediate"
+}
+```
+
+Example candle subscription:
+
+```json
+{
+  "event_kinds": ["market_candle_closed"],
+  "venues": ["binance"],
+  "symbols": ["BTCUSDT"],
+  "timeframes": ["15m"],
+  "delivery": "silent"
+}
+```
+
+Default delivery is `silent`. Immediate delivery is bounded by per-subscription
+cooldown and hourly budget; events above the budget are appended to tape rather
+than waking the session.
+
+## Acceptance checklist
+
+Use this checklist before considering a deployment ready:
+
+1. Create an authenticated `rss` data feed with tags `["finance", "macro"]`.
+2. Create an authenticated `market_candle` data feed with tags
+   `["finance", "market-data"]`.
+3. Confirm each closed candle is upserted into `market_candles` exactly once
+   for `(source_name, venue, symbol, timeframe, open_time)`.
+4. Use a conversation to call `finance_subscribe` for article `source_names`
+   and `watch_terms`.
+5. Use a conversation to call `finance_subscribe` for candle `symbols` and
+   `timeframes`.
+6. Confirm the admin event endpoint stores one event per article and one event
+   per closed candle across two polls.
+7. Confirm one matching item wakes the same session at most once.
+8. Confirm a seventh matching item in an hour is tape-only under the default
+   immediate-delivery budget.
+9. Confirm no feed URL, ticker provider URL, credentials, order, deployment, or
+   account tool is agent-callable.
+
+## Non-goals
+
+This MVP does not include arbitrary URL ingestion, arbitrary ticker/provider
+fetches, LLM entity extraction at ingestion, article scraping, portfolio-aware
+impact scoring, price-threshold alerts, backtests, account access, order
+placement, or strategy deployment.

--- a/docs/plans/2026-07-10-rara-finance-subscriptions-implementation.md
+++ b/docs/plans/2026-07-10-rara-finance-subscriptions-implementation.md
@@ -1,0 +1,684 @@
+# Rara Finance Information Subscriptions Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Let a user ask rara to subscribe a conversation to selected financial RSS/Atom news and latest closed market candles, then receive only deduplicated, rate-limited matching updates as a proactive message or silent memory entry.
+
+**Architecture:** Add normalized financial feed events through `rara-trading`: RSS/Atom articles and latest closed market candles both become individually deduplicated `FeedEvent`s rather than raw polling blobs. The kernel `data_feed` layer keeps only generic feed types/lifecycle/storage; source-specific parsing lives in `crates/extensions/rara-trading`. Closed candles are also upserted into a TimescaleDB/PostgreSQL-backed `MarketDataRepository` for durable OHLCV history. `rara-trading` owns finance-specific subscription matching and its three Deferred tools; the app injects that registry into the existing feed-dispatch loop, which already persists every event and can deliver a proactive turn to the source session.
+
+**Tech Stack:** Rust 2024, `feed-rs`, `reqwest`, `rust_decimal`, TimescaleDB/PostgreSQL hypertables, `sqlx-core`/`sqlx-postgres`, `rara-kernel::data_feed`, `rara-kernel::notification::NotifyAction`, `rara-tool-macro::ToolDef`, Tokio, JSON-file persistence, SQLite feed-event store.
+
+---
+
+## MVP boundary
+
+The first user experience is:
+
+> “订阅 BTC、NVDA 和美联储相关消息；重要的直接告诉我。”
+
+> “订阅 BTC 15m K 线收盘；有 NVDA 和美联储相关新闻也告诉我。”
+
+The agent uses `finance_subscribe`; an operator has previously registered one or more trusted RSS/Atom sources and market candle sources via the existing admin data-feed API. New articles and latest closed candles are normalized and persisted, then matched against the subscriber's source/category/watch-term/symbol/timeframe filters. A matching event is delivered to the originating session as either `immediate` (one proactive rara turn) or `silent` (tape only).
+
+MVP deliberately excludes arbitrary user-supplied feed URLs, arbitrary ticker/provider fetches, LLM-based entity extraction at ingestion, article scraping, portfolio-aware impact scoring, digest scheduling, derived price-threshold alerts, strategy backtests, orders, accounts, and all execution capability.
+
+### Product decisions
+
+- **Sources are operator configured.** The conversation can choose among enabled source names, but cannot make rara fetch an arbitrary URL. This keeps ingestion configuration, SSRF exposure, licensing review, and rate limits out of the LLM surface.
+- **RSS source parsing is deterministic.** The parser emits title, canonical URL, summary, author, published time, categories, and a stable per-entry `FeedEventId`. `feed-rs` supplies a unified model for RSS, Atom and JSON Feed inputs. [feed-rs documentation](https://docs.rs/feed-rs/latest/feed_rs/index.html)
+- **Market candle sources are operator configured.** The conversation can choose among enabled symbols, venues and timeframes for a configured source, but cannot make rara query an arbitrary ticker/provider pair.
+- **Market ingestion is batched by source.** One `MarketCandleSource` covers a provider/venue/timeframe and a symbol allowlist. User subscriptions never create provider polling tasks; they only match against already-ingested candle events and TSDB rows.
+- **Hundreds of symbols are in scope.** The MVP schema and ingestion loop assume at least hundreds of symbols across common bar timeframes. This is still bar data, not tick data; fan-out happens inside subscription matching, not at the provider request layer.
+- **Only closed candles wake the user by default.** MVP emits `market_candle_closed` for the latest completed bar. Provider updates for an in-progress bar are either ignored or coalesced into the final close; high-frequency `market_candle_update` is a later explicit mode.
+- **Closed candles are dual-written.** Each closed candle becomes a `FeedEvent` for notification matching and is upserted into `MarketDataRepository` for OHLCV history. The feed-event store is not the historical market-data store.
+- **TSDB choice is TimescaleDB/PostgreSQL for MVP.** It gives us hypertables, SQL, transactions, precise upsert/correction semantics and straightforward Rust `sqlx` integration. ClickHouse or QuestDB can be added later behind `MarketDataRepository` for high-throughput market-data lake workloads.
+- **Market values are decimal strings.** Open/high/low/close/volume are parsed into `Decimal`, serialized as strings in feed events, and stored as `NUMERIC` in TSDB. Do not use `f64` for prices or volumes.
+- **Watch terms are literal normalized matches.** They match title plus summary after Unicode case folding and whitespace normalization; no LLM runs for each incoming item.
+- **Filter groups are ANDed; values in a group are ORed.** A subscription constrained to `event_kinds=["rss_article"]`, `sources=["fed"]` and `watch_terms=["BTC", "NVDA"]` must be an article from `fed` and mention either term. A subscription constrained to `event_kinds=["market_candle_closed"]`, `symbols=["BTCUSDT"]` and `timeframes=["15m"]` must be the latest closed 15m candle for BTCUSDT. Empty optional groups impose no constraint.
+- **Immediate delivery is bounded.** Default is `silent`; `immediate` has a fixed per-subscription cooldown and maximum-per-hour budget. Items exceeding the budget are silently appended, never discarded from the feed store.
+- **No financial decision is made.** Proactive prompts say that the event is information, include source metadata, and ask rara to summarize or report facts; they must not recommend trades by default.
+
+### Normalized event shape
+
+Every RSS item becomes one normal `FeedEvent`:
+
+```json
+{
+  "source_name": "fed-news",
+  "event_type": "rss_article",
+  "tags": ["finance", "source:fed-news", "category:monetary-policy"],
+  "payload": {
+    "title": "...",
+    "url": "https://example.org/article",
+    "summary": "...",
+    "author": "...",
+    "published_at": "2026-07-10T08:30:00Z",
+    "categories": ["Monetary Policy"]
+  }
+}
+```
+
+The event ID is `FeedEventId::deterministic("<feed-url>:<guid-or-url-or-content-fallback>")`, never a poll timestamp. This makes repeated polls and process restarts idempotent.
+
+Every closed candle becomes one normal `FeedEvent`:
+
+```json
+{
+  "source_name": "binance-spot",
+  "event_type": "market_candle_closed",
+  "tags": [
+    "finance",
+    "market-data",
+    "source:binance-spot",
+    "venue:binance",
+    "symbol:BTCUSDT",
+    "timeframe:15m"
+  ],
+  "payload": {
+    "venue": "binance",
+    "symbol": "BTCUSDT",
+    "timeframe": "15m",
+    "open_time": "2026-07-10T08:15:00Z",
+    "close_time": "2026-07-10T08:30:00Z",
+    "open": "61500.12",
+    "high": "61640.00",
+    "low": "61480.50",
+    "close": "61610.30",
+    "volume": "124.551"
+  }
+}
+```
+
+The event ID is `FeedEventId::deterministic("<source>:<venue>:<symbol>:<timeframe>:<open-time>")`. This preserves exactly-once notification semantics across polling, websocket reconnects and process restarts.
+
+The TSDB primary key is `(source_name, venue, symbol, timeframe, open_time)`. Corrections for the same candle update the current row and append a small correction/audit record with `ingested_at`, provider sequence if available, and the previous OHLCV values. Consumers that need immutable snapshots use exported dataset artifacts with content hashes.
+
+## Task 1: Add a normalized RSS/Atom feed transport
+
+Implementation note: this transport belongs in `crates/extensions/rara-trading/src/feed/rss.rs`.
+`crates/kernel/src/data_feed/config.rs` only adds the generic `FeedType::Rss`
+variant so the admin/feed registry can route it.
+
+**Files:**
+- Modify: `Cargo.toml`
+- Modify: `crates/kernel/Cargo.toml`
+- Modify: `crates/kernel/src/data_feed/config.rs`
+- Modify: `crates/kernel/src/data_feed/mod.rs`
+- Create: `crates/kernel/src/data_feed/rss.rs`
+- Test: `crates/kernel/src/data_feed/rss.rs`
+
+**Step 1: Write failing parser tests**
+
+Add fixtures inline for RSS 2.0 and Atom. Test canonical extraction, category tags, and duplicate identity:
+
+```rust
+#[test]
+fn rss_item_becomes_one_normalized_article_event() { /* title/url/categories */ }
+
+#[test]
+fn same_guid_has_same_event_id_across_polls() { /* parse twice */ }
+
+#[test]
+fn missing_guid_uses_link_then_content_fallback() { /* stable fallback */ }
+```
+
+**Step 2: Run focused tests to verify they fail**
+
+Run: `cargo test -p rara-kernel rss`
+
+Expected: FAIL because `FeedType::Rss` and `rss` module do not exist.
+
+**Step 3: Implement the transport**
+
+- Add workspace dependency `feed-rs = "2.3.1"` and consume it only from `rara-kernel`.
+- Add `FeedType::Rss` and `pub mod rss` to the data-feed module.
+- Define `RssTransport { url, interval_secs, headers, max_entries_per_poll }`; reject non-HTTPS URLs, zero intervals, zero/max-excessive entry counts, and invalid headers before starting a task.
+- Implement `RssSource::from_config`, `DataFeed::run`, and `poll_once` with the same cancellation/error-status behavior as `PollingSource`.
+- Cap response bodies before parsing, parse with `feed_rs::parser::parse`, and emit at most `max_entries_per_poll` normalized `rss_article` events per poll.
+- Build tags as `config.tags + ["source:<name>"] + normalized feed categories`; deduplicate and sort tags before constructing the event.
+- Use `reqwest` timeouts matching the existing polling source. Do not add a generic arbitrary-URL agent tool.
+
+**Step 4: Run focused tests**
+
+Run: `cargo test -p rara-kernel rss`
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add Cargo.toml crates/kernel/Cargo.toml crates/kernel/src/data_feed
+git commit -m "feat(data-feed): add normalized RSS ingestion"
+```
+
+## Task 2: Start RSS feeds through the existing admin and boot paths
+
+**Files:**
+- Modify: `crates/extensions/backend-admin/src/data_feeds/router.rs`
+- Test: `crates/extensions/backend-admin/src/data_feeds/router.rs`
+- Modify: `config.example.yaml`
+
+**Step 1: Write failing task-start tests**
+
+Add a test that creates an enabled `FeedType::Rss` configuration, calls `start_feed_task`, and observes a running task which stops when the registry cancels it. Add a request test that accepts valid RSS transport JSON and rejects an HTTP URL.
+
+**Step 2: Run the tests to verify they fail**
+
+Run: `cargo test -p rara-backend-admin data_feeds::router::tests`
+
+Expected: FAIL because the router only starts polling feeds.
+
+**Step 3: Add RSS task dispatch**
+
+Extend `start_feed_task` to build `RssSource` for `FeedType::Rss`, attach the existing status reporter, and reuse the registry cancellation token. Leave webhook and polling behavior unchanged.
+
+Add a commented operator example to `config.example.yaml` and the data-feed admin docs:
+
+```yaml
+# Managed through the authenticated /api/v1/data-feeds admin API:
+# feed_type: rss
+# tags: [finance, macro]
+# transport:
+#   url: "https://trusted-publisher.example/feed.xml"
+#   interval_secs: 300
+#   max_entries_per_poll: 20
+```
+
+**Step 4: Run focused tests**
+
+Run: `cargo test -p rara-backend-admin data_feeds::router::tests`
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add crates/extensions/backend-admin/src/data_feeds/router.rs config.example.yaml
+git commit -m "feat(data-feed): start RSS feeds from admin config"
+```
+
+## Task 3: Add normalized market candle ingestion
+
+Implementation note: this transport belongs in
+`crates/extensions/rara-trading/src/feed/market_candle.rs`.
+`crates/kernel/src/data_feed/config.rs` only adds the generic
+`FeedType::MarketCandle` variant.
+
+**Files:**
+- Modify: `Cargo.toml`
+- Modify: `crates/kernel/Cargo.toml`
+- Modify: `crates/kernel/src/data_feed/config.rs`
+- Modify: `crates/kernel/src/data_feed/mod.rs`
+- Create: `crates/kernel/src/data_feed/market_candle.rs`
+- Modify: `crates/extensions/backend-admin/src/data_feeds/router.rs`
+- Test: `crates/kernel/src/data_feed/market_candle.rs`
+- Test: `crates/extensions/backend-admin/src/data_feeds/router.rs`
+
+**Step 1: Write failing candle normalization tests**
+
+Use an inline fixture for an operator-managed normalized endpoint:
+
+```json
+{
+  "candles": [
+    {
+      "venue": "binance",
+      "symbol": "BTCUSDT",
+      "timeframe": "15m",
+      "open_time": "2026-07-10T08:15:00Z",
+      "close_time": "2026-07-10T08:30:00Z",
+      "open": "61500.12",
+      "high": "61640.00",
+      "low": "61480.50",
+      "close": "61610.30",
+      "volume": "124.551",
+      "closed": true
+    }
+  ]
+}
+```
+
+Add tests:
+
+```rust
+#[test]
+fn closed_candles_for_many_symbols_become_batched_events() { /* symbol/timeframe/decimal strings */ }
+
+#[test]
+fn same_candle_has_same_event_id_across_polls() { /* parse twice */ }
+
+#[test]
+fn open_or_invalid_decimal_candles_are_not_emitted() { /* closed=false, bad price */ }
+```
+
+**Step 2: Run focused tests to verify they fail**
+
+Run: `cargo test -p rara-kernel market_candle`
+
+Expected: FAIL because `FeedType::MarketCandle` and `market_candle` module do not exist.
+
+**Step 3: Implement the market candle transport**
+
+- Add `rust_decimal` as a workspace dependency if it is not already present.
+- Add `FeedType::MarketCandle` and `pub mod market_candle` to the data-feed module.
+- Define `MarketCandleTransport { url, interval_secs, headers, venue, symbols, timeframes, max_candles_per_poll }`; reject non-HTTPS URLs, zero intervals, empty symbol/timeframe allowlists, and excessive candle counts. Set `max_candles_per_poll` high enough for hundreds of symbols across the configured timeframes, but bounded to protect memory.
+- Poll only operator-configured URLs. Do not add a tool that lets the LLM request arbitrary market data endpoints. Do not create one task per symbol; one task should fetch a batch for its configured symbol/timeframe allowlist.
+- Parse the normalized endpoint response into `MarketCandle` values using `Decimal` for OHLCV fields.
+- Emit only `closed == true` candles as `market_candle_closed`; ignore in-progress candles for MVP.
+- Build tags as `config.tags + ["finance", "market-data", "source:<name>", "venue:<venue>", "symbol:<symbol>", "timeframe:<timeframe>"]`, deduplicated and sorted.
+- Use deterministic event IDs from `source_name`, `venue`, `symbol`, `timeframe`, and `open_time`.
+- Return normalized closed candles to the caller so the app can both persist a notification `FeedEvent` and upsert the candle into `MarketDataRepository`.
+
+**Step 4: Start market candle feeds from admin config**
+
+Add backend-admin tests that accept a valid `market_candle` feed config and reject an HTTP URL or a symbol outside the configured allowlist. Extend `start_feed_task` to build `MarketCandleSource` for `FeedType::MarketCandle`, attach the existing status reporter, and reuse the registry cancellation token.
+
+Add a commented operator example to `config.example.yaml`:
+
+```yaml
+# Managed through the authenticated /api/v1/data-feeds admin API:
+# feed_type: market_candle
+# tags: [finance, market-data, crypto]
+# transport:
+#   url: "https://trusted-market-data.example/candles/latest"
+#   interval_secs: 60
+#   venue: "binance"
+#   symbols: ["BTCUSDT", "ETHUSDT"]
+#   timeframes: ["15m", "1h"]
+#   max_candles_per_poll: 1000
+```
+
+**Step 5: Run focused tests**
+
+Run:
+
+```bash
+cargo test -p rara-kernel market_candle
+cargo test -p rara-backend-admin data_feeds::router::tests
+```
+
+Expected: PASS.
+
+**Step 6: Commit**
+
+```bash
+git add Cargo.toml crates/kernel/Cargo.toml crates/kernel/src/data_feed crates/extensions/backend-admin/src/data_feeds/router.rs config.example.yaml
+git commit -m "feat(data-feed): add latest market candle ingestion"
+```
+
+## Task 4: Add the TSDB-backed market data repository
+
+**Files:**
+- Modify: `Cargo.toml`
+- Modify: `crates/extensions/rara-trading/Cargo.toml`
+- Create: `crates/extensions/rara-trading/src/market_data/mod.rs`
+- Create: `crates/extensions/rara-trading/src/market_data/model.rs`
+- Create: `crates/extensions/rara-trading/src/market_data/repository.rs`
+- Create: `crates/extensions/rara-trading/src/market_data/timescale.rs`
+- Create: `crates/extensions/rara-trading/migrations/0001_market_candles.sql`
+- Test: `crates/extensions/rara-trading/src/market_data/repository.rs`
+
+**Step 1: Write failing repository tests**
+
+Use repository-contract tests that run against an in-memory fake and a local TimescaleDB testcontainer:
+
+```rust
+#[tokio::test]
+async fn upsert_candle_is_idempotent_for_same_primary_key() { /* insert twice */ }
+
+#[tokio::test]
+async fn corrected_candle_updates_current_row_and_records_audit() { /* changed close */ }
+
+#[tokio::test]
+async fn query_range_returns_ordered_candles_for_symbol_timeframe() { /* range scan */ }
+
+#[tokio::test]
+async fn gap_detection_reports_missing_open_times() { /* missing 15m bar */ }
+```
+
+**Step 2: Run focused tests to verify they fail**
+
+Run: `cargo test -p rara-trading market_data`
+
+Expected: FAIL because `market_data` module and repository do not exist.
+
+**Step 3: Define the domain model and repository trait**
+
+Create:
+
+```rust
+pub struct MarketCandle {
+    pub source_name: String,
+    pub venue: String,
+    pub symbol: String,
+    pub timeframe: Timeframe,
+    pub open_time: OffsetDateTime,
+    pub close_time: OffsetDateTime,
+    pub open: Decimal,
+    pub high: Decimal,
+    pub low: Decimal,
+    pub close: Decimal,
+    pub volume: Decimal,
+    pub ingested_at: OffsetDateTime,
+}
+
+#[async_trait]
+pub trait MarketDataRepository: Send + Sync {
+    async fn upsert_closed_candle(&self, candle: MarketCandle) -> Result<UpsertOutcome>;
+    async fn candles(&self, query: CandleRangeQuery) -> Result<Vec<MarketCandle>>;
+    async fn missing_open_times(&self, query: CandleRangeQuery) -> Result<Vec<OffsetDateTime>>;
+}
+```
+
+`UpsertOutcome` distinguishes inserted, duplicate unchanged, and corrected.
+
+**Step 4: Add TimescaleDB schema**
+
+Migration:
+
+```sql
+CREATE TABLE market_candles (
+  source_name TEXT NOT NULL,
+  venue TEXT NOT NULL,
+  symbol TEXT NOT NULL,
+  timeframe TEXT NOT NULL,
+  open_time TIMESTAMPTZ NOT NULL,
+  close_time TIMESTAMPTZ NOT NULL,
+  open NUMERIC NOT NULL,
+  high NUMERIC NOT NULL,
+  low NUMERIC NOT NULL,
+  close NUMERIC NOT NULL,
+  volume NUMERIC NOT NULL,
+  ingested_at TIMESTAMPTZ NOT NULL,
+  provider_sequence TEXT,
+  PRIMARY KEY (source_name, venue, symbol, timeframe, open_time)
+);
+
+SELECT create_hypertable('market_candles', 'open_time', if_not_exists => TRUE);
+
+CREATE TABLE market_candle_corrections (
+  id UUID PRIMARY KEY,
+  source_name TEXT NOT NULL,
+  venue TEXT NOT NULL,
+  symbol TEXT NOT NULL,
+  timeframe TEXT NOT NULL,
+  open_time TIMESTAMPTZ NOT NULL,
+  corrected_at TIMESTAMPTZ NOT NULL,
+  previous_payload JSONB NOT NULL,
+  new_payload JSONB NOT NULL
+);
+```
+
+Use `NUMERIC`, not floating-point columns. Add indexes for `(venue, symbol, timeframe, open_time DESC)` and `(source_name, symbol, timeframe, open_time DESC)`.
+
+**Step 5: Implement TimescaleDB repository**
+
+- Use `sqlx` with PostgreSQL.
+- Upsert by primary key.
+- If existing OHLCV equals the incoming candle, return `DuplicateUnchanged`.
+- If OHLCV differs, write one correction row, update the current row, and return `Corrected`.
+- Keep retention/compression policy as operator config, not hard-coded in the migration.
+
+**Step 6: Run focused tests**
+
+Run:
+
+```bash
+cargo test -p rara-trading market_data
+```
+
+Expected: PASS for fake repository tests and the TimescaleDB testcontainer contract.
+
+**Step 7: Commit**
+
+```bash
+git add Cargo.toml crates/extensions/rara-trading
+git commit -m "feat(trading): add market data repository"
+```
+
+## Task 5: Create the finance subscription domain registry
+
+**Files:**
+- Modify: `Cargo.toml`
+- Create: `crates/extensions/rara-trading/Cargo.toml`
+- Create: `crates/extensions/rara-trading/src/lib.rs`
+- Create: `crates/extensions/rara-trading/src/finance/mod.rs`
+- Create: `crates/extensions/rara-trading/src/finance/model.rs`
+- Create: `crates/extensions/rara-trading/src/finance/registry.rs`
+- Test: `crates/extensions/rara-trading/src/finance/registry.rs`
+
+**Step 1: Write failing registry tests**
+
+```rust
+#[tokio::test]
+async fn article_source_and_watch_terms_are_anded() { /* source=Fed, term=BTC */ }
+
+#[tokio::test]
+async fn candle_symbol_and_timeframe_are_anded() { /* BTCUSDT + 15m */ }
+
+#[tokio::test]
+async fn values_inside_filter_groups_are_ored() { /* BTC OR NVDA; 15m OR 1h */ }
+
+#[tokio::test]
+async fn duplicate_event_is_delivered_once_after_reload() { /* JSON persistence */ }
+
+#[tokio::test]
+async fn immediate_budget_downgrades_excess_events_to_silent() { /* clock injection */ }
+```
+
+**Step 2: Run focused tests to verify they fail**
+
+Run: `cargo test -p rara-trading finance::registry`
+
+Expected: FAIL because the extension and registry do not exist.
+
+**Step 3: Implement persistence, matching and delivery decisions**
+
+Create a JSON-backed `FinanceSubscriptionRegistry` at `<data_dir>/trading/finance-subscriptions.json`. It owns:
+
+```rust
+pub struct FinanceSubscription {
+    pub id: Uuid,
+    pub owner: UserId,
+    pub session_key: SessionKey,
+    pub event_kinds: Vec<FinanceEventKind>, // RssArticle | MarketCandleClosed
+    pub source_names: Vec<String>,
+    pub category_tags: Vec<String>,
+    pub watch_terms: Vec<String>,
+    pub venues: Vec<String>,
+    pub symbols: Vec<String>,
+    pub timeframes: Vec<String>,
+    pub delivery: FinanceDelivery, // Immediate | Silent
+    pub cooldown_secs: u64,
+    pub max_immediate_per_hour: u16,
+}
+```
+
+Persist a bounded delivery ledger `(subscription_id, event_id, delivered_at, action)` with the registry. `match_event` returns `FinanceDeliveryDecision`s, not a notification side effect. It must:
+
+1. accept only `event_type == "rss_article"` or `event_type == "market_candle_closed"` with a `finance` tag;
+2. match event kind, sources, categories, watch terms, venues, symbols and timeframes using the stated AND-group/OR-value rule;
+3. normalize article title + summary with Unicode lowercase and collapsed whitespace;
+4. match candle venues, symbols and timeframes from structured payload fields, not from free text;
+5. suppress an already-seen `(subscription,event)` pair;
+6. return `Silent` when immediate cooldown/budget is exhausted and record why.
+
+No LLM dependency belongs in this crate.
+
+**Step 4: Run focused tests**
+
+Run: `cargo test -p rara-trading finance::registry`
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add Cargo.toml crates/extensions/rara-trading
+git commit -m "feat(trading): add finance subscription registry"
+```
+
+## Task 6: Add conversation-native finance subscription tools
+
+**Files:**
+- Create: `crates/extensions/rara-trading/src/finance/tools.rs`
+- Modify: `crates/extensions/rara-trading/src/finance/mod.rs`
+- Test: `crates/extensions/rara-trading/src/finance/tools.rs`
+
+**Step 1: Write failing tool tests**
+
+```rust
+#[tokio::test]
+async fn subscribe_uses_context_owner_and_session_not_llm_fields() { /* ToolContext fixture */ }
+
+#[tokio::test]
+async fn unsubscribe_cannot_remove_another_users_subscription() { /* two owners */ }
+
+#[test]
+fn list_schema_has_no_identity_or_session_parameter() { /* ToolDef schema */ }
+```
+
+**Step 2: Run focused tests to verify they fail**
+
+Run: `cargo test -p rara-trading finance::tools`
+
+Expected: FAIL because the tools do not exist.
+
+**Step 3: Implement three Deferred tools**
+
+Implement `finance_subscribe`, `finance_unsubscribe`, and `finance_list_subscriptions` using `ToolContext.user_id` and `ToolContext.session_key` as the only identity/routing inputs. Never accept owner or session from LLM parameters.
+
+`finance_subscribe` accepts `event_kinds`, `source_names`, `category_tags`, `watch_terms`, `venues`, `symbols`, `timeframes`, optional `delivery` (`silent` default; `immediate` explicit), `cooldown_secs` (default 900), and `max_immediate_per_hour` (default 6). Validate non-empty selectors, bounded selector counts/lengths, and normalized deduplicated terms. It returns a subscription ID and exact delivery policy.
+
+Mark subscribe/unsubscribe non-read-only; mark list read-only. Do not mark them destructive: they only manage the caller's notification preference and never alter a financial account.
+
+**Step 4: Run focused tests**
+
+Run: `cargo test -p rara-trading finance::tools`
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add crates/extensions/rara-trading/src/finance
+git commit -m "feat(trading): add finance subscription tools"
+```
+
+## Task 7: Register the extension, market-data store and finance dispatch safely
+
+**Files:**
+- Modify: `crates/app/Cargo.toml`
+- Modify: `crates/app/src/tools/mod.rs`
+- Modify: `crates/app/src/boot.rs`
+- Modify: `crates/app/src/lib.rs`
+- Test: `crates/app/src/lib.rs`
+
+**Step 1: Write failing app-level tests**
+
+Extract feed delivery into a testable async helper. Verify:
+
+```rust
+#[tokio::test]
+async fn matched_immediate_finance_article_creates_one_synthetic_turn() { /* fake handle */ }
+
+#[tokio::test]
+async fn matched_immediate_candle_creates_compact_market_update_turn() { /* fake handle */ }
+
+#[tokio::test]
+async fn closed_candle_is_upserted_before_subscription_delivery() { /* fake repo */ }
+
+#[tokio::test]
+async fn silent_finance_event_appends_to_tape_without_turn() { /* fake tape */ }
+
+#[tokio::test]
+async fn unmatched_finance_event_does_not_wake_a_session() { /* empty decisions */ }
+```
+
+**Step 2: Run focused tests to verify they fail**
+
+Run: `cargo test -p rara-app finance_event`
+
+Expected: FAIL because the finance registry and market-data repository are not constructed or dispatched.
+
+**Step 3: Wire the registry once**
+
+- Add `rara-trading` as an app dependency and construct `Arc<FinanceSubscriptionRegistry>` at boot using `rara_paths::data_dir().join("trading/finance-subscriptions.json")`.
+- Construct one `Arc<dyn MarketDataRepository>` at boot. Production config points it at TimescaleDB/PostgreSQL; tests use a fake repository.
+- Add the finance registry `Arc` to `ToolDeps` and register all three tools as Deferred. Do not put them in the core manifest.
+- Refactor the existing feed dispatch loop in `crates/app/src/lib.rs` into a helper that receives generic tag subscriptions, market-data repository and finance delivery decisions. Keep current generic `SubscriptionRegistry` behavior byte-for-byte equivalent.
+- When the event is `market_candle_closed`, parse its structured payload into `MarketCandle` and call `upsert_closed_candle` before notification delivery. A TSDB failure should mark the data-feed task unhealthy and skip proactive delivery for that candle; do not wake the user for a candle that failed durable storage.
+- For `Immediate`, issue the existing synthetic inbound message to the matched session. Article directives contain source, title, canonical URL, published time, matching selectors and the instruction: “Summarize factual relevance; do not give trade advice unless the user asks.” Candle directives contain source, venue, symbol, timeframe, close time, OHLCV values and the instruction: “Report the market update factually; do not infer a trade unless the user asks.”
+- For `Silent`, append the normalized event and matching metadata to that session's tape using `TapEntryKind::FeedEvent`.
+- If the target session is absent from the process table, downgrade immediate to silent exactly as the existing generic dispatch path does.
+
+**Step 4: Run focused tests**
+
+Run: `cargo test -p rara-app finance_event`
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add crates/app/Cargo.toml crates/app/src/tools/mod.rs crates/app/src/boot.rs crates/app/src/lib.rs
+git commit -m "feat(trading): deliver matched finance information to sessions"
+```
+
+## Task 8: Document the new first milestone and verify the whole feature
+
+**Files:**
+- Modify: `docs/plans/2026-07-10-rara-trading-design.md`
+- Modify: `config.example.yaml`
+- Create: `docs/guides/finance-subscriptions.md`
+
+**Step 1: Write an operator acceptance checklist**
+
+Document this exact manual lane:
+
+1. Create an authenticated `rss` data feed with tags `["finance", "macro"]`.
+2. Create an authenticated `market_candle` data feed with tags `["finance", "market-data"]`.
+3. Confirm each closed candle is upserted into `market_candles` exactly once for `(source, venue, symbol, timeframe, open_time)`.
+4. Use a conversation to call `finance_subscribe` for article `source_names` and `watch_terms`.
+5. Use a conversation to call `finance_subscribe` for candle `symbols` and `timeframes`.
+6. Confirm the admin event endpoint stores one event per article and one event per closed candle across two polls.
+7. Confirm one matching item wakes the same session at most once.
+8. Confirm a seventh matching item in an hour is tape-only under the default budget.
+9. Confirm no feed URL, ticker provider URL, credentials, order, deployment, or account tool is agent-callable.
+
+**Step 2: Update product sequencing**
+
+Amend the trading design: finance information subscriptions for news and latest closed candles become the first deliverable, the isolated research bench becomes the second deliverable, and execution remains gated behind the existing mandate/OMS/reconciliation criteria. Link both implementation plans.
+
+**Step 3: Run verification**
+
+Run:
+
+```bash
+cargo fmt --check
+cargo clippy -p rara-kernel -p rara-backend-admin -p rara-trading -p rara-app -- -D warnings
+cargo test -p rara-trading feed
+cargo test -p rara-kernel data_feed::registry::tests
+cargo test -p rara-backend-admin data_feeds::router::tests
+cargo test -p rara-trading market_data
+cargo test -p rara-trading --test timescale_container
+cargo test -p rara-trading finance
+cargo test -p rara-app finance_event
+```
+
+Expected: all commands PASS.
+
+**Step 4: Commit**
+
+```bash
+git add docs/plans/2026-07-10-rara-trading-design.md docs/guides/finance-subscriptions.md config.example.yaml
+git commit -m "docs(trading): prioritize finance information subscriptions"
+```
+
+## Follow-up milestones (not part of this MVP)
+
+1. Scheduled per-user digests that summarize silent matches without re-reading the entire feed history.
+2. Curated ticker aliases and deterministic named-entity extraction; no regex guesswork over all-caps titles.
+3. Article fetching with publisher-specific policy, robots/licensing review and content-size limits.
+4. Portfolio-aware relevance only after positions are durable and consented; it must remain informational, never an order trigger.
+5. The isolated backtest research bench defined in `2026-07-10-rara-trading-research-mvp-implementation.md`.

--- a/docs/plans/2026-07-10-rara-trading-design.md
+++ b/docs/plans/2026-07-10-rara-trading-design.md
@@ -1,6 +1,6 @@
 # rara Trading — 产品设计
 
-> Status: 产品设计已定稿，待拆解实现计划。
+> Status: 产品设计已定稿；金融信息订阅 MVP 优先，研究台随后实施。
 > Author: Ryan + Claude
 > Date: 2026-07-10
 
@@ -26,10 +26,10 @@ Go 的编排层由 rara kernel 覆盖，Go 的半成品 agent 层删除。
 | Agent 归属 | rara 是唯一 agent | 不在交易引擎里再造一个 agent；rara 就是个人 agent |
 | 集成方式 | Rust 原生 extension，**不走 MCP/进程边界** | 用户要 tool 直接可执行；kernel Tool 直调 |
 | 交易引擎哲学 | 自主交易（沿用 trading-agent 现状） | LLM 是监控/副驾层，不是每单审批的 gatekeeper |
-| 操作审批 | confirm-on-mutation | 引擎自主成交不打扰；**rara 主动发起的改状态操作**要用户确认一次（走 Guard） |
+| 操作审批 | mandate + confirm-on-mutation | 引擎只能在已确认的交易授权内自主成交；rara 主动发起的改状态操作须由 Guard 确认 |
 | 主表面 | 对话优先（多通道） | rara 价值在 agent + 记忆 + 主动 + 多通道，不是重型交易终端 |
 | 可视化 | Web UI 承载（K线/回测曲线/持仓） | 交易有天生视觉的东西；rara 已有 web channel + browser driver |
-| 策略/回测 | 保留 Python + vectorbt，rara-sandbox 驱动 | 研究闭环是最值钱资产，语言无关，零重写 |
+| 策略/回测 | 保留 Python + vectorbt，受约束的独立 sandbox 驱动 | 研究闭环是最值钱资产，语言无关，零重写 |
 | 新写代码 | crates/extensions/rara-trading | 交易所执行 + OMS + 信号/仓位；调研 barter-rs 复用 |
 
 ## Product Shape
@@ -42,21 +42,101 @@ rara = 用户的私人量化操盘副驾。交易是 rara 的能力，不是独�
 |------|------|
 | 对话（Telegram / TUI / Web-chat） | **主入口**：研究 / 盯盘 / 下单 / 策略进化全靠说 |
 | Web UI | 承载天生视觉的东西：K线、回测资金曲线、持仓/盈亏。看一眼用，非重型终端 |
-| 主动推送 | rara heartbeat：异动、成交、新闻、策略表现，主动找用户 |
+| 主动推送 | rara heartbeat：异动、最新 K 线、成交、新闻、策略表现，主动找用户 |
 
-### 能力地图（研究 / 盯盘 / 运维 / 情报，四项全要）
+### 能力地图（研究 / 盯盘 / 运维 / 信息，四项全要）
 | 能力 | 用户怎么用 | 底层 |
 |------|-----------|------|
-| 研究台 | "回测 rsi2 在 15m，跟 v2 比" | Python 策略 + vectorbt，跑在 rara-sandbox |
+| 研究台 | "回测 rsi2 在 15m，跟 v2 比" | Python 策略 + vectorbt，跑在受约束的独立 sandbox |
 | 盯盘 Copilot | "现在什么情况" "为啥开这单" | rara memory + 引擎持仓/信号 |
 | 运维操作员 | "上 testnet" "平一半 ETH" "halt" | 新 Rust 执行/OMS，**改状态需确认** |
-| 情报分析 | "有影响我持仓的新闻吗" | rara data_feed + LLM |
+| 信息订阅 | "订阅 BTC 15m K线和美联储新闻" | rara data_feed + 订阅匹配 + LLM 摘要 |
+
+### 当前落地顺序
+
+1. **金融信息订阅**：RSS/Atom 新闻源 + 最新已收盘 K 线 → 标的/主题/时间框订阅 → 限流的主动推送或静默入记忆；不涉及策略、账户或订单。
+2. **研究台**：隔离 sandbox 跑 Python/vectorbt 回测，产出可复现 artifact；不涉及部署或下单。
+3. **执行**：只在 mandate、OMS、reconciliation 和硬风控齐备后，从 paper/testnet 开始。
+
+对应实现计划：
+
+- `docs/plans/2026-07-10-rara-finance-subscriptions-implementation.md`
+- `docs/plans/2026-07-10-rara-trading-research-mvp-implementation.md`
+
+### 第一阶段：金融信息订阅（新闻 + 最新 K 线，无交易能力）
+
+金融信息订阅复用 rara 的 `data_feed`、Tape、主动消息和多通道。运营者配置可信 RSS/Atom
+新闻源和 market candle source；用户通过对话订阅来源、分类、watch term、symbol 与
+timeframe（如 BTC 15m、NVDA 1d、美联储）。新闻条目会被规范化、去重并持久化为
+`FeedEvent`；最新已收盘 K 线会同时写入 `FeedEvent` 和专用 TSDB-backed
+`MarketDataRepository`。订阅匹配后：`immediate` 才启动一次主动 rara turn，`silent`
+只写入会话记忆。两种模式都不做交易建议，更不触发任何订单。
+
+第一版不让 LLM 任意抓取 URL，也不让 LLM 任意拉取 ticker 行情。来源 URL、market data
+provider、symbol 白名单和 timeframe 白名单归运营者管理。新闻匹配使用确定性文本和分类
+标签；K 线匹配使用 provider/source、symbol、venue 和 timeframe。主动消息用
+cooldown/每小时预算控制噪音。
+
+K 线订阅首批只推送 `market_candle_closed`，即最近一个已收盘 bar。未收盘 bar 的
+`market_candle_update` 高频且会反复修订，后续作为显式高频模式增加；默认不进入对话主动
+推送。K 线 payload 使用字符串化 Decimal 表达 open/high/low/close/volume，事件 ID 使用
+`source + venue + symbol + timeframe + open_time` 的确定性键，重复轮询或重启不能重复通知。
+TSDB 主键使用 `source + venue + symbol + timeframe + open_time`，允许 provider 修正同一根
+bar 时按版本/ingested_at 记录可追溯更新。
 
 ### 控制模型
-- 引擎**自主交易**，成交不打扰用户。
-- rara **主动发起的改状态操作**（部署/下架策略、手动下单、调仓位上限、halt）
-  → 走 rara 的 **Guard**，用户**确认一次**。
-- 不是 OpenAlice 的每单审批，是「agent 动手前点头」。
+- 引擎**自主交易**，但只能在一个已确认、不可变的 `TradingMandate` 内成交；成交本身
+  不打扰用户。
+- `TradingMandate` 是部署时 Guard 确认的精确对象，至少包含：策略版本/hash、账户与
+  `paper` / `testnet` / `live` 环境、交易对白名单、仓位和名义金额上限、杠杆、止损/日损
+  阈值、有效期，以及撤销条件。修改任一字段就是新的改状态操作，必须重新确认。
+- rara **主动发起的改状态操作**（部署/下架策略、改变 mandate、手动下单、调仓位上限）
+  → 走 rara 的 **Guard**，用户**确认一次**。手动单确认的是精确的 `OrderIntent`
+  （账户、方向、数量、价格保护、client-order-id），不复用某次部署授权。
+- 风控阈值命中的 `halt` 是引擎本地、立即生效的硬保护，不能依赖 LLM、Guard 或消息通道。
+  rara 提议的非紧急 halt 仍走 Guard；两类 halt 都必须写入审计记录。
+- 不是 OpenAlice 的每单审批，而是「用户先批准边界，引擎只在边界内自动执行」。
+
+### 第二阶段：研究台 MVP（无交易能力）
+
+第二阶段只交付原生 `trading_backtest` tool，验证“与 rara 对话做量化研究”的体验。它
+**没有**部署、下单、调仓、交易所连接或读取交易所凭据的能力；研究产物也不能直接变成
+运行中的策略。
+
+| 项目 | MVP 决定 |
+|------|----------|
+| Tool 输入 | `BacktestSpec + StrategyRef + DatasetRef`，而不是模型可任意拼接的 Python 命令 |
+| 策略输入 | `StrategyRef` 指向版本化策略文件及内容 hash；先冻结一个只读、确定性的 Python 策略 ABI |
+| 数据输入 | `DatasetRef` 指向已导入、带 schema/hash/时间范围/时区的行情数据集 |
+| 执行隔离 | 每次回测使用独立 sandbox：禁网、无交易所凭据、策略与数据只读挂载；只允许写入本次 artifact 目录 |
+| 输出 | `BacktestArtifact`：结果表、资金曲线/交易明细，以及完整可复现 manifest |
+
+`BacktestArtifact` 的 manifest 必须记录策略 hash、数据集 hash、Python/vectorbt 镜像与依赖
+锁、时间框与时区、warmup、手续费、滑点、撮合/填充模型和随机种子。相同输入必须可以重跑；
+结果不满足该条件，就不是可用于讨论或演进的研究结论。
+
+策略 ABI 首批只支持确定性回测所需的最小子集：输入 OHLCV schema、指标、entry/exit 信号
+和 warmup。禁止策略自行取数或出网；跨时间框、动态参数搜索和实盘运行时语义在后续阶段
+扩展，不能隐式沿用 Go 的行为。
+
+### 市场数据边界
+
+`data_feed` 继续承载新闻、最新 K 线、告警、异动和成交通知等通用事件，不作为 OHLCV
+历史库。第一阶段一旦摄取 K 线，就同时引入专门的 `MarketDataRepository`，生产实现选
+TimescaleDB/PostgreSQL hypertable 保存 OHLCV；`data_feed` 只保存通知事件、原始 payload
+摘要和去重水位线。`MarketDataRepository` 负责 OHLCV 的分区、补洞、去重、provider 修正、
+resample 与数据质量。第二阶段的 `DatasetRef` 可以从 TSDB 固化导出为带 hash 的
+Parquet/CSV artifact；执行阶段也只读取该 repository，不从 `FeedEvent` 表拼历史。
+
+TSDB 选型首发固定为 TimescaleDB/PostgreSQL，而不是 ClickHouse、QuestDB 或 InfluxDB。
+原因是 MVP 更重视精确 upsert、修正审计、普通 SQL、事务、Rust `sqlx` 集成和后续与账户/
+配置数据的关系查询。ClickHouse/QuestDB 留作后续高吞吐行情湖：当我们需要全市场 tick 级
+摄取、跨资产大扫描或长期冷数据分层时，再通过 `MarketDataRepository` 增加实现，不改上层。
+
+容量假设按上百个标的设计。100 个标的即使订阅 1m/5m/15m/1d，日新增 bar 量也仍是
+TimescaleDB 的轻量级负载；真正要避免的是按用户订阅或按 symbol 启动独立抓取任务。行情
+摄取必须按 provider/venue/timeframe 批量运行，一个 source 覆盖一组 symbol，订阅层只消费
+已摄取的事件和 TSDB 数据，不触发额外 provider 请求。
 
 ## Architecture
 
@@ -69,25 +149,27 @@ rara = 用户的私人量化操盘副驾。交易是 rara 的能力，不是独�
                 │  kernel Tool 直调（原生 Rust，无进程边界）
 ┌───────────────▼──────────────────────────────────────────┐
 │  crates/extensions/rara-trading (新写 Rust)               │
-│  · 交易所执行 / OMS / 下单        (调研 barter-rs)         │
-│  · 信号 / Fusion / 仓位·组合                               │
-│  · 策略运行时 & 回测编排 ──► rara-sandbox 跑 Python+vectorbt│
+│  · 金融订阅：RSS article + latest candle 匹配与投递          │
+│  · 研究台：回测编排 ──► 独立、禁网 sandbox 跑 Python+vectorbt│
+│  · 执行阶段：交易所执行 / OMS / 下单      (调研 barter-rs)   │
+│  · 执行阶段：信号 / Fusion / 仓位·组合                     │
 └──────────────────────────────────────────────────────────┘
 ```
 
 ### rara 里 新建 vs 复用 vs 删
-- **新建 Rust**：crates/extensions/rara-trading = 交易所执行 + OMS + 信号/仓位
-- **保留 Python**：策略 + vectorbt 回测，经 rara-sandbox 驱动
+- **新建 Rust**：crates/extensions/rara-trading = 金融信息订阅（第一阶段：新闻 + 最新 K 线）+ 研究台（第二阶段）；后续交易所执行 + OMS + 信号/仓位
+- **保留 Python**：策略 + vectorbt 回测，经受约束的回测 runner 驱动
 - **复用 rara**：LLM · Tape 记忆 · Guard · Proactive · Scheduler · Channels · data_feed
+- **新增专用边界**：TSDB-backed MarketDataRepository、版本化 Dataset/Artifact store；后续 Trading ledger
 - **删除**：trading-agent 的 Go internal/agent/，及 rara 已覆盖的 Go 编排层
 
 ## 从 trading-agent 迁移映射
 
 | trading-agent (Go) | 去向 |
 |--------------------|------|
-| Python 策略 + vectorbt 回测 | 保留，rara-sandbox 跑 |
+| Python 策略 + vectorbt 回测 | 保留，经独立、禁网的回测 runner 跑 |
 | 调度 / 记忆 / guard / 通道 / LLM | 删，用 rara kernel |
-| 市场数据摄取（CCXT / TimescaleDB） | 移植进 data_feed + rara-trading |
+| 市场数据摄取（CCXT / TimescaleDB） | 最新 K 线/通知类事件进 data_feed；OHLCV 历史进入专用 MarketDataRepository |
 | 交易所执行 / OMS / 下单 | Rust 重写（barter-rs 调研） |
 | 信号 / Fusion / 仓位组合 | Rust 重写（逻辑量不大） |
 | internal/agent/（半成品 agent 框架） | 删 |
@@ -99,11 +181,25 @@ rara = 用户的私人量化操盘副驾。交易是 rara 的能力，不是独�
 - Hermes Agent — rara 自身 North Star 参照的个人 agent 品类。
 - 前身 trading-agent Go 项目（同 org），已实现完整自主交易 pipeline + 策略进化闭环。
 
-## Open Questions（下一步实现计划要解决）
+## 执行阶段的准入条件
 
-1. **落地顺序**：增量（先研究台：sandbox 跑 Python 回测作为原生 tool，最低风险）
-   vs 一次性 port 执行引擎？—— rara 信奉 "Slow is Fast"，倾向增量。
-2. **Rust 执行层选型**：barter-rs 能覆盖多少 CCXT 交易所？testnet（Bybit/OKX）支持？
-3. **策略运行时契约**：Go 现有 IStrategy（populate_indicators/entry/exit）如何在
-   Rust↔Python(sandbox) 边界保留。
-4. **市场数据存储**：复用 rara 现有 data_feed store，还是引入 TimescaleDB？
+研究台完成不等于可以开始碰真钱。以下条件全部满足后，才开始 paper/testnet 执行；live
+在 testnet 验证完成后另行批准：
+
+1. **OMS 状态一致性**：持久化订单/仓位 ledger 与订单状态机；每个 `OrderIntent` 使用稳定
+   `client-order-id` 作为幂等键。
+2. **交易所 reconciliation**：下单/撤单超时、断线和重启后，从交易所拉取订单与成交并收敛
+   本地状态；未知提交状态必须 fail closed，禁止盲目重试。
+3. **集中风控**：所有下单路径（策略、手动、恢复）经过同一 mandate 与限额检查；账户级并发
+   控制、限速、时钟异常处理和本地硬 halt 已测试。
+4. **可审计性**：每笔动作可追溯到用户、Guard 决定、`TradingMandate`、策略版本和
+   `BacktestArtifact`；密钥永不进入策略 sandbox、聊天上下文或审计载荷。
+5. **集成形态**：`rara-trading` 作为 workspace 的编译期 extension，由 app 显式注册 tool、
+   配置、生命周期 hook、迁移与只读 Web 路由；它不是动态插件。
+
+## Remaining Open Questions（进入执行阶段前调研）
+
+1. **Rust 执行层选型**：barter-rs 覆盖哪些目标交易所？Bybit/OKX testnet 的下单、撤单、
+   websocket 成交回报和 reconciliation 是否足够？不足部分的 adapter 边界如何设计？
+2. **资金与账户模型**：首发限定现货、永续或两者？多账户/子账户、保证金模式、币种精度和
+   最小下单单位如何映射为强类型约束？

--- a/docs/plans/2026-07-10-rara-trading-design.md
+++ b/docs/plans/2026-07-10-rara-trading-design.md
@@ -1,0 +1,109 @@
+# rara Trading — 产品设计
+
+> Status: 产品设计已定稿，待拆解实现计划。
+> Author: Ryan + Claude
+> Date: 2026-07-10
+
+## Summary
+
+把量化交易做成 **rara 的一项能力**，而不是一个外挂的独立系统。
+
+用户不是在用一个交易软件——用户是在跟自己的 rara 说「帮我盯盘 / 研究 / 下单」。
+rara 有多年记忆、会主动提醒、跨 Telegram / TUI / Web 陪着用户。底层交易引擎
+**自主运行**，rara 作为副驾替用户看着、研究、必要时代为操作（改状态需用户确认一次）。
+
+这跟 rara 自身的 North Star 同频：`goal.md` 里「注意到用户每周一看股票，自己建个
+定时任务」——交易本就是 rara 要主动承担的一类生活/工作事务。
+
+前身是独立的 Go 项目 `trading-agent`（signal-driven 自主交易基建）。本设计将其
+**核心交易能力用 Rust 重写进 rara**，Python 策略/回测原样保留（经 sandbox 驱动），
+Go 的编排层由 rara kernel 覆盖，Go 的半成品 agent 层删除。
+
+## Design Decisions
+
+| 决策 | 选项 | 理由 |
+|------|------|------|
+| Agent 归属 | rara 是唯一 agent | 不在交易引擎里再造一个 agent；rara 就是个人 agent |
+| 集成方式 | Rust 原生 extension，**不走 MCP/进程边界** | 用户要 tool 直接可执行；kernel Tool 直调 |
+| 交易引擎哲学 | 自主交易（沿用 trading-agent 现状） | LLM 是监控/副驾层，不是每单审批的 gatekeeper |
+| 操作审批 | confirm-on-mutation | 引擎自主成交不打扰；**rara 主动发起的改状态操作**要用户确认一次（走 Guard） |
+| 主表面 | 对话优先（多通道） | rara 价值在 agent + 记忆 + 主动 + 多通道，不是重型交易终端 |
+| 可视化 | Web UI 承载（K线/回测曲线/持仓） | 交易有天生视觉的东西；rara 已有 web channel + browser driver |
+| 策略/回测 | 保留 Python + vectorbt，rara-sandbox 驱动 | 研究闭环是最值钱资产，语言无关，零重写 |
+| 新写代码 | crates/extensions/rara-trading | 交易所执行 + OMS + 信号/仓位；调研 barter-rs 复用 |
+
+## Product Shape
+
+### 身份
+rara = 用户的私人量化操盘副驾。交易是 rara 的能力，不是独立软件。
+
+### 表面（surfaces）
+| 通道 | 角色 |
+|------|------|
+| 对话（Telegram / TUI / Web-chat） | **主入口**：研究 / 盯盘 / 下单 / 策略进化全靠说 |
+| Web UI | 承载天生视觉的东西：K线、回测资金曲线、持仓/盈亏。看一眼用，非重型终端 |
+| 主动推送 | rara heartbeat：异动、成交、新闻、策略表现，主动找用户 |
+
+### 能力地图（研究 / 盯盘 / 运维 / 情报，四项全要）
+| 能力 | 用户怎么用 | 底层 |
+|------|-----------|------|
+| 研究台 | "回测 rsi2 在 15m，跟 v2 比" | Python 策略 + vectorbt，跑在 rara-sandbox |
+| 盯盘 Copilot | "现在什么情况" "为啥开这单" | rara memory + 引擎持仓/信号 |
+| 运维操作员 | "上 testnet" "平一半 ETH" "halt" | 新 Rust 执行/OMS，**改状态需确认** |
+| 情报分析 | "有影响我持仓的新闻吗" | rara data_feed + LLM |
+
+### 控制模型
+- 引擎**自主交易**，成交不打扰用户。
+- rara **主动发起的改状态操作**（部署/下架策略、手动下单、调仓位上限、halt）
+  → 走 rara 的 **Guard**，用户**确认一次**。
+- 不是 OpenAlice 的每单审批，是「agent 动手前点头」。
+
+## Architecture
+
+```
+┌──────────────────────────────────────────────────────────┐
+│  rara kernel (既有)                                        │
+│  LLM · Tape 记忆 · Guard · Proactive · Scheduler          │
+│  Channels: Telegram / TUI / Web        data_feed · sandbox │
+└───────────────┬──────────────────────────────────────────┘
+                │  kernel Tool 直调（原生 Rust，无进程边界）
+┌───────────────▼──────────────────────────────────────────┐
+│  crates/extensions/rara-trading (新写 Rust)               │
+│  · 交易所执行 / OMS / 下单        (调研 barter-rs)         │
+│  · 信号 / Fusion / 仓位·组合                               │
+│  · 策略运行时 & 回测编排 ──► rara-sandbox 跑 Python+vectorbt│
+└──────────────────────────────────────────────────────────┘
+```
+
+### rara 里 新建 vs 复用 vs 删
+- **新建 Rust**：crates/extensions/rara-trading = 交易所执行 + OMS + 信号/仓位
+- **保留 Python**：策略 + vectorbt 回测，经 rara-sandbox 驱动
+- **复用 rara**：LLM · Tape 记忆 · Guard · Proactive · Scheduler · Channels · data_feed
+- **删除**：trading-agent 的 Go internal/agent/，及 rara 已覆盖的 Go 编排层
+
+## 从 trading-agent 迁移映射
+
+| trading-agent (Go) | 去向 |
+|--------------------|------|
+| Python 策略 + vectorbt 回测 | 保留，rara-sandbox 跑 |
+| 调度 / 记忆 / guard / 通道 / LLM | 删，用 rara kernel |
+| 市场数据摄取（CCXT / TimescaleDB） | 移植进 data_feed + rara-trading |
+| 交易所执行 / OMS / 下单 | Rust 重写（barter-rs 调研） |
+| 信号 / Fusion / 仓位组合 | Rust 重写（逻辑量不大） |
+| internal/agent/（半成品 agent 框架） | 删 |
+
+## 参考
+
+- OpenAlice — file-driven personal trading agent，trading-as-git 审批模型（我们只借鉴
+  工作台 UX，不借鉴每单审批）。
+- Hermes Agent — rara 自身 North Star 参照的个人 agent 品类。
+- 前身 trading-agent Go 项目（同 org），已实现完整自主交易 pipeline + 策略进化闭环。
+
+## Open Questions（下一步实现计划要解决）
+
+1. **落地顺序**：增量（先研究台：sandbox 跑 Python 回测作为原生 tool，最低风险）
+   vs 一次性 port 执行引擎？—— rara 信奉 "Slow is Fast"，倾向增量。
+2. **Rust 执行层选型**：barter-rs 能覆盖多少 CCXT 交易所？testnet（Bybit/OKX）支持？
+3. **策略运行时契约**：Go 现有 IStrategy（populate_indicators/entry/exit）如何在
+   Rust↔Python(sandbox) 边界保留。
+4. **市场数据存储**：复用 rara 现有 data_feed store，还是引入 TimescaleDB？

--- a/web/e2e/harness/data-feeds.spec.ts
+++ b/web/e2e/harness/data-feeds.spec.ts
@@ -51,6 +51,9 @@ interface FeedCatalogEntry {
   tags: string[];
   enabled: boolean;
   feed_id: string | null;
+  requires_configuration: boolean;
+  setup_hint: string | null;
+  transport_template: Record<string, unknown> | null;
 }
 
 // ---------------------------------------------------------------------------
@@ -405,6 +408,34 @@ test.describe('Data Feeds Management', () => {
           tags: ['finance', 'news', 'fed'],
           enabled: false,
           feed_id: null,
+          requires_configuration: false,
+          setup_hint: null,
+          transport_template: {
+            url: 'https://www.federalreserve.gov/feeds/press_all.xml',
+            interval_secs: 300,
+            headers: {},
+            max_entries_per_poll: 50,
+          },
+        },
+        {
+          id: 'binance-market-candles',
+          name: 'Binance Market Candles',
+          description: 'Preset for Binance OHLCV ingestion.',
+          feed_type: 'market_candle',
+          tags: ['finance', 'market-data', 'crypto', 'binance'],
+          enabled: false,
+          feed_id: null,
+          requires_configuration: true,
+          setup_hint: 'Connect a normalized Binance candle endpoint before enabling.',
+          transport_template: {
+            url: '',
+            interval_secs: 60,
+            headers: {},
+            venue: 'binance',
+            symbols: [],
+            timeframes: [],
+            max_candles_per_poll: 1000,
+          },
         },
       ],
     });
@@ -417,6 +448,47 @@ test.describe('Data Feeds Management', () => {
 
     await expect(page.getByText('finance-fed-press-releases')).toBeVisible({ timeout: 5_000 });
     await expect(page.getByRole('button', { name: 'Disable' })).toBeVisible();
+  });
+
+  test('provider preset opens a prefilled market candle form', async ({ page }) => {
+    await setupRoutes(page, {
+      feeds: [],
+      events: [],
+      catalog: [
+        {
+          id: 'binance-market-candles',
+          name: 'Binance Market Candles',
+          description: 'Preset for Binance OHLCV ingestion.',
+          feed_type: 'market_candle',
+          tags: ['finance', 'market-data', 'crypto', 'binance'],
+          enabled: false,
+          feed_id: null,
+          requires_configuration: true,
+          setup_hint: 'Connect a normalized Binance candle endpoint before enabling.',
+          transport_template: {
+            url: '',
+            interval_secs: 60,
+            headers: {},
+            venue: 'binance',
+            symbols: [],
+            timeframes: [],
+            max_candles_per_poll: 1000,
+          },
+        },
+      ],
+    });
+    await goToDataFeeds(page);
+
+    await expect(page.getByText(/^Provider presets$/)).toBeVisible({ timeout: 10_000 });
+    await expect(page.getByText('Binance Market Candles')).toBeVisible();
+
+    await page.getByRole('button', { name: 'Use template' }).click();
+
+    await expect(page.getByText('New Data Feed')).toBeVisible({ timeout: 5_000 });
+    await expect(page.locator('input[placeholder="e.g. github-rara"]')).toHaveValue(
+      'finance-binance-market-candles',
+    );
+    await expect(page.locator('input[placeholder="binance"]')).toHaveValue('binance');
   });
 
   // -----------------------------------------------------------------------

--- a/web/e2e/harness/data-feeds.spec.ts
+++ b/web/e2e/harness/data-feeds.spec.ts
@@ -23,7 +23,7 @@ import { test, expect } from '@playwright/test';
 interface DataFeedConfig {
   id: string;
   name: string;
-  feed_type: 'webhook' | 'websocket' | 'polling';
+  feed_type: 'webhook' | 'websocket' | 'polling' | 'rss' | 'market_candle';
   tags: string[];
   transport: Record<string, unknown>;
   auth: { type: string; [key: string]: unknown } | null;
@@ -41,6 +41,16 @@ interface FeedEvent {
   tags: string[];
   payload: unknown;
   received_at: string;
+}
+
+interface FeedCatalogEntry {
+  id: string;
+  name: string;
+  description: string;
+  feed_type: DataFeedConfig['feed_type'];
+  tags: string[];
+  enabled: boolean;
+  feed_id: string | null;
 }
 
 // ---------------------------------------------------------------------------
@@ -164,6 +174,7 @@ async function setupRoutes(
   state: {
     feeds: DataFeedConfig[];
     events: FeedEvent[];
+    catalog?: FeedCatalogEntry[];
   },
 ) {
   // Suppress onboarding & connection dialogs via localStorage.
@@ -192,6 +203,64 @@ async function setupRoutes(
   await page.route('**/api/v1/settings', (route) =>
     route.fulfill({ status: 200, json: MOCK_SETTINGS }),
   );
+
+  // Default feed source catalog.
+  await page.route('**/api/v1/data-feeds/catalog', async (route) => {
+    await route.fulfill({ json: state.catalog ?? [] });
+  });
+
+  await page.route('**/api/v1/data-feeds/catalog/*/enable', async (route, request) => {
+    if (request.method() !== 'POST') {
+      await route.continue();
+      return;
+    }
+
+    const id = request.url().match(/catalog\/([^/]+)\/enable/)?.[1];
+    const entry = state.catalog?.find((item) => item.id === id);
+    if (!entry) {
+      await route.fulfill({ status: 404, json: { error: 'not found' } });
+      return;
+    }
+
+    const now = new Date().toISOString();
+    const feed: DataFeedConfig = {
+      id: entry.feed_id ?? `feed-${entry.id}`,
+      name: `finance-${entry.id}`,
+      feed_type: entry.feed_type,
+      tags: entry.tags,
+      transport: {},
+      auth: null,
+      enabled: true,
+      status: 'running',
+      last_error: null,
+      created_at: now,
+      updated_at: now,
+    };
+    state.feeds.push(feed);
+    entry.enabled = true;
+    entry.feed_id = feed.id;
+    await route.fulfill({ status: 201, json: feed });
+  });
+
+  await page.route('**/api/v1/data-feeds/catalog/*/disable', async (route, request) => {
+    if (request.method() !== 'POST') {
+      await route.continue();
+      return;
+    }
+
+    const id = request.url().match(/catalog\/([^/]+)\/disable/)?.[1];
+    const entry = state.catalog?.find((item) => item.id === id);
+    const feed = state.feeds.find((item) => item.id === entry?.feed_id);
+    if (!entry || !feed) {
+      await route.fulfill({ status: 404, json: { error: 'not found' } });
+      return;
+    }
+
+    feed.enabled = false;
+    feed.status = 'idle';
+    entry.enabled = false;
+    await route.fulfill({ json: feed });
+  });
 
   // Data feeds list + create.
   await page.route('**/api/v1/data-feeds', async (route, request) => {
@@ -252,7 +321,7 @@ async function setupRoutes(
   });
 
   // Single feed operations (GET/PUT/DELETE by id).
-  await page.route(/\/api\/v1\/data-feeds\/[^/]+$/, async (route, request) => {
+  await page.route(/\/api\/v1\/data-feeds\/(?!catalog$)[^/]+$/, async (route, request) => {
     const method = request.method();
     const url = request.url();
     const idMatch = url.match(/data-feeds\/([^/]+)$/);
@@ -321,6 +390,33 @@ test.describe('Data Feeds Management', () => {
 
     await expect(page.getByText('No data feeds configured')).toBeVisible({ timeout: 10_000 });
     await expect(page.getByText('Create Feed')).toBeVisible();
+  });
+
+  test('shows default finance sources and enables one', async ({ page }) => {
+    await setupRoutes(page, {
+      feeds: [],
+      events: [],
+      catalog: [
+        {
+          id: 'fed-press-releases',
+          name: 'Federal Reserve Press Releases',
+          description: 'Official Federal Reserve press releases.',
+          feed_type: 'rss',
+          tags: ['finance', 'news', 'fed'],
+          enabled: false,
+          feed_id: null,
+        },
+      ],
+    });
+    await goToDataFeeds(page);
+
+    await expect(page.getByText('Default finance sources')).toBeVisible({ timeout: 10_000 });
+    await expect(page.getByText('Federal Reserve Press Releases', { exact: true })).toBeVisible();
+
+    await page.getByRole('button', { name: 'Enable' }).click();
+
+    await expect(page.getByText('finance-fed-press-releases')).toBeVisible({ timeout: 5_000 });
+    await expect(page.getByRole('button', { name: 'Disable' })).toBeVisible();
   });
 
   // -----------------------------------------------------------------------

--- a/web/src/api/data-feeds.ts
+++ b/web/src/api/data-feeds.ts
@@ -23,7 +23,7 @@ import { api } from './client';
 export interface DataFeedConfig {
   id: string;
   name: string;
-  feed_type: 'webhook' | 'websocket' | 'polling';
+  feed_type: FeedType;
   tags: string[];
   transport: Record<string, unknown>;
   auth: AuthConfig | null;
@@ -35,6 +35,8 @@ export interface DataFeedConfig {
 }
 
 export type AuthType = 'header' | 'query' | 'bearer' | 'basic' | 'hmac';
+
+export type FeedType = 'webhook' | 'websocket' | 'polling' | 'rss' | 'market_candle';
 
 export interface AuthConfig {
   type: AuthType;
@@ -58,10 +60,20 @@ export interface FeedEventsResponse {
 
 export interface CreateFeedRequest {
   name: string;
-  feed_type: 'webhook' | 'websocket' | 'polling';
+  feed_type: FeedType;
   tags: string[];
   transport: Record<string, unknown>;
   auth: AuthConfig | null;
+}
+
+export interface FeedCatalogEntry {
+  id: string;
+  name: string;
+  description: string;
+  feed_type: FeedType;
+  tags: string[];
+  enabled: boolean;
+  feed_id: string | null;
 }
 
 // ---------------------------------------------------------------------------
@@ -70,6 +82,8 @@ export interface CreateFeedRequest {
 
 export const dataFeedsApi = {
   list: () => api.get<DataFeedConfig[]>('/api/v1/data-feeds'),
+
+  catalog: () => api.get<FeedCatalogEntry[]>('/api/v1/data-feeds/catalog'),
 
   get: (id: string) => api.get<DataFeedConfig>(`/api/v1/data-feeds/${id}`),
 
@@ -81,6 +95,12 @@ export const dataFeedsApi = {
   delete: (id: string) => api.del(`/api/v1/data-feeds/${id}`),
 
   toggle: (id: string) => api.put<DataFeedConfig>(`/api/v1/data-feeds/${id}/toggle`),
+
+  enableCatalogEntry: (id: string) =>
+    api.post<DataFeedConfig>(`/api/v1/data-feeds/catalog/${id}/enable`),
+
+  disableCatalogEntry: (id: string) =>
+    api.post<DataFeedConfig>(`/api/v1/data-feeds/catalog/${id}/disable`),
 
   events: (id: string, params?: { since?: string; limit?: number; offset?: number }) => {
     const query = new URLSearchParams();

--- a/web/src/api/data-feeds.ts
+++ b/web/src/api/data-feeds.ts
@@ -74,6 +74,9 @@ export interface FeedCatalogEntry {
   tags: string[];
   enabled: boolean;
   feed_id: string | null;
+  requires_configuration: boolean;
+  setup_hint: string | null;
+  transport_template: Record<string, unknown> | null;
 }
 
 // ---------------------------------------------------------------------------

--- a/web/src/components/DataFeedsPanel.tsx
+++ b/web/src/components/DataFeedsPanel.tsx
@@ -26,7 +26,7 @@ import {
   Radio,
   Trash2,
 } from 'lucide-react';
-import { useState, useCallback } from 'react';
+import { useState, useCallback, useEffect } from 'react';
 
 import {
   dataFeedsApi,
@@ -135,13 +135,15 @@ function StatusBadge({ status, enabled }: { status: DataFeedConfig['status']; en
   switch (status) {
     case 'running':
       return (
-        <Badge className="border-green-200 bg-green-50 text-green-700 dark:border-green-900 dark:bg-green-950 dark:text-green-400">
+        <Badge variant="outline" className="gap-1.5 text-foreground">
+          <span className="h-1.5 w-1.5 rounded-full bg-primary" aria-hidden="true" />
           Running
         </Badge>
       );
     case 'idle':
       return (
-        <Badge className="border-yellow-200 bg-yellow-50 text-yellow-700 dark:border-yellow-900 dark:bg-yellow-950 dark:text-yellow-400">
+        <Badge variant="outline" className="gap-1.5 text-muted-foreground">
+          <span className="h-1.5 w-1.5 rounded-full bg-muted-foreground" aria-hidden="true" />
           Idle
         </Badge>
       );
@@ -534,13 +536,17 @@ function FeedFormDialog({
   open,
   onOpenChange,
   editFeed,
+  initialForm,
 }: {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   editFeed?: DataFeedConfig | undefined;
+  initialForm?: FeedFormState | undefined;
 }) {
   const queryClient = useQueryClient();
-  const [form, setForm] = useState<FeedFormState>(editFeed ? feedToForm(editFeed) : INITIAL_FORM);
+  const [form, setForm] = useState<FeedFormState>(
+    editFeed ? feedToForm(editFeed) : (initialForm ?? INITIAL_FORM),
+  );
   const [error, setError] = useState<string | null>(null);
 
   const isEdit = !!editFeed;
@@ -581,10 +587,16 @@ function FeedFormDialog({
 
   const saving = createMutation.isPending || updateMutation.isPending;
 
+  useEffect(() => {
+    if (!open) return;
+    setForm(editFeed ? feedToForm(editFeed) : (initialForm ?? INITIAL_FORM));
+    setError(null);
+  }, [open, editFeed, initialForm]);
+
   // Reset form when dialog opens with a new feed
   const handleOpenChange = (next: boolean) => {
     if (next) {
-      setForm(editFeed ? feedToForm(editFeed) : INITIAL_FORM);
+      setForm(editFeed ? feedToForm(editFeed) : (initialForm ?? INITIAL_FORM));
       setError(null);
     }
     onOpenChange(next);
@@ -975,7 +987,13 @@ function EventHistoryView({ feed, onBack }: { feed: DataFeedConfig; onBack: () =
 // Feed List View
 // ---------------------------------------------------------------------------
 
-function FeedCatalogCard({ entries }: { entries: FeedCatalogEntry[] }) {
+function FeedCatalogCard({
+  entries,
+  onUseTemplate,
+}: {
+  entries: FeedCatalogEntry[];
+  onUseTemplate: (entry: FeedCatalogEntry) => void;
+}) {
   const queryClient = useQueryClient();
 
   const refresh = () => {
@@ -995,69 +1013,99 @@ function FeedCatalogCard({ entries }: { entries: FeedCatalogEntry[] }) {
 
   if (entries.length === 0) return null;
 
+  const readyEntries = entries.filter((entry) => !entry.requires_configuration);
+  const providerEntries = entries.filter((entry) => entry.requires_configuration);
+
+  const renderEntry = (entry: FeedCatalogEntry) => {
+    const pending =
+      (enableMutation.isPending && enableMutation.variables === entry.id) ||
+      (disableMutation.isPending && disableMutation.variables === entry.id);
+
+    return (
+      <div
+        key={entry.id}
+        className="flex flex-col gap-3 px-4 py-3 sm:flex-row sm:items-center sm:justify-between"
+      >
+        <div className="min-w-0 space-y-1">
+          <div className="flex flex-wrap items-center gap-2">
+            <span className="text-sm font-medium">{entry.name}</span>
+            <Badge variant="outline" className="text-xs">
+              {typeLabel(entry.feed_type)}
+            </Badge>
+            {entry.enabled && (
+              <Badge variant="secondary" className="text-xs text-foreground">
+                Enabled
+              </Badge>
+            )}
+            {entry.requires_configuration && (
+              <Badge variant="secondary" className="text-xs text-muted-foreground">
+                Requires config
+              </Badge>
+            )}
+          </div>
+          <p className="text-xs text-muted-foreground">{entry.description}</p>
+          {entry.setup_hint && <p className="text-xs text-muted-foreground">{entry.setup_hint}</p>}
+          <p className="text-[11px] text-muted-foreground">Tags: {entry.tags.join(' · ')}</p>
+        </div>
+        {entry.requires_configuration ? (
+          <Button
+            variant="outline"
+            size="sm"
+            className="h-8 shrink-0"
+            onClick={() => onUseTemplate(entry)}
+          >
+            Use template
+          </Button>
+        ) : entry.enabled ? (
+          <Button
+            variant="outline"
+            size="sm"
+            className="h-8 shrink-0"
+            onClick={() => disableMutation.mutate(entry.id)}
+            disabled={pending}
+          >
+            {pending ? 'Disabling...' : 'Disable'}
+          </Button>
+        ) : (
+          <Button
+            size="sm"
+            className="h-8 shrink-0"
+            onClick={() => enableMutation.mutate(entry.id)}
+            disabled={pending}
+          >
+            {pending ? 'Enabling...' : 'Enable'}
+          </Button>
+        )}
+      </div>
+    );
+  };
+
   return (
     <div className="rounded-lg border bg-card">
       <div className="border-b px-4 py-3">
         <h3 className="text-sm font-semibold">Default finance sources</h3>
         <p className="text-xs text-muted-foreground">
-          Enable built-in official feeds without manually entering source URLs.
+          Official feeds can run immediately. Provider presets need your own endpoint or
+          credentials.
         </p>
       </div>
       <div className="divide-y">
-        {entries.map((entry) => {
-          const pending =
-            (enableMutation.isPending && enableMutation.variables === entry.id) ||
-            (disableMutation.isPending && disableMutation.variables === entry.id);
-
-          return (
-            <div
-              key={entry.id}
-              className="flex flex-col gap-3 px-4 py-3 sm:flex-row sm:items-center sm:justify-between"
-            >
-              <div className="min-w-0 space-y-1">
-                <div className="flex flex-wrap items-center gap-2">
-                  <span className="text-sm font-medium">{entry.name}</span>
-                  <Badge variant="outline" className="text-xs">
-                    {typeLabel(entry.feed_type)}
-                  </Badge>
-                  {entry.enabled && (
-                    <Badge className="border-green-200 bg-green-50 text-green-700 dark:border-green-900 dark:bg-green-950 dark:text-green-400">
-                      Enabled
-                    </Badge>
-                  )}
-                </div>
-                <p className="text-xs text-muted-foreground">{entry.description}</p>
-                <div className="flex flex-wrap gap-1">
-                  {entry.tags.map((tag) => (
-                    <Badge key={tag} variant="secondary" className="text-[10px] px-1.5 py-0">
-                      {tag}
-                    </Badge>
-                  ))}
-                </div>
-              </div>
-              {entry.enabled ? (
-                <Button
-                  variant="outline"
-                  size="sm"
-                  className="h-8 shrink-0"
-                  onClick={() => disableMutation.mutate(entry.id)}
-                  disabled={pending}
-                >
-                  {pending ? 'Disabling...' : 'Disable'}
-                </Button>
-              ) : (
-                <Button
-                  size="sm"
-                  className="h-8 shrink-0"
-                  onClick={() => enableMutation.mutate(entry.id)}
-                  disabled={pending}
-                >
-                  {pending ? 'Enabling...' : 'Enable'}
-                </Button>
-              )}
+        {readyEntries.length > 0 && (
+          <div>
+            <div className="px-4 pt-3 text-xs font-medium text-muted-foreground">
+              Ready to enable
             </div>
-          );
-        })}
+            {readyEntries.map(renderEntry)}
+          </div>
+        )}
+        {providerEntries.length > 0 && (
+          <div>
+            <div className="px-4 pt-3 text-xs font-medium text-muted-foreground">
+              Provider presets
+            </div>
+            {providerEntries.map(renderEntry)}
+          </div>
+        )}
       </div>
     </div>
   );
@@ -1073,6 +1121,7 @@ function FeedListView({
   const queryClient = useQueryClient();
   const [formOpen, setFormOpen] = useState(false);
   const [editFeed, setEditFeed] = useState<DataFeedConfig | undefined>();
+  const [draftForm, setDraftForm] = useState<FeedFormState | undefined>();
   const [deleteId, setDeleteId] = useState<string | null>(null);
   const catalogQuery = useQuery({
     queryKey: ['data-feed-catalog'],
@@ -1098,11 +1147,26 @@ function FeedListView({
 
   const handleEdit = (feed: DataFeedConfig) => {
     setEditFeed(feed);
+    setDraftForm(undefined);
     setFormOpen(true);
   };
 
   const handleNew = () => {
     setEditFeed(undefined);
+    setDraftForm(undefined);
+    setFormOpen(true);
+  };
+
+  const handleUseTemplate = (entry: FeedCatalogEntry) => {
+    setEditFeed(undefined);
+    setDraftForm({
+      name: `finance-${entry.id}`,
+      feed_type: entry.feed_type,
+      tags: entry.tags.join(', '),
+      transport: entry.transport_template ?? emptyTransport(entry.feed_type),
+      authType: 'none',
+      authFields: {},
+    });
     setFormOpen(true);
   };
 
@@ -1122,7 +1186,9 @@ function FeedListView({
         </Button>
       </div>
 
-      {catalogQuery.data && <FeedCatalogCard entries={catalogQuery.data} />}
+      {catalogQuery.data && (
+        <FeedCatalogCard entries={catalogQuery.data} onUseTemplate={handleUseTemplate} />
+      )}
 
       {/* Table */}
       {feeds.length === 0 ? (
@@ -1217,7 +1283,12 @@ function FeedListView({
       )}
 
       {/* Create/Edit Dialog */}
-      <FeedFormDialog open={formOpen} onOpenChange={setFormOpen} editFeed={editFeed} />
+      <FeedFormDialog
+        open={formOpen}
+        onOpenChange={setFormOpen}
+        editFeed={editFeed}
+        initialForm={draftForm}
+      />
 
       {/* Delete Confirmation */}
       <Dialog

--- a/web/src/components/DataFeedsPanel.tsx
+++ b/web/src/components/DataFeedsPanel.tsx
@@ -31,6 +31,7 @@ import { useState, useCallback } from 'react';
 import {
   dataFeedsApi,
   type DataFeedConfig,
+  type FeedCatalogEntry,
   type FeedEvent,
   type CreateFeedRequest,
   type AuthType,
@@ -112,6 +113,10 @@ function typeLabel(t: DataFeedConfig['feed_type']): string {
       return 'Webhook';
     case 'websocket':
       return 'WebSocket';
+    case 'rss':
+      return 'RSS';
+    case 'market_candle':
+      return 'Market Candle';
   }
 }
 
@@ -171,6 +176,18 @@ function emptyTransport(feedType: CreateFeedRequest['feed_type']): Record<string
         url: '',
         reconnect_backoff: [5, 10, 30, 60],
         heartbeat_secs: 30,
+      };
+    case 'rss':
+      return { url: '', interval_secs: 300, headers: {}, max_entries_per_poll: 50 };
+    case 'market_candle':
+      return {
+        url: '',
+        interval_secs: 60,
+        headers: {},
+        venue: '',
+        symbols: [],
+        timeframes: [],
+        max_candles_per_poll: 1000,
       };
   }
 }
@@ -289,6 +306,102 @@ function TransportFields({
               placeholder="wss://stream.example.com/ws"
               className="h-9 font-mono text-sm"
             />
+          </div>
+        </div>
+      );
+    case 'rss':
+      return (
+        <div className="space-y-3">
+          <div className="space-y-1.5">
+            <Label className="text-sm font-medium">RSS/Atom URL</Label>
+            <Input
+              value={String(transport.url ?? '')}
+              onChange={(e) => set('url', e.target.value)}
+              placeholder="https://example.com/feed.xml"
+              className="h-9 font-mono text-sm"
+            />
+          </div>
+          <div className="flex gap-3">
+            <div className="space-y-1.5">
+              <Label className="text-sm font-medium">Interval (seconds)</Label>
+              <Input
+                type="number"
+                min={1}
+                value={String(transport.interval_secs ?? 300)}
+                onChange={(e) => set('interval_secs', Number(e.target.value))}
+                className="h-9 w-32 text-sm"
+              />
+            </div>
+            <div className="space-y-1.5">
+              <Label className="text-sm font-medium">Max entries</Label>
+              <Input
+                type="number"
+                min={1}
+                value={String(transport.max_entries_per_poll ?? 50)}
+                onChange={(e) => set('max_entries_per_poll', Number(e.target.value))}
+                className="h-9 w-32 text-sm"
+              />
+            </div>
+          </div>
+        </div>
+      );
+    case 'market_candle':
+      return (
+        <div className="space-y-3">
+          <div className="space-y-1.5">
+            <Label className="text-sm font-medium">Normalized candle endpoint</Label>
+            <Input
+              value={String(transport.url ?? '')}
+              onChange={(e) => set('url', e.target.value)}
+              placeholder="https://market-data.example/candles/latest"
+              className="h-9 font-mono text-sm"
+            />
+          </div>
+          <div className="space-y-1.5">
+            <Label className="text-sm font-medium">Venue</Label>
+            <Input
+              value={String(transport.venue ?? '')}
+              onChange={(e) => set('venue', e.target.value)}
+              placeholder="binance"
+              className="h-9 text-sm"
+            />
+          </div>
+          <div className="space-y-1.5">
+            <Label className="text-sm font-medium">Symbols</Label>
+            <Input
+              value={Array.isArray(transport.symbols) ? transport.symbols.join(', ') : ''}
+              onChange={(e) =>
+                set(
+                  'symbols',
+                  e.target.value
+                    .split(',')
+                    .map((item) => item.trim())
+                    .filter(Boolean),
+                )
+              }
+              placeholder="BTCUSDT, ETHUSDT"
+              className="h-9 font-mono text-sm"
+            />
+          </div>
+          <div className="space-y-1.5">
+            <Label className="text-sm font-medium">Timeframes</Label>
+            <Input
+              value={Array.isArray(transport.timeframes) ? transport.timeframes.join(', ') : ''}
+              onChange={(e) =>
+                set(
+                  'timeframes',
+                  e.target.value
+                    .split(',')
+                    .map((item) => item.trim())
+                    .filter(Boolean),
+                )
+              }
+              placeholder="1m, 15m, 1h"
+              className="h-9 font-mono text-sm"
+            />
+            <p className="text-xs text-muted-foreground">
+              Endpoint must return rara's normalized candle batch JSON.
+            </p>
           </div>
         </div>
       );
@@ -436,6 +549,7 @@ function FeedFormDialog({
     mutationFn: (req: CreateFeedRequest) => dataFeedsApi.create(req),
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: ['data-feeds'] });
+      void queryClient.invalidateQueries({ queryKey: ['data-feed-catalog'] });
       onOpenChange(false);
     },
     onError: (err: Error) => setError(err.message),
@@ -445,6 +559,7 @@ function FeedFormDialog({
     mutationFn: (req: Partial<CreateFeedRequest>) => dataFeedsApi.update(editFeed!.id, req),
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: ['data-feeds'] });
+      void queryClient.invalidateQueries({ queryKey: ['data-feed-catalog'] });
       onOpenChange(false);
     },
     onError: (err: Error) => setError(err.message),
@@ -522,6 +637,8 @@ function FeedFormDialog({
                 <SelectItem value="polling">Polling</SelectItem>
                 <SelectItem value="webhook">Webhook</SelectItem>
                 <SelectItem value="websocket">WebSocket</SelectItem>
+                <SelectItem value="rss">RSS</SelectItem>
+                <SelectItem value="market_candle">Market Candle</SelectItem>
               </SelectContent>
             </Select>
           </div>
@@ -858,6 +975,94 @@ function EventHistoryView({ feed, onBack }: { feed: DataFeedConfig; onBack: () =
 // Feed List View
 // ---------------------------------------------------------------------------
 
+function FeedCatalogCard({ entries }: { entries: FeedCatalogEntry[] }) {
+  const queryClient = useQueryClient();
+
+  const refresh = () => {
+    void queryClient.invalidateQueries({ queryKey: ['data-feeds'] });
+    void queryClient.invalidateQueries({ queryKey: ['data-feed-catalog'] });
+  };
+
+  const enableMutation = useMutation({
+    mutationFn: (id: string) => dataFeedsApi.enableCatalogEntry(id),
+    onSuccess: refresh,
+  });
+
+  const disableMutation = useMutation({
+    mutationFn: (id: string) => dataFeedsApi.disableCatalogEntry(id),
+    onSuccess: refresh,
+  });
+
+  if (entries.length === 0) return null;
+
+  return (
+    <div className="rounded-lg border bg-card">
+      <div className="border-b px-4 py-3">
+        <h3 className="text-sm font-semibold">Default finance sources</h3>
+        <p className="text-xs text-muted-foreground">
+          Enable built-in official feeds without manually entering source URLs.
+        </p>
+      </div>
+      <div className="divide-y">
+        {entries.map((entry) => {
+          const pending =
+            (enableMutation.isPending && enableMutation.variables === entry.id) ||
+            (disableMutation.isPending && disableMutation.variables === entry.id);
+
+          return (
+            <div
+              key={entry.id}
+              className="flex flex-col gap-3 px-4 py-3 sm:flex-row sm:items-center sm:justify-between"
+            >
+              <div className="min-w-0 space-y-1">
+                <div className="flex flex-wrap items-center gap-2">
+                  <span className="text-sm font-medium">{entry.name}</span>
+                  <Badge variant="outline" className="text-xs">
+                    {typeLabel(entry.feed_type)}
+                  </Badge>
+                  {entry.enabled && (
+                    <Badge className="border-green-200 bg-green-50 text-green-700 dark:border-green-900 dark:bg-green-950 dark:text-green-400">
+                      Enabled
+                    </Badge>
+                  )}
+                </div>
+                <p className="text-xs text-muted-foreground">{entry.description}</p>
+                <div className="flex flex-wrap gap-1">
+                  {entry.tags.map((tag) => (
+                    <Badge key={tag} variant="secondary" className="text-[10px] px-1.5 py-0">
+                      {tag}
+                    </Badge>
+                  ))}
+                </div>
+              </div>
+              {entry.enabled ? (
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className="h-8 shrink-0"
+                  onClick={() => disableMutation.mutate(entry.id)}
+                  disabled={pending}
+                >
+                  {pending ? 'Disabling...' : 'Disable'}
+                </Button>
+              ) : (
+                <Button
+                  size="sm"
+                  className="h-8 shrink-0"
+                  onClick={() => enableMutation.mutate(entry.id)}
+                  disabled={pending}
+                >
+                  {pending ? 'Enabling...' : 'Enable'}
+                </Button>
+              )}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
 function FeedListView({
   feeds,
   onSelectFeed,
@@ -869,16 +1074,24 @@ function FeedListView({
   const [formOpen, setFormOpen] = useState(false);
   const [editFeed, setEditFeed] = useState<DataFeedConfig | undefined>();
   const [deleteId, setDeleteId] = useState<string | null>(null);
+  const catalogQuery = useQuery({
+    queryKey: ['data-feed-catalog'],
+    queryFn: () => dataFeedsApi.catalog(),
+  });
 
   const toggleMutation = useMutation({
     mutationFn: (id: string) => dataFeedsApi.toggle(id),
-    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['data-feeds'] }),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ['data-feeds'] });
+      void queryClient.invalidateQueries({ queryKey: ['data-feed-catalog'] });
+    },
   });
 
   const deleteMutation = useMutation({
     mutationFn: (id: string) => dataFeedsApi.delete(id),
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: ['data-feeds'] });
+      void queryClient.invalidateQueries({ queryKey: ['data-feed-catalog'] });
       setDeleteId(null);
     },
   });
@@ -894,7 +1107,7 @@ function FeedListView({
   };
 
   return (
-    <>
+    <div className="space-y-4">
       {/* Toolbar */}
       <div className="flex items-center justify-between">
         <div>
@@ -908,6 +1121,8 @@ function FeedListView({
           New Feed
         </Button>
       </div>
+
+      {catalogQuery.data && <FeedCatalogCard entries={catalogQuery.data} />}
 
       {/* Table */}
       {feeds.length === 0 ? (
@@ -1033,7 +1248,7 @@ function FeedListView({
           </DialogFooter>
         </DialogContent>
       </Dialog>
-    </>
+    </div>
   );
 }
 


### PR DESCRIPTION
## Summary

Adds the first `rara-trading` deliverable: finance information subscriptions for operator-configured RSS/Atom sources and latest closed market candles.

## What changed

- Add `crates/extensions/rara-trading` with normalized RSS/Atom ingestion, closed candle ingestion, finance subscription tools, Timescale-backed market data storage, and a Timescale testcontainer contract.
- Wire finance feed dispatch into the app feed loop: persist events, upsert closed candles before delivery, and route matched finance events as immediate synthetic turns or silent tape appends.
- Extend backend-admin feed startup for `rss` and `market_candle` feed types.
- Keep kernel `data_feed` source-agnostic; it only gets generic feed type variants.
- Add operator docs and update the trading design/implementation plan.

## Validation

- `cargo test -p rara-trading -- --nocapture`
- `cargo test -p rara-app finance_event`
- `cargo test -p rara-app tools::tests`
- `cargo test -p rara-backend-admin data_feeds::router::tests`
- `cargo test -p rara-kernel data_feed::registry::tests`
- `rustup run nightly cargo fmt --check`
- `git diff --check`
- `cargo clippy -p rara-kernel -p rara-backend-admin -p rara-trading -p rara-app --all-targets -- -D warnings`
- pre-commit hook: `cargo check`, `cargo fmt`, `cargo clippy`, `cargo doc`, AGENT.md check

## Notes

This PR intentionally does not add account access, orders, deployment, or execution capability. Conversation tools can subscribe only to operator-configured sources; they cannot pass feed URLs, provider URLs, credentials, account IDs, or order parameters.