### PR TITLE
feat(finance): surface candle quality checks

### DIFF
--- a/crates/extensions/backend-admin/src/data_feeds/router.rs
+++ b/crates/extensions/backend-admin/src/data_feeds/router.rs
@@ -28,6 +28,8 @@
 //! | GET    | `/api/v1/data-feeds/finance/subscriptions` | list current user's finance subscriptions |
 //! | POST   | `/api/v1/data-feeds/finance/subscriptions` | create/update current user's finance subscription |
 //! | GET    | `/api/v1/data-feeds/market-data/candle-streams` | list stored market-data candle streams |
+//! | GET    | `/api/v1/data-feeds/market-data/candles/freshness` | check stored candle freshness |
+//! | GET    | `/api/v1/data-feeds/market-data/candles/gaps` | find missing stored candle open times |
 //!
 //! All mutations synchronise both the database (via [`DataFeedSvc`]) and the
 //! in-memory [`DataFeedRegistry`]. When an active feed is created and
@@ -82,6 +84,7 @@ const DEFAULT_MARKET_DATA_STREAM_LIMIT: usize = 500;
 const MAX_MARKET_DATA_STREAM_LIMIT: usize = 10_000;
 const DEFAULT_MARKET_DATA_CANDLE_LIMIT: usize = 500;
 const MAX_MARKET_DATA_CANDLE_LIMIT: usize = 10_000;
+const MAX_MARKET_DATA_FRESHNESS_STALE_AFTER_SECS: u64 = 31_536_000;
 const MAX_MARKET_DATA_SELECTOR_LEN: usize = 128;
 
 /// Shared state for data feed routes.
@@ -133,6 +136,14 @@ pub fn data_feed_routes(state: DataFeedRouterState) -> Router {
         .route(
             "/api/v1/data-feeds/market-data/candles/latest",
             get(get_latest_market_data_candle),
+        )
+        .route(
+            "/api/v1/data-feeds/market-data/candles/freshness",
+            get(get_market_data_candle_freshness),
+        )
+        .route(
+            "/api/v1/data-feeds/market-data/candles/gaps",
+            get(find_market_data_candle_gaps),
         )
         .route(
             "/api/v1/data-feeds/market-data/candles",
@@ -284,6 +295,28 @@ struct CandleRangeQueryParams {
     limit:       Option<usize>,
 }
 
+/// Query parameters for stored closed-candle freshness.
+#[derive(Debug, Deserialize)]
+struct CandleFreshnessQueryParams {
+    source_name:      Option<String>,
+    venue:            String,
+    symbol:           String,
+    timeframe:        String,
+    as_of:            Option<String>,
+    stale_after_secs: Option<u64>,
+}
+
+/// Query parameters for stored closed-candle gap detection.
+#[derive(Debug, Deserialize)]
+struct CandleGapsQueryParams {
+    source_name: Option<String>,
+    venue:       String,
+    symbol:      String,
+    timeframe:   String,
+    start:       String,
+    end:         String,
+}
+
 #[derive(Debug, Serialize)]
 struct CandleLatestResponse {
     candle: Option<CandleResponse>,
@@ -294,6 +327,24 @@ struct CandleRangeResponse {
     candles:     Vec<CandleResponse>,
     count:       usize,
     query_limit: usize,
+}
+
+#[derive(Debug, Serialize)]
+struct CandleFreshnessResponse {
+    latest:           Option<CandleResponse>,
+    as_of:            String,
+    stale_after_secs: u64,
+    lag_secs:         Option<i64>,
+    is_stale:         bool,
+    status:           String,
+}
+
+#[derive(Debug, Serialize)]
+struct CandleGapsResponse {
+    missing_open_times: Vec<String>,
+    missing_count:      usize,
+    expected_count:     usize,
+    complete:           bool,
 }
 
 #[derive(Debug, Serialize)]
@@ -1203,6 +1254,111 @@ async fn get_latest_market_data_candle(
     }))
 }
 
