### PR TITLE
ci: return Rust merge gate to restored arc-runner-set, invert #2166 runner guard (#2226)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -26,9 +26,11 @@ defaults:
 permissions:
   contents: read
 
-# GitHub-hosted runners only — see the note in rust.yml: the self-hosted
-# `arc-runner-set` fleet is gone, and it must not appear in any job the
-# `Lint Success` required check depends on (#2166).
+# Lint jobs run on GitHub-hosted runners. Unlike rust.yml's compile-heavy
+# gate, these are light (fmt/proto/go/zig/ratchet) and were never the arm64
+# hang source, so they stay GitHub-hosted even though the Rust gate returned
+# to the restored `arc-runner-set` fleet (#2226). See rust.yml's top note for
+# the runner-policy history.
 jobs:
   rust-format:
     name: Rust Format

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -26,13 +26,15 @@ env:
   CARGO_INCREMENTAL: false
   CARGO_NET_RETRY: 10
   RUSTUP_MAX_RETRIES: 10
-  # arc-runner-set reuses ~/.cargo/git across jobs. libgit2 chokes checking
-  # out the boxlite git dependency's nested e2fsprogs submodule when a prior
-  # run left residual files ("could not create symlink RELEASE-NOTES: File
-  # exists"). Fetch git deps via the system `git` CLI instead of libgit2 —
-  # `git submodule update` is robust to residual state. Paired with the
-  # per-job stale-checkout clean below. GitHub-hosted runners never hit this
-  # (fresh ~/.cargo each run); arc's persistent cache does. See #2226.
+  # The three Rust jobs run concurrently on arc pods that share one
+  # /home/runner/.cargo volume, so they raced on the boxlite git dependency's
+  # checkout (nested e2fsprogs submodule): one job's fetch/checkout against
+  # another's, giving "could not create symlink RELEASE-NOTES: File exists" /
+  # "failed to remove directory .../apps" / ".git/index.lock: No such file".
+  # The primary fix is a per-job CARGO_HOME (see each job's env), which drops
+  # the shared state entirely. This stays as hardening: fetch git deps via the
+  # system `git` CLI (robust `git submodule update`) rather than libgit2.
+  # GitHub-hosted runners never hit this (fresh ~/.cargo each run). See #2226.
   CARGO_NET_GIT_FETCH_WITH_CLI: "true"
   # Kept "" defensively: no sccache backend is configured, and a preset
   # wrapper would make `rustc -vV` probes (notably `cargo +nightly doc`)
@@ -78,6 +80,11 @@ jobs:
     env:
       # See top-of-file note: stub native boxlite build in CI.
       BOXLITE_DEPS_STUB: "1"
+      # Isolate CARGO_HOME per job: arc schedules these three Rust jobs
+      # concurrently on pods sharing one /home/runner/.cargo, and they raced
+      # on the boxlite git checkout. runner.temp is wiped per job, so each
+      # gets a clean, private cargo home. See top-of-file note + #2226.
+      CARGO_HOME: ${{ runner.temp }}/cargo-${{ github.job }}
     steps:
       - name: Checkout code
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -92,13 +99,16 @@ jobs:
 
       - name: Rust cache
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2.9.1
+        with:
+          # Per-job key: the jobs use isolated CARGO_HOME paths and share one
+          # arc OS/arch (no matrix), so give each its own cache entry (#2226).
+          key: ${{ github.job }}
 
-      # arc-runner-set is a persistent runner (~/.cargo/git reused across
-      # jobs). Drop any residual boxlite git checkout so cargo re-fetches it
-      # clean before the first cargo invocation — see the top-of-file
-      # CARGO_NET_GIT_FETCH_WITH_CLI note and #2226. Runs after the cache
-      # restore so a restored-but-stale entry is cleaned too.
-      - name: Clear stale boxlite git checkout (persistent arc cache)
+      # Defensive: with per-job CARGO_HOME (see env) this only touches THIS
+      # job's cargo home — no cross-job race — and normally matches nothing on
+      # a wiped runner.temp. Kept to clear any boxlite checkout a restored
+      # rust-cache git/db entry might reconstruct stale. See #2226.
+      - name: Clear any stale boxlite git checkout (defensive)
         run: rm -rf "${CARGO_HOME:-$HOME/.cargo}/git/checkouts/boxlite-"* "${CARGO_HOME:-$HOME/.cargo}/git/db/boxlite-"*
 
       - name: Run clippy
