### PR TITLE
feat(data-feeds): expand default finance presets

### DIFF
--- a/crates/extensions/rara-trading/src/feed/catalog.rs
+++ b/crates/extensions/rara-trading/src/feed/catalog.rs
@@ -83,6 +83,18 @@ pub fn default_finance_feed_sources() -> Vec<DefaultFeedSource> {
             "Binance Market Candles",
             "Public Binance spot OHLCV feed for BTCUSDT and ETHUSDT 1m candles.",
             ["finance", "market-data", "crypto", "binance"],
+            &["BTCUSDT", "ETHUSDT"],
+            &["1m"],
+            60,
+        ),
+        binance_market_candles_source(
+            "binance-major-crypto-15m",
+            "Binance Major Crypto 15m",
+            "Public Binance spot OHLCV feed for major crypto USDT pairs on 15m candles.",
+            ["finance", "market-data", "crypto", "binance"],
+            &["BTCUSDT", "ETHUSDT", "SOLUSDT", "BNBUSDT", "XRPUSDT"],
+            &["15m"],
+            300,
         ),
         provider_preset(
             "longbridge-market-candles",
@@ -91,6 +103,8 @@ pub fn default_finance_feed_sources() -> Vec<DefaultFeedSource> {
             "longbridge",
             ["finance", "market-data", "equities", "longbridge"],
             "Connect Longbridge credentials behind a normalized candle endpoint before enabling.",
+            &["AAPL.US", "NVDA.US", "700.HK"],
+            &["1d"],
         ),
     ]
 }
