### PR TITLE
feat(finance): add candle query tools

### DIFF
--- a/crates/app/src/boot.rs
+++ b/crates/app/src/boot.rs
@@ -251,6 +251,7 @@ pub(crate) async fn boot(
     sandbox_config: Option<crate::SandboxToolConfig>,
     sandbox_map: crate::tools::SandboxMap,
     finance_registry: Arc<rara_trading::finance::registry::FinanceSubscriptionRegistry>,
+    market_data_repo: rara_trading::market_data::MarketDataRepositoryRef,
 ) -> Result<BootResult, Whatever> {
     // -- credential store --------------------------------------------------
     let credential_store: rara_keyring_store::KeyringStoreRef =
@@ -403,6 +404,7 @@ pub(crate) async fn boot(
             sandbox_config,
             sandbox_map,
             finance_registry,
+            market_data_repo,
         },
     );
 

--- a/crates/app/src/lib.rs
+++ b/crates/app/src/lib.rs
@@ -716,6 +716,36 @@ pub async fn start_with_options(
             rara_paths::data_dir().join("trading/finance-subscriptions.json"),
         ),
     );
+    let market_data_repo: rara_trading::market_data::MarketDataRepositoryRef =
+        match std::env::var("RARA_MARKET_DATA_DATABASE_URL") {
+            Ok(database_url) if !database_url.trim().is_empty() => {
+                match rara_trading::market_data::TimescaleMarketDataRepository::connect(
+                    &database_url,
+                )
+                .await
+                {
+                    Ok(repo) => {
+                        if let Err(e) = repo.apply_schema().await {
+                            warn!(error = %e, "failed to apply market-data Timescale schema");
+                        }
+                        Arc::new(repo)
+                    }
+                    Err(e) => {
+                        warn!(
+                            error = %e,
+                            "market-data Timescale connection failed; using in-memory repository"
+                        );
+                        Arc::new(rara_trading::market_data::InMemoryMarketDataRepository::default())
+                    }
+                }
+            }
+            _ => {
+                warn!(
+                    "RARA_MARKET_DATA_DATABASE_URL not set; using in-memory market-data repository"
+                );
+                Arc::new(rara_trading::market_data::InMemoryMarketDataRepository::default())
+            }
+        };
 
     let rara = crate::boot::boot(
         diesel_pools.clone(),
@@ -726,6 +756,7 @@ pub async fn start_with_options(
         config.sandbox.clone(),
         sandbox_map.clone(),
         finance_registry.clone(),
+        market_data_repo.clone(),
     )
     .await
     .whatever_context("Failed to boot kernel dependencies")?;
@@ -968,37 +999,6 @@ pub async fn start_with_options(
     backend
         .session_service
         .set_kernel_handle(kernel_handle.clone());
-
-    let market_data_repo: Arc<dyn rara_trading::market_data::MarketDataRepository> =
-        match std::env::var("RARA_MARKET_DATA_DATABASE_URL") {
-            Ok(database_url) if !database_url.trim().is_empty() => {
-                match rara_trading::market_data::TimescaleMarketDataRepository::connect(
-                    &database_url,
-                )
-                .await
-                {
-                    Ok(repo) => {
-                        if let Err(e) = repo.apply_schema().await {
-                            warn!(error = %e, "failed to apply market-data Timescale schema");
-                        }
-                        Arc::new(repo)
-                    }
-                    Err(e) => {
-                        warn!(
-                            error = %e,
-                            "market-data Timescale connection failed; using in-memory repository"
-                        );
-                        Arc::new(rara_trading::market_data::InMemoryMarketDataRepository::default())
-                    }
-                }
-            }
-            _ => {
-                warn!(
-                    "RARA_MARKET_DATA_DATABASE_URL not set; using in-memory market-data repository"
-                );
-                Arc::new(rara_trading::market_data::InMemoryMarketDataRepository::default())
-            }
-        };
 
     // Spawn the feed dispatch task — consumes events from all transports,
     // persists them to the data_feed_events table, upserts closed market

--- a/crates/app/src/tools/mod.rs
+++ b/crates/app/src/tools/mod.rs
@@ -168,6 +168,8 @@ pub struct ToolDeps {
     pub sandbox_map:           SandboxMap,
     /// Finance information subscription registry.
     pub finance_registry:      Arc<rara_trading::finance::registry::FinanceSubscriptionRegistry>,
+    /// Shared market-data repository for closed OHLCV candles.
+    pub market_data_repo:      rara_trading::market_data::MarketDataRepositoryRef,
 }
 
 /// Result of tool registration, carrying handles needed for post-init wiring.
@@ -297,6 +299,14 @@ pub fn register_all(registry: &mut ToolRegistry, deps: ToolDeps) -> ToolRegistra
         Arc::new(FinanceSubscribeTool::new(deps.finance_registry.clone())),
         Arc::new(FinanceUnsubscribeTool::new(deps.finance_registry.clone())),
         Arc::new(FinanceListSubscriptionsTool::new(deps.finance_registry)),
+        Arc::new(
+            rara_trading::market_data::tools::FinanceGetLatestCandleTool::new(
+                deps.market_data_repo.clone(),
+            ),
+        ),
+        Arc::new(
+            rara_trading::market_data::tools::FinanceQueryCandlesTool::new(deps.market_data_repo),
+        ),
         // Artifacts (rich-content side panel — deferred tier)
         Arc::new(ArtifactsTool::new(deps.tape_service.clone())),
     ];

--- a/crates/extensions/rara-trading/src/market_data/mod.rs
+++ b/crates/extensions/rara-trading/src/market_data/mod.rs
@@ -17,8 +17,9 @@
 pub mod model;
 pub mod repository;
 pub mod timescale;
+pub mod tools;
 
-pub use model::{CandleRangeQuery, MarketCandle, Timeframe};
+pub use model::{CandleLatestQuery, CandleRangeQuery, MarketCandle, Timeframe};
 pub use repository::{
     InMemoryMarketDataRepository, MarketDataRepository, MarketDataRepositoryRef, UpsertOutcome,
 };

--- a/crates/extensions/rara-trading/src/market_data/model.rs
+++ b/crates/extensions/rara-trading/src/market_data/model.rs
@@ -132,3 +132,12 @@ pub struct CandleRangeQuery {
     pub end:         Timestamp,
     pub limit:       usize,
 }
+
+/// Latest-candle query for a venue/symbol/timeframe stream.
+#[derive(Debug, Clone)]
+pub struct CandleLatestQuery {
+    pub source_name: Option<String>,
+    pub venue:       String,
+    pub symbol:      String,
+    pub timeframe:   Timeframe,
+}

--- a/crates/extensions/rara-trading/src/market_data/repository.rs
+++ b/crates/extensions/rara-trading/src/market_data/repository.rs
@@ -18,7 +18,7 @@ use async_trait::async_trait;
 use jiff::Timestamp;
 use tokio::sync::RwLock;
 
-use super::model::{CandleRangeQuery, MarketCandle};
+use super::model::{CandleLatestQuery, CandleRangeQuery, MarketCandle};
 
 /// Result of upserting a closed candle.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -40,6 +40,12 @@ pub trait MarketDataRepository: Send + Sync {
 
     /// Query ordered candles for a venue/symbol/timeframe range.
     async fn candles(&self, query: CandleRangeQuery) -> anyhow::Result<Vec<MarketCandle>>;
+
+    /// Return the newest closed candle for a venue/symbol/timeframe stream.
+    async fn latest_closed_candle(
+        &self,
+        query: CandleLatestQuery,
+    ) -> anyhow::Result<Option<MarketCandle>>;
 
     /// Return missing open times in `[start, end)` based on the query
     /// timeframe.
@@ -142,6 +148,18 @@ impl MarketDataRepository for InMemoryMarketDataRepository {
         Ok(rows)
     }
 
+    async fn latest_closed_candle(
+        &self,
+        query: CandleLatestQuery,
+    ) -> anyhow::Result<Option<MarketCandle>> {
+        let candles = self.candles.read().await;
+        Ok(candles
+            .values()
+            .filter(|candle| matches_latest_query(candle, &query))
+            .max_by_key(|candle| candle.open_time)
+            .cloned())
+    }
+
     async fn missing_open_times(&self, query: CandleRangeQuery) -> anyhow::Result<Vec<Timestamp>> {
         let rows = self.candles(query.clone()).await?;
         let present: std::collections::HashSet<Timestamp> =
@@ -175,12 +193,22 @@ fn matches_query(candle: &MarketCandle, query: &CandleRangeQuery) -> bool {
         && candle.open_time < query.end
 }
 
+fn matches_latest_query(candle: &MarketCandle, query: &CandleLatestQuery) -> bool {
+    query
+        .source_name
+        .as_ref()
+        .is_none_or(|source| source == &candle.source_name)
+        && candle.venue == query.venue
+        && candle.symbol == query.symbol
+        && candle.timeframe == query.timeframe
+}
+
 #[cfg(test)]
 mod tests {
     use rust_decimal::Decimal;
 
     use super::{InMemoryMarketDataRepository, MarketDataRepository, UpsertOutcome};
-    use crate::market_data::{CandleRangeQuery, MarketCandle, Timeframe};
+    use crate::market_data::{CandleLatestQuery, CandleRangeQuery, MarketCandle, Timeframe};
 
     fn ts(value: &str) -> jiff::Timestamp { value.parse().expect("timestamp fixture should parse") }
 
@@ -291,5 +319,36 @@ mod tests {
 
         let missing = repo.missing_open_times(query()).await.unwrap();
         assert_eq!(missing, vec![ts("2026-07-10T08:15:00Z")]);
+    }
+
+    #[tokio::test]
+    async fn latest_closed_candle_returns_newest_matching_stream() {
+        let repo = InMemoryMarketDataRepository::default();
+        repo.upsert_closed_candle(candle("2026-07-10T08:00:00Z", "61500.00"))
+            .await
+            .unwrap();
+        repo.upsert_closed_candle(candle("2026-07-10T08:30:00Z", "61700.00"))
+            .await
+            .unwrap();
+        repo.upsert_closed_candle(MarketCandle {
+            source_name: "other-source".to_owned(),
+            ..candle("2026-07-10T08:45:00Z", "61800.00")
+        })
+        .await
+        .unwrap();
+
+        let latest = repo
+            .latest_closed_candle(CandleLatestQuery {
+                source_name: Some("binance-spot".to_owned()),
+                venue:       "binance".to_owned(),
+                symbol:      "BTCUSDT".to_owned(),
+                timeframe:   Timeframe::parse("15m").unwrap(),
+            })
+            .await
+            .unwrap()
+            .expect("matching candle should exist");
+
+        assert_eq!(latest.open_time, ts("2026-07-10T08:30:00Z"));
+        assert_eq!(latest.close, dec("61700.00"));
     }
 }

--- a/crates/extensions/rara-trading/src/market_data/timescale.rs
+++ b/crates/extensions/rara-trading/src/market_data/timescale.rs
@@ -20,7 +20,7 @@ use sqlx_postgres::{PgPool, Postgres};
 use uuid::Uuid;
 
 use super::{
-    model::{CandleRangeQuery, MarketCandle, Timeframe},
+    model::{CandleLatestQuery, CandleRangeQuery, MarketCandle, Timeframe},
     repository::{MarketDataRepository, UpsertOutcome},
 };
 
@@ -141,6 +141,42 @@ impl MarketDataRepository for TimescaleMarketDataRepository {
         .await?;
 
         rows.into_iter().map(row_to_candle).collect()
+    }
+
+    async fn latest_closed_candle(
+        &self,
+        query: CandleLatestQuery,
+    ) -> anyhow::Result<Option<MarketCandle>> {
+        let row = sqlx_core::query::query(
+            r#"
+            SELECT
+              source_name, venue, symbol, timeframe,
+              open_time::text AS open_time,
+              close_time::text AS close_time,
+              open::text AS open,
+              high::text AS high,
+              low::text AS low,
+              close::text AS close,
+              volume::text AS volume,
+              ingested_at::text AS ingested_at,
+              provider_sequence
+            FROM market_candles
+            WHERE ($1::text IS NULL OR source_name = $1)
+              AND venue = $2
+              AND symbol = $3
+              AND timeframe = $4
+            ORDER BY open_time DESC
+            LIMIT 1
+            "#,
+        )
+        .bind(query.source_name.as_deref())
+        .bind(&query.venue)
+        .bind(&query.symbol)
+        .bind(query.timeframe.as_str())
+        .fetch_optional(&self.pool)
+        .await?;
+
+        row.map(row_to_candle).transpose()
     }
 
     async fn missing_open_times(&self, query: CandleRangeQuery) -> anyhow::Result<Vec<Timestamp>> {

--- a/crates/extensions/rara-trading/src/market_data/tools.rs
+++ b/crates/extensions/rara-trading/src/market_data/tools.rs
@@ -1,0 +1,388 @@
+// Copyright 2026 Rararulab
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Conversation-facing market candle query tools.
+
+use async_trait::async_trait;
+use jiff::Timestamp;
+use rara_kernel::tool::{ToolContext, ToolExecute};
+use rara_tool_macro::ToolDef;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+use super::{
+    CandleLatestQuery, CandleRangeQuery, MarketCandle, MarketDataRepositoryRef, Timeframe,
+};
+
+const DEFAULT_CANDLE_LIMIT: usize = 500;
+const MAX_CANDLE_LIMIT: usize = 10_000;
+const MAX_SELECTOR_LEN: usize = 128;
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct FinanceGetLatestCandleParams {
+    #[serde(default)]
+    pub source_name: Option<String>,
+    pub venue:       String,
+    pub symbol:      String,
+    pub timeframe:   String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct FinanceGetLatestCandleResult {
+    pub candle: Option<FinanceCandle>,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct FinanceQueryCandlesParams {
+    #[serde(default)]
+    pub source_name: Option<String>,
+    pub venue:       String,
+    pub symbol:      String,
+    pub timeframe:   String,
+    /// Inclusive candle open time, as an RFC3339 timestamp.
+    pub start:       String,
+    /// Exclusive candle open time, as an RFC3339 timestamp.
+    pub end:         String,
+    #[serde(default)]
+    pub limit:       Option<usize>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct FinanceQueryCandlesResult {
+    pub candles:     Vec<FinanceCandle>,
+    pub count:       usize,
+    pub query_limit: usize,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct FinanceCandle {
+    pub source_name:       String,
+    pub venue:             String,
+    pub symbol:            String,
+    pub timeframe:         String,
+    pub open_time:         String,
+    pub close_time:        String,
+    pub open:              String,
+    pub high:              String,
+    pub low:               String,
+    pub close:             String,
+    pub volume:            String,
+    pub ingested_at:       String,
+    pub provider_sequence: Option<String>,
+}
+
+#[derive(ToolDef)]
+#[tool(
+    name = "finance_get_latest_candle",
+    description = "Return the newest closed OHLCV candle stored in the market-data TSDB for a \
+                   venue, symbol, and timeframe. Decimal values are returned as strings to \
+                   preserve financial precision. This is read-only and never places trades.",
+    tier = "deferred",
+    read_only,
+    concurrency_safe
+)]
+pub struct FinanceGetLatestCandleTool {
+    repository: MarketDataRepositoryRef,
+}
+
+impl FinanceGetLatestCandleTool {
+    pub fn new(repository: MarketDataRepositoryRef) -> Self { Self { repository } }
+}
+
+#[async_trait]
+impl ToolExecute for FinanceGetLatestCandleTool {
+    type Output = FinanceGetLatestCandleResult;
+    type Params = FinanceGetLatestCandleParams;
+
+    async fn run(
+        &self,
+        params: FinanceGetLatestCandleParams,
+        _context: &ToolContext,
+    ) -> anyhow::Result<FinanceGetLatestCandleResult> {
+        let query = CandleLatestQuery {
+            source_name: normalize_optional_selector("source_name", params.source_name)?,
+            venue:       normalize_required_selector("venue", params.venue)?,
+            symbol:      normalize_required_selector("symbol", params.symbol)?,
+            timeframe:   Timeframe::parse(params.timeframe)?,
+        };
+        let candle = self.repository.latest_closed_candle(query).await?;
+        Ok(FinanceGetLatestCandleResult {
+            candle: candle.map(FinanceCandle::from),
+        })
+    }
+}
+
+#[derive(ToolDef)]
+#[tool(
+    name = "finance_query_candles",
+    description = "Query ordered closed OHLCV candles from the market-data TSDB for a venue, \
+                   symbol, timeframe, and open-time range. Decimal values are returned as strings \
+                   to preserve financial precision. This is read-only and never places trades.",
+    tier = "deferred",
+    read_only,
+    concurrency_safe
+)]
+pub struct FinanceQueryCandlesTool {
+    repository: MarketDataRepositoryRef,
+}
+
+impl FinanceQueryCandlesTool {
+    pub fn new(repository: MarketDataRepositoryRef) -> Self { Self { repository } }
+}
+
+#[async_trait]
+impl ToolExecute for FinanceQueryCandlesTool {
+    type Output = FinanceQueryCandlesResult;
+    type Params = FinanceQueryCandlesParams;
+
+    async fn run(
+        &self,
+        params: FinanceQueryCandlesParams,
+        _context: &ToolContext,
+    ) -> anyhow::Result<FinanceQueryCandlesResult> {
+        let limit = params.limit.unwrap_or(DEFAULT_CANDLE_LIMIT);
+        anyhow::ensure!(limit > 0, "limit must be positive");
+        anyhow::ensure!(
+            limit <= MAX_CANDLE_LIMIT,
+            "limit must be <= {MAX_CANDLE_LIMIT}"
+        );
+        let start = parse_timestamp("start", &params.start)?;
+        let end = parse_timestamp("end", &params.end)?;
+        anyhow::ensure!(start < end, "start must be before end");
+
+        let query = CandleRangeQuery {
+            source_name: normalize_optional_selector("source_name", params.source_name)?,
+            venue: normalize_required_selector("venue", params.venue)?,
+            symbol: normalize_required_selector("symbol", params.symbol)?,
+            timeframe: Timeframe::parse(params.timeframe)?,
+            start,
+            end,
+            limit,
+        };
+        let candles = self.repository.candles(query).await?;
+        let count = candles.len();
+        Ok(FinanceQueryCandlesResult {
+            candles: candles.into_iter().map(FinanceCandle::from).collect(),
+            count,
+            query_limit: limit,
+        })
+    }
+}
+
+impl From<MarketCandle> for FinanceCandle {
+    fn from(candle: MarketCandle) -> Self {
+        Self {
+            source_name:       candle.source_name,
+            venue:             candle.venue,
+            symbol:            candle.symbol,
+            timeframe:         candle.timeframe.to_string(),
+            open_time:         candle.open_time.to_string(),
+            close_time:        candle.close_time.to_string(),
+            open:              candle.open.to_string(),
+            high:              candle.high.to_string(),
+            low:               candle.low.to_string(),
+            close:             candle.close.to_string(),
+            volume:            candle.volume.to_string(),
+            ingested_at:       candle.ingested_at.to_string(),
+            provider_sequence: candle.provider_sequence,
+        }
+    }
+}
+
+fn normalize_required_selector(name: &str, value: String) -> anyhow::Result<String> {
+    let value = value.trim();
+    anyhow::ensure!(!value.is_empty(), "{name} must not be empty");
+    anyhow::ensure!(
+        value.chars().count() <= MAX_SELECTOR_LEN,
+        "{name} is too long"
+    );
+    Ok(value.to_owned())
+}
+
+fn normalize_optional_selector(
+    name: &str,
+    value: Option<String>,
+) -> anyhow::Result<Option<String>> {
+    value
+        .map(|value| normalize_required_selector(name, value))
+        .transpose()
+}
+
+fn parse_timestamp(name: &str, value: &str) -> anyhow::Result<Timestamp> {
+    value
+        .parse()
+        .map_err(|err| anyhow::anyhow!("{name} must be an RFC3339 timestamp: {err}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use rara_kernel::{
+        io::MessageId,
+        queue::{ShardedEventQueue, ShardedEventQueueConfig},
+        session::SessionKey,
+        tool::{AgentTool, ToolContext, ToolExecute},
+    };
+    use rust_decimal::Decimal;
+
+    use super::{
+        FinanceGetLatestCandleParams, FinanceGetLatestCandleTool, FinanceQueryCandlesParams,
+        FinanceQueryCandlesTool,
+    };
+    use crate::market_data::{
+        InMemoryMarketDataRepository, MarketCandle, MarketDataRepository, Timeframe,
+    };
+
+    fn context() -> ToolContext {
+        ToolContext {
+            user_id:               "alice".to_owned(),
+            session_key:           SessionKey::new(),
+            origin_endpoint:       None,
+            origin_user_id:        None,
+            event_queue:           Arc::new(ShardedEventQueue::new(ShardedEventQueueConfig {
+                num_shards:      0,
+                shard_capacity:  1,
+                global_capacity: 16,
+            })),
+            rara_turn_id:          MessageId::new(),
+            context_window_tokens: 0,
+            tool_registry:         None,
+            stream_handle:         None,
+            tool_call_id:          None,
+        }
+    }
+
+    fn ts(value: &str) -> jiff::Timestamp { value.parse().expect("timestamp fixture should parse") }
+
+    fn dec(value: &str) -> Decimal { value.parse().expect("decimal fixture should parse") }
+
+    fn candle(open_time: &str, close: &str) -> MarketCandle {
+        MarketCandle {
+            source_name:       "binance-spot".to_owned(),
+            venue:             "binance".to_owned(),
+            symbol:            "BTCUSDT".to_owned(),
+            timeframe:         Timeframe::parse("1m").expect("timeframe fixture should parse"),
+            open_time:         ts(open_time),
+            close_time:        ts("2026-07-10T08:01:00Z"),
+            open:              dec("61500.12"),
+            high:              dec("61640.00"),
+            low:               dec("61480.50"),
+            close:             dec(close),
+            volume:            dec("124.551"),
+            ingested_at:       ts("2026-07-10T08:01:01Z"),
+            provider_sequence: Some(open_time.to_owned()),
+        }
+    }
+
+    async fn repository() -> Arc<InMemoryMarketDataRepository> {
+        let repository = Arc::new(InMemoryMarketDataRepository::default());
+        repository
+            .upsert_closed_candle(candle("2026-07-10T08:00:00Z", "61510.00"))
+            .await
+            .unwrap();
+        repository
+            .upsert_closed_candle(candle("2026-07-10T08:01:00Z", "61520.00"))
+            .await
+            .unwrap();
+        repository
+    }
+
+    #[tokio::test]
+    async fn latest_candle_tool_returns_newest_candle_as_strings() {
+        let repository = repository().await;
+        let tool = FinanceGetLatestCandleTool::new(repository);
+        let result = tool
+            .run(
+                FinanceGetLatestCandleParams {
+                    source_name: Some("binance-spot".to_owned()),
+                    venue:       "binance".to_owned(),
+                    symbol:      "BTCUSDT".to_owned(),
+                    timeframe:   "1m".to_owned(),
+                },
+                &context(),
+            )
+            .await
+            .unwrap();
+
+        let candle = result.candle.expect("latest candle should exist");
+        assert_eq!(candle.open_time, "2026-07-10T08:01:00Z");
+        assert_eq!(candle.close, "61520.00");
+        assert_eq!(candle.volume, "124.551");
+    }
+
+    #[tokio::test]
+    async fn query_candles_tool_returns_ordered_range() {
+        let repository = repository().await;
+        let tool = FinanceQueryCandlesTool::new(repository);
+        let result = tool
+            .run(
+                FinanceQueryCandlesParams {
+                    source_name: Some("binance-spot".to_owned()),
+                    venue:       "binance".to_owned(),
+                    symbol:      "BTCUSDT".to_owned(),
+                    timeframe:   "1m".to_owned(),
+                    start:       "2026-07-10T08:00:00Z".to_owned(),
+                    end:         "2026-07-10T08:02:00Z".to_owned(),
+                    limit:       Some(10),
+                },
+                &context(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(result.count, 2);
+        assert_eq!(result.query_limit, 10);
+        assert_eq!(
+            result
+                .candles
+                .iter()
+                .map(|candle| candle.open_time.as_str())
+                .collect::<Vec<_>>(),
+            vec!["2026-07-10T08:00:00Z", "2026-07-10T08:01:00Z"]
+        );
+    }
+
+    #[tokio::test]
+    async fn query_candles_tool_rejects_invalid_ranges() {
+        let tool = FinanceQueryCandlesTool::new(repository().await);
+        let err = tool
+            .run(
+                FinanceQueryCandlesParams {
+                    source_name: None,
+                    venue:       "binance".to_owned(),
+                    symbol:      "BTCUSDT".to_owned(),
+                    timeframe:   "1m".to_owned(),
+                    start:       "2026-07-10T08:02:00Z".to_owned(),
+                    end:         "2026-07-10T08:00:00Z".to_owned(),
+                    limit:       Some(10),
+                },
+                &context(),
+            )
+            .await
+            .unwrap_err();
+
+        assert!(err.to_string().contains("start must be before end"));
+    }
+
+    #[test]
+    fn candle_query_tools_are_read_only() {
+        let repository = Arc::new(InMemoryMarketDataRepository::default());
+        let latest = FinanceGetLatestCandleTool::new(repository.clone());
+        let query = FinanceQueryCandlesTool::new(repository);
+
+        assert!(latest.is_read_only(&serde_json::json!({})));
+        assert!(query.is_read_only(&serde_json::json!({})));
+    }
+}

--- a/crates/extensions/rara-trading/tests/timescale_container.rs
+++ b/crates/extensions/rara-trading/tests/timescale_container.rs
@@ -13,8 +13,8 @@
 // limitations under the License.
 
 use rara_trading::market_data::{
-    CandleRangeQuery, MarketCandle, MarketDataRepository, Timeframe, TimescaleMarketDataRepository,
-    UpsertOutcome,
+    CandleLatestQuery, CandleRangeQuery, MarketCandle, MarketDataRepository, Timeframe,
+    TimescaleMarketDataRepository, UpsertOutcome,
 };
 use rust_decimal::Decimal;
 use sqlx_core::row::Row;
@@ -70,6 +70,23 @@ async fn timescale_repository_contract_runs_against_testcontainer() -> anyhow::R
         .await?;
     assert_eq!(rows.len(), 1);
     assert_eq!(rows[0].close, dec("61611.00"));
+
+    assert_eq!(
+        repo.upsert_closed_candle(candle("2026-07-10T08:30:00Z", "61700.00"))
+            .await?,
+        UpsertOutcome::Inserted
+    );
+    let latest = repo
+        .latest_closed_candle(CandleLatestQuery {
+            source_name: Some("timescale-container-contract".to_owned()),
+            venue:       "binance".to_owned(),
+            symbol:      "BTCUSDT".to_owned(),
+            timeframe:   Timeframe::parse("15m")?,
+        })
+        .await?
+        .expect("latest candle should exist");
+    assert_eq!(latest.open_time, ts("2026-07-10T08:30:00Z"));
+    assert_eq!(latest.close, dec("61700.00"));
 
     let audit_pool = sqlx_postgres::PgPool::connect(&database_url).await?;
     let correction_count: i64 =


### PR DESCRIPTION
## Summary
- add market-data repository support for latest closed candle queries
- expose read-only finance_get_latest_candle and finance_query_candles tools
- inject the shared market-data repository into app tool registration
- extend the Timescale testcontainer contract to verify latest-candle reads

## Validation
- rustup run nightly cargo fmt
- cargo check -p rara-trading -p rara-app
- cargo test -p rara-trading market_data --lib
- cargo test -p rara-app tools::tests --lib
- cargo test -p rara-trading
- cargo clippy -p rara-trading -p rara-app --all-targets --no-deps -- -D warnings
- git diff --check
- pre-commit passed: cargo check, cargo fmt, cargo clippy, cargo doc, AGENT.md check