### PR TITLE
fix(finance): make candle gap queries ignore limits

### DIFF
--- a/crates/extensions/rara-trading/src/market_data/repository.rs
+++ b/crates/extensions/rara-trading/src/market_data/repository.rs
@@ -211,9 +211,12 @@ impl MarketDataRepository for InMemoryMarketDataRepository {
     }
 
     async fn missing_open_times(&self, query: CandleRangeQuery) -> anyhow::Result<Vec<Timestamp>> {
-        let rows = self.candles(query.clone()).await?;
-        let present: std::collections::HashSet<Timestamp> =
-            rows.into_iter().map(|row| row.open_time).collect();
+        let candles = self.candles.read().await;
+        let present: std::collections::HashSet<Timestamp> = candles
+            .values()
+            .filter(|candle| matches_query(candle, &query))
+            .map(|row| row.open_time)
+            .collect();
         let step = query.timeframe.step()?;
         let mut missing = Vec::new();
         let mut cursor = query.start;
@@ -422,6 +425,26 @@ mod tests {
 
         let missing = repo.missing_open_times(query()).await.unwrap();
         assert_eq!(missing, vec![ts("2026-07-10T08:15:00Z")]);
+    }
+
+    #[tokio::test]
+    async fn gap_detection_ignores_range_query_limit() {
+        let repo = InMemoryMarketDataRepository::default();
+        repo.upsert_closed_candle(candle("2026-07-10T08:00:00Z", "61500.00"))
+            .await
+            .unwrap();
+        repo.upsert_closed_candle(candle("2026-07-10T08:15:00Z", "61610.30"))
+            .await
+            .unwrap();
+        repo.upsert_closed_candle(candle("2026-07-10T08:30:00Z", "61700.00"))
+            .await
+            .unwrap();
+
+        let mut query = query();
+        query.limit = 1;
+
+        let missing = repo.missing_open_times(query).await.unwrap();
+        assert!(missing.is_empty());
     }
 
     #[tokio::test]

--- a/crates/extensions/rara-trading/src/market_data/timescale.rs
+++ b/crates/extensions/rara-trading/src/market_data/timescale.rs
@@ -242,9 +242,35 @@ impl MarketDataRepository for TimescaleMarketDataRepository {
     }
 
     async fn missing_open_times(&self, query: CandleRangeQuery) -> anyhow::Result<Vec<Timestamp>> {
-        let rows = self.candles(query.clone()).await?;
-        let present: std::collections::HashSet<Timestamp> =
-            rows.into_iter().map(|row| row.open_time).collect();
+        let rows = sqlx_core::query::query(
+            r#"
+            SELECT open_time::text AS open_time
+            FROM market_candles
+            WHERE ($1::text IS NULL OR source_name = $1)
+              AND venue = $2
+              AND symbol = $3
+              AND timeframe = $4
+              AND open_time >= $5::timestamptz
+              AND open_time < $6::timestamptz
+            ORDER BY open_time ASC
+            "#,
+        )
+        .bind(query.source_name.as_deref())
+        .bind(&query.venue)
+        .bind(&query.symbol)
+        .bind(query.timeframe.as_str())
+        .bind(query.start.to_string())
+        .bind(query.end.to_string())
+        .fetch_all(&self.pool)
+        .await?;
+        let present: std::collections::HashSet<Timestamp> = rows
+            .into_iter()
+            .map(|row| {
+                row.try_get::<String, _>("open_time")?
+                    .parse()
+                    .map_err(Into::into)
+            })
+            .collect::<anyhow::Result<_>>()?;
         let step = query.timeframe.step()?;
         let mut missing = Vec::new();
         let mut cursor = query.start;

--- a/crates/extensions/rara-trading/tests/timescale_container.rs
+++ b/crates/extensions/rara-trading/tests/timescale_container.rs
@@ -126,7 +126,7 @@ async fn timescale_repository_contract_runs_against_testcontainer() -> anyhow::R
             timeframe:   Timeframe::parse("15m")?,
             start:       ts("2026-07-10T08:00:00Z"),
             end:         ts("2026-07-10T08:45:00Z"),
-            limit:       3,
+            limit:       1,
         })
         .await?;
     assert_eq!(missing, vec![ts("2026-07-10T08:00:00Z")]);


### PR DESCRIPTION
## Summary
- make in-memory candle gap detection scan the full requested range instead of reusing limited candle queries
- make Timescale gap detection issue an exact open_time scan independent of CandleRangeQuery.limit
- tighten the Timescale testcontainer contract so gap detection still works with limit=1

## Verification
- cargo +nightly fmt --check --all
- cargo test -p rara-trading market_data::repository::tests::gap_detection_ignores_range_query_limit -- --nocapture
- cargo test -p rara-trading market_data::repository::tests -- --nocapture
- cargo test -p rara-trading --test timescale_container -- --nocapture
- cargo clippy -p rara-trading -- -D warnings
- pre-commit hook: cargo check, cargo fmt, cargo clippy, cargo doc