+/// `GET /api/v1/data-feeds/market-data/candles/freshness` — report whether
+/// the newest stored closed candle is fresh relative to `as_of`.
+async fn get_market_data_candle_freshness(
+    State(state): State<DataFeedRouterState>,
+    Query(params): Query<CandleFreshnessQueryParams>,
+) -> Result<Json<CandleFreshnessResponse>, ProblemDetails> {
+    let timeframe = normalize_required_market_data_timeframe(params.timeframe)?;
+    let default_stale_after_secs = u64::try_from(
+        timeframe
+            .step()
+            .map_err(|err| ProblemDetails::bad_request(format!("invalid timeframe: {err}")))?
+            .as_secs(),
+    )
+    .map_err(|err| ProblemDetails::bad_request(format!("invalid timeframe step: {err}")))?
+    .saturating_mul(2);
+    let stale_after_secs = params.stale_after_secs.unwrap_or(default_stale_after_secs);
+    validate_market_data_stale_after_secs(stale_after_secs)?;
+    let as_of = params
+        .as_of
+        .map(|value| parse_market_data_timestamp("as_of", value))
+        .transpose()?
+        .unwrap_or_else(Timestamp::now);
+
+    let query = CandleLatestQuery {
+        source_name: normalize_optional_market_data_selector("source_name", params.source_name)?,
+        venue: normalize_required_market_data_venue(params.venue)?,
+        symbol: normalize_required_market_data_symbol(params.symbol)?,
+        timeframe,
+    };
+    let latest = state
+        .market_data_repo
+        .latest_closed_candle(query)
+        .await
+        .map_err(|err| {
+            ProblemDetails::internal(format!("failed to get candle freshness: {err}"))
+        })?;
+    let Some(candle) = latest else {
+        return Ok(Json(CandleFreshnessResponse {
+            latest: None,
+            as_of: as_of.to_string(),
+            stale_after_secs,
+            lag_secs: None,
+            is_stale: true,
+            status: "missing".to_owned(),
+        }));
+    };
+
+    let lag_secs = as_of.as_second() - candle.close_time.as_second();
+    let is_stale = lag_secs >= 0 && lag_secs as u64 > stale_after_secs;
+    let status = if lag_secs < 0 {
+        "future"
+    } else if is_stale {
+        "stale"
+    } else {
+        "fresh"
+    };
+
+    Ok(Json(CandleFreshnessResponse {
+        latest: Some(CandleResponse::from(candle)),
+        as_of: as_of.to_string(),
+        stale_after_secs,
+        lag_secs: Some(lag_secs),
+        is_stale,
+        status: status.to_owned(),
+    }))
+}
+
+/// `GET /api/v1/data-feeds/market-data/candles/gaps` — find missing expected
+/// open times for a stored closed-candle stream.
+async fn find_market_data_candle_gaps(
+    State(state): State<DataFeedRouterState>,
+    Query(params): Query<CandleGapsQueryParams>,
+) -> Result<Json<CandleGapsResponse>, ProblemDetails> {
+    let timeframe = normalize_required_market_data_timeframe(params.timeframe)?;
+    let start = parse_market_data_timestamp("start", params.start)?;
+    let end = parse_market_data_timestamp("end", params.end)?;
+    if end <= start {
+        return Err(ProblemDetails::bad_request("end must be after start"));
+    }
+    let expected_count = expected_market_data_open_time_count(&timeframe, start, end)?;
+
+    let query = CandleRangeQuery {
+        source_name: normalize_optional_market_data_selector("source_name", params.source_name)?,
+        venue: normalize_required_market_data_venue(params.venue)?,
+        symbol: normalize_required_market_data_symbol(params.symbol)?,
+        timeframe,
+        start,
+        end,
+        limit: expected_count,
+    };
+    let missing = state
+        .market_data_repo
+        .missing_open_times(query)
+        .await
+        .map_err(|err| ProblemDetails::internal(format!("failed to find candle gaps: {err}")))?;
+    let missing_count = missing.len();
+
+    Ok(Json(CandleGapsResponse {
+        missing_open_times: missing.into_iter().map(|ts| ts.to_string()).collect(),
+        missing_count,
+        expected_count,
+        complete: missing_count == 0,
+    }))
+}
+
 /// `GET /api/v1/data-feeds/market-data/candles` — query a bounded ordered
 /// range of stored closed candles for a stream.
 async fn query_market_data_candles(
@@ -1388,6 +1544,46 @@ fn validate_market_data_candle_limit(limit: Option<usize>) -> Result<usize, Prob
         )));
     }
     Ok(limit)
