### PR TITLE
feat(finance): show finance subscriptions in data feeds

### DIFF
--- a/crates/extensions/backend-admin/src/data_feeds/router.rs
+++ b/crates/extensions/backend-admin/src/data_feeds/router.rs
@@ -25,6 +25,7 @@
 //! | GET    | `/api/v1/data-feeds/{id}/events`             | query feed events   |
 //! | GET    | `/api/v1/data-feeds/{id}/events/{event_id}` | get single event    |
 //! | POST   | `/api/v1/data-feeds/catalog/{id}/unsubscribe` | remove current user's catalog subscriptions |
+//! | GET    | `/api/v1/data-feeds/finance/subscriptions` | list current user's finance subscriptions |
 //!
 //! All mutations synchronise both the database (via [`DataFeedSvc`]) and the
 //! in-memory [`DataFeedRegistry`]. When an active feed is created and
@@ -53,7 +54,9 @@ use rara_trading::{
         market_candle::MarketCandleSource,
         rss::RssSource,
     },
-    finance::registry::{FinanceSubscription, FinanceSubscriptionRegistry},
+    finance::registry::{
+        FinanceDelivery, FinanceEventKind, FinanceSubscription, FinanceSubscriptionRegistry,
+    },
 };
 use serde::{Deserialize, Deserializer, Serialize};
 use tokio_util::sync::CancellationToken;
