### PR TITLE
fix(finance): report partial candle watch coverage

### DIFF
--- a/web/src/components/topology/FinanceWatchesCard.tsx
+++ b/web/src/components/topology/FinanceWatchesCard.tsx
@@ -28,7 +28,7 @@ import { useSettingsModal } from '@/components/settings/SettingsModalContext';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
-import { candleStreamHealthForSelectors } from '@/lib/finance-candle-health';
+import { expectedCandleStreamHealth } from '@/lib/finance-candle-health';
 
 interface FinanceWatchesCardProps {
   sessionKey: string;
@@ -344,10 +344,10 @@ function marketCandleEntryStreamHealth(
     };
   }
 
-  return candleStreamHealthForSelectors(
+  return expectedCandleStreamHealth(
     {
-      sourceNames: [catalogSourceName(entry)],
-      venues: optionalList(catalogVenue(entry)),
+      sourceName: catalogSourceName(entry),
+      venue: catalogVenue(entry),
       symbols: catalogSymbols(entry),
       timeframes: catalogTimeframes(entry),
     },

--- a/web/src/components/topology/__tests__/FinanceWatchesCard.test.tsx
+++ b/web/src/components/topology/__tests__/FinanceWatchesCard.test.tsx
@@ -343,6 +343,68 @@ describe('FinanceWatchesCard', () => {
           latest_close_time: '2026-07-12T00:41:59Z',
           latest_ingested_at: '2026-07-12T00:42:02Z',
         },
+        {
+          source_name: 'finance-binance-market-candles',
+          venue: 'binance',
+          symbol: 'ETHUSDT',
+          timeframe: '1m',
+          candle_count: 42,
+          first_open_time: '2026-07-12T00:00:00Z',
+          latest_open_time: '2026-07-12T00:41:00Z',
+          latest_close_time: '2026-07-12T00:41:59Z',
+          latest_ingested_at: '2026-07-12T00:42:02Z',
+        },
+      ],
+      count: 2,
+      query_limit: 100,
+    } satisfies CandleStreamsResponse);
+
+    renderCard('session-1');
+
+    expect(await screen.findByText('watching')).toBeInTheDocument();
+    expect(await screen.findByText('Data Fresh')).toBeInTheDocument();
+    expect(screen.getByText('2/2 expected streams fresh.')).toBeInTheDocument();
+    await waitFor(() => {
+      expect(candleStreamsMock).toHaveBeenCalledWith({ limit: 100 });
+    });
+  });
+
+  it('shows_partial_stream_health_when_a_watched_kline_symbol_has_no_stored_stream', async () => {
+    vi.spyOn(Date, 'now').mockReturnValue(Date.parse('2026-07-12T00:42:30Z'));
+    catalogMock.mockResolvedValue([
+      catalogEntry({
+        id: 'binance-market-candles',
+        name: 'Binance Market Candles',
+        feed_type: 'market_candle',
+        source_name: 'finance-binance-market-candles',
+        venue: 'binance',
+        configured_symbols: ['BTCUSDT', 'ETHUSDT'],
+        configured_timeframes: ['1m'],
+        tags: ['finance', 'market-data', 'crypto', 'binance'],
+        transport_template: {
+          venue: 'binance',
+          symbols: ['BTCUSDT', 'ETHUSDT'],
+          timeframes: ['1m'],
+        },
+      }),
+    ]);
+    financeSubscriptionsMock.mockResolvedValue({
+      subscriptions: [financeSubscription()],
+      count: 1,
+    } satisfies FinanceSubscriptionsResponse);
+    candleStreamsMock.mockResolvedValue({
+      streams: [
+        {
+          source_name: 'finance-binance-market-candles',
+          venue: 'binance',
+          symbol: 'BTCUSDT',
+          timeframe: '1m',
+          candle_count: 42,
+          first_open_time: '2026-07-12T00:00:00Z',
+          latest_open_time: '2026-07-12T00:41:00Z',
+          latest_close_time: '2026-07-12T00:41:59Z',
+          latest_ingested_at: '2026-07-12T00:42:02Z',
+        },
       ],
       count: 1,
       query_limit: 100,
@@ -351,10 +413,7 @@ describe('FinanceWatchesCard', () => {
     renderCard('session-1');
 
     expect(await screen.findByText('watching')).toBeInTheDocument();
-    expect(await screen.findByText('Data Fresh')).toBeInTheDocument();
-    expect(screen.getByText('1/1 matched stream fresh.')).toBeInTheDocument();
-    await waitFor(() => {
-      expect(candleStreamsMock).toHaveBeenCalledWith({ limit: 100 });
-    });
+    expect(await screen.findByText('Data Partial')).toBeInTheDocument();
+    expect(screen.getByText('1/2 expected streams present; 1 missing.')).toBeInTheDocument();
   });
 });

--- a/web/src/lib/finance-candle-health.ts
+++ b/web/src/lib/finance-candle-health.ts
@@ -30,6 +30,13 @@ export type CandleStreamSelectors = {
   timeframes?: string[];
 };
 
+export type ExpectedCandleStreamSelectors = {
+  sourceName: string;
+  venue?: string | null;
+  symbols: string[];
+  timeframes: string[];
+};
+
 export function candleSubscriptionStreamHealth(
   subscription: FinanceSubscription,
   streams: CandleStream[],
@@ -78,6 +85,87 @@ export function candleStreamHealthForSelectors(
   };
 }
 
+export function expectedCandleStreamHealth(
+  selectors: ExpectedCandleStreamSelectors,
+  streams: CandleStream[],
+): CandleStreamHealth {
+  const symbols = Array.from(normalizedSelectorSet(selectors.symbols, 'upper'));
+  const timeframes = Array.from(normalizedSelectorSet(selectors.timeframes, 'timeframe'));
+  const sourceName = selectors.sourceName.trim().toLowerCase();
+  const venue = selectors.venue?.trim().toLowerCase() || null;
+
+  if (!sourceName || symbols.length === 0 || timeframes.length === 0) {
+    return candleStreamHealthForSelectors(
+      {
+        sourceNames: sourceName ? [sourceName] : [],
+        venues: venue ? [venue] : [],
+        symbols,
+        timeframes,
+      },
+      streams,
+    );
+  }
+
+  const expected = symbols.flatMap((symbol) =>
+    timeframes.map((timeframe) => ({
+      sourceName,
+      venue,
+      symbol,
+      timeframe,
+    })),
+  );
+  const matchedStreams: CandleStream[] = [];
+  const missing = expected.filter((selector) => {
+    const stream = streams.find((candidate) => expectedSelectorMatchesStream(selector, candidate));
+    if (stream) {
+      matchedStreams.push(stream);
+      return false;
+    }
+    return true;
+  });
+
+  if (missing.length > 0) {
+    const presentCount = expected.length - missing.length;
+    if (presentCount === 0) {
+      return {
+        status: 'missing',
+        label: 'Missing',
+        detail: 'No stored K-line stream matches this subscription yet.',
+      };
+    }
+
+    return {
+      status: 'missing',
+      label: 'Partial',
+      detail: `${presentCount}/${expected.length} expected stream${expected.length === 1 ? '' : 's'} present; ${missing.length} missing.`,
+    };
+  }
+
+  const staleCount = matchedStreams.filter(isStaleStream).length;
+  if (staleCount === matchedStreams.length) {
+    return {
+      status: 'stale',
+      label: 'Stale',
+      detail: `${staleCount} expected stream${staleCount === 1 ? '' : 's'} past the freshness window.`,
+    };
+  }
+
+  if (staleCount > 0) {
+    const freshCount = matchedStreams.length - staleCount;
+    return {
+      status: 'stale',
+      label: 'Partial',
+      detail: `${freshCount}/${expected.length} expected stream${expected.length === 1 ? '' : 's'} fresh; ${staleCount} stale.`,
+    };
+  }
+
+  return {
+    status: 'fresh',
+    label: 'Fresh',
+    detail: `${expected.length}/${expected.length} expected stream${expected.length === 1 ? '' : 's'} fresh.`,
+  };
+}
+
 function streamMatchesSelectors(stream: CandleStream, selectors: CandleStreamSelectors): boolean {
   const sourceNames = normalizedSelectorSet(selectors.sourceNames ?? [], 'lower');
   const venues = normalizedSelectorSet(selectors.venues ?? [], 'lower');
@@ -95,6 +183,16 @@ function streamMatchesSelectors(stream: CandleStream, selectors: CandleStreamSel
   if (symbols.size > 0 && !symbols.has(stream.symbol.toUpperCase())) return false;
   if (timeframes.size > 0 && !timeframes.has(stream.timeframe.toLowerCase())) return false;
   return true;
+}
+
+function expectedSelectorMatchesStream(
+  selector: { sourceName: string; venue: string | null; symbol: string; timeframe: string },
+  stream: CandleStream,
+): boolean {
+  if (stream.source_name.toLowerCase() !== selector.sourceName) return false;
+  if (selector.venue && stream.venue.toLowerCase() !== selector.venue) return false;
+  if (stream.symbol.toUpperCase() !== selector.symbol) return false;
+  return stream.timeframe.toLowerCase() === selector.timeframe;
 }
 
 function normalizedSelectorSet(


### PR DESCRIPTION
## Summary
- compute expected K-line watch coverage from catalog source selectors
- report partial coverage when only some subscribed symbol/timeframe streams are stored
- update FinanceWatchesCard tests for complete and partial coverage

## Tests
- npm --prefix web test -- src/components/topology/__tests__/FinanceWatchesCard.test.tsx
- npm --prefix web run typecheck
- npm --prefix web run format:check
- npm --prefix web run lint
- git diff --check
- pre-commit web lint-staged