### PR TITLE
feat(finance): expose candle range pagination state

### DIFF
--- a/crates/extensions/backend-admin/src/data_feeds/router.rs
+++ b/crates/extensions/backend-admin/src/data_feeds/router.rs
@@ -84,6 +84,7 @@ const DEFAULT_MARKET_DATA_STREAM_LIMIT: usize = 500;
 const MAX_MARKET_DATA_STREAM_LIMIT: usize = 10_000;
 const DEFAULT_MARKET_DATA_CANDLE_LIMIT: usize = 500;
 const MAX_MARKET_DATA_CANDLE_LIMIT: usize = 10_000;
+const MAX_MARKET_DATA_CANDLE_RANGE_LIMIT: usize = MAX_MARKET_DATA_CANDLE_LIMIT - 1;
 const MAX_MARKET_DATA_FRESHNESS_STALE_AFTER_SECS: u64 = 31_536_000;
 const MAX_MARKET_DATA_SELECTOR_LEN: usize = 128;
 
@@ -328,6 +329,7 @@ struct CandleRangeResponse {
     candles:     Vec<CandleResponse>,
     count:       usize,
     query_limit: usize,
+    has_more:    bool,
 }
 
 #[derive(Debug, Serialize)]
@@ -1370,7 +1372,8 @@ async fn query_market_data_candles(
     State(state): State<DataFeedRouterState>,
     Query(params): Query<CandleRangeQueryParams>,
 ) -> Result<Json<CandleRangeResponse>, ProblemDetails> {
-    let limit = validate_market_data_candle_limit(params.limit)?;
+    let limit = validate_market_data_candle_range_limit(params.limit)?;
+    let probe_limit = limit.saturating_add(1);
     let start = parse_market_data_timestamp("start", params.start)?;
     let end = parse_market_data_timestamp("end", params.end)?;
     if end <= start {
@@ -1384,20 +1387,23 @@ async fn query_market_data_candles(
         timeframe: normalize_required_market_data_timeframe(params.timeframe)?,
         start,
         end,
-        limit,
+        limit: probe_limit,
     };
 
-    let candles = state
+    let mut candles = state
         .market_data_repo
         .candles(query)
         .await
         .map_err(|err| ProblemDetails::internal(format!("failed to query candles: {err}")))?;
+    let has_more = candles.len() > limit;
+    candles.truncate(limit);
     let count = candles.len();
 
     Ok(Json(CandleRangeResponse {
         candles: candles.into_iter().map(CandleResponse::from).collect(),
         count,
         query_limit: limit,
+        has_more,
     }))
 }
 
@@ -1538,14 +1544,14 @@ fn validate_market_data_stream_limit(limit: Option<usize>) -> Result<usize, Prob
     Ok(limit)
 }
 
