### PR TITLE
feat(finance): report latest feed event type

### DIFF
--- a/crates/app/src/tools/finance_diagnostics.rs
+++ b/crates/app/src/tools/finance_diagnostics.rs
@@ -81,6 +81,7 @@ pub(super) struct FeedSourceDiagnostic {
     pub runtime_state:         FeedRuntimeState,
     pub last_error:            Option<String>,
     pub event_count:           i64,
+    pub last_event_type:       Option<String>,
     pub last_event_at:         Option<String>,
     pub lag_seconds:           Option<i64>,
 }
@@ -125,10 +126,11 @@ pub(super) enum FeedSelectorCoverage {
     Unavailable,
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone)]
 struct FeedEventSummary {
-    event_count:   i64,
-    last_event_at: Option<Timestamp>,
+    event_count:     i64,
+    last_event_type: Option<String>,
+    last_event_at:   Option<Timestamp>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
@@ -203,8 +205,9 @@ impl ToolExecute for FinanceDiagnoseCandleSubscriptionsTool {
                 (
                     summary.source_name,
                     FeedEventSummary {
-                        event_count:   summary.event_count,
-                        last_event_at: summary.last_event_at,
+                        event_count:     summary.event_count,
+                        last_event_type: summary.last_event_type,
+                        last_event_at:   summary.last_event_at,
                     },
                 )
             })
@@ -325,6 +328,8 @@ impl FinanceDiagnoseCandleSubscriptionsTool {
                     ),
                     last_error: feed.and_then(|feed| feed.last_error.clone()),
                     event_count: event_summary.map_or(0, |summary| summary.event_count),
+                    last_event_type: event_summary
+                        .and_then(|summary| summary.last_event_type.clone()),
                     last_event_at: last_event_at.map(|timestamp| timestamp.to_string()),
                     lag_seconds,
                 }
