### PR TITLE
feat(finance): allow unwatching session feeds

### DIFF
--- a/web/src/components/topology/FinanceWatchesCard.tsx
+++ b/web/src/components/topology/FinanceWatchesCard.tsx
@@ -52,6 +52,19 @@ export function FinanceWatchesCard({ sessionKey }: FinanceWatchesCardProps) {
       void queryClient.invalidateQueries({ queryKey: ['data-feed-catalog'] });
     },
   });
+  const unsubscribeMutation = useMutation({
+    mutationFn: ({
+      entry,
+      subscriptionIds,
+    }: {
+      entry: FeedCatalogEntry;
+      subscriptionIds: string[];
+    }) => dataFeedsApi.unsubscribeCatalogEntry(entry.id, { subscription_ids: subscriptionIds }),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ['finance-subscriptions'] });
+      void queryClient.invalidateQueries({ queryKey: ['data-feed-catalog'] });
+    },
+  });
 
   const entries = (catalogQuery.data ?? []).filter(isFinanceWatchableEntry);
   const sessionSubscriptions = (subscriptionsQuery.data?.subscriptions ?? []).filter(
@@ -62,6 +75,7 @@ export function FinanceWatchesCard({ sessionKey }: FinanceWatchesCardProps) {
     catalogQuery.error?.message ??
     subscriptionsQuery.error?.message ??
     subscribeMutation.error?.message ??
+    unsubscribeMutation.error?.message ??
     null;
 
   return (
@@ -93,11 +107,14 @@ export function FinanceWatchesCard({ sessionKey }: FinanceWatchesCardProps) {
         ) : (
           <div className="space-y-2">
             {entries.map((entry) => {
-              const subscribed = sessionSubscriptions.some((subscription) =>
+              const matchingSubscriptions = sessionSubscriptions.filter((subscription) =>
                 subscriptionMatchesEntry(subscription, entry),
               );
+              const subscribed = matchingSubscriptions.length > 0;
               const pending =
-                subscribeMutation.isPending && subscribeMutation.variables?.id === entry.id;
+                (subscribeMutation.isPending && subscribeMutation.variables?.id === entry.id) ||
+                (unsubscribeMutation.isPending &&
+                  unsubscribeMutation.variables?.entry.id === entry.id);
               return (
                 <div key={entry.id} className="rounded-md border bg-background/60 px-3 py-2">
                   <div className="flex items-start justify-between gap-2">
@@ -126,10 +143,27 @@ export function FinanceWatchesCard({ sessionKey }: FinanceWatchesCardProps) {
                       size="sm"
                       variant={subscribed ? 'outline' : 'default'}
                       className="h-7 shrink-0 px-2 text-[11px]"
-                      disabled={subscribed || pending}
-                      onClick={() => subscribeMutation.mutate(entry)}
+                      disabled={pending}
+                      onClick={() => {
+                        if (subscribed) {
+                          unsubscribeMutation.mutate({
+                            entry,
+                            subscriptionIds: matchingSubscriptions.map(
+                              (subscription) => subscription.subscription_id,
+                            ),
+                          });
+                        } else {
+                          subscribeMutation.mutate(entry);
+                        }
+                      }}
                     >
-                      {subscribed ? 'Watching' : pending ? 'Adding…' : 'Watch'}
+                      {pending
+                        ? subscribed
+                          ? 'Removing…'
+                          : 'Adding…'
+                        : subscribed
+                          ? 'Unwatch'
+                          : 'Watch'}
                     </Button>
                   </div>
                 </div>

--- a/web/src/components/topology/__tests__/FinanceWatchesCard.test.tsx
+++ b/web/src/components/topology/__tests__/FinanceWatchesCard.test.tsx
@@ -25,12 +25,14 @@ import type { FeedCatalogEntry, FinanceSubscriptionsResponse } from '@/api/data-
 const catalogMock = vi.fn();
 const financeSubscriptionsMock = vi.fn();
 const createFinanceSubscriptionMock = vi.fn();
+const unsubscribeCatalogEntryMock = vi.fn();
 
 vi.mock('@/api/data-feeds', () => ({
   dataFeedsApi: {
     catalog: (...args: unknown[]) => catalogMock(...args),
     financeSubscriptions: (...args: unknown[]) => financeSubscriptionsMock(...args),
     createFinanceSubscription: (...args: unknown[]) => createFinanceSubscriptionMock(...args),
+    unsubscribeCatalogEntry: (...args: unknown[]) => unsubscribeCatalogEntryMock(...args),
   },
 }));
 
@@ -81,6 +83,7 @@ beforeEach(() => {
   catalogMock.mockReset();
   financeSubscriptionsMock.mockReset();
   createFinanceSubscriptionMock.mockReset();
+  unsubscribeCatalogEntryMock.mockReset();
 });
 
 afterEach(() => {
@@ -146,7 +149,7 @@ describe('FinanceWatchesCard', () => {
     });
   });
 
-  it('marks_existing_session_subscription_as_watching', async () => {
+  it('removes_existing_session_watch_by_subscription_id', async () => {
     catalogMock.mockResolvedValue([
       catalogEntry({
         id: 'fed-press-releases',
@@ -175,10 +178,23 @@ describe('FinanceWatchesCard', () => {
         },
       ],
     } satisfies FinanceSubscriptionsResponse);
+    unsubscribeCatalogEntryMock.mockResolvedValue({
+      catalog_source_id: 'fed-press-releases',
+      source_name: 'finance-fed-press-releases',
+      removed_subscription_ids: ['sub-1'],
+      removed_count: 1,
+      remaining_subscription_ids: [],
+    });
 
     renderCard('session-1');
 
     expect(await screen.findByText('watching')).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Watching' })).toBeDisabled();
+    fireEvent.click(screen.getByRole('button', { name: 'Unwatch' }));
+
+    await waitFor(() => {
+      expect(unsubscribeCatalogEntryMock).toHaveBeenCalledWith('fed-press-releases', {
+        subscription_ids: ['sub-1'],
+      });
+    });
   });
 });


### PR DESCRIPTION
## Summary
- Let the Chat right-rail Finance watches card remove existing watches
- Remove only the current session's matching subscription ids for a catalog source
- Cover the Unwatch path in FinanceWatchesCard tests

## Verification
- npm --prefix web run format:check
- npm --prefix web run typecheck
- npm --prefix web run test -- FinanceWatchesCard
- git diff --check