### PR TITLE
feat(finance): link watch configuration to data feeds

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -21,10 +21,8 @@ import { BrowserRouter, Navigate, Routes, Route, useNavigate, useParams } from '
 import { ConnectionSetupDialog } from '@/components/ConnectionSetupDialog';
 import { RequireAuth } from '@/components/RequireAuth';
 import { ServerStatusProvider } from '@/components/ServerStatusProvider';
-import {
-  SettingsModalProvider,
-  useSettingsModal,
-} from '@/components/settings/SettingsModalProvider';
+import { useSettingsModal } from '@/components/settings/SettingsModalContext';
+import { SettingsModalProvider } from '@/components/settings/SettingsModalProvider';
 import type { SettingsPage } from '@/components/settings/SettingsPanel';
 import DashboardLayout from '@/layouts/DashboardLayout';
 import Docs from '@/pages/Docs';

--- a/web/src/components/DataFeedsPanel.tsx
+++ b/web/src/components/DataFeedsPanel.tsx
@@ -1243,12 +1243,22 @@ function CatalogConfigureDialog({
 function FeedCatalogCard({
   entries,
   onUseTemplate,
+  focusCatalogEntryId,
 }: {
   entries: FeedCatalogEntry[];
   onUseTemplate: (entry: FeedCatalogEntry) => void;
+  focusCatalogEntryId?: string | undefined;
 }) {
   const queryClient = useQueryClient();
   const [configureEntry, setConfigureEntry] = useState<FeedCatalogEntry | null>(null);
+
+  useEffect(() => {
+    if (!focusCatalogEntryId) return;
+    const entry = entries.find((candidate) => candidate.id === focusCatalogEntryId);
+    if (entry?.requires_configuration) {
+      setConfigureEntry(entry);
+    }
+  }, [entries, focusCatalogEntryId]);
 
   const refresh = () => {
     void queryClient.invalidateQueries({ queryKey: ['data-feeds'] });
@@ -1516,10 +1526,12 @@ function FeedListView({
   feeds,
   summaries,
   onSelectFeed,
+  focusCatalogEntryId,
 }: {
   feeds: DataFeedConfig[];
   summaries: FeedSummary[];
   onSelectFeed: (feed: DataFeedConfig) => void;
+  focusCatalogEntryId?: string | undefined;
 }) {
   const queryClient = useQueryClient();
   const [formOpen, setFormOpen] = useState(false);
@@ -1599,7 +1611,11 @@ function FeedListView({
       </div>
 
       {catalogQuery.data && (
-        <FeedCatalogCard entries={catalogQuery.data} onUseTemplate={handleUseTemplate} />
+        <FeedCatalogCard
+          entries={catalogQuery.data}
+          onUseTemplate={handleUseTemplate}
+          focusCatalogEntryId={focusCatalogEntryId}
+        />
       )}
       {financeSubscriptionsQuery.data && (
         <FinanceSubscriptionsCard result={financeSubscriptionsQuery.data} />
@@ -1762,7 +1778,11 @@ function FeedListView({
 
 type View = { kind: 'list' } | { kind: 'events'; feed: DataFeedConfig };
 
-export default function DataFeedsPanel() {
+export default function DataFeedsPanel({
+  focusCatalogEntryId,
+}: {
+  focusCatalogEntryId?: string | undefined;
+} = {}) {
   const [view, setView] = useState<View>({ kind: 'list' });
 
   const feedsQuery = useQuery({
@@ -1814,6 +1834,7 @@ export default function DataFeedsPanel() {
       feeds={feeds}
       summaries={summaries}
       onSelectFeed={(feed) => setView({ kind: 'events', feed })}
+      focusCatalogEntryId={focusCatalogEntryId}
     />
   );
 }

--- a/web/src/components/OnboardingModal.tsx
+++ b/web/src/components/OnboardingModal.tsx
@@ -16,7 +16,7 @@
 
 import { Sparkles } from 'lucide-react';
 
-import { useSettingsModal } from '@/components/settings/SettingsModalProvider';
+import { useSettingsModal } from '@/components/settings/SettingsModalContext';
 import { Button } from '@/components/ui/button';
 import {
   Dialog,

--- a/web/src/components/settings/SettingsModal.tsx
+++ b/web/src/components/settings/SettingsModal.tsx
@@ -17,12 +17,14 @@
 import { X } from 'lucide-react';
 import { useEffect, useRef } from 'react';
 
+import type { SettingsOpenOptions } from './SettingsModalContext';
 import SettingsPanel, { type SettingsPage } from './SettingsPanel';
 
 interface SettingsModalProps {
   open: boolean;
   onClose: () => void;
   section?: SettingsPage | undefined;
+  options?: SettingsOpenOptions | undefined;
 }
 
 /**
@@ -32,7 +34,7 @@ interface SettingsModalProps {
  * its own internal scroll regions that `Dialog`'s capped `max-w-lg`/`grid`
  * content layout fights against.
  */
-export default function SettingsModal({ open, onClose, section }: SettingsModalProps) {
+export default function SettingsModal({ open, onClose, section, options }: SettingsModalProps) {
   const backdropRef = useRef<HTMLDivElement>(null);
   // Tracks whether the current click began on the backdrop itself, so a drag
   // that started inside an input (text selection) and released on the backdrop
@@ -87,7 +89,11 @@ export default function SettingsModal({ open, onClose, section }: SettingsModalP
           <X className="h-4 w-4" />
         </button>
         <div className="min-h-0 flex-1 overflow-hidden">
-          <SettingsPanel key={section ?? 'connection'} initialSection={section} />
+          <SettingsPanel
+            key={`${section ?? 'connection'}:${options?.dataFeedCatalogId ?? ''}`}
+            initialSection={section}
+            dataFeedCatalogId={options?.dataFeedCatalogId}
+          />
         </div>
       </div>
     </div>

--- a/web/src/components/settings/SettingsModalContext.tsx
+++ b/web/src/components/settings/SettingsModalContext.tsx
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2026 Rararulab
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { createContext, useContext } from 'react';
+
+import type { SettingsPage } from './SettingsPanel';
+
+export interface SettingsOpenOptions {
+  dataFeedCatalogId?: string | undefined;
+}
+
+export interface SettingsModalContextValue {
+  openSettings: (section?: SettingsPage, options?: SettingsOpenOptions) => void;
+  closeSettings: () => void;
+}
+
+export const SettingsModalContext = createContext<SettingsModalContextValue | null>(null);
+
+/**
+ * Read the settings-modal controls. Throws when called outside the
+ * provider so a misplaced caller fails loudly rather than silently no-op.
+ */
+export function useSettingsModal(): SettingsModalContextValue {
+  const ctx = useContext(SettingsModalContext);
+  if (!ctx) {
+    throw new Error('useSettingsModal must be used inside <SettingsModalProvider>');
+  }
+  return ctx;
+}

--- a/web/src/components/settings/SettingsModalProvider.tsx
+++ b/web/src/components/settings/SettingsModalProvider.tsx
@@ -14,17 +14,15 @@
  * limitations under the License.
  */
 
-import { createContext, useCallback, useContext, useMemo, useState, type ReactNode } from 'react';
+import { useCallback, useMemo, useState, type ReactNode } from 'react';
 
 import SettingsModal from './SettingsModal';
+import {
+  SettingsModalContext,
+  type SettingsModalContextValue,
+  type SettingsOpenOptions,
+} from './SettingsModalContext';
 import type { SettingsPage } from './SettingsPanel';
-
-interface SettingsModalContextValue {
-  openSettings: (section?: SettingsPage) => void;
-  closeSettings: () => void;
-}
-
-const SettingsModalContext = createContext<SettingsModalContextValue | null>(null);
 
 /**
  * Provides a single admin-settings modal instance to the whole tree and
@@ -35,9 +33,11 @@ const SettingsModalContext = createContext<SettingsModalContextValue | null>(nul
 export function SettingsModalProvider({ children }: { children: ReactNode }) {
   const [open, setOpen] = useState(false);
   const [section, setSection] = useState<SettingsPage | undefined>(undefined);
+  const [options, setOptions] = useState<SettingsOpenOptions | undefined>(undefined);
 
-  const openSettings = useCallback((next?: SettingsPage) => {
+  const openSettings = useCallback((next?: SettingsPage, nextOptions?: SettingsOpenOptions) => {
     setSection(next);
+    setOptions(nextOptions);
     setOpen(true);
   }, []);
 
@@ -53,19 +53,7 @@ export function SettingsModalProvider({ children }: { children: ReactNode }) {
   return (
     <SettingsModalContext.Provider value={value}>
       {children}
-      <SettingsModal open={open} onClose={closeSettings} section={section} />
+      <SettingsModal open={open} onClose={closeSettings} section={section} options={options} />
     </SettingsModalContext.Provider>
   );
-}
-
-/**
- * Read the settings-modal controls. Throws when called outside the
- * provider so a misplaced caller fails loudly rather than silently no-op.
- */
-export function useSettingsModal(): SettingsModalContextValue {
-  const ctx = useContext(SettingsModalContext);
-  if (!ctx) {
-    throw new Error('useSettingsModal must be used inside <SettingsModalProvider>');
-  }
-  return ctx;
 }

--- a/web/src/components/settings/SettingsPanel.tsx
+++ b/web/src/components/settings/SettingsPanel.tsx
@@ -692,8 +692,10 @@ type SettingsNavGroup = {
  */
 export default function SettingsPanel({
   initialSection,
+  dataFeedCatalogId,
 }: {
   initialSection?: SettingsPage | undefined;
+  dataFeedCatalogId?: string | undefined;
 }) {
   const { theme, setTheme } = useTheme();
   const queryClient = useQueryClient();
@@ -1556,7 +1558,7 @@ export default function SettingsPanel({
           {/* ── Data Feeds ── */}
           {activeCategory === 'data-feeds' && (
             <div className="data-panel p-4">
-              <DataFeedsPanel />
+              <DataFeedsPanel focusCatalogEntryId={dataFeedCatalogId} />
             </div>
           )}
 

--- a/web/src/components/shell/NavRail.tsx
+++ b/web/src/components/shell/NavRail.tsx
@@ -18,7 +18,7 @@ import { BookOpen, MessageSquare, PanelLeft, PanelLeftClose, Settings } from 'lu
 import { useEffect, useState } from 'react';
 import { NavLink } from 'react-router';
 
-import { useSettingsModal } from '@/components/settings/SettingsModalProvider';
+import { useSettingsModal } from '@/components/settings/SettingsModalContext';
 import { Button } from '@/components/ui/button';
 import { useServerStatus } from '@/hooks/use-server-status';
 import { cn } from '@/lib/utils';

--- a/web/src/components/topology/FinanceWatchesCard.tsx
+++ b/web/src/components/topology/FinanceWatchesCard.tsx
@@ -23,6 +23,7 @@ import {
   type FinanceEventKind,
   type FinanceSubscription,
 } from '@/api/data-feeds';
+import { useSettingsModal } from '@/components/settings/SettingsModalContext';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
@@ -33,6 +34,7 @@ interface FinanceWatchesCardProps {
 
 export function FinanceWatchesCard({ sessionKey }: FinanceWatchesCardProps) {
   const queryClient = useQueryClient();
+  const { openSettings } = useSettingsModal();
   const catalogQuery = useQuery({
     queryKey: ['data-feed-catalog'],
     queryFn: () => dataFeedsApi.catalog(),
@@ -161,10 +163,12 @@ export function FinanceWatchesCard({ sessionKey }: FinanceWatchesCardProps) {
                       size="sm"
                       variant={subscribed ? 'outline' : 'default'}
                       className="h-7 shrink-0 px-2 text-[11px]"
-                      disabled={pending || needsConfiguration}
+                      disabled={pending}
                       onClick={() => {
                         if (canEnableInline) {
                           enableMutation.mutate(entry);
+                        } else if (needsConfiguration) {
+                          openSettings('data-feeds', { dataFeedCatalogId: entry.id });
                         } else if (subscribed) {
                           unsubscribeMutation.mutate({
                             entry,

--- a/web/src/components/topology/__tests__/FinanceWatchesCard.test.tsx
+++ b/web/src/components/topology/__tests__/FinanceWatchesCard.test.tsx
@@ -27,6 +27,7 @@ const financeSubscriptionsMock = vi.fn();
 const enableCatalogEntryMock = vi.fn();
 const createFinanceSubscriptionMock = vi.fn();
 const unsubscribeCatalogEntryMock = vi.fn();
+const openSettingsMock = vi.fn();
 
 vi.mock('@/api/data-feeds', () => ({
   dataFeedsApi: {
@@ -36,6 +37,13 @@ vi.mock('@/api/data-feeds', () => ({
     createFinanceSubscription: (...args: unknown[]) => createFinanceSubscriptionMock(...args),
     unsubscribeCatalogEntry: (...args: unknown[]) => unsubscribeCatalogEntryMock(...args),
   },
+}));
+
+vi.mock('@/components/settings/SettingsModalContext', () => ({
+  useSettingsModal: () => ({
+    openSettings: openSettingsMock,
+    closeSettings: vi.fn(),
+  }),
 }));
 
 function buildClient() {
@@ -87,6 +95,7 @@ beforeEach(() => {
   enableCatalogEntryMock.mockReset();
   createFinanceSubscriptionMock.mockReset();
   unsubscribeCatalogEntryMock.mockReset();
+  openSettingsMock.mockReset();
 });
 
 afterEach(() => {
@@ -236,5 +245,32 @@ describe('FinanceWatchesCard', () => {
         subscription_ids: ['sub-1'],
       });
     });
+  });
+
+  it('opens_data_feed_settings_for_sources_that_require_configuration', async () => {
+    catalogMock.mockResolvedValue([
+      catalogEntry({
+        id: 'longport-market-candles',
+        name: 'LongPort Market Candles',
+        feed_type: 'market_candle',
+        enabled: false,
+        requires_configuration: true,
+        setup_hint: 'Configure LongPort credentials and selectors before enabling.',
+      }),
+    ]);
+    financeSubscriptionsMock.mockResolvedValue({
+      subscriptions: [],
+      count: 0,
+    } satisfies FinanceSubscriptionsResponse);
+
+    renderCard('session-1');
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Configure' }));
+
+    expect(openSettingsMock).toHaveBeenCalledWith('data-feeds', {
+      dataFeedCatalogId: 'longport-market-candles',
+    });
+    expect(createFinanceSubscriptionMock).not.toHaveBeenCalled();
+    expect(enableCatalogEntryMock).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- add a lightweight settings modal context so finance watches can open settings without loading the full settings panel import chain
- make Finance watches Configure open Settings → Data feeds with the selected catalog source focused
- auto-open the catalog configure dialog for focused provider presets and cover the chat-side behavior in tests

## Verification
- npm --prefix web run format:check
- npm --prefix web run typecheck
- npm --prefix web run test -- FinanceWatchesCard
- npm --prefix web run test
- git diff --check