### PR TITLE
fix(app): add exec timeout to run_code — bound runaway commands (#2217)

### DIFF
--- a/crates/app/src/tools/bash.rs
+++ b/crates/app/src/tools/bash.rs
@@ -59,11 +59,12 @@ use rara_kernel::{
 use rara_sandbox::ExecRequest;
 use rara_tool_macro::ToolDef;
 use schemars::JsonSchema;
-use serde::{Deserialize, Deserializer, Serialize};
+use serde::{Deserialize, Serialize};
 
 use crate::{
     SandboxToolConfig,
     sandbox::{GUEST_WORKSPACE, SandboxMap, sandbox_for_session, sandbox_not_configured_error},
+    tools::timeout::deserialize_timeout,
 };
 
 /// Maximum output size in bytes (50 KB).
@@ -89,87 +90,6 @@ pub struct BashParams {
     /// are translated to the guest mount; paths outside the workspace are
     /// rejected.
     cwd:     Option<String>,
-}
-
-/// Accept `30` (integer), `"30"` (stringified integer), or `"30s"` /
-/// `"2m"` (humantime duration) for the timeout field.
-fn deserialize_timeout<'de, D>(deserializer: D) -> Result<Option<Duration>, D::Error>
-where
-    D: Deserializer<'de>,
-{
-    use std::fmt;
-
-    use serde::de::{self, Visitor};
-
-    struct TimeoutVisitor;
-
-    impl<'de> Visitor<'de> for TimeoutVisitor {
-        type Value = Option<Duration>;
-
-        fn expecting(&self, f: &mut fmt::Formatter) -> fmt::Result {
-            f.write_str("an integer, stringified integer, or humantime duration")
-        }
-
-        fn visit_none<E: de::Error>(self) -> Result<Self::Value, E> { Ok(None) }
-
-        fn visit_some<D2: Deserializer<'de>>(self, d: D2) -> Result<Self::Value, D2::Error> {
-            d.deserialize_any(DurationVisitor).map(Some)
-        }
-    }
-
-    struct DurationVisitor;
-
-    impl<'de> Visitor<'de> for DurationVisitor {
-        type Value = Duration;
-
-        fn expecting(&self, f: &mut fmt::Formatter) -> fmt::Result {
-            f.write_str(
-                "an integer (seconds), stringified integer, humantime duration, or {\"secs\": N, \
-                 \"nanos\": N} map",
-            )
-        }
-
-        fn visit_u64<E: de::Error>(self, v: u64) -> Result<Duration, E> {
-            Ok(Duration::from_secs(v))
-        }
-
-        fn visit_i64<E: de::Error>(self, v: i64) -> Result<Duration, E> {
-            let secs = u64::try_from(v).map_err(|_| E::custom(format!("negative timeout: {v}")))?;
-            Ok(Duration::from_secs(secs))
-        }
-
-        fn visit_str<E: de::Error>(self, v: &str) -> Result<Duration, E> {
-            let s = v.trim();
-            // Try bare integer first ("30" → 30 seconds).
-            if let Ok(secs) = s.parse::<u64>() {
-                return Ok(Duration::from_secs(secs));
-            }
-            // Fall back to humantime ("30s", "2m").
-            humantime::parse_duration(s).map_err(|_| E::custom(format!("invalid timeout: {v:?}")))
-        }
-
-        /// Accept `{"secs": 30, "nanos": 0}` — the Duration struct layout
-        /// that some LLMs (e.g. GPT-5.4) emit when they see the JSON schema.
-        fn visit_map<A: de::MapAccess<'de>>(self, mut map: A) -> Result<Duration, A::Error> {
-            let mut secs: Option<u64> = None;
-            let mut nanos: Option<u32> = None;
-
-            while let Some(key) = map.next_key::<String>()? {
-                match key.as_str() {
-                    "secs" => secs = Some(map.next_value()?),
-                    "nanos" => nanos = Some(map.next_value()?),
-                    _ => {
-                        let _ = map.next_value::<de::IgnoredAny>()?;
-                    }
-                }
-            }
-
-            let secs = secs.ok_or_else(|| de::Error::missing_field("secs"))?;
-            Ok(Duration::new(secs, nanos.unwrap_or(0)))
-        }
-    }
-
-    deserializer.deserialize_option(TimeoutVisitor)
 }
 
 /// Typed result returned by the bash tool.

--- a/crates/app/src/tools/mod.rs
+++ b/crates/app/src/tools/mod.rs
@@ -58,6 +58,7 @@ mod set_avatar;
 mod settings;
 mod skill_tools;
 mod system_paths;
+mod timeout;
 mod user_note;
 mod walk_directory;
 mod wechat_login;

--- a/crates/app/src/tools/run_code.rs
+++ b/crates/app/src/tools/run_code.rs
@@ -22,7 +22,7 @@
 //! `LifecycleHook::on_session_end` hook installed at startup
 //! (see [`SandboxCleanupHook`]).
 
-use std::sync::Arc;
+use std::{sync::Arc, time::Duration};
 
 use async_trait::async_trait;
 use futures::StreamExt;
