### PR TITLE
feat(finance): surface catalog feed coverage

### DIFF
--- a/crates/extensions/backend-admin/src/data_feeds/router.rs
+++ b/crates/extensions/backend-admin/src/data_feeds/router.rs
@@ -189,6 +189,9 @@ struct FeedCatalogEntryResponse {
     requires_configuration: bool,
     setup_hint:             Option<String>,
     transport_template:     Option<serde_json::Value>,
+    venue:                  Option<String>,
+    configured_symbols:     Vec<String>,
+    configured_timeframes:  Vec<String>,
 }
 
 // ---------------------------------------------------------------------------
@@ -828,19 +831,49 @@ fn catalog_response(feeds: &[DataFeedConfig]) -> Vec<FeedCatalogEntryResponse> {
         .map(|source| {
             let feed_name = source.feed_name();
             let feed = feeds.iter().find(|feed| feed.name == feed_name);
+            let venue = catalog_transport_string(source.transport.as_ref(), "venue");
+            let configured_symbols =
+                catalog_transport_string_list(source.transport.as_ref(), "symbols");
+            let configured_timeframes =
+                catalog_transport_string_list(source.transport.as_ref(), "timeframes");
             FeedCatalogEntryResponse {
-                id:                     source.id,
-                name:                   source.name,
-                description:            source.description,
-                feed_type:              source.feed_type,
-                tags:                   source.tags,
-                enabled:                feed.is_some_and(|feed| feed.enabled),
-                feed_id:                feed.map(|feed| feed.id.clone()),
+                id: source.id,
+                name: source.name,
+                description: source.description,
+                feed_type: source.feed_type,
+                tags: source.tags,
+                enabled: feed.is_some_and(|feed| feed.enabled),
+                feed_id: feed.map(|feed| feed.id.clone()),
                 requires_configuration: source.requires_configuration,
-                setup_hint:             source.setup_hint,
-                transport_template:     source.transport,
+                setup_hint: source.setup_hint,
+                transport_template: source.transport,
+                venue,
+                configured_symbols,
+                configured_timeframes,
             }
         })
+        .collect()
+}
+
+fn catalog_transport_string(transport: Option<&serde_json::Value>, key: &str) -> Option<String> {
+    transport
+        .and_then(|transport| transport.get(key))
+        .and_then(serde_json::Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_owned)
+}
+
+fn catalog_transport_string_list(transport: Option<&serde_json::Value>, key: &str) -> Vec<String> {
+    transport
+        .and_then(|transport| transport.get(key))
+        .and_then(serde_json::Value::as_array)
+        .into_iter()
+        .flatten()
+        .filter_map(serde_json::Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_owned)
         .collect()
 }
 
@@ -1277,6 +1310,12 @@ mod tests {
             binance["transport_template"]["provider"].as_str().unwrap(),
             "binance"
         );
+        assert_eq!(binance["venue"], "binance");
+        assert_eq!(
+            binance["configured_symbols"],
+            serde_json::json!(["BTCUSDT", "ETHUSDT"])
+        );
+        assert_eq!(binance["configured_timeframes"], serde_json::json!(["1m"]));
     }
 
     #[tokio::test]

--- a/web/e2e/harness/data-feeds.spec.ts
+++ b/web/e2e/harness/data-feeds.spec.ts
@@ -62,6 +62,9 @@ interface FeedCatalogEntry {
   requires_configuration: boolean;
   setup_hint: string | null;
   transport_template: Record<string, unknown> | null;
+  venue?: string | null;
+  configured_symbols?: string[];
+  configured_timeframes?: string[];
 }
 
 // ---------------------------------------------------------------------------
