### PR TITLE
feat(finance): expose candle stream pagination state

### DIFF
--- a/crates/extensions/backend-admin/src/data_feeds/router.rs
+++ b/crates/extensions/backend-admin/src/data_feeds/router.rs
@@ -259,6 +259,7 @@ struct CandleStreamListResponse {
     streams:     Vec<CandleStreamResponse>,
     count:       usize,
     query_limit: usize,
+    has_more:    bool,
 }
 
 #[derive(Debug, Serialize)]
@@ -1205,19 +1206,22 @@ async fn list_market_data_candle_streams(
     Query(params): Query<CandleStreamQueryParams>,
 ) -> Result<Json<CandleStreamListResponse>, ProblemDetails> {
     let limit = validate_market_data_stream_limit(params.limit)?;
+    let probe_limit = limit.saturating_add(1);
     let query = CandleStreamListQuery {
         source_name: normalize_optional_market_data_selector("source_name", params.source_name)?,
-        venue: normalize_optional_market_data_venue(params.venue)?,
-        symbol: normalize_optional_market_data_symbol(params.symbol)?,
-        timeframe: normalize_optional_market_data_timeframe(params.timeframe)?,
-        limit,
+        venue:       normalize_optional_market_data_venue(params.venue)?,
+        symbol:      normalize_optional_market_data_symbol(params.symbol)?,
+        timeframe:   normalize_optional_market_data_timeframe(params.timeframe)?,
+        limit:       probe_limit,
     };
 
-    let streams = state
+    let mut streams = state
         .market_data_repo
         .candle_streams(query)
         .await
         .map_err(|err| ProblemDetails::internal(format!("failed to list candle streams: {err}")))?;
+    let has_more = streams.len() > limit;
+    streams.truncate(limit);
     let count = streams.len();
 
     Ok(Json(CandleStreamListResponse {
@@ -1227,6 +1231,7 @@ async fn list_market_data_candle_streams(
             .collect(),
         count,
         query_limit: limit,
+        has_more,
     }))
 }
 
@@ -3297,6 +3302,7 @@ mod tests {
 
         assert_eq!(result["count"], 1);
         assert_eq!(result["query_limit"], 500);
+        assert_eq!(result["has_more"], false);
         let stream = &result["streams"][0];
         assert_eq!(stream["source_name"], "finance-binance-market-candles");
         assert_eq!(stream["venue"], "binance");
@@ -3307,6 +3313,59 @@ mod tests {
         assert_eq!(stream["latest_open_time"], "2026-07-10T08:00:00Z");
         assert_eq!(stream["latest_close_time"], "2026-07-10T08:01:00Z");
         assert_eq!(stream["latest_ingested_at"], "2026-07-10T08:01:03Z");
+    }
+
+    #[tokio::test]
+    async fn market_data_candle_streams_endpoint_reports_has_more() {
+        let market_data_repo = test_market_data_repo();
+        market_data_repo
+            .upsert_closed_candle(market_data_candle(
+                "2026-07-10T08:00:00Z",
+                "2026-07-10T08:01:00Z",
+                "1005.00",
+                Some("seq-1"),
+            ))
+            .await
+            .unwrap();
+        market_data_repo
+            .upsert_closed_candle(MarketCandle {
+                symbol: "ETHUSDT".to_owned(),
+                open_time: "2026-07-10T08:01:00Z".parse().unwrap(),
+                close_time: "2026-07-10T08:02:00Z".parse().unwrap(),
+                close: rust_decimal::Decimal::new(320_000, 2),
+                ..market_data_candle(
+                    "2026-07-10T08:01:00Z",
+                    "2026-07-10T08:02:00Z",
+                    "3200.00",
+                    Some("seq-2"),
+                )
+            })
+            .await
+            .unwrap();
+
+        let app = app_with_user_and_market_data_repo(user_of(Role::Admin), market_data_repo).await;
+        let res = app
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri("/api/v1/data-feeds/market-data/candle-streams?limit=1")
+                    .header("Authorization", "Bearer s3cret")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(res.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(res.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let result: serde_json::Value = serde_json::from_slice(&body).unwrap();
+
+        assert_eq!(result["count"], 1);
+        assert_eq!(result["query_limit"], 1);
+        assert_eq!(result["has_more"], true);
+        assert_eq!(result["streams"].as_array().unwrap().len(), 1);
     }
 
     #[tokio::test]

--- a/web/src/api/data-feeds.ts
+++ b/web/src/api/data-feeds.ts
@@ -84,6 +84,7 @@ export interface CandleStreamsResponse {
   streams: CandleStream[];
   count: number;
   query_limit: number;
+  has_more: boolean;
 }
 
 export interface MarketCandle {

--- a/web/src/components/DataFeedsPanel.tsx
+++ b/web/src/components/DataFeedsPanel.tsx
@@ -1655,18 +1655,19 @@ function FinanceSubscriptionsCard({
 function MarketDataStreamsCard({
   streams,
   queryLimit,
+  hasMore,
   isLoading,
   isError,
   onRetry,
 }: {
   streams: CandleStream[];
   queryLimit: number | null;
+  hasMore: boolean;
   isLoading: boolean;
   isError: boolean;
   onRetry: () => void;
 }) {
   const [previewStream, setPreviewStream] = useState<CandleStream | null>(null);
-  const limitReached = queryLimit != null && streams.length >= queryLimit;
   const previewRequest = previewStream ? candlePreviewRequest(previewStream) : null;
   const previewQuery = useQuery({
     queryKey: [
@@ -1746,7 +1747,7 @@ function MarketDataStreamsCard({
             {streams.length} stream{streams.length === 1 ? '' : 's'}
           </Badge>
         </div>
-        {!isLoading && !isError && limitReached && (
+        {!isLoading && !isError && hasMore && queryLimit != null && (
           <div className="border-b bg-muted/30 px-4 py-2 text-xs text-muted-foreground">
             Showing the first {queryLimit} streams. Narrow by source, venue, symbol, or timeframe if
             a watched K-line stream is missing from this overview.
@@ -1987,6 +1988,7 @@ function FeedListView({
   summaries,
   candleStreams,
   candleStreamQueryLimit,
+  candleStreamHasMore,
   candleStreamsLoading,
   candleStreamsError,
   onRetryCandleStreams,
@@ -1997,6 +1999,7 @@ function FeedListView({
   summaries: FeedSummary[];
   candleStreams: CandleStream[];
   candleStreamQueryLimit: number | null;
+  candleStreamHasMore: boolean;
   candleStreamsLoading: boolean;
   candleStreamsError: boolean;
   onRetryCandleStreams: () => void;
@@ -2096,6 +2099,7 @@ function FeedListView({
       <MarketDataStreamsCard
         streams={candleStreams}
         queryLimit={candleStreamQueryLimit}
+        hasMore={candleStreamHasMore}
         isLoading={candleStreamsLoading}
         isError={candleStreamsError}
         onRetry={onRetryCandleStreams}
@@ -2320,6 +2324,7 @@ export default function DataFeedsPanel({
       summaries={summaries}
       candleStreams={candleStreamsQuery.data?.streams ?? []}
       candleStreamQueryLimit={candleStreamsQuery.data?.query_limit ?? null}
+      candleStreamHasMore={candleStreamsQuery.data?.has_more ?? false}
       candleStreamsLoading={candleStreamsQuery.isLoading}
       candleStreamsError={candleStreamsQuery.isError}
       onRetryCandleStreams={() => {

--- a/web/src/components/__tests__/DataFeedsPanel.test.tsx
+++ b/web/src/components/__tests__/DataFeedsPanel.test.tsx
@@ -135,6 +135,7 @@ beforeEach(() => {
     streams: [],
     count: 0,
     query_limit: 100,
+    has_more: false,
   } satisfies CandleStreamsResponse);
   candlesMock.mockResolvedValue({
     candles: [],
@@ -181,6 +182,7 @@ describe('DataFeedsPanel', () => {
       ],
       count: 1,
       query_limit: 100,
+      has_more: false,
     } satisfies CandleStreamsResponse);
 
     renderPanel();
@@ -223,6 +225,7 @@ describe('DataFeedsPanel', () => {
       ],
       count: 1,
       query_limit: 1,
+      has_more: true,
     } satisfies CandleStreamsResponse);
 
     renderPanel();
@@ -257,6 +260,7 @@ describe('DataFeedsPanel', () => {
       ],
       count: 1,
       query_limit: 100,
+      has_more: false,
     } satisfies CandleStreamsResponse);
 
     renderPanel();
@@ -296,6 +300,7 @@ describe('DataFeedsPanel', () => {
       ],
       count: 1,
       query_limit: 100,
+      has_more: false,
     } satisfies CandleStreamsResponse);
     candlesMock.mockResolvedValue({
       candles: [

--- a/web/src/components/topology/FinanceWatchesCard.tsx
+++ b/web/src/components/topology/FinanceWatchesCard.tsx
@@ -90,9 +90,7 @@ export function FinanceWatchesCard({ sessionKey }: FinanceWatchesCardProps) {
 
   const entries = (catalogQuery.data ?? []).filter(isFinanceWatchableEntry);
   const candleStreams = candleStreamsQuery.data?.streams ?? [];
-  const candleStreamLimitReached =
-    candleStreamsQuery.data != null &&
-    candleStreamsQuery.data.streams.length >= candleStreamsQuery.data.query_limit;
+  const candleStreamHasMore = candleStreamsQuery.data?.has_more ?? false;
   const sessionSubscriptions = (subscriptionsQuery.data?.subscriptions ?? []).filter(
     (subscription) => subscription.session_key === sessionKey,
   );
@@ -134,7 +132,7 @@ export function FinanceWatchesCard({ sessionKey }: FinanceWatchesCardProps) {
           </div>
         ) : (
           <div className="space-y-2">
-            {candleStreamLimitReached && (
+            {candleStreamHasMore && candleStreamsQuery.data != null && (
               <div className="rounded-md border border-dashed bg-muted/30 px-3 py-2 text-[11px] text-muted-foreground">
                 K-line stream overview is limited to {candleStreamsQuery.data.query_limit} streams;
                 a missing health check may need a narrower source, symbol, or timeframe query.

--- a/web/src/components/topology/__tests__/FinanceWatchesCard.test.tsx
+++ b/web/src/components/topology/__tests__/FinanceWatchesCard.test.tsx
@@ -128,6 +128,7 @@ beforeEach(() => {
     streams: [],
     count: 0,
     query_limit: 100,
+    has_more: false,
   } satisfies CandleStreamsResponse);
 });
 
@@ -358,6 +359,7 @@ describe('FinanceWatchesCard', () => {
       ],
       count: 2,
       query_limit: 100,
+      has_more: false,
     } satisfies CandleStreamsResponse);
 
     renderCard('session-1');
@@ -409,6 +411,7 @@ describe('FinanceWatchesCard', () => {
       ],
       count: 1,
       query_limit: 100,
+      has_more: false,
     } satisfies CandleStreamsResponse);
 
     renderCard('session-1');
@@ -459,6 +462,7 @@ describe('FinanceWatchesCard', () => {
       ],
       count: 1,
       query_limit: 1,
+      has_more: true,
     } satisfies CandleStreamsResponse);
 
     renderCard('session-1');
@@ -515,6 +519,7 @@ describe('FinanceWatchesCard', () => {
       ],
       count: 1,
       query_limit: 100,
+      has_more: false,
     } satisfies CandleStreamsResponse);
 
     renderCard('session-1');


### PR DESCRIPTION
## Summary
- add has_more to the candle stream list API by probing one extra stream beyond the requested limit
- return truncated streams/count while preserving query_limit for the requested page size
- use has_more in Data Feeds and Finance watches instead of inferring truncation from count >= query_limit
- update Rust endpoint tests and web component tests

## Tests
- cargo test -p rara-backend-admin market_data_candle_streams_endpoint --lib
- cargo check -p rara-backend-admin --lib
- npm --prefix web test -- src/components/__tests__/DataFeedsPanel.test.tsx src/components/topology/__tests__/FinanceWatchesCard.test.tsx
- npm --prefix web run typecheck
- npm --prefix web run format:check
- npm --prefix web run lint
- git diff --check
- pre-commit: cargo check/fmt/clippy/doc, AGENT.md, web lint-staged