### PR TITLE
feat(feeds): show feed runtime summaries

### DIFF
--- a/crates/extensions/backend-admin/src/data_feeds/router.rs
+++ b/crates/extensions/backend-admin/src/data_feeds/router.rs
@@ -29,7 +29,7 @@
 //! in-memory [`DataFeedRegistry`]. When an active feed is created and
 //! enabled, a background task is spawned automatically.
 
-use std::sync::Arc;
+use std::{collections::HashMap, sync::Arc};
 
 use axum::{
     Json, Router,
@@ -71,6 +71,7 @@ pub struct DataFeedRouterState {
 pub fn data_feed_routes(state: DataFeedRouterState) -> Router {
     Router::new()
         .route("/api/v1/data-feeds", get(list_feeds).post(create_feed))
+        .route("/api/v1/data-feeds/summary", get(list_feed_summaries))
         .route("/api/v1/data-feeds/catalog", get(list_feed_catalog))
         .route(
             "/api/v1/data-feeds/catalog/{id}/enable",
@@ -153,6 +154,16 @@ struct EventListResponse {
     has_more: bool,
 }
 
+/// Runtime read-model for a feed's persisted event stream.
+#[derive(Debug, Serialize)]
+struct FeedSummaryResponse {
+    feed_id:       String,
+    source_name:   String,
+    event_count:   i64,
+    last_event_at: Option<Timestamp>,
+    lag_seconds:   Option<i64>,
+}
+
 /// Built-in feed catalog entry plus current materialized state.
 #[derive(Debug, Serialize)]
 struct FeedCatalogEntryResponse {
@@ -186,6 +197,43 @@ async fn list_feed_catalog(
 ) -> Result<Json<Vec<FeedCatalogEntryResponse>>, ProblemDetails> {
     let feeds = state.svc.list_feeds().await?;
     Ok(Json(catalog_response(&feeds)))
+}
+
+/// `GET /api/v1/data-feeds/summary` — list per-feed persisted-event health.
+async fn list_feed_summaries(
+    State(state): State<DataFeedRouterState>,
+) -> Result<Json<Vec<FeedSummaryResponse>>, ProblemDetails> {
+    let feeds = state.svc.list_feeds().await?;
+    let summaries = state
+        .svc
+        .event_summaries()
+        .await?
+        .into_iter()
+        .map(|summary| (summary.source_name.clone(), summary))
+        .collect::<HashMap<_, _>>();
+    let now = Timestamp::now();
+
+    Ok(Json(
+        feeds
+            .into_iter()
+            .map(|feed| {
+                let summary = summaries.get(&feed.name);
+                let last_event_at = summary.and_then(|summary| summary.last_event_at);
+                let lag_seconds = last_event_at.map(|last_event_at| {
+                    let lag = now.duration_since(last_event_at);
+                    lag.as_secs().max(0)
+                });
+
+                FeedSummaryResponse {
+                    feed_id: feed.id,
+                    source_name: feed.name,
+                    event_count: summary.map_or(0, |summary| summary.event_count),
+                    last_event_at,
+                    lag_seconds,
+                }
+            })
+            .collect(),
+    ))
 }
 
 /// `POST /api/v1/data-feeds/catalog/{id}/enable` — materialize a default feed.
@@ -855,6 +903,22 @@ mod tests {
         data_feed_routes(state).layer(middleware::from_fn_with_state(auth, auth_layer))
     }
 
+    async fn app_with_user_and_pools(
+        user: KernelUser,
+    ) -> (Router, yunara_store::diesel_pool::DieselSqlitePools) {
+        let pools = build_memory_diesel_pools().await;
+        bootstrap_data_feed_schema(&pools).await;
+        let svc = DataFeedSvc::new(pools.clone());
+        let (event_tx, _event_rx) = tokio::sync::mpsc::channel(16);
+        let registry = Arc::new(DataFeedRegistry::new(event_tx));
+        let state = DataFeedRouterState { svc, registry };
+        let auth = auth_state_direct(user);
+        (
+            data_feed_routes(state).layer(middleware::from_fn_with_state(auth, auth_layer)),
+            pools,
+        )
+    }
+
     async fn bootstrap_data_feed_schema(pools: &yunara_store::diesel_pool::DieselSqlitePools) {
         let mut conn = pools.writer.get().await.expect("pool conn");
         for ddl in [
@@ -1132,6 +1196,149 @@ mod tests {
         assert_eq!(feed.name, "finance-sec-press-releases");
         assert!(!feed.enabled);
         assert_eq!(feed.status, FeedStatus::Idle);
+    }
+
+    #[tokio::test]
+    async fn feed_summary_reports_event_count_and_lag() {
+        let (app, pools) = app_with_user_and_pools(user_of(Role::Admin)).await;
+        let create_body = serde_json::json!({
+            "name": "summary-feed",
+            "feed_type": "polling",
+            "tags": ["finance"],
+            "transport": {
+                "url": "https://example.com/feed",
+                "interval_secs": 60,
+                "headers": {},
+                "method": "GET"
+            },
+        });
+        let create_res = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/v1/data-feeds")
+                    .header("Authorization", "Bearer s3cret")
+                    .header("Content-Type", "application/json")
+                    .body(Body::from(create_body.to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(create_res.status(), StatusCode::CREATED);
+
+        let body = axum::body::to_bytes(create_res.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let feed: DataFeedConfig = serde_json::from_slice(&body).unwrap();
+        let event_at = Timestamp::now()
+            .checked_sub(jiff::SignedDuration::from_secs(60))
+            .unwrap();
+        let event_id = rara_kernel::data_feed::FeedEventId::deterministic("summary-feed:event");
+
+        let mut conn = pools.writer.get().await.expect("pool conn");
+        diesel::sql_query(
+            "INSERT INTO data_feed_events (id, source_name, event_type, tags, payload, \
+             received_at) VALUES (?, ?, ?, ?, ?, ?)",
+        )
+        .bind::<diesel::sql_types::Text, _>(event_id.to_string())
+        .bind::<diesel::sql_types::Text, _>("summary-feed")
+        .bind::<diesel::sql_types::Text, _>("poll_response")
+        .bind::<diesel::sql_types::Text, _>("[\"finance\"]")
+        .bind::<diesel::sql_types::Text, _>("{\"ok\":true}")
+        .bind::<diesel::sql_types::Text, _>(event_at.to_string())
+        .execute(&mut *conn)
+        .await
+        .expect("insert event");
+        drop(conn);
+
+        let res = app
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri("/api/v1/data-feeds/summary")
+                    .header("Authorization", "Bearer s3cret")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(res.status(), StatusCode::OK);
+
+        let body = axum::body::to_bytes(res.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let summaries: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        let summary = summaries
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|summary| summary["feed_id"] == feed.id)
+            .unwrap();
+
+        assert_eq!(summary["source_name"], "summary-feed");
+        assert_eq!(summary["event_count"], 1);
+        assert_eq!(summary["last_event_at"], event_at.to_string());
+        let lag_seconds = summary["lag_seconds"].as_i64().unwrap();
+        assert!((58..=62).contains(&lag_seconds), "lag={lag_seconds}");
+    }
+
+    #[tokio::test]
+    async fn feed_summary_includes_zero_event_feeds() {
+        let app = app_with_user(user_of(Role::Admin)).await;
+        let create_body = serde_json::json!({
+            "name": "empty-feed",
+            "feed_type": "polling",
+            "tags": [],
+            "transport": {
+                "url": "https://example.com/feed",
+                "interval_secs": 60,
+                "headers": {},
+                "method": "GET"
+            },
+        });
+        let create_res = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/v1/data-feeds")
+                    .header("Authorization", "Bearer s3cret")
+                    .header("Content-Type", "application/json")
+                    .body(Body::from(create_body.to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(create_res.status(), StatusCode::CREATED);
+
+        let res = app
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri("/api/v1/data-feeds/summary")
+                    .header("Authorization", "Bearer s3cret")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(res.status(), StatusCode::OK);
+
+        let body = axum::body::to_bytes(res.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let summaries: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        let summary = summaries
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|summary| summary["source_name"] == "empty-feed")
+            .unwrap();
+
+        assert_eq!(summary["event_count"], 0);
+        assert!(summary["last_event_at"].is_null());
+        assert!(summary["lag_seconds"].is_null());
     }
 
     #[tokio::test]

--- a/crates/extensions/backend-admin/src/data_feeds/service.rs
+++ b/crates/extensions/backend-admin/src/data_feeds/service.rs
@@ -20,7 +20,10 @@
 //!
 //! [`DataFeedRegistry`]: rara_kernel::data_feed::DataFeedRegistry
 
-use diesel::{ExpressionMethods, QueryDsl, Queryable, Selectable, SelectableHelper};
+use diesel::{
+    ExpressionMethods, QueryDsl, Queryable, QueryableByName, Selectable, SelectableHelper,
+    sql_types::{BigInt, Nullable, Text},
+};
 use diesel_async::RunQueryDsl;
 use jiff::Timestamp;
 use rara_kernel::data_feed::{
@@ -264,6 +267,27 @@ impl DataFeedSvc {
         })
     }
 
+    /// Return event-count and last-event aggregates keyed by feed source name.
+    ///
+    /// This is intentionally an event-table read model rather than a new
+    /// column on `data_feeds`: it reflects what was actually persisted, not
+    /// what a feed task intended to emit.
+    #[instrument(skip(self))]
+    pub async fn event_summaries(&self) -> Result<Vec<EventSummary>> {
+        let mut conn = self.pools.reader.get().await.context(PoolAcquireSnafu)?;
+        let rows: Vec<EventSummaryRow> = diesel::sql_query(
+            "SELECT source_name, COUNT(*) AS event_count, MAX(received_at) AS last_event_at FROM \
+             data_feed_events GROUP BY source_name",
+        )
+        .load(&mut *conn)
+        .await
+        .context(QuerySnafu)?;
+
+        rows.into_iter()
+            .map(EventSummaryRow::into_summary)
+            .collect()
+    }
+
     /// Get a single event by ID within a feed.
     #[instrument(skip(self))]
     pub async fn get_event(&self, source_name: &str, event_id: &str) -> Result<Option<FeedEvent>> {
@@ -292,6 +316,17 @@ pub struct EventPage {
     pub total:    i64,
     /// Whether more events exist beyond this page.
     pub has_more: bool,
+}
+
+/// Persisted-event aggregate for a single feed source.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct EventSummary {
+    /// Feed source name.
+    pub source_name:   String,
+    /// Number of persisted events for this source.
+    pub event_count:   i64,
+    /// Most recent persisted event receive time, if any.
+    pub last_event_at: Option<Timestamp>,
 }
 
 // ---------------------------------------------------------------------------
@@ -367,6 +402,34 @@ struct EventRow {
     tags:        String,
     payload:     String,
     received_at: String,
+}
+
+#[derive(QueryableByName)]
+struct EventSummaryRow {
+    #[diesel(sql_type = Text)]
+    source_name:   String,
+    #[diesel(sql_type = BigInt)]
+    event_count:   i64,
+    #[diesel(sql_type = Nullable<Text>)]
+    last_event_at: Option<String>,
+}
+
+impl EventSummaryRow {
+    fn into_summary(self) -> Result<EventSummary> {
+        let decode = |msg: String| DataFeedSvcError::DecodeRow { message: msg };
+        let last_event_at = self
+            .last_event_at
+            .as_deref()
+            .map(str::parse)
+            .transpose()
+            .map_err(|e| decode(format!("last_event_at: {e}")))?;
+
+        Ok(EventSummary {
+            source_name: self.source_name,
+            event_count: self.event_count,
+            last_event_at,
+        })
+    }
 }
 
 impl EventRow {

--- a/web/e2e/harness/data-feeds.spec.ts
+++ b/web/e2e/harness/data-feeds.spec.ts
@@ -43,6 +43,14 @@ interface FeedEvent {
   received_at: string;
 }
 
+interface FeedSummary {
+  feed_id: string;
+  source_name: string;
+  event_count: number;
+  last_event_at: string | null;
+  lag_seconds: number | null;
+}
+
 interface FeedCatalogEntry {
   id: string;
   name: string;
@@ -137,6 +145,30 @@ function makeEvent(overrides: Partial<FeedEvent> = {}): FeedEvent {
   };
 }
 
+function makeSummary(
+  feed: DataFeedConfig,
+  events: FeedEvent[],
+  overrides: Partial<FeedSummary> = {},
+): FeedSummary {
+  const matchingEvents = events.filter((event) => event.source_name === feed.name);
+  const lastEventAt =
+    matchingEvents
+      .map((event) => event.received_at)
+      .sort()
+      .at(-1) ?? null;
+
+  return {
+    feed_id: feed.id,
+    source_name: feed.name,
+    event_count: matchingEvents.length,
+    last_event_at: lastEventAt,
+    lag_seconds: lastEventAt
+      ? Math.max(0, Math.floor((Date.now() - Date.parse(lastEventAt)) / 1000))
+      : null,
+    ...overrides,
+  };
+}
+
 // ---------------------------------------------------------------------------
 // Setup — fetch real Yahoo Finance data once for realistic payloads
 // ---------------------------------------------------------------------------
@@ -177,6 +209,7 @@ async function setupRoutes(
   state: {
     feeds: DataFeedConfig[];
     events: FeedEvent[];
+    summaries?: FeedSummary[];
     catalog?: FeedCatalogEntry[];
   },
 ) {
@@ -210,6 +243,12 @@ async function setupRoutes(
   // Default feed source catalog.
   await page.route('**/api/v1/data-feeds/catalog', async (route) => {
     await route.fulfill({ json: state.catalog ?? [] });
+  });
+
+  await page.route('**/api/v1/data-feeds/summary', async (route) => {
+    await route.fulfill({
+      json: state.summaries ?? state.feeds.map((feed) => makeSummary(feed, state.events)),
+    });
   });
 
   await page.route('**/api/v1/data-feeds/catalog/*/enable', async (route, request) => {
@@ -324,7 +363,7 @@ async function setupRoutes(
   });
 
   // Single feed operations (GET/PUT/DELETE by id).
-  await page.route(/\/api\/v1\/data-feeds\/(?!catalog$)[^/]+$/, async (route, request) => {
+  await page.route(/\/api\/v1\/data-feeds\/(?!catalog$|summary$)[^/]+$/, async (route, request) => {
     const method = request.method();
     const url = request.url();
     const idMatch = url.match(/data-feeds\/([^/]+)$/);
@@ -551,6 +590,10 @@ test.describe('Data Feeds Management', () => {
 
     // Status badge.
     await expect(page.getByText('Running')).toBeVisible();
+
+    // Runtime summary columns.
+    await expect(page.getByText('0 events')).toBeVisible();
+    await expect(page.getByText('No events yet')).toBeVisible();
 
     // Tags.
     await expect(page.getByText('stock')).toBeVisible();

--- a/web/src/api/data-feeds.ts
+++ b/web/src/api/data-feeds.ts
@@ -58,6 +58,14 @@ export interface FeedEventsResponse {
   has_more: boolean;
 }
 
+export interface FeedSummary {
+  feed_id: string;
+  source_name: string;
+  event_count: number;
+  last_event_at: string | null;
+  lag_seconds: number | null;
+}
+
 export interface CreateFeedRequest {
   name: string;
   feed_type: FeedType;
@@ -87,6 +95,8 @@ export const dataFeedsApi = {
   list: () => api.get<DataFeedConfig[]>('/api/v1/data-feeds'),
 
   catalog: () => api.get<FeedCatalogEntry[]>('/api/v1/data-feeds/catalog'),
+
+  summaries: () => api.get<FeedSummary[]>('/api/v1/data-feeds/summary'),
 
   get: (id: string) => api.get<DataFeedConfig>(`/api/v1/data-feeds/${id}`),
 

--- a/web/src/components/DataFeedsPanel.tsx
+++ b/web/src/components/DataFeedsPanel.tsx
@@ -33,6 +33,7 @@ import {
   type DataFeedConfig,
   type FeedCatalogEntry,
   type FeedEvent,
+  type FeedSummary,
   type CreateFeedRequest,
   type AuthType,
 } from '@/api/data-feeds';
@@ -102,6 +103,23 @@ function payloadSize(payload: unknown): string {
   const bytes = new Blob([JSON.stringify(payload)]).size;
   if (bytes < 1024) return `${bytes}B`;
   return `${(bytes / 1024).toFixed(1)}K`;
+}
+
+function eventCountLabel(count: number): string {
+  return `${count} event${count === 1 ? '' : 's'}`;
+}
+
+function lagLabel(summary: FeedSummary | undefined): string {
+  if (!summary?.last_event_at || summary.lag_seconds == null) return 'No events yet';
+  if (summary.lag_seconds < 60) return `${summary.lag_seconds}s lag`;
+
+  const minutes = Math.floor(summary.lag_seconds / 60);
+  if (minutes < 60) return `${minutes}m lag`;
+
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h lag`;
+
+  return `${Math.floor(hours / 24)}d lag`;
 }
 
 /** Format type badge label. */
@@ -556,6 +574,7 @@ function FeedFormDialog({
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: ['data-feeds'] });
       void queryClient.invalidateQueries({ queryKey: ['data-feed-catalog'] });
+      void queryClient.invalidateQueries({ queryKey: ['data-feed-summaries'] });
       onOpenChange(false);
     },
     onError: (err: Error) => setError(err.message),
@@ -566,6 +585,7 @@ function FeedFormDialog({
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: ['data-feeds'] });
       void queryClient.invalidateQueries({ queryKey: ['data-feed-catalog'] });
+      void queryClient.invalidateQueries({ queryKey: ['data-feed-summaries'] });
       onOpenChange(false);
     },
     onError: (err: Error) => setError(err.message),
@@ -1112,9 +1132,11 @@ function FeedCatalogCard({
 
 function FeedListView({
   feeds,
+  summaries,
   onSelectFeed,
 }: {
   feeds: DataFeedConfig[];
+  summaries: FeedSummary[];
   onSelectFeed: (feed: DataFeedConfig) => void;
 }) {
   const queryClient = useQueryClient();
@@ -1140,9 +1162,12 @@ function FeedListView({
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: ['data-feeds'] });
       void queryClient.invalidateQueries({ queryKey: ['data-feed-catalog'] });
+      void queryClient.invalidateQueries({ queryKey: ['data-feed-summaries'] });
       setDeleteId(null);
     },
   });
+
+  const summariesByFeedId = new Map(summaries.map((summary) => [summary.feed_id, summary]));
 
   const handleEdit = (feed: DataFeedConfig) => {
     setEditFeed(feed);
@@ -1207,76 +1232,94 @@ function FeedListView({
               <TableHead>Name</TableHead>
               <TableHead className="w-24">Type</TableHead>
               <TableHead className="w-24">Status</TableHead>
+              <TableHead className="w-24 text-right">Events</TableHead>
+              <TableHead className="w-28 text-right">Last Event</TableHead>
               <TableHead className="w-24 text-right">Updated</TableHead>
               <TableHead className="w-32 text-right">Actions</TableHead>
             </TableRow>
           </TableHeader>
           <TableBody>
-            {feeds.map((feed) => (
-              <TableRow key={feed.id}>
-                <TableCell>
-                  <button
-                    className="font-medium text-primary hover:underline"
-                    onClick={() => onSelectFeed(feed)}
+            {feeds.map((feed) => {
+              const summary = summariesByFeedId.get(feed.id);
+              return (
+                <TableRow key={feed.id}>
+                  <TableCell>
+                    <button
+                      className="font-medium text-primary hover:underline"
+                      onClick={() => onSelectFeed(feed)}
+                    >
+                      {feed.name}
+                    </button>
+                    {feed.tags.length > 0 && (
+                      <div className="mt-0.5 flex flex-wrap gap-1">
+                        {feed.tags.slice(0, 3).map((tag) => (
+                          <Badge key={tag} variant="secondary" className="text-[10px] px-1.5 py-0">
+                            {tag}
+                          </Badge>
+                        ))}
+                        {feed.tags.length > 3 && (
+                          <span className="text-[10px] text-muted-foreground">
+                            +{feed.tags.length - 3}
+                          </span>
+                        )}
+                      </div>
+                    )}
+                  </TableCell>
+                  <TableCell>
+                    <Badge variant="outline" className="text-xs">
+                      {typeLabel(feed.feed_type)}
+                    </Badge>
+                  </TableCell>
+                  <TableCell>
+                    <StatusBadge status={feed.status} enabled={feed.enabled} />
+                  </TableCell>
+                  <TableCell className="text-right text-xs text-muted-foreground">
+                    {eventCountLabel(summary?.event_count ?? 0)}
+                  </TableCell>
+                  <TableCell
+                    className="text-right text-xs text-muted-foreground"
+                    title={
+                      summary?.last_event_at
+                        ? new Date(summary.last_event_at).toLocaleString()
+                        : undefined
+                    }
                   >
-                    {feed.name}
-                  </button>
-                  {feed.tags.length > 0 && (
-                    <div className="mt-0.5 flex flex-wrap gap-1">
-                      {feed.tags.slice(0, 3).map((tag) => (
-                        <Badge key={tag} variant="secondary" className="text-[10px] px-1.5 py-0">
-                          {tag}
-                        </Badge>
-                      ))}
-                      {feed.tags.length > 3 && (
-                        <span className="text-[10px] text-muted-foreground">
-                          +{feed.tags.length - 3}
-                        </span>
-                      )}
+                    {lagLabel(summary)}
+                  </TableCell>
+                  <TableCell
+                    className="text-right text-xs text-muted-foreground"
+                    title={new Date(feed.updated_at).toLocaleString()}
+                  >
+                    {timeAgo(feed.updated_at)}
+                  </TableCell>
+                  <TableCell className="text-right">
+                    <div className="flex items-center justify-end gap-2">
+                      <Switch
+                        checked={feed.enabled}
+                        onCheckedChange={() => toggleMutation.mutate(feed.id)}
+                        disabled={toggleMutation.isPending}
+                      />
+                      <Button
+                        variant="outline"
+                        size="icon"
+                        className="h-7 w-7"
+                        onClick={() => handleEdit(feed)}
+                      >
+                        <Pencil className="h-3 w-3" />
+                      </Button>
+                      <Button
+                        variant="outline"
+                        size="icon"
+                        className="h-7 w-7 text-destructive hover:bg-destructive/10"
+                        onClick={() => setDeleteId(feed.id)}
+                      >
+                        <Trash2 className="h-3 w-3" />
+                      </Button>
                     </div>
-                  )}
-                </TableCell>
-                <TableCell>
-                  <Badge variant="outline" className="text-xs">
-                    {typeLabel(feed.feed_type)}
-                  </Badge>
-                </TableCell>
-                <TableCell>
-                  <StatusBadge status={feed.status} enabled={feed.enabled} />
-                </TableCell>
-                <TableCell
-                  className="text-right text-xs text-muted-foreground"
-                  title={new Date(feed.updated_at).toLocaleString()}
-                >
-                  {timeAgo(feed.updated_at)}
-                </TableCell>
-                <TableCell className="text-right">
-                  <div className="flex items-center justify-end gap-2">
-                    <Switch
-                      checked={feed.enabled}
-                      onCheckedChange={() => toggleMutation.mutate(feed.id)}
-                      disabled={toggleMutation.isPending}
-                    />
-                    <Button
-                      variant="outline"
-                      size="icon"
-                      className="h-7 w-7"
-                      onClick={() => handleEdit(feed)}
-                    >
-                      <Pencil className="h-3 w-3" />
-                    </Button>
-                    <Button
-                      variant="outline"
-                      size="icon"
-                      className="h-7 w-7 text-destructive hover:bg-destructive/10"
-                      onClick={() => setDeleteId(feed.id)}
-                    >
-                      <Trash2 className="h-3 w-3" />
-                    </Button>
-                  </div>
-                </TableCell>
-              </TableRow>
-            ))}
+                  </TableCell>
+                </TableRow>
+              );
+            })}
           </TableBody>
         </Table>
       )}
@@ -1335,6 +1378,11 @@ export default function DataFeedsPanel() {
     queryKey: ['data-feeds'],
     queryFn: () => dataFeedsApi.list(),
   });
+  const summariesQuery = useQuery({
+    queryKey: ['data-feed-summaries'],
+    queryFn: () => dataFeedsApi.summaries(),
+    refetchInterval: 30_000,
+  });
 
   if (feedsQuery.isLoading) {
     return (
@@ -1361,6 +1409,7 @@ export default function DataFeedsPanel() {
   }
 
   const feeds = feedsQuery.data ?? [];
+  const summaries = summariesQuery.data ?? [];
 
   if (view.kind === 'events') {
     // When we navigate to events, refresh the feed object from the list
@@ -1369,5 +1418,11 @@ export default function DataFeedsPanel() {
     return <EventHistoryView feed={freshFeed} onBack={() => setView({ kind: 'list' })} />;
   }
 
-  return <FeedListView feeds={feeds} onSelectFeed={(feed) => setView({ kind: 'events', feed })} />;
+  return (
+    <FeedListView
+      feeds={feeds}
+      summaries={summaries}
+      onSelectFeed={(feed) => setView({ kind: 'events', feed })}
+    />
+  );
 }


### PR DESCRIPTION
## Summary
- add `GET /api/v1/data-feeds/summary` for per-feed persisted-event health
- aggregate event count, last event timestamp, and lag seconds from `data_feed_events`
- show Events and Last Event columns in the Data Feeds settings table
- extend harness mocks and e2e assertions for zero-event runtime summaries

## Validation
- cargo test -p rara-backend-admin data_feeds::router::tests --lib
- cargo check -p rara-backend-admin
- cargo clippy -p rara-backend-admin --all-targets --no-deps -- -D warnings
- rustup run nightly cargo fmt
- git diff --check
- npm --prefix web install
- npm --prefix web run typecheck
- npm --prefix web run format:check
- npx --prefix web prettier --check web/e2e/harness/data-feeds.spec.ts
- npm --prefix web run build
- npm --prefix web run test:e2e -- e2e/harness/data-feeds.spec.ts (36 passed)

Pre-commit also passed: cargo check, cargo fmt, cargo clippy, cargo doc, AGENT.md presence, web lint-staged.

Note: PR #2233 is green. This branch was checked against #2233 with merge-tree and has no text conflicts.