@@ -491,7 +494,10 @@ test.describe('Data Feeds Management', () => {
     await goToDataFeeds(page);
 
     await expect(page.getByText('Default finance sources')).toBeVisible({ timeout: 10_000 });
+    await expect(page.getByText('News feeds', { exact: true })).toBeVisible();
+    await expect(page.getByText('K-line feeds', { exact: true })).toBeVisible();
     await expect(page.getByText('Federal Reserve Press Releases', { exact: true })).toBeVisible();
+    await expect(page.getByText('binance · BTCUSDT, ETHUSDT · 1m')).toBeVisible();
 
     const fedEntry = page
       .getByText('Federal Reserve Press Releases', { exact: true })

--- a/web/src/api/data-feeds.ts
+++ b/web/src/api/data-feeds.ts
@@ -85,6 +85,9 @@ export interface FeedCatalogEntry {
   requires_configuration: boolean;
   setup_hint: string | null;
   transport_template: Record<string, unknown> | null;
+  venue?: string | null;
+  configured_symbols?: string[];
+  configured_timeframes?: string[];
 }
 
 export interface EnableCatalogEntryRequest {

--- a/web/src/components/DataFeedsPanel.tsx
+++ b/web/src/components/DataFeedsPanel.tsx
@@ -139,6 +139,59 @@ function typeLabel(t: DataFeedConfig['feed_type']): string {
   }
 }
 
+function transportString(entry: FeedCatalogEntry, key: string): string | null {
+  const value = entry.transport_template?.[key];
+  return typeof value === 'string' && value.trim() ? value.trim() : null;
+}
+
+function transportStringList(entry: FeedCatalogEntry, key: string): string[] {
+  const value = entry.transport_template?.[key];
+  if (!Array.isArray(value)) return [];
+  return value
+    .filter((item): item is string => typeof item === 'string')
+    .map((item) => item.trim())
+    .filter(Boolean);
+}
+
+function catalogVenue(entry: FeedCatalogEntry): string | null {
+  return entry.venue?.trim() || transportString(entry, 'venue');
+}
+
+function catalogSymbols(entry: FeedCatalogEntry): string[] {
+  return entry.configured_symbols?.length
+    ? entry.configured_symbols
+    : transportStringList(entry, 'symbols');
+}
+
+function catalogTimeframes(entry: FeedCatalogEntry): string[] {
+  return entry.configured_timeframes?.length
+    ? entry.configured_timeframes
+    : transportStringList(entry, 'timeframes');
+}
+
+function summarizeList(values: string[], max = 4): string {
+  if (values.length <= max) return values.join(', ');
+  return `${values.slice(0, max).join(', ')} +${values.length - max}`;
+}
+
+function catalogCoverageLabel(entry: FeedCatalogEntry): string | null {
+  if (entry.feed_type === 'market_candle') {
+    const parts = [
+      catalogVenue(entry),
+      summarizeList(catalogSymbols(entry)),
+      summarizeList(catalogTimeframes(entry), 3),
+    ].filter(Boolean);
+    return parts.length > 0 ? parts.join(' · ') : null;
+  }
+
+  if (entry.feed_type === 'rss') {
+    const tags = entry.tags.filter((tag) => tag !== 'finance' && tag !== 'news');
+    return tags.length > 0 ? `RSS news · ${tags.join(' · ')}` : 'RSS news';
+  }
+
+  return null;
+}
+
 // ---------------------------------------------------------------------------
 // Status badge
 // ---------------------------------------------------------------------------
@@ -1182,13 +1235,17 @@ function FeedCatalogCard({
 
   if (entries.length === 0) return null;
 
-  const readyEntries = entries.filter((entry) => !entry.requires_configuration);
+  const newsEntries = entries.filter((entry) => entry.feed_type === 'rss');
+  const candleEntries = entries.filter(
+    (entry) => entry.feed_type === 'market_candle' && !entry.requires_configuration,
+  );
   const providerEntries = entries.filter((entry) => entry.requires_configuration);
 
   const renderEntry = (entry: FeedCatalogEntry) => {
     const pending =
       (enableMutation.isPending && enableMutation.variables?.id === entry.id) ||
       (disableMutation.isPending && disableMutation.variables === entry.id);
+    const coverage = catalogCoverageLabel(entry);
 
     return (
       <div
@@ -1214,7 +1271,7 @@ function FeedCatalogCard({
           </div>
           <p className="text-xs text-muted-foreground">{entry.description}</p>
           {entry.setup_hint && <p className="text-xs text-muted-foreground">{entry.setup_hint}</p>}
-          <p className="text-[11px] text-muted-foreground">Tags: {entry.tags.join(' · ')}</p>
+          {coverage && <p className="text-[11px] text-muted-foreground">{coverage}</p>}
         </div>
         {entry.requires_configuration ? (
           <div className="flex shrink-0 gap-2">
@@ -1265,17 +1322,23 @@ function FeedCatalogCard({
         <div className="border-b px-4 py-3">
           <h3 className="text-sm font-semibold">Default finance sources</h3>
           <p className="text-xs text-muted-foreground">
-            Ready sources can run immediately. Provider presets need your own endpoint or
-            credentials.
+            Enable built-in news and K-line feeds, or configure provider presets with your own
+            endpoint.
           </p>
         </div>
         <div className="divide-y">
-          {readyEntries.length > 0 && (
+          {newsEntries.length > 0 && (
+            <div>
+              <div className="px-4 pt-3 text-xs font-medium text-muted-foreground">News feeds</div>
+              {newsEntries.map(renderEntry)}
+            </div>
+          )}
+          {candleEntries.length > 0 && (
             <div>
               <div className="px-4 pt-3 text-xs font-medium text-muted-foreground">
-                Ready to enable
+                K-line feeds
               </div>
-              {readyEntries.map(renderEntry)}
+              {candleEntries.map(renderEntry)}
             </div>
           )}
           {providerEntries.length > 0 && (


### PR DESCRIPTION
## Summary
- add venue, configured symbols, and configured timeframes to the data feed catalog API
- group default finance sources in the Web UI by News, K-line feeds, and Provider presets
- show coverage summaries for built-in RSS and market-candle feed presets

## Verification
- cargo test -p rara-backend-admin data_feeds::router::tests::finance_catalog -- --nocapture
- cargo clippy -p rara-backend-admin --lib -- -D warnings
- cargo +nightly fmt --check --all
- npm run typecheck
- npm run lint -- --quiet
- npm run format:check -- src/components/DataFeedsPanel.tsx src/api/data-feeds.ts
- npm run build
- npm run test:e2e -- e2e/harness/data-feeds.spec.ts