@@ -111,6 +121,11 @@ jobs:
     env:
       # See top-of-file note: stub native boxlite build in CI.
       BOXLITE_DEPS_STUB: "1"
+      # Isolate CARGO_HOME per job: arc schedules these three Rust jobs
+      # concurrently on pods sharing one /home/runner/.cargo, and they raced
+      # on the boxlite git checkout. runner.temp is wiped per job, so each
+      # gets a clean, private cargo home. See top-of-file note + #2226.
+      CARGO_HOME: ${{ runner.temp }}/cargo-${{ github.job }}
     steps:
       - name: Checkout code
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -125,10 +140,14 @@ jobs:
 
       - name: Rust cache
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2.9.1
+        with:
+          # Per-job key: the jobs use isolated CARGO_HOME paths and share one
+          # arc OS/arch (no matrix), so give each its own cache entry (#2226).
+          key: ${{ github.job }}
 
-      # See the clippy job: clear the residual boxlite git checkout the
-      # persistent arc runner reuses across jobs, before any cargo call (#2226).
-      - name: Clear stale boxlite git checkout (persistent arc cache)
+      # See the clippy job: defensive clear within this job's isolated
+      # CARGO_HOME before any cargo call (#2226).
+      - name: Clear any stale boxlite git checkout (defensive)
         run: rm -rf "${CARGO_HOME:-$HOME/.cargo}/git/checkouts/boxlite-"* "${CARGO_HOME:-$HOME/.cargo}/git/db/boxlite-"*
 
       # Kept defensively (the arc image historically baked nextest in).
@@ -155,6 +174,11 @@ jobs:
     env:
       # See top-of-file note: stub native boxlite build in CI.
       BOXLITE_DEPS_STUB: "1"
+      # Isolate CARGO_HOME per job: arc schedules these three Rust jobs
+      # concurrently on pods sharing one /home/runner/.cargo, and they raced
+      # on the boxlite git checkout. runner.temp is wiped per job, so each
+      # gets a clean, private cargo home. See top-of-file note + #2226.
+      CARGO_HOME: ${{ runner.temp }}/cargo-${{ github.job }}
     steps:
       - name: Checkout code
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -178,10 +202,14 @@ jobs:
 
       - name: Rust cache
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2.9.1
+        with:
+          # Per-job key: the jobs use isolated CARGO_HOME paths and share one
+          # arc OS/arch (no matrix), so give each its own cache entry (#2226).
+          key: ${{ github.job }}
 
-      # See the clippy job: clear the residual boxlite git checkout the
-      # persistent arc runner reuses across jobs, before any cargo call (#2226).
-      - name: Clear stale boxlite git checkout (persistent arc cache)
+      # See the clippy job: defensive clear within this job's isolated
+      # CARGO_HOME before any cargo call (#2226).
+      - name: Clear any stale boxlite git checkout (defensive)
         run: rm -rf "${CARGO_HOME:-$HOME/.cargo}/git/checkouts/boxlite-"* "${CARGO_HOME:-$HOME/.cargo}/git/db/boxlite-"*
 
       - name: Generate documentation

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -26,6 +26,14 @@ env:
   CARGO_INCREMENTAL: false
   CARGO_NET_RETRY: 10
   RUSTUP_MAX_RETRIES: 10
+  # arc-runner-set reuses ~/.cargo/git across jobs. libgit2 chokes checking
+  # out the boxlite git dependency's nested e2fsprogs submodule when a prior
+  # run left residual files ("could not create symlink RELEASE-NOTES: File
+  # exists"). Fetch git deps via the system `git` CLI instead of libgit2 —
+  # `git submodule update` is robust to residual state. Paired with the
+  # per-job stale-checkout clean below. GitHub-hosted runners never hit this
+  # (fresh ~/.cargo each run); arc's persistent cache does. See #2226.
+  CARGO_NET_GIT_FETCH_WITH_CLI: "true"
   # Kept "" defensively: no sccache backend is configured, and a preset
   # wrapper would make `rustc -vV` probes (notably `cargo +nightly doc`)
   # time out trying to start a server.
@@ -85,6 +93,14 @@ jobs:
       - name: Rust cache
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2.9.1
 
