### PR TITLE
feat(finance): list candle streams

### DIFF
--- a/crates/app/src/tools/mod.rs
+++ b/crates/app/src/tools/mod.rs
@@ -300,6 +300,11 @@ pub fn register_all(registry: &mut ToolRegistry, deps: ToolDeps) -> ToolRegistra
         Arc::new(FinanceUnsubscribeTool::new(deps.finance_registry.clone())),
         Arc::new(FinanceListSubscriptionsTool::new(deps.finance_registry)),
         Arc::new(
+            rara_trading::market_data::tools::FinanceListCandleStreamsTool::new(
+                deps.market_data_repo.clone(),
+            ),
+        ),
+        Arc::new(
             rara_trading::market_data::tools::FinanceGetLatestCandleTool::new(
                 deps.market_data_repo.clone(),
             ),

--- a/crates/extensions/rara-trading/src/market_data/mod.rs
+++ b/crates/extensions/rara-trading/src/market_data/mod.rs
@@ -19,7 +19,10 @@ pub mod repository;
 pub mod timescale;
 pub mod tools;
 
-pub use model::{CandleLatestQuery, CandleRangeQuery, MarketCandle, Timeframe};
+pub use model::{
+    CandleLatestQuery, CandleRangeQuery, CandleStreamListQuery, CandleStreamSummary, MarketCandle,
+    Timeframe,
+};
 pub use repository::{
     InMemoryMarketDataRepository, MarketDataRepository, MarketDataRepositoryRef, UpsertOutcome,
 };

--- a/crates/extensions/rara-trading/src/market_data/model.rs
+++ b/crates/extensions/rara-trading/src/market_data/model.rs
@@ -141,3 +141,28 @@ pub struct CandleLatestQuery {
     pub symbol:      String,
     pub timeframe:   Timeframe,
 }
+
+/// Stream inventory query for stored candle data.
+#[derive(Debug, Clone)]
+pub struct CandleStreamListQuery {
+    pub source_name: Option<String>,
+    pub venue:       Option<String>,
+    pub symbol:      Option<String>,
+    pub timeframe:   Option<Timeframe>,
+    pub limit:       usize,
+}
+
+/// Aggregated summary for one `(source, venue, symbol, timeframe)` candle
+/// stream.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CandleStreamSummary {
+    pub source_name:        String,
+    pub venue:              String,
+    pub symbol:             String,
+    pub timeframe:          Timeframe,
+    pub candle_count:       usize,
+    pub first_open_time:    Timestamp,
+    pub latest_open_time:   Timestamp,
+    pub latest_close_time:  Timestamp,
+    pub latest_ingested_at: Timestamp,
+}

--- a/crates/extensions/rara-trading/src/market_data/repository.rs
+++ b/crates/extensions/rara-trading/src/market_data/repository.rs
@@ -18,7 +18,9 @@ use async_trait::async_trait;
 use jiff::Timestamp;
 use tokio::sync::RwLock;
 
-use super::model::{CandleLatestQuery, CandleRangeQuery, MarketCandle};
+use super::model::{
+    CandleLatestQuery, CandleRangeQuery, CandleStreamListQuery, CandleStreamSummary, MarketCandle,
+};
 
 /// Result of upserting a closed candle.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -46,6 +48,12 @@ pub trait MarketDataRepository: Send + Sync {
         &self,
         query: CandleLatestQuery,
     ) -> anyhow::Result<Option<MarketCandle>>;
+
+    /// List stored candle streams with their latest watermarks.
+    async fn candle_streams(
+        &self,
+        query: CandleStreamListQuery,
+    ) -> anyhow::Result<Vec<CandleStreamSummary>>;
 
     /// Return missing open times in `[start, end)` based on the query
     /// timeframe.
@@ -160,6 +168,48 @@ impl MarketDataRepository for InMemoryMarketDataRepository {
             .cloned())
     }
 
