### PR TITLE
feat(finance): filter feed events by kind

### DIFF
--- a/crates/app/src/tools/finance_feed.rs
+++ b/crates/app/src/tools/finance_feed.rs
@@ -116,6 +116,9 @@ pub(super) struct FinanceListFeedEventsParams {
     /// Existing persisted finance DataFeedConfig ids.
     #[serde(default)]
     pub feed_ids:           Vec<String>,
+    /// Optional event-kind filter, e.g. rss_article or market_candle_closed.
+    #[serde(default)]
+    pub event_kinds:        Vec<FinanceEventKind>,
     /// Duration string such as "1h", "24h", or "7d".
     #[serde(default)]
     pub since:              Option<String>,
@@ -716,12 +719,17 @@ impl ToolExecute for FinanceListFeedEventsTool {
             .unwrap_or(DEFAULT_FEED_EVENT_LIMIT)
             .clamp(1, MAX_FEED_EVENT_LIMIT);
         let offset = params.offset.unwrap_or(0).max(0);
+        let event_types = dedupe_event_kinds(params.event_kinds)
+            .into_iter()
+            .map(finance_event_kind_type)
+            .map(ToOwned::to_owned)
+            .collect::<Vec<_>>();
 
         let mut sources = Vec::with_capacity(source_refs.len());
         for source_ref in source_refs {
             let page = self
                 .svc
-                .query_events(&source_ref.source_name, since, limit, offset)
+                .query_events(&source_ref.source_name, since, &event_types, limit, offset)
                 .await?;
             sources.push(FinanceFeedEventPage {
                 source_name:       source_ref.source_name,
@@ -1986,6 +1994,13 @@ fn dedupe_event_kinds(values: Vec<FinanceEventKind>) -> Vec<FinanceEventKind> {
     out
 }
 
+fn finance_event_kind_type(kind: FinanceEventKind) -> &'static str {
+    match kind {
+        FinanceEventKind::RssArticle => "rss_article",
+        FinanceEventKind::MarketCandleClosed => "market_candle_closed",
+    }
+}
+
 fn unsubscribe_selector_matches(
     subscription: &FinanceSubscription,
     selector: &UnsubscribeSelector,
@@ -3019,6 +3034,7 @@ mod tests {
                     catalog_source_ids: vec!["fed-press-releases".to_owned()],
                     source_names:       Vec::new(),
                     feed_ids:           Vec::new(),
+                    event_kinds:        Vec::new(),
                     since:              None,
                     limit:              Some(1),
                     offset:             None,
@@ -3040,6 +3056,77 @@ mod tests {
         assert_eq!(page.events.len(), 1);
         assert_eq!(page.events[0].event_type, "rss_article");
         assert_eq!(page.events[0].payload["title"], "Latest Fed update");
+    }
+
+    #[tokio::test]
+    async fn list_feed_events_filters_by_event_kind() {
+        let pools = rara_kernel::testing::build_memory_diesel_pools().await;
+        bootstrap_data_feed_schema(&pools).await;
+        let svc = rara_backend_admin::data_feeds::DataFeedSvc::new(pools.clone());
+        let store = crate::feed_store::SqliteFeedStore::new(pools);
+        let (event_tx, _event_rx) = tokio::sync::mpsc::channel(16);
+        let registry = Arc::new(rara_kernel::data_feed::DataFeedRegistry::new(event_tx));
+        let enable = FinanceEnableFeedSourceTool::new(svc.clone(), registry);
+        enable
+            .run(
+                FinanceEnableFeedSourceParams {
+                    catalog_source_id: "fed-press-releases".to_owned(),
+                    start_now:         Some(false),
+                },
+                &context(),
+            )
+            .await
+            .unwrap();
+
+        for (id, event_type, title, received_at) in [
+            (
+                "rss-fed-event",
+                "rss_article",
+                "Fed update",
+                "2026-07-12T08:00:00Z",
+            ),
+            (
+                "candle-fed-event",
+                "market_candle_closed",
+                "BTCUSDT candle",
+                "2026-07-12T08:01:00Z",
+            ),
+        ] {
+            let event = FeedEvent::builder()
+                .id(FeedEventId::deterministic(id))
+                .source_name("finance-fed-press-releases".to_owned())
+                .event_type(event_type.to_owned())
+                .tags(vec!["finance".to_owned()])
+                .payload(serde_json::json!({ "title": title }))
+                .received_at(received_at.parse().unwrap())
+                .build();
+            store.append(&event).await.unwrap();
+        }
+
+        let tool = FinanceListFeedEventsTool::new(svc);
+        let result = tool
+            .run(
+                FinanceListFeedEventsParams {
+                    catalog_source_ids: vec!["fed-press-releases".to_owned()],
+                    source_names:       Vec::new(),
+                    feed_ids:           Vec::new(),
+                    event_kinds:        vec![FinanceEventKind::MarketCandleClosed],
+                    since:              None,
+                    limit:              Some(20),
+                    offset:             None,
+                },
+                &context(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(result.sources.len(), 1);
+        let page = &result.sources[0];
+        assert_eq!(page.total, 1);
+        assert!(!page.has_more);
+        assert_eq!(page.events.len(), 1);
+        assert_eq!(page.events[0].event_type, "market_candle_closed");
+        assert_eq!(page.events[0].payload["title"], "BTCUSDT candle");
     }
 
     #[tokio::test]

--- a/crates/extensions/backend-admin/src/data_feeds/router.rs
+++ b/crates/extensions/backend-admin/src/data_feeds/router.rs
@@ -1216,7 +1216,7 @@ async fn query_events(
 
     let page = state
         .svc
-        .query_events(&feed.name, since, limit, offset)
+        .query_events(&feed.name, since, &[], limit, offset)
         .await?;
 
     Ok(Json(EventListResponse {

--- a/crates/extensions/backend-admin/src/data_feeds/service.rs
+++ b/crates/extensions/backend-admin/src/data_feeds/service.rs
@@ -220,6 +220,7 @@ impl DataFeedSvc {
         &self,
         source_name: &str,
         since: Option<Timestamp>,
+        event_types: &[String],
         limit: i64,
         offset: i64,
     ) -> Result<EventPage> {
@@ -232,6 +233,9 @@ impl DataFeedSvc {
         if let Some(ref ts) = since {
             count_q = count_q.filter(data_feed_events::received_at.ge(ts.to_string()));
         }
+        if !event_types.is_empty() {
+            count_q = count_q.filter(data_feed_events::event_type.eq_any(event_types));
+        }
         let total: i64 = count_q
             .count()
             .get_result(&mut *conn)
@@ -243,6 +247,9 @@ impl DataFeedSvc {
             .into_boxed();
         if let Some(ref ts) = since {
             rows_q = rows_q.filter(data_feed_events::received_at.ge(ts.to_string()));
+        }
+        if !event_types.is_empty() {
+            rows_q = rows_q.filter(data_feed_events::event_type.eq_any(event_types));
         }
         let rows: Vec<EventRow> = rows_q
             .select(EventRow::as_select())

--- a/docs/guides/finance-subscriptions.md
+++ b/docs/guides/finance-subscriptions.md
@@ -151,8 +151,9 @@ runtime state, event watermarks, configured K-line selectors, and source-name
 subscription matches for the current user/session. Use
 `finance_list_feed_events` when the user asks what recent finance news or
 closed-candle notifications were actually received. It reads persisted events by
-`catalog_source_ids`, `source_names`, or `feed_ids` and returns per-source pages
-with `total`, `has_more`, `query_limit`, and `query_offset`.
+`catalog_source_ids`, `source_names`, or `feed_ids`, can narrow mixed sources by
+`event_kinds` (`rss_article`, `market_candle_closed`), and returns per-source
+pages with `total`, `has_more`, `query_limit`, and `query_offset`.
 
 Stored closed candles are queryable through read-only market-data tools:
 
@@ -270,7 +271,8 @@ Use this checklist before considering a deployment ready:
    `subscriptions.session_subscribed = true`.
 7. Confirm the admin event endpoint stores one event per article and one event
    per closed candle across two polls, and `finance_list_feed_events` returns
-   recent persisted events for the subscribed source.
+   recent persisted events for the subscribed source, including filtered views
+   by `event_kinds`.
 8. Confirm `finance_diagnose_candle_subscriptions` reports a running feed, a
    recent feed event, and a fresh latest candle for the subscribed stream.
 9. Confirm `finance_get_latest_candle` returns the latest stored closed candle


### PR DESCRIPTION
## Summary
- add event_kinds filtering to finance_list_feed_events
- apply event_type filters in DataFeedSvc before pagination so total/has_more remain correct
- document filtered feed event queries for mixed RSS/candle sources

## Tests
- cargo test -p rara-app list_feed_events_filters_by_event_kind --lib
- cargo test -p rara-app tools::finance_feed --lib
- cargo check -p rara-app -p rara-backend-admin
- cargo +nightly fmt --all -- --check
- git diff --check
- cargo test -p rara-backend-admin data_feeds --lib
- pre-commit: cargo check, cargo fmt, cargo clippy, cargo doc