### PR TITLE
feat(finance): surface watch stream health

### DIFF
--- a/web/src/components/DataFeedsPanel.tsx
+++ b/web/src/components/DataFeedsPanel.tsx
@@ -78,6 +78,7 @@ import {
   TableHeader,
   TableRow,
 } from '@/components/ui/table';
+import { candleSubscriptionStreamHealth } from '@/lib/finance-candle-health';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -229,114 +230,6 @@ function financeSubscriptionSelectors(subscription: FinanceSubscription): string
 
 function streamLabel(stream: CandleStream): string {
   return `${stream.venue.toUpperCase()} · ${stream.symbol} · ${stream.timeframe}`;
-}
-
-type CandleSubscriptionStreamHealth = {
-  status: 'fresh' | 'stale' | 'missing';
-  label: string;
-  detail: string;
-};
-
-function normalizedSelectorSet(
-  values: string[],
-  mode: 'lower' | 'upper' | 'timeframe',
-): Set<string> {
-  return new Set(
-    values
-      .map((value) => value.trim())
-      .filter(Boolean)
-      .map((value) => {
-        if (mode === 'lower') return value.toLowerCase();
-        if (mode === 'upper') return value.toUpperCase();
-        return value.toLowerCase();
-      }),
-  );
-}
-
-function streamMatchesSubscription(
-  stream: CandleStream,
-  subscription: FinanceSubscription,
-): boolean {
-  const sourceNames = normalizedSelectorSet(subscription.source_names, 'lower');
-  const venues = normalizedSelectorSet(subscription.venues, 'lower');
-  const symbols = normalizedSelectorSet(subscription.symbols, 'upper');
-  const timeframes = normalizedSelectorSet(subscription.timeframes, 'timeframe');
-
-  if (
-    sourceNames.size > 0 &&
-    !subscription.matches_all_sources &&
-    !sourceNames.has(stream.source_name.toLowerCase())
-  ) {
-    return false;
-  }
-  if (venues.size > 0 && !venues.has(stream.venue.toLowerCase())) return false;
-  if (symbols.size > 0 && !symbols.has(stream.symbol.toUpperCase())) return false;
-  if (timeframes.size > 0 && !timeframes.has(stream.timeframe.toLowerCase())) return false;
-  return true;
-}
-
-function timeframeSeconds(timeframe: string): number | null {
-  const match = /^(\d+)([smhd])$/i.exec(timeframe.trim());
-  if (!match) return null;
-  const [, amountText, unit] = match;
-  if (!amountText || !unit) return null;
-  const amount = Number(amountText);
-  if (!Number.isFinite(amount) || amount <= 0) return null;
-  switch (unit.toLowerCase()) {
-    case 's':
-      return amount;
-    case 'm':
-      return amount * 60;
-    case 'h':
-      return amount * 60 * 60;
-    case 'd':
-      return amount * 24 * 60 * 60;
-    default:
-      return null;
-  }
-}
-
-function isStaleStream(stream: CandleStream): boolean {
-  const stepSeconds = timeframeSeconds(stream.timeframe);
-  if (stepSeconds == null) return false;
-  const latestCloseMs = new Date(stream.latest_close_time).getTime();
-  if (!Number.isFinite(latestCloseMs)) return false;
-  const lagSeconds = Math.floor((Date.now() - latestCloseMs) / 1000);
-  return lagSeconds > stepSeconds * 2;
-}
-
-function candleSubscriptionStreamHealth(
-  subscription: FinanceSubscription,
-  streams: CandleStream[],
-): CandleSubscriptionStreamHealth | null {
-  if (!subscription.event_kinds.includes('market_candle_closed')) return null;
-
-  const matchingStreams = streams.filter((stream) =>
-    streamMatchesSubscription(stream, subscription),
-  );
-  if (matchingStreams.length === 0) {
-    return {
-      status: 'missing',
-      label: 'Missing',
-      detail: 'No stored K-line stream matches this subscription yet.',
-    };
-  }
-
-  const staleCount = matchingStreams.filter(isStaleStream).length;
-  if (staleCount === matchingStreams.length) {
-    return {
-      status: 'stale',
-      label: 'Stale',
-      detail: `${staleCount} matched stream${staleCount === 1 ? '' : 's'} past the freshness window.`,
-    };
-  }
-
-  const freshCount = matchingStreams.length - staleCount;
-  return {
-    status: 'fresh',
-    label: 'Fresh',
-    detail: `${freshCount}/${matchingStreams.length} matched stream${matchingStreams.length === 1 ? '' : 's'} fresh.`,
-  };
 }
 
 // ---------------------------------------------------------------------------

