### PR TITLE
chore(ci): containerize rara — server-only image + k8s manifests + build-smoke CI (#2239)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,33 +1,58 @@
-# Build artifacts
-target/
-.cargo/
-web/node_modules/
-web/dist/
+# Build context for docker/Dockerfile (server-only rara image).
+#
+# Keep this a BLOCK-list: the Rust workspace has many build.rs scripts that
+# read files across the tree, so excluding by allow-list is fragile. We only
+# drop heavy or build-irrelevant paths.
+#
+# IMPORTANT: do NOT exclude `.cargo/` — the repo's `.cargo/config.toml` sets
+# the mold linker flags the release build relies on (see docker/Dockerfile).
 
-# Git
+# Rust build artifacts (rebuilt inside the image)
+target/
+
+# Vendored third-party reference repos (not part of the workspace build)
+vendor/
+
+# Git metadata
 .git/
 .gitignore
+.gitattributes
 
-# Worktrees
+# Nested worktrees
 .worktrees/
 
-# IDE
+# Frontend / desktop — server-only image, no web build, no nginx
+web/
+desktop/
+extension/
+site/
+
+# Node / bun caches anywhere
+node_modules/
+**/node_modules/
+
+# Go tooling caches (scripts/bin build outputs)
+scripts/bin/
+
+# CI, docs, harness, specs — not needed to compile the binary
+.github/
+docs/
+harness/
+specs/
+verification/
+
+# IDE / editor
 .idea/
 .vscode/
+.cursor/
+.devcontainer/
 *.swp
 *.swo
 
-# CI / Docs
-.github/
-docs/
-!docs/book/
-*.md
-!CHANGELOG.md
-
-# Docker (avoid recursive context)
+# Docker compose (avoid recursive context)
 docker-compose*.yml
 
-# Miscellaneous
+# Local secrets / env
 .env
 .env.*
 env.local*

--- a/.github/workflows/container-smoke.yml
+++ b/.github/workflows/container-smoke.yml
@@ -1,0 +1,155 @@
+name: container-smoke
+
+# Build the server-only rara image (docker/Dockerfile) and prove it boots
+# and serves /api/health → healthy. This is the canonical, executable Verify
+# for the containerization work (issue #2239).
+#
+# It does NOT push to any registry — publishing is deliberately out of scope
+# (decision #9; it must not re-introduce the publish pipeline #443 removed).
+# The image is built and loaded locally, run, and probed.
+#
+# Gated behind a paths filter so it only runs on PRs touching the
+# container / deploy files. Not a required merge gate.
+
+on:
+  pull_request:
+    paths:
+      - "docker/**"
+      - ".dockerignore"
+      - "deploy/k8s/**"
+      - ".github/workflows/container-smoke.yml"
+      # A workspace-wide dependency/lock change can break the release build
+      # this job smokes.
+      - "Cargo.lock"
+  workflow_dispatch:
+
+concurrency:
+  group: container-smoke-${{ github.ref }}
+  cancel-in-progress: true
+
+# Read-only token: this job builds and loads locally, it never pushes.
+permissions:
+  contents: read
+
+jobs:
+  smoke:
+    name: build + boot + health
+    runs-on: ubuntu-latest
+    # First cold build is a full-workspace `cargo build --release`. Native
+    # amd64 on the x64 runner, but still slow; cache-from/to keeps reruns fast.
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+
+      - name: Build image (linux/amd64, load locally — no push)
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: .
+          file: docker/Dockerfile
+          platforms: linux/amd64
+          load: true
+          push: false
+          tags: rara-server:smoke
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Assert image runs as non-root
+        run: |
+          user="$(docker inspect -f '{{.Config.User}}' rara-server:smoke)"
+          echo "image User = '${user}'"
+          if [ -z "${user}" ] || [ "${user}" = "root" ] || [ "${user}" = "0" ]; then
+            echo "FAIL: image must run as a non-root user"
+            exit 1
+          fi
+
+      - name: Assert shipped config has no sandbox block and binds 0.0.0.0
+        run: |
+          cfg=deploy/k8s/secret.example.yaml
+          grep -q '0.0.0.0:25555' "$cfg" || { echo "FAIL: config must bind 0.0.0.0:25555"; exit 1; }
+          if grep -qE '^\s*sandbox:' "$cfg"; then
+            echo "FAIL: sandbox block must be absent (sandbox disabled in this image)"
+            exit 1
+          fi
+          echo "OK: 0.0.0.0 bind present, no sandbox block"
+
+      - name: Boot container and assert /api/health → healthy
+        run: |
+          # Self-contained smoke config: dummy secrets, 0.0.0.0 bind, no
+          # sandbox block. Placeholder for the health smoke, NOT a real
+          # deployment config (real secrets come from the rara-secrets Secret).
+          cat > smoke-config.yaml <<'YAML'
+          http:
+            bind_address: "0.0.0.0:25555"
+            cors_allowed_origins:
+              - "http://localhost:*"
+          grpc:
+            bind_address: "0.0.0.0:50051"
+            server_address: "127.0.0.1:50051"
+          owner_token: "smoke-placeholder-token"
+          owner_user_id: "you"
+          users:
+            - name: "you"
+              role: root
+              platforms: []
+          mita:
+            heartbeat_interval: "30m"
+          llm:
+            default_provider: "openrouter"
+            providers:
+              openrouter:
+                base_url: "https://openrouter.ai/api/v1"
+                default_model: "anthropic/claude-3.5-sonnet"
+                api_key: "smoke-placeholder-key"
+          knowledge:
+            embedding_model: "text-embedding-3-small"
+            embedding_dimensions: 1536
+            search_top_k: 10
+            similarity_threshold: 0.85
+          YAML
+
+          # Mirror the k8s deployment's init container: COPY the config into a
+          # writable config dir, then boot from there. rara's config dir must
+          # be writable — it creates workspace/, settings.json,
+          # mcp-servers.json there, and ConfigFileSync writes config.yaml back
+          # (KV → File). A read-only mount would log a spurious
+          # "Read-only file system" writeback error. A fresh named volume is
+          # seeded from the image's non-root-owned /config, so the copied file
+          # is owned by (and writable by) the rara user.
+          docker volume create rara-cfg >/dev/null
+          docker run --rm --entrypoint sh \
+            -v rara-cfg:/config \
+            -v "$PWD/smoke-config.yaml":/tmp/config.yaml:ro \
+            rara-server:smoke \
+            -c "cp /tmp/config.yaml /config/rara/config.yaml"
+
+          docker run -d --name rara-smoke -p 25555:25555 \
+            -v rara-cfg:/config \
+            rara-server:smoke
+
+          ok=0
+          for i in $(seq 1 40); do
+            if curl -sf --max-time 4 http://127.0.0.1:25555/api/health | grep -q healthy; then
+              echo "healthy after ~$((i * 3))s"
+              curl -s http://127.0.0.1:25555/api/health
+              ok=1
+              break
+            fi
+            sleep 3
+          done
+          if [ "$ok" -ne 1 ]; then
+            echo "FAIL: /api/health did not report healthy in time"
+            exit 1
+          fi
+
+      - name: Container logs (always)
+        if: always()
+        run: docker logs rara-smoke || true
+
+      - name: Cleanup
+        if: always()
+        run: docker rm -f rara-smoke || true; docker volume rm rara-cfg || true

--- a/deploy/k8s/README.md
+++ b/deploy/k8s/README.md
@@ -1,0 +1,220 @@
+# Deploying rara-server on Kubernetes
+
+Server-only, sandbox-disabled container image + plain k8s manifests for
+running the **rara backend as an in-cluster control-plane process** — the
+deploy substrate the fleet direction (`crates/rara-fleet`, kube-rs
+dispatcher) needs so rara-server runs inside the cluster it dispatches
+Jobs into.
+
+This ships **only** the `rara server` process. No web bundle, no nginx, no
+sandbox/microVM runtime. Untrusted-code execution is deliberately not solved
+here — it is deferred to fleet's separate microVM layer.
+
+## What's in the box
+
+| File | Purpose |
+| --- | --- |
+| `../../docker/Dockerfile` | Multi-stage, server-only image (`linux/amd64`) |
+| `secret.example.yaml` | **Template** Secret carrying the complete `config.yaml` (owner token + LLM key + all runtime config) |
+| `pvc.yaml` | `ReadWriteOnce` PVC for the writable config dir + SQLite DB / sessions |
+| `deployment.yaml` | 1 replica, `Recreate`, non-root, init container seeds config, probes, resource limits |
+| `service.yaml` | ClusterIP exposing HTTP (25555) + gRPC (50051) |
+
+## Build the image
+
+```bash
+# From the repo root. linux/amd64 only.
+docker build -f docker/Dockerfile -t rara-server:latest .
+```
+
+The build is a full-workspace `cargo build --release` and is slow on the
+first run. Build facts baked into the Dockerfile so you don't hit the wall
+the team already mapped:
+
+- **`ubuntu:24.04` (gcc-13)** for both stages — not bookworm/gcc-12, which
+  fails numkong's SIMD compile.
+- **zig 0.16.0** downloaded from ziglang.org (not in apt) — required
+  unconditionally by `crates/app`'s zlob build.rs.
+- **clang + mold** — `.cargo/config.toml` forces `-fuse-ld=mold` +
+  `linker=clang` on `x86_64-unknown-linux-gnu`.
+- **`BOXLITE_DEPS_STUB=1`** stubs the native boxlite dependency so the
+  sandbox subsystem builds without its microVM runtime.
+- Runtime is **ubuntu slim (not distroless)** — rara links `libsqlite3`,
+  `libpq`, `libssl`, and `zlib` at runtime.
+
+### Architecture: amd64 only
+
+The image is `linux/amd64` only. The real build-and-boot verification runs
+in CI (`.github/workflows/container-smoke.yml`) on GitHub's `ubuntu-latest`
+**native amd64** runner — that is the amd64 oracle.
+
+**Building on an Apple-Silicon (arm64) dev machine:** a `--platform=linux/amd64`
+build under Docker Desktop's Rosetta emulation fails at the zig `translate-c`
+step with `rosetta error: bss_size overflow` (a Rosetta limitation, not a
+recipe defect). To build locally on arm64, either build on a native amd64
+host, or use a QEMU-backed buildx builder instead of Rosetta — but the
+canonical amd64 check is the CI job, so you normally don't need to.
+
+## Two container-specific config facts
+
+1. **Bind `0.0.0.0`, not `127.0.0.1`.** `config.example.yaml` binds loopback.
+   In a pod, the kubelet liveness/readiness probe and the Service reach the
+   container on its Pod IP — a loopback bind is unreachable and the pod
+   crashloops as unhealthy. The Secret's `config.yaml` sets
+   `http.bind_address: "0.0.0.0:25555"` and the gRPC bind to `0.0.0.0:50051`.
+   (The `PORT` env var only rewrites the *port*, not the host — it cannot fix
+   loopback.) The gateway admin port (25556) is not used by this image.
+
+2. **The config dir must be WRITABLE, and secrets live only in a Secret.**
+   rara's config dir (`$XDG_CONFIG_HOME/rara`) is not a read-only config
+   location — rara creates `workspace/`, `settings.json`, `skills/`,
+   `mcp-servers.json` there at runtime, and its config sync
+   (`ConfigFileSync`) reads a single `config.yaml` as a complete `AppConfig`
+   **and writes it back** (settings KV → file). rara also reads LLM API keys
+   and the owner token from `config.yaml` (`llm.providers.<name>.api_key`,
+   `owner_token`) — there is **no** env-var override for these in the loader.
+
+### How config + secrets are delivered
+
+Because rara needs **one complete, writable `config.yaml`** and that file
+must contain secrets, the whole `config.yaml` lives in the **`rara-secrets`
+Secret** (`secret.example.yaml`). An **init container** copies it into the
+writable, persistent config dir on the PVC at startup:
+
+```
+Secret rara-secrets (config.yaml, read-only)
+   │  init container: cp → /state/config/rara/config.yaml  (writable, on PVC)
+   ▼
+rara-server reads/writes /state/config/rara/config.yaml
+            data dir      /state/data/rara/…  (DB, sessions, memory)
+```
+
+Secret material therefore never lives in the image or in git — only in the
+Secret. (Note: rara's KV→file writeback serializes the running config,
+including secrets, into the config file on the PVC at rest — inherent to
+rara, the same PVC already holds the DB. The Secret stays the source of
+truth.)
+
+> A partial "secret overlay" merged via rara's two-file config precedence
+> was evaluated and rejected: `ConfigFileSync` parses/writes a **single**
+> complete file, so a partial overlay fails (`missing field owner_user_id`).
+> The whole-config-in-Secret approach is the one that works.
+
+## Deploy
+
+```bash
+# 1. Namespace (pick your own; manifests carry no hardcoded namespace).
+kubectl create namespace rara
+
+# 2. Create the real Secret from the template — DO NOT commit this file.
+cp deploy/k8s/secret.example.yaml /tmp/rara-secret.yaml
+$EDITOR /tmp/rara-secret.yaml          # replace both REPLACE_WITH_* placeholders
+kubectl apply -n rara -f /tmp/rara-secret.yaml
+
+# 3. Apply the rest.
+kubectl apply -n rara \
+  -f deploy/k8s/pvc.yaml \
+  -f deploy/k8s/deployment.yaml \
+  -f deploy/k8s/service.yaml
+
+# 4. Watch it come up (startup probe covers first-boot migrations).
+kubectl -n rara rollout status deploy/rara-server
+kubectl -n rara port-forward svc/rara-server 25555:25555 &
+curl -s http://127.0.0.1:25555/api/health   # {"service":"job","status":"healthy",...}
+```
+
+> Update the `image:` field in `deployment.yaml` to your image reference.
+> This issue does not publish to a registry (out of scope), so you load the
+> image into your cluster yourself (e.g. `kind load` / `minikube image load`
+> / your own registry).
+
+## Why single-replica / Recreate / RWO
+
+rara's store is a **single SQLite file with one writer**. The Deployment is
+pinned to `replicas: 1` with `strategy: Recreate` and a `ReadWriteOnce` PVC.
+A rolling update or `replicas > 1` would briefly run two pods both mounting
+the volume / writing the DB and corrupt it. This also matches "rara is NOT
+multi-user" — one pod is one user's rara.
+
+**Never back a real deployment with `emptyDir`** — the DB, memory, and the
+config dir (skills, settings) would not survive a restart. Swap the PVC's
+storage class or point it at an external/managed volume as needed, but keep
+it durable.
+
+## Local smoke test (no cluster)
+
+Proves the image boots and serves health — the same thing CI's
+`container-smoke` workflow does on every PR touching these files.
+
+**Note on architecture:** the Dockerfile is pinned to `linux/amd64`
+(`--platform=linux/amd64` + the x86_64 zig tarball), so `docker build`
+always produces an **amd64** image regardless of your host. On an
+Apple-Silicon (arm64) machine that amd64 build runs under Rosetta and
+**fails** at the zig step (`bss_size overflow`) — so the authoritative
+amd64 build+smoke is CI's `container-smoke.yml` (native amd64 runner). To
+run the boot check *locally* on arm64, build an arch-adapted variant
+first (swap `--platform=linux/amd64` → `linux/arm64` and the zig tarball
+`zig-x86_64-linux` → `zig-aarch64-linux`); the boot/health behavior below
+is arch-independent.
+
+```bash
+# amd64 host (or CI): builds directly. arm64 host: build an arch-adapted
+# variant as described above, then tag it rara-server:smoke.
+docker build -f docker/Dockerfile -t rara-server:smoke .
+
+cat > /tmp/rara-smoke.yaml <<'YAML'
+http:
+  bind_address: "0.0.0.0:25555"
+  cors_allowed_origins: ["http://localhost:*"]
+grpc:
+  bind_address: "0.0.0.0:50051"
+  server_address: "127.0.0.1:50051"
+owner_token: "smoke-placeholder-token"
+owner_user_id: "you"
+users:
+  - name: "you"
+    role: root
+    platforms: []
+mita:
+  heartbeat_interval: "30m"
+llm:
+  default_provider: "openrouter"
+  providers:
+    openrouter:
+      base_url: "https://openrouter.ai/api/v1"
+      default_model: "anthropic/claude-3.5-sonnet"
+      api_key: "smoke-placeholder-key"
+knowledge:
+  embedding_model: "text-embedding-3-small"
+  embedding_dimensions: 1536
+  search_top_k: 10
+  similarity_threshold: 0.85
+YAML
+
+# Mirror the k8s init container: copy the config into a writable config dir
+# (a named volume seeded from the image's non-root-owned /config), then boot.
+docker volume create rara-cfg
+docker run --rm --entrypoint sh \
+  -v rara-cfg:/config \
+  -v /tmp/rara-smoke.yaml:/tmp/config.yaml:ro \
+  rara-server:smoke \
+  -c "cp /tmp/config.yaml /config/rara/config.yaml"
+docker run -d --name rara-smoke -p 25555:25555 \
+  -v rara-cfg:/config \
+  rara-server:smoke
+
+curl -sf --max-time 5 http://127.0.0.1:25555/api/health | grep -q healthy && echo OK
+docker rm -f rara-smoke; docker volume rm rara-cfg
+```
+
+## Not included (deliberately)
+
+- **Registry publish + tag/versioning** — follow-up; would re-introduce the
+  publish pipeline #443 removed.
+- **arm64 / multi-arch.**
+- **Sandbox / code execution** — disabled; deferred to fleet's microVM layer.
+- **Web UI / nginx** — server-only image.
+- **Pod-management RBAC** — only needed if rara's `k8s` client feature (the
+  `rara` pod-manager ServiceAccount in `docs/k8s-setup.md`) is enabled later;
+  a keep-separate concern.
+- **Helm / kustomize** — plain manifests only for now.

