### PR TITLE
feat(finance): flag limited candle stream overviews

### DIFF
--- a/web/src/components/DataFeedsPanel.tsx
+++ b/web/src/components/DataFeedsPanel.tsx
@@ -1654,16 +1654,19 @@ function FinanceSubscriptionsCard({
 
 function MarketDataStreamsCard({
   streams,
+  queryLimit,
   isLoading,
   isError,
   onRetry,
 }: {
   streams: CandleStream[];
+  queryLimit: number | null;
   isLoading: boolean;
   isError: boolean;
   onRetry: () => void;
 }) {
   const [previewStream, setPreviewStream] = useState<CandleStream | null>(null);
+  const limitReached = queryLimit != null && streams.length >= queryLimit;
   const previewRequest = previewStream ? candlePreviewRequest(previewStream) : null;
   const previewQuery = useQuery({
     queryKey: [
@@ -1743,6 +1746,12 @@ function MarketDataStreamsCard({
             {streams.length} stream{streams.length === 1 ? '' : 's'}
           </Badge>
         </div>
+        {!isLoading && !isError && limitReached && (
+          <div className="border-b bg-muted/30 px-4 py-2 text-xs text-muted-foreground">
+            Showing the first {queryLimit} streams. Narrow by source, venue, symbol, or timeframe if
+            a watched K-line stream is missing from this overview.
+          </div>
+        )}
         {isLoading ? (
           <div className="space-y-2 px-4 py-4">
             <Skeleton className="h-4 w-1/2" />
@@ -1977,6 +1986,7 @@ function FeedListView({
   feeds,
   summaries,
   candleStreams,
+  candleStreamQueryLimit,
   candleStreamsLoading,
   candleStreamsError,
   onRetryCandleStreams,
@@ -1986,6 +1996,7 @@ function FeedListView({
   feeds: DataFeedConfig[];
   summaries: FeedSummary[];
   candleStreams: CandleStream[];
+  candleStreamQueryLimit: number | null;
   candleStreamsLoading: boolean;
   candleStreamsError: boolean;
   onRetryCandleStreams: () => void;
@@ -2084,6 +2095,7 @@ function FeedListView({
       )}
       <MarketDataStreamsCard
         streams={candleStreams}
+        queryLimit={candleStreamQueryLimit}
         isLoading={candleStreamsLoading}
         isError={candleStreamsError}
         onRetry={onRetryCandleStreams}
@@ -2307,6 +2319,7 @@ export default function DataFeedsPanel({
       feeds={feeds}
       summaries={summaries}
       candleStreams={candleStreamsQuery.data?.streams ?? []}
+      candleStreamQueryLimit={candleStreamsQuery.data?.query_limit ?? null}
       candleStreamsLoading={candleStreamsQuery.isLoading}
       candleStreamsError={candleStreamsQuery.isError}
       onRetryCandleStreams={() => {

--- a/web/src/components/__tests__/DataFeedsPanel.test.tsx
+++ b/web/src/components/__tests__/DataFeedsPanel.test.tsx
@@ -206,6 +206,35 @@ describe('DataFeedsPanel', () => {
     ).toBeInTheDocument();
   });
 
+  it('warns when the stored K-line stream overview reaches the query limit', async () => {
+    candleStreamsMock.mockResolvedValue({
+      streams: [
+        {
+          source_name: 'finance-binance-market-candles',
+          venue: 'binance',
+          symbol: 'BTCUSDT',
+          timeframe: '1m',
+          candle_count: 42,
+          first_open_time: '2026-07-12T00:00:00Z',
+          latest_open_time: '2026-07-12T00:41:00Z',
+          latest_close_time: '2026-07-12T00:41:59Z',
+          latest_ingested_at: '2026-07-12T00:42:02Z',
+        },
+      ],
+      count: 1,
+      query_limit: 1,
+    } satisfies CandleStreamsResponse);
+
+    renderPanel();
+
+    expect(await screen.findByText('Stored K-line streams')).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        'Showing the first 1 streams. Narrow by source, venue, symbol, or timeframe if a watched K-line stream is missing from this overview.',
+      ),
+    ).toBeInTheDocument();
+  });
+
   it('shows fresh health for a K-line subscription with a matching stored stream', async () => {
     vi.spyOn(Date, 'now').mockReturnValue(Date.parse('2026-07-12T00:42:30Z'));
     financeSubscriptionsMock.mockResolvedValue({

--- a/web/src/components/topology/FinanceWatchesCard.tsx
+++ b/web/src/components/topology/FinanceWatchesCard.tsx
@@ -90,6 +90,9 @@ export function FinanceWatchesCard({ sessionKey }: FinanceWatchesCardProps) {
 
   const entries = (catalogQuery.data ?? []).filter(isFinanceWatchableEntry);
   const candleStreams = candleStreamsQuery.data?.streams ?? [];
+  const candleStreamLimitReached =
+    candleStreamsQuery.data != null &&
+    candleStreamsQuery.data.streams.length >= candleStreamsQuery.data.query_limit;
   const sessionSubscriptions = (subscriptionsQuery.data?.subscriptions ?? []).filter(
     (subscription) => subscription.session_key === sessionKey,
   );
@@ -131,6 +134,12 @@ export function FinanceWatchesCard({ sessionKey }: FinanceWatchesCardProps) {
           </div>
         ) : (
           <div className="space-y-2">
+            {candleStreamLimitReached && (
+              <div className="rounded-md border border-dashed bg-muted/30 px-3 py-2 text-[11px] text-muted-foreground">
+                K-line stream overview is limited to {candleStreamsQuery.data.query_limit} streams;
+                a missing health check may need a narrower source, symbol, or timeframe query.
+              </div>
+            )}
             {entries.map((entry) => {
               const matchingSubscriptions = sessionSubscriptions.filter((subscription) =>
                 subscriptionMatchesEntry(subscription, entry),

--- a/web/src/components/topology/__tests__/FinanceWatchesCard.test.tsx
+++ b/web/src/components/topology/__tests__/FinanceWatchesCard.test.tsx
@@ -420,6 +420,57 @@ describe('FinanceWatchesCard', () => {
     ).toBeInTheDocument();
   });
 
+  it('warns_when_watched_kline_health_uses_a_limited_stream_overview', async () => {
+    vi.spyOn(Date, 'now').mockReturnValue(Date.parse('2026-07-12T00:42:30Z'));
+    catalogMock.mockResolvedValue([
+      catalogEntry({
+        id: 'binance-market-candles',
+        name: 'Binance Market Candles',
+        feed_type: 'market_candle',
+        source_name: 'finance-binance-market-candles',
+        venue: 'binance',
+        configured_symbols: ['BTCUSDT'],
+        configured_timeframes: ['1m'],
+        tags: ['finance', 'market-data', 'crypto', 'binance'],
+        transport_template: {
+          venue: 'binance',
+          symbols: ['BTCUSDT'],
+          timeframes: ['1m'],
+        },
+      }),
+    ]);
+    financeSubscriptionsMock.mockResolvedValue({
+      subscriptions: [financeSubscription({ symbols: ['BTCUSDT'] })],
+      count: 1,
+    } satisfies FinanceSubscriptionsResponse);
+    candleStreamsMock.mockResolvedValue({
+      streams: [
+        {
+          source_name: 'finance-binance-market-candles',
+          venue: 'binance',
+          symbol: 'BTCUSDT',
+          timeframe: '1m',
+          candle_count: 42,
+          first_open_time: '2026-07-12T00:00:00Z',
+          latest_open_time: '2026-07-12T00:41:00Z',
+          latest_close_time: '2026-07-12T00:41:59Z',
+          latest_ingested_at: '2026-07-12T00:42:02Z',
+        },
+      ],
+      count: 1,
+      query_limit: 1,
+    } satisfies CandleStreamsResponse);
+
+    renderCard('session-1');
+
+    expect(await screen.findByText('watching')).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        'K-line stream overview is limited to 1 streams; a missing health check may need a narrower source, symbol, or timeframe query.',
+      ),
+    ).toBeInTheDocument();
+  });
+
   it('uses_subscription_selectors_for_watched_kline_health', async () => {
     vi.spyOn(Date, 'now').mockReturnValue(Date.parse('2026-07-12T00:42:30Z'));
     catalogMock.mockResolvedValue([


### PR DESCRIPTION
## Summary
- show a limited-result hint when stored K-line stream overview reaches the API query limit
- surface the same warning in Finance watches so missing health checks are not mistaken for definitive absence
- add focused DataFeedsPanel and FinanceWatchesCard coverage

## Tests
- npm --prefix web test -- src/components/__tests__/DataFeedsPanel.test.tsx src/components/topology/__tests__/FinanceWatchesCard.test.tsx
- npm --prefix web run typecheck
- npm --prefix web run format:check
- npm --prefix web run lint
- git diff --check