@@ -47,7 +47,21 @@ use crate::{
         RECLAIM_BACKOFF, RECLAIM_MAX_ATTEMPTS, ReclaimOutcome, reclaim_when_idle,
         sandbox_for_session, sandbox_not_configured_error,
     },
+    tools::timeout::deserialize_timeout,
 };
+
+/// Default hard timeout for a `run_code` exec, in seconds.
+///
+/// A `run_code`-local mechanism-level safety backstop: without it a
+/// non-terminating command (`while true`) holds the per-session sandbox lock
+/// until the kernel's coarse per-tool wall drops the future, stalling every
+/// other exec in the session and leaving the guest process burning a vCPU.
+/// It is deliberately a **separate** const from `bash`'s `DEFAULT_TIMEOUT_SECS`
+/// — coupling two independent tools' safety backstops via one symbol is a
+/// footgun — and a Rust `const` rather than a YAML knob, per
+/// `docs/guides/anti-patterns.md` (mechanism-tuning constants are not config).
+/// The value matches bash's proven default rather than inventing a new number.
+const DEFAULT_EXEC_TIMEOUT_SECS: u64 = 120;
 
 /// Input parameters for the `run_code` tool.
 #[derive(Debug, Deserialize, JsonSchema)]
@@ -57,6 +71,11 @@ pub struct RunCodeParams {
     /// Arguments to pass, in order. Empty vec means no args.
     #[serde(default)]
     args:    Vec<String>,
+    /// Hard timeout for the exec (default 120s). Accepts an integer (`120`),
+    /// a stringified integer (`"120"`), a humantime duration (`"2m"`), or a
+    /// `{"secs": N, "nanos": N}` map — the same forms `bash` accepts.
+    #[serde(default, deserialize_with = "deserialize_timeout")]
+    timeout: Option<Duration>,
 }
 
 /// Typed result returned by `run_code`.
@@ -71,6 +90,10 @@ pub struct RunCodeResult {
     /// Combined stderr captured during execution. Empty when the sandbox
     /// declined to materialise a stderr stream.
     pub stderr:    String,
+    /// Whether the exec was hard-killed by boxlite for exceeding its timeout.
+    /// Mirrors `BashResult::timed_out` so the model can distinguish a timeout
+    /// from an ordinary non-zero exit.
+    pub timed_out: bool,
 }
 
 /// Sandboxed code execution tool.
@@ -85,6 +108,7 @@ pub struct RunCodeResult {
                    one VM per session; the VM is destroyed when the session ends. Use this for \
                    running LLM-generated code that should not touch the host.",
     tier = "deferred",
+    timeout_secs = 150,
     destructive
 )]
 pub struct RunCodeTool {
@@ -139,10 +163,7 @@ impl ToolExecute for RunCodeTool {
         context: &ToolContext,
     ) -> anyhow::Result<RunCodeResult> {
         let sandbox = self.sandbox_for_session(context.session_key).await?;
-        let request = ExecRequest::builder()
-            .command(params.command)
-            .args(params.args)
-            .build();
+        let request = build_exec_request(params.command, params.args, params.timeout);
 
         // Hold the per-session lock for the whole exec — boxlite's `LiteBox`
         // is not assumed `Sync` (see `rara-sandbox/AGENT.md`), so concurrent
@@ -185,11 +206,18 @@ impl ToolExecute for RunCodeTool {
             }
         }
 
-        let exit_code = match outcome.execution.wait().await {
-            Ok(status) => Some(status.code()),
+        // boxlite enforces the per-exec timeout itself; if it fired, `wait`
+        // returns an error whose message names the timeout. We surface that as
+        // `timed_out = true` (mirroring `bash`) so the model sees an explicit
+        // signal rather than a generic error. Any other wait error degrades to
+        // `exit_code = None` with `timed_out = false`.
+        let (exit_code, timed_out) = match outcome.execution.wait().await {
+            Ok(status) => (Some(status.code()), false),
             Err(e) => {
-                tracing::warn!(error = %e, "sandbox exec wait failed; reporting None");
-                None
+                let msg = e.to_string();
+                let timed_out = is_timeout_error(&msg);
+                tracing::warn!(error = %msg, timed_out, "sandbox exec wait failed; reporting None");
+                (None, timed_out)
             }
         };
 
@@ -197,9 +225,35 @@ impl ToolExecute for RunCodeTool {
             exit_code,
             stdout,
             stderr,
+            timed_out,
         })
     }
 }
+
+/// Build the [`ExecRequest`] for a `run_code` invocation, resolving the
+/// timeout to the per-call value or the [`DEFAULT_EXEC_TIMEOUT_SECS`] backstop.
+///
+/// Extracted as a pure function so the timeout-resolution behavior is unit
+/// testable without a live boxlite VM (the real exec path is `#[ignore]`d in
+/// `tests/run_code_session.rs`).
+fn build_exec_request(
+    command: String,
+    args: Vec<String>,
+    timeout: Option<Duration>,
+) -> ExecRequest {
+    let timeout_dur = timeout.unwrap_or_else(|| Duration::from_secs(DEFAULT_EXEC_TIMEOUT_SECS));
+    ExecRequest::builder()
+        .command(command)
+        .args(args)
+        .timeout(timeout_dur)
+        .build()
+}
+
+/// Classify a boxlite `wait` error message as a timeout kill.
+///
+/// boxlite reports a hit timeout as an error string containing "timeout" or
+/// "timed out"; any other message is an ordinary failure, not a timeout.
+fn is_timeout_error(msg: &str) -> bool { msg.contains("timeout") || msg.contains("timed out") }
 
 /// Lifecycle hook that destroys per-session sandboxes when their owning
 /// session ends.
