### PR TITLE
feat(finance): enable feeds from session watches

### DIFF
--- a/web/src/components/topology/FinanceWatchesCard.tsx
+++ b/web/src/components/topology/FinanceWatchesCard.tsx
@@ -52,6 +52,14 @@ export function FinanceWatchesCard({ sessionKey }: FinanceWatchesCardProps) {
       void queryClient.invalidateQueries({ queryKey: ['data-feed-catalog'] });
     },
   });
+  const enableMutation = useMutation({
+    mutationFn: (entry: FeedCatalogEntry) => dataFeedsApi.enableCatalogEntry(entry.id),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ['data-feed-catalog'] });
+      void queryClient.invalidateQueries({ queryKey: ['data-feeds'] });
+      void queryClient.invalidateQueries({ queryKey: ['data-feed-summaries'] });
+    },
+  });
   const unsubscribeMutation = useMutation({
     mutationFn: ({
       entry,
@@ -74,6 +82,7 @@ export function FinanceWatchesCard({ sessionKey }: FinanceWatchesCardProps) {
   const error =
     catalogQuery.error?.message ??
     subscriptionsQuery.error?.message ??
+    enableMutation.error?.message ??
     subscribeMutation.error?.message ??
     unsubscribeMutation.error?.message ??
     null;
@@ -111,10 +120,19 @@ export function FinanceWatchesCard({ sessionKey }: FinanceWatchesCardProps) {
                 subscriptionMatchesEntry(subscription, entry),
               );
               const subscribed = matchingSubscriptions.length > 0;
+              const canEnableInline = !entry.enabled && !entry.requires_configuration;
+              const needsConfiguration = !entry.enabled && entry.requires_configuration;
               const pending =
+                (enableMutation.isPending && enableMutation.variables?.id === entry.id) ||
                 (subscribeMutation.isPending && subscribeMutation.variables?.id === entry.id) ||
                 (unsubscribeMutation.isPending &&
                   unsubscribeMutation.variables?.entry.id === entry.id);
+              const actionLabel = financeWatchActionLabel({
+                pending,
+                canEnableInline,
+                needsConfiguration,
+                subscribed,
+              });
               return (
                 <div key={entry.id} className="rounded-md border bg-background/60 px-3 py-2">
                   <div className="flex items-start justify-between gap-2">
@@ -126,7 +144,7 @@ export function FinanceWatchesCard({ sessionKey }: FinanceWatchesCardProps) {
                         </Badge>
                         {!entry.enabled && (
                           <Badge variant="secondary" className="px-1.5 py-0 text-[10px]">
-                            source off
+                            {needsConfiguration ? 'needs config' : 'source off'}
                           </Badge>
                         )}
                         {subscribed && (
@@ -143,9 +161,11 @@ export function FinanceWatchesCard({ sessionKey }: FinanceWatchesCardProps) {
                       size="sm"
                       variant={subscribed ? 'outline' : 'default'}
                       className="h-7 shrink-0 px-2 text-[11px]"
-                      disabled={pending}
+                      disabled={pending || needsConfiguration}
                       onClick={() => {
-                        if (subscribed) {
+                        if (canEnableInline) {
+                          enableMutation.mutate(entry);
+                        } else if (subscribed) {
                           unsubscribeMutation.mutate({
                             entry,
                             subscriptionIds: matchingSubscriptions.map(
@@ -157,13 +177,7 @@ export function FinanceWatchesCard({ sessionKey }: FinanceWatchesCardProps) {
                         }
                       }}
                     >
-                      {pending
-                        ? subscribed
-                          ? 'Removing…'
-                          : 'Adding…'
-                        : subscribed
-                          ? 'Unwatch'
-                          : 'Watch'}
+                      {actionLabel}
                     </Button>
                   </div>
                 </div>
@@ -183,6 +197,26 @@ export function FinanceWatchesCard({ sessionKey }: FinanceWatchesCardProps) {
 
 function isFinanceWatchableEntry(entry: FeedCatalogEntry): boolean {
   return entry.feed_type === 'rss' || entry.feed_type === 'market_candle';
+}
+
+function financeWatchActionLabel({
+  pending,
+  canEnableInline,
+  needsConfiguration,
+  subscribed,
+}: {
+  pending: boolean;
+  canEnableInline: boolean;
+  needsConfiguration: boolean;
+  subscribed: boolean;
+}): string {
+  if (pending) {
+    if (canEnableInline) return 'Enabling…';
+    return subscribed ? 'Removing…' : 'Adding…';
+  }
+  if (needsConfiguration) return 'Configure';
+  if (canEnableInline) return 'Enable source';
+  return subscribed ? 'Unwatch' : 'Watch';
 }
 
 function subscriptionRequestForEntry(

--- a/web/src/components/topology/__tests__/FinanceWatchesCard.test.tsx
+++ b/web/src/components/topology/__tests__/FinanceWatchesCard.test.tsx
@@ -24,6 +24,7 @@ import type { FeedCatalogEntry, FinanceSubscriptionsResponse } from '@/api/data-
 
 const catalogMock = vi.fn();
 const financeSubscriptionsMock = vi.fn();
+const enableCatalogEntryMock = vi.fn();
 const createFinanceSubscriptionMock = vi.fn();
 const unsubscribeCatalogEntryMock = vi.fn();
 
@@ -31,6 +32,7 @@ vi.mock('@/api/data-feeds', () => ({
   dataFeedsApi: {
     catalog: (...args: unknown[]) => catalogMock(...args),
     financeSubscriptions: (...args: unknown[]) => financeSubscriptionsMock(...args),
+    enableCatalogEntry: (...args: unknown[]) => enableCatalogEntryMock(...args),
     createFinanceSubscription: (...args: unknown[]) => createFinanceSubscriptionMock(...args),
     unsubscribeCatalogEntry: (...args: unknown[]) => unsubscribeCatalogEntryMock(...args),
   },
@@ -82,6 +84,7 @@ function catalogEntry(partial: Partial<FeedCatalogEntry> & { id: string }): Feed
 beforeEach(() => {
   catalogMock.mockReset();
   financeSubscriptionsMock.mockReset();
+  enableCatalogEntryMock.mockReset();
   createFinanceSubscriptionMock.mockReset();
   unsubscribeCatalogEntryMock.mockReset();
 });
@@ -147,6 +150,43 @@ describe('FinanceWatchesCard', () => {
         timeframes: ['1m'],
       });
     });
+  });
+
+  it('enables_ready_source_before_allowing_session_watch', async () => {
+    catalogMock.mockResolvedValue([
+      catalogEntry({
+        id: 'fed-press-releases',
+        name: 'Federal Reserve Press Releases',
+        source_name: 'finance-fed-press-releases',
+        enabled: false,
+      }),
+    ]);
+    financeSubscriptionsMock.mockResolvedValue({
+      subscriptions: [],
+      count: 0,
+    } satisfies FinanceSubscriptionsResponse);
+    enableCatalogEntryMock.mockResolvedValue({
+      id: 'feed-1',
+      name: 'finance-fed-press-releases',
+      feed_type: 'rss',
+      tags: ['finance', 'news'],
+      transport: {},
+      auth: null,
+      enabled: true,
+      status: 'idle',
+      last_error: null,
+      created_at: '2026-01-01T00:00:00Z',
+      updated_at: '2026-01-01T00:00:00Z',
+    });
+
+    renderCard('session-1');
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Enable source' }));
+
+    await waitFor(() => {
+      expect(enableCatalogEntryMock).toHaveBeenCalledWith('fed-press-releases');
+    });
+    expect(createFinanceSubscriptionMock).not.toHaveBeenCalled();
   });
 
   it('removes_existing_session_watch_by_subscription_id', async () => {


### PR DESCRIPTION
## Summary
- Let the Chat Finance watches card enable ready built-in feed sources before watching them
- Keep provider presets disabled with a Configure affordance instead of creating inert watches
- Cover the source-enable path in FinanceWatchesCard tests

## Verification
- npm --prefix web run format:check
- npm --prefix web run typecheck
- npm --prefix web run test -- FinanceWatchesCard
- npm --prefix web run test
- git diff --check