-fn validate_market_data_candle_limit(limit: Option<usize>) -> Result<usize, ProblemDetails> {
+fn validate_market_data_candle_range_limit(limit: Option<usize>) -> Result<usize, ProblemDetails> {
     let limit = limit.unwrap_or(DEFAULT_MARKET_DATA_CANDLE_LIMIT);
     if limit == 0 {
         return Err(ProblemDetails::bad_request("limit must be positive"));
     }
-    if limit > MAX_MARKET_DATA_CANDLE_LIMIT {
+    if limit > MAX_MARKET_DATA_CANDLE_RANGE_LIMIT {
         return Err(ProblemDetails::bad_request(format!(
-            "limit must be <= {MAX_MARKET_DATA_CANDLE_LIMIT}"
+            "limit must be <= {MAX_MARKET_DATA_CANDLE_RANGE_LIMIT}"
         )));
     }
     Ok(limit)
@@ -3462,10 +3468,45 @@ mod tests {
 
         assert_eq!(result["count"], 2);
         assert_eq!(result["query_limit"], 2);
+        assert_eq!(result["has_more"], true);
         assert_eq!(result["candles"][0]["open_time"], "2026-07-10T08:00:00Z");
         assert_eq!(result["candles"][0]["close"], "1005.00");
         assert_eq!(result["candles"][1]["open_time"], "2026-07-10T08:01:00Z");
         assert_eq!(result["candles"][1]["close"], "1006.25");
+    }
+
+    #[tokio::test]
+    async fn market_data_candles_endpoint_rejects_unprobeable_limit() {
+        let app =
+            app_with_user_and_market_data_repo(user_of(Role::Admin), test_market_data_repo()).await;
+        let res = app
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri(
+                        "/api/v1/data-feeds/market-data/candles?venue=binance&symbol=BTCUSDT&\
+                         timeframe=1m&start=2026-07-10T08:00:00Z&end=2026-07-10T08:03:00Z&\
+                         limit=10000",
+                    )
+                    .header("Authorization", "Bearer s3cret")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(res.status(), StatusCode::BAD_REQUEST);
+        let body = axum::body::to_bytes(res.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let result: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert!(
+            result["detail"]
+                .as_str()
+                .unwrap_or_default()
+                .contains("limit must be <= 9999"),
+            "unexpected body: {result}"
+        );
     }
 
     #[tokio::test]

--- a/crates/extensions/rara-trading/src/market_data/tools.rs
+++ b/crates/extensions/rara-trading/src/market_data/tools.rs
@@ -28,6 +28,7 @@ use super::{
 
 const DEFAULT_CANDLE_LIMIT: usize = 500;
 const MAX_CANDLE_LIMIT: usize = 10_000;
+const MAX_CANDLE_RANGE_LIMIT: usize = MAX_CANDLE_LIMIT - 1;
 const MAX_CANDLE_STREAM_LIMIT: usize = MAX_CANDLE_LIMIT - 1;
 const MAX_SELECTOR_LEN: usize = 128;
 
@@ -65,6 +66,7 @@ pub struct FinanceQueryCandlesResult {
     pub candles:     Vec<FinanceCandle>,
     pub count:       usize,
     pub query_limit: usize,
+    pub has_more:    bool,
 }
 
 #[derive(Debug, Deserialize, JsonSchema)]
@@ -285,7 +287,8 @@ impl ToolExecute for FinanceQueryCandlesTool {
         params: FinanceQueryCandlesParams,
         _context: &ToolContext,
     ) -> anyhow::Result<FinanceQueryCandlesResult> {
-        let limit = validate_candle_limit(params.limit)?;
+        let limit = validate_candle_range_limit(params.limit)?;
+        let probe_limit = limit.saturating_add(1);
         let start = parse_timestamp("start", &params.start)?;
         let end = parse_timestamp("end", &params.end)?;
         anyhow::ensure!(start < end, "start must be before end");
@@ -297,14 +300,17 @@ impl ToolExecute for FinanceQueryCandlesTool {
             timeframe: normalize_required_timeframe_selector(params.timeframe)?,
             start,
             end,
-            limit,
+            limit: probe_limit,
         };
-        let candles = self.repository.candles(query).await?;
+        let mut candles = self.repository.candles(query).await?;
+        let has_more = candles.len() > limit;
+        candles.truncate(limit);
         let count = candles.len();
         Ok(FinanceQueryCandlesResult {
             candles: candles.into_iter().map(FinanceCandle::from).collect(),
             count,
             query_limit: limit,
+            has_more,
         })
     }
 }
@@ -535,12 +541,12 @@ fn normalize_optional_timeframe_selector(
     value.map(normalize_required_timeframe_selector).transpose()
 }
 
-fn validate_candle_limit(limit: Option<usize>) -> anyhow::Result<usize> {
+fn validate_candle_range_limit(limit: Option<usize>) -> anyhow::Result<usize> {
     let limit = limit.unwrap_or(DEFAULT_CANDLE_LIMIT);
     anyhow::ensure!(limit > 0, "limit must be positive");
     anyhow::ensure!(
-        limit <= MAX_CANDLE_LIMIT,
-        "limit must be <= {MAX_CANDLE_LIMIT}"
+        limit <= MAX_CANDLE_RANGE_LIMIT,
+        "limit must be <= {MAX_CANDLE_RANGE_LIMIT}"
     );
     Ok(limit)
 }
@@ -880,6 +886,7 @@ mod tests {
 
         assert_eq!(result.count, 2);
         assert_eq!(result.query_limit, 10);
+        assert!(!result.has_more);
         assert_eq!(
             result
                 .candles
@@ -887,6 +894,58 @@ mod tests {
                 .map(|candle| candle.open_time.as_str())
                 .collect::<Vec<_>>(),
             vec!["2026-07-10T08:00:00Z", "2026-07-10T08:01:00Z"]
+        );
+    }
+
+    #[tokio::test]
+    async fn query_candles_tool_reports_when_more_candles_match() {
+        let repository = repository().await;
+        let tool = FinanceQueryCandlesTool::new(repository);
+        let result = tool
+            .run(
+                FinanceQueryCandlesParams {
+                    source_name: Some("binance-spot".to_owned()),
+                    venue:       "binance".to_owned(),
+                    symbol:      "BTCUSDT".to_owned(),
+                    timeframe:   "1m".to_owned(),
+                    start:       "2026-07-10T08:00:00Z".to_owned(),
+                    end:         "2026-07-10T08:02:00Z".to_owned(),
+                    limit:       Some(1),
+                },
+                &context(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(result.count, 1);
+        assert_eq!(result.query_limit, 1);
+        assert!(result.has_more);
+        assert_eq!(result.candles[0].open_time, "2026-07-10T08:00:00Z");
+    }
+
+    #[tokio::test]
+    async fn query_candles_tool_rejects_unprobeable_limit() {
+        let repository = repository().await;
+        let tool = FinanceQueryCandlesTool::new(repository);
+        let error = tool
+            .run(
+                FinanceQueryCandlesParams {
+                    source_name: Some("binance-spot".to_owned()),
+                    venue:       "binance".to_owned(),
+                    symbol:      "BTCUSDT".to_owned(),
+                    timeframe:   "1m".to_owned(),
+                    start:       "2026-07-10T08:00:00Z".to_owned(),
+                    end:         "2026-07-10T08:02:00Z".to_owned(),
+                    limit:       Some(10_000),
+                },
+                &context(),
+            )
+            .await
+            .unwrap_err();
+
+        assert!(
+            error.to_string().contains("limit must be <= 9999"),
+            "unexpected error: {error}"
         );
     }
 

--- a/docs/guides/finance-subscriptions.md
+++ b/docs/guides/finance-subscriptions.md
@@ -232,11 +232,12 @@ stored streams, `finance_get_latest_candle` for the newest closed bar, and
 `finance_query_candles` for bounded historical windows. `finance_find_candle_gaps`
 checks completeness over a bounded range, while `finance_get_candle_freshness`
 answers whether a stream is currently stale. All prices and volumes are returned
-as strings to preserve decimal precision. `finance_list_candle_streams` returns
-`has_more` when additional streams match the selectors beyond the returned
-`query_limit`; narrow by `source_name`, `venue`, `symbol`, or `timeframe` before
-assuming a broad stream overview is exhaustive. The stream-list limit is capped
-at 9,999 so the tool can probe one extra row and report `has_more` accurately.
+as strings to preserve decimal precision. `finance_list_candle_streams` and
+`finance_query_candles` return `has_more` when additional rows match the
+selectors beyond the returned `query_limit`; narrow by `source_name`, `venue`,
+`symbol`, `timeframe`, or time range before assuming a broad query is exhaustive.
+The stream-list and candle-range limits are capped at 9,999 so the tools can
+probe one extra row and report `has_more` accurately.
 
 ## Acceptance checklist
 

--- a/web/src/api/data-feeds.ts
+++ b/web/src/api/data-feeds.ts
@@ -111,6 +111,7 @@ export interface MarketCandlesResponse {
   candles: MarketCandle[];
   count: number;
   query_limit: number;
+  has_more: boolean;
 }
 
 export interface MarketCandleFreshnessResponse {

--- a/web/src/components/DataFeedsPanel.tsx
+++ b/web/src/components/DataFeedsPanel.tsx
@@ -2030,6 +2030,14 @@ function MarketDataStreamsCard({
                 </div>
               </div>
 
+              {previewQuery.data?.has_more ? (
+                <div className="flex items-center gap-2 rounded-md border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-xs text-amber-700 dark:text-amber-300">
+                  <AlertTriangle className="h-4 w-4 shrink-0" />
+                  Showing the first {previewQuery.data.query_limit} candles in this preview. Narrow
+                  the time range before treating it as exhaustive.
+                </div>
+              ) : null}
+
               <div className="grid gap-3 sm:grid-cols-2">
                 <div className="rounded-md border px-3 py-2">
                   <div className="mb-1 flex items-center justify-between gap-2">

--- a/web/src/components/__tests__/DataFeedsPanel.test.tsx
+++ b/web/src/components/__tests__/DataFeedsPanel.test.tsx
@@ -141,6 +141,7 @@ beforeEach(() => {
     candles: [],
     count: 0,
     query_limit: 50,
+    has_more: false,
   } satisfies MarketCandlesResponse);
   candleFreshnessMock.mockResolvedValue({
     latest: null,
@@ -388,6 +389,7 @@ describe('DataFeedsPanel', () => {
       ],
       count: 2,
       query_limit: 50,
+      has_more: false,
     } satisfies MarketCandlesResponse);
     candleFreshnessMock.mockResolvedValue({
       latest: {
@@ -457,5 +459,57 @@ describe('DataFeedsPanel', () => {
     expect(screen.getByText('0/50 missing in preview window')).toBeInTheDocument();
     expect(screen.getAllByText('64140.25').length).toBeGreaterThan(0);
     expect(screen.getByText('12.34')).toBeInTheDocument();
+  });
+
+  it('warns when the candle preview reaches the query limit', async () => {
+    candleStreamsMock.mockResolvedValue({
+      streams: [
+        {
+          source_name: 'finance-binance-market-candles',
+          venue: 'binance',
+          symbol: 'BTCUSDT',
+          timeframe: '1m',
+          candle_count: 75,
+          first_open_time: '2026-07-12T00:00:00Z',
+          latest_open_time: '2026-07-12T01:14:00Z',
+          latest_close_time: '2026-07-12T01:14:59Z',
+          latest_ingested_at: '2026-07-12T01:15:02Z',
+        },
+      ],
+      count: 1,
+      query_limit: 100,
+      has_more: false,
+    } satisfies CandleStreamsResponse);
+    candlesMock.mockResolvedValue({
+      candles: Array.from({ length: 50 }, (_, index) => ({
+        source_name: 'finance-binance-market-candles',
+        venue: 'binance',
+        symbol: 'BTCUSDT',
+        timeframe: '1m',
+        open_time: new Date(Date.UTC(2026, 6, 12, 0, index)).toISOString(),
+        close_time: new Date(Date.UTC(2026, 6, 12, 0, index, 59)).toISOString(),
+        open: '64100.00',
+        high: '64150.00',
+        low: '64090.00',
+        close: '64125.00',
+        volume: '10.00',
+        ingested_at: new Date(Date.UTC(2026, 6, 12, 0, index, 59)).toISOString(),
+        provider_sequence: null,
+      })),
+      count: 50,
+      query_limit: 50,
+      has_more: true,
+    } satisfies MarketCandlesResponse);
+
+    renderPanel();
+
+    const previewButton = await screen.findByRole('button', {
+      name: 'Preview BINANCE · BTCUSDT · 1m',
+    });
+    fireEvent.click(previewButton);
+
+    expect(
+      await screen.findByText(/Showing the first 50 candles in this preview/),
+    ).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary
- add has_more to finance_query_candles and admin candle range responses using a limit+1 probe
- cap candle range query limits at 9,999 so has_more remains exact
- surface truncated candle previews in the data feeds UI and update docs/types/tests

## Tests
- cargo test -p rara-trading market_data::tools --lib
- cargo test -p rara-backend-admin market_data_candles_endpoint --lib
- npm --prefix web run test -- DataFeedsPanel.test.tsx
- npm --prefix web run typecheck
- cargo +nightly fmt --all -- --check
- git diff --check

Local commit hook also passed cargo check, cargo fmt, cargo clippy, cargo doc, AGENT.md presence, and web lint-staged.