### PR TITLE
chore(deps): update dependabot wave

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,7 +120,7 @@ jobs:
         uses: ./.github/actions/setup-rara-build
 
       - name: Install just
-        uses: taiki-e/install-action@c93ccc03e00cd0e08e494f5fd058a6c55a6a1907 # v2
+        uses: taiki-e/install-action@c7eb1735f09259a5035e8e5d44b1406b1cddc0fb # v2
         with:
           tool: just
 
@@ -180,7 +180,7 @@ jobs:
           persist-credentials: false
 
       - name: Install cargo-deny
-        uses: taiki-e/install-action@c93ccc03e00cd0e08e494f5fd058a6c55a6a1907 # v2
+        uses: taiki-e/install-action@c7eb1735f09259a5035e8e5d44b1406b1cddc0fb # v2
         with:
           tool: cargo-deny
 
@@ -205,7 +205,7 @@ jobs:
           persist-credentials: false
 
       - name: Install cargo-shear
-        uses: taiki-e/install-action@c93ccc03e00cd0e08e494f5fd058a6c55a6a1907 # v2
+        uses: taiki-e/install-action@c7eb1735f09259a5035e8e5d44b1406b1cddc0fb # v2
         with:
           tool: cargo-shear
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -128,7 +128,7 @@ jobs:
       BOXLITE_DEPS_STUB: "1"
     steps:
       - name: Checkout code
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           persist-credentials: false
 
@@ -151,7 +151,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           persist-credentials: false
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -114,7 +114,7 @@ jobs:
       # The old arc image had nextest baked in; GitHub-hosted images do not.
       # `.config/nextest.toml` profile `ci` exists since #1912.
       - name: Install cargo-nextest
-        uses: taiki-e/install-action@c93ccc03e00cd0e08e494f5fd058a6c55a6a1907 # v2
+        uses: taiki-e/install-action@c7eb1735f09259a5035e8e5d44b1406b1cddc0fb # v2
         with:
           tool: cargo-nextest
 

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -30,7 +30,7 @@ jobs:
           fetch-depth: false
           persist-credentials: false
       - name: Install mdbook and mdbook-mermaid