+    async fn candle_streams(
+        &self,
+        query: CandleStreamListQuery,
+    ) -> anyhow::Result<Vec<CandleStreamSummary>> {
+        let candles = self.candles.read().await;
+        let mut streams = BTreeMap::<StreamKey, CandleStreamSummary>::new();
+
+        for candle in candles
+            .values()
+            .filter(|candle| matches_stream_query(candle, &query))
+        {
+            let key = StreamKey::from(candle);
+            streams
+                .entry(key)
+                .and_modify(|summary| update_stream_summary(summary, candle))
+                .or_insert_with(|| CandleStreamSummary {
+                    source_name:        candle.source_name.clone(),
+                    venue:              candle.venue.clone(),
+                    symbol:             candle.symbol.clone(),
+                    timeframe:          candle.timeframe.clone(),
+                    candle_count:       1,
+                    first_open_time:    candle.open_time,
+                    latest_open_time:   candle.open_time,
+                    latest_close_time:  candle.close_time,
+                    latest_ingested_at: candle.ingested_at,
+                });
+        }
+
+        let mut rows: Vec<_> = streams.into_values().collect();
+        rows.sort_by(|left, right| {
+            right
+                .latest_open_time
+                .cmp(&left.latest_open_time)
+                .then_with(|| left.venue.cmp(&right.venue))
+                .then_with(|| left.symbol.cmp(&right.symbol))
+                .then_with(|| left.timeframe.cmp(&right.timeframe))
+                .then_with(|| left.source_name.cmp(&right.source_name))
+        });
+        rows.truncate(query.limit.min(10_000));
+        Ok(rows)
+    }
+
     async fn missing_open_times(&self, query: CandleRangeQuery) -> anyhow::Result<Vec<Timestamp>> {
         let rows = self.candles(query.clone()).await?;
         let present: std::collections::HashSet<Timestamp> =
@@ -178,6 +228,38 @@ impl MarketDataRepository for InMemoryMarketDataRepository {
         }
 
         Ok(missing)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+struct StreamKey {
+    source_name: String,
+    venue:       String,
+    symbol:      String,
+    timeframe:   String,
+}
+
+impl From<&MarketCandle> for StreamKey {
+    fn from(candle: &MarketCandle) -> Self {
+        Self {
+            source_name: candle.source_name.clone(),
+            venue:       candle.venue.clone(),
+            symbol:      candle.symbol.clone(),
+            timeframe:   candle.timeframe.to_string(),
+        }
+    }
+}
+
+fn update_stream_summary(summary: &mut CandleStreamSummary, candle: &MarketCandle) {
+    summary.candle_count = summary.candle_count.saturating_add(1);
+    summary.first_open_time = summary.first_open_time.min(candle.open_time);
+    if candle.open_time > summary.latest_open_time
+        || (candle.open_time == summary.latest_open_time
+            && candle.ingested_at > summary.latest_ingested_at)
+    {
+        summary.latest_open_time = candle.open_time;
+        summary.latest_close_time = candle.close_time;
+        summary.latest_ingested_at = candle.ingested_at;
     }
 }
 
@@ -203,12 +285,33 @@ fn matches_latest_query(candle: &MarketCandle, query: &CandleLatestQuery) -> boo
         && candle.timeframe == query.timeframe
 }
 