+      # arc-runner-set is a persistent runner (~/.cargo/git reused across
+      # jobs). Drop any residual boxlite git checkout so cargo re-fetches it
+      # clean before the first cargo invocation — see the top-of-file
+      # CARGO_NET_GIT_FETCH_WITH_CLI note and #2226. Runs after the cache
+      # restore so a restored-but-stale entry is cleaned too.
+      - name: Clear stale boxlite git checkout (persistent arc cache)
+        run: rm -rf "${CARGO_HOME:-$HOME/.cargo}/git/checkouts/boxlite-"* "${CARGO_HOME:-$HOME/.cargo}/git/db/boxlite-"*
+
       - name: Run clippy
         run: cargo clippy --workspace --all-targets --no-deps -- -D warnings
 
@@ -109,6 +125,11 @@ jobs:
 
       - name: Rust cache
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2.9.1
+
+      # See the clippy job: clear the residual boxlite git checkout the
+      # persistent arc runner reuses across jobs, before any cargo call (#2226).
+      - name: Clear stale boxlite git checkout (persistent arc cache)
+        run: rm -rf "${CARGO_HOME:-$HOME/.cargo}/git/checkouts/boxlite-"* "${CARGO_HOME:-$HOME/.cargo}/git/db/boxlite-"*
 
       # Kept defensively (the arc image historically baked nextest in).
       # `.config/nextest.toml` profile `ci` exists since #1912.
@@ -157,6 +178,11 @@ jobs:
 
       - name: Rust cache
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2.9.1
+
+      # See the clippy job: clear the residual boxlite git checkout the
+      # persistent arc runner reuses across jobs, before any cargo call (#2226).
+      - name: Clear stale boxlite git checkout (persistent arc cache)
+        run: rm -rf "${CARGO_HOME:-$HOME/.cargo}/git/checkouts/boxlite-"* "${CARGO_HOME:-$HOME/.cargo}/git/db/boxlite-"*
 
       - name: Generate documentation
         run: cargo +nightly-2026-06-19 doc --workspace --no-deps --document-private-items

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -44,29 +44,29 @@ defaults:
 permissions:
   contents: read
 
-# All jobs run on GitHub-hosted runners. The self-hosted `arc-runner-set`
-# fleet no longer exists (gone since ~2026-05-08); jobs targeting it queued
-# for 24h and were cancelled by GitHub, so `arc-runner-set` must NOT appear
-# in any job a required check `needs` (#2166). Re-adding an ARC leg once the
-# fleet returns is a follow-up — keep it out of the gate aggregate.
+# The Rust merge gate (clippy/test/docs) runs on the self-hosted
+# `arc-runner-set` fleet again. That fleet went away ~2026-05-08 and #2166
+# moved the gate to GitHub-hosted runners (x64 + `ubuntu-24.04-arm` arm64
+# matrix); on 2026-07-10 the GitHub-hosted arm64 pool hung systematically
+# (`Test (linux-arm64)` stuck 37–51min in `Run tests` on unrelated
+# branches, x64 green in ~6min). `arc-runner-set` came back online
+# 2026-07-11, so the gate returns to it — x64-only, dropping the
+# GitHub-hosted arm64 leg that was the hang source (#2226). `devtool
+# check-ci-runners` now locks this posture (rust.yml MUST reference
+# `arc-runner-set`) so a silent switch back to a hung GitHub-hosted runner
+# is caught. The aarch64-linux *release* artifact (cargo-dist in
+# release.yml) is unaffected and still builds on a GitHub-hosted arm runner.
 #
-# `.cargo/config.toml` forces `linker = "clang"` + `-fuse-ld=mold` for
-# x86_64-unknown-linux-gnu, and GitHub-hosted images do not bake mold
-# (the arc image did, #1942) — so the x64 legs install mold + clang
-# explicitly before any cargo invocation.
+# `setup-rara-build` + the cargo-nextest install are kept defensively: the
+# arc image historically baked diesel headers / protoc / zig / mold /
+# nextest, but rather than assume, we install and let a green arc run
+# confirm redundancy before pruning. `.cargo/config.toml` still forces
+# `linker = "clang"` + `-fuse-ld=mold` for x86_64-unknown-linux-gnu.
 jobs:
   clippy:
-    name: Clippy (${{ matrix.arch }})
+    name: Clippy
     if: ${{ inputs.run }}
-    runs-on: ${{ matrix.runner }}
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - arch: linux-x64
-            runner: ubuntu-latest
-          - arch: linux-arm64
-            runner: ubuntu-24.04-arm
+    runs-on: arc-runner-set
     env:
       # See top-of-file note: stub native boxlite build in CI.
       BOXLITE_DEPS_STUB: "1"
@@ -76,9 +76,9 @@ jobs:
         with:
           persist-credentials: false
 