@@ -291,5 +345,59 @@ mod tests {
             required.iter().any(|v| v.as_str() == Some("command")),
             "command must be required, got: {required:?}"
         );
+    }
+
+    #[test]
+    fn run_code_sets_default_exec_timeout() {
+        // No caller-supplied timeout → the ExecRequest carries the default
+        // backstop. Before this change the field was `None` (no `.timeout()`
+        // was ever set), so this assertion inverts the pre-change behavior.
+        let request = build_exec_request("sh".to_owned(), vec!["-c".to_owned()], None);
+        assert_eq!(
+            request.timeout,
+            Some(Duration::from_secs(DEFAULT_EXEC_TIMEOUT_SECS))
+        );
+    }
+
+    #[test]
+    fn run_code_honors_per_call_timeout() {
+        // A caller-supplied timeout is used verbatim; the default const is
+        // not consulted.
+        let five = Duration::from_secs(5);
+        let request = build_exec_request("sh".to_owned(), vec![], Some(five));
+        assert_eq!(request.timeout, Some(five));
+        assert_ne!(five, Duration::from_secs(DEFAULT_EXEC_TIMEOUT_SECS));
+    }
+
+    #[test]
+    fn run_code_params_accepts_timeout_forms() {
+        // The shared `deserialize_timeout` visitor accepts every shape `bash`
+        // does: integer, stringified integer, humantime, and secs/nanos map.
+        let cases = [
+            (serde_json::json!({"command": "sh", "timeout": 120}), 120),
+            (serde_json::json!({"command": "sh", "timeout": "120"}), 120),
+            (serde_json::json!({"command": "sh", "timeout": "2m"}), 120),
+            (
+                serde_json::json!({"command": "sh", "timeout": {"secs": 120, "nanos": 0}}),
+                120,
+            ),
+        ];
+        for (json, expected_secs) in cases {
+            let p: RunCodeParams = serde_json::from_value(json.clone()).expect("parse");
+            assert_eq!(
+                p.timeout,
+                Some(Duration::from_secs(expected_secs)),
+                "unexpected timeout for {json}"
+            );
+        }
+    }
+
+    #[test]
+    fn run_code_maps_timeout_error_to_flag() {
+        // A boxlite wait-error that names the timeout classifies as timed_out;
+        // any other wait error does not.
+        assert!(is_timeout_error("exec killed: timeout exceeded"));
+        assert!(is_timeout_error("command timed out after 120s"));
+        assert!(!is_timeout_error("connection reset by peer"));
     }
 }

--- a/crates/app/src/tools/timeout.rs
+++ b/crates/app/src/tools/timeout.rs
@@ -1,0 +1,104 @@
+// Copyright 2025 Rararulab
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Shared timeout coercion for sandbox exec tools.
+//!
+//! Both `bash` and `run_code` accept an optional per-call `timeout` param
+//! that LLMs express in several shapes. This module owns the single
+//! `deserialize_timeout` visitor so the two tools cannot drift.
+
+use std::{fmt, time::Duration};
+
+use serde::{
+    Deserializer,
+    de::{self, Visitor},
+};
+
+/// Accept `30` (integer), `"30"` (stringified integer), `"30s"` / `"2m"`
+/// (humantime duration), or `{"secs": N, "nanos": N}` (Duration struct
+/// layout that some LLMs emit) for a `timeout` field.
+pub(crate) fn deserialize_timeout<'de, D>(deserializer: D) -> Result<Option<Duration>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    struct TimeoutVisitor;
+
+    impl<'de> Visitor<'de> for TimeoutVisitor {
+        type Value = Option<Duration>;
+
+        fn expecting(&self, f: &mut fmt::Formatter) -> fmt::Result {
+            f.write_str("an integer, stringified integer, or humantime duration")
+        }
+
+        fn visit_none<E: de::Error>(self) -> Result<Self::Value, E> { Ok(None) }
+
+        fn visit_some<D2: Deserializer<'de>>(self, d: D2) -> Result<Self::Value, D2::Error> {
+            d.deserialize_any(DurationVisitor).map(Some)
+        }
+    }
+
+    struct DurationVisitor;
+
+    impl<'de> Visitor<'de> for DurationVisitor {
+        type Value = Duration;
+
+        fn expecting(&self, f: &mut fmt::Formatter) -> fmt::Result {
+            f.write_str(
+                "an integer (seconds), stringified integer, humantime duration, or {\"secs\": N, \
+                 \"nanos\": N} map",
+            )
+        }
+
+        fn visit_u64<E: de::Error>(self, v: u64) -> Result<Duration, E> {
+            Ok(Duration::from_secs(v))
+        }
+
+        fn visit_i64<E: de::Error>(self, v: i64) -> Result<Duration, E> {
+            let secs = u64::try_from(v).map_err(|_| E::custom(format!("negative timeout: {v}")))?;
+            Ok(Duration::from_secs(secs))
+        }
+
+        fn visit_str<E: de::Error>(self, v: &str) -> Result<Duration, E> {
+            let s = v.trim();
+            // Try bare integer first ("30" → 30 seconds).
+            if let Ok(secs) = s.parse::<u64>() {
+                return Ok(Duration::from_secs(secs));
+            }
+            // Fall back to humantime ("30s", "2m").
+            humantime::parse_duration(s).map_err(|_| E::custom(format!("invalid timeout: {v:?}")))
+        }
+
+        /// Accept `{"secs": 30, "nanos": 0}` — the Duration struct layout
+        /// that some LLMs (e.g. GPT-5.4) emit when they see the JSON schema.
+        fn visit_map<A: de::MapAccess<'de>>(self, mut map: A) -> Result<Duration, A::Error> {
+            let mut secs: Option<u64> = None;
+            let mut nanos: Option<u32> = None;
+
+            while let Some(key) = map.next_key::<String>()? {
+                match key.as_str() {
+                    "secs" => secs = Some(map.next_value()?),
+                    "nanos" => nanos = Some(map.next_value()?),
+                    _ => {
+                        let _ = map.next_value::<de::IgnoredAny>()?;
+                    }
+                }
+            }
+
+            let secs = secs.ok_or_else(|| de::Error::missing_field("secs"))?;
+            Ok(Duration::new(secs, nanos.unwrap_or(0)))
+        }
+    }
+
+    deserializer.deserialize_option(TimeoutVisitor)
+}