--- a/deploy/k8s/deployment.yaml
+++ b/deploy/k8s/deployment.yaml
@@ -1,0 +1,135 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: rara-server
+  labels:
+    app.kubernetes.io/name: rara
+    app.kubernetes.io/component: server
+spec:
+  # Single writer only — rara's SQLite DB has one writer, and the RWO PVC
+  # can only be mounted by one pod. Never scale beyond 1.
+  replicas: 1
+  # Recreate (not RollingUpdate): a rolling update would briefly run two pods
+  # both mounting the RWO volume / writing the DB → corruption.
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: rara
+      app.kubernetes.io/component: server
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: rara
+        app.kubernetes.io/component: server
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 10001
+        runAsGroup: 10001
+        # fsGroup makes the RWO state volume group-writable by the rara user
+        # (uid/gid 10001) so the config dir, migrations, and the DB can be
+        # created on boot.
+        fsGroup: 10001
+        seccompProfile:
+          type: RuntimeDefault
+      # rara needs ONE complete, WRITABLE config.yaml: its config sync
+      # (ConfigFileSync) reads a single file as a full AppConfig and writes it
+      # back (KV → File), and the config dir holds writable runtime state
+      # (workspace/, settings.json, skills/). So the Secret (read-only) cannot
+      # BE the config file. This init container copies the complete config from
+      # the Secret into the writable, persistent config dir on the state
+      # volume, re-copying on every start so Secret edits take effect on the
+      # next pod restart.
+      initContainers:
+        - name: seed-config
+          image: rara-server:latest
+          imagePullPolicy: IfNotPresent
+          command:
+            - sh
+            - -c
+            - "mkdir -p /state/config/rara && cp /secret-src/config.yaml /state/config/rara/config.yaml"
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
+            readOnlyRootFilesystem: true
+          volumeMounts:
+            - name: secret
+              mountPath: /secret-src
+              readOnly: true
+            - name: state
+              mountPath: /state
+      containers:
+        - name: rara-server
+          # Built from docker/Dockerfile (linux/amd64). Replace with your
+          # registry ref once a publish pipeline exists (out of scope here).
+          image: rara-server:latest
+          imagePullPolicy: IfNotPresent
+          args: ["server"]
+          # config dir ($XDG_CONFIG_HOME/rara) -> /state/config/rara (writable)
+          # data dir   ($XDG_DATA_HOME/rara)   -> /state/data/rara   (writable)
+          env:
+            - name: XDG_CONFIG_HOME
+              value: /state/config
+            - name: XDG_DATA_HOME
+              value: /state/data
+          ports:
+            - name: http
+              containerPort: 25555
+            - name: grpc
+              containerPort: 50051
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
+            # rara writes to $HOME/.cache and the config/data dirs (mounted
+            # writable below); a read-only root FS would need extra emptyDir
+            # mounts for /home/rara. Left writable for MVP — future hardening.
+            readOnlyRootFilesystem: false
+          resources:
+            requests:
+              cpu: "250m"
+              memory: "256Mi"
+            limits:
+              cpu: "1"
+              memory: "1Gi"
+          # startupProbe covers first-boot migration time; liveness/readiness
+          # take over once the server answers. All three hit /api/health,
+          # which is why the config MUST bind 0.0.0.0 (see the Secret's
+          # config.yaml).
+          startupProbe:
+            httpGet:
+              path: /api/health
+              port: http
+            periodSeconds: 5
+            failureThreshold: 30
+          readinessProbe:
+            httpGet:
+              path: /api/health
+              port: http
+            periodSeconds: 10
+            failureThreshold: 3
+          livenessProbe:
+            httpGet:
+              path: /api/health
+              port: http
+            periodSeconds: 15
+            failureThreshold: 3
+          volumeMounts:
+            # Persistent, writable config + data dirs (single RWO volume).
+            - name: state
+              mountPath: /state
+      volumes:
+        # Complete config.yaml (incl. secrets) — consumed only by the init
+        # container, which copies it into the writable config dir. See
+        # secret.example.yaml.
+        - name: secret
+          secret:
+            secretName: rara-secrets
+        # Persistent, writable state: SQLite DB + sessions + memory (data dir)
+        # AND the config dir (config.yaml, settings.json, skills, workspace).
+        # ReadWriteOnce, single writer — see pvc.yaml.
+        - name: state
+          persistentVolumeClaim:
+            claimName: rara-data