-      # Single source of truth for the system toolchain the retired arc
-      # image implicitly provided (diesel headers, protoc, zig, mold) —
-      # see .github/actions/setup-rara-build/action.yml (#2166).
+      # System toolchain (diesel headers, protoc, zig, mold). Kept
+      # defensively while the gate moves back to arc-runner-set — see
+      # top-of-file note; prune once a green arc run proves it redundant.
       - name: Setup rara build environment
         uses: ./.github/actions/setup-rara-build
 
@@ -89,17 +89,9 @@ jobs:
         run: cargo clippy --workspace --all-targets --no-deps -- -D warnings
 
   test:
-    name: Test (${{ matrix.arch }})
+    name: Test
     if: ${{ inputs.run }}
-    runs-on: ${{ matrix.runner }}
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - arch: linux-x64
-            runner: ubuntu-latest
-          - arch: linux-arm64
-            runner: ubuntu-24.04-arm
+    runs-on: arc-runner-set
     env:
       # See top-of-file note: stub native boxlite build in CI.
       BOXLITE_DEPS_STUB: "1"
@@ -109,16 +101,16 @@ jobs:
         with:
           persist-credentials: false
 
-      # Single source of truth for the system toolchain the retired arc
-      # image implicitly provided (diesel headers, protoc, zig, mold) —
-      # see .github/actions/setup-rara-build/action.yml (#2166).
+      # System toolchain (diesel headers, protoc, zig, mold). Kept
+      # defensively while the gate moves back to arc-runner-set — see
+      # top-of-file note; prune once a green arc run proves it redundant.
       - name: Setup rara build environment
         uses: ./.github/actions/setup-rara-build
 
       - name: Rust cache
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2.9.1
 
-      # The old arc image had nextest baked in; GitHub-hosted images do not.
+      # Kept defensively (the arc image historically baked nextest in).
       # `.config/nextest.toml` profile `ci` exists since #1912.
       - name: Install cargo-nextest
         uses: taiki-e/install-action@c93ccc03e00cd0e08e494f5fd058a6c55a6a1907 # v2
@@ -136,17 +128,9 @@ jobs:
         run: cargo run -p rara-cli -- setup boxlite --check
 
   docs:
-    name: Documentation (${{ matrix.arch }})
+    name: Documentation
     if: ${{ inputs.run }}
-    runs-on: ${{ matrix.runner }}
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - arch: linux-x64
-            runner: ubuntu-latest
-          - arch: linux-arm64
-            runner: ubuntu-24.04-arm
+    runs-on: arc-runner-set
     env:
       # See top-of-file note: stub native boxlite build in CI.
       BOXLITE_DEPS_STUB: "1"
@@ -156,9 +140,9 @@ jobs:
         with:
           persist-credentials: false
 
-      # Single source of truth for the system toolchain the retired arc
-      # image implicitly provided (diesel headers, protoc, zig, mold) —
-      # see .github/actions/setup-rara-build/action.yml (#2166).
+      # System toolchain (diesel headers, protoc, zig, mold). Kept
+      # defensively while the gate moves back to arc-runner-set — see
+      # top-of-file note; prune once a green arc run proves it redundant.
       - name: Setup rara build environment
         uses: ./.github/actions/setup-rara-build
 

--- a/scripts/internal/ci/commands.go
+++ b/scripts/internal/ci/commands.go
@@ -16,19 +16,16 @@ const (
 	arm64Runner = "ubuntu-24.04-arm"
 	arm64Target = "aarch64-unknown-linux-gnu"
 
-	// The self-hosted ARC fleet is gone (#2166); any job targeting it
-	// queues for 24h and is cancelled by GitHub. It must never appear in
-	// a workflow that a required merge-gate check depends on.
-	retiredRunner = "arc-runner-set"
+	// The self-hosted ARC fleet came back online 2026-07-11 and is the
+	// Rust merge-gate runner again (#2226). #2166 had moved the gate to
+	// GitHub-hosted runners after arc went away ~2026-05-08, but the
+	// GitHub-hosted arm64 pool then hung the gate systematically. Lock
+	// rust.yml to reference this runner so a silent switch back to a hung
+	// GitHub-hosted runner is caught. NOTE: this reverses #2166's earlier
+	// "arc-runner-set is retired, never reference it" invariant on the
+	// deliberate premise correction that the fleet is no longer retired.
+	rustGateRunner = "arc-runner-set"
 )
