### PR TITLE
feat(finance): show candle stream watermarks

### DIFF
--- a/web/src/components/DataFeedsPanel.tsx
+++ b/web/src/components/DataFeedsPanel.tsx
@@ -30,6 +30,7 @@ import { useState, useCallback, useEffect } from 'react';
 
 import {
   dataFeedsApi,
+  type CandleStream,
   type DataFeedConfig,
   type FeedCatalogEntry,
   type FeedEvent,
@@ -224,6 +225,10 @@ function financeSubscriptionSelectors(subscription: FinanceSubscription): string
     summarizeList(subscription.watch_terms),
   ].filter(Boolean);
   return selectors.length > 0 ? selectors : ['All matching events'];
+}
+
+function streamLabel(stream: CandleStream): string {
+  return `${stream.venue.toUpperCase()} · ${stream.symbol} · ${stream.timeframe}`;
 }
 
 // ---------------------------------------------------------------------------
@@ -1522,14 +1527,110 @@ function FinanceSubscriptionsCard({ result }: { result: FinanceSubscriptionsResp
   );
 }
 
+function MarketDataStreamsCard({
+  streams,
+  isLoading,
+  isError,
+  onRetry,
+}: {
+  streams: CandleStream[];
+  isLoading: boolean;
+  isError: boolean;
+  onRetry: () => void;
+}) {
+  return (
+    <div className="rounded-lg border bg-card">
+      <div className="flex items-center justify-between gap-3 border-b px-4 py-3">
+        <div>
+          <h3 className="text-sm font-semibold">Stored K-line streams</h3>
+          <p className="text-xs text-muted-foreground">
+            Latest closed candles persisted in the market-data repository.
+          </p>
+        </div>
+        <Badge variant="outline" className="shrink-0 text-xs">
+          {streams.length} stream{streams.length === 1 ? '' : 's'}
+        </Badge>
+      </div>
+      {isLoading ? (
+        <div className="space-y-2 px-4 py-4">
+          <Skeleton className="h-4 w-1/2" />
+          <Skeleton className="h-4 w-2/3" />
+        </div>
+      ) : isError ? (
+        <div className="flex items-center justify-between gap-3 px-4 py-4">
+          <p className="text-xs text-muted-foreground">Failed to load K-line stream watermarks.</p>
+          <Button variant="outline" size="sm" className="h-8" onClick={onRetry}>
+            Retry
+          </Button>
+        </div>
+      ) : streams.length === 0 ? (
+        <div className="px-4 py-4 text-xs text-muted-foreground">
+          No closed candles have been stored yet. Enable a K-line feed and wait for the first
+          persisted candle.
+        </div>
+      ) : (
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Stream</TableHead>
+              <TableHead className="w-36 text-right">Candles</TableHead>
+              <TableHead className="w-40 text-right">Latest Close</TableHead>
+              <TableHead className="w-40 text-right">Ingested</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {streams.map((stream) => (
+              <TableRow
+                key={`${stream.source_name}:${stream.venue}:${stream.symbol}:${stream.timeframe}`}
+              >
+                <TableCell>
+                  <div className="space-y-0.5">
+                    <div className="text-sm font-medium">{streamLabel(stream)}</div>
+                    <div className="font-mono text-[11px] text-muted-foreground">
+                      {stream.source_name}
+                    </div>
+                  </div>
+                </TableCell>
+                <TableCell className="text-right text-xs text-muted-foreground">
+                  {stream.candle_count.toLocaleString()}
+                </TableCell>
+                <TableCell
+                  className="text-right text-xs text-muted-foreground"
+                  title={new Date(stream.latest_close_time).toLocaleString()}
+                >
+                  {timeAgo(stream.latest_close_time)}
+                </TableCell>
+                <TableCell
+                  className="text-right text-xs text-muted-foreground"
+                  title={new Date(stream.latest_ingested_at).toLocaleString()}
+                >
+                  {timeAgo(stream.latest_ingested_at)}
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      )}
+    </div>
+  );
+}
+
 function FeedListView({
   feeds,
   summaries,
+  candleStreams,
+  candleStreamsLoading,
+  candleStreamsError,
+  onRetryCandleStreams,
   onSelectFeed,
   focusCatalogEntryId,
 }: {
   feeds: DataFeedConfig[];
   summaries: FeedSummary[];
+  candleStreams: CandleStream[];
+  candleStreamsLoading: boolean;
+  candleStreamsError: boolean;
+  onRetryCandleStreams: () => void;
   onSelectFeed: (feed: DataFeedConfig) => void;
   focusCatalogEntryId?: string | undefined;
 }) {
@@ -1620,6 +1721,12 @@ function FeedListView({
       {financeSubscriptionsQuery.data && (
         <FinanceSubscriptionsCard result={financeSubscriptionsQuery.data} />
       )}
+      <MarketDataStreamsCard
+        streams={candleStreams}
+        isLoading={candleStreamsLoading}
+        isError={candleStreamsError}
+        onRetry={onRetryCandleStreams}
+      />
 
       {/* Table */}
       {feeds.length === 0 ? (
@@ -1794,6 +1901,11 @@ export default function DataFeedsPanel({
     queryFn: () => dataFeedsApi.summaries(),
     refetchInterval: 30_000,
   });
+  const candleStreamsQuery = useQuery({
+    queryKey: ['market-data-candle-streams'],
+    queryFn: () => dataFeedsApi.candleStreams({ limit: 100 }),
+    refetchInterval: 30_000,
+  });
 
   if (feedsQuery.isLoading) {
     return (
@@ -1833,6 +1945,12 @@ export default function DataFeedsPanel({
     <FeedListView
       feeds={feeds}
       summaries={summaries}
+      candleStreams={candleStreamsQuery.data?.streams ?? []}
+      candleStreamsLoading={candleStreamsQuery.isLoading}
+      candleStreamsError={candleStreamsQuery.isError}
+      onRetryCandleStreams={() => {
+        void candleStreamsQuery.refetch();
+      }}
       onSelectFeed={(feed) => setView({ kind: 'events', feed })}
       focusCatalogEntryId={focusCatalogEntryId}
     />

--- a/web/src/components/__tests__/DataFeedsPanel.test.tsx
+++ b/web/src/components/__tests__/DataFeedsPanel.test.tsx
@@ -1,0 +1,155 @@
+/*
+ * Copyright 2026 Rararulab
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { cleanup, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import DataFeedsPanel from '../DataFeedsPanel';
+
+import type {
+  CandleStreamsResponse,
+  DataFeedConfig,
+  FeedCatalogEntry,
+  FinanceSubscriptionsResponse,
+} from '@/api/data-feeds';
+
+const listMock = vi.fn();
+const summariesMock = vi.fn();
+const catalogMock = vi.fn();
+const financeSubscriptionsMock = vi.fn();
+const candleStreamsMock = vi.fn();
+
+vi.mock('@/api/data-feeds', () => ({
+  dataFeedsApi: {
+    list: (...args: unknown[]) => listMock(...args),
+    summaries: (...args: unknown[]) => summariesMock(...args),
+    catalog: (...args: unknown[]) => catalogMock(...args),
+    financeSubscriptions: (...args: unknown[]) => financeSubscriptionsMock(...args),
+    candleStreams: (...args: unknown[]) => candleStreamsMock(...args),
+    toggle: vi.fn(),
+    delete: vi.fn(),
+    enableCatalogEntry: vi.fn(),
+    disableCatalogEntry: vi.fn(),
+    unsubscribeCatalogEntry: vi.fn(),
+    deleteFinanceSubscription: vi.fn(),
+  },
+}));
+
+function buildClient() {
+  return new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, gcTime: 0, staleTime: 0 },
+      mutations: { retry: false },
+    },
+  });
+}
+
+function renderPanel() {
+  const client = buildClient();
+  const utils = render(
+    <QueryClientProvider client={client}>
+      <DataFeedsPanel />
+    </QueryClientProvider>,
+  );
+  return { ...utils, client };
+}
+
+function feed(partial: Partial<DataFeedConfig> = {}): DataFeedConfig {
+  return {
+    id: partial.id ?? 'feed-1',
+    name: partial.name ?? 'finance-binance-market-candles',
+    feed_type: partial.feed_type ?? 'market_candle',
+    tags: partial.tags ?? ['finance', 'market-data'],
+    transport: partial.transport ?? {},
+    auth: partial.auth ?? null,
+    enabled: partial.enabled ?? true,
+    status: partial.status ?? 'running',
+    last_error: partial.last_error ?? null,
+    created_at: partial.created_at ?? '2026-07-01T00:00:00Z',
+    updated_at: partial.updated_at ?? '2026-07-01T00:00:00Z',
+  };
+}
+
+beforeEach(() => {
+  listMock.mockReset();
+  summariesMock.mockReset();
+  catalogMock.mockReset();
+  financeSubscriptionsMock.mockReset();
+  candleStreamsMock.mockReset();
+
+  listMock.mockResolvedValue([]);
+  summariesMock.mockResolvedValue([]);
+  catalogMock.mockResolvedValue([] satisfies FeedCatalogEntry[]);
+  financeSubscriptionsMock.mockResolvedValue({
+    subscriptions: [],
+    count: 0,
+  } satisfies FinanceSubscriptionsResponse);
+  candleStreamsMock.mockResolvedValue({
+    streams: [],
+    count: 0,
+    query_limit: 100,
+  } satisfies CandleStreamsResponse);
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('DataFeedsPanel', () => {
+  it('requests and displays stored K-line stream watermarks', async () => {
+    listMock.mockResolvedValue([feed()]);
+    candleStreamsMock.mockResolvedValue({
+      streams: [
+        {
+          source_name: 'finance-binance-market-candles',
+          venue: 'binance',
+          symbol: 'BTCUSDT',
+          timeframe: '1m',
+          candle_count: 42,
+          first_open_time: '2026-07-12T00:00:00Z',
+          latest_open_time: '2026-07-12T00:41:00Z',
+          latest_close_time: '2026-07-12T00:41:59Z',
+          latest_ingested_at: '2026-07-12T00:42:02Z',
+        },
+      ],
+      count: 1,
+      query_limit: 100,
+    } satisfies CandleStreamsResponse);
+
+    renderPanel();
+
+    expect(await screen.findByText('Stored K-line streams')).toBeInTheDocument();
+    expect(await screen.findByText('BINANCE · BTCUSDT · 1m')).toBeInTheDocument();
+    expect(screen.getAllByText('finance-binance-market-candles').length).toBeGreaterThan(0);
+    expect(screen.getByText('42')).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(candleStreamsMock).toHaveBeenCalledWith({ limit: 100 });
+    });
+  });
+
+  it('shows an empty state before the first persisted candle', async () => {
+    renderPanel();
+
+    expect(await screen.findByText('Stored K-line streams')).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        'No closed candles have been stored yet. Enable a K-line feed and wait for the first persisted candle.',
+      ),
+    ).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- add a read-only Stored K-line streams card to Data Feeds settings
- poll the candle stream watermark API every 30s with a conservative limit
- cover the stream card and empty state with a DataFeedsPanel component test

## Validation
- npm test -- src/components/__tests__/DataFeedsPanel.test.tsx
- npm --prefix web run typecheck
- npm --prefix web run format:check
- npm --prefix web run lint