--- a/crates/app/tests/run_code_session.rs
+++ b/crates/app/tests/run_code_session.rs
@@ -10,11 +10,14 @@ use std::sync::Arc;
 use dashmap::DashMap;
 use rara_app::{
     SandboxToolConfig,
-    tools::run_code::{RunCodeTool, SandboxCleanupHook, SandboxMap},
+    tools::run_code::{RunCodeParams, RunCodeTool, SandboxCleanupHook, SandboxMap},
 };
 use rara_kernel::{
+    io::MessageId,
     lifecycle::{LifecycleHook, SessionEndContext},
+    queue::{ShardedEventQueue, ShardedEventQueueConfig},
     session::SessionKey,
+    tool::{ToolContext, ToolExecute},
 };
 
 #[tokio::test]
@@ -56,4 +59,62 @@ async fn run_code_reuses_sandbox_across_calls_and_destroys_on_session_end() {
     })
     .await;
     assert_eq!(map.len(), 0, "session-end hook must remove the entry");
+}
+
+/// A non-terminating command is hard-killed by boxlite once the exec timeout
+/// elapses, and `run` returns normally with `timed_out = true` — releasing the
+/// per-session lock at a bounded point instead of hanging on the kernel wall.
+///
+/// `#[ignore]`d for the same boxlite-runtime reason as the test above; not
+/// bound to a lifecycle scenario (the CI-runnable binding lives in the
+/// `run_code` unit tests). This is the real end-to-end backstop.
+#[tokio::test]
+#[ignore = "requires boxlite runtime files (issue #1699) and a local OCI image cache"]
+async fn run_code_times_out_a_runaway_command() {
+    let cfg = SandboxToolConfig::builder()
+        .default_rootfs_image("alpine:latest".to_owned())
+        .build();
+    let map: SandboxMap = Arc::new(DashMap::new());
+    let tool = RunCodeTool::new(Some(cfg), map.clone());
+
+    let params: RunCodeParams = serde_json::from_value(serde_json::json!({
+        "command": "sh",
+        "args": ["-c", "while true; do :; done"],
+        "timeout": 1,
+    }))
+    .expect("params parse");
+
+    let ctx = tool_context();
+
+    // boxlite must kill the runaway within a small multiple of the 1s timeout;
+    // the outer bound guards against the pre-fix hang.
+    let result = tokio::time::timeout(std::time::Duration::from_secs(30), tool.run(params, &ctx))
+        .await
+        .expect("run must return well before the kernel wall")
+        .expect("run must not error");
+
+    assert!(
+        result.timed_out,
+        "runaway exec must report timed_out = true"
+    );
+}
+
+/// Minimal [`ToolContext`] for driving a tool's `run` in an integration test.
+fn tool_context() -> ToolContext {
+    ToolContext {
+        user_id:               "test-user".to_owned(),
+        session_key:           SessionKey::new(),
+        origin_endpoint:       None,
+        origin_user_id:        None,
+        event_queue:           Arc::new(ShardedEventQueue::new(ShardedEventQueueConfig {
+            num_shards:      0,
+            shard_capacity:  1,
+            global_capacity: 16,
+        })),
+        rara_turn_id:          MessageId::new(),
+        context_window_tokens: 0,
+        tool_registry:         None,
+        stream_handle:         None,
+        tool_call_id:          None,
+    }
 }

