### PR TITLE
feat(finance): expose candle range cursor

### DIFF
--- a/crates/extensions/backend-admin/src/data_feeds/router.rs
+++ b/crates/extensions/backend-admin/src/data_feeds/router.rs
@@ -330,6 +330,7 @@ struct CandleRangeResponse {
     count:       usize,
     query_limit: usize,
     has_more:    bool,
+    next_start:  Option<String>,
 }
 
 #[derive(Debug, Serialize)]
@@ -1396,6 +1397,9 @@ async fn query_market_data_candles(
         .await
         .map_err(|err| ProblemDetails::internal(format!("failed to query candles: {err}")))?;
     let has_more = candles.len() > limit;
+    let next_start = candles
+        .get(limit)
+        .map(|candle| candle.open_time.to_string());
     candles.truncate(limit);
     let count = candles.len();
 
@@ -1404,6 +1408,7 @@ async fn query_market_data_candles(
         count,
         query_limit: limit,
         has_more,
+        next_start,
     }))
 }
 
@@ -3469,6 +3474,7 @@ mod tests {
         assert_eq!(result["count"], 2);
         assert_eq!(result["query_limit"], 2);
         assert_eq!(result["has_more"], true);
+        assert_eq!(result["next_start"], "2026-07-10T08:02:00Z");
         assert_eq!(result["candles"][0]["open_time"], "2026-07-10T08:00:00Z");
         assert_eq!(result["candles"][0]["close"], "1005.00");
         assert_eq!(result["candles"][1]["open_time"], "2026-07-10T08:01:00Z");

--- a/crates/extensions/rara-trading/src/market_data/tools.rs
+++ b/crates/extensions/rara-trading/src/market_data/tools.rs
@@ -67,6 +67,7 @@ pub struct FinanceQueryCandlesResult {
     pub count:       usize,
     pub query_limit: usize,
     pub has_more:    bool,
+    pub next_start:  Option<String>,
 }
 
 #[derive(Debug, Deserialize, JsonSchema)]
@@ -304,6 +305,9 @@ impl ToolExecute for FinanceQueryCandlesTool {
         };
         let mut candles = self.repository.candles(query).await?;
         let has_more = candles.len() > limit;
+        let next_start = candles
+            .get(limit)
+            .map(|candle| candle.open_time.to_string());
         candles.truncate(limit);
         let count = candles.len();
         Ok(FinanceQueryCandlesResult {
@@ -311,6 +315,7 @@ impl ToolExecute for FinanceQueryCandlesTool {
             count,
             query_limit: limit,
             has_more,
+            next_start,
         })
     }
 }
@@ -887,6 +892,7 @@ mod tests {
         assert_eq!(result.count, 2);
         assert_eq!(result.query_limit, 10);
         assert!(!result.has_more);
+        assert_eq!(result.next_start, None);
         assert_eq!(
             result
                 .candles
@@ -920,6 +926,7 @@ mod tests {
         assert_eq!(result.count, 1);
         assert_eq!(result.query_limit, 1);
         assert!(result.has_more);
+        assert_eq!(result.next_start.as_deref(), Some("2026-07-10T08:01:00Z"));
         assert_eq!(result.candles[0].open_time, "2026-07-10T08:00:00Z");
     }
 

--- a/docs/guides/finance-subscriptions.md
+++ b/docs/guides/finance-subscriptions.md
@@ -236,8 +236,10 @@ as strings to preserve decimal precision. `finance_list_candle_streams` and
 `finance_query_candles` return `has_more` when additional rows match the
 selectors beyond the returned `query_limit`; narrow by `source_name`, `venue`,
 `symbol`, `timeframe`, or time range before assuming a broad query is exhaustive.
-The stream-list and candle-range limits are capped at 9,999 so the tools can
-probe one extra row and report `has_more` accurately.
+When `finance_query_candles.has_more` is true, `next_start` contains the next
+candle open time to use as the following query's inclusive `start`. The
+stream-list and candle-range limits are capped at 9,999 so the tools can probe
+one extra row and report pagination state accurately.
 
 ## Acceptance checklist
 

--- a/web/src/api/data-feeds.ts
+++ b/web/src/api/data-feeds.ts
@@ -112,6 +112,7 @@ export interface MarketCandlesResponse {
   count: number;
   query_limit: number;
   has_more: boolean;
+  next_start: string | null;
 }
 
 export interface MarketCandleFreshnessResponse {

--- a/web/src/components/DataFeedsPanel.tsx
+++ b/web/src/components/DataFeedsPanel.tsx
@@ -2031,10 +2031,20 @@ function MarketDataStreamsCard({
               </div>
 
               {previewQuery.data?.has_more ? (
-                <div className="flex items-center gap-2 rounded-md border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-xs text-amber-700 dark:text-amber-300">
+                <div className="flex items-start gap-2 rounded-md border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-xs text-amber-700 dark:text-amber-300">
                   <AlertTriangle className="h-4 w-4 shrink-0" />
-                  Showing the first {previewQuery.data.query_limit} candles in this preview. Narrow
-                  the time range before treating it as exhaustive.
+                  <div className="space-y-1">
+                    <div>
+                      Showing the first {previewQuery.data.query_limit} candles in this preview.
+                      Narrow the time range before treating it as exhaustive.
+                    </div>
+                    {previewQuery.data.next_start ? (
+                      <div>
+                        Next page starts at{' '}
+                        <span className="font-mono">{previewQuery.data.next_start}</span>.
+                      </div>
+                    ) : null}
+                  </div>
                 </div>
               ) : null}
 

--- a/web/src/components/__tests__/DataFeedsPanel.test.tsx
+++ b/web/src/components/__tests__/DataFeedsPanel.test.tsx
@@ -142,6 +142,7 @@ beforeEach(() => {
     count: 0,
     query_limit: 50,
     has_more: false,
+    next_start: null,
   } satisfies MarketCandlesResponse);
   candleFreshnessMock.mockResolvedValue({
     latest: null,
@@ -390,6 +391,7 @@ describe('DataFeedsPanel', () => {
       count: 2,
       query_limit: 50,
       has_more: false,
+      next_start: null,
     } satisfies MarketCandlesResponse);
     candleFreshnessMock.mockResolvedValue({
       latest: {
@@ -499,6 +501,7 @@ describe('DataFeedsPanel', () => {
       count: 50,
       query_limit: 50,
       has_more: true,
+      next_start: '2026-07-12T00:50:00Z',
     } satisfies MarketCandlesResponse);
 
     renderPanel();
@@ -511,5 +514,7 @@ describe('DataFeedsPanel', () => {
     expect(
       await screen.findByText(/Showing the first 50 candles in this preview/),
     ).toBeInTheDocument();
+    expect(screen.getByText(/Next page starts at/)).toBeInTheDocument();
+    expect(screen.getByText('2026-07-12T00:50:00Z')).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary
- add next_start to finance_query_candles and admin candle range responses
- derive next_start from the probe candle when has_more is true
- surface the next-page start timestamp in the stored candle preview and document the cursor semantics

## Tests
- cargo test -p rara-trading query_candles_tool --lib
- cargo test -p rara-backend-admin market_data_candles_endpoint --lib
- npm --prefix web run test -- DataFeedsPanel.test.tsx
- npm --prefix web run typecheck
- cargo check -p rara-trading -p rara-backend-admin
- cargo +nightly fmt --all -- --check
- git diff --check

Local commit hook also passed cargo check, cargo fmt, cargo clippy, cargo doc, AGENT.md presence, and web lint-staged.