--- a/web/src/components/topology/FinanceWatchesCard.tsx
+++ b/web/src/components/topology/FinanceWatchesCard.tsx
@@ -18,6 +18,7 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 
 import {
   dataFeedsApi,
+  type CandleStream,
   type CreateFinanceSubscriptionRequest,
   type FeedCatalogEntry,
   type FinanceEventKind,
@@ -27,6 +28,7 @@ import { useSettingsModal } from '@/components/settings/SettingsModalContext';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { candleStreamHealthForSelectors } from '@/lib/finance-candle-health';
 
 interface FinanceWatchesCardProps {
   sessionKey: string;
@@ -45,6 +47,12 @@ export function FinanceWatchesCard({ sessionKey }: FinanceWatchesCardProps) {
     queryFn: () => dataFeedsApi.financeSubscriptions(),
     staleTime: 30_000,
   });
+  const candleStreamsQuery = useQuery({
+    queryKey: ['market-data-candle-streams'],
+    queryFn: () => dataFeedsApi.candleStreams({ limit: 100 }),
+    refetchInterval: 30_000,
+    staleTime: 30_000,
+  });
 
   const subscribeMutation = useMutation({
     mutationFn: (entry: FeedCatalogEntry) =>
@@ -52,6 +60,7 @@ export function FinanceWatchesCard({ sessionKey }: FinanceWatchesCardProps) {
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: ['finance-subscriptions'] });
       void queryClient.invalidateQueries({ queryKey: ['data-feed-catalog'] });
+      void queryClient.invalidateQueries({ queryKey: ['market-data-candle-streams'] });
     },
   });
   const enableMutation = useMutation({
@@ -60,6 +69,7 @@ export function FinanceWatchesCard({ sessionKey }: FinanceWatchesCardProps) {
       void queryClient.invalidateQueries({ queryKey: ['data-feed-catalog'] });
       void queryClient.invalidateQueries({ queryKey: ['data-feeds'] });
       void queryClient.invalidateQueries({ queryKey: ['data-feed-summaries'] });
+      void queryClient.invalidateQueries({ queryKey: ['market-data-candle-streams'] });
     },
   });
   const unsubscribeMutation = useMutation({
@@ -73,10 +83,12 @@ export function FinanceWatchesCard({ sessionKey }: FinanceWatchesCardProps) {
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: ['finance-subscriptions'] });
       void queryClient.invalidateQueries({ queryKey: ['data-feed-catalog'] });
+      void queryClient.invalidateQueries({ queryKey: ['market-data-candle-streams'] });
     },
   });
 
   const entries = (catalogQuery.data ?? []).filter(isFinanceWatchableEntry);
+  const candleStreams = candleStreamsQuery.data?.streams ?? [];
   const sessionSubscriptions = (subscriptionsQuery.data?.subscriptions ?? []).filter(
     (subscription) => subscription.session_key === sessionKey,
   );