--- a/deploy/k8s/pvc.yaml
+++ b/deploy/k8s/pvc.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: rara-data
+  labels:
+    app.kubernetes.io/name: rara
+    app.kubernetes.io/component: server
+spec:
+  # ReadWriteOnce: this single volume holds BOTH the writable config dir
+  # (config.yaml, settings.json, skills, workspace) and the data dir (the
+  # single-writer SQLite DB, sessions, memory). The Deployment is pinned to
+  # replicas=1 with strategy Recreate so it is never double-mounted / written
+  # by two pods at once — that would corrupt the DB. This also matches
+  # "rara is NOT multi-user".
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 5Gi
+  # storageClassName intentionally omitted → uses the cluster default class.
+  # An operator may set it, or swap this PVC for an external/managed volume.
+  # NEVER back a real deployment with emptyDir — memory would not survive a
+  # restart (goal signal #5).

--- a/deploy/k8s/secret.example.yaml
+++ b/deploy/k8s/secret.example.yaml
@@ -1,0 +1,71 @@
+# TEMPLATE — do NOT commit real secrets. Copy to secret.yaml, fill in the
+# REPLACE_WITH_* placeholders, and apply that copy. Keep the real file out of
+# git (add it to your local ignore).
+#
+# Secret-B model: rara needs ONE complete, WRITABLE config.yaml — its config
+# loader/sync (`ConfigFileSync`) reads a single file as a full AppConfig and
+# writes it back (KV -> File), and the config dir holds writable runtime state
+# (workspace/, settings.json, skills/). A partial overlay or read-only mount
+# does not work. Since the config must contain secrets (owner_token, LLM
+# api_key), the WHOLE config.yaml lives here in the Secret; the Deployment's
+# init container copies it into a writable dir on the PVC at startup.
+#
+# Secret material therefore NEVER lives in the image or in git — only here.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: rara-secrets
+  labels:
+    app.kubernetes.io/name: rara
+    app.kubernetes.io/component: server
+type: Opaque
+stringData:
+  # The complete rara config.yaml. Mirrors config.example.yaml with two
+  # container-specific changes: 0.0.0.0 binds (loopback is unreachable by the
+  # kubelet probe / Service) and NO sandbox block (sandbox disabled in this
+  # image). Replace both REPLACE_WITH_* values before applying.
+  config.yaml: |
+    # --- HTTP + gRPC: MUST bind 0.0.0.0 in a pod --------------------------
+    http:
+      bind_address: "0.0.0.0:25555"
+      # Browser origins allowed to call /api/v1/*. At least one entry is
+      # required. Add the origin your UI is served from for a real deploy.
+      cors_allowed_origins:
+        - "http://localhost:*"
+        - "http://127.0.0.1:*"
+    grpc:
+      bind_address: "0.0.0.0:50051"
+      server_address: "127.0.0.1:50051"
+
+    # --- Owner identity (owner_token is SECRET) ---------------------------
+    owner_token: "REPLACE_WITH_A_LONG_RANDOM_STRING"
+    owner_user_id: "you"
+
+    users:
+      - name: "you"
+        role: root
+        platforms: []
+
+    # --- Mita proactive agent (required) ----------------------------------
+    mita:
+      heartbeat_interval: "30m"
+
+    # --- LLM provider registry (api_key is SECRET) ------------------------
+    llm:
+      default_provider: "openrouter"
+      providers:
+        openrouter:
+          base_url: "https://openrouter.ai/api/v1"
+          api_key: "REPLACE_WITH_OPENROUTER_API_KEY"
+          default_model: "anthropic/claude-3.5-sonnet"
+
+    # --- Knowledge layer (required) ---------------------------------------
+    knowledge:
+      embedding_model: "text-embedding-3-small"
+      embedding_dimensions: 1536
+      search_top_k: 10
+      similarity_threshold: 0.85
+
+    # NOTE: no `sandbox:` block. The sandbox/microVM runtime is disabled in
+    # this image (built with BOXLITE_DEPS_STUB=1). Sandbox tools stay
+    # registered and return a clear "sandbox not configured" error.