@@ -126,6 +140,9 @@ fn binance_market_candles_source(
     name: &str,
     description: &str,
     tags: impl IntoIterator<Item = &'static str>,
+    symbols: &[&str],
+    timeframes: &[&str],
+    interval_secs: u64,
 ) -> DefaultFeedSource {
     DefaultFeedSource {
         id:                     id.to_owned(),
@@ -136,11 +153,11 @@ fn binance_market_candles_source(
         transport:              Some(serde_json::json!({
             "provider": "binance",
             "base_url": "https://api.binance.com",
-            "interval_secs": 60,
+            "interval_secs": interval_secs,
             "headers": {},
             "venue": "binance",
-            "symbols": ["BTCUSDT", "ETHUSDT"],
-            "timeframes": ["1m"],
+            "symbols": symbols,
+            "timeframes": timeframes,
             "max_candles_per_poll": 1000
         })),
         auth:                   None,
@@ -156,6 +173,8 @@ fn provider_preset(
     venue: &str,
     tags: impl IntoIterator<Item = &'static str>,
     setup_hint: &str,
+    symbols: &[&str],
+    timeframes: &[&str],
 ) -> DefaultFeedSource {
     DefaultFeedSource {
         id:                     id.to_owned(),
@@ -168,12 +187,120 @@ fn provider_preset(
             "interval_secs": 60,
             "headers": {},
             "venue": venue,
-            "symbols": [],
-            "timeframes": [],
+            "symbols": symbols,
+            "timeframes": timeframes,
             "max_candles_per_poll": 1000
         })),
         auth:                   None,
         requires_configuration: true,
         setup_hint:             Some(setup_hint.to_owned()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashSet;
+
+    use rara_kernel::data_feed::{DataFeedConfig, FeedStatus, FeedType};
+
+    use super::default_finance_feed_sources;
+    use crate::feed::{market_candle::MarketCandleSource, rss::RssSource};
+
+    #[test]
+    fn catalog_ids_and_feed_names_are_unique() {
+        let catalog = default_finance_feed_sources();
+        let mut ids = HashSet::new();
+        let mut feed_names = HashSet::new();
+
+        for source in catalog {
+            assert!(!source.id.trim().is_empty());
+            assert!(ids.insert(source.id.clone()), "duplicate id {}", source.id);
+            assert!(
+                feed_names.insert(source.feed_name()),
+                "duplicate feed name for {}",
+                source.id
+            );
+            assert!(
+                source.tags.iter().any(|tag| tag == "finance"),
+                "{} must include finance tag",
+                source.id
+            );
+        }
+    }
+
+    #[test]
+    fn ready_catalog_sources_have_valid_transport_templates() {
+        for source in default_finance_feed_sources()
+            .into_iter()
+            .filter(|source| source.can_enable())
+        {
+            let config = DataFeedConfig::builder()
+                .id(format!("test-{}", source.id))
+                .name(source.feed_name())
+                .feed_type(source.feed_type)
+                .tags(source.tags)
+                .transport(
+                    source
+                        .transport
+                        .expect("ready source must have a transport template"),
+                )
+                .maybe_auth(source.auth)
+                .enabled(true)
+                .status(FeedStatus::Idle)
+                .created_at(jiff::Timestamp::UNIX_EPOCH)
+                .updated_at(jiff::Timestamp::UNIX_EPOCH)
+                .build();
+
+            match config.feed_type {
+                FeedType::Rss => {
+                    RssSource::from_config(&config)
+                        .unwrap_or_else(|err| panic!("{} should be valid: {err}", config.name));
+                }
+                FeedType::MarketCandle => {
+                    MarketCandleSource::from_config(&config)
+                        .unwrap_or_else(|err| panic!("{} should be valid: {err}", config.name));
+                }
+                other => panic!("unexpected ready finance feed type {other:?}"),
+            }
+        }
+    }
+
+    #[test]
+    fn catalog_contains_public_binance_15m_major_crypto_preset() {
+        let source = default_finance_feed_sources()
+            .into_iter()
+            .find(|source| source.id == "binance-major-crypto-15m")
+            .expect("missing Binance major crypto 15m preset");
+
+        assert!(source.can_enable());
+        assert_eq!(source.feed_type, FeedType::MarketCandle);
+        let transport = source.transport.expect("transport template");
+        assert_eq!(transport["provider"], "binance");
+        assert_eq!(transport["venue"], "binance");
+        assert_eq!(transport["timeframes"], serde_json::json!(["15m"]));
+        assert_eq!(
+            transport["symbols"],
+            serde_json::json!(["BTCUSDT", "ETHUSDT", "SOLUSDT", "BNBUSDT", "XRPUSDT"])
+        );
+    }
+
+    #[test]
+    fn longbridge_preset_is_prefilled_but_requires_operator_endpoint() {
+        let source = default_finance_feed_sources()
+            .into_iter()
+            .find(|source| source.id == "longbridge-market-candles")
+            .expect("missing Longbridge preset");
+
+        assert!(!source.can_enable());
+        assert!(source.requires_configuration);
+        assert!(source.setup_hint.is_some());
+        let transport = source.transport.expect("transport template");
+        assert_eq!(transport["venue"], "longbridge");
+        assert_eq!(
+            transport["symbols"],
+            serde_json::json!(["AAPL.US", "NVDA.US", "700.HK"])
+        );
+        assert_eq!(transport["timeframes"], serde_json::json!(["1d"]));
+        assert_eq!(transport["url"], "");
     }
 }

--- a/docs/guides/finance-subscriptions.md
+++ b/docs/guides/finance-subscriptions.md
@@ -59,9 +59,10 @@ The Settings → Data Feeds panel lists built-in finance sources under "Default
 finance sources":
 
 - official RSS feeds that can be enabled immediately;
-- provider presets such as Binance and Longbridge that prefill a
-  `market_candle` configuration but still require an operator-managed endpoint
-  or credentials.
+- ready public market-data feeds such as Binance spot candles;
+- provider presets such as Longbridge that prefill a `market_candle`
+  configuration but still require an operator-managed normalized endpoint or
+  credentials.
 
 Enabling a ready source creates or re-enables a deterministic data feed named
 `finance-{catalog_id}`; disabling it turns the feed off without deleting the
@@ -71,10 +72,12 @@ config row. The same catalog is available through the authenticated admin API:
 - `POST /api/v1/data-feeds/catalog/{id}/enable`
 - `POST /api/v1/data-feeds/catalog/{id}/disable`
 
-Built-in provider presets are not directly enabled by the catalog API. A direct
-enable attempt returns `400 Bad Request` until the operator supplies a complete
-feed configuration. Market-candle feeds still require an operator-managed
-normalized endpoint.
+Ready catalog entries can be enabled with an empty body. Provider presets that
+require setup return `400 Bad Request` without operator configuration, but can
+be materialized by supplying a complete `transport` and optional `auth` body to
+`POST /api/v1/data-feeds/catalog/{id}/enable`. The body is merged over the
+catalog template, so a Longbridge preset can keep its default symbols/timeframe
+while the operator supplies the normalized endpoint and credentials.
 
 Custom finance feeds can also be created through the authenticated admin API.
 Example payloads are documented in `config.example.yaml`.
@@ -95,7 +98,7 @@ RSS/Atom:
 }
 ```
 
-Latest closed candles:
+Latest closed candles through an operator-managed normalized endpoint:
 
 ```json
 {
@@ -116,6 +119,10 @@ Latest closed candles:
 
 The market-candle endpoint must return normalized JSON with decimal strings.
 Only `closed: true` bars are emitted. In-progress bars are ignored in the MVP.
+
+Ready Binance catalog entries use Binance's public spot kline API directly and
+do not require rara to hold exchange credentials. They still emit only
+`market_candle_closed` feed events.
 
 ## Conversation tools
 


### PR DESCRIPTION
## Summary
- add a ready Binance major-crypto 15m market-candle preset
- prefill Longbridge market-data preset with default symbols/timeframe while keeping operator endpoint configuration required
- add catalog invariant tests and update finance subscription operator docs

## Verification
- cargo test -p rara-trading feed::catalog::tests -- --nocapture
- cargo test -p rara-backend-admin finance_catalog_ -- --nocapture
- cargo +nightly fmt --check --all
- cargo clippy -p rara-trading -p rara-backend-admin -- -D warnings
- commit hook: cargo check, cargo fmt, cargo clippy, cargo doc