-
-// gateWorkflows are the workflows whose jobs feed the required
-// branch-protection checks (Rust Success / Lint Success).
-var gateWorkflows = []string{
-	".github/workflows/ci.yml",
-	".github/workflows/rust.yml",
-	".github/workflows/lint.yml",
-}
 
 // Cmd returns the "check-ci-runners" command.
 func Cmd() *cli.Command {
@@ -47,19 +44,21 @@ func runCheck() error {
 		return err
 	}
 
+	// arm64 *release-artifact* invariants — unaffected by the CI merge-gate
+	// runner switch. cargo-dist still cross-builds the aarch64-linux binary
+	// (release.yml, push/tag only) and .cargo/config.toml carries its
+	// warnings-as-errors stanza.
 	if err := checkCargoDist(filepath.Join(root, "Cargo.toml")); err != nil {
-		return err
-	}
-	if err := checkContains(filepath.Join(root, ".github/workflows/rust.yml"), []byte(arm64Runner)); err != nil {
 		return err
 	}
 	if err := checkContains(filepath.Join(root, ".cargo/config.toml"), []byte("[target."+arm64Target+"]")); err != nil {
 		return err
 	}
-	for _, wf := range gateWorkflows {
-		if err := checkNotContains(filepath.Join(root, wf), []byte(retiredRunner)); err != nil {
-			return err
-		}
+	// Merge-gate runner invariant: the Rust gate must run on the restored
+	// self-hosted arc-runner-set fleet (#2226), not a GitHub-hosted runner
+	// whose arm64 pool hung the gate.
+	if err := checkContains(filepath.Join(root, ".github/workflows/rust.yml"), []byte(rustGateRunner)); err != nil {
+		return err
 	}
 
 	fmt.Println("CI runner checks passed.")
@@ -119,26 +118,6 @@ func checkContains(path string, needle []byte) error {
 	}
 	if !bytes.Contains(data, needle) {
 		return fmt.Errorf("%s must contain %q", path, needle)
-	}
-	return nil
-}
-
-// checkNotContains fails when any non-comment line of the file references
-// the needle. YAML comment lines are skipped so workflows can still explain
-// WHY the retired runner must not come back.
-func checkNotContains(path string, needle []byte) error {
-	data, err := os.ReadFile(path)
-	if err != nil {
-		return err
-	}
-	for _, line := range bytes.Split(data, []byte("\n")) {
-		trimmed := bytes.TrimSpace(line)
-		if len(trimmed) == 0 || trimmed[0] == '#' {
-			continue
-		}
-		if bytes.Contains(trimmed, needle) {
-			return fmt.Errorf("%s must not reference %q (retired runner fleet, see #2166)", path, needle)
-		}
 	}
 	return nil
 }

--- a/scripts/internal/ci/commands_test.go
+++ b/scripts/internal/ci/commands_test.go
@@ -40,15 +40,20 @@ func TestCargoDistBuildsLinuxArm64OnArmRunner(t *testing.T) {
 	}
 }
 
