### PR TITLE
fix(finance): expand candle stream overview limit

### DIFF
--- a/web/src/api/data-feeds.ts
+++ b/web/src/api/data-feeds.ts
@@ -16,6 +16,8 @@
 
 import { api } from './client';
 
+export const CANDLE_STREAM_OVERVIEW_LIMIT = 500;
+
 // ---------------------------------------------------------------------------
 // Types — mirrors kernel::data_feed::config
 // ---------------------------------------------------------------------------

--- a/web/src/components/DataFeedsPanel.tsx
+++ b/web/src/components/DataFeedsPanel.tsx
@@ -29,6 +29,7 @@ import {
 import { useState, useCallback, useEffect } from 'react';
 
 import {
+  CANDLE_STREAM_OVERVIEW_LIMIT,
   dataFeedsApi,
   type CandleStream,
   type MarketCandle,
@@ -2263,7 +2264,7 @@ export default function DataFeedsPanel({
   });
   const candleStreamsQuery = useQuery({
     queryKey: ['market-data-candle-streams'],
-    queryFn: () => dataFeedsApi.candleStreams({ limit: 100 }),
+    queryFn: () => dataFeedsApi.candleStreams({ limit: CANDLE_STREAM_OVERVIEW_LIMIT }),
     refetchInterval: 30_000,
   });
 

--- a/web/src/components/__tests__/DataFeedsPanel.test.tsx
+++ b/web/src/components/__tests__/DataFeedsPanel.test.tsx
@@ -41,6 +41,7 @@ const candleFreshnessMock = vi.fn();
 const candleGapsMock = vi.fn();
 
 vi.mock('@/api/data-feeds', () => ({
+  CANDLE_STREAM_OVERVIEW_LIMIT: 500,
   dataFeedsApi: {
     list: (...args: unknown[]) => listMock(...args),
     summaries: (...args: unknown[]) => summariesMock(...args),
@@ -190,7 +191,7 @@ describe('DataFeedsPanel', () => {
     expect(screen.getByText('42')).toBeInTheDocument();
 
     await waitFor(() => {
-      expect(candleStreamsMock).toHaveBeenCalledWith({ limit: 100 });
+      expect(candleStreamsMock).toHaveBeenCalledWith({ limit: 500 });
     });
   });
 

--- a/web/src/components/topology/FinanceWatchesCard.tsx
+++ b/web/src/components/topology/FinanceWatchesCard.tsx
@@ -17,6 +17,7 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 
 import {
+  CANDLE_STREAM_OVERVIEW_LIMIT,
   dataFeedsApi,
   type CandleStream,
   type CreateFinanceSubscriptionRequest,
@@ -49,7 +50,7 @@ export function FinanceWatchesCard({ sessionKey }: FinanceWatchesCardProps) {
   });
   const candleStreamsQuery = useQuery({
     queryKey: ['market-data-candle-streams'],
-    queryFn: () => dataFeedsApi.candleStreams({ limit: 100 }),
+    queryFn: () => dataFeedsApi.candleStreams({ limit: CANDLE_STREAM_OVERVIEW_LIMIT }),
     refetchInterval: 30_000,
     staleTime: 30_000,
   });

--- a/web/src/components/topology/__tests__/FinanceWatchesCard.test.tsx
+++ b/web/src/components/topology/__tests__/FinanceWatchesCard.test.tsx
@@ -36,6 +36,7 @@ const unsubscribeCatalogEntryMock = vi.fn();
 const openSettingsMock = vi.fn();
 
 vi.mock('@/api/data-feeds', () => ({
+  CANDLE_STREAM_OVERVIEW_LIMIT: 500,
   dataFeedsApi: {
     catalog: (...args: unknown[]) => catalogMock(...args),
     financeSubscriptions: (...args: unknown[]) => financeSubscriptionsMock(...args),
@@ -365,7 +366,7 @@ describe('FinanceWatchesCard', () => {
     expect(await screen.findByText('Data Fresh')).toBeInTheDocument();
     expect(screen.getByText('2/2 expected streams fresh.')).toBeInTheDocument();
     await waitFor(() => {
-      expect(candleStreamsMock).toHaveBeenCalledWith({ limit: 100 });
+      expect(candleStreamsMock).toHaveBeenCalledWith({ limit: 500 });
     });
   });
 


### PR DESCRIPTION
## Summary
- add a shared frontend candle stream overview limit of 500, matching the backend default stream list limit
- use it in both Data Feeds and Finance watches K-line stream queries
- update tests so the health UI does not silently regress back to 100 streams

## Tests
- npm --prefix web test -- src/components/__tests__/DataFeedsPanel.test.tsx src/components/topology/__tests__/FinanceWatchesCard.test.tsx
- npm --prefix web run typecheck
- npm --prefix web run format:check
- npm --prefix web run lint
- git diff --check