### PR TITLE
feat(data-feeds): configure market feed presets

### DIFF
--- a/crates/extensions/backend-admin/src/data_feeds/router.rs
+++ b/crates/extensions/backend-admin/src/data_feeds/router.rs
@@ -33,6 +33,7 @@ use std::{collections::HashMap, sync::Arc};
 
 use axum::{
     Json, Router,
+    body::Bytes,
     extract::{Path, Query, State},
     http::StatusCode,
     routing::{get, post, put},
@@ -121,6 +122,17 @@ struct UpdateFeedRequest {
     /// Pass `null` to clear auth, omit the field to keep existing auth.
     #[serde(default, deserialize_with = "deserialize_optional_field")]
     auth:      Option<Option<serde_json::Value>>,
+}
+
+/// Optional request body for enabling a built-in catalog feed.
+///
+/// Ready sources can still be enabled with an empty body. Provider presets can
+/// be materialized by supplying the operator-owned transport/auth details in
+/// this body.
+#[derive(Debug, Default, Deserialize)]
+struct EnableCatalogFeedRequest {
+    transport: Option<serde_json::Value>,
+    auth:      Option<serde_json::Value>,
 }
 
 /// Deserialize a double-`Option` field so that:
@@ -243,6 +255,7 @@ async fn enable_catalog_feed(
         rara_kernel::identity::Principal<rara_kernel::identity::Resolved>,
     >,
     Path(id): Path<String>,
+    body: Bytes,
 ) -> Result<(StatusCode, Json<DataFeedConfig>), ProblemDetails> {
     if !principal.is_admin() {
         return Err(ProblemDetails::forbidden(
@@ -251,15 +264,27 @@ async fn enable_catalog_feed(
     }
 
     let source = find_catalog_source(&id)?;
-    if !source.can_enable() {
+    let request = parse_enable_catalog_feed_request(&body)?;
+    if !source.can_enable() && request.transport.is_none() {
         return Err(ProblemDetails::bad_request(format!(
             "catalog source requires configuration before it can be enabled: {id}"
         )));
     }
     let feed_name = source.feed_name();
-    let transport = source.transport.clone().ok_or_else(|| {
-        ProblemDetails::bad_request(format!("catalog source has no transport template: {id}"))
-    })?;
+    let transport = catalog_transport(source.transport.clone(), request.transport, &id)?;
+    let auth_value = match request.auth {
+        Some(auth) => Some(auth),
+        None => source
+            .auth
+            .clone()
+            .map(serde_json::to_value)
+            .transpose()
+            .map_err(|e| ProblemDetails::bad_request(format!("invalid auth config: {e}")))?,
+    };
+    let auth = auth_value
+        .map(serde_json::from_value)
+        .transpose()
+        .map_err(|e| ProblemDetails::bad_request(format!("invalid auth config: {e}")))?;
     let existing = state
         .svc
         .list_feeds()
@@ -272,30 +297,32 @@ async fn enable_catalog_feed(
         let updated = DataFeedConfig::builder()
             .id(existing.id)
             .name(feed_name)
-            .feed_type(source.feed_type)
-            .tags(source.tags)
-            .transport(transport)
-            .maybe_auth(source.auth)
+            .feed_type(source.feed_type.clone())
+            .tags(source.tags.clone())
+            .transport(transport.clone())
+            .maybe_auth(auth.clone())
             .enabled(true)
             .status(FeedStatus::Idle)
             .created_at(existing.created_at)
             .updated_at(now)
             .build();
+        validate_active_feed_config(&updated)?;
         state.svc.update_feed(&updated).await?;
         (StatusCode::OK, updated)
     } else {
         let created = DataFeedConfig::builder()
             .id(Uuid::new_v4().to_string())
             .name(feed_name)
-            .feed_type(source.feed_type)
-            .tags(source.tags)
+            .feed_type(source.feed_type.clone())
+            .tags(source.tags.clone())
             .transport(transport)
-            .maybe_auth(source.auth)
+            .maybe_auth(auth)
             .enabled(true)
             .status(FeedStatus::Idle)
             .created_at(now)
             .updated_at(now)
             .build();
+        validate_active_feed_config(&created)?;
         state.svc.create_feed(&created).await?;
         (StatusCode::CREATED, created)
     };
@@ -819,6 +846,59 @@ fn find_catalog_source(id: &str) -> Result<DefaultFeedSource, ProblemDetails> {
         })
 }
 
+fn parse_enable_catalog_feed_request(
+    body: &[u8],
+) -> Result<EnableCatalogFeedRequest, ProblemDetails> {
+    if body.iter().all(u8::is_ascii_whitespace) {
+        return Ok(EnableCatalogFeedRequest::default());
+    }
+    serde_json::from_slice(body)
+        .map_err(|e| ProblemDetails::bad_request(format!("invalid catalog enable body: {e}")))
+}
+
+fn catalog_transport(
+    template: Option<serde_json::Value>,
+    override_value: Option<serde_json::Value>,
+    id: &str,
+) -> Result<serde_json::Value, ProblemDetails> {
+    match (template, override_value) {
+        (Some(serde_json::Value::Object(mut base)), Some(serde_json::Value::Object(overrides))) => {
+            for (key, value) in overrides {
+                base.insert(key, value);
+            }
+            Ok(serde_json::Value::Object(base))
+        }
+        (Some(_), Some(override_value @ serde_json::Value::Object(_))) => Ok(override_value),
+        (None, Some(override_value @ serde_json::Value::Object(_))) => Ok(override_value),
+        (Some(template), None) => Ok(template),
+        (None, None) => Err(ProblemDetails::bad_request(format!(
+            "catalog source has no transport template: {id}"
+        ))),
+        (_, Some(_)) => Err(ProblemDetails::bad_request(
+            "catalog enable transport must be a JSON object",
+        )),
+    }
+}
+
+fn validate_active_feed_config(config: &DataFeedConfig) -> Result<(), ProblemDetails> {
+    match config.feed_type {
+        FeedType::Polling => PollingSource::from_config(config)
+            .map(|_| ())
+            .map_err(|e| ProblemDetails::bad_request(format!("invalid polling feed config: {e}"))),
+        FeedType::Rss => RssSource::from_config(config)
+            .map(|_| ())
+            .map_err(|e| ProblemDetails::bad_request(format!("invalid rss feed config: {e}"))),
+        FeedType::MarketCandle => {
+            MarketCandleSource::from_config(config)
+                .map(|_| ())
+                .map_err(|e| {
+                    ProblemDetails::bad_request(format!("invalid market candle feed config: {e}"))
+                })
+        }
+        FeedType::Webhook | FeedType::WebSocket => Ok(()),
+    }
+}
+
 fn sync_registry_and_maybe_start(config: &DataFeedConfig, registry: &Arc<DataFeedRegistry>) {
     let _ = registry.remove(&config.name);
     if let Err(e) = registry.register(config.clone()) {
@@ -1155,6 +1235,51 @@ mod tests {
             .unwrap();
 
         assert_eq!(res.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn finance_catalog_enable_accepts_market_preset_configuration() {
+        let app = app_with_user(user_of(Role::Admin)).await;
+        let res = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/v1/data-feeds/catalog/longbridge-market-candles/enable")
+                    .header("Authorization", "Bearer s3cret")
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        serde_json::json!({
+                            "transport": {
+                                "url": "https://market-data.local/longbridge/candles/latest",
+                                "interval_secs": 120,
+                                "headers": {},
+                                "venue": "longbridge",
+                                "symbols": ["AAPL.US", "NVDA.US"],
+                                "timeframes": ["1d"],
+                                "max_candles_per_poll": 500
+                            }
+                        })
+                        .to_string(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(res.status(), StatusCode::CREATED);
+
+        let body = axum::body::to_bytes(res.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let feed: DataFeedConfig = serde_json::from_slice(&body).unwrap();
+
+        assert_eq!(feed.name, "finance-longbridge-market-candles");
+        assert_eq!(feed.feed_type, FeedType::MarketCandle);
+        assert_eq!(feed.transport["venue"], "longbridge");
+        assert_eq!(feed.transport["symbols"][0], "AAPL.US");
+        assert_eq!(feed.transport["timeframes"][0], "1d");
+        assert_eq!(feed.transport["interval_secs"], 120);
+        assert!(feed.enabled);
     }
 
     #[tokio::test]

--- a/web/e2e/harness/data-feeds.spec.ts
+++ b/web/e2e/harness/data-feeds.spec.ts
@@ -211,6 +211,7 @@ async function setupRoutes(
     events: FeedEvent[];
     summaries?: FeedSummary[];
     catalog?: FeedCatalogEntry[];
+    lastCatalogEnableBody?: unknown;
   },
 ) {
   // Suppress onboarding & connection dialogs via localStorage.
@@ -264,14 +265,22 @@ async function setupRoutes(
       return;
     }
 
+    const body = request.postData()
+      ? (request.postDataJSON() as {
+          transport?: Record<string, unknown>;
+          auth?: { type: string; [key: string]: unknown } | null;
+        })
+      : {};
+    state.lastCatalogEnableBody = body;
+
     const now = new Date().toISOString();
     const feed: DataFeedConfig = {
       id: entry.feed_id ?? `feed-${entry.id}`,
       name: `finance-${entry.id}`,
       feed_type: entry.feed_type,
       tags: entry.tags,
-      transport: entry.transport_template ?? {},
-      auth: null,
+      transport: { ...(entry.transport_template ?? {}), ...(body.transport ?? {}) },
+      auth: body.auth ?? null,
       enabled: true,
       status: 'running',
       last_error: null,
@@ -532,6 +541,62 @@ test.describe('Data Feeds Management', () => {
       'finance-longbridge-market-candles',
     );
     await expect(page.locator('input[placeholder="binance"]')).toHaveValue('longbridge');
+  });
+
+  test('provider preset can be configured and enabled from the catalog', async ({ page }) => {
+    const state = {
+      feeds: [] as DataFeedConfig[],
+      events: [] as FeedEvent[],
+      lastCatalogEnableBody: null as unknown,
+      catalog: [
+        {
+          id: 'longbridge-market-candles',
+          name: 'Longbridge Market Data',
+          description: 'Preset for Longbridge equities market data.',
+          feed_type: 'market_candle' as const,
+          tags: ['finance', 'market-data', 'equities', 'longbridge'],
+          enabled: false,
+          feed_id: null,
+          requires_configuration: true,
+          setup_hint: 'Connect Longbridge credentials behind a normalized candle endpoint.',
+          transport_template: {
+            url: '',
+            interval_secs: 60,
+            headers: {},
+            venue: 'longbridge',
+            symbols: [],
+            timeframes: [],
+            max_candles_per_poll: 1000,
+          },
+        },
+      ],
+    };
+    await setupRoutes(page, state);
+    await goToDataFeeds(page);
+
+    await page.getByRole('button', { name: 'Configure' }).click();
+
+    await expect(page.getByText('Configure Longbridge Market Data')).toBeVisible({
+      timeout: 5_000,
+    });
+    await page
+      .locator('input[placeholder="https://market-data.example/candles/latest"]')
+      .fill('https://market-data.local/longbridge/candles/latest');
+    await page.locator('input[placeholder="BTCUSDT, ETHUSDT"]').fill('AAPL.US, NVDA.US');
+    await page.locator('input[placeholder="1m, 15m, 1h"]').fill('1d');
+    await page.getByRole('button', { name: 'Enable source' }).click();
+
+    await expect(page.getByText('finance-longbridge-market-candles')).toBeVisible({
+      timeout: 5_000,
+    });
+    expect(state.lastCatalogEnableBody).toMatchObject({
+      transport: {
+        url: 'https://market-data.local/longbridge/candles/latest',
+        venue: 'longbridge',
+        symbols: ['AAPL.US', 'NVDA.US'],
+        timeframes: ['1d'],
+      },
+    });
   });
 
   // -----------------------------------------------------------------------

--- a/web/src/api/data-feeds.ts
+++ b/web/src/api/data-feeds.ts
@@ -87,6 +87,11 @@ export interface FeedCatalogEntry {
   transport_template: Record<string, unknown> | null;
 }
 
+export interface EnableCatalogEntryRequest {
+  transport?: Record<string, unknown>;
+  auth?: AuthConfig | null;
+}
+
 // ---------------------------------------------------------------------------
 // API client
 // ---------------------------------------------------------------------------
@@ -109,8 +114,8 @@ export const dataFeedsApi = {
 
   toggle: (id: string) => api.put<DataFeedConfig>(`/api/v1/data-feeds/${id}/toggle`),
 
-  enableCatalogEntry: (id: string) =>
-    api.post<DataFeedConfig>(`/api/v1/data-feeds/catalog/${id}/enable`),
+  enableCatalogEntry: (id: string, body?: EnableCatalogEntryRequest) =>
+    api.post<DataFeedConfig>(`/api/v1/data-feeds/catalog/${id}/enable`, body),
 
   disableCatalogEntry: (id: string) =>
     api.post<DataFeedConfig>(`/api/v1/data-feeds/catalog/${id}/disable`),

--- a/web/src/components/DataFeedsPanel.tsx
+++ b/web/src/components/DataFeedsPanel.tsx
@@ -35,6 +35,7 @@ import {
   type FeedEvent,
   type FeedSummary,
   type CreateFeedRequest,
+  type EnableCatalogEntryRequest,
   type AuthType,
 } from '@/api/data-feeds';
 import { JsonTree } from '@/components/JsonTree';
@@ -1007,6 +1008,151 @@ function EventHistoryView({ feed, onBack }: { feed: DataFeedConfig; onBack: () =
 // Feed List View
 // ---------------------------------------------------------------------------
 
+function catalogEntryToForm(entry: FeedCatalogEntry): FeedFormState {
+  return {
+    name: `finance-${entry.id}`,
+    feed_type: entry.feed_type,
+    tags: entry.tags.join(', '),
+    transport: entry.transport_template ?? emptyTransport(entry.feed_type),
+    authType: 'none',
+    authFields: {},
+  };
+}
+
+function buildCatalogEnableRequest(form: FeedFormState): EnableCatalogEntryRequest {
+  const req = formToRequest(form);
+  return {
+    transport: req.transport,
+    auth: req.auth,
+  };
+}
+
+function validateCatalogEnableForm(form: FeedFormState): string | null {
+  if (form.feed_type !== 'market_candle') return null;
+
+  const provider = String(form.transport.provider ?? 'normalized');
+  const url = String(form.transport.url ?? '').trim();
+  if (provider === 'normalized' && !url) return 'Normalized candle endpoint is required';
+
+  if (!Array.isArray(form.transport.symbols) || form.transport.symbols.length === 0) {
+    return 'At least one symbol is required';
+  }
+
+  if (!Array.isArray(form.transport.timeframes) || form.transport.timeframes.length === 0) {
+    return 'At least one timeframe is required';
+  }
+
+  return null;
+}
+
+function CatalogConfigureDialog({
+  entry,
+  onOpenChange,
+  onSubmit,
+  saving,
+  serverError,
+}: {
+  entry: FeedCatalogEntry | null;
+  onOpenChange: (open: boolean) => void;
+  onSubmit: (body: EnableCatalogEntryRequest) => void;
+  saving: boolean;
+  serverError: string | null;
+}) {
+  const [form, setForm] = useState<FeedFormState>(entry ? catalogEntryToForm(entry) : INITIAL_FORM);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!entry) return;
+    setForm(catalogEntryToForm(entry));
+    setError(null);
+  }, [entry]);
+
+  const handleSubmit = () => {
+    const validationError = validateCatalogEnableForm(form);
+    if (validationError) {
+      setError(validationError);
+      return;
+    }
+    setError(null);
+    onSubmit(buildCatalogEnableRequest(form));
+  };
+
+  return (
+    <Dialog open={!!entry} onOpenChange={onOpenChange}>
+      <DialogContent className="max-h-[85vh] overflow-y-auto sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle>{entry ? `Configure ${entry.name}` : 'Configure source'}</DialogTitle>
+          <DialogDescription>
+            Fill the operator-owned feed settings, then materialize this built-in source.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4 py-2">
+          <div className="space-y-1.5">
+            <Label className="text-sm font-medium">Transport</Label>
+            <TransportFields
+              feedType={form.feed_type}
+              transport={form.transport}
+              onChange={(transport) => setForm({ ...form, transport })}
+            />
+          </div>
+
+          <div className="space-y-1.5">
+            <Label className="text-sm font-medium">Authentication</Label>
+            <Select
+              value={form.authType}
+              onValueChange={(v) => {
+                setForm({
+                  ...form,
+                  authType: v as FeedFormState['authType'],
+                  authFields: {},
+                });
+              }}
+            >
+              <SelectTrigger className="h-9 w-48">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="none">None</SelectItem>
+                <SelectItem value="header">API Key (Header)</SelectItem>
+                <SelectItem value="query">API Key (Query)</SelectItem>
+                <SelectItem value="bearer">Bearer Token</SelectItem>
+                <SelectItem value="basic">Basic Auth</SelectItem>
+                <SelectItem value="hmac">HMAC Signature</SelectItem>
+              </SelectContent>
+            </Select>
+            {form.authType !== 'none' && (
+              <div className="mt-3">
+                <AuthFields
+                  authType={form.authType}
+                  fields={form.authFields}
+                  onChange={(authFields) => setForm({ ...form, authFields })}
+                />
+              </div>
+            )}
+          </div>
+
+          {(error || serverError) && (
+            <div className="flex items-center gap-2 rounded-lg border border-destructive/30 bg-destructive/5 px-3 py-2 text-sm text-destructive">
+              <AlertTriangle className="h-4 w-4 shrink-0" />
+              {error ?? serverError}
+            </div>
+          )}
+        </div>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)} disabled={saving}>
+            Cancel
+          </Button>
+          <Button onClick={handleSubmit} disabled={saving}>
+            {saving ? 'Enabling...' : 'Enable source'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
 function FeedCatalogCard({
   entries,
   onUseTemplate,
@@ -1015,14 +1161,17 @@ function FeedCatalogCard({
   onUseTemplate: (entry: FeedCatalogEntry) => void;
 }) {
   const queryClient = useQueryClient();
+  const [configureEntry, setConfigureEntry] = useState<FeedCatalogEntry | null>(null);
 
   const refresh = () => {
     void queryClient.invalidateQueries({ queryKey: ['data-feeds'] });
     void queryClient.invalidateQueries({ queryKey: ['data-feed-catalog'] });
+    void queryClient.invalidateQueries({ queryKey: ['data-feed-summaries'] });
   };
 
   const enableMutation = useMutation({
-    mutationFn: (id: string) => dataFeedsApi.enableCatalogEntry(id),
+    mutationFn: ({ id, body }: { id: string; body?: EnableCatalogEntryRequest }) =>
+      dataFeedsApi.enableCatalogEntry(id, body),
     onSuccess: refresh,
   });
 
@@ -1038,7 +1187,7 @@ function FeedCatalogCard({
 
   const renderEntry = (entry: FeedCatalogEntry) => {
     const pending =
-      (enableMutation.isPending && enableMutation.variables === entry.id) ||
+      (enableMutation.isPending && enableMutation.variables?.id === entry.id) ||
       (disableMutation.isPending && disableMutation.variables === entry.id);
 
     return (
@@ -1068,14 +1217,24 @@ function FeedCatalogCard({
           <p className="text-[11px] text-muted-foreground">Tags: {entry.tags.join(' · ')}</p>
         </div>
         {entry.requires_configuration ? (
-          <Button
-            variant="outline"
-            size="sm"
-            className="h-8 shrink-0"
-            onClick={() => onUseTemplate(entry)}
-          >
-            Use template
-          </Button>
+          <div className="flex shrink-0 gap-2">
+            <Button
+              size="sm"
+              className="h-8"
+              onClick={() => setConfigureEntry(entry)}
+              disabled={pending}
+            >
+              Configure
+            </Button>
+            <Button
+              variant="outline"
+              size="sm"
+              className="h-8"
+              onClick={() => onUseTemplate(entry)}
+            >
+              Use template
+            </Button>
+          </div>
         ) : entry.enabled ? (
           <Button
             variant="outline"
@@ -1090,7 +1249,7 @@ function FeedCatalogCard({
           <Button
             size="sm"
             className="h-8 shrink-0"
-            onClick={() => enableMutation.mutate(entry.id)}
+            onClick={() => enableMutation.mutate({ id: entry.id })}
             disabled={pending}
           >
             {pending ? 'Enabling...' : 'Enable'}
@@ -1101,32 +1260,56 @@ function FeedCatalogCard({
   };
 
   return (
-    <div className="rounded-lg border bg-card">
-      <div className="border-b px-4 py-3">
-        <h3 className="text-sm font-semibold">Default finance sources</h3>
-        <p className="text-xs text-muted-foreground">
-          Ready sources can run immediately. Provider presets need your own endpoint or credentials.
-        </p>
-      </div>
-      <div className="divide-y">
-        {readyEntries.length > 0 && (
-          <div>
-            <div className="px-4 pt-3 text-xs font-medium text-muted-foreground">
-              Ready to enable
+    <>
+      <div className="rounded-lg border bg-card">
+        <div className="border-b px-4 py-3">
+          <h3 className="text-sm font-semibold">Default finance sources</h3>
+          <p className="text-xs text-muted-foreground">
+            Ready sources can run immediately. Provider presets need your own endpoint or
+            credentials.
+          </p>
+        </div>
+        <div className="divide-y">
+          {readyEntries.length > 0 && (
+            <div>
+              <div className="px-4 pt-3 text-xs font-medium text-muted-foreground">
+                Ready to enable
+              </div>
+              {readyEntries.map(renderEntry)}
             </div>
-            {readyEntries.map(renderEntry)}
-          </div>
-        )}
-        {providerEntries.length > 0 && (
-          <div>
-            <div className="px-4 pt-3 text-xs font-medium text-muted-foreground">
-              Provider presets
+          )}
+          {providerEntries.length > 0 && (
+            <div>
+              <div className="px-4 pt-3 text-xs font-medium text-muted-foreground">
+                Provider presets
+              </div>
+              {providerEntries.map(renderEntry)}
             </div>
-            {providerEntries.map(renderEntry)}
-          </div>
-        )}
+          )}
+        </div>
       </div>
-    </div>
+      <CatalogConfigureDialog
+        entry={configureEntry}
+        onOpenChange={(open) => {
+          if (!open) setConfigureEntry(null);
+        }}
+        onSubmit={(body) => {
+          if (!configureEntry) return;
+          enableMutation.mutate(
+            { id: configureEntry.id, body },
+            {
+              onSuccess: () => setConfigureEntry(null),
+            },
+          );
+        }}
+        saving={enableMutation.isPending && enableMutation.variables?.id === configureEntry?.id}
+        serverError={
+          enableMutation.isError && enableMutation.variables?.id === configureEntry?.id
+            ? enableMutation.error.message
+            : null
+        }
+      />
+    </>
   );
 }
 


### PR DESCRIPTION
## Summary
- allow built-in feed catalog enable calls to carry operator-provided transport/auth configuration
- validate active catalog feed configs before persisting or starting them
- add Data Feeds UI flow to configure provider presets directly from the catalog while preserving Use template

## Verification
- cargo test -p rara-backend-admin finance_catalog_ -- --nocapture
- cargo clippy -p rara-backend-admin -- -D warnings
- npm --prefix web run typecheck
- npm --prefix web run format:check
- npm --prefix web run build
- npm --prefix web run test:e2e -- data-feeds.spec.ts