@@ -94,6 +97,14 @@ pub fn data_feed_routes(state: DataFeedRouterState) -> Router {
         .route(
             "/api/v1/data-feeds/catalog/{id}/unsubscribe",
             post(unsubscribe_catalog_feed),
+        )
+        .route(
+            "/api/v1/data-feeds/finance/subscriptions",
+            get(list_finance_subscriptions),
+        )
+        .route(
+            "/api/v1/data-feeds/finance/subscriptions/{id}",
+            get(get_finance_subscription).delete(delete_finance_subscription),
         )
         .route(
             "/api/v1/data-feeds/{id}",
@@ -234,6 +245,47 @@ struct FeedCatalogSubscriptionResponse {
     user_subscription_ids: Vec<Uuid>,
 }
 
+#[derive(Debug, Serialize)]
+struct FinanceSubscriptionListResponse {
+    subscriptions: Vec<FinanceSubscriptionResponse>,
+    count:         usize,
+}
+
+#[derive(Debug, Serialize)]
+struct FinanceSubscriptionResponse {
+    subscription_id:        Uuid,
+    session_key:            String,
+    event_kinds:            Vec<FinanceEventKind>,
+    source_names:           Vec<String>,
+    matches_all_sources:    bool,
+    sources:                Vec<FinanceSubscriptionSourceResponse>,
+    category_tags:          Vec<String>,
+    watch_terms:            Vec<String>,
+    venues:                 Vec<String>,
+    symbols:                Vec<String>,
+    timeframes:             Vec<String>,
+    delivery:               FinanceDelivery,
+    cooldown_secs:          u64,
+    max_immediate_per_hour: u16,
+}
+
+#[derive(Debug, Serialize)]
+struct FinanceSubscriptionSourceResponse {
+    source_name:       String,
+    catalog_source_id: Option<String>,
+    catalog_name:      Option<String>,
+    feed_id:           Option<String>,
+    feed_type:         Option<FeedType>,
+    enabled:           Option<bool>,
+    status:            Option<FeedStatus>,
+}
+
+#[derive(Debug, Serialize)]
+struct DeleteFinanceSubscriptionResponse {
+    subscription_id: Uuid,
+    removed:         bool,
+}
+
 // ---------------------------------------------------------------------------
 // Handlers
 // ---------------------------------------------------------------------------
@@ -255,6 +307,82 @@ async fn list_feed_catalog(
     let owner = UserId(principal.user_id.0);
     let subscriptions = state.finance_registry.list_for_owner(&owner).await;
     Ok(Json(catalog_response(&feeds, &subscriptions)))
+}
+
+/// `GET /api/v1/data-feeds/finance/subscriptions` — list current user's
+/// finance information subscriptions.
+async fn list_finance_subscriptions(
+    State(state): State<DataFeedRouterState>,
+    axum::Extension(principal): axum::Extension<Principal<Resolved>>,
+) -> Result<Json<FinanceSubscriptionListResponse>, ProblemDetails> {
+    let feeds = state.svc.list_feeds().await?;
+    let catalog_by_source_name = catalog_by_source_name();
+    let owner = UserId(principal.user_id.0);
+    let subscriptions = state
+        .finance_registry
+        .list_for_owner(&owner)
+        .await
+        .into_iter()
+        .map(|subscription| {
+            finance_subscription_response(subscription, &feeds, &catalog_by_source_name)
+        })
+        .collect::<Vec<_>>();
+
+    Ok(Json(FinanceSubscriptionListResponse {
+        count: subscriptions.len(),
+        subscriptions,
+    }))
+}
+
+/// `GET /api/v1/data-feeds/finance/subscriptions/{id}` — fetch one current-user
+/// finance information subscription.
+async fn get_finance_subscription(
+    State(state): State<DataFeedRouterState>,
+    axum::Extension(principal): axum::Extension<Principal<Resolved>>,
+    Path(id): Path<Uuid>,
+) -> Result<Json<FinanceSubscriptionResponse>, ProblemDetails> {
+    let feeds = state.svc.list_feeds().await?;
+    let catalog_by_source_name = catalog_by_source_name();
+    let owner = UserId(principal.user_id.0);
+    let subscription = state
+        .finance_registry
+        .list_for_owner(&owner)
+        .await
+        .into_iter()
+        .find(|subscription| subscription.id == id)
+        .ok_or_else(|| finance_subscription_not_found(id))?;
+
+    Ok(Json(finance_subscription_response(
+        subscription,
+        &feeds,
+        &catalog_by_source_name,
+    )))
+}
+
+/// `DELETE /api/v1/data-feeds/finance/subscriptions/{id}` — remove one
+/// current-user finance information subscription.
+async fn delete_finance_subscription(
+    State(state): State<DataFeedRouterState>,
+    axum::Extension(principal): axum::Extension<Principal<Resolved>>,
+    Path(id): Path<Uuid>,
+) -> Result<Json<DeleteFinanceSubscriptionResponse>, ProblemDetails> {
+    let owner = UserId(principal.user_id.0);
+    let removed = state
+        .finance_registry
+        .remove(&owner, id)
+        .await
+        .map_err(|err| {
+            ProblemDetails::internal(format!("failed to remove finance subscription: {err}"))
+        })?;
+
+    if !removed {
+        return Err(finance_subscription_not_found(id));
+    }
+
+    Ok(Json(DeleteFinanceSubscriptionResponse {
+        subscription_id: id,
+        removed,
+    }))
 }
 
 /// `GET /api/v1/data-feeds/summary` — list per-feed persisted-event health.
@@ -989,6 +1117,72 @@ fn catalog_subscription_response(
     }
 }
 
+fn finance_subscription_response(
+    subscription: FinanceSubscription,
+    feeds: &[DataFeedConfig],
+    catalog_by_source_name: &HashMap<String, DefaultFeedSource>,
+) -> FinanceSubscriptionResponse {
+    let matches_all_sources = subscription.source_names.is_empty();
+    let sources = subscription
+        .source_names
+        .iter()
+        .map(|source_name| {
+            finance_subscription_source_response(
+                source_name,
+                feeds.iter().find(|feed| feed.name == *source_name),
+                catalog_by_source_name.get(source_name),
+            )
+        })
+        .collect();
+
+    FinanceSubscriptionResponse {
+        subscription_id: subscription.id,
+        session_key: subscription.session_key.to_string(),
+        event_kinds: subscription.event_kinds,
+        source_names: subscription.source_names,
+        matches_all_sources,
+        sources,
+        category_tags: subscription.category_tags,
+        watch_terms: subscription.watch_terms,
+        venues: subscription.venues,
+        symbols: subscription.symbols,
+        timeframes: subscription.timeframes,
+        delivery: subscription.delivery,
+        cooldown_secs: subscription.cooldown_secs,
+        max_immediate_per_hour: subscription.max_immediate_per_hour,
+    }
+}
+
+fn finance_subscription_source_response(
+    source_name: &str,
+    feed: Option<&DataFeedConfig>,
+    catalog_source: Option<&DefaultFeedSource>,
+) -> FinanceSubscriptionSourceResponse {
+    FinanceSubscriptionSourceResponse {
+        source_name:       source_name.to_owned(),
+        catalog_source_id: catalog_source.map(|source| source.id.clone()),
+        catalog_name:      catalog_source.map(|source| source.name.clone()),
+        feed_id:           feed.map(|feed| feed.id.clone()),
+        feed_type:         feed.map(|feed| feed.feed_type.clone()),
+        enabled:           feed.map(|feed| feed.enabled),
+        status:            feed.map(|feed| feed.status),
+    }
+}
+
+fn catalog_by_source_name() -> HashMap<String, DefaultFeedSource> {
+    default_finance_feed_sources()
+        .into_iter()
+        .map(|source| (source.feed_name(), source))
+        .collect()
+}
+
+fn finance_subscription_not_found(id: Uuid) -> ProblemDetails {
+    ProblemDetails::not_found(
+        "Finance Subscription Not Found",
+        format!("no finance subscription owned by current user with id: {id}"),
+    )
+}
+
 fn catalog_transport_string(transport: Option<&serde_json::Value>, key: &str) -> Option<String> {
     transport
         .and_then(|transport| transport.get(key))
@@ -1649,6 +1843,164 @@ mod tests {
             .await;
         assert_eq!(admin_subscriptions.len(), 1);
         assert_eq!(admin_subscriptions[0].id, admin_fed);
+    }
+
+    #[tokio::test]
+    async fn finance_subscriptions_list_returns_current_user_read_model() {
+        let finance_registry = test_finance_registry();
+        let subscription_id = Uuid::new_v4();
+        finance_registry
+            .upsert(FinanceSubscription {
+                id:                     subscription_id,
+                owner:                  UserId("alice".to_owned()),
+                session_key:            SessionKey::new(),
+                event_kinds:            vec![FinanceEventKind::MarketCandleClosed],
+                source_names:           vec!["finance-binance-market-candles".to_owned()],
+                category_tags:          Vec::new(),
+                watch_terms:            Vec::new(),
+                venues:                 vec!["binance".to_owned()],
+                symbols:                vec!["BTCUSDT".to_owned()],
+                timeframes:             vec!["1m".to_owned()],
+                delivery:               FinanceDelivery::Silent,
+                cooldown_secs:          900,
+                max_immediate_per_hour: 6,
+            })
+            .await
+            .unwrap();
+        finance_registry
+            .upsert(FinanceSubscription {
+                id:                     Uuid::new_v4(),
+                owner:                  UserId("admin".to_owned()),
+                session_key:            SessionKey::new(),
+                event_kinds:            vec![FinanceEventKind::RssArticle],
+                source_names:           vec!["finance-fed-press-releases".to_owned()],
+                category_tags:          Vec::new(),
+                watch_terms:            Vec::new(),
+                venues:                 Vec::new(),
+                symbols:                Vec::new(),
+                timeframes:             Vec::new(),
+                delivery:               FinanceDelivery::Silent,
+                cooldown_secs:          900,
+                max_immediate_per_hour: 6,
+            })
+            .await
+            .unwrap();
+
+        let app =
+            app_with_user_and_finance_registry(user_of(Role::User), finance_registry.clone()).await;
+        let res = app
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri("/api/v1/data-feeds/finance/subscriptions")
+                    .header("Authorization", "Bearer s3cret")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(res.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(res.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let result: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(result["count"], 1);
+        let subscription = &result["subscriptions"][0];
+        assert_eq!(subscription["subscription_id"], subscription_id.to_string());
+        assert_eq!(
+            subscription["event_kinds"],
+            serde_json::json!(["market_candle_closed"])
+        );
+        assert_eq!(
+            subscription["source_names"],
+            serde_json::json!(["finance-binance-market-candles"])
+        );
+        assert_eq!(
+            subscription["sources"][0]["catalog_source_id"],
+            "binance-market-candles"
+        );
+        assert_eq!(subscription["venues"], serde_json::json!(["binance"]));
+        assert_eq!(subscription["symbols"], serde_json::json!(["BTCUSDT"]));
+        assert_eq!(subscription["timeframes"], serde_json::json!(["1m"]));
+    }
+
+    #[tokio::test]
+    async fn finance_subscriptions_delete_is_scoped_to_current_user() {
+        let finance_registry = test_finance_registry();
+        let alice_id = Uuid::new_v4();
+        let admin_id = Uuid::new_v4();
+
+        for (id, owner) in [
+            (alice_id, UserId("alice".to_owned())),
+            (admin_id, UserId("admin".to_owned())),
+        ] {
+            finance_registry
+                .upsert(FinanceSubscription {
+                    id,
+                    owner,
+                    session_key: SessionKey::new(),
+                    event_kinds: vec![FinanceEventKind::RssArticle],
+                    source_names: vec!["finance-fed-press-releases".to_owned()],
+                    category_tags: Vec::new(),
+                    watch_terms: Vec::new(),
+                    venues: Vec::new(),
+                    symbols: Vec::new(),
+                    timeframes: Vec::new(),
+                    delivery: FinanceDelivery::Silent,
+                    cooldown_secs: 900,
+                    max_immediate_per_hour: 6,
+                })
+                .await
+                .unwrap();
+        }
+
+        let app =
+            app_with_user_and_finance_registry(user_of(Role::User), finance_registry.clone()).await;
+        let forbidden_res = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("DELETE")
+                    .uri(format!(
+                        "/api/v1/data-feeds/finance/subscriptions/{admin_id}"
+                    ))
+                    .header("Authorization", "Bearer s3cret")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(forbidden_res.status(), StatusCode::NOT_FOUND);
+
+        let delete_res = app
+            .oneshot(
+                Request::builder()
+                    .method("DELETE")
+                    .uri(format!(
+                        "/api/v1/data-feeds/finance/subscriptions/{alice_id}"
+                    ))
+                    .header("Authorization", "Bearer s3cret")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(delete_res.status(), StatusCode::OK);
+
+        assert!(
+            finance_registry
+                .list_for_owner(&UserId("alice".to_owned()))
+                .await
+                .is_empty()
+        );
+        assert_eq!(
+            finance_registry
+                .list_for_owner(&UserId("admin".to_owned()))
+                .await
+                .len(),
+            1
+        );
     }
 
     #[tokio::test]

--- a/web/src/api/data-feeds.ts
+++ b/web/src/api/data-feeds.ts
@@ -114,6 +114,46 @@ export interface UnsubscribeCatalogEntryResponse {
   remaining_subscription_ids: string[];
 }
 
+export type FinanceEventKind = 'rss_article' | 'market_candle_closed';
+export type FinanceDelivery = 'immediate' | 'silent';
+
+export interface FinanceSubscriptionSource {
+  source_name: string;
+  catalog_source_id: string | null;
+  catalog_name: string | null;
+  feed_id: string | null;
+  feed_type: FeedType | null;
+  enabled: boolean | null;
+  status: DataFeedConfig['status'] | null;
+}
+
+export interface FinanceSubscription {
+  subscription_id: string;
+  session_key: string;
+  event_kinds: FinanceEventKind[];
+  source_names: string[];
+  matches_all_sources: boolean;
+  sources: FinanceSubscriptionSource[];
+  category_tags: string[];
+  watch_terms: string[];
+  venues: string[];
+  symbols: string[];
+  timeframes: string[];
+  delivery: FinanceDelivery;
+  cooldown_secs: number;
+  max_immediate_per_hour: number;
+}
+
+export interface FinanceSubscriptionsResponse {
+  subscriptions: FinanceSubscription[];
+  count: number;
+}
+
+export interface DeleteFinanceSubscriptionResponse {
+  subscription_id: string;
+  removed: boolean;
+}
+
 // ---------------------------------------------------------------------------
 // API client
 // ---------------------------------------------------------------------------
@@ -144,6 +184,15 @@ export const dataFeedsApi = {
 
   unsubscribeCatalogEntry: (id: string, body?: UnsubscribeCatalogEntryRequest) =>
     api.post<UnsubscribeCatalogEntryResponse>(`/api/v1/data-feeds/catalog/${id}/unsubscribe`, body),
+
+  financeSubscriptions: () =>
+    api.get<FinanceSubscriptionsResponse>('/api/v1/data-feeds/finance/subscriptions'),
+
+  getFinanceSubscription: (id: string) =>
+    api.get<FinanceSubscription>(`/api/v1/data-feeds/finance/subscriptions/${id}`),
+
+  deleteFinanceSubscription: (id: string) =>
+    api.del<DeleteFinanceSubscriptionResponse>(`/api/v1/data-feeds/finance/subscriptions/${id}`),
 
   events: (id: string, params?: { since?: string; limit?: number; offset?: number }) => {
     const query = new URLSearchParams();

--- a/web/src/components/DataFeedsPanel.tsx
+++ b/web/src/components/DataFeedsPanel.tsx
@@ -34,6 +34,8 @@ import {
   type FeedCatalogEntry,
   type FeedEvent,
   type FeedSummary,
+  type FinanceSubscription,
+  type FinanceSubscriptionsResponse,
   type CreateFeedRequest,
   type EnableCatalogEntryRequest,
   type AuthType,
@@ -194,6 +196,34 @@ function catalogCoverageLabel(entry: FeedCatalogEntry): string | null {
 
 function catalogSourceName(entry: FeedCatalogEntry): string {
   return entry.source_name?.trim() || `finance-${entry.id}`;
+}
+
+function financeEventKindLabel(kind: FinanceSubscription['event_kinds'][number]): string {
+  switch (kind) {
+    case 'rss_article':
+      return 'News';
+    case 'market_candle_closed':
+      return 'K-line';
+  }
+}
+
+function financeSubscriptionTitle(subscription: FinanceSubscription): string {
+  const source =
+    subscription.sources[0]?.catalog_name ??
+    subscription.source_names[0] ??
+    (subscription.matches_all_sources ? 'All finance sources' : 'Custom source');
+  const kinds = subscription.event_kinds.map(financeEventKindLabel).join(' + ');
+  return kinds ? `${source} · ${kinds}` : source;
+}
+
+function financeSubscriptionSelectors(subscription: FinanceSubscription): string[] {
+  const selectors = [
+    summarizeList(subscription.symbols),
+    summarizeList(subscription.timeframes, 3),
+    summarizeList(subscription.category_tags),
+    summarizeList(subscription.watch_terms),
+  ].filter(Boolean);
+  return selectors.length > 0 ? selectors : ['All matching events'];
 }
 
 // ---------------------------------------------------------------------------
@@ -1224,6 +1254,7 @@ function FeedCatalogCard({
     void queryClient.invalidateQueries({ queryKey: ['data-feeds'] });
     void queryClient.invalidateQueries({ queryKey: ['data-feed-catalog'] });
     void queryClient.invalidateQueries({ queryKey: ['data-feed-summaries'] });
+    void queryClient.invalidateQueries({ queryKey: ['finance-subscriptions'] });
   };
 
   const enableMutation = useMutation({
@@ -1413,6 +1444,74 @@ function FeedCatalogCard({
   );
 }
 
+function FinanceSubscriptionsCard({ result }: { result: FinanceSubscriptionsResponse }) {
+  const queryClient = useQueryClient();
+  const deleteMutation = useMutation({
+    mutationFn: (id: string) => dataFeedsApi.deleteFinanceSubscription(id),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ['finance-subscriptions'] });
+      void queryClient.invalidateQueries({ queryKey: ['data-feed-catalog'] });
+    },
+  });
+
+  return (
+    <div className="rounded-lg border bg-card">
+      <div className="border-b px-4 py-3">
+        <h3 className="text-sm font-semibold">Finance subscriptions</h3>
+        <p className="text-xs text-muted-foreground">
+          Conversation-created watches for finance news and K-line events. Feed ingestion keeps
+          running when a subscription is removed.
+        </p>
+      </div>
+      {result.count === 0 ? (
+        <div className="px-4 py-4 text-xs text-muted-foreground">
+          No active finance subscriptions for the current user.
+        </div>
+      ) : (
+        <div className="divide-y">
+          {result.subscriptions.map((subscription) => {
+            const deleting =
+              deleteMutation.isPending && deleteMutation.variables === subscription.subscription_id;
+            return (
+              <div
+                key={subscription.subscription_id}
+                className="flex flex-col gap-3 px-4 py-3 sm:flex-row sm:items-center sm:justify-between"
+              >
+                <div className="min-w-0 space-y-1">
+                  <div className="flex flex-wrap items-center gap-2">
+                    <span className="text-sm font-medium">
+                      {financeSubscriptionTitle(subscription)}
+                    </span>
+                    <Badge variant="outline" className="text-xs">
+                      {subscription.delivery}
+                    </Badge>
+                  </div>
+                  <p className="text-xs text-muted-foreground">
+                    {financeSubscriptionSelectors(subscription).join(' · ')}
+                  </p>
+                  <p className="font-mono text-[11px] text-muted-foreground">
+                    {subscription.subscription_id}
+                  </p>
+                </div>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className="h-8 shrink-0 gap-1"
+                  onClick={() => deleteMutation.mutate(subscription.subscription_id)}
+                  disabled={deleting}
+                >
+                  <Trash2 className="h-3.5 w-3.5" />
+                  {deleting ? 'Removing...' : 'Remove'}
+                </Button>
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}
+
 function FeedListView({
   feeds,
   summaries,
@@ -1431,12 +1530,17 @@ function FeedListView({
     queryKey: ['data-feed-catalog'],
     queryFn: () => dataFeedsApi.catalog(),
   });
+  const financeSubscriptionsQuery = useQuery({
+    queryKey: ['finance-subscriptions'],
+    queryFn: () => dataFeedsApi.financeSubscriptions(),
+  });
 
   const toggleMutation = useMutation({
     mutationFn: (id: string) => dataFeedsApi.toggle(id),
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: ['data-feeds'] });
       void queryClient.invalidateQueries({ queryKey: ['data-feed-catalog'] });
+      void queryClient.invalidateQueries({ queryKey: ['finance-subscriptions'] });
     },
   });
 
@@ -1446,6 +1550,7 @@ function FeedListView({
       void queryClient.invalidateQueries({ queryKey: ['data-feeds'] });
       void queryClient.invalidateQueries({ queryKey: ['data-feed-catalog'] });
       void queryClient.invalidateQueries({ queryKey: ['data-feed-summaries'] });
+      void queryClient.invalidateQueries({ queryKey: ['finance-subscriptions'] });
       setDeleteId(null);
     },
   });
@@ -1495,6 +1600,9 @@ function FeedListView({
 
       {catalogQuery.data && (
         <FeedCatalogCard entries={catalogQuery.data} onUseTemplate={handleUseTemplate} />
+      )}
+      {financeSubscriptionsQuery.data && (
+        <FinanceSubscriptionsCard result={financeSubscriptionsQuery.data} />
       )}
 
       {/* Table */}


### PR DESCRIPTION
## Summary
- add current-user finance subscription REST read-model under data feeds
- add GET/DELETE endpoints for individual finance subscriptions scoped to the current user
- surface active finance subscriptions in the Data Feeds UI with a Remove action

## Verification
- cargo test -p rara-backend-admin data_feeds::router::tests::finance_ -- --nocapture
- cargo check -p rara-backend-admin
- cargo clippy -p rara-backend-admin --lib -- -D warnings
- npm --prefix web run typecheck
- npm --prefix web run format:check
- npm --prefix web run test
- scripts/lint-ratchet.sh
- cargo +nightly fmt --check --all
- git diff --check
- commit hook: cargo check, cargo fmt, cargo clippy, cargo doc, web lint-staged