### PR TITLE
feat(finance): surface feed source names in UI

### DIFF
--- a/crates/extensions/backend-admin/src/data_feeds/router.rs
+++ b/crates/extensions/backend-admin/src/data_feeds/router.rs
@@ -192,6 +192,7 @@ struct FeedCatalogEntryResponse {
     description:            String,
     feed_type:              FeedType,
     tags:                   Vec<String>,
+    source_name:            String,
     enabled:                bool,
     feed_id:                Option<String>,
     requires_configuration: bool,
@@ -864,6 +865,7 @@ fn catalog_response(
                 description: source.description,
                 feed_type: source.feed_type,
                 tags: source.tags,
+                source_name: feed_name.clone(),
                 enabled: feed.is_some_and(|feed| feed.enabled),
                 feed_id: feed.map(|feed| feed.id.clone()),
                 requires_configuration: source.requires_configuration,
@@ -1385,6 +1387,7 @@ mod tests {
             .iter()
             .find(|entry| entry["id"] == "binance-market-candles")
             .unwrap();
+        assert_eq!(binance["source_name"], "finance-binance-market-candles");
         assert_eq!(binance["requires_configuration"], false);
         assert_eq!(binance["feed_type"], "market_candle");
         assert_eq!(

--- a/web/e2e/harness/data-feeds.spec.ts
+++ b/web/e2e/harness/data-feeds.spec.ts
@@ -57,6 +57,7 @@ interface FeedCatalogEntry {
   description: string;
   feed_type: DataFeedConfig['feed_type'];
   tags: string[];
+  source_name?: string;
   enabled: boolean;
   feed_id: string | null;
   requires_configuration: boolean;
@@ -65,6 +66,10 @@ interface FeedCatalogEntry {
   venue?: string | null;
   configured_symbols?: string[];
   configured_timeframes?: string[];
+  subscriptions?: {
+    user_subscribed: boolean;
+    user_subscription_ids: string[];
+  };
 }
 
 // ---------------------------------------------------------------------------
@@ -457,10 +462,15 @@ test.describe('Data Feeds Management', () => {
           description: 'Official Federal Reserve press releases.',
           feed_type: 'rss',
           tags: ['finance', 'news', 'fed'],
+          source_name: 'finance-fed-press-releases',
           enabled: false,
           feed_id: null,
           requires_configuration: false,
           setup_hint: null,
+          subscriptions: {
+            user_subscribed: true,
+            user_subscription_ids: ['sub-fed'],
+          },
           transport_template: {
             url: 'https://www.federalreserve.gov/feeds/press_all.xml',
             interval_secs: 300,
@@ -497,6 +507,8 @@ test.describe('Data Feeds Management', () => {
     await expect(page.getByText('News feeds', { exact: true })).toBeVisible();
     await expect(page.getByText('K-line feeds', { exact: true })).toBeVisible();
     await expect(page.getByText('Federal Reserve Press Releases', { exact: true })).toBeVisible();
+    await expect(page.getByText('Source finance-fed-press-releases')).toBeVisible();
+    await expect(page.getByText('Subscribed')).toBeVisible();
     await expect(page.getByText('binance · BTCUSDT, ETHUSDT · 1m')).toBeVisible();
 
     const fedEntry = page

--- a/web/src/api/data-feeds.ts
+++ b/web/src/api/data-feeds.ts
@@ -80,6 +80,7 @@ export interface FeedCatalogEntry {
   description: string;
   feed_type: FeedType;
   tags: string[];
+  source_name?: string;
   enabled: boolean;
   feed_id: string | null;
   requires_configuration: boolean;

--- a/web/src/components/DataFeedsPanel.tsx
+++ b/web/src/components/DataFeedsPanel.tsx
@@ -192,6 +192,10 @@ function catalogCoverageLabel(entry: FeedCatalogEntry): string | null {
   return null;
 }
 
+function catalogSourceName(entry: FeedCatalogEntry): string {
+  return entry.source_name?.trim() || `finance-${entry.id}`;
+}
+
 // ---------------------------------------------------------------------------
 // Status badge
 // ---------------------------------------------------------------------------
@@ -1275,6 +1279,9 @@ function FeedCatalogCard({
             )}
           </div>
           <p className="text-xs text-muted-foreground">{entry.description}</p>
+          <p className="font-mono text-[11px] text-muted-foreground">
+            Source {catalogSourceName(entry)}
+          </p>
           {entry.setup_hint && <p className="text-xs text-muted-foreground">{entry.setup_hint}</p>}
           {coverage && <p className="text-[11px] text-muted-foreground">{coverage}</p>}
         </div>


### PR DESCRIPTION
## Summary
- expose catalog source_name from backend-admin data feed catalog responses
- show source names in the Data Feeds catalog so users know what to subscribe to in conversation
- cover source-name display and subscribed badge in the Data Feeds harness

## Verification
- cargo test -p rara-backend-admin data_feeds -- --nocapture
- cargo check -p rara-app
- cargo clippy -p rara-app --lib -- -D warnings
- cargo +nightly fmt --check --all
- pnpm -C web exec tsc --noEmit
- pnpm -C web lint
- pnpm -C web build
- pnpm -C web exec playwright test e2e/harness/data-feeds.spec.ts --project=desktop-1920
- git diff --check