--- a/deploy/k8s/service.yaml
+++ b/deploy/k8s/service.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: rara-server
+  labels:
+    app.kubernetes.io/name: rara
+    app.kubernetes.io/component: server
+spec:
+  # ClusterIP: the control-plane server is reached from inside the cluster
+  # (e.g. by the fleet dispatcher). Expose externally with an Ingress /
+  # LoadBalancer as needed — out of scope here.
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: rara
+    app.kubernetes.io/component: server
+  ports:
+    - name: http
+      port: 25555
+      targetPort: http
+    - name: grpc
+      port: 50051
+      targetPort: grpc

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,145 @@
+# syntax=docker/dockerfile:1
+#
+# Server-only, sandbox-disabled container image for the rara backend.
+#
+# This image ships ONLY the `rara server` control-plane process — no web
+# bundle, no nginx, no boxlite/microVM sandbox runtime. Untrusted-code
+# execution is deliberately NOT solved here; it is deferred to the fleet
+# microVM layer (see issue #2239 and the fleet direction, 2026-07-05).
+#
+# Target architecture: linux/amd64 ONLY. Both stages pin
+# `--platform=linux/amd64` so a bare `docker build` (no --platform flag)
+# still produces an amd64 image. arm64 is out of scope (doubles CI cost
+# and needs gcc-13 for the numkong SIMD build).
+#
+# Build:
+#   docker build -f docker/Dockerfile -t rara-server:smoke .
+#
+# The build is a full-workspace `cargo build --release` — expect it to be
+# slow on the first run. GitHub-hosted x64 runners build it natively; on an
+# arm64 dev machine it runs under QEMU emulation (slower still).
+
+# ---------------------------------------------------------------------------
+# Builder — ubuntu:24.04 (gcc-13). Do NOT downgrade to bookworm/gcc-12:
+# numkong's SIMD code fails to compile there.
+# ---------------------------------------------------------------------------
+FROM --platform=linux/amd64 ubuntu:24.04 AS builder
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+# System toolchain. This mirrors `.github/actions/setup-rara-build` plus the
+# extra bits a from-scratch container needs (git, curl, xz, ca-certificates):
+#   - libsqlite3-dev / libpq-dev : diesel (libsqlite3-sys, pq-sys) headers
+#   - protobuf-compiler          : api/build.rs (prost-build)
+#   - clang + mold               : `.cargo/config.toml` forces
+#                                  `-C link-arg=-fuse-ld=mold` + `linker=clang`
+#                                  on x86_64-unknown-linux-gnu
+#   - libssl-dev                 : openssl-sys (pulled in transitively via
+#                                  pq-sys/libpq); make the dep explicit
+#   - zlib1g-dev + pkg-config    : zlob / native deps
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        build-essential \
+        clang \
+        mold \
+        protobuf-compiler \
+        libsqlite3-dev \
+        libpq-dev \
+        libssl-dev \
+        zlib1g-dev \
+        pkg-config \
+        git \
+        curl \
+        xz-utils \
+        ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+# Rust toolchain via rustup. `rust-toolchain.toml` (channel = stable) is
+# honored automatically once the source tree is copied in, so we only need a
+# working rustup + stable here.
+ENV RUSTUP_HOME=/usr/local/rustup \
+    CARGO_HOME=/usr/local/cargo \
+    PATH=/usr/local/cargo/bin:$PATH
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
+      | sh -s -- -y --default-toolchain stable --profile minimal
+
+# Zig 0.16.0 — required unconditionally by `crates/app`'s zlob build.rs.
+# Not available via apt; download the official release tarball and put it on
+# PATH. Version kept in lockstep with .github/workflows/zig-codec-smoke.yml.
+ARG ZIG_VERSION=0.16.0
+RUN curl -fsSL "https://ziglang.org/download/${ZIG_VERSION}/zig-x86_64-linux-${ZIG_VERSION}.tar.xz" \
+      | tar -xJ -C /opt \
+    && ln -s "/opt/zig-x86_64-linux-${ZIG_VERSION}/zig" /usr/local/bin/zig \
+    && zig version
+
+WORKDIR /build
+COPY . .
+
+# BOXLITE_DEPS_STUB=1 stubs out the native boxlite dependency so the sandbox
+# subsystem builds without its microVM runtime. The sandbox is disabled in
+# this image (no sandbox block in the shipped config); its tools stay
+# registered and return a clear "sandbox not configured" error at runtime.
+ENV BOXLITE_DEPS_STUB=1
+
+# Build the CLI (`rara` binary) in release mode and stage it. The cache
+# mounts speed up local iterative rebuilds; the binary is copied OUT of the
+# ephemeral target/ cache within the same RUN so it survives into the layer.
+RUN --mount=type=cache,target=/usr/local/cargo/registry \
+    --mount=type=cache,target=/build/target \
+    cargo build --release --locked -p rara-cli \
+    && cp target/release/rara /usr/local/bin/rara
+
+# ---------------------------------------------------------------------------
+# Runtime — ubuntu:24.04 slim (NOT distroless): rara links libsqlite3, libpq
+# and zlib at runtime, so their shared objects must be present.
+# ---------------------------------------------------------------------------
+FROM --platform=linux/amd64 ubuntu:24.04 AS runtime
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Runtime shared objects + curl (for HEALTHCHECK). Dedicated non-root user.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        libsqlite3-0 \
+        libpq5 \
+        libssl3 \
+        zlib1g \
+        ca-certificates \
+        curl \
+    && rm -rf /var/lib/apt/lists/* \
+    && groupadd --gid 10001 rara \
+    && useradd --uid 10001 --gid 10001 --home-dir /home/rara \
+        --create-home --shell /usr/sbin/nologin rara \
+    && mkdir -p /config/rara /data /run/rara \
+    && chown -R rara:rara /home/rara /config /data /run/rara
+
+COPY --from=builder /usr/local/bin/rara /usr/local/bin/rara
+
+# Path wiring (rara's `rara-paths` crate honors XDG on Linux; `dirs` reads
+# XDG_CONFIG_HOME / XDG_DATA_HOME / HOME):
+#   - config (base, non-secret) : $XDG_CONFIG_HOME/rara/config.yaml
+#                                 -> /config/rara/config.yaml  (ConfigMap)
+#   - config (secret overlay)   : $CWD/config.yaml
+#                                 -> /run/rara/config.yaml     (Secret)
+#   - data (SQLite DB, sessions): $XDG_DATA_HOME/rara/...
+#                                 -> /data/rara/...            (PVC)
+# rara natively merges the two config files (global then local; local wins),
+# so secrets never need to live in the image or the ConfigMap.
+ENV HOME=/home/rara \
+    XDG_CONFIG_HOME=/config \
+    XDG_DATA_HOME=/data
+
+USER rara
+# CWD holds the optional secret overlay (./config.yaml). Empty when no
+# Secret is mounted, in which case only the base config is used.
+WORKDIR /run/rara
+
+# 25555 = HTTP (REST + WS), 50051 = gRPC. 25556 (gateway admin) is NOT
+# exposed — it stays pod-internal loopback.
+EXPOSE 25555 50051
+
+HEALTHCHECK --interval=15s --timeout=5s --start-period=45s --retries=5 \
+    CMD curl -sf --max-time 4 http://127.0.0.1:25555/api/health | grep -q healthy || exit 1
+
+# Run the server directly. In a pod the kubelet is the supervisor, so we do
+# NOT wrap it in the `rara gateway` process supervisor.
+ENTRYPOINT ["rara"]
+CMD ["server"]


### PR DESCRIPTION
## Summary

Server-only, sandbox-disabled **container image of the rara backend + plain k8s manifests + a CI build-smoke job**, so rara-server can run as an in-cluster control-plane process (the deploy substrate the fleet direction needs). No Rust source changed — containerization needs zero code changes.

- `docker/Dockerfile` — multi-stage, **linux/amd64 only**. Builder `ubuntu:24.04` (gcc-13) + zig 0.16.0 + clang/mold + `BOXLITE_DEPS_STUB=1`; runtime ubuntu slim (`libsqlite3`/`libpq`/`libssl`/`zlib`), non-root `rara` (uid 10001), HEALTHCHECK, `EXPOSE 25555 50051`, `ENTRYPOINT ["rara"]` / `CMD ["server"]`.
- `deploy/k8s/**` — Deployment (replicas 1, `Recreate`, non-root securityContext, resource requests/limits, startup+liveness+readiness probes on `/api/health`, **init container that copies the config into a writable dir**), Service (ClusterIP 25555/50051), RWO PVC (config + data), Secret template (complete `config.yaml`), deploy README.
- `.github/workflows/container-smoke.yml` — build the amd64 image → boot container → assert `/api/health` healthy. **No registry push** (does not re-introduce the publish pipeline #443 removed).
- `.dockerignore` — keep `.cargo/config.toml` (mold linker), drop heavy paths.

### Supersedes #443 (not a repeat)

`5ae9f916` removed a **web + nginx publish/distribution** pipeline as "no use case" for a local-first agent. This is a different artifact for a use case that appeared afterward (the fleet in-cluster control plane, 2026-07-05): **server-only, no web, no nginx, sandbox disabled, build-and-smoke only (no publish)**.

## Type of change

CI / Infrastructure — `ci` · `chore`

## Component

`ci`

## Closes

Closes #2239

## Key decisions (empirically settled during implementation)

- **amd64-only.** numkong SIMD + zlob/zig both compile cleanly on native **arm64 / `ubuntu:24.04` (gcc-13)** (verified: 0 SIMD/rosetta/build errors), so the spec's "arm64 out-of-scope for gcc/SIMD" premise no longer holds — amd64-only is a deliberate scope choice. Local `--platform=linux/amd64` builds on Apple Silicon fail under Rosetta at the zig step (`bss_size overflow`, a Rosetta limitation), so **the amd64 build+boot is verified by CI's `container-smoke.yml` on the native-amd64 runner — that is the amd64 oracle.**
- **Secret mechanism changed from decision-8 option-b → "Secret-B".** Decision-8 option-b (partial secret overlay merged via rara's two-file config precedence) is **incompatible** and was rejected on evidence: the initial `AppConfig::new()` merge succeeds (owner auth resolved from the overlay), but `ConfigFileSync` then resolves a **single** path and parses/writes it back as a **complete** `AppConfig`, so a partial overlay crashes with `missing field owner_user_id`. rara also writes into its config dir at runtime (`workspace/`, `settings.json`, `mcp-servers.json`). So the whole `config.yaml` (incl. secrets) lives in the **`rara-secrets` Secret**, and an **init container copies it into a writable dir on the PVC**. No ConfigMap. Keys never enter the image or git.
- **Bind `0.0.0.0`** (loopback is unreachable by the kubelet probe / Service; `PORT` only rewrites the port, not the host) and **no `sandbox:` block** (sandbox disabled; tools degrade gracefully).
- **Single-replica / `Recreate` / RWO PVC** — the SQLite DB has one writer; also keeps "rara is NOT multi-user".

> Note: the issue's Verify step #4 (`grep configmap`) is superseded by this Secret-only design; the CI smoke's config assertion is re-targeted to `deploy/k8s/secret.example.yaml`.

## Verification

**Verifier: PASS** (arch-independent scope). amd64 image build+boot is CI-gated (see `container-smoke.yml` below) — the one part that cannot be verified on an Apple-Silicon host.

Reproduced locally on a **native arm64 build** of the same recipe (arch-independent behavior):

- Secret-B flow (init-container-copy → writable dir → boot): `/api/health` → `{"service":"job","status":"healthy","version":"0.0.1"}`; Docker HEALTHCHECK `Up (healthy)`; **clean logs, no read-only/writeback error**.
- Writable config dir proven: rara created `workspace/`, `settings.json`, `mcp-servers.json`, `marketplaces.json` next to the copied `config.yaml`; DB (`rara.db` + `-wal`/`-shm`) written to the data dir.
- Runs non-root: `uid=10001(rara)` at runtime.

Gate: `prek run --all-files` ✓ · `kubectl apply --dry-run=client -f deploy/k8s/` ✓ (4 resources) · `zizmor` ✓ · `actionlint` ✓ · `yamllint-rs` ✓.

## Test plan

- [x] `prek run --all-files` passes
- [x] `kubectl apply --dry-run=client -f deploy/k8s/` valid
- [x] Native-arm64 image builds, boots, `/api/health → healthy` (Secret-B writable-copy path)
- [ ] **CI `container-smoke` (amd64 oracle) green** — the authoritative amd64 build+boot check

🤖 Generated with [Claude Code](https://claude.com/claude-code)