+fn matches_stream_query(candle: &MarketCandle, query: &CandleStreamListQuery) -> bool {
+    query
+        .source_name
+        .as_ref()
+        .is_none_or(|source| source == &candle.source_name)
+        && query
+            .venue
+            .as_ref()
+            .is_none_or(|venue| venue == &candle.venue)
+        && query
+            .symbol
+            .as_ref()
+            .is_none_or(|symbol| symbol == &candle.symbol)
+        && query
+            .timeframe
+            .as_ref()
+            .is_none_or(|timeframe| timeframe == &candle.timeframe)
+}
+
 #[cfg(test)]
 mod tests {
     use rust_decimal::Decimal;
 
     use super::{InMemoryMarketDataRepository, MarketDataRepository, UpsertOutcome};
-    use crate::market_data::{CandleLatestQuery, CandleRangeQuery, MarketCandle, Timeframe};
+    use crate::market_data::{
+        CandleLatestQuery, CandleRangeQuery, CandleStreamListQuery, MarketCandle, Timeframe,
+    };
 
     fn ts(value: &str) -> jiff::Timestamp { value.parse().expect("timestamp fixture should parse") }
 
@@ -350,5 +453,46 @@ mod tests {
 
         assert_eq!(latest.open_time, ts("2026-07-10T08:30:00Z"));
         assert_eq!(latest.close, dec("61700.00"));
+    }
+
+    #[tokio::test]
+    async fn candle_streams_returns_latest_watermarks_per_stream() {
+        let repo = InMemoryMarketDataRepository::default();
+        repo.upsert_closed_candle(candle("2026-07-10T08:00:00Z", "61500.00"))
+            .await
+            .unwrap();
+        repo.upsert_closed_candle(candle("2026-07-10T08:30:00Z", "61700.00"))
+            .await
+            .unwrap();
+        repo.upsert_closed_candle(MarketCandle {
+            symbol: "ETHUSDT".to_owned(),
+            open_time: ts("2026-07-10T08:45:00Z"),
+            close_time: ts("2026-07-10T09:00:00Z"),
+            close: dec("3200.00"),
+            ..candle("2026-07-10T08:45:00Z", "3200.00")
+        })
+        .await
+        .unwrap();
+
+        let streams = repo
+            .candle_streams(CandleStreamListQuery {
+                source_name: Some("binance-spot".to_owned()),
+                venue:       Some("binance".to_owned()),
+                symbol:      None,
+                timeframe:   Some(Timeframe::parse("15m").unwrap()),
+                limit:       10,
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(streams.len(), 2);
+        assert_eq!(streams[0].symbol, "ETHUSDT");
+        assert_eq!(streams[0].candle_count, 1);
+        assert_eq!(streams[0].latest_open_time, ts("2026-07-10T08:45:00Z"));
+        assert_eq!(streams[0].latest_close_time, ts("2026-07-10T09:00:00Z"));
+        assert_eq!(streams[1].symbol, "BTCUSDT");
+        assert_eq!(streams[1].candle_count, 2);
+        assert_eq!(streams[1].first_open_time, ts("2026-07-10T08:00:00Z"));
+        assert_eq!(streams[1].latest_open_time, ts("2026-07-10T08:30:00Z"));
     }
 }

--- a/crates/extensions/rara-trading/src/market_data/timescale.rs
+++ b/crates/extensions/rara-trading/src/market_data/timescale.rs
@@ -20,7 +20,10 @@ use sqlx_postgres::{PgPool, Postgres};
 use uuid::Uuid;
 
 use super::{
-    model::{CandleLatestQuery, CandleRangeQuery, MarketCandle, Timeframe},
+    model::{
+        CandleLatestQuery, CandleRangeQuery, CandleStreamListQuery, CandleStreamSummary,
+        MarketCandle, Timeframe,
+    },
     repository::{MarketDataRepository, UpsertOutcome},
 };
 
@@ -179,6 +182,65 @@ impl MarketDataRepository for TimescaleMarketDataRepository {
         row.map(row_to_candle).transpose()
     }
 
+    async fn candle_streams(
+        &self,
+        query: CandleStreamListQuery,
+    ) -> anyhow::Result<Vec<CandleStreamSummary>> {
+        let limit = i64::try_from(query.limit.min(10_000))?;
+        let rows = sqlx_core::query::query(
+            r#"
+            WITH grouped AS (
+              SELECT
+                source_name,
+                venue,
+                symbol,
+                timeframe,
+                COUNT(*)::bigint AS candle_count,
+                MIN(open_time)::text AS first_open_time,
+                MAX(open_time)::text AS latest_open_time
+              FROM market_candles
+              WHERE ($1::text IS NULL OR source_name = $1)
+                AND ($2::text IS NULL OR venue = $2)
+                AND ($3::text IS NULL OR symbol = $3)
+                AND ($4::text IS NULL OR timeframe = $4)
+              GROUP BY source_name, venue, symbol, timeframe
+            )
+            SELECT
+              grouped.source_name,
+              grouped.venue,
+              grouped.symbol,
+              grouped.timeframe,
+              grouped.candle_count,
+              grouped.first_open_time,
+              grouped.latest_open_time,
+              candles.close_time::text AS latest_close_time,
+              candles.ingested_at::text AS latest_ingested_at
+            FROM grouped
+            JOIN market_candles candles
+              ON candles.source_name = grouped.source_name
+             AND candles.venue = grouped.venue
+             AND candles.symbol = grouped.symbol
+             AND candles.timeframe = grouped.timeframe
+             AND candles.open_time = grouped.latest_open_time::timestamptz
+            ORDER BY grouped.latest_open_time::timestamptz DESC,
+                     grouped.venue ASC,
+                     grouped.symbol ASC,
+                     grouped.timeframe ASC,
+                     grouped.source_name ASC
+            LIMIT $5
+            "#,
+        )
+        .bind(query.source_name.as_deref())
+        .bind(query.venue.as_deref())
+        .bind(query.symbol.as_deref())
+        .bind(query.timeframe.as_ref().map(Timeframe::as_str))
+        .bind(limit)
+        .fetch_all(&self.pool)
+        .await?;
+
+        rows.into_iter().map(row_to_stream_summary).collect()
+    }
+
     async fn missing_open_times(&self, query: CandleRangeQuery) -> anyhow::Result<Vec<Timestamp>> {
         let rows = self.candles(query.clone()).await?;
         let present: std::collections::HashSet<Timestamp> =
@@ -326,5 +388,20 @@ fn row_to_candle(row: sqlx_postgres::PgRow) -> anyhow::Result<MarketCandle> {
         volume:            Decimal::from_str_exact(&row.try_get::<String, _>("volume")?)?,
         ingested_at:       row.try_get::<String, _>("ingested_at")?.parse()?,
         provider_sequence: row.try_get("provider_sequence")?,
+    })
+}
+
+fn row_to_stream_summary(row: sqlx_postgres::PgRow) -> anyhow::Result<CandleStreamSummary> {
+    let candle_count: i64 = row.try_get("candle_count")?;
+    Ok(CandleStreamSummary {
+        source_name:        row.try_get("source_name")?,
+        venue:              row.try_get("venue")?,
+        symbol:             row.try_get("symbol")?,
+        timeframe:          Timeframe::parse(row.try_get::<String, _>("timeframe")?)?,
+        candle_count:       usize::try_from(candle_count)?,
+        first_open_time:    row.try_get::<String, _>("first_open_time")?.parse()?,
+        latest_open_time:   row.try_get::<String, _>("latest_open_time")?.parse()?,
+        latest_close_time:  row.try_get::<String, _>("latest_close_time")?.parse()?,
+        latest_ingested_at: row.try_get::<String, _>("latest_ingested_at")?.parse()?,
     })
 }

--- a/crates/extensions/rara-trading/src/market_data/tools.rs
+++ b/crates/extensions/rara-trading/src/market_data/tools.rs
@@ -22,7 +22,8 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use super::{
-    CandleLatestQuery, CandleRangeQuery, MarketCandle, MarketDataRepositoryRef, Timeframe,
+    CandleLatestQuery, CandleRangeQuery, CandleStreamListQuery, CandleStreamSummary, MarketCandle,
+    MarketDataRepositoryRef, Timeframe,
 };
 
 const DEFAULT_CANDLE_LIMIT: usize = 500;
@@ -111,6 +112,40 @@ pub struct FinanceGetCandleFreshnessResult {
     pub status:           String,
 }
 
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct FinanceListCandleStreamsParams {
+    #[serde(default)]
+    pub source_name: Option<String>,
+    #[serde(default)]
+    pub venue:       Option<String>,
+    #[serde(default)]
+    pub symbol:      Option<String>,
+    #[serde(default)]
+    pub timeframe:   Option<String>,
+    #[serde(default)]
+    pub limit:       Option<usize>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct FinanceListCandleStreamsResult {
+    pub streams:     Vec<FinanceCandleStream>,
+    pub count:       usize,
+    pub query_limit: usize,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct FinanceCandleStream {
+    pub source_name:        String,
+    pub venue:              String,
+    pub symbol:             String,
+    pub timeframe:          String,
+    pub candle_count:       usize,
+    pub first_open_time:    String,
+    pub latest_open_time:   String,
+    pub latest_close_time:  String,
+    pub latest_ingested_at: String,
+}
+
 #[derive(Debug, Clone, Serialize)]
 pub struct FinanceCandle {
     pub source_name:       String,
@@ -126,6 +161,55 @@ pub struct FinanceCandle {
     pub volume:            String,
     pub ingested_at:       String,
     pub provider_sequence: Option<String>,
+}
+
+#[derive(ToolDef)]
+#[tool(
+    name = "finance_list_candle_streams",
+    description = "List stored OHLCV candle streams and their latest watermarks from the \
+                   market-data TSDB. Use this to discover available source/venue/symbol/timeframe \
+                   combinations before querying candles, freshness, or gaps. This is read-only \
+                   and never places trades.",
+    tier = "deferred",
+    read_only,
+    concurrency_safe
+)]
+pub struct FinanceListCandleStreamsTool {
+    repository: MarketDataRepositoryRef,
+}
+
+impl FinanceListCandleStreamsTool {
+    pub fn new(repository: MarketDataRepositoryRef) -> Self { Self { repository } }
+}
+
+#[async_trait]
+impl ToolExecute for FinanceListCandleStreamsTool {
+    type Output = FinanceListCandleStreamsResult;
+    type Params = FinanceListCandleStreamsParams;
+
+    async fn run(
+        &self,
+        params: FinanceListCandleStreamsParams,
+        _context: &ToolContext,
+    ) -> anyhow::Result<FinanceListCandleStreamsResult> {
+        let limit = validate_limit(params.limit)?;
+        let query = CandleStreamListQuery {
+            source_name: normalize_optional_selector("source_name", params.source_name)?,
+            venue: normalize_optional_selector("venue", params.venue)?,
+            symbol: normalize_optional_selector("symbol", params.symbol)?,
+            timeframe: normalize_optional_selector("timeframe", params.timeframe)?
+                .map(Timeframe::parse)
+                .transpose()?,
+            limit,
+        };
+        let streams = self.repository.candle_streams(query).await?;
+        let count = streams.len();
+        Ok(FinanceListCandleStreamsResult {
+            streams: streams.into_iter().map(FinanceCandleStream::from).collect(),
+            count,
+            query_limit: limit,
+        })
+    }
 }
 
 #[derive(ToolDef)]
@@ -197,12 +281,7 @@ impl ToolExecute for FinanceQueryCandlesTool {
         params: FinanceQueryCandlesParams,
         _context: &ToolContext,
     ) -> anyhow::Result<FinanceQueryCandlesResult> {
-        let limit = params.limit.unwrap_or(DEFAULT_CANDLE_LIMIT);
-        anyhow::ensure!(limit > 0, "limit must be positive");
-        anyhow::ensure!(
-            limit <= MAX_CANDLE_LIMIT,
-            "limit must be <= {MAX_CANDLE_LIMIT}"
-        );
+        let limit = validate_limit(params.limit)?;
         let start = parse_timestamp("start", &params.start)?;
         let end = parse_timestamp("end", &params.end)?;
         anyhow::ensure!(start < end, "start must be before end");
@@ -365,6 +444,22 @@ impl ToolExecute for FinanceGetCandleFreshnessTool {
     }
 }
 
+impl From<CandleStreamSummary> for FinanceCandleStream {
+    fn from(summary: CandleStreamSummary) -> Self {
+        Self {
+            source_name:        summary.source_name,
+            venue:              summary.venue,
+            symbol:             summary.symbol,
+            timeframe:          summary.timeframe.to_string(),
+            candle_count:       summary.candle_count,
+            first_open_time:    summary.first_open_time.to_string(),
+            latest_open_time:   summary.latest_open_time.to_string(),
+            latest_close_time:  summary.latest_close_time.to_string(),
+            latest_ingested_at: summary.latest_ingested_at.to_string(),
+        }
+    }
+}
+
 impl From<MarketCandle> for FinanceCandle {
     fn from(candle: MarketCandle) -> Self {
         Self {
@@ -402,6 +497,16 @@ fn normalize_optional_selector(
     value
         .map(|value| normalize_required_selector(name, value))
         .transpose()
+}
+
+fn validate_limit(limit: Option<usize>) -> anyhow::Result<usize> {
+    let limit = limit.unwrap_or(DEFAULT_CANDLE_LIMIT);
+    anyhow::ensure!(limit > 0, "limit must be positive");
+    anyhow::ensure!(
+        limit <= MAX_CANDLE_LIMIT,
+        "limit must be <= {MAX_CANDLE_LIMIT}"
+    );
+    Ok(limit)
 }
 
 fn parse_timestamp(name: &str, value: &str) -> anyhow::Result<Timestamp> {
@@ -446,7 +551,8 @@ mod tests {
     use super::{
         FinanceFindCandleGapsParams, FinanceFindCandleGapsTool, FinanceGetCandleFreshnessParams,
         FinanceGetCandleFreshnessTool, FinanceGetLatestCandleParams, FinanceGetLatestCandleTool,
-        FinanceQueryCandlesParams, FinanceQueryCandlesTool,
+        FinanceListCandleStreamsParams, FinanceListCandleStreamsTool, FinanceQueryCandlesParams,
+        FinanceQueryCandlesTool,
     };
     use crate::market_data::{
         InMemoryMarketDataRepository, MarketCandle, MarketDataRepository, Timeframe,
@@ -517,6 +623,73 @@ mod tests {
             .await
             .unwrap();
         repository
+    }
+
+    async fn repository_with_multiple_streams() -> Arc<InMemoryMarketDataRepository> {
+        let repository = repository().await;
+        repository
+            .upsert_closed_candle(MarketCandle {
+                symbol: "ETHUSDT".to_owned(),
+                open_time: ts("2026-07-10T08:03:00Z"),
+                close_time: ts("2026-07-10T08:04:00Z"),
+                close: dec("3200.00"),
+                provider_sequence: Some("eth".to_owned()),
+                ..candle("2026-07-10T08:03:00Z", "3200.00")
+            })
+            .await
+            .unwrap();
+        repository
+    }
+
+    #[tokio::test]
+    async fn list_candle_streams_tool_returns_available_stream_watermarks() {
+        let repository = repository_with_multiple_streams().await;
+        let tool = FinanceListCandleStreamsTool::new(repository);
+        let result = tool
+            .run(
+                FinanceListCandleStreamsParams {
+                    source_name: Some("binance-spot".to_owned()),
+                    venue:       Some("binance".to_owned()),
+                    symbol:      None,
+                    timeframe:   Some("1m".to_owned()),
+                    limit:       Some(10),
+                },
+                &context(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(result.count, 2);
+        assert_eq!(result.query_limit, 10);
+        assert_eq!(result.streams[0].symbol, "ETHUSDT");
+        assert_eq!(result.streams[0].candle_count, 1);
+        assert_eq!(result.streams[0].latest_open_time, "2026-07-10T08:03:00Z");
+        assert_eq!(result.streams[1].symbol, "BTCUSDT");
+        assert_eq!(result.streams[1].candle_count, 2);
+        assert_eq!(result.streams[1].first_open_time, "2026-07-10T08:00:00Z");
+    }
+
+    #[tokio::test]
+    async fn list_candle_streams_tool_filters_by_symbol() {
+        let repository = repository_with_multiple_streams().await;
+        let tool = FinanceListCandleStreamsTool::new(repository);
+        let result = tool
+            .run(
+                FinanceListCandleStreamsParams {
+                    source_name: None,
+                    venue:       Some("binance".to_owned()),
+                    symbol:      Some("BTCUSDT".to_owned()),
+                    timeframe:   Some("1m".to_owned()),
+                    limit:       None,
+                },
+                &context(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(result.count, 1);
+        assert_eq!(result.streams[0].symbol, "BTCUSDT");
+        assert_eq!(result.streams[0].candle_count, 2);
     }
 
     #[tokio::test]
@@ -665,11 +838,13 @@ mod tests {
     #[test]
     fn candle_query_tools_are_read_only() {
         let repository = Arc::new(InMemoryMarketDataRepository::default());
+        let streams = FinanceListCandleStreamsTool::new(repository.clone());
         let latest = FinanceGetLatestCandleTool::new(repository.clone());
         let query = FinanceQueryCandlesTool::new(repository.clone());
         let gaps = FinanceFindCandleGapsTool::new(repository.clone());
         let freshness = FinanceGetCandleFreshnessTool::new(repository);
 
+        assert!(streams.is_read_only(&serde_json::json!({})));
         assert!(latest.is_read_only(&serde_json::json!({})));
         assert!(query.is_read_only(&serde_json::json!({})));
         assert!(gaps.is_read_only(&serde_json::json!({})));

--- a/crates/extensions/rara-trading/tests/timescale_container.rs
+++ b/crates/extensions/rara-trading/tests/timescale_container.rs
@@ -13,8 +13,8 @@
 // limitations under the License.
 
 use rara_trading::market_data::{
-    CandleLatestQuery, CandleRangeQuery, MarketCandle, MarketDataRepository, Timeframe,
-    TimescaleMarketDataRepository, UpsertOutcome,
+    CandleLatestQuery, CandleRangeQuery, CandleStreamListQuery, MarketCandle, MarketDataRepository,
+    Timeframe, TimescaleMarketDataRepository, UpsertOutcome,
 };
 use rust_decimal::Decimal;
 use sqlx_core::row::Row;
@@ -87,6 +87,36 @@ async fn timescale_repository_contract_runs_against_testcontainer() -> anyhow::R
         .expect("latest candle should exist");
     assert_eq!(latest.open_time, ts("2026-07-10T08:30:00Z"));
     assert_eq!(latest.close, dec("61700.00"));
+
+    assert_eq!(
+        repo.upsert_closed_candle(MarketCandle {
+            symbol: "ETHUSDT".to_owned(),
+            open_time: ts("2026-07-10T08:45:00Z"),
+            close_time: ts("2026-07-10T09:00:00Z"),
+            close: dec("3200.00"),
+            ..candle("2026-07-10T08:45:00Z", "3200.00")
+        })
+        .await?,
+        UpsertOutcome::Inserted
+    );
+    let streams = repo
+        .candle_streams(CandleStreamListQuery {
+            source_name: Some("timescale-container-contract".to_owned()),
+            venue:       Some("binance".to_owned()),
+            symbol:      None,
+            timeframe:   Some(Timeframe::parse("15m")?),
+            limit:       10,
+        })
+        .await?;
+    assert_eq!(streams.len(), 2);
+    assert_eq!(streams[0].symbol, "ETHUSDT");
+    assert_eq!(streams[0].candle_count, 1);
+    assert_eq!(streams[0].latest_open_time, ts("2026-07-10T08:45:00Z"));
+    assert_eq!(streams[0].latest_close_time, ts("2026-07-10T09:00:00Z"));
+    assert_eq!(streams[1].symbol, "BTCUSDT");
+    assert_eq!(streams[1].candle_count, 2);
+    assert_eq!(streams[1].first_open_time, ts("2026-07-10T08:15:00Z"));
+    assert_eq!(streams[1].latest_open_time, ts("2026-07-10T08:30:00Z"));
 
     let missing = repo
         .missing_open_times(CandleRangeQuery {


### PR DESCRIPTION
## Summary
- add candle stream inventory models and repository query support
- implement Timescale/Postgres stream aggregation with latest watermarks
- expose read-only finance_list_candle_streams tool and register it in app tools

## Validation
- cargo test -p rara-trading market_data --lib
- cargo test -p rara-trading
- cargo test -p rara-app tools::tests --lib
- cargo check -p rara-trading -p rara-app
- rustup run nightly cargo fmt --all --check
- cargo clippy -p rara-trading -p rara-app --all-targets --no-deps -- -D warnings
- cargo deny check
- git diff --check