### PR TITLE
chore(ci): drop arm64 test leg from Rust merge-gate (#2228)

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -44,6 +44,15 @@ defaults:
 permissions:
   contents: read
 
+# The merge-gate legs (clippy / test / docs) run x64-only, on GitHub-hosted
+# `ubuntu-latest`. The Linux arm64 test leg (`ubuntu-24.04-arm`) was removed
+# (#2228): it took ~18min and was the dominant driver of CI latency, tripling
+# turnaround for no proportional signal. arm64 coverage now comes from two
+# cheaper places — the `aarch64-unknown-linux-gnu` release build in
+# `[workspace.metadata.dist]` (Cargo.toml) and day-to-day local dev on
+# macOS-arm64 machines. The `.cargo/config.toml` arm64 stanza stays for that
+# release build. Re-adding an arm64 test leg is a follow-up if signal warrants.
+#
 # All jobs run on GitHub-hosted runners. The self-hosted `arc-runner-set`
 # fleet no longer exists (gone since ~2026-05-08); jobs targeting it queued
 # for 24h and were cancelled by GitHub, so `arc-runner-set` must NOT appear
@@ -56,17 +65,9 @@ permissions:
 # explicitly before any cargo invocation.
 jobs:
   clippy:
-    name: Clippy (${{ matrix.arch }})
+    name: Clippy (linux-x64)
     if: ${{ inputs.run }}
-    runs-on: ${{ matrix.runner }}
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - arch: linux-x64
-            runner: ubuntu-latest
-          - arch: linux-arm64
-            runner: ubuntu-24.04-arm
+    runs-on: ubuntu-latest
     env:
       # See top-of-file note: stub native boxlite build in CI.
       BOXLITE_DEPS_STUB: "1"
@@ -89,17 +90,9 @@ jobs:
         run: cargo clippy --workspace --all-targets --no-deps -- -D warnings
 
   test:
-    name: Test (${{ matrix.arch }})
+    name: Test (linux-x64)
     if: ${{ inputs.run }}
-    runs-on: ${{ matrix.runner }}
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - arch: linux-x64
-            runner: ubuntu-latest
-          - arch: linux-arm64
-            runner: ubuntu-24.04-arm
+    runs-on: ubuntu-latest
     env:
       # See top-of-file note: stub native boxlite build in CI.
       BOXLITE_DEPS_STUB: "1"
@@ -136,17 +129,9 @@ jobs:
         run: cargo run -p rara-cli -- setup boxlite --check
 
   docs:
-    name: Documentation (${{ matrix.arch }})
+    name: Documentation (linux-x64)
     if: ${{ inputs.run }}
-    runs-on: ${{ matrix.runner }}
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - arch: linux-x64
-            runner: ubuntu-latest
-          - arch: linux-arm64
-            runner: ubuntu-24.04-arm
+    runs-on: ubuntu-latest
     env:
       # See top-of-file note: stub native boxlite build in CI.
       BOXLITE_DEPS_STUB: "1"

--- a/scripts/internal/ci/commands.go
+++ b/scripts/internal/ci/commands.go
@@ -50,9 +50,11 @@ func runCheck() error {
 	if err := checkCargoDist(filepath.Join(root, "Cargo.toml")); err != nil {
 		return err
 	}
-	if err := checkContains(filepath.Join(root, ".github/workflows/rust.yml"), []byte(arm64Runner)); err != nil {
-		return err
-	}
+	// The merge-gate Rust workflow runs x64-only since #2228; the arm64 test
+	// leg was removed for CI latency. arm64 coverage now comes from the
+	// release build (checkCargoDist above) + the .cargo/config.toml arm64
+	// stanza below, so rust.yml is no longer required to mention the arm64
+	// runner.
 	if err := checkContains(filepath.Join(root, ".cargo/config.toml"), []byte("[target."+arm64Target+"]")); err != nil {
 		return err
 	}

--- a/scripts/internal/ci/commands_test.go
+++ b/scripts/internal/ci/commands_test.go
@@ -40,15 +40,26 @@ func TestCargoDistBuildsLinuxArm64OnArmRunner(t *testing.T) {
 	}
 }
 
-func TestRustWorkflowRunsOnX64AndArm64Linux(t *testing.T) {
+// TestRustWorkflowRunsX64Only guards the #2228 decision: the merge-gate Rust
+// workflow runs x64-only on GitHub-hosted ubuntu-latest. The arm64 test leg was
+// removed for CI latency; arm64 coverage lives in the release build + local dev.
+// Comment lines may still explain the removal, so only non-comment lines are
+// checked for a lingering arm64 runner reference.
+func TestRustWorkflowRunsX64Only(t *testing.T) {
 	data := readRepoFile(t, ".github/workflows/rust.yml")
 
 	text := string(data)
-	if !strings.Contains(text, linuxArm64Runner) {
-		t.Fatalf("rust.yml does not mention runner %q", linuxArm64Runner)
+	if !strings.Contains(text, "ubuntu-latest") {
+		t.Fatalf("rust.yml should run its jobs on ubuntu-latest (x64)")
 	}
-	if !strings.Contains(text, "${{ matrix.runner }}") {
-		t.Fatalf("rust.yml should use matrix.runner for Rust jobs")
+	for _, line := range strings.Split(text, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" || strings.HasPrefix(trimmed, "#") {
+			continue // comments may explain why the arm64 leg was removed
+		}
+		if strings.Contains(trimmed, linuxArm64Runner) {
+			t.Errorf("rust.yml schedules an arm64 leg (%q) — removed for CI latency (#2228)", linuxArm64Runner)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

The Rust merge-gate (`.github/workflows/rust.yml`) ran clippy/test/docs as a
`linux-x64` (ubuntu-latest) + `linux-arm64` (ubuntu-24.04-arm) matrix. The arm64
leg took ~18min and was the dominant driver of CI latency. This drops the arm64
**test leg** so the merge-gate is x64-only (target ~6min). Stays on GitHub-hosted
public runners — no arc / self-hosted runner involved.

arm64 coverage is preserved where it matters and is cheaper:
- the `aarch64-unknown-linux-gnu` release build in `[workspace.metadata.dist]`
  (`Cargo.toml`) — **untouched**
- `.cargo/config.toml` `[target.aarch64-unknown-linux-gnu]` stanza — **untouched**
- day-to-day local dev on macOS-arm64 machines

## Changes

- `.github/workflows/rust.yml` — remove the `linux-arm64` matrix leg from
  clippy/test/docs; each job now runs directly on `ubuntu-latest` (matrix
  scaffolding dropped since it held a single entry). Top-of-file comment
  explains x64-only + where arm64 coverage now lives.
- `scripts/internal/ci/commands.go` — drop the `checkContains(rust.yml,
  "ubuntu-24.04-arm")` guard (it would make `Lint / Lint Success` red). Keep
  `checkCargoDist` + the `.cargo/config.toml` arm64-stanza check + the
  retired-runner (`arc-runner-set`) assertions.
- `scripts/internal/ci/commands_test.go` — `TestRustWorkflowRunsOnX64AndArm64Linux`
  → `TestRustWorkflowRunsX64Only`, asserting no non-comment line schedules an
  arm64 leg.

Required aggregates `Rust / Rust Success` + `Lint / Lint Success` are unchanged;
branch protection is not left dangling.

## Verification

- `cd scripts && go test ./internal/ci/...` → `ok` (all 4 tests pass, including
  the new x64-only guard and the preserved dist/config-stanza/retired-runner tests)
- `devtool check-ci-runners` → `CI runner checks passed.`
- `yamllint-rs` + `zizmor` on `rust.yml` → no findings
- No Rust source touched → prek cargo hooks correctly skip; no e2e lane applies

## Lane

Lane 2 (CI chore). No BDD scenarios; the `Verify:` commands are the Go tests +
`check-ci-runners` above.

Closes #2228