### PR TITLE
fix(finance): use watch selectors for candle health

### DIFF
--- a/web/src/components/topology/FinanceWatchesCard.tsx
+++ b/web/src/components/topology/FinanceWatchesCard.tsx
@@ -28,7 +28,7 @@ import { useSettingsModal } from '@/components/settings/SettingsModalContext';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
-import { expectedCandleStreamHealth } from '@/lib/finance-candle-health';
+import { expectedCandleStreamHealthForGroups } from '@/lib/finance-candle-health';
 
 interface FinanceWatchesCardProps {
   sessionKey: string;
@@ -141,6 +141,7 @@ export function FinanceWatchesCard({ sessionKey }: FinanceWatchesCardProps) {
                 subscribed && entry.feed_type === 'market_candle'
                   ? marketCandleEntryStreamHealth(
                       entry,
+                      matchingSubscriptions,
                       candleStreams,
                       candleStreamsQuery.isLoading,
                     )
@@ -329,6 +330,7 @@ function coverageLabel(entry: FeedCatalogEntry): string {
 
 function marketCandleEntryStreamHealth(
   entry: FeedCatalogEntry,
+  subscriptions: FinanceSubscription[],
   streams: CandleStream[],
   loading: boolean,
 ): {
@@ -344,13 +346,14 @@ function marketCandleEntryStreamHealth(
     };
   }
 
-  return expectedCandleStreamHealth(
-    {
+  return expectedCandleStreamHealthForGroups(
+    subscriptions.map((subscription) => ({
       sourceName: catalogSourceName(entry),
-      venue: catalogVenue(entry),
-      symbols: catalogSymbols(entry),
-      timeframes: catalogTimeframes(entry),
-    },
+      venue: subscription.venues[0] ?? catalogVenue(entry),
+      symbols: subscription.symbols.length > 0 ? subscription.symbols : catalogSymbols(entry),
+      timeframes:
+        subscription.timeframes.length > 0 ? subscription.timeframes : catalogTimeframes(entry),
+    })),
     streams,
   );
 }

--- a/web/src/components/topology/__tests__/FinanceWatchesCard.test.tsx
+++ b/web/src/components/topology/__tests__/FinanceWatchesCard.test.tsx
@@ -416,4 +416,57 @@ describe('FinanceWatchesCard', () => {
     expect(await screen.findByText('Data Partial')).toBeInTheDocument();
     expect(screen.getByText('1/2 expected streams present; 1 missing.')).toBeInTheDocument();
   });
+
+  it('uses_subscription_selectors_for_watched_kline_health', async () => {
+    vi.spyOn(Date, 'now').mockReturnValue(Date.parse('2026-07-12T00:42:30Z'));
+    catalogMock.mockResolvedValue([
+      catalogEntry({
+        id: 'binance-market-candles',
+        name: 'Binance Market Candles',
+        feed_type: 'market_candle',
+        source_name: 'finance-binance-market-candles',
+        venue: 'binance',
+        configured_symbols: ['BTCUSDT', 'ETHUSDT'],
+        configured_timeframes: ['1m'],
+        tags: ['finance', 'market-data', 'crypto', 'binance'],
+        transport_template: {
+          venue: 'binance',
+          symbols: ['BTCUSDT', 'ETHUSDT'],
+          timeframes: ['1m'],
+        },
+      }),
+    ]);
+    financeSubscriptionsMock.mockResolvedValue({
+      subscriptions: [
+        financeSubscription({
+          symbols: ['BTCUSDT'],
+          timeframes: ['1m'],
+        }),
+      ],
+      count: 1,
+    } satisfies FinanceSubscriptionsResponse);
+    candleStreamsMock.mockResolvedValue({
+      streams: [
+        {
+          source_name: 'finance-binance-market-candles',
+          venue: 'binance',
+          symbol: 'BTCUSDT',
+          timeframe: '1m',
+          candle_count: 42,
+          first_open_time: '2026-07-12T00:00:00Z',
+          latest_open_time: '2026-07-12T00:41:00Z',
+          latest_close_time: '2026-07-12T00:41:59Z',
+          latest_ingested_at: '2026-07-12T00:42:02Z',
+        },
+      ],
+      count: 1,
+      query_limit: 100,
+    } satisfies CandleStreamsResponse);
+
+    renderCard('session-1');
+
+    expect(await screen.findByText('watching')).toBeInTheDocument();
+    expect(await screen.findByText('Data Fresh')).toBeInTheDocument();
+    expect(screen.getByText('1/1 expected stream fresh.')).toBeInTheDocument();
+  });
 });

--- a/web/src/lib/finance-candle-health.ts
+++ b/web/src/lib/finance-candle-health.ts
@@ -89,31 +89,18 @@ export function expectedCandleStreamHealth(
   selectors: ExpectedCandleStreamSelectors,
   streams: CandleStream[],
 ): CandleStreamHealth {
-  const symbols = Array.from(normalizedSelectorSet(selectors.symbols, 'upper'));
-  const timeframes = Array.from(normalizedSelectorSet(selectors.timeframes, 'timeframe'));
-  const sourceName = selectors.sourceName.trim().toLowerCase();
-  const venue = selectors.venue?.trim().toLowerCase() || null;
+  return expectedCandleStreamHealthForGroups([selectors], streams);
+}
 
-  if (!sourceName || symbols.length === 0 || timeframes.length === 0) {
-    return candleStreamHealthForSelectors(
-      {
-        sourceNames: sourceName ? [sourceName] : [],
-        venues: venue ? [venue] : [],
-        symbols,
-        timeframes,
-      },
-      streams,
-    );
+export function expectedCandleStreamHealthForGroups(
+  selectorGroups: ExpectedCandleStreamSelectors[],
+  streams: CandleStream[],
+): CandleStreamHealth {
+  const expected = uniqueExpectedSelectors(selectorGroups.flatMap(expectedSelectorsForGroup));
+  if (expected.length === 0) {
+    return candleStreamHealthForSelectors(fallbackSelectorsForGroups(selectorGroups), streams);
   }
 
-  const expected = symbols.flatMap((symbol) =>
-    timeframes.map((timeframe) => ({
-      sourceName,
-      venue,
-      symbol,
-      timeframe,
-    })),
-  );
   const matchedStreams: CandleStream[] = [];
   const missing = expected.filter((selector) => {
     const stream = streams.find((candidate) => expectedSelectorMatchesStream(selector, candidate));
@@ -163,6 +150,62 @@ export function expectedCandleStreamHealth(
     status: 'fresh',
     label: 'Fresh',
     detail: `${expected.length}/${expected.length} expected stream${expected.length === 1 ? '' : 's'} fresh.`,
+  };
+}
+
+function expectedSelectorsForGroup(selectors: ExpectedCandleStreamSelectors): Array<{
+  sourceName: string;
+  venue: string | null;
+  symbol: string;
+  timeframe: string;
+}> {
+  const symbols = Array.from(normalizedSelectorSet(selectors.symbols, 'upper'));
+  const timeframes = Array.from(normalizedSelectorSet(selectors.timeframes, 'timeframe'));
+  const sourceName = selectors.sourceName.trim().toLowerCase();
+  const venue = selectors.venue?.trim().toLowerCase() || null;
+
+  if (!sourceName || symbols.length === 0 || timeframes.length === 0) return [];
+
+  return symbols.flatMap((symbol) =>
+    timeframes.map((timeframe) => ({
+      sourceName,
+      venue,
+      symbol,
+      timeframe,
+    })),
+  );
+}
+
+function uniqueExpectedSelectors(
+  selectors: Array<{
+    sourceName: string;
+    venue: string | null;
+    symbol: string;
+    timeframe: string;
+  }>,
+): Array<{
+  sourceName: string;
+  venue: string | null;
+  symbol: string;
+  timeframe: string;
+}> {
+  const seen = new Set<string>();
+  return selectors.filter((selector) => {
+    const key = `${selector.sourceName}:${selector.venue ?? ''}:${selector.symbol}:${selector.timeframe}`;
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+}
+
+function fallbackSelectorsForGroups(
+  selectorGroups: ExpectedCandleStreamSelectors[],
+): CandleStreamSelectors {
+  return {
+    sourceNames: selectorGroups.map((group) => group.sourceName),
+    venues: selectorGroups.flatMap((group) => (group.venue ? [group.venue] : [])),
+    symbols: selectorGroups.flatMap((group) => group.symbols),
+    timeframes: selectorGroups.flatMap((group) => group.timeframes),
   };
 }
 


### PR DESCRIPTION
## Summary
- compute K-line watch health from the matching subscription selectors instead of the full catalog source defaults
- keep catalog defaults as fallback only when a subscription has no explicit symbol/timeframe selectors
- aggregate multiple selector groups without creating invalid cross-product combinations

## Tests
- npm --prefix web test -- src/components/topology/__tests__/FinanceWatchesCard.test.tsx
- npm --prefix web run typecheck
- npm --prefix web run format:check
- npm --prefix web run lint
- git diff --check
- pre-commit web lint-staged