### PR TITLE
feat(finance): expose recent candle queries

### DIFF
--- a/crates/app/src/tools/mod.rs
+++ b/crates/app/src/tools/mod.rs
@@ -380,6 +380,11 @@ fn finance_market_data_tools(
             ),
         ),
         Arc::new(
+            rara_trading::market_data::tools::FinanceGetRecentCandlesTool::new(
+                market_data_repo.clone(),
+            ),
+        ),
+        Arc::new(
             rara_trading::market_data::tools::FinanceQueryCandlesTool::new(
                 market_data_repo.clone(),
             ),
@@ -468,6 +473,7 @@ mod tests {
             "finance_diagnose_candle_subscriptions",
             "finance_list_candle_streams",
             "finance_get_latest_candle",
+            "finance_get_recent_candles",
             "finance_query_candles",
             "finance_find_candle_gaps",
             "finance_get_candle_freshness",
@@ -503,6 +509,7 @@ mod tests {
         for expected in [
             "finance_list_candle_streams",
             "finance_get_latest_candle",
+            "finance_get_recent_candles",
             "finance_query_candles",
             "finance_find_candle_gaps",
             "finance_get_candle_freshness",
@@ -514,7 +521,7 @@ mod tests {
         }
         assert_eq!(
             names.len(),
-            5,
+            6,
             "finance market-data helper should only register read-side candle tools"
         );
     }
@@ -542,6 +549,7 @@ mod tests {
         for expected in [
             "finance_list_candle_streams",
             "finance_get_latest_candle",
+            "finance_get_recent_candles",
             "finance_query_candles",
             "finance_find_candle_gaps",
             "finance_get_candle_freshness",

--- a/crates/extensions/backend-admin/src/data_feeds/router.rs
+++ b/crates/extensions/backend-admin/src/data_feeds/router.rs
@@ -28,6 +28,7 @@
 //! | GET    | `/api/v1/data-feeds/finance/subscriptions` | list current user's finance subscriptions |
 //! | POST   | `/api/v1/data-feeds/finance/subscriptions` | create/update current user's finance subscription |
 //! | GET    | `/api/v1/data-feeds/market-data/candle-streams` | list stored market-data candle streams |
+//! | GET    | `/api/v1/data-feeds/market-data/candles/recent` | query newest stored candles |
 //! | GET    | `/api/v1/data-feeds/market-data/candles/freshness` | check stored candle freshness |
 //! | GET    | `/api/v1/data-feeds/market-data/candles/gaps` | find missing stored candle open times |
 //!
@@ -66,8 +67,8 @@ use rara_trading::{
         FinanceDelivery, FinanceEventKind, FinanceSubscription, FinanceSubscriptionRegistry,
     },
     market_data::{
-        CandleLatestQuery, CandleRangeQuery, CandleStreamListQuery, CandleStreamSummary,
-        MarketCandle, MarketDataRepositoryRef, Timeframe,
+        CandleLatestQuery, CandleRangeQuery, CandleRecentQuery, CandleStreamListQuery,
+        CandleStreamSummary, MarketCandle, MarketDataRepositoryRef, Timeframe,
     },
 };
 use serde::{Deserialize, Deserializer, Serialize};
@@ -137,6 +138,10 @@ pub fn data_feed_routes(state: DataFeedRouterState) -> Router {
         .route(
             "/api/v1/data-feeds/market-data/candles/latest",
             get(get_latest_market_data_candle),
+        )
+        .route(
+            "/api/v1/data-feeds/market-data/candles/recent",
+            get(get_recent_market_data_candles),
         )
         .route(
             "/api/v1/data-feeds/market-data/candles/freshness",
@@ -285,6 +290,16 @@ struct CandleLatestQueryParams {
     timeframe:   String,
 }
 
+/// Query parameters for the newest stored closed candles.
+#[derive(Debug, Deserialize)]
+struct CandleRecentQueryParams {
+    source_name: Option<String>,
+    venue:       String,
+    symbol:      String,
+    timeframe:   String,
+    limit:       Option<usize>,
+}
+
 /// Query parameters for a bounded stored closed-candle range.
 #[derive(Debug, Deserialize)]
 struct CandleRangeQueryParams {
@@ -331,6 +346,15 @@ struct CandleRangeResponse {
     query_limit: usize,
     has_more:    bool,
     next_start:  Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+struct CandleRecentResponse {
+    candles:     Vec<CandleResponse>,
+    count:       usize,
+    query_limit: usize,
+    has_more:    bool,
+    next_end:    Option<String>,
 }
 
 #[derive(Debug, Serialize)]
@@ -1259,6 +1283,46 @@ async fn get_latest_market_data_candle(
 
     Ok(Json(CandleLatestResponse {
         candle: candle.map(CandleResponse::from),
+    }))
+}
+
+/// `GET /api/v1/data-feeds/market-data/candles/recent` — fetch the newest
+/// stored closed candles for a stream, ordered oldest to newest.
+async fn get_recent_market_data_candles(
+    State(state): State<DataFeedRouterState>,
+    Query(params): Query<CandleRecentQueryParams>,
+) -> Result<Json<CandleRecentResponse>, ProblemDetails> {
+    let limit = validate_market_data_candle_range_limit(params.limit)?;
+    let probe_limit = limit.saturating_add(1);
+    let query = CandleRecentQuery {
+        source_name: normalize_optional_market_data_selector("source_name", params.source_name)?,
+        venue:       normalize_required_market_data_venue(params.venue)?,
+        symbol:      normalize_required_market_data_symbol(params.symbol)?,
+        timeframe:   normalize_required_market_data_timeframe(params.timeframe)?,
+        limit:       probe_limit,
+    };
+
+    let mut candles = state
+        .market_data_repo
+        .recent_candles(query)
+        .await
+        .map_err(|err| ProblemDetails::internal(format!("failed to get recent candles: {err}")))?;
+    let has_more = candles.len() > limit;
+    if has_more {
+        candles.remove(0);
+    }
+    let next_end = candles
+        .first()
+        .filter(|_| has_more)
+        .map(|candle| candle.open_time.to_string());
+    let count = candles.len();
+
+    Ok(Json(CandleRecentResponse {
+        candles: candles.into_iter().map(CandleResponse::from).collect(),
+        count,
+        query_limit: limit,
+        has_more,
+        next_end,
     }))
 }
 
@@ -3479,6 +3543,52 @@ mod tests {
         assert_eq!(result["candles"][0]["close"], "1005.00");
         assert_eq!(result["candles"][1]["open_time"], "2026-07-10T08:01:00Z");
         assert_eq!(result["candles"][1]["close"], "1006.25");
+    }
+
+    #[tokio::test]
+    async fn market_data_recent_candles_endpoint_returns_latest_candles() {
+        let market_data_repo = test_market_data_repo();
+        for (open_time, close_time, close) in [
+            ("2026-07-10T08:00:00Z", "2026-07-10T08:01:00Z", "1005.00"),
+            ("2026-07-10T08:01:00Z", "2026-07-10T08:02:00Z", "1006.25"),
+            ("2026-07-10T08:02:00Z", "2026-07-10T08:03:00Z", "1007.75"),
+        ] {
+            market_data_repo
+                .upsert_closed_candle(market_data_candle(open_time, close_time, close, None))
+                .await
+                .unwrap();
+        }
+
+        let app = app_with_user_and_market_data_repo(user_of(Role::Admin), market_data_repo).await;
+        let res = app
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri(
+                        "/api/v1/data-feeds/market-data/candles/recent?venue=binance&\
+                         symbol=BTCUSDT&timeframe=1m&limit=2",
+                    )
+                    .header("Authorization", "Bearer s3cret")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(res.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(res.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let result: serde_json::Value = serde_json::from_slice(&body).unwrap();
+
+        assert_eq!(result["count"], 2);
+        assert_eq!(result["query_limit"], 2);
+        assert_eq!(result["has_more"], true);
+        assert_eq!(result["next_end"], "2026-07-10T08:01:00Z");
+        assert_eq!(result["candles"][0]["open_time"], "2026-07-10T08:01:00Z");
+        assert_eq!(result["candles"][0]["close"], "1006.25");
+        assert_eq!(result["candles"][1]["open_time"], "2026-07-10T08:02:00Z");
+        assert_eq!(result["candles"][1]["close"], "1007.75");
     }
 
     #[tokio::test]

--- a/crates/extensions/rara-trading/src/market_data/mod.rs
+++ b/crates/extensions/rara-trading/src/market_data/mod.rs
@@ -20,8 +20,8 @@ pub mod timescale;
 pub mod tools;
 
 pub use model::{
-    CandleLatestQuery, CandleRangeQuery, CandleStreamListQuery, CandleStreamSummary, MarketCandle,
-    Timeframe,
+    CandleLatestQuery, CandleRangeQuery, CandleRecentQuery, CandleStreamListQuery,
+    CandleStreamSummary, MarketCandle, Timeframe,
 };
 pub use repository::{
     InMemoryMarketDataRepository, MarketDataRepository, MarketDataRepositoryRef, UpsertOutcome,

--- a/crates/extensions/rara-trading/src/market_data/model.rs
+++ b/crates/extensions/rara-trading/src/market_data/model.rs
@@ -142,6 +142,16 @@ pub struct CandleLatestQuery {
     pub timeframe:   Timeframe,
 }
 
+/// Recent-candle query for the newest closed candles in a stream.
+#[derive(Debug, Clone)]
+pub struct CandleRecentQuery {
+    pub source_name: Option<String>,
+    pub venue:       String,
+    pub symbol:      String,
+    pub timeframe:   Timeframe,
+    pub limit:       usize,
+}
+
 /// Stream inventory query for stored candle data.
 #[derive(Debug, Clone)]
 pub struct CandleStreamListQuery {

--- a/crates/extensions/rara-trading/src/market_data/repository.rs
+++ b/crates/extensions/rara-trading/src/market_data/repository.rs
@@ -19,7 +19,8 @@ use jiff::Timestamp;
 use tokio::sync::RwLock;
 
 use super::model::{
-    CandleLatestQuery, CandleRangeQuery, CandleStreamListQuery, CandleStreamSummary, MarketCandle,
+    CandleLatestQuery, CandleRangeQuery, CandleRecentQuery, CandleStreamListQuery,
+    CandleStreamSummary, MarketCandle,
 };
 
 /// Result of upserting a closed candle.
@@ -48,6 +49,9 @@ pub trait MarketDataRepository: Send + Sync {
         &self,
         query: CandleLatestQuery,
     ) -> anyhow::Result<Option<MarketCandle>>;
+
+    /// Return the newest closed candles for a stream, ordered by open time.
+    async fn recent_candles(&self, query: CandleRecentQuery) -> anyhow::Result<Vec<MarketCandle>>;
 
     /// List stored candle streams with their latest watermarks.
     async fn candle_streams(
@@ -166,6 +170,19 @@ impl MarketDataRepository for InMemoryMarketDataRepository {
             .filter(|candle| matches_latest_query(candle, &query))
             .max_by_key(|candle| candle.open_time)
             .cloned())
+    }
+
+    async fn recent_candles(&self, query: CandleRecentQuery) -> anyhow::Result<Vec<MarketCandle>> {
+        let candles = self.candles.read().await;
+        let mut rows: Vec<MarketCandle> = candles
+            .values()
+            .filter(|candle| matches_recent_query(candle, &query))
+            .cloned()
+            .collect();
+        rows.sort_by_key(|candle| std::cmp::Reverse(candle.open_time));
+        rows.truncate(query.limit.min(10_000));
+        rows.sort_by_key(|candle| candle.open_time);
+        Ok(rows)
     }
 
     async fn candle_streams(
@@ -288,6 +305,16 @@ fn matches_latest_query(candle: &MarketCandle, query: &CandleLatestQuery) -> boo
         && candle.timeframe == query.timeframe
 }
 
+fn matches_recent_query(candle: &MarketCandle, query: &CandleRecentQuery) -> bool {
+    query
+        .source_name
+        .as_ref()
+        .is_none_or(|source| source == &candle.source_name)
+        && candle.venue == query.venue
+        && candle.symbol == query.symbol
+        && candle.timeframe == query.timeframe
+}
+
 fn matches_stream_query(candle: &MarketCandle, query: &CandleStreamListQuery) -> bool {
     query
         .source_name
@@ -313,7 +340,8 @@ mod tests {
 
     use super::{InMemoryMarketDataRepository, MarketDataRepository, UpsertOutcome};
     use crate::market_data::{
-        CandleLatestQuery, CandleRangeQuery, CandleStreamListQuery, MarketCandle, Timeframe,
+        CandleLatestQuery, CandleRangeQuery, CandleRecentQuery, CandleStreamListQuery,
+        MarketCandle, Timeframe,
     };
 
     fn ts(value: &str) -> jiff::Timestamp { value.parse().expect("timestamp fixture should parse") }
@@ -476,6 +504,44 @@ mod tests {
 
         assert_eq!(latest.open_time, ts("2026-07-10T08:30:00Z"));
         assert_eq!(latest.close, dec("61700.00"));
+    }
+
+    #[tokio::test]
+    async fn recent_candles_returns_latest_n_in_ascending_order() {
+        let repo = InMemoryMarketDataRepository::default();
+        for (open_time, close) in [
+            ("2026-07-10T08:00:00Z", "61500.00"),
+            ("2026-07-10T08:15:00Z", "61610.30"),
+            ("2026-07-10T08:30:00Z", "61700.00"),
+        ] {
+            repo.upsert_closed_candle(candle(open_time, close))
+                .await
+                .unwrap();
+        }
+        repo.upsert_closed_candle(MarketCandle {
+            source_name: "other-source".to_owned(),
+            ..candle("2026-07-10T08:45:00Z", "61800.00")
+        })
+        .await
+        .unwrap();
+
+        let rows = repo
+            .recent_candles(CandleRecentQuery {
+                source_name: Some("binance-spot".to_owned()),
+                venue:       "binance".to_owned(),
+                symbol:      "BTCUSDT".to_owned(),
+                timeframe:   Timeframe::parse("15m").unwrap(),
+                limit:       2,
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(
+            rows.iter()
+                .map(|row| row.open_time.to_string())
+                .collect::<Vec<_>>(),
+            vec!["2026-07-10T08:15:00Z", "2026-07-10T08:30:00Z"]
+        );
     }
 
     #[tokio::test]

--- a/crates/extensions/rara-trading/src/market_data/timescale.rs
+++ b/crates/extensions/rara-trading/src/market_data/timescale.rs
@@ -21,8 +21,8 @@ use uuid::Uuid;
 
 use super::{
     model::{
-        CandleLatestQuery, CandleRangeQuery, CandleStreamListQuery, CandleStreamSummary,
-        MarketCandle, Timeframe,
+        CandleLatestQuery, CandleRangeQuery, CandleRecentQuery, CandleStreamListQuery,
+        CandleStreamSummary, MarketCandle, Timeframe,
     },
     repository::{MarketDataRepository, UpsertOutcome},
 };
@@ -180,6 +180,45 @@ impl MarketDataRepository for TimescaleMarketDataRepository {
         .await?;
 
         row.map(row_to_candle).transpose()
+    }
+
+    async fn recent_candles(&self, query: CandleRecentQuery) -> anyhow::Result<Vec<MarketCandle>> {
+        let limit = i64::try_from(query.limit.min(10_000))?;
+        let rows = sqlx_core::query::query(
+            r#"
+            SELECT
+              source_name, venue, symbol, timeframe,
+              open_time::text AS open_time,
+              close_time::text AS close_time,
+              open::text AS open,
+              high::text AS high,
+              low::text AS low,
+              close::text AS close,
+              volume::text AS volume,
+              ingested_at::text AS ingested_at,
+              provider_sequence
+            FROM (
+              SELECT *
+              FROM market_candles
+              WHERE ($1::text IS NULL OR source_name = $1)
+                AND venue = $2
+                AND symbol = $3
+                AND timeframe = $4
+              ORDER BY open_time DESC
+              LIMIT $5
+            ) recent
+            ORDER BY open_time ASC
+            "#,
+        )
+        .bind(query.source_name.as_deref())
+        .bind(&query.venue)
+        .bind(&query.symbol)
+        .bind(query.timeframe.as_str())
+        .bind(limit)
+        .fetch_all(&self.pool)
+        .await?;
+
+        rows.into_iter().map(row_to_candle).collect()
     }
 
     async fn candle_streams(

--- a/crates/extensions/rara-trading/src/market_data/tools.rs
+++ b/crates/extensions/rara-trading/src/market_data/tools.rs
@@ -22,8 +22,8 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use super::{
-    CandleLatestQuery, CandleRangeQuery, CandleStreamListQuery, CandleStreamSummary, MarketCandle,
-    MarketDataRepositoryRef, Timeframe,
+    CandleLatestQuery, CandleRangeQuery, CandleRecentQuery, CandleStreamListQuery,
+    CandleStreamSummary, MarketCandle, MarketDataRepositoryRef, Timeframe,
 };
 
 const DEFAULT_CANDLE_LIMIT: usize = 500;
@@ -44,6 +44,26 @@ pub struct FinanceGetLatestCandleParams {
 #[derive(Debug, Clone, Serialize)]
 pub struct FinanceGetLatestCandleResult {
     pub candle: Option<FinanceCandle>,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct FinanceGetRecentCandlesParams {
+    #[serde(default)]
+    pub source_name: Option<String>,
+    pub venue:       String,
+    pub symbol:      String,
+    pub timeframe:   String,
+    #[serde(default)]
+    pub limit:       Option<usize>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct FinanceGetRecentCandlesResult {
+    pub candles:     Vec<FinanceCandle>,
+    pub count:       usize,
+    pub query_limit: usize,
+    pub has_more:    bool,
+    pub next_end:    Option<String>,
 }
 
 #[derive(Debug, Deserialize, JsonSchema)]
@@ -256,6 +276,64 @@ impl ToolExecute for FinanceGetLatestCandleTool {
         let candle = self.repository.latest_closed_candle(query).await?;
         Ok(FinanceGetLatestCandleResult {
             candle: candle.map(FinanceCandle::from),
+        })
+    }
+}
+
+#[derive(ToolDef)]
+#[tool(
+    name = "finance_get_recent_candles",
+    description = "Return the newest closed OHLCV candles stored in the market-data TSDB for a \
+                   venue, symbol, and timeframe, ordered from oldest to newest. Decimal values \
+                   are returned as strings to preserve financial precision. This is read-only and \
+                   never places trades.",
+    tier = "deferred",
+    read_only,
+    concurrency_safe
+)]
+pub struct FinanceGetRecentCandlesTool {
+    repository: MarketDataRepositoryRef,
+}
+
+impl FinanceGetRecentCandlesTool {
+    pub fn new(repository: MarketDataRepositoryRef) -> Self { Self { repository } }
+}
+
+#[async_trait]
+impl ToolExecute for FinanceGetRecentCandlesTool {
+    type Output = FinanceGetRecentCandlesResult;
+    type Params = FinanceGetRecentCandlesParams;
+
+    async fn run(
+        &self,
+        params: FinanceGetRecentCandlesParams,
+        _context: &ToolContext,
+    ) -> anyhow::Result<FinanceGetRecentCandlesResult> {
+        let limit = validate_candle_range_limit(params.limit)?;
+        let probe_limit = limit.saturating_add(1);
+        let query = CandleRecentQuery {
+            source_name: normalize_optional_source_name_selector(params.source_name)?,
+            venue:       normalize_required_venue_selector(params.venue)?,
+            symbol:      normalize_required_symbol_selector(params.symbol)?,
+            timeframe:   normalize_required_timeframe_selector(params.timeframe)?,
+            limit:       probe_limit,
+        };
+        let mut candles = self.repository.recent_candles(query).await?;
+        let has_more = candles.len() > limit;
+        if has_more {
+            candles.remove(0);
+        }
+        let next_end = candles
+            .first()
+            .filter(|_| has_more)
+            .map(|candle| candle.open_time.to_string());
+        let count = candles.len();
+        Ok(FinanceGetRecentCandlesResult {
+            candles: candles.into_iter().map(FinanceCandle::from).collect(),
+            count,
+            query_limit: limit,
+            has_more,
+            next_end,
         })
     }
 }
@@ -608,8 +686,8 @@ mod tests {
     use super::{
         FinanceFindCandleGapsParams, FinanceFindCandleGapsTool, FinanceGetCandleFreshnessParams,
         FinanceGetCandleFreshnessTool, FinanceGetLatestCandleParams, FinanceGetLatestCandleTool,
-        FinanceListCandleStreamsParams, FinanceListCandleStreamsTool, FinanceQueryCandlesParams,
-        FinanceQueryCandlesTool,
+        FinanceGetRecentCandlesParams, FinanceGetRecentCandlesTool, FinanceListCandleStreamsParams,
+        FinanceListCandleStreamsTool, FinanceQueryCandlesParams, FinanceQueryCandlesTool,
     };
     use crate::market_data::{
         InMemoryMarketDataRepository, MarketCandle, MarketDataRepository, Timeframe,
@@ -870,6 +948,32 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn recent_candles_tool_returns_latest_candles_in_order() {
+        let repository = repository().await;
+        let tool = FinanceGetRecentCandlesTool::new(repository);
+        let result = tool
+            .run(
+                FinanceGetRecentCandlesParams {
+                    source_name: Some("binance-spot".to_owned()),
+                    venue:       "binance".to_owned(),
+                    symbol:      "BTCUSDT".to_owned(),
+                    timeframe:   "1m".to_owned(),
+                    limit:       Some(1),
+                },
+                &context(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(result.count, 1);
+        assert_eq!(result.query_limit, 1);
+        assert!(result.has_more);
+        assert_eq!(result.next_end.as_deref(), Some("2026-07-10T08:01:00Z"));
+        assert_eq!(result.candles[0].open_time, "2026-07-10T08:01:00Z");
+        assert_eq!(result.candles[0].close, "61520.00");
+    }
+
+    #[tokio::test]
     async fn query_candles_tool_returns_ordered_range() {
         let repository = repository().await;
         let tool = FinanceQueryCandlesTool::new(repository);
@@ -1107,12 +1211,14 @@ mod tests {
         let repository = Arc::new(InMemoryMarketDataRepository::default());
         let streams = FinanceListCandleStreamsTool::new(repository.clone());
         let latest = FinanceGetLatestCandleTool::new(repository.clone());
+        let recent = FinanceGetRecentCandlesTool::new(repository.clone());
         let query = FinanceQueryCandlesTool::new(repository.clone());
         let gaps = FinanceFindCandleGapsTool::new(repository.clone());
         let freshness = FinanceGetCandleFreshnessTool::new(repository);
 
         assert!(streams.is_read_only(&serde_json::json!({})));
         assert!(latest.is_read_only(&serde_json::json!({})));
+        assert!(recent.is_read_only(&serde_json::json!({})));
         assert!(query.is_read_only(&serde_json::json!({})));
         assert!(gaps.is_read_only(&serde_json::json!({})));
         assert!(freshness.is_read_only(&serde_json::json!({})));

--- a/crates/extensions/rara-trading/tests/timescale_container.rs
+++ b/crates/extensions/rara-trading/tests/timescale_container.rs
@@ -13,8 +13,8 @@
 // limitations under the License.
 
 use rara_trading::market_data::{
-    CandleLatestQuery, CandleRangeQuery, CandleStreamListQuery, MarketCandle, MarketDataRepository,
-    Timeframe, TimescaleMarketDataRepository, UpsertOutcome,
+    CandleLatestQuery, CandleRangeQuery, CandleRecentQuery, CandleStreamListQuery, MarketCandle,
+    MarketDataRepository, Timeframe, TimescaleMarketDataRepository, UpsertOutcome,
 };
 use rust_decimal::Decimal;
 use sqlx_core::row::Row;
@@ -87,6 +87,19 @@ async fn timescale_repository_contract_runs_against_testcontainer() -> anyhow::R
         .expect("latest candle should exist");
     assert_eq!(latest.open_time, ts("2026-07-10T08:30:00Z"));
     assert_eq!(latest.close, dec("61700.00"));
+
+    let recent = repo
+        .recent_candles(CandleRecentQuery {
+            source_name: Some("timescale-container-contract".to_owned()),
+            venue:       "binance".to_owned(),
+            symbol:      "BTCUSDT".to_owned(),
+            timeframe:   Timeframe::parse("15m")?,
+            limit:       1,
+        })
+        .await?;
+    assert_eq!(recent.len(), 1);
+    assert_eq!(recent[0].open_time, ts("2026-07-10T08:30:00Z"));
+    assert_eq!(recent[0].close, dec("61700.00"));
 
     assert_eq!(
         repo.upsert_closed_candle(MarketCandle {

--- a/docs/guides/finance-subscriptions.md
+++ b/docs/guides/finance-subscriptions.md
@@ -153,6 +153,7 @@ Stored closed candles are queryable through read-only market-data tools:
 
 - `finance_list_candle_streams`
 - `finance_get_latest_candle`
+- `finance_get_recent_candles`
 - `finance_query_candles`
 - `finance_find_candle_gaps`
 - `finance_get_candle_freshness`
@@ -162,6 +163,7 @@ agent via:
 
 - `GET /api/v1/data-feeds/market-data/candle-streams`
 - `GET /api/v1/data-feeds/market-data/candles/latest`
+- `GET /api/v1/data-feeds/market-data/candles/recent`
 - `GET /api/v1/data-feeds/market-data/candles`
 - `GET /api/v1/data-feeds/market-data/candles/freshness`
 - `GET /api/v1/data-feeds/market-data/candles/gaps`
@@ -228,18 +230,22 @@ subscription diagnostic includes:
   `(source_name, venue, symbol, timeframe)`.
 
 For ad hoc market-data inspection, use `finance_list_candle_streams` to discover
-stored streams, `finance_get_latest_candle` for the newest closed bar, and
+stored streams, `finance_get_latest_candle` for one newest closed bar,
+`finance_get_recent_candles` for the newest N closed bars, and
 `finance_query_candles` for bounded historical windows. `finance_find_candle_gaps`
 checks completeness over a bounded range, while `finance_get_candle_freshness`
 answers whether a stream is currently stale. All prices and volumes are returned
-as strings to preserve decimal precision. `finance_list_candle_streams` and
-`finance_query_candles` return `has_more` when additional rows match the
-selectors beyond the returned `query_limit`; narrow by `source_name`, `venue`,
-`symbol`, `timeframe`, or time range before assuming a broad query is exhaustive.
-When `finance_query_candles.has_more` is true, `next_start` contains the next
-candle open time to use as the following query's inclusive `start`. The
-stream-list and candle-range limits are capped at 9,999 so the tools can probe
-one extra row and report pagination state accurately.
+as strings to preserve decimal precision. `finance_list_candle_streams`,
+`finance_get_recent_candles`, and `finance_query_candles` return `has_more` when
+additional rows match the selectors beyond the returned `query_limit`; narrow by
+`source_name`, `venue`, `symbol`, `timeframe`, or time range before assuming a
+broad query is exhaustive. When `finance_query_candles.has_more` is true,
+`next_start` contains the next candle open time to use as the following query's
+inclusive `start`. When `finance_get_recent_candles.has_more` is true,
+`next_end` contains the oldest returned candle open time to use as an exclusive
+`end` when paging older history via `finance_query_candles`. The stream-list,
+recent-candle, and candle-range limits are capped at 9,999 so the tools can
+probe one extra row and report pagination state accurately.
 
 ## Acceptance checklist
 
@@ -266,9 +272,11 @@ Use this checklist before considering a deployment ready:
 10. Confirm
    `GET /api/v1/data-feeds/market-data/candle-streams?venue=...&symbol=...`
    returns the stored stream watermark.
-11. Confirm `finance_query_candles` and
+11. Confirm `finance_get_recent_candles`,
+   `GET /api/v1/data-feeds/market-data/candles/recent?venue=...&symbol=...&timeframe=...`,
+   `finance_query_candles`, and
    `GET /api/v1/data-feeds/market-data/candles?venue=...&symbol=...&timeframe=...&start=...&end=...`
-   return bounded ordered ranges with decimal values encoded as strings.
+   return ordered candles with decimal values encoded as strings.
 12. Confirm one matching item wakes the same session at most once.
 13. Confirm a seventh matching item in an hour is tape-only under the default
    immediate-delivery budget.

--- a/web/src/api/data-feeds.ts
+++ b/web/src/api/data-feeds.ts
@@ -115,6 +115,14 @@ export interface MarketCandlesResponse {
   next_start: string | null;
 }
 
+export interface RecentMarketCandlesResponse {
+  candles: MarketCandle[];
+  count: number;
+  query_limit: number;
+  has_more: boolean;
+  next_end: string | null;
+}
+
 export interface MarketCandleFreshnessResponse {
   latest: MarketCandle | null;
   as_of: string;
@@ -283,6 +291,24 @@ export const dataFeedsApi = {
     query.set('timeframe', params.timeframe);
     return api.get<LatestMarketCandleResponse>(
       `/api/v1/data-feeds/market-data/candles/latest?${query.toString()}`,
+    );
+  },
+
+  recentCandles: (params: {
+    source_name?: string;
+    venue: string;
+    symbol: string;
+    timeframe: string;
+    limit?: number;
+  }) => {
+    const query = new URLSearchParams();
+    if (params.source_name) query.set('source_name', params.source_name);
+    query.set('venue', params.venue);
+    query.set('symbol', params.symbol);
+    query.set('timeframe', params.timeframe);
+    if (params.limit) query.set('limit', String(params.limit));
+    return api.get<RecentMarketCandlesResponse>(
+      `/api/v1/data-feeds/market-data/candles/recent?${query.toString()}`,
     );
   },
 

--- a/web/src/components/DataFeedsPanel.tsx
+++ b/web/src/components/DataFeedsPanel.tsx
@@ -1753,7 +1753,13 @@ function MarketDataStreamsCard({
     ],
     queryFn: () => {
       if (!previewRequest) throw new Error('Missing candle preview request');
-      return dataFeedsApi.candles(previewRequest);
+      return dataFeedsApi.recentCandles({
+        source_name: previewRequest.source_name,
+        venue: previewRequest.venue,
+        symbol: previewRequest.symbol,
+        timeframe: previewRequest.timeframe,
+        limit: previewRequest.limit,
+      });
     },
     enabled: previewRequest != null,
     refetchInterval: previewRequest != null ? 30_000 : false,
@@ -2035,13 +2041,13 @@ function MarketDataStreamsCard({
                   <AlertTriangle className="h-4 w-4 shrink-0" />
                   <div className="space-y-1">
                     <div>
-                      Showing the first {previewQuery.data.query_limit} candles in this preview.
+                      Showing the latest {previewQuery.data.query_limit} candles in this preview.
                       Narrow the time range before treating it as exhaustive.
                     </div>
-                    {previewQuery.data.next_start ? (
+                    {previewQuery.data.next_end ? (
                       <div>
-                        Next page starts at{' '}
-                        <span className="font-mono">{previewQuery.data.next_start}</span>.
+                        Older page ends before{' '}
+                        <span className="font-mono">{previewQuery.data.next_end}</span>.
                       </div>
                     ) : null}
                   </div>

--- a/web/src/components/__tests__/DataFeedsPanel.test.tsx
+++ b/web/src/components/__tests__/DataFeedsPanel.test.tsx
@@ -37,6 +37,7 @@ const catalogMock = vi.fn();
 const financeSubscriptionsMock = vi.fn();
 const candleStreamsMock = vi.fn();
 const candlesMock = vi.fn();
+const recentCandlesMock = vi.fn();
 const candleFreshnessMock = vi.fn();
 const candleGapsMock = vi.fn();
 
@@ -49,6 +50,7 @@ vi.mock('@/api/data-feeds', () => ({
     financeSubscriptions: (...args: unknown[]) => financeSubscriptionsMock(...args),
     candleStreams: (...args: unknown[]) => candleStreamsMock(...args),
     candles: (...args: unknown[]) => candlesMock(...args),
+    recentCandles: (...args: unknown[]) => recentCandlesMock(...args),
     candleFreshness: (...args: unknown[]) => candleFreshnessMock(...args),
     candleGaps: (...args: unknown[]) => candleGapsMock(...args),
     toggle: vi.fn(),
@@ -121,6 +123,7 @@ beforeEach(() => {
   financeSubscriptionsMock.mockReset();
   candleStreamsMock.mockReset();
   candlesMock.mockReset();
+  recentCandlesMock.mockReset();
   candleFreshnessMock.mockReset();
   candleGapsMock.mockReset();
 
@@ -144,6 +147,13 @@ beforeEach(() => {
     has_more: false,
     next_start: null,
   } satisfies MarketCandlesResponse);
+  recentCandlesMock.mockResolvedValue({
+    candles: [],
+    count: 0,
+    query_limit: 50,
+    has_more: false,
+    next_end: null,
+  });
   candleFreshnessMock.mockResolvedValue({
     latest: null,
     as_of: '2026-07-12T00:50:00Z',
@@ -355,7 +365,7 @@ describe('DataFeedsPanel', () => {
       query_limit: 100,
       has_more: false,
     } satisfies CandleStreamsResponse);
-    candlesMock.mockResolvedValue({
+    recentCandlesMock.mockResolvedValue({
       candles: [
         {
           source_name: 'finance-binance-market-candles',
@@ -391,8 +401,8 @@ describe('DataFeedsPanel', () => {
       count: 2,
       query_limit: 50,
       has_more: false,
-      next_start: null,
-    } satisfies MarketCandlesResponse);
+      next_end: null,
+    });
     candleFreshnessMock.mockResolvedValue({
       latest: {
         source_name: 'finance-binance-market-candles',
@@ -430,13 +440,11 @@ describe('DataFeedsPanel', () => {
     fireEvent.click(previewButton);
 
     await waitFor(() => {
-      expect(candlesMock).toHaveBeenCalledWith({
+      expect(recentCandlesMock).toHaveBeenCalledWith({
         source_name: 'finance-binance-market-candles',
         venue: 'binance',
         symbol: 'BTCUSDT',
         timeframe: '1m',
-        start: '2026-07-12T00:00:00.000Z',
-        end: '2026-07-12T00:50:00.000Z',
         limit: 50,
       });
     });
@@ -482,7 +490,7 @@ describe('DataFeedsPanel', () => {
       query_limit: 100,
       has_more: false,
     } satisfies CandleStreamsResponse);
-    candlesMock.mockResolvedValue({
+    recentCandlesMock.mockResolvedValue({
       candles: Array.from({ length: 50 }, (_, index) => ({
         source_name: 'finance-binance-market-candles',
         venue: 'binance',
@@ -501,8 +509,8 @@ describe('DataFeedsPanel', () => {
       count: 50,
       query_limit: 50,
       has_more: true,
-      next_start: '2026-07-12T00:50:00Z',
-    } satisfies MarketCandlesResponse);
+      next_end: '2026-07-12T00:00:00Z',
+    });
 
     renderPanel();
 
@@ -512,9 +520,9 @@ describe('DataFeedsPanel', () => {
     fireEvent.click(previewButton);
 
     expect(
-      await screen.findByText(/Showing the first 50 candles in this preview/),
+      await screen.findByText(/Showing the latest 50 candles in this preview/),
     ).toBeInTheDocument();
-    expect(screen.getByText(/Next page starts at/)).toBeInTheDocument();
-    expect(screen.getByText('2026-07-12T00:50:00Z')).toBeInTheDocument();
+    expect(screen.getByText(/Older page ends before/)).toBeInTheDocument();
+    expect(screen.getByText('2026-07-12T00:00:00Z')).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary
- add CandleRecentQuery across market-data repositories, including Timescale and in-memory implementations
- expose finance_get_recent_candles as a deferred read-only tool and add the admin candles/recent endpoint
- switch stored-candle preview UI to recent candles and document next_end pagination semantics

## Verification
- cargo +nightly fmt --all -- --check
- cargo check -p rara-trading -p rara-backend-admin -p rara-app
- cargo test -p rara-trading market_data::repository::tests --lib
- cargo test -p rara-trading market_data::tools --lib
- cargo test -p rara-backend-admin market_data_candles_endpoint --lib
- cargo test -p rara-backend-admin market_data_recent_candles_endpoint_returns_latest_candles --lib
- cargo test -p rara-app finance_market_data --lib
- cargo test -p rara-app discover_tools_finds_finance_market_data_candle_tools --lib
- npm --prefix web run test -- DataFeedsPanel.test.tsx
- npm --prefix web run typecheck
- cargo deny check

## Local testcontainer note
- cargo test -p rara-trading --test timescale_container -- --nocapture compiled, then failed locally because Docker client initialization could not find /Users/ryan/.orbstack/run/docker.sock. The Timescale recent-candle assertion is included for CI/testcontainer environments.