+}
+
+fn validate_market_data_stale_after_secs(value: u64) -> Result<(), ProblemDetails> {
+    if value == 0 {
+        return Err(ProblemDetails::bad_request(
+            "stale_after_secs must be positive",
+        ));
+    }
+    if value > MAX_MARKET_DATA_FRESHNESS_STALE_AFTER_SECS {
+        return Err(ProblemDetails::bad_request(format!(
+            "stale_after_secs must be <= {MAX_MARKET_DATA_FRESHNESS_STALE_AFTER_SECS}"
+        )));
+    }
+    Ok(())
+}
+
+fn expected_market_data_open_time_count(
+    timeframe: &Timeframe,
+    start: Timestamp,
+    end: Timestamp,
+) -> Result<usize, ProblemDetails> {
+    let step = timeframe
+        .step()
+        .map_err(|err| ProblemDetails::bad_request(format!("invalid timeframe: {err}")))?;
+    let mut cursor = start;
+    let mut count = 0usize;
+
+    while cursor < end {
+        count = count.saturating_add(1);
+        if count > MAX_MARKET_DATA_CANDLE_LIMIT {
+            return Err(ProblemDetails::bad_request(format!(
+                "range contains more than {MAX_MARKET_DATA_CANDLE_LIMIT} expected candles"
+            )));
+        }
+        cursor = cursor.checked_add(step).map_err(|err| {
+            ProblemDetails::bad_request(format!("timeframe addition overflowed: {err}"))
+        })?;
+    }
+
+    Ok(count)
 }
 
 fn parse_market_data_timestamp(name: &str, value: String) -> Result<Timestamp, ProblemDetails> {
@@ -3211,6 +3407,91 @@ mod tests {
         assert_eq!(result["candles"][0]["close"], "1005.00");
         assert_eq!(result["candles"][1]["open_time"], "2026-07-10T08:01:00Z");
         assert_eq!(result["candles"][1]["close"], "1006.25");
+    }
+
+    #[tokio::test]
+    async fn market_data_candle_gaps_endpoint_reports_missing_open_times() {
+        let market_data_repo = test_market_data_repo();
+        for (open_time, close_time, close) in [
+            ("2026-07-10T08:00:00Z", "2026-07-10T08:01:00Z", "1005.00"),
+            ("2026-07-10T08:02:00Z", "2026-07-10T08:03:00Z", "1007.75"),
+        ] {
+            market_data_repo
+                .upsert_closed_candle(market_data_candle(open_time, close_time, close, None))
+                .await
+                .unwrap();
+        }
+
+        let app = app_with_user_and_market_data_repo(user_of(Role::Admin), market_data_repo).await;
+        let res = app
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri(
+                        "/api/v1/data-feeds/market-data/candles/gaps?venue=binance&symbol=BTCUSDT&\
+                         timeframe=1m&start=2026-07-10T08:00:00Z&end=2026-07-10T08:03:00Z",
+                    )
+                    .header("Authorization", "Bearer s3cret")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(res.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(res.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let result: serde_json::Value = serde_json::from_slice(&body).unwrap();
+
+        assert_eq!(result["expected_count"], 3);
+        assert_eq!(result["missing_count"], 1);
+        assert_eq!(result["complete"], false);
+        assert_eq!(result["missing_open_times"][0], "2026-07-10T08:01:00Z");
+    }
+
+    #[tokio::test]
+    async fn market_data_candle_freshness_endpoint_reports_latest_status() {
+        let market_data_repo = test_market_data_repo();
+        market_data_repo
+            .upsert_closed_candle(market_data_candle(
+                "2026-07-10T08:01:00Z",
+                "2026-07-10T08:02:00Z",
+                "1006.25",
+                None,
+            ))
+            .await
+            .unwrap();
+
+        let app = app_with_user_and_market_data_repo(user_of(Role::Admin), market_data_repo).await;
+        let res = app
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri(
+                        "/api/v1/data-feeds/market-data/candles/freshness?venue=BINANCE&\
+                         symbol=btcusdt&timeframe=1M&as_of=2026-07-10T08:03:00Z&\
+                         stale_after_secs=120",
+                    )
+                    .header("Authorization", "Bearer s3cret")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(res.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(res.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let result: serde_json::Value = serde_json::from_slice(&body).unwrap();
+
+        assert_eq!(result["status"], "fresh");
+        assert_eq!(result["is_stale"], false);
+        assert_eq!(result["lag_secs"], 60);
+        assert_eq!(result["stale_after_secs"], 120);
+        assert_eq!(result["latest"]["open_time"], "2026-07-10T08:01:00Z");
+        assert_eq!(result["latest"]["close"], "1006.25");
     }
 
     #[tokio::test]

--- a/docs/guides/finance-subscriptions.md
+++ b/docs/guides/finance-subscriptions.md
@@ -163,11 +163,15 @@ agent via:
 - `GET /api/v1/data-feeds/market-data/candle-streams`
 - `GET /api/v1/data-feeds/market-data/candles/latest`
 - `GET /api/v1/data-feeds/market-data/candles`
+- `GET /api/v1/data-feeds/market-data/candles/freshness`
+- `GET /api/v1/data-feeds/market-data/candles/gaps`
 
 The candle endpoints are read-only. They require canonical selectors
 (`venue`, `symbol`, `timeframe`) and return decimal OHLCV values as strings.
 The range endpoint uses `start` as an inclusive open-time lower bound and `end`
-as an exclusive open-time upper bound.
+as an exclusive open-time upper bound. Freshness defaults its stale threshold to
+2x the timeframe step. Gap checks use the same inclusive/exclusive range
+semantics and are capped at 10,000 expected candles.
 
 Identity and session routing are always taken from `ToolContext`. The tool
 schema has no `owner` or `session` parameter, so an agent cannot subscribe or

--- a/web/src/api/data-feeds.ts
+++ b/web/src/api/data-feeds.ts
@@ -110,6 +110,22 @@ export interface MarketCandlesResponse {
   query_limit: number;
 }
 
+export interface MarketCandleFreshnessResponse {
+  latest: MarketCandle | null;
+  as_of: string;
+  stale_after_secs: number;
+  lag_secs: number | null;
+  is_stale: boolean;
+  status: 'missing' | 'future' | 'stale' | 'fresh';
+}
+
+export interface MarketCandleGapsResponse {
+  missing_open_times: string[];
+  missing_count: number;
+  expected_count: number;
+  complete: boolean;
+}
+
 export interface CreateFeedRequest {
   name: string;
   feed_type: FeedType;
@@ -284,6 +300,46 @@ export const dataFeedsApi = {
     if (params.limit) query.set('limit', String(params.limit));
     return api.get<MarketCandlesResponse>(
       `/api/v1/data-feeds/market-data/candles?${query.toString()}`,
+    );
+  },
+
+  candleFreshness: (params: {
+    source_name?: string;
+    venue: string;
+    symbol: string;
+    timeframe: string;
+    as_of?: string;
+    stale_after_secs?: number;
+  }) => {
+    const query = new URLSearchParams();
+    if (params.source_name) query.set('source_name', params.source_name);
+    query.set('venue', params.venue);
+    query.set('symbol', params.symbol);
+    query.set('timeframe', params.timeframe);
+    if (params.as_of) query.set('as_of', params.as_of);
+    if (params.stale_after_secs) query.set('stale_after_secs', String(params.stale_after_secs));
+    return api.get<MarketCandleFreshnessResponse>(
+      `/api/v1/data-feeds/market-data/candles/freshness?${query.toString()}`,
+    );
+  },
+
+  candleGaps: (params: {
+    source_name?: string;
+    venue: string;
+    symbol: string;
+    timeframe: string;
+    start: string;
+    end: string;
+  }) => {
+    const query = new URLSearchParams();
+    if (params.source_name) query.set('source_name', params.source_name);
+    query.set('venue', params.venue);
+    query.set('symbol', params.symbol);
+    query.set('timeframe', params.timeframe);
+    query.set('start', params.start);
+    query.set('end', params.end);
+    return api.get<MarketCandleGapsResponse>(
+      `/api/v1/data-feeds/market-data/candles/gaps?${query.toString()}`,
     );
   },
 

--- a/web/src/components/DataFeedsPanel.tsx
+++ b/web/src/components/DataFeedsPanel.tsx
@@ -1682,6 +1682,50 @@ function MarketDataStreamsCard({
     enabled: previewRequest != null,
     refetchInterval: previewRequest != null ? 30_000 : false,
   });
+  const freshnessQuery = useQuery({
+    queryKey: [
+      'market-data-candle-freshness-preview',
+      previewRequest?.source_name,
+      previewRequest?.venue,
+      previewRequest?.symbol,
+      previewRequest?.timeframe,
+    ],
+    queryFn: () => {
+      if (!previewRequest) throw new Error('Missing candle freshness request');
+      return dataFeedsApi.candleFreshness({
+        source_name: previewRequest.source_name,
+        venue: previewRequest.venue,
+        symbol: previewRequest.symbol,
+        timeframe: previewRequest.timeframe,
+      });
+    },
+    enabled: previewRequest != null,
+    refetchInterval: previewRequest != null ? 30_000 : false,
+  });
+  const gapsQuery = useQuery({
+    queryKey: [
+      'market-data-candle-gaps-preview',
+      previewRequest?.source_name,
+      previewRequest?.venue,
+      previewRequest?.symbol,
+      previewRequest?.timeframe,
+      previewRequest?.start,
+      previewRequest?.end,
+    ],
+    queryFn: () => {
+      if (!previewRequest) throw new Error('Missing candle gaps request');
+      return dataFeedsApi.candleGaps({
+        source_name: previewRequest.source_name,
+        venue: previewRequest.venue,
+        symbol: previewRequest.symbol,
+        timeframe: previewRequest.timeframe,
+        start: previewRequest.start,
+        end: previewRequest.end,
+      });
+    },
+    enabled: previewRequest != null,
+    refetchInterval: previewRequest != null ? 30_000 : false,
+  });
   const previewCandles = previewQuery.data?.candles ?? [];
 
   return (
@@ -1828,6 +1872,60 @@ function MarketDataStreamsCard({
                     Query limit
                   </div>
                   <div className="text-sm font-medium">{previewQuery.data?.query_limit}</div>
+                </div>
+              </div>
+
+              <div className="grid gap-3 sm:grid-cols-2">
+                <div className="rounded-md border px-3 py-2">
+                  <div className="mb-1 flex items-center justify-between gap-2">
+                    <div className="text-[11px] uppercase tracking-wide text-muted-foreground">
+                      Freshness
+                    </div>
+                    {freshnessQuery.data ? (
+                      <Badge
+                        variant={freshnessQuery.data.is_stale ? 'destructive' : 'outline'}
+                        className="text-[11px]"
+                      >
+                        {freshnessQuery.data.status}
+                      </Badge>
+                    ) : null}
+                  </div>
+                  {freshnessQuery.isLoading ? (
+                    <Skeleton className="h-4 w-32" />
+                  ) : freshnessQuery.isError ? (
+                    <div className="text-xs text-destructive">Freshness check failed.</div>
+                  ) : freshnessQuery.data ? (
+                    <div className="text-xs text-muted-foreground">
+                      {freshnessQuery.data.lag_secs == null
+                        ? 'No latest candle found.'
+                        : `${freshnessQuery.data.lag_secs}s lag · stale after ${freshnessQuery.data.stale_after_secs}s`}
+                    </div>
+                  ) : null}
+                </div>
+                <div className="rounded-md border px-3 py-2">
+                  <div className="mb-1 flex items-center justify-between gap-2">
+                    <div className="text-[11px] uppercase tracking-wide text-muted-foreground">
+                      Gaps
+                    </div>
+                    {gapsQuery.data ? (
+                      <Badge
+                        variant={gapsQuery.data.complete ? 'outline' : 'destructive'}
+                        className="text-[11px]"
+                      >
+                        {gapsQuery.data.complete ? 'complete' : 'missing'}
+                      </Badge>
+                    ) : null}
+                  </div>
+                  {gapsQuery.isLoading ? (
+                    <Skeleton className="h-4 w-32" />
+                  ) : gapsQuery.isError ? (
+                    <div className="text-xs text-destructive">Gap check failed.</div>
+                  ) : gapsQuery.data ? (
+                    <div className="text-xs text-muted-foreground">
+                      {gapsQuery.data.missing_count}/{gapsQuery.data.expected_count} missing in
+                      preview window
+                    </div>
+                  ) : null}
                 </div>
               </div>
 

--- a/web/src/components/__tests__/DataFeedsPanel.test.tsx
+++ b/web/src/components/__tests__/DataFeedsPanel.test.tsx
@@ -26,6 +26,8 @@ import type {
   FeedCatalogEntry,
   FinanceSubscription,
   FinanceSubscriptionsResponse,
+  MarketCandleFreshnessResponse,
+  MarketCandleGapsResponse,
   MarketCandlesResponse,
 } from '@/api/data-feeds';
 
@@ -35,6 +37,8 @@ const catalogMock = vi.fn();
 const financeSubscriptionsMock = vi.fn();
 const candleStreamsMock = vi.fn();
 const candlesMock = vi.fn();
+const candleFreshnessMock = vi.fn();
+const candleGapsMock = vi.fn();
 
 vi.mock('@/api/data-feeds', () => ({
   dataFeedsApi: {
@@ -44,6 +48,8 @@ vi.mock('@/api/data-feeds', () => ({
     financeSubscriptions: (...args: unknown[]) => financeSubscriptionsMock(...args),
     candleStreams: (...args: unknown[]) => candleStreamsMock(...args),
     candles: (...args: unknown[]) => candlesMock(...args),
+    candleFreshness: (...args: unknown[]) => candleFreshnessMock(...args),
+    candleGaps: (...args: unknown[]) => candleGapsMock(...args),
     toggle: vi.fn(),
     delete: vi.fn(),
     enableCatalogEntry: vi.fn(),
@@ -114,6 +120,8 @@ beforeEach(() => {
   financeSubscriptionsMock.mockReset();
   candleStreamsMock.mockReset();
   candlesMock.mockReset();
+  candleFreshnessMock.mockReset();
+  candleGapsMock.mockReset();
 
   listMock.mockResolvedValue([]);
   summariesMock.mockResolvedValue([]);
@@ -132,6 +140,20 @@ beforeEach(() => {
     count: 0,
     query_limit: 50,
   } satisfies MarketCandlesResponse);
+  candleFreshnessMock.mockResolvedValue({
+    latest: null,
+    as_of: '2026-07-12T00:50:00Z',
+    stale_after_secs: 120,
+    lag_secs: null,
+    is_stale: true,
+    status: 'missing',
+  } satisfies MarketCandleFreshnessResponse);
+  candleGapsMock.mockResolvedValue({
+    missing_open_times: [],
+    missing_count: 0,
+    expected_count: 50,
+    complete: true,
+  } satisfies MarketCandleGapsResponse);
 });
 
 afterEach(() => {
@@ -281,6 +303,34 @@ describe('DataFeedsPanel', () => {
       count: 2,
       query_limit: 50,
     } satisfies MarketCandlesResponse);
+    candleFreshnessMock.mockResolvedValue({
+      latest: {
+        source_name: 'finance-binance-market-candles',
+        venue: 'binance',
+        symbol: 'BTCUSDT',
+        timeframe: '1m',
+        open_time: '2026-07-12T00:49:00Z',
+        close_time: '2026-07-12T00:49:59Z',
+        open: '64110.50',
+        high: '64150.00',
+        low: '64105.00',
+        close: '64140.25',
+        volume: '8.75',
+        ingested_at: '2026-07-12T00:50:02Z',
+        provider_sequence: null,
+      },
+      as_of: '2026-07-12T00:50:30Z',
+      stale_after_secs: 120,
+      lag_secs: 31,
+      is_stale: false,
+      status: 'fresh',
+    } satisfies MarketCandleFreshnessResponse);
+    candleGapsMock.mockResolvedValue({
+      missing_open_times: [],
+      missing_count: 0,
+      expected_count: 50,
+      complete: true,
+    } satisfies MarketCandleGapsResponse);
 
     renderPanel();
 
@@ -300,7 +350,25 @@ describe('DataFeedsPanel', () => {
         limit: 50,
       });
     });
+    await waitFor(() => {
+      expect(candleFreshnessMock).toHaveBeenCalledWith({
+        source_name: 'finance-binance-market-candles',
+        venue: 'binance',
+        symbol: 'BTCUSDT',
+        timeframe: '1m',
+      });
+      expect(candleGapsMock).toHaveBeenCalledWith({
+        source_name: 'finance-binance-market-candles',
+        venue: 'binance',
+        symbol: 'BTCUSDT',
+        timeframe: '1m',
+        start: '2026-07-12T00:00:00.000Z',
+        end: '2026-07-12T00:50:00.000Z',
+      });
+    });
     expect(await screen.findByText('Recent candles · BINANCE · BTCUSDT · 1m')).toBeInTheDocument();
+    expect(screen.getByText('31s lag · stale after 120s')).toBeInTheDocument();
+    expect(screen.getByText('0/50 missing in preview window')).toBeInTheDocument();
     expect(screen.getAllByText('64140.25').length).toBeGreaterThan(0);
     expect(screen.getByText('12.34')).toBeInTheDocument();
   });


### PR DESCRIPTION
## Summary
- add read-only admin endpoints for stored candle freshness and gap checks
- expose freshness/gaps through the web data-feeds API client
- show freshness and preview-window gap status in the stored K-line preview dialog
- document the new market-data quality endpoints

## Tests
- cargo +nightly fmt --check
- cargo test -p rara-backend-admin data_feeds::router::tests -- --nocapture
- npm --prefix web test -- src/components/__tests__/DataFeedsPanel.test.tsx
- npm --prefix web run typecheck
- npm --prefix web run format:check
- npm --prefix web run lint
- git diff --check
- pre-commit: cargo check/fmt/clippy/doc, AGENT.md presence, web lint-staged