@@ -910,6 +915,10 @@ mod tests {
         assert_eq!(sub.feed_sources[0].runtime_state, FeedRuntimeState::Running);
         assert_eq!(sub.feed_sources[0].event_count, 1);
         assert_eq!(
+            sub.feed_sources[0].last_event_type.as_deref(),
+            Some("market_candle_closed")
+        );
+        assert_eq!(
             sub.feed_sources[0].configured_venue.as_deref(),
             Some("binance")
         );
@@ -1013,6 +1022,7 @@ mod tests {
         assert_eq!(sub.status, SubscriptionHealth::NeedsRuntime);
         assert_eq!(sub.feed_sources[0].runtime_state, FeedRuntimeState::Stopped);
         assert_eq!(sub.feed_sources[0].event_count, 0);
+        assert_eq!(sub.feed_sources[0].last_event_type, None);
         assert_eq!(sub.feed_sources[0].last_event_at, None);
         assert_eq!(sub.feed_sources[0].lag_seconds, None);
         assert_eq!(sub.streams[0].status, CandleStreamStatus::Missing);

--- a/crates/app/src/tools/finance_feed.rs
+++ b/crates/app/src/tools/finance_feed.rs
@@ -81,15 +81,16 @@ pub(super) struct FinanceFeedSourceEntry {
 
 #[derive(Debug, Clone, Serialize)]
 pub(super) struct FinanceFeedSourceRuntime {
-    pub persisted:     bool,
-    pub feed_id:       Option<String>,
-    pub enabled:       bool,
-    pub running:       bool,
-    pub status:        Option<String>,
-    pub last_error:    Option<String>,
-    pub event_count:   i64,
-    pub last_event_at: Option<String>,
-    pub lag_seconds:   Option<i64>,
+    pub persisted:       bool,
+    pub feed_id:         Option<String>,
+    pub enabled:         bool,
+    pub running:         bool,
+    pub status:          Option<String>,
+    pub last_error:      Option<String>,
+    pub event_count:     i64,
+    pub last_event_type: Option<String>,
+    pub last_event_at:   Option<String>,
+    pub lag_seconds:     Option<i64>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -677,6 +678,7 @@ impl ToolExecute for FinanceListFeedSourcesTool {
                         persisted,
                         self.registry.is_running(&source_name),
                         summary.map_or(0, |summary| summary.event_count),
+                        summary.and_then(|summary| summary.last_event_type.clone()),
                         last_event_at.map(|timestamp| timestamp.to_string()),
                         lag_seconds,
                         source_subscription_summary(
@@ -2129,6 +2131,7 @@ fn feed_source_entry(
     persisted: Option<&DataFeedConfig>,
     running: bool,
     event_count: i64,
+    last_event_type: Option<String>,
     last_event_at: Option<String>,
     lag_seconds: Option<i64>,
     subscriptions: FinanceFeedSourceSubscriptions,
@@ -2156,6 +2159,7 @@ fn feed_source_entry(
             status: persisted.map(|feed| feed.status.to_string()),
             last_error: persisted.and_then(|feed| feed.last_error.clone()),
             event_count,
+            last_event_type,
             last_event_at,
             lag_seconds,
         },
@@ -2542,6 +2546,7 @@ mod tests {
         assert!(!fed.runtime.running);
         assert_eq!(fed.runtime.status, None);
         assert_eq!(fed.runtime.event_count, 0);
+        assert_eq!(fed.runtime.last_event_type, None);
         assert_eq!(fed.runtime.last_event_at, None);
         assert_eq!(fed.runtime.lag_seconds, None);
         assert!(!fed.subscriptions.user_subscribed);
@@ -2994,6 +2999,7 @@ mod tests {
             .expect("fed source should be listed");
 
         assert_eq!(fed.runtime.event_count, 1);
+        assert_eq!(fed.runtime.last_event_type.as_deref(), Some("rss_article"));
         assert_eq!(fed.runtime.last_event_at, Some(received_at.to_string()));
         assert!(fed.runtime.lag_seconds.is_some_and(|lag| lag >= 0));
     }

--- a/crates/extensions/backend-admin/src/data_feeds/router.rs
+++ b/crates/extensions/backend-admin/src/data_feeds/router.rs
@@ -406,11 +406,12 @@ struct EventListResponse {
 /// Runtime read-model for a feed's persisted event stream.
 #[derive(Debug, Serialize)]
 struct FeedSummaryResponse {
-    feed_id:       String,
-    source_name:   String,
-    event_count:   i64,
-    last_event_at: Option<Timestamp>,
-    lag_seconds:   Option<i64>,
+    feed_id:         String,
+    source_name:     String,
+    event_count:     i64,
+    last_event_type: Option<String>,
+    last_event_at:   Option<Timestamp>,
+    lag_seconds:     Option<i64>,
 }
 
 /// Built-in feed catalog entry plus current materialized state.
@@ -745,6 +746,7 @@ async fn list_feed_summaries(
                     feed_id: feed.id,
                     source_name: feed.name,
                     event_count: summary.map_or(0, |summary| summary.event_count),
+                    last_event_type: summary.and_then(|summary| summary.last_event_type.clone()),
                     last_event_at,
                     lag_seconds,
                 }
@@ -3304,6 +3306,7 @@ mod tests {
 
         assert_eq!(summary["source_name"], "summary-feed");
         assert_eq!(summary["event_count"], 1);
+        assert_eq!(summary["last_event_type"], "poll_response");
         assert_eq!(summary["last_event_at"], event_at.to_string());
         let lag_seconds = summary["lag_seconds"].as_i64().unwrap();
         assert!((58..=62).contains(&lag_seconds), "lag={lag_seconds}");

--- a/crates/extensions/backend-admin/src/data_feeds/service.rs
+++ b/crates/extensions/backend-admin/src/data_feeds/service.rs
@@ -283,8 +283,12 @@ impl DataFeedSvc {
     pub async fn event_summaries(&self) -> Result<Vec<EventSummary>> {
         let mut conn = self.pools.reader.get().await.context(PoolAcquireSnafu)?;
         let rows: Vec<EventSummaryRow> = diesel::sql_query(
-            "SELECT source_name, COUNT(*) AS event_count, MAX(received_at) AS last_event_at FROM \
-             data_feed_events GROUP BY source_name",
+            "SELECT summary.source_name, summary.event_count, summary.last_event_at, (SELECT \
+             latest.event_type FROM data_feed_events latest WHERE latest.source_name = \
+             summary.source_name ORDER BY latest.received_at DESC, latest.created_at DESC, \
+             latest.id DESC LIMIT 1) AS last_event_type FROM (SELECT source_name, COUNT(*) AS \
+             event_count, MAX(received_at) AS last_event_at FROM data_feed_events GROUP BY \
+             source_name) summary",
         )
         .load(&mut *conn)
         .await
@@ -329,11 +333,13 @@ pub struct EventPage {
 #[derive(Debug, Clone, serde::Serialize)]
 pub struct EventSummary {
     /// Feed source name.
-    pub source_name:   String,
+    pub source_name:     String,
     /// Number of persisted events for this source.
-    pub event_count:   i64,
+    pub event_count:     i64,
+    /// Event type for the most recent persisted event, if any.
+    pub last_event_type: Option<String>,
     /// Most recent persisted event receive time, if any.
-    pub last_event_at: Option<Timestamp>,
+    pub last_event_at:   Option<Timestamp>,
 }
 
 // ---------------------------------------------------------------------------
@@ -414,11 +420,13 @@ struct EventRow {
 #[derive(QueryableByName)]
 struct EventSummaryRow {
     #[diesel(sql_type = Text)]
-    source_name:   String,
+    source_name:     String,
     #[diesel(sql_type = BigInt)]
-    event_count:   i64,
+    event_count:     i64,
     #[diesel(sql_type = Nullable<Text>)]
-    last_event_at: Option<String>,
+    last_event_type: Option<String>,
+    #[diesel(sql_type = Nullable<Text>)]
+    last_event_at:   Option<String>,
 }
 
 impl EventSummaryRow {
@@ -434,6 +442,7 @@ impl EventSummaryRow {
         Ok(EventSummary {
             source_name: self.source_name,
             event_count: self.event_count,
+            last_event_type: self.last_event_type,
             last_event_at,
         })
     }

--- a/docs/guides/finance-subscriptions.md
+++ b/docs/guides/finance-subscriptions.md
@@ -147,8 +147,9 @@ checks:
 
 `finance_list_feed_sources` is the preferred status view before and after
 subscription changes. It combines the built-in source catalog, persisted feed
-runtime state, event watermarks, configured K-line selectors, and source-name
-subscription matches for the current user/session. Use
+runtime state, event watermarks (`event_count`, `last_event_type`,
+`last_event_at`, and `lag_seconds`), configured K-line selectors, and
+source-name subscription matches for the current user/session. Use
 `finance_list_feed_events` when the user asks what recent finance news or
 closed-candle notifications were actually received. It reads persisted events by
 `catalog_source_ids`, `source_names`, or `feed_ids`, can narrow mixed sources by
@@ -243,8 +244,9 @@ subscription diagnostic includes:
   deterministic diagnostic such as `missing symbols: ETHUSDT; missing
   timeframes: 5m`, so a fresh-runtime/no-data case can be separated from a
   feed configuration that cannot emit the subscribed stream;
-- persisted feed-event summary (`event_count`, `last_event_at`, and
-  `lag_seconds`) to confirm the source is emitting events;
+- persisted feed-event summary (`event_count`, `last_event_type`,
+  `last_event_at`, and `lag_seconds`) to confirm the source is emitting the
+  expected event kind;
 - latest stored closed candle and freshness per
   `(source_name, venue, symbol, timeframe)`.
 


### PR DESCRIPTION
## Summary
- include last_event_type in DataFeedSvc event summaries
- expose last_event_type through admin feed summaries, finance_list_feed_sources, and finance_diagnose_candle_subscriptions
- document the expanded event watermark fields

## Verification
- cargo test -p rara-app tools::finance_feed --lib
- cargo test -p rara-app tools::finance_diagnostics --lib
- cargo test -p rara-backend-admin data_feeds --lib
- cargo check -p rara-app
- cargo check -p rara-backend-admin
- cargo +nightly fmt --all -- --check
- git diff --check
- commit hook: cargo check, cargo fmt, cargo clippy, cargo doc