### PR TITLE
fix(finance): fallback when market data schema init fails

### DIFF
--- a/crates/app/src/lib.rs
+++ b/crates/app/src/lib.rs
@@ -720,36 +720,7 @@ pub async fn start_with_options(
             rara_paths::data_dir().join("trading/finance-subscriptions.json"),
         ),
     );
-    let market_data_repo: rara_trading::market_data::MarketDataRepositoryRef =
-        match std::env::var("RARA_MARKET_DATA_DATABASE_URL") {
-            Ok(database_url) if !database_url.trim().is_empty() => {
-                match rara_trading::market_data::TimescaleMarketDataRepository::connect(
-                    &database_url,
-                )
-                .await
-                {
-                    Ok(repo) => {
-                        if let Err(e) = repo.apply_schema().await {
-                            warn!(error = %e, "failed to apply market-data Timescale schema");
-                        }
-                        Arc::new(repo)
-                    }
-                    Err(e) => {
-                        warn!(
-                            error = %e,
-                            "market-data Timescale connection failed; using in-memory repository"
-                        );
-                        Arc::new(rara_trading::market_data::InMemoryMarketDataRepository::default())
-                    }
-                }
-            }
-            _ => {
-                warn!(
-                    "RARA_MARKET_DATA_DATABASE_URL not set; using in-memory market-data repository"
-                );
-                Arc::new(rara_trading::market_data::InMemoryMarketDataRepository::default())
-            }
-        };
+    let market_data_repo = init_market_data_repository().await;
 
     // -- Data feed subsystem --------------------------------------------------
     // Create the event channel and registry before tool registration so
@@ -1536,6 +1507,48 @@ fn normalize_restored_data_feed_config(config: &mut DataFeedConfig) -> anyhow::R
     Ok(config.transport != before)
 }
 
+async fn init_market_data_repository() -> rara_trading::market_data::MarketDataRepositoryRef {
+    let database_url = std::env::var("RARA_MARKET_DATA_DATABASE_URL").ok();
+    init_market_data_repository_from_database_url(database_url.as_deref()).await
+}
+
+async fn init_market_data_repository_from_database_url(
+    database_url: Option<&str>,
+) -> rara_trading::market_data::MarketDataRepositoryRef {
+    match database_url
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    {
+        Some(database_url) => match connect_timescale_market_data_repository(database_url).await {
+            Ok(repo) => Arc::new(repo),
+            Err(e) => {
+                warn!(
+                    error = %e,
+                    "market-data Timescale initialization failed; using in-memory repository"
+                );
+                in_memory_market_data_repository()
+            }
+        },
+        _ => {
+            warn!("RARA_MARKET_DATA_DATABASE_URL not set; using in-memory market-data repository");
+            in_memory_market_data_repository()
+        }
+    }
+}
+
+async fn connect_timescale_market_data_repository(
+    database_url: &str,
+) -> anyhow::Result<rara_trading::market_data::TimescaleMarketDataRepository> {
+    let repo =
+        rara_trading::market_data::TimescaleMarketDataRepository::connect(database_url).await?;
+    repo.apply_schema().await?;
+    Ok(repo)
+}
+
+fn in_memory_market_data_repository() -> rara_trading::market_data::MarketDataRepositoryRef {
+    Arc::new(rara_trading::market_data::InMemoryMarketDataRepository::default())
+}
+
 /// Diesel-embedded SQLite migrations, shipped inside the binary at build time.
 const EMBEDDED_MIGRATIONS: diesel_migrations::EmbeddedMigrations =
     diesel_migrations::embed_migrations!("../rara-model/migrations");
@@ -1696,6 +1709,8 @@ mod tests {
 
     use jiff::Timestamp;
     use rara_kernel::data_feed::{DataFeedConfig, FeedStatus, FeedType};
+    use rara_trading::market_data::{MarketCandle, Timeframe};
+    use rust_decimal::Decimal;
 
     use super::AppConfig;
 
@@ -1803,6 +1818,31 @@ mita:
             config.transport["timeframes"],
             serde_json::json!(["15m", "1m"])
         );
+    }
+
+    #[tokio::test]
+    async fn market_data_repository_falls_back_when_timescale_initialization_fails() {
+        let repo =
+            super::init_market_data_repository_from_database_url(Some("not-a-postgres-url")).await;
+        let candle = MarketCandle {
+            source_name:       "fallback-test".to_owned(),
+            venue:             "binance".to_owned(),
+            symbol:            "BTCUSDT".to_owned(),
+            timeframe:         Timeframe::parse("1m").unwrap(),
+            open_time:         "2026-07-10T08:00:00Z".parse().unwrap(),
+            close_time:        "2026-07-10T08:01:00Z".parse().unwrap(),
+            open:              Decimal::from_str_exact("61500.12").unwrap(),
+            high:              Decimal::from_str_exact("61640.00").unwrap(),
+            low:               Decimal::from_str_exact("61480.50").unwrap(),
+            close:             Decimal::from_str_exact("61610.30").unwrap(),
+            volume:            Decimal::from_str_exact("124.551").unwrap(),
+            ingested_at:       Timestamp::now(),
+            provider_sequence: None,
+        };
+
+        repo.upsert_closed_candle(candle)
+            .await
+            .expect("fallback repository should accept candles");
     }
 
     #[test]

--- a/docs/guides/finance-subscriptions.md
+++ b/docs/guides/finance-subscriptions.md
@@ -43,8 +43,9 @@ export RARA_MARKET_DATA_DATABASE_URL='postgres://user:pass@host:5432/rara'
 On startup, rara applies the market-candle migration from
 `crates/extensions/rara-trading/migrations/0001_market_candles.sql`. The
 TimescaleDB extension must be installed in the target database. If the variable
-is missing, rara falls back to an in-memory repository, which is suitable only
-for local development because candle history is not durable.
+is missing, or if the connection or schema migration fails, rara falls back to
+an in-memory repository, which is suitable only for local development because
+candle history is not durable.
 
 Local Timescale contract tests use testcontainers and do not require a manually
 managed database:


### PR DESCRIPTION
## Summary
- treat Timescale connect + market-data schema migration as one initialization step
- fall back to the in-memory market-data repository when either connect or schema init fails
- document the schema-failure fallback behavior

## Tests
- cargo test -p rara-app tests::market_data_repository_falls_back_when_timescale_initialization_fails -- --nocapture
- cargo test -p rara-trading --test timescale_container -- --nocapture
- cargo +nightly fmt --check --all
- cargo clippy -p rara-app --lib -- -D warnings
- cargo test -p rara-app --lib
- git diff --check