### PR TITLE
chore(ci): add zlib1g-dev to setup-rara-build (#2238)

### DIFF
--- a/.github/actions/setup-rara-build/action.yml
+++ b/.github/actions/setup-rara-build/action.yml
@@ -17,7 +17,7 @@ runs:
       shell: bash
       run: |
         sudo apt-get update
-        sudo apt-get install -y --no-install-recommends libsqlite3-dev libpq-dev protobuf-compiler
+        sudo apt-get install -y --no-install-recommends libsqlite3-dev libpq-dev protobuf-compiler zlib1g-dev
         # mold is target-scoped to x86_64-unknown-linux-gnu in
         # .cargo/config.toml; arm64 legs use the default linker.
         if [[ "$(uname -m)" == "x86_64" ]]; then


### PR DESCRIPTION
## Summary

Declare `zlib1g-dev` explicitly in the `setup-rara-build` composite action's unconditional apt install line. Previously the action relied on GitHub-hosted `ubuntu-latest` shipping zlib dev headers pre-installed — an implicit dependency. On a clean Linux base (e.g. `ubuntu:24.04` slim, the container build in #2239) the workspace link step fails with `/usr/bin/ld: cannot find -lz`. Adding the package on the non-x86_64-gated line covers both x86_64 and arm64 legs.

No-op on `ubuntu-latest` (package already present; `apt-get install` is idempotent). No workflow YAML consuming the action changes — it inherits the package automatically.

## Verification

- `grep -n 'zlib1g-dev'` confirms the package sits on the unconditional install line, not inside the `x86_64` branch.
- `python3 yaml.safe_load` → YAML valid.
- `prek run --all-files` → all hooks Passed.
- The real gate is CI compiling the workspace through this action and staying green.

Closes #2238