-func TestRustWorkflowRunsOnX64AndArm64Linux(t *testing.T) {
+func TestRustGateRunsOnArcRunnerSet(t *testing.T) {
 	data := readRepoFile(t, ".github/workflows/rust.yml")
 
 	text := string(data)
-	if !strings.Contains(text, linuxArm64Runner) {
-		t.Fatalf("rust.yml does not mention runner %q", linuxArm64Runner)
+	// The Rust merge gate returned to the restored self-hosted fleet
+	// (#2226); rust.yml must reference it so a silent switch back to a
+	// GitHub-hosted runner (whose arm64 pool hung the gate) is caught.
+	if !strings.Contains(text, rustGateRunner) {
+		t.Fatalf("rust.yml must run the Rust gate on %q", rustGateRunner)
 	}
-	if !strings.Contains(text, "${{ matrix.runner }}") {
-		t.Fatalf("rust.yml should use matrix.runner for Rust jobs")
+	// The GitHub-hosted x64+arm64 runner matrix (the #2226 hang source) is
+	// gone; the gate is single-runner on arc-runner-set.
+	if strings.Contains(text, "${{ matrix.runner }}") {
+		t.Errorf("rust.yml still uses a runner matrix; the Rust gate must be single-runner on %q (#2226)", rustGateRunner)
 	}
 }
 
@@ -102,19 +107,4 @@ func containsAny(items []any, needle string) bool {
 		}
 	}
 	return false
-}
-
-func TestGateWorkflowsDoNotTargetRetiredRunner(t *testing.T) {
-	for _, wf := range gateWorkflows {
-		data := readRepoFile(t, wf)
-		for _, line := range strings.Split(string(data), "\n") {
-			trimmed := strings.TrimSpace(line)
-			if trimmed == "" || strings.HasPrefix(trimmed, "#") {
-				continue // comments may explain why the runner is retired
-			}
-			if strings.Contains(trimmed, retiredRunner) {
-				t.Errorf("%s references retired runner %q — gate jobs would queue forever (#2166)", wf, retiredRunner)
-			}
-		}
-	}
 }


### PR DESCRIPTION
## What

Return the Rust merge gate (`rust.yml` clippy/test/docs) to the self-hosted
`arc-runner-set` fleet (x64-only), reversing the GitHub-hosted-runner posture
#2166 set. Closes #2226.

## Why

On 2026-07-10 the GitHub-hosted `ubuntu-24.04-arm` pool hung systematically:
`Rust / Test (linux-arm64)` stuck 37–51min in `Run tests` on multiple unrelated
branches, while the x64 leg of the same matrix passed in ~6min — a GitHub arm64
runner-pool infra problem, not our code. `arc-runner-set` came back online
2026-07-11 (`gh api orgs/rararulab/actions/runners` → `status=online`), so the
gate returns to it and drops the arm64 matrix leg that was the hang source.

## Deliberate premise correction (regression-decision note — read before REQUEST_CHANGES)

This PR **intentionally reverses the codified anti-reversal invariants #2166/#1907
put in place** — `devtool check-ci-runners`'s "rust.yml MUST reference
`ubuntu-24.04-arm`" and "no gate workflow may reference `arc-runner-set`" rules,
plus the top-of-file comments in `rust.yml`/`lint.yml`. Those encoded the premise
**"the arc fleet is gone permanently."** That premise is now **false**:
`arc-runner-set` is back online (2026-07-11). This is a deliberate premise update,
**NOT** a forgotten regression of the #1941 kind. The guard is **inverted, not
deleted** — `check-ci-runners` now asserts `rust.yml` MUST reference
`arc-runner-set`, so a future silent switch back to a hung GitHub-hosted runner is
caught. Coordinator-authorized (2026-07-11).

## Scope / boundaries

- **Changed:** `rust.yml` (clippy/test/docs → `arc-runner-set`, drop arch matrix;
  aggregate stays on `ubuntu-latest`, name unchanged), `scripts/internal/ci/commands.go`
  + its test (inverted runner invariant), `lint.yml`/`rust.yml` policy comments.
- **Unchanged (retained on purpose):** the aarch64-linux **release artifact** —
  `Cargo.toml` `[workspace.metadata.dist]` aarch64 target + `github-custom-runners`
  and the `.cargo/config.toml` `[target.aarch64-unknown-linux-gnu]` stanza.
  `check-ci-runners`' `checkCargoDist` + config.toml checks still enforce these.
- `setup-rara-build` + `cargo-nextest` install **kept defensively** — the arc image
  historically baked these; prune in a follow-up once a green arc run confirms
  redundancy rather than assuming.

## Required-check names unchanged

`Rust / Rust Success` + `Lint / Lint Success` are reusable-workflow contexts
`<caller job name> / <aggregate job name>`. The switch touches neither the caller
job names (`Rust`/`Lint`) nor the aggregate names (`Rust Success`/`Lint Success`),
so branch protection is unaffected. The per-matrix check runs (`Test (linux-arm64)`
etc.) were never required.

## Known issue (out of scope)

The same GitHub-hosted arm64 outage will hang `release.yml`'s cargo-dist
aarch64-linux build. `release.yml` is push/tag triggered, not a merge gate — out of
scope here; revisit when arm64 infra recovers or open a follow-up.

## Verification

Local (this diff touches CI YAML + Go, not `crates/**`):
- `gofmt -l internal/ci/` → clean; `go build`/`go vet` → ok
- `go test ./internal/ci/...` → `ok`
- `scripts/bin/devtool check-ci-runners` → `CI runner checks passed.`
- `golangci-lint run ./internal/ci/...` → `0 issues`
- `rust.yml`/`lint.yml` parse as valid YAML

**The real gate is this PR's own CI:** `Rust / Rust Success` + `Lint / Lint Success`
green, with the clippy/test/docs jobs' `runner_name` resolving to an
`arc-runner-set-*` node. (actionlint flags `arc-runner-set` as an unknown label —
expected for a self-hosted runner; no workflow in this repo runs actionlint, and
pre-#2166 used the same label.)