@@ -84,6 +96,7 @@ export function FinanceWatchesCard({ sessionKey }: FinanceWatchesCardProps) {
   const error =
     catalogQuery.error?.message ??
     subscriptionsQuery.error?.message ??
+    candleStreamsQuery.error?.message ??
     enableMutation.error?.message ??
     subscribeMutation.error?.message ??
     unsubscribeMutation.error?.message ??
@@ -124,6 +137,14 @@ export function FinanceWatchesCard({ sessionKey }: FinanceWatchesCardProps) {
               const subscribed = matchingSubscriptions.length > 0;
               const canEnableInline = !entry.enabled && !entry.requires_configuration;
               const needsConfiguration = !entry.enabled && entry.requires_configuration;
+              const streamHealth =
+                subscribed && entry.feed_type === 'market_candle'
+                  ? marketCandleEntryStreamHealth(
+                      entry,
+                      candleStreams,
+                      candleStreamsQuery.isLoading,
+                    )
+                  : null;
               const pending =
                 (enableMutation.isPending && enableMutation.variables?.id === entry.id) ||
                 (subscribeMutation.isPending && subscribeMutation.variables?.id === entry.id) ||
@@ -158,6 +179,23 @@ export function FinanceWatchesCard({ sessionKey }: FinanceWatchesCardProps) {
                       <p className="line-clamp-2 text-[11px] text-muted-foreground">
                         {coverageLabel(entry)}
                       </p>
+                      {streamHealth && (
+                        <div className="flex flex-wrap items-center gap-1.5 text-[11px] text-muted-foreground">
+                          <Badge
+                            variant={streamHealth.status === 'missing' ? 'secondary' : 'outline'}
+                            className={
+                              streamHealth.status === 'fresh'
+                                ? 'px-1.5 py-0 text-[10px] text-foreground'
+                                : streamHealth.status === 'stale'
+                                  ? 'px-1.5 py-0 text-[10px] text-amber-600'
+                                  : 'px-1.5 py-0 text-[10px] text-muted-foreground'
+                            }
+                          >
+                            Data {streamHealth.label}
+                          </Badge>
+                          <span>{streamHealth.detail}</span>
+                        </div>
+                      )}
                     </div>
                     <Button
                       size="sm"
@@ -287,6 +325,34 @@ function coverageLabel(entry: FeedCatalogEntry): string {
 
   const tags = entry.tags.filter((tag) => tag !== 'finance' && tag !== 'news');
   return tags.length > 0 ? tags.join(' · ') : entry.description;
+}
+
+function marketCandleEntryStreamHealth(
+  entry: FeedCatalogEntry,
+  streams: CandleStream[],
+  loading: boolean,
+): {
+  status: 'checking' | 'fresh' | 'stale' | 'missing';
+  label: string;
+  detail: string;
+} {
+  if (loading) {
+    return {
+      status: 'checking',
+      label: 'Checking',
+      detail: 'Checking stored K-line streams.',
+    };
+  }
+
+  return candleStreamHealthForSelectors(
+    {
+      sourceNames: [catalogSourceName(entry)],
+      venues: optionalList(catalogVenue(entry)),
+      symbols: catalogSymbols(entry),
+      timeframes: catalogTimeframes(entry),
+    },
+    streams,
+  );
 }
 
 function transportString(entry: FeedCatalogEntry, key: string): string | null {

--- a/web/src/components/topology/__tests__/FinanceWatchesCard.test.tsx
+++ b/web/src/components/topology/__tests__/FinanceWatchesCard.test.tsx
@@ -20,10 +20,16 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { FinanceWatchesCard } from '../FinanceWatchesCard';
 
-import type { FeedCatalogEntry, FinanceSubscriptionsResponse } from '@/api/data-feeds';
+import type {
+  CandleStreamsResponse,
+  FeedCatalogEntry,
+  FinanceSubscription,
+  FinanceSubscriptionsResponse,
+} from '@/api/data-feeds';
 
 const catalogMock = vi.fn();
 const financeSubscriptionsMock = vi.fn();
+const candleStreamsMock = vi.fn();
 const enableCatalogEntryMock = vi.fn();
 const createFinanceSubscriptionMock = vi.fn();
 const unsubscribeCatalogEntryMock = vi.fn();
@@ -33,6 +39,7 @@ vi.mock('@/api/data-feeds', () => ({
   dataFeedsApi: {
     catalog: (...args: unknown[]) => catalogMock(...args),
     financeSubscriptions: (...args: unknown[]) => financeSubscriptionsMock(...args),
+    candleStreams: (...args: unknown[]) => candleStreamsMock(...args),
     enableCatalogEntry: (...args: unknown[]) => enableCatalogEntryMock(...args),
     createFinanceSubscription: (...args: unknown[]) => createFinanceSubscriptionMock(...args),
     unsubscribeCatalogEntry: (...args: unknown[]) => unsubscribeCatalogEntryMock(...args),
@@ -89,17 +96,43 @@ function catalogEntry(partial: Partial<FeedCatalogEntry> & { id: string }): Feed
   return entry;
 }
 
+function financeSubscription(partial: Partial<FinanceSubscription> = {}): FinanceSubscription {
+  return {
+    subscription_id: partial.subscription_id ?? 'sub-1',
+    session_key: partial.session_key ?? 'session-1',
+    event_kinds: partial.event_kinds ?? ['market_candle_closed'],
+    source_names: partial.source_names ?? ['finance-binance-market-candles'],
+    matches_all_sources: partial.matches_all_sources ?? false,
+    sources: partial.sources ?? [],
+    category_tags: partial.category_tags ?? [],
+    watch_terms: partial.watch_terms ?? [],
+    venues: partial.venues ?? ['binance'],
+    symbols: partial.symbols ?? ['BTCUSDT', 'ETHUSDT'],
+    timeframes: partial.timeframes ?? ['1m'],
+    delivery: partial.delivery ?? 'silent',
+    cooldown_secs: partial.cooldown_secs ?? 900,
+    max_immediate_per_hour: partial.max_immediate_per_hour ?? 6,
+  };
+}
+
 beforeEach(() => {
   catalogMock.mockReset();
   financeSubscriptionsMock.mockReset();
+  candleStreamsMock.mockReset();
   enableCatalogEntryMock.mockReset();
   createFinanceSubscriptionMock.mockReset();
   unsubscribeCatalogEntryMock.mockReset();
   openSettingsMock.mockReset();
+  candleStreamsMock.mockResolvedValue({
+    streams: [],
+    count: 0,
+    query_limit: 100,
+  } satisfies CandleStreamsResponse);
 });
 
 afterEach(() => {
   cleanup();
+  vi.restoreAllMocks();
 });
 
 describe('FinanceWatchesCard', () => {
@@ -272,5 +305,56 @@ describe('FinanceWatchesCard', () => {
     });
     expect(createFinanceSubscriptionMock).not.toHaveBeenCalled();
     expect(enableCatalogEntryMock).not.toHaveBeenCalled();
+  });
+
+  it('shows_fresh_stream_health_for_watched_kline_source', async () => {
+    vi.spyOn(Date, 'now').mockReturnValue(Date.parse('2026-07-12T00:42:30Z'));
+    catalogMock.mockResolvedValue([
+      catalogEntry({
+        id: 'binance-market-candles',
+        name: 'Binance Market Candles',
+        feed_type: 'market_candle',
+        source_name: 'finance-binance-market-candles',
+        venue: 'binance',
+        configured_symbols: ['BTCUSDT', 'ETHUSDT'],
+        configured_timeframes: ['1m'],
+        tags: ['finance', 'market-data', 'crypto', 'binance'],
+        transport_template: {
+          venue: 'binance',
+          symbols: ['BTCUSDT', 'ETHUSDT'],
+          timeframes: ['1m'],
+        },
+      }),
+    ]);
+    financeSubscriptionsMock.mockResolvedValue({
+      subscriptions: [financeSubscription()],
+      count: 1,
+    } satisfies FinanceSubscriptionsResponse);
+    candleStreamsMock.mockResolvedValue({
+      streams: [
+        {
+          source_name: 'finance-binance-market-candles',
+          venue: 'binance',
+          symbol: 'BTCUSDT',
+          timeframe: '1m',
+          candle_count: 42,
+          first_open_time: '2026-07-12T00:00:00Z',
+          latest_open_time: '2026-07-12T00:41:00Z',
+          latest_close_time: '2026-07-12T00:41:59Z',
+          latest_ingested_at: '2026-07-12T00:42:02Z',
+        },
+      ],
+      count: 1,
+      query_limit: 100,
+    } satisfies CandleStreamsResponse);
+
+    renderCard('session-1');
+
+    expect(await screen.findByText('watching')).toBeInTheDocument();
+    expect(await screen.findByText('Data Fresh')).toBeInTheDocument();
+    expect(screen.getByText('1/1 matched stream fresh.')).toBeInTheDocument();
+    await waitFor(() => {
+      expect(candleStreamsMock).toHaveBeenCalledWith({ limit: 100 });
+    });
   });
 });

--- a/web/src/lib/finance-candle-health.ts
+++ b/web/src/lib/finance-candle-health.ts
@@ -1,0 +1,144 @@
+/*
+ * Copyright 2026 Rararulab
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { CandleStream, FinanceSubscription } from '@/api/data-feeds';
+
+export type CandleStreamHealth = {
+  status: 'fresh' | 'stale' | 'missing';
+  label: string;
+  detail: string;
+};
+
+export type CandleStreamSelectors = {
+  sourceNames?: string[];
+  matchesAllSources?: boolean;
+  venues?: string[];
+  symbols?: string[];
+  timeframes?: string[];
+};
+
+export function candleSubscriptionStreamHealth(
+  subscription: FinanceSubscription,
+  streams: CandleStream[],
+): CandleStreamHealth | null {
+  if (!subscription.event_kinds.includes('market_candle_closed')) return null;
+
+  return candleStreamHealthForSelectors(
+    {
+      sourceNames: subscription.source_names,
+      matchesAllSources: subscription.matches_all_sources,
+      venues: subscription.venues,
+      symbols: subscription.symbols,
+      timeframes: subscription.timeframes,
+    },
+    streams,
+  );
+}
+
+export function candleStreamHealthForSelectors(
+  selectors: CandleStreamSelectors,
+  streams: CandleStream[],
+): CandleStreamHealth {
+  const matchingStreams = streams.filter((stream) => streamMatchesSelectors(stream, selectors));
+  if (matchingStreams.length === 0) {
+    return {
+      status: 'missing',
+      label: 'Missing',
+      detail: 'No stored K-line stream matches this subscription yet.',
+    };
+  }
+
+  const staleCount = matchingStreams.filter(isStaleStream).length;
+  if (staleCount === matchingStreams.length) {
+    return {
+      status: 'stale',
+      label: 'Stale',
+      detail: `${staleCount} matched stream${staleCount === 1 ? '' : 's'} past the freshness window.`,
+    };
+  }
+
+  const freshCount = matchingStreams.length - staleCount;
+  return {
+    status: 'fresh',
+    label: 'Fresh',
+    detail: `${freshCount}/${matchingStreams.length} matched stream${matchingStreams.length === 1 ? '' : 's'} fresh.`,
+  };
+}
+
+function streamMatchesSelectors(stream: CandleStream, selectors: CandleStreamSelectors): boolean {
+  const sourceNames = normalizedSelectorSet(selectors.sourceNames ?? [], 'lower');
+  const venues = normalizedSelectorSet(selectors.venues ?? [], 'lower');
+  const symbols = normalizedSelectorSet(selectors.symbols ?? [], 'upper');
+  const timeframes = normalizedSelectorSet(selectors.timeframes ?? [], 'timeframe');
+
+  if (
+    sourceNames.size > 0 &&
+    !selectors.matchesAllSources &&
+    !sourceNames.has(stream.source_name.toLowerCase())
+  ) {
+    return false;
+  }
+  if (venues.size > 0 && !venues.has(stream.venue.toLowerCase())) return false;
+  if (symbols.size > 0 && !symbols.has(stream.symbol.toUpperCase())) return false;
+  if (timeframes.size > 0 && !timeframes.has(stream.timeframe.toLowerCase())) return false;
+  return true;
+}
+
+function normalizedSelectorSet(
+  values: string[],
+  mode: 'lower' | 'upper' | 'timeframe',
+): Set<string> {
+  return new Set(
+    values
+      .map((value) => value.trim())
+      .filter(Boolean)
+      .map((value) => {
+        if (mode === 'lower') return value.toLowerCase();
+        if (mode === 'upper') return value.toUpperCase();
+        return value.toLowerCase();
+      }),
+  );
+}
+
+function isStaleStream(stream: CandleStream): boolean {
+  const stepSeconds = timeframeSeconds(stream.timeframe);
+  if (stepSeconds == null) return false;
+  const latestCloseMs = new Date(stream.latest_close_time).getTime();
+  if (!Number.isFinite(latestCloseMs)) return false;
+  const lagSeconds = Math.floor((Date.now() - latestCloseMs) / 1000);
+  return lagSeconds > stepSeconds * 2;
+}
+
+function timeframeSeconds(timeframe: string): number | null {
+  const match = /^(\d+)([smhd])$/i.exec(timeframe.trim());
+  if (!match) return null;
+  const [, amountText, unit] = match;
+  if (!amountText || !unit) return null;
+  const amount = Number(amountText);
+  if (!Number.isFinite(amount) || amount <= 0) return null;
+  switch (unit.toLowerCase()) {
+    case 's':
+      return amount;
+    case 'm':
+      return amount * 60;
+    case 'h':
+      return amount * 60 * 60;
+    case 'd':
+      return amount * 24 * 60 * 60;
+    default:
+      return null;
+  }
+}


### PR DESCRIPTION
## Summary
- extract shared frontend candle stream health calculation
- show K-line data Fresh/Stale/Missing state on the session Finance watches card
- keep Data Feeds settings on the same shared health logic
- cover watched K-line Fresh state in FinanceWatchesCard tests

## Validation
- npm test -- src/components/topology/__tests__/FinanceWatchesCard.test.tsx src/components/__tests__/DataFeedsPanel.test.tsx
- npm --prefix web run format:check
- npm --prefix web run lint
- npm --prefix web run typecheck