--- a/specs/issue-2217-run-code-exec-timeout.spec.md
+++ b/specs/issue-2217-run-code-exec-timeout.spec.md
@@ -1,0 +1,297 @@
+spec: task
+name: "issue-2217-run-code-exec-timeout"
+inherits: project
+tags: []
+---
+
+## Intent
+
+The `run_code` tool executes untrusted, LLM-generated code inside the
+shared per-session boxlite microVM. Unlike its sibling `bash`, it builds
+its `ExecRequest` **without a timeout**:
+`crates/app/src/tools/run_code.rs` (around line 138) calls
+`ExecRequest::builder().command(...).args(...).build()` — no `.timeout(...)`
+— then holds the per-session `Arc<Mutex<Sandbox>>` lock for the whole
+exec and streams stdout to completion. `bash` does the opposite
+(`crates/app/src/tools/bash.rs`, ~line 243): it resolves a duration from
+`params.timeout` (else the `DEFAULT_TIMEOUT_SECS` const), passes
+`.timeout(timeout_dur)` so boxlite hard-kills the exec, and maps the
+kill into a clean `timed_out = true` result. `ExecRequest.timeout:
+Option<Duration>` already exists and is enforced by boxlite
+(`crates/rara-sandbox/src/config.rs`, ~line 84) — `run_code` simply never
+sets it.
+
+Because `run_code` sets no boxlite timeout, its only backstop is the
+kernel's coarse per-tool wall: `crates/kernel/src/agent/mod.rs` (~line
+2932) wraps every `tool.execute()` in
+`tokio::time::timeout(per_tool_timeout, ...)` where `per_tool_timeout =
+tool.execution_timeout().unwrap_or(default_tool_timeout)`. `bash`'s
+`ToolDef` sets `timeout_secs = 150` so its `execution_timeout()` returns
+`Some(150s)`; `run_code`'s `ToolDef` sets no `timeout_secs`, so it falls
+back to `default_tool_timeout` (kernel default 2 minutes). That backstop
+fires by **dropping** the `run` future — which is a blunt instrument, not
+a clean kill.
+
+Reproducer for the failure mode (what breaks if we do not do this):
+
+1. Start rara with a `sandbox:` block configured. In a session the agent
+   invokes `run_code` with a non-terminating command, e.g.
+   `sh -c 'while true; do :; done'` (or `sh -c 'sleep 999'`).
+2. `run_code` acquires the per-session sandbox mutex and enters the exec.
+   boxlite was given no timeout, so it never kills the guest process. The
+   `run` future stays alive holding both the `Arc<Mutex<Sandbox>>` clone
+   and the mutex guard. For up to `default_tool_timeout` (~2 minutes)
+   **every other `bash` / `run_code` call in that session blocks on
+   `sandbox.lock().await`** — the whole session's exec surface is stalled
+   on one runaway command, with no per-call timeout the agent can use to
+   bound it.
+3. When the 2-minute kernel wall finally fires it drops the `run` future.
+   That releases the lock and the `Arc` clone, but it does **not** kill
+   the boxlite guest process — the `while true` keeps burning a guest
+   vCPU inside the VM until the VM itself is destroyed at session end.
+   The agent receives a generic "tool execution timed out" error with no
+   `timed_out` signal it can reason about, unlike `bash`.
+4. This is exactly the fragile pattern issue 1866 documents. Relying on
+   future-drop for cleanup means the `run` future holds its `Arc` clone
+   right up to the 2-minute wall; if the session ends inside that window
+   the `SandboxCleanupHook` reaper sees `strong_count > 1` and the runaway
+   VM leaks (issue 1866's race). A boxlite-enforced timeout makes
+   `run_code` **return normally** — like `bash` — so the lock and the
+   `Arc` clone are released at a deterministic, short bound instead of via
+   cancellation, and the guest process is actually killed.
+
+The fix mirrors `bash` exactly: resolve a duration (per-call
+`params.timeout`, else a `run_code`-local default `const`), pass
+`.timeout(...)` on the `ExecRequest`, and map the boxlite timeout error
+into a `timed_out = true` field on `RunCodeResult`. The security /
+network surface is untouched (that is issue 2216's concern); this issue
+is purely about bounding exec duration.
+
+Goal alignment: signal 1 ("the process runs for months without
+intervention. Memory does not grow unboundedly, file descriptors do not
+leak, internal state recovers without supervisor restarts") and the
+stated 2026-Q2 "Safety and stability hardening" focus. A single runaway
+`run_code` today stalls a session's entire exec surface for two minutes
+and leaves a guest process burning CPU until VM teardown — a direct
+stability defect. It also reinforces signal 4 ("every action is
+inspectable"): a timeout becomes an explicit `timed_out` result the model
+can see and act on, not a swallowed generic error. Crosses no `NOT` line
+— single-user local stability hygiene, not feature-parity, not
+multi-user, not a framework surface. Hermes parity: N/A — bounding a
+local untrusted-code exec is internal resource discipline, not a
+user-facing capability.
+
+Prior art reviewed (mandatory search):
+
+- `gh issue list --search "run_code timeout" / "sandbox timeout exec" /
+  "bash timeout"` — no open or closed issue asks for a `run_code`
+  timeout. The only structurally related open item is issue 1866
+  ("handle in-flight exec at session end without leaking VM"), which this
+  issue complements rather than duplicates: 1866 fixes the reaper that
+  reclaims a leaked VM; this fixes the source that makes the leak likely
+  (an unbounded exec holding the clone). Distinct surfaces
+  (`SandboxCleanupHook` reclamation loop vs. `ExecRequest.timeout`
+  resolution), no code overlap.
+- `gh pr list --search "bash timeout" / "run_code timeout"` — the bash
+  timeout machinery landed in PR 746 (issue 744, "spawn with process
+  group, incremental read, clean kill"), PR 1115 (issue 1114, coerce
+  string timeout to Duration), PR 1308 (issue 1307, accept Duration-style
+  map), and the per-tool kernel granularity in PR 782 (issue 778). None
+  of these touched `run_code`, which did not exist yet. No PR proposes or
+  reverts a `run_code` timeout.
+- `git log --all --grep "run_code"` — `run_code` was introduced by PR 1861
+  (issue 1700, "expose run_code via boxlite"). Its body and diff mention
+  no timeout at all: the omission is a gap, **not** a documented decision
+  to leave `run_code` unbounded. There is no prior decision this issue
+  reverses.
+- `rg` on `crates/app/src/tools/{bash.rs,run_code.rs}` confirms the
+  asymmetry: `bash` owns `DEFAULT_TIMEOUT_SECS`, a `deserialize_timeout`
+  visitor for the `timeout` param, and `.timeout(timeout_dur)` on its
+  `ExecRequest`; `run_code` owns none of these. `ExecRequest.timeout`
+  (`crates/rara-sandbox/src/config.rs`) is already a public builder field,
+  so no `rara-sandbox` surface change is needed.
+- Sibling touching the same file: issue 2216
+  (`specs/issue-2216-run-code-default-deny-egress.spec.md`) also edits
+  `crates/app/src/tools/run_code.rs`, but on the **network policy**
+  surface (`fused_network_policy`), not exec timeout. No conceptual
+  overlap; flagged only so the parent can sequence the two run_code.rs
+  edits to avoid a merge conflict.
+
+## Decisions
+
+- **Mirror `bash`: resolve a duration and set `.timeout(...)` on the
+  `ExecRequest`.** In `RunCodeTool::run`, resolve
+  `params.timeout.unwrap_or_else(|| Duration::from_secs(
+  DEFAULT_EXEC_TIMEOUT_SECS))` and pass it to
+  `ExecRequest::builder().timeout(...)`. This is the core fix — boxlite
+  then hard-kills a runaway exec and `run` returns normally, releasing
+  the lock and the `Arc` clone at a bounded, deterministic point.
+- **`DEFAULT_EXEC_TIMEOUT_SECS` is a `run_code`-local Rust `const`, not
+  YAML, and not shared with `bash`'s const.** It is a mechanism-level
+  safety backstop: a deploy operator has no principled "right" value, so
+  per `docs/guides/anti-patterns.md` ("mechanism-tuning constants … are
+  Rust `const`") and the #1804→#1882 lineage it must not become a YAML
+  knob. It is deliberately a **separate** const from `bash`'s
+  `DEFAULT_TIMEOUT_SECS` (not a shared import): coupling two independent
+  tools' safety backstops via one symbol is a footgun — a future change
+  to bash's default would silently move run_code's, and the two tools are
+  semantically different (a shell one-liner vs. an arbitrary program that
+  may legitimately compile/run for a while). Value: **120 seconds**,
+  matching bash's proven default rather than inventing a new number.
+- **Add a per-call `timeout` field to `RunCodeParams`, with bash's exact
+  coercion semantics.** `run_code`'s whole purpose is running
+  LLM-generated code that can legitimately run for minutes, so the agent
+  needs the same escape hatch `bash` already has. It must accept an
+  integer (`120`), a stringified integer (`"120"`), a humantime duration
+  (`"2m"`), and the `{"secs": N, "nanos": N}` Duration-map form that some
+  LLMs emit — i.e. the identical behavior of bash's `deserialize_timeout`.
+  To avoid drift, the implementer extracts bash's `deserialize_timeout`
+  (and its `DurationVisitor`) into a shared module under
+  `crates/app/src/tools/` (e.g. `timeout.rs`) and has **both** `bash` and
+  `run_code` use it, rather than copy-pasting the visitor. Moving a
+  private helper is a mechanical, behavior-preserving refactor; bash's
+  existing behavior must not change.
+- **Add `timed_out: bool` to `RunCodeResult`, mirroring `BashResult`.**
+  Derive it the same way `bash` does: after `outcome.execution.wait()`,
+  treat a wait error whose message contains "timeout" / "timed out" as
+  `timed_out = true`. This turns a boxlite kill into an explicit,
+  inspectable signal the model can reason about (goal signal 4) instead
+  of the current generic error, and it is what "照 bash 的做法" means. The
+  addition is additive to the result schema (a new boolean field);
+  `exit_code` / `stdout` / `stderr` keep their current meaning.
+- **Also give `run_code`'s `ToolDef` a kernel-level `timeout_secs`, set
+  above the boxlite default so boxlite fires first.** Add
+  `timeout_secs = 150` to the `#[tool(...)]` attribute (matching bash's
+  150 over its 120s boxlite default). This keeps the kernel wall strictly
+  above the boxlite kill for the default case, so in the common runaway
+  path boxlite kills the exec and `run_code` returns a clean
+  `timed_out = true` result rather than the kernel dropping the future.
+  It is defense-in-depth parity with bash, not a replacement for the
+  boxlite timeout.
+- **Known inherited limitation (not fixed here): a per-call
+  `timeout` larger than the kernel `timeout_secs` still hits the kernel
+  wall first.** If the agent passes `timeout = "10m"` while the ToolDef
+  wall is 150s, the kernel drops the future at 150s — the same latent
+  tension `bash` already has. Bounding the common no-timeout runaway case
+  is the win here; reconciling a user-supplied timeout that exceeds the
+  kernel wall is a separate, cross-cutting concern (it would touch the
+  kernel per-tool-timeout contract) and is out of scope.
+- **Testable seam so the fix is falsifiable in CI without boxlite.**
+  `run_code`'s real exec goes through boxlite, which CI cannot run (the
+  existing `crates/app/tests/run_code_session.rs` is `#[ignore]`d for
+  exactly this reason). So the fail-before/pass-after binding lives in
+  pure, unit-testable seams, following the pattern issues 1866 and 2216
+  used for the same crate:
+  - Extract `ExecRequest` construction into a pure function
+    (e.g. `build_exec_request(command, args, timeout: Option<Duration>)
+    -> ExecRequest`) that resolves the default and sets `.timeout(...)`.
+    A unit test reads back `request.timeout` (a public field) and asserts
+    it is `Some(DEFAULT_EXEC_TIMEOUT_SECS)` when the param is absent and
+    `Some(v)` when the param is `v`. This test **fails before** the change
+    (today `run_code` never sets `.timeout`, so the field is `None`) and
+    **passes after**.
+  - A `RunCodeParams` parse test asserts the `timeout` field accepts the
+    same forms bash accepts (integer, stringified integer, humantime,
+    Duration-map), reusing the shared visitor.
+  - The timeout→`timed_out` classification is a small pure helper
+    (mapping a wait-error message to a bool) with its own unit test.
+  The genuine end-to-end ("a `while true` is actually killed and the lock
+  is released") stays an `#[ignore]`d real-boxlite integration test — not
+  bound to a lifecycle scenario, same as 1866/2216 leave their boxlite
+  behavior to `#[ignore]`d tests.
+- **No `rara-sandbox` change.** `ExecRequest.timeout` is already public
+  and boxlite already enforces it; the crate's minimal-surface invariant
+  (`crates/rara-sandbox/AGENT.md`) stands. All changes live at the app
+  boundary.
+
+## Boundaries
+
+### Allowed Changes
+- crates/app/src/tools/run_code.rs
+- **/crates/app/src/tools/run_code.rs
+- crates/app/src/tools/bash.rs
+- **/crates/app/src/tools/bash.rs
+- crates/app/src/tools/timeout.rs
+- **/crates/app/src/tools/timeout.rs
+- crates/app/src/tools/mod.rs
+- **/crates/app/src/tools/mod.rs
+- crates/app/src/tools/AGENT.md
+- **/crates/app/src/tools/AGENT.md
+- crates/app/tests/run_code_session.rs
+- **/crates/app/tests/run_code_session.rs
+- specs/issue-2217-run-code-exec-timeout.spec.md
+- **/specs/issue-2217-run-code-exec-timeout.spec.md
+
+### Forbidden
+- crates/app/src/sandbox.rs
+- crates/rara-sandbox/**
+- crates/kernel/**
+- crates/rara-model/**
+- crates/rara-fleet/**
+- config.example.yaml
+- web/**
+- extension/**
+- .github/workflows/**
+
+## Acceptance Criteria
+
+Scenario: run_code sets a default boxlite timeout when the caller omits one
+  Test:
+    Package: rara-app
+    Filter: tools::run_code::tests::run_code_sets_default_exec_timeout
+  Given a run_code invocation whose params carry no timeout
+  When the ExecRequest for that invocation is built
+  Then its timeout field is Some, equal to DEFAULT_EXEC_TIMEOUT_SECS
+  And this inverts the pre-change behavior where the ExecRequest timeout was None
+
+Scenario: run_code honors a per-call timeout when the caller supplies one
+  Test:
+    Package: rara-app
+    Filter: tools::run_code::tests::run_code_honors_per_call_timeout
+  Given a run_code invocation whose params carry an explicit timeout of five seconds
+  When the ExecRequest for that invocation is built
+  Then its timeout field is Some equal to five seconds
+  And the default const is not used
+
+Scenario: run_code timeout param accepts the same forms as bash
+  Test:
+    Package: rara-app
+    Filter: tools::run_code::tests::run_code_params_accepts_timeout_forms
+  Given run_code params JSON using an integer, a stringified integer, a humantime string, and a secs/nanos map for the timeout
+  When each is deserialized into RunCodeParams
+  Then every form parses to the expected Duration using the shared timeout visitor
+
+Scenario: a boxlite timeout error is reported as timed_out on the result
+  Test:
+    Package: rara-app
+    Filter: tools::run_code::tests::run_code_maps_timeout_error_to_flag
+  Given a wait-error message that indicates a boxlite timeout
+  When run_code classifies that error for the result
+  Then the RunCodeResult timed_out flag is true
+  And a non-timeout wait error classifies as timed_out false
+
+## Out of Scope
+
+- **Real-boxlite end-to-end verification that a `while true` is actually
+  killed and the session lock released.** That behavior is real and worth
+  a test, but boxlite is unavailable in CI (the existing
+  `crates/app/tests/run_code_session.rs` is `#[ignore]`d). It is added as
+  an `#[ignore]`d integration test, not bound to a lifecycle scenario,
+  matching how issues 1866 and 2216 keep their boxlite behavior out of the
+  CI-runnable binding.
+- **Reconciling a per-call `timeout` that exceeds the kernel per-tool
+  wall** (`timeout_secs`). The kernel would still drop the future first;
+  fixing that touches the kernel per-tool-timeout contract
+  (`crates/kernel/src/agent/mod.rs`) and is a separate cross-cutting
+  concern. bash has the same latent limitation today.
+- **The session-end VM reclaim race itself** — that is issue 1866. This
+  issue reduces how often that race is hit (by bounding the exec that
+  holds the clone) but does not change `SandboxCleanupHook`.
+- **Any change to `run_code`'s network / egress policy** — that is issue
+  2216. This issue does not touch `fused_network_policy` or the network
+  surface.
+- **Killing an in-flight exec on turn cancellation before the boxlite
+  timeout fires.** The kernel signal pipeline already cancels the turn;
+  this issue only bounds the exec's own duration.
+- **Any change to `ExecRequest` / `Sandbox` signatures in
+  `rara-sandbox`.** The timeout field already exists and is enforced.


### PR DESCRIPTION
## Summary

`run_code` built its `ExecRequest` without a timeout, so a non-terminating
command (`while true`) was never killed by boxlite. It held the per-session
sandbox lock until the kernel's ~2min per-tool wall dropped the future —
stalling every other exec in the session, leaving the guest process burning a
vCPU, widening the #1866 VM-reclaim race, and returning a generic error with no
`timed_out` signal.

This mirrors `bash` exactly:

- Resolve a duration (`params.timeout`, else the `run_code`-local
  `DEFAULT_EXEC_TIMEOUT_SECS` = 120s Rust `const`, separate from bash's const,
  not YAML) and set `.timeout(...)` on the `ExecRequest` via a pure,
  unit-testable `build_exec_request`.
- Add a per-call `timeout` field to `RunCodeParams` with bash's exact coercion
  (int / `"120"` / `"2m"` / `{secs,nanos}`), extracted into a shared
  `crates/app/src/tools/timeout.rs` so the two tools cannot drift.
- Add `timed_out: bool` to `RunCodeResult`, classified from the boxlite
  wait-error via a small pure helper (`is_timeout_error`).
- Add `timeout_secs = 150` to `run_code`'s `ToolDef` so the kernel wall sits
  above the boxlite kill (defense-in-depth parity with bash).

Network/egress surface (#2216) is untouched.

## Type of change

Bug fix — `bug`

## Component

`core`

## Closes

Closes #2217

## Test plan

Lane 1 (bugfix with a CI-runnable, fail-before/pass-after unit binding).

- CI-runnable binding = `run_code` unit tests over pure seams
  (`build_exec_request` timeout resolution, `RunCodeParams` timeout coercion
  via the shared `deserialize_timeout`, `is_timeout_error` classification).
- The genuine real-boxlite `while true`-is-killed end-to-end is an `#[ignore]`d
  integration test in `tests/run_code_session.rs` — CI has no boxlite
  (`BOXLITE_DEPS_STUB=1`), so it is not bound to a lifecycle scenario (spec
  out-of-scope, same pattern as #1866 / #2216).

## Verification: PASS (independent verifier, fresh context)

- **VERDICT: PASS.** base `cab91ffe` → head `ecaf60b0`.
- Clean-state quality gate all green: `cargo check --all-targets`,
  `cargo +nightly fmt --all --check`, `cargo clippy --workspace --all-targets
  --all-features --no-deps -D warnings`, `cargo test -p rara-app` (lib: 104
  passed), `prek run --all-files`.
- Lane-1 `just spec-lifecycle`: **4/4 scenarios PASS** + boundaries PASS +
  spec-lifecycle-guard OK.
- **fail-before / pass-after is a real inversion**: pre-change the `ExecRequest`
  timeout was `None`; post-change it is `Some(120s)` when the caller omits a
  timeout (`run_code_sets_default_exec_timeout`).
- **bash extraction is byte-identical, zero regression**: `deserialize_timeout`
  moved verbatim into the shared module; bash's 4 tests stay green.
- **15 hostile inputs** (boundary / negative / CJK / empty / type-confusion /
  map-missing-`secs`) — zero panics. `pass_to_fail = 0`.
- Real-boxlite `while true` kill covered by the `#[ignore]`d e2e (not runnable
  in CI).