### PR TITLE
feat(trading): enable default Binance candle feed

### DIFF
--- a/crates/extensions/backend-admin/src/data_feeds/router.rs
+++ b/crates/extensions/backend-admin/src/data_feeds/router.rs
@@ -1007,8 +1007,12 @@ mod tests {
             .iter()
             .find(|entry| entry["id"] == "binance-market-candles")
             .unwrap();
-        assert_eq!(binance["requires_configuration"], true);
+        assert_eq!(binance["requires_configuration"], false);
         assert_eq!(binance["feed_type"], "market_candle");
+        assert_eq!(
+            binance["transport_template"]["provider"].as_str().unwrap(),
+            "binance"
+        );
     }
 
     #[tokio::test]
@@ -1042,13 +1046,43 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn finance_catalog_enable_rejects_provider_preset_without_config() {
+    async fn finance_catalog_enable_creates_default_binance_feed() {
         let app = app_with_user(user_of(Role::Admin)).await;
         let res = app
             .oneshot(
                 Request::builder()
                     .method("POST")
                     .uri("/api/v1/data-feeds/catalog/binance-market-candles/enable")
+                    .header("Authorization", "Bearer s3cret")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(res.status(), StatusCode::CREATED);
+
+        let body = axum::body::to_bytes(res.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let feed: DataFeedConfig = serde_json::from_slice(&body).unwrap();
+
+        assert_eq!(feed.name, "finance-binance-market-candles");
+        assert_eq!(feed.feed_type, FeedType::MarketCandle);
+        assert_eq!(feed.transport["provider"], "binance");
+        assert_eq!(feed.transport["venue"], "binance");
+        assert_eq!(feed.transport["symbols"][0], "BTCUSDT");
+        assert!(feed.enabled);
+    }
+
+    #[tokio::test]
+    async fn finance_catalog_enable_rejects_provider_preset_without_config() {
+        let app = app_with_user(user_of(Role::Admin)).await;
+        let res = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/v1/data-feeds/catalog/longbridge-market-candles/enable")
                     .header("Authorization", "Bearer s3cret")
                     .body(Body::empty())
                     .unwrap(),

--- a/crates/extensions/rara-trading/src/feed/catalog.rs
+++ b/crates/extensions/rara-trading/src/feed/catalog.rs
@@ -78,14 +78,11 @@ pub fn default_finance_feed_sources() -> Vec<DefaultFeedSource> {
             ["finance", "news", "sec", "regulatory"],
             300,
         ),
-        provider_preset(
+        binance_market_candles_source(
             "binance-market-candles",
             "Binance Market Candles",
-            "Preset for Binance OHLCV ingestion through a normalized candle endpoint.",
-            "binance",
+            "Public Binance spot OHLCV feed for BTCUSDT and ETHUSDT 1m candles.",
             ["finance", "market-data", "crypto", "binance"],
-            "Connect a normalized Binance candle endpoint and choose symbols/timeframes before \
-             enabling.",
         ),
         provider_preset(
             "longbridge-market-candles",
@@ -117,6 +114,34 @@ fn rss_source(
             "interval_secs": interval_secs,
             "headers": {},
             "max_entries_per_poll": 50
+        })),
+        auth:                   None,
+        requires_configuration: false,
+        setup_hint:             None,
+    }
+}
+
+fn binance_market_candles_source(
+    id: &str,
+    name: &str,
+    description: &str,
+    tags: impl IntoIterator<Item = &'static str>,
+) -> DefaultFeedSource {
+    DefaultFeedSource {
+        id:                     id.to_owned(),
+        name:                   name.to_owned(),
+        description:            description.to_owned(),
+        feed_type:              FeedType::MarketCandle,
+        tags:                   tags.into_iter().map(str::to_owned).collect(),
+        transport:              Some(serde_json::json!({
+            "provider": "binance",
+            "base_url": "https://api.binance.com",
+            "interval_secs": 60,
+            "headers": {},
+            "venue": "binance",
+            "symbols": ["BTCUSDT", "ETHUSDT"],
+            "timeframes": ["1m"],
+            "max_candles_per_poll": 1000
         })),
         auth:                   None,
         requires_configuration: false,

--- a/crates/extensions/rara-trading/src/feed/market_candle.rs
+++ b/crates/extensions/rara-trading/src/feed/market_candle.rs
@@ -14,8 +14,9 @@
 
 //! Config-driven latest market candle data feed.
 //!
-//! This transport fetches an operator-managed normalized candle endpoint and
-//! emits one `market_candle_closed` event per closed bar.
+//! This transport fetches either an operator-managed normalized candle endpoint
+//! or a built-in public provider such as Binance, then emits one
+//! `market_candle_closed` event per closed bar.
 
 use std::{
     collections::{HashMap, HashSet},
@@ -48,7 +49,12 @@ const MAX_BODY_BYTES: usize = 4 * 1024 * 1024;
 
 #[derive(Debug, Clone, Deserialize)]
 pub struct MarketCandleTransport {
-    pub url:                  String,
+    #[serde(default)]
+    pub provider:             Option<String>,
+    #[serde(default)]
+    pub url:                  Option<String>,
+    #[serde(default)]
+    pub base_url:             Option<String>,
     pub interval_secs:        u64,
     #[serde(default)]
     pub headers:              HashMap<String, String>,
@@ -132,8 +138,13 @@ impl MarketCandleSource {
         self
     }
 
-    fn build_url(&self) -> anyhow::Result<Url> {
-        let mut url = Url::parse(&self.transport.url)?;
+    fn build_normalized_url(&self) -> anyhow::Result<Url> {
+        let url = self
+            .transport
+            .url
+            .as_deref()
+            .ok_or_else(|| anyhow::anyhow!("normalized market candle URL is required"))?;
+        let mut url = Url::parse(url)?;
         if let Some(AuthConfig::Query {
             ref name,
             ref value,
@@ -141,6 +152,20 @@ impl MarketCandleSource {
         {
             url.query_pairs_mut().append_pair(name, value);
         }
+        Ok(url)
+    }
+
+    fn build_binance_klines_url(&self, symbol: &str, timeframe: &str) -> anyhow::Result<Url> {
+        let base_url = self
+            .transport
+            .base_url
+            .as_deref()
+            .unwrap_or("https://api.binance.com");
+        let mut url = Url::parse(base_url)?.join("/api/v3/klines")?;
+        url.query_pairs_mut()
+            .append_pair("symbol", symbol)
+            .append_pair("interval", timeframe)
+            .append_pair("limit", "2");
         Ok(url)
     }
 
@@ -173,7 +198,7 @@ impl MarketCandleSource {
         }
     }
 
-    fn parse_candle_events(&self, body: &[u8]) -> anyhow::Result<Vec<FeedEvent>> {
+    fn parse_normalized_candle_events(&self, body: &[u8]) -> anyhow::Result<Vec<FeedEvent>> {
         let batch: CandleBatch = serde_json::from_slice(body)?;
         let received_at = Timestamp::now();
         let mut events = Vec::new();
@@ -186,52 +211,75 @@ impl MarketCandleSource {
             let Some(candle) = self.parse_raw_candle(raw) else {
                 continue;
             };
-            let mut tags = self.tags.clone();
-            tags.extend([
-                "finance".to_owned(),
-                "market-data".to_owned(),
-                format!("source:{}", self.name),
-                format!("venue:{}", candle.venue),
-                format!("symbol:{}", candle.symbol),
-                format!("timeframe:{}", candle.timeframe),
-            ]);
-            dedupe_sort(&mut tags);
-
-            let payload = serde_json::json!({
-                "venue": candle.venue,
-                "symbol": candle.symbol,
-                "timeframe": candle.timeframe,
-                "open_time": candle.open_time,
-                "close_time": candle.close_time,
-                "open": candle.open.to_string(),
-                "high": candle.high.to_string(),
-                "low": candle.low.to_string(),
-                "close": candle.close.to_string(),
-                "volume": candle.volume.to_string(),
-            });
-
-            let identity = format!(
-                "{}:{}:{}:{}:{}",
-                self.name,
-                payload["venue"].as_str().unwrap_or_default(),
-                payload["symbol"].as_str().unwrap_or_default(),
-                payload["timeframe"].as_str().unwrap_or_default(),
-                payload["open_time"].as_str().unwrap_or_default()
-            );
-
-            events.push(
-                FeedEvent::builder()
-                    .id(FeedEventId::deterministic(&identity))
-                    .source_name(self.name.clone())
-                    .event_type("market_candle_closed".to_owned())
-                    .tags(tags)
-                    .payload(payload)
-                    .received_at(received_at)
-                    .build(),
-            );
+            events.push(self.event_from_candle(candle, received_at));
         }
 
         Ok(events)
+    }
+
+    fn parse_binance_candle_events(
+        &self,
+        symbol: &str,
+        timeframe: &str,
+        body: &[u8],
+    ) -> anyhow::Result<Vec<FeedEvent>> {
+        let rows: Vec<Vec<serde_json::Value>> = serde_json::from_slice(body)?;
+        let received_at = Timestamp::now();
+        let now_ms = received_at.as_millisecond();
+        let mut events = Vec::new();
+
+        for row in rows.into_iter().take(self.transport.max_candles_per_poll) {
+            let Some(candle) = self.parse_binance_row(symbol, timeframe, row, now_ms) else {
+                continue;
+            };
+            events.push(self.event_from_candle(candle, received_at));
+        }
+
+        Ok(events)
+    }
+
+    fn event_from_candle(&self, candle: ParsedCandle, received_at: Timestamp) -> FeedEvent {
+        let mut tags = self.tags.clone();
+        tags.extend([
+            "finance".to_owned(),
+            "market-data".to_owned(),
+            format!("source:{}", self.name),
+            format!("venue:{}", candle.venue),
+            format!("symbol:{}", candle.symbol),
+            format!("timeframe:{}", candle.timeframe),
+        ]);
+        dedupe_sort(&mut tags);
+
+        let payload = serde_json::json!({
+            "venue": candle.venue,
+            "symbol": candle.symbol,
+            "timeframe": candle.timeframe,
+            "open_time": candle.open_time,
+            "close_time": candle.close_time,
+            "open": candle.open.to_string(),
+            "high": candle.high.to_string(),
+            "low": candle.low.to_string(),
+            "close": candle.close.to_string(),
+            "volume": candle.volume.to_string(),
+        });
+
+        let identity = format!(
+            "{}:{}:{}:{}:{}",
+            self.name,
+            payload["venue"].as_str().unwrap_or_default(),
+            payload["symbol"].as_str().unwrap_or_default(),
+            payload["timeframe"].as_str().unwrap_or_default(),
+            payload["open_time"].as_str().unwrap_or_default()
+        );
+
+        FeedEvent::builder()
+            .id(FeedEventId::deterministic(&identity))
+            .source_name(self.name.clone())
+            .event_type("market_candle_closed".to_owned())
+            .tags(tags)
+            .payload(payload)
+            .received_at(received_at)
+            .build()
     }
 
     fn parse_raw_candle(&self, raw: RawCandle) -> Option<ParsedCandle> {
@@ -258,8 +306,35 @@ impl MarketCandleSource {
         })
     }
 
-    async fn poll_once(&self, tx: &mpsc::Sender<FeedEvent>) -> bool {
-        let url = match self.build_url() {
+    fn parse_binance_row(
+        &self,
+        symbol: &str,
+        timeframe: &str,
+        row: Vec<serde_json::Value>,
+        now_ms: i64,
+    ) -> Option<ParsedCandle> {
+        let open_time_ms = row.first()?.as_i64()?;
+        let close_time_ms = row.get(6)?.as_i64()?;
+        if close_time_ms > now_ms {
+            return None;
+        }
+
+        Some(ParsedCandle {
+            venue:      self.transport.venue.clone(),
+            symbol:     symbol.to_owned(),
+            timeframe:  timeframe.to_owned(),
+            open_time:  Timestamp::from_millisecond(open_time_ms).ok()?.to_string(),
+            close_time: Timestamp::from_millisecond(close_time_ms).ok()?.to_string(),
+            open:       Decimal::from_str(row.get(1)?.as_str()?).ok()?,
+            high:       Decimal::from_str(row.get(2)?.as_str()?).ok()?,
+            low:        Decimal::from_str(row.get(3)?.as_str()?).ok()?,
+            close:      Decimal::from_str(row.get(4)?.as_str()?).ok()?,
+            volume:     Decimal::from_str(row.get(5)?.as_str()?).ok()?,
+        })
+    }
+
+    async fn poll_normalized_once(&self, tx: &mpsc::Sender<FeedEvent>) -> bool {
+        let url = match self.build_normalized_url() {
             Ok(url) => url,
             Err(err) => {
                 self.record_error(format!("failed to build market candle URL: {err}"));
@@ -303,7 +378,7 @@ impl MarketCandleSource {
             return true;
         }
 
-        let events = match self.parse_candle_events(&body) {
+        let events = match self.parse_normalized_candle_events(&body) {
             Ok(events) => events,
             Err(err) => {
                 self.record_error(format!("failed to parse market candle response: {err}"));
@@ -319,6 +394,89 @@ impl MarketCandleSource {
 
         self.record_success();
         true
+    }
+
+    async fn poll_binance_once(&self, tx: &mpsc::Sender<FeedEvent>) -> bool {
+        let mut any_success = false;
+
+        for symbol in &self.transport.symbols {
+            for timeframe in &self.transport.timeframes {
+                let url = match self.build_binance_klines_url(symbol, timeframe) {
+                    Ok(url) => url,
+                    Err(err) => {
+                        self.record_error(format!("failed to build Binance klines URL: {err}"));
+                        continue;
+                    }
+                };
+
+                let mut request = self.client.get(url);
+                for (key, value) in &self.transport.headers {
+                    request = request.header(key.as_str(), value.as_str());
+                }
+                request = apply_request_auth(request, &self.auth);
+
+                let response = match request.send().await {
+                    Ok(response) => response,
+                    Err(err) => {
+                        self.record_error(format!("Binance klines fetch failed: {err}"));
+                        continue;
+                    }
+                };
+
+                let status = response.status();
+                if !status.is_success() {
+                    self.record_error(format!(
+                        "Binance klines fetch received non-success status: {status}"
+                    ));
+                    continue;
+                }
+
+                let body = match response.bytes().await {
+                    Ok(body) => body,
+                    Err(err) => {
+                        self.record_error(format!("failed to read Binance klines body: {err}"));
+                        continue;
+                    }
+                };
+                if body.len() > MAX_BODY_BYTES {
+                    self.record_error(format!(
+                        "Binance klines response exceeded {MAX_BODY_BYTES} bytes"
+                    ));
+                    continue;
+                }
+
+                let events = match self.parse_binance_candle_events(symbol, timeframe, &body) {
+                    Ok(events) => events,
+                    Err(err) => {
+                        self.record_error(format!(
+                            "failed to parse Binance klines response: {err}"
+                        ));
+                        continue;
+                    }
+                };
+
+                any_success = true;
+                for event in events {
+                    if tx.send(event).await.is_err() {
+                        tracing::info!("event channel closed, stopping market candle loop");
+                        return false;
+                    }
+                }
+            }
+        }
+
+        if any_success {
+            self.record_success();
+        }
+        true
+    }
+
+    async fn poll_once(&self, tx: &mpsc::Sender<FeedEvent>) -> bool {
+        if self.transport.provider.as_deref() == Some("binance") {
+            self.poll_binance_once(tx).await
+        } else {
+            self.poll_normalized_once(tx).await
+        }
     }
 }
 
@@ -336,7 +494,9 @@ impl DataFeed for MarketCandleSource {
     ) -> anyhow::Result<()> {
         let interval = Duration::from_secs(self.transport.interval_secs);
         tracing::info!(
-            url = %self.transport.url,
+            provider = ?self.transport.provider,
+            url = ?self.transport.url,
+            base_url = ?self.transport.base_url,
             ?interval,
             "market candle feed started"
         );
@@ -363,8 +523,28 @@ impl DataFeed for MarketCandleSource {
 }
 
 fn validate_transport(transport: &MarketCandleTransport) -> anyhow::Result<()> {
-    let url = Url::parse(&transport.url)?;
-    anyhow::ensure!(url.scheme() == "https", "market candle URL must use HTTPS");
+    match transport.provider.as_deref().unwrap_or("normalized") {
+        "normalized" => {
+            let url = transport
+                .url
+                .as_deref()
+                .ok_or_else(|| anyhow::anyhow!("market candle URL is required"))?;
+            let url = Url::parse(url)?;
+            anyhow::ensure!(url.scheme() == "https", "market candle URL must use HTTPS");
+        }
+        "binance" => {
+            let base_url = transport
+                .base_url
+                .as_deref()
+                .unwrap_or("https://api.binance.com");
+            let url = Url::parse(base_url)?;
+            anyhow::ensure!(
+                url.scheme() == "https",
+                "Binance market candle base_url must use HTTPS"
+            );
+        }
+        provider => anyhow::bail!("unsupported market candle provider: {provider}"),
+    }
     anyhow::ensure!(
         transport.interval_secs > 0,
         "market candle interval_secs must be greater than zero"
@@ -431,11 +611,35 @@ mod tests {
         MarketCandleSource::from_config(&config).expect("market candle config should parse")
     }
 
+    fn binance_source() -> MarketCandleSource {
+        let config = DataFeedConfig::builder()
+            .id("binance-candles-test".to_owned())
+            .name("binance-public".to_owned())
+            .feed_type(FeedType::MarketCandle)
+            .tags(vec!["finance".to_owned(), "crypto".to_owned()])
+            .transport(serde_json::json!({
+                "provider": "binance",
+                "base_url": "https://api.binance.com",
+                "interval_secs": 60,
+                "venue": "binance",
+                "symbols": ["BTCUSDT"],
+                "timeframes": ["1m"],
+                "max_candles_per_poll": 1000
+            }))
+            .enabled(true)
+            .status(FeedStatus::Idle)
+            .created_at(jiff::Timestamp::UNIX_EPOCH)
+            .updated_at(jiff::Timestamp::UNIX_EPOCH)
+            .build();
+
+        MarketCandleSource::from_config(&config).expect("Binance config should parse")
+    }
+
     #[test]
     fn closed_candles_for_many_symbols_become_batched_events() {
         let source = candle_source();
         let events = source
-            .parse_candle_events(
+            .parse_normalized_candle_events(
                 br#"{
   "candles": [
     {
@@ -505,8 +709,12 @@ mod tests {
   ]
 }"#;
 
-        let first = source.parse_candle_events(body).expect("first parse");
-        let second = source.parse_candle_events(body).expect("second parse");
+        let first = source
+            .parse_normalized_candle_events(body)
+            .expect("first parse");
+        let second = source
+            .parse_normalized_candle_events(body)
+            .expect("second parse");
 
         assert_eq!(first[0].id, second[0].id);
     }
@@ -515,7 +723,7 @@ mod tests {
     fn open_or_invalid_decimal_candles_are_not_emitted() {
         let source = candle_source();
         let events = source
-            .parse_candle_events(
+            .parse_normalized_candle_events(
                 br#"{
   "candles": [
     {
@@ -550,5 +758,61 @@ mod tests {
             .expect("payload should parse while invalid candles are skipped");
 
         assert!(events.is_empty());
+    }
+
+    #[test]
+    fn binance_provider_builds_public_klines_url() {
+        let source = binance_source();
+        let url = source
+            .build_binance_klines_url("BTCUSDT", "1m")
+            .expect("URL should build");
+
+        assert_eq!(
+            url.as_str(),
+            "https://api.binance.com/api/v3/klines?symbol=BTCUSDT&interval=1m&limit=2"
+        );
+    }
+
+    #[test]
+    fn binance_klines_become_closed_candle_events() {
+        let source = binance_source();
+        let events = source
+            .parse_binance_candle_events(
+                "BTCUSDT",
+                "1m",
+                br#"[
+  [
+    1713100200000,
+    "61500.12",
+    "61640.00",
+    "61480.50",
+    "61610.30",
+    "124.551",
+    1713100259999,
+    "7669543.21",
+    42,
+    "60.1",
+    "3700000.00",
+    "0"
+  ]
+]"#,
+            )
+            .expect("Binance klines should parse");
+
+        assert_eq!(events.len(), 1);
+        let event = &events[0];
+        assert_eq!(event.source_name, "binance-public");
+        assert_eq!(event.event_type, "market_candle_closed");
+        assert!(event.tags.contains(&"venue:binance".to_owned()));
+        assert!(event.tags.contains(&"symbol:BTCUSDT".to_owned()));
+        assert!(event.tags.contains(&"timeframe:1m".to_owned()));
+        assert_eq!(event.payload["venue"], "binance");
+        assert_eq!(event.payload["symbol"], "BTCUSDT");
+        assert_eq!(event.payload["timeframe"], "1m");
+        assert_eq!(event.payload["open"], "61500.12");
+        assert_eq!(event.payload["high"], "61640.00");
+        assert_eq!(event.payload["low"], "61480.50");
+        assert_eq!(event.payload["close"], "61610.30");
+        assert_eq!(event.payload["volume"], "124.551");
     }
 }

--- a/web/e2e/harness/data-feeds.spec.ts
+++ b/web/e2e/harness/data-feeds.spec.ts
@@ -231,7 +231,7 @@ async function setupRoutes(
       name: `finance-${entry.id}`,
       feed_type: entry.feed_type,
       tags: entry.tags,
-      transport: {},
+      transport: entry.transport_template ?? {},
       auth: null,
       enabled: true,
       status: 'running',
@@ -420,20 +420,21 @@ test.describe('Data Feeds Management', () => {
         {
           id: 'binance-market-candles',
           name: 'Binance Market Candles',
-          description: 'Preset for Binance OHLCV ingestion.',
+          description: 'Public Binance spot OHLCV feed.',
           feed_type: 'market_candle',
           tags: ['finance', 'market-data', 'crypto', 'binance'],
           enabled: false,
           feed_id: null,
-          requires_configuration: true,
-          setup_hint: 'Connect a normalized Binance candle endpoint before enabling.',
+          requires_configuration: false,
+          setup_hint: null,
           transport_template: {
-            url: '',
+            provider: 'binance',
+            base_url: 'https://api.binance.com',
             interval_secs: 60,
             headers: {},
             venue: 'binance',
-            symbols: [],
-            timeframes: [],
+            symbols: ['BTCUSDT', 'ETHUSDT'],
+            timeframes: ['1m'],
             max_candles_per_poll: 1000,
           },
         },
@@ -444,7 +445,10 @@ test.describe('Data Feeds Management', () => {
     await expect(page.getByText('Default finance sources')).toBeVisible({ timeout: 10_000 });
     await expect(page.getByText('Federal Reserve Press Releases', { exact: true })).toBeVisible();
 
-    await page.getByRole('button', { name: 'Enable' }).click();
+    const fedEntry = page
+      .getByText('Federal Reserve Press Releases', { exact: true })
+      .locator('xpath=ancestor::div[contains(@class, "justify-between")][1]');
+    await fedEntry.getByRole('button', { name: 'Enable' }).click();
 
     await expect(page.getByText('finance-fed-press-releases')).toBeVisible({ timeout: 5_000 });
     await expect(page.getByRole('button', { name: 'Disable' })).toBeVisible();
@@ -456,20 +460,20 @@ test.describe('Data Feeds Management', () => {
       events: [],
       catalog: [
         {
-          id: 'binance-market-candles',
-          name: 'Binance Market Candles',
-          description: 'Preset for Binance OHLCV ingestion.',
+          id: 'longbridge-market-candles',
+          name: 'Longbridge Market Data',
+          description: 'Preset for Longbridge equities market data.',
           feed_type: 'market_candle',
-          tags: ['finance', 'market-data', 'crypto', 'binance'],
+          tags: ['finance', 'market-data', 'equities', 'longbridge'],
           enabled: false,
           feed_id: null,
           requires_configuration: true,
-          setup_hint: 'Connect a normalized Binance candle endpoint before enabling.',
+          setup_hint: 'Connect Longbridge credentials behind a normalized candle endpoint.',
           transport_template: {
             url: '',
             interval_secs: 60,
             headers: {},
-            venue: 'binance',
+            venue: 'longbridge',
             symbols: [],
             timeframes: [],
             max_candles_per_poll: 1000,
@@ -480,15 +484,15 @@ test.describe('Data Feeds Management', () => {
     await goToDataFeeds(page);
 
     await expect(page.getByText(/^Provider presets$/)).toBeVisible({ timeout: 10_000 });
-    await expect(page.getByText('Binance Market Candles')).toBeVisible();
+    await expect(page.getByText('Longbridge Market Data')).toBeVisible();
 
     await page.getByRole('button', { name: 'Use template' }).click();
 
     await expect(page.getByText('New Data Feed')).toBeVisible({ timeout: 5_000 });
     await expect(page.locator('input[placeholder="e.g. github-rara"]')).toHaveValue(
-      'finance-binance-market-candles',
+      'finance-longbridge-market-candles',
     );
-    await expect(page.locator('input[placeholder="binance"]')).toHaveValue('binance');
+    await expect(page.locator('input[placeholder="binance"]')).toHaveValue('longbridge');
   });
 
   // -----------------------------------------------------------------------

--- a/web/src/components/DataFeedsPanel.tsx
+++ b/web/src/components/DataFeedsPanel.tsx
@@ -1085,8 +1085,7 @@ function FeedCatalogCard({
       <div className="border-b px-4 py-3">
         <h3 className="text-sm font-semibold">Default finance sources</h3>
         <p className="text-xs text-muted-foreground">
-          Official feeds can run immediately. Provider presets need your own endpoint or
-          credentials.
+          Ready sources can run immediately. Provider presets need your own endpoint or credentials.
         </p>
       </div>
       <div className="divide-y">


### PR DESCRIPTION
## Summary
- make the built-in Binance market-candle catalog entry directly enableable
- add native `provider: "binance"` support to `MarketCandleSource` using Binance public `/api/v3/klines`
- keep normalized endpoint support for custom providers and keep Longbridge as a configuration-required preset
- update Data Feeds UI copy and harness mocks for ready sources vs provider presets

## Validation
- cargo test -p rara-trading feed::market_candle::tests --lib
- cargo test -p rara-backend-admin data_feeds::router::tests --lib
- cargo test -p rara-trading
- cargo check -p rara-trading -p rara-backend-admin
- cargo clippy -p rara-trading -p rara-backend-admin --all-targets --no-deps -- -D warnings
- cargo check --workspace --all-targets
- rustup run nightly cargo fmt --check
- git diff --check
- npm --prefix web run typecheck
- npm --prefix web run format:check
- npx --prefix web prettier --check web/e2e/harness/data-feeds.spec.ts
- npm --prefix web run build
- npm --prefix web run test:e2e -- e2e/harness/data-feeds.spec.ts (36 passed)

Pre-commit also passed: cargo check, cargo fmt, cargo clippy, cargo doc, AGENT.md presence, web lint-staged.