### PR TITLE
feat(finance): add session watch controls

### DIFF
--- a/web/src/components/topology/FinanceWatchesCard.tsx
+++ b/web/src/components/topology/FinanceWatchesCard.tsx
@@ -1,0 +1,241 @@
+/*
+ * Copyright 2026 Rararulab
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+
+import {
+  dataFeedsApi,
+  type CreateFinanceSubscriptionRequest,
+  type FeedCatalogEntry,
+  type FinanceEventKind,
+  type FinanceSubscription,
+} from '@/api/data-feeds';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+
+interface FinanceWatchesCardProps {
+  sessionKey: string;
+}
+
+export function FinanceWatchesCard({ sessionKey }: FinanceWatchesCardProps) {
+  const queryClient = useQueryClient();
+  const catalogQuery = useQuery({
+    queryKey: ['data-feed-catalog'],
+    queryFn: () => dataFeedsApi.catalog(),
+    staleTime: 30_000,
+  });
+  const subscriptionsQuery = useQuery({
+    queryKey: ['finance-subscriptions'],
+    queryFn: () => dataFeedsApi.financeSubscriptions(),
+    staleTime: 30_000,
+  });
+
+  const subscribeMutation = useMutation({
+    mutationFn: (entry: FeedCatalogEntry) =>
+      dataFeedsApi.createFinanceSubscription(subscriptionRequestForEntry(entry, sessionKey)),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ['finance-subscriptions'] });
+      void queryClient.invalidateQueries({ queryKey: ['data-feed-catalog'] });
+    },
+  });
+
+  const entries = (catalogQuery.data ?? []).filter(isFinanceWatchableEntry);
+  const sessionSubscriptions = (subscriptionsQuery.data?.subscriptions ?? []).filter(
+    (subscription) => subscription.session_key === sessionKey,
+  );
+  const loading = catalogQuery.isLoading || subscriptionsQuery.isLoading;
+  const error =
+    catalogQuery.error?.message ??
+    subscriptionsQuery.error?.message ??
+    subscribeMutation.error?.message ??
+    null;
+
+  return (
+    <Card className="rounded-lg">
+      <CardHeader className="p-3 pb-2">
+        <div className="flex items-center justify-between gap-2">
+          <div>
+            <CardTitle className="text-xs">Finance watches</CardTitle>
+            <CardDescription className="mt-1 text-[11px]">
+              Subscribe this session to built-in news and K-line feeds.
+            </CardDescription>
+          </div>
+          {sessionSubscriptions.length > 0 && (
+            <Badge variant="outline" className="shrink-0 text-[10px]">
+              {sessionSubscriptions.length} active
+            </Badge>
+          )}
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-2 p-3 pt-0">
+        {loading ? (
+          <div className="rounded-md border border-dashed px-3 py-2 text-[11px] text-muted-foreground">
+            Loading finance sources…
+          </div>
+        ) : entries.length === 0 ? (
+          <div className="rounded-md border border-dashed px-3 py-2 text-[11px] text-muted-foreground">
+            No finance feed sources are configured.
+          </div>
+        ) : (
+          <div className="space-y-2">
+            {entries.map((entry) => {
+              const subscribed = sessionSubscriptions.some((subscription) =>
+                subscriptionMatchesEntry(subscription, entry),
+              );
+              const pending =
+                subscribeMutation.isPending && subscribeMutation.variables?.id === entry.id;
+              return (
+                <div key={entry.id} className="rounded-md border bg-background/60 px-3 py-2">
+                  <div className="flex items-start justify-between gap-2">
+                    <div className="min-w-0 space-y-1">
+                      <div className="flex flex-wrap items-center gap-1.5">
+                        <span className="truncate text-xs font-medium">{entry.name}</span>
+                        <Badge variant="outline" className="px-1.5 py-0 text-[10px]">
+                          {entry.feed_type === 'rss' ? 'News' : 'K-line'}
+                        </Badge>
+                        {!entry.enabled && (
+                          <Badge variant="secondary" className="px-1.5 py-0 text-[10px]">
+                            source off
+                          </Badge>
+                        )}
+                        {subscribed && (
+                          <Badge variant="secondary" className="px-1.5 py-0 text-[10px]">
+                            watching
+                          </Badge>
+                        )}
+                      </div>
+                      <p className="line-clamp-2 text-[11px] text-muted-foreground">
+                        {coverageLabel(entry)}
+                      </p>
+                    </div>
+                    <Button
+                      size="sm"
+                      variant={subscribed ? 'outline' : 'default'}
+                      className="h-7 shrink-0 px-2 text-[11px]"
+                      disabled={subscribed || pending}
+                      onClick={() => subscribeMutation.mutate(entry)}
+                    >
+                      {subscribed ? 'Watching' : pending ? 'Adding…' : 'Watch'}
+                    </Button>
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        )}
+        {error && (
+          <div className="rounded-md border border-destructive/30 bg-destructive/5 px-3 py-2 text-[11px] text-destructive">
+            {error}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+function isFinanceWatchableEntry(entry: FeedCatalogEntry): boolean {
+  return entry.feed_type === 'rss' || entry.feed_type === 'market_candle';
+}
+
+function subscriptionRequestForEntry(
+  entry: FeedCatalogEntry,
+  sessionKey: string,
+): CreateFinanceSubscriptionRequest {
+  const request: CreateFinanceSubscriptionRequest = {
+    session_key: sessionKey,
+    catalog_source_ids: [entry.id],
+    delivery: 'silent',
+  };
+  if (entry.feed_type === 'market_candle') {
+    request.venues = optionalList(catalogVenue(entry));
+    request.symbols = catalogSymbols(entry);
+    request.timeframes = catalogTimeframes(entry);
+  }
+  return request;
+}
+
+function subscriptionMatchesEntry(
+  subscription: FinanceSubscription,
+  entry: FeedCatalogEntry,
+): boolean {
+  return (
+    subscription.source_names.includes(catalogSourceName(entry)) &&
+    subscription.event_kinds.includes(eventKindForEntry(entry))
+  );
+}
+
+function eventKindForEntry(entry: FeedCatalogEntry): FinanceEventKind {
+  return entry.feed_type === 'market_candle' ? 'market_candle_closed' : 'rss_article';
+}
+
+function catalogSourceName(entry: FeedCatalogEntry): string {
+  return entry.source_name?.trim() || `finance-${entry.id}`;
+}
+
+function catalogVenue(entry: FeedCatalogEntry): string | null {
+  return entry.venue?.trim() || transportString(entry, 'venue');
+}
+
+function catalogSymbols(entry: FeedCatalogEntry): string[] {
+  return entry.configured_symbols?.length
+    ? entry.configured_symbols
+    : transportStringList(entry, 'symbols');
+}
+
+function catalogTimeframes(entry: FeedCatalogEntry): string[] {
+  return entry.configured_timeframes?.length
+    ? entry.configured_timeframes
+    : transportStringList(entry, 'timeframes');
+}
+
+function coverageLabel(entry: FeedCatalogEntry): string {
+  if (entry.feed_type === 'market_candle') {
+    return [
+      catalogVenue(entry),
+      summarizeList(catalogSymbols(entry)),
+      summarizeList(catalogTimeframes(entry), 2),
+    ]
+      .filter(Boolean)
+      .join(' · ');
+  }
+
+  const tags = entry.tags.filter((tag) => tag !== 'finance' && tag !== 'news');
+  return tags.length > 0 ? tags.join(' · ') : entry.description;
+}
+
+function transportString(entry: FeedCatalogEntry, key: string): string | null {
+  const value = entry.transport_template?.[key];
+  return typeof value === 'string' && value.trim() ? value.trim() : null;
+}
+
+function transportStringList(entry: FeedCatalogEntry, key: string): string[] {
+  const value = entry.transport_template?.[key];
+  if (!Array.isArray(value)) return [];
+  return value
+    .filter((item): item is string => typeof item === 'string')
+    .map((item) => item.trim())
+    .filter(Boolean);
+}
+
+function optionalList(value: string | null): string[] {
+  return value ? [value] : [];
+}
+
+function summarizeList(values: string[], max = 3): string {
+  if (values.length <= max) return values.join(', ');
+  return `${values.slice(0, max).join(', ')} +${values.length - max}`;
+}

--- a/web/src/components/topology/__tests__/FinanceWatchesCard.test.tsx
+++ b/web/src/components/topology/__tests__/FinanceWatchesCard.test.tsx
@@ -1,0 +1,184 @@
+/*
+ * Copyright 2026 Rararulab
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { FinanceWatchesCard } from '../FinanceWatchesCard';
+
+import type { FeedCatalogEntry, FinanceSubscriptionsResponse } from '@/api/data-feeds';
+
+const catalogMock = vi.fn();
+const financeSubscriptionsMock = vi.fn();
+const createFinanceSubscriptionMock = vi.fn();
+
+vi.mock('@/api/data-feeds', () => ({
+  dataFeedsApi: {
+    catalog: (...args: unknown[]) => catalogMock(...args),
+    financeSubscriptions: (...args: unknown[]) => financeSubscriptionsMock(...args),
+    createFinanceSubscription: (...args: unknown[]) => createFinanceSubscriptionMock(...args),
+  },
+}));
+
+function buildClient() {
+  return new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, gcTime: 0, staleTime: 0 },
+      mutations: { retry: false },
+    },
+  });
+}
+
+function renderCard(sessionKey = 'session-1') {
+  const client = buildClient();
+  const utils = render(
+    <QueryClientProvider client={client}>
+      <FinanceWatchesCard sessionKey={sessionKey} />
+    </QueryClientProvider>,
+  );
+  return { ...utils, client };
+}
+
+function catalogEntry(partial: Partial<FeedCatalogEntry> & { id: string }): FeedCatalogEntry {
+  const entry: FeedCatalogEntry = {
+    id: partial.id,
+    name: partial.name ?? partial.id,
+    description: partial.description ?? 'source description',
+    feed_type: partial.feed_type ?? 'rss',
+    tags: partial.tags ?? ['finance', 'news'],
+    enabled: partial.enabled ?? true,
+    feed_id: partial.feed_id ?? null,
+    requires_configuration: partial.requires_configuration ?? false,
+    setup_hint: partial.setup_hint ?? null,
+    transport_template: partial.transport_template ?? null,
+  };
+  if (partial.source_name !== undefined) entry.source_name = partial.source_name;
+  if (partial.venue !== undefined) entry.venue = partial.venue;
+  if (partial.configured_symbols !== undefined)
+    entry.configured_symbols = partial.configured_symbols;
+  if (partial.configured_timeframes !== undefined) {
+    entry.configured_timeframes = partial.configured_timeframes;
+  }
+  if (partial.subscriptions !== undefined) entry.subscriptions = partial.subscriptions;
+  return entry;
+}
+
+beforeEach(() => {
+  catalogMock.mockReset();
+  financeSubscriptionsMock.mockReset();
+  createFinanceSubscriptionMock.mockReset();
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('FinanceWatchesCard', () => {
+  it('creates_session_watch_from_catalog_kline_source_with_configured_selectors', async () => {
+    const binance = catalogEntry({
+      id: 'binance-market-candles',
+      name: 'Binance Market Candles',
+      feed_type: 'market_candle',
+      source_name: 'finance-binance-market-candles',
+      venue: 'binance',
+      configured_symbols: ['BTCUSDT', 'ETHUSDT'],
+      configured_timeframes: ['1m'],
+      tags: ['finance', 'market-data', 'crypto', 'binance'],
+      transport_template: {
+        venue: 'binance',
+        symbols: ['BTCUSDT', 'ETHUSDT'],
+        timeframes: ['1m'],
+      },
+    });
+    catalogMock.mockResolvedValue([binance]);
+    financeSubscriptionsMock.mockResolvedValue({
+      subscriptions: [],
+      count: 0,
+    } satisfies FinanceSubscriptionsResponse);
+    createFinanceSubscriptionMock.mockResolvedValue({
+      created: true,
+      subscription: {
+        subscription_id: 'sub-1',
+        session_key: 'session-1',
+        event_kinds: ['market_candle_closed'],
+        source_names: ['finance-binance-market-candles'],
+        matches_all_sources: false,
+        sources: [],
+        category_tags: [],
+        watch_terms: [],
+        venues: ['binance'],
+        symbols: ['BTCUSDT', 'ETHUSDT'],
+        timeframes: ['1m'],
+        delivery: 'silent',
+        cooldown_secs: 900,
+        max_immediate_per_hour: 6,
+      },
+    });
+
+    renderCard('session-1');
+
+    const button = await screen.findByRole('button', { name: 'Watch' });
+    fireEvent.click(button);
+
+    await waitFor(() => {
+      expect(createFinanceSubscriptionMock).toHaveBeenCalledWith({
+        session_key: 'session-1',
+        catalog_source_ids: ['binance-market-candles'],
+        delivery: 'silent',
+        venues: ['binance'],
+        symbols: ['BTCUSDT', 'ETHUSDT'],
+        timeframes: ['1m'],
+      });
+    });
+  });
+
+  it('marks_existing_session_subscription_as_watching', async () => {
+    catalogMock.mockResolvedValue([
+      catalogEntry({
+        id: 'fed-press-releases',
+        name: 'Federal Reserve Press Releases',
+        source_name: 'finance-fed-press-releases',
+      }),
+    ]);
+    financeSubscriptionsMock.mockResolvedValue({
+      count: 1,
+      subscriptions: [
+        {
+          subscription_id: 'sub-1',
+          session_key: 'session-1',
+          event_kinds: ['rss_article'],
+          source_names: ['finance-fed-press-releases'],
+          matches_all_sources: false,
+          sources: [],
+          category_tags: [],
+          watch_terms: [],
+          venues: [],
+          symbols: [],
+          timeframes: [],
+          delivery: 'silent',
+          cooldown_secs: 900,
+          max_immediate_per_hour: 6,
+        },
+      ],
+    } satisfies FinanceSubscriptionsResponse);
+
+    renderCard('session-1');
+
+    expect(await screen.findByText('watching')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Watching' })).toBeDisabled();
+  });
+});

--- a/web/src/pages/Chat.tsx
+++ b/web/src/pages/Chat.tsx
@@ -24,6 +24,7 @@ import { api } from '@/api/client';
 import { fetchSessionMessagesBetweenAnchors } from '@/api/sessions';
 import type { ChatMessageData, ChatSession, SessionAnchor } from '@/api/types';
 import { usePublishPageStatus, type PageLiveStatus } from '@/components/shell/PageStatusContext';
+import { FinanceWatchesCard } from '@/components/topology/FinanceWatchesCard';
 import { SessionAnchorMinimap } from '@/components/topology/SessionAnchorMinimap';
 import { SessionPicker } from '@/components/topology/SessionPicker';
 import { TimelineView } from '@/components/topology/TimelineView';
@@ -295,6 +296,7 @@ export default function Chat() {
                 onSelectChild={setViewChild}
               />
             </div>
+            <FinanceWatchesCard sessionKey={rootSessionKey} />
             <div>
               <div className="mb-1.5 text-xs font-medium text-muted-foreground">Anchors</div>
               <SessionAnchorMinimap


### PR DESCRIPTION
## Summary
- Add a Chat right-rail Finance watches card for the active root session
- Let users subscribe the current session to built-in finance news and K-line catalog sources
- Pass catalog K-line venue/symbol/timeframe selectors when creating watches

## Verification
- npm --prefix web run format:check
- npm --prefix web run typecheck
- npm --prefix web run test
- git diff --check