-        uses: taiki-e/install-action@c93ccc03e00cd0e08e494f5fd058a6c55a6a1907 # v2
+        uses: taiki-e/install-action@c7eb1735f09259a5035e8e5d44b1406b1cddc0fb # v2
         with:
           tool: mdbook,mdbook-mermaid
       - name: Build mdbook

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -778,7 +778,7 @@ dependencies = [
  "bitflags 2.13.0",
  "cexpr",
  "clang-sys",
- "itertools 0.13.0",
+ "itertools 0.10.5",
  "log",
  "prettyplease",
  "proc-macro2",
@@ -1855,9 +1855,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-queue"
-version = "0.3.12"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f58bbc28f91df819d0aa2a2c00cd19754769c2fad90579b3592b1c9ba7a3115"
+checksum = "803d13fb3b09d88be9f4dbc29062c66b19bf7170867ceb746d2a8689bf6c7a26"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -4037,9 +4037,9 @@ dependencies = [
 
 [[package]]
 name = "ignore"
-version = "0.4.27"
+version = "0.4.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe112b004901c62c2faa11f4f75e9864e0cc5af8da71c9115d184a3aa888749f"
+checksum = "2adf14691c72bcfc1058740436a35bdd3ae9c07d1a941ef00b749e9ea16aefa7"
 dependencies = [
  "crossbeam-deque",
  "globset",
@@ -4282,15 +4282,6 @@ dependencies = [
 
 [[package]]
 name = "itertools"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
@@ -4339,9 +4330,9 @@ dependencies = [
 
 [[package]]
 name = "jiff"
-version = "0.2.31"
+version = "0.2.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccfe6121cbe750cf81efa362d85c0bde7ea298ec43092d3a193baca59cdbd634"
+checksum = "961d16382652bfdd8c6f68b223b26a8c93e0d475c672f414411db31c6c5c900e"
 dependencies = [
  "defmt",
  "jiff-static",
@@ -4357,9 +4348,9 @@ dependencies = [
 
 [[package]]
 name = "jiff-static"
-version = "0.2.31"
+version = "0.2.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e165e897f662d428f3cd3828a919dbe067c2d42bb1031eede74ef9d27ecdedd2"
+checksum = "d0879bd39df99c4c5e2c6615ccc026391a423dde10532c573e6086eb94a802cc"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4889,9 +4880,9 @@ dependencies = [
 
 [[package]]
 name = "md5"
-version = "0.7.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "490cc448043f947bae3cbee9c203358d62dbee0db12107a74be5c30ccfd09771"
+checksum = "7ebb8d8732c6a6df3d8f032a82911cfc747e00efb95cc46e8d0acd5b5b88570c"
 
 [[package]]
 name = "mea"
@@ -5296,9 +5287,9 @@ dependencies = [
 
 [[package]]
 name = "num-bigint"
-version = "0.4.7"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c863e9ab5e7bf9c99ba75e1050f1e4d624ae87ed3532d6238ffbdc7b585dbbe6"
+checksum = "c89e69e7e0f03bea5ef08013795c25018e101932225a656383bd384495ecc367"
 dependencies = [
  "num-integer",
  "num-traits",
@@ -6621,20 +6612,19 @@ checksum = "e0c5ccf5294c6ccd63a74f1565028353830a9c2f5eb0c682c355c471726a6e3f"
 
 [[package]]
 name = "pyroscope"
-version = "2.0.6"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6869e0f2cae5cef10281c57d5a260f91372d7f190a7f717eb1a54f643d92151"
+checksum = "7b9adfbc87341b5976c0bbab196ed2e2c188e2acf9f4d434d46eb9433f0f529c"
 dependencies = [
  "aligned-vec",
  "backtrace",
  "findshlibs",
  "framehop",
- "lazy_static",
  "libc",
  "libflate",
  "log",
  "memmap2",
- "nix 0.26.4",
+ "nix 0.31.3",
  "object 0.39.1",
  "once_cell",
  "prost 0.14.4",
@@ -7762,9 +7752,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.12.4"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba"
+checksum = "2a0e75113e14dc5acb068cd0786884f214f1312650a3d36d269f5c4f3cdee8a2"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -10388,9 +10378,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-width"
-version = "0.2.0"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
 name = "unicode-xid"
@@ -11652,9 +11642,9 @@ checksum = "5431d5661c32445236631278f27946e444ddafe4684cac70b185272d4f9c52d5"
 
 [[package]]
 name = "zlob"
-version = "1.5.0"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d9315a2e188489e16825c7c281001b48af0e09adf989708ae707c4d11b41cb0"
+checksum = "e41cb327ac1b7e7e0d4514658500cb5734cd655edbe4e5ffeda69955da9028ee"
 dependencies = [
  "bindgen",
  "bitflags 2.13.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -186,7 +186,7 @@ lettre = { version = "0.11", default-features = false, features = [
     "builder",
     "hostname",
 ] }
-md5 = "0.7"
+md5 = "0.8"
 moka = { version = "0.12", features = ["future"] }
 notify = "8"
 oauth2 = "5"
@@ -290,9 +290,9 @@ fff-query-parser = { git = "https://github.com/dmtrKovalenko/fff.nvim", rev = "e
 # pins the version across the workspace because `Cargo.lock` is gitignored.
 # zlob's bundled `build.zig` targets zig 0.16's `Build.Step.Compile` API
 # (the `linkLibC()` method call was removed upstream); releases before 1.3.2
-# only compile on zig 0.15. 1.5.0 still builds against the zig 0.16 toolchain.
+# only compile on zig 0.15. 1.6.1 still builds against the zig 0.16 toolchain.
 # Bump this in lockstep with the CI runner's zig toolchain.
-zlob = "=1.5.0"
+zlob = "=1.6.1"
 
 rara-tool-macro = { path = "crates/common/tool-macro" }
 tape-codec-zig = { path = "crates/tape-codec-zig", default-features = false }

--- a/deny.toml
+++ b/deny.toml
@@ -33,8 +33,6 @@ allow = [
     "BSL-1.0",
     "MPL-2.0",
     "ISC",
-    "OpenSSL",
-    "PostgreSQL",
     "0BSD",
     "CDLA-Permissive-2.0",
 ]
@@ -66,9 +64,6 @@ skip = [
     { crate = "darling@0.20.11", reason = "croner -> derive_builder uses older version" },
     { crate = "darling_core@0.20.11", reason = "transitive from darling 0.20" },
     { crate = "darling_macro@0.20.11", reason = "transitive from darling 0.20" },
-    # fixedbitset/petgraph: parking_lot_core (v0.4/v0.6) vs prost-build (v0.5/v0.8)
-    { crate = "fixedbitset@0.4.2", reason = "parking_lot_core -> petgraph uses older version" },
-    { crate = "petgraph@0.6.5", reason = "parking_lot_core uses older version" },
     # hashbrown: petgraph 0.8 (v0.15) vs indexmap (v0.16)
     { crate = "hashbrown@0.15.5", reason = "petgraph 0.8 uses older version" },
     # linux-raw-sys/rustix: procfs (v0.38/v0.4) vs tempfile (v1.x/v0.11)
@@ -90,10 +85,6 @@ skip = [
     { crate = "windows_x86_64_gnu@0.52.6", reason = "windows-targets 0.52.6 uses older version" },
     { crate = "windows_x86_64_gnullvm@0.52.6", reason = "windows-targets 0.52.6 uses older version" },
     { crate = "windows_x86_64_msvc@0.52.6", reason = "windows-targets 0.52.6 uses older version" },
-    { crate = "windows-core@0.61.2", reason = "sysinfo uses older version" },
-    { crate = "windows-link@0.1.3", reason = "windows-core 0.61 uses older version" },
-    { crate = "windows-result@0.3.4", reason = "windows-core 0.61 uses older version" },
-    { crate = "windows-strings@0.4.2", reason = "windows-core 0.61 uses older version" },
     { crate = "windows-sys@0.60.2", reason = "socket2 uses intermediate version" },
     { crate = "windows-targets@0.52.6", reason = "windows-sys 0.52 uses older version" },
 


### PR DESCRIPTION
## Summary
- batch safe Dependabot updates for Rust dependencies and pinned GitHub Actions
- update md5 to 0.8, zlob to 1.6.1, and refresh the lockfile for compatible patch/minor bumps
- clean stale cargo-deny allow/skip entries and update yanked num-bigint 0.4.7 -> 0.4.8

## Included Dependabot PRs
- #2215 ignore 0.4.27 -> 0.4.28
- #2214 md5 0.7.0 -> 0.8.1
- #2213 jiff 0.2.31 -> 0.2.32
- #2212 zlob 1.5.0 -> 1.6.1
- #2211 regex 1.12.4 -> 1.13.0
- #2210 taiki-e/install-action 2.82.8 -> 2.83.0
- #2209 pyroscope 2.0.6 -> 2.1.0
- #2207 crossbeam-queue 0.3.12 -> 0.3.13
- #2202 unicode-width 0.2.0 -> 0.2.2
- #2200 actions/checkout 6.0.1 -> 7.0.0

## Left out intentionally
- #2208 agent-client-protocol 1.2.0: breaks rara-acp API usage and needs a real migration
- #2205 jieba-rs 0.10.2: upstream crate does not compile on the current toolchain (`EMIT_PROBS.get(&ch)` indexes a slice with `&char`)

## Validation
- `cargo check --workspace --all-targets`
- `cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings`
- `cargo deny check`
- `cargo shear`
- `rustup run nightly cargo fmt --check`
- `git diff --check`
- `cargo nextest run --workspace --profile ci` — 1191 passed, 4 skipped
- pre-commit hook on commit: cargo check/fmt/clippy/doc passed

Note: raw `cargo test --workspace --all-features` is not the CI gate here. It exposed two non-regression local failures: a global config-dir ordering issue that passes in isolation and a Yahoo Finance e2e timeout caused by local network/Yahoo reachability (`curl` to the same URL timed out). CI-equivalent nextest passed.