### PR TITLE
feat(finance): expose feed source providers

### DIFF
--- a/crates/app/src/tools/finance_feed.rs
+++ b/crates/app/src/tools/finance_feed.rs
@@ -67,6 +67,7 @@ pub(super) struct FinanceFeedSourceEntry {
     pub name:                   String,
     pub description:            String,
     pub feed_type:              String,
+    pub provider:               Option<String>,
     pub tags:                   Vec<String>,
     pub source_name:            String,
     pub requires_configuration: bool,
@@ -2141,11 +2142,18 @@ fn feed_source_entry(
         .map(|feed| &feed.transport)
         .or(source.transport.as_ref());
     let can_enable = source.can_enable();
+    let provider = source.provider.clone().or_else(|| {
+        transport
+            .and_then(|value| value.get("provider"))
+            .and_then(serde_json::Value::as_str)
+            .map(str::to_owned)
+    });
     FinanceFeedSourceEntry {
         id: source.id,
         name: source.name,
         description: source.description,
         feed_type: source.feed_type.to_string(),
+        provider,
         tags: source.tags,
         source_name,
         requires_configuration: source.requires_configuration,
@@ -2559,9 +2567,25 @@ mod tests {
             .iter()
             .find(|source| source.id == "binance-market-candles")
             .expect("binance source should be listed");
+        assert_eq!(binance.provider.as_deref(), Some("binance"));
         assert_eq!(binance.venue.as_deref(), Some("binance"));
         assert_eq!(binance.configured_symbols, ["BTCUSDT", "ETHUSDT"]);
         assert_eq!(binance.configured_timeframes, ["1m"]);
+
+        let longbridge = result
+            .sources
+            .iter()
+            .find(|source| source.id == "longbridge-market-candles")
+            .expect("longbridge source should be listed");
+        assert_eq!(longbridge.provider.as_deref(), Some("longbridge"));
+        assert!(longbridge.requires_configuration);
+        assert!(!longbridge.can_enable);
+        assert!(
+            longbridge
+                .setup_hint
+                .as_deref()
+                .is_some_and(|hint| hint.contains("Longbridge"))
+        );
     }
 
     #[tokio::test]

--- a/crates/extensions/backend-admin/src/data_feeds/router.rs
+++ b/crates/extensions/backend-admin/src/data_feeds/router.rs
@@ -421,6 +421,7 @@ struct FeedCatalogEntryResponse {
     name:                   String,
     description:            String,
     feed_type:              FeedType,
+    provider:               Option<String>,
     tags:                   Vec<String>,
     source_name:            String,
     enabled:                bool,
@@ -1833,6 +1834,10 @@ fn catalog_response(
         .map(|source| {
             let feed_name = source.feed_name();
             let feed = feeds.iter().find(|feed| feed.name == feed_name);
+            let provider = source
+                .provider
+                .clone()
+                .or_else(|| catalog_transport_string(source.transport.as_ref(), "provider"));
             let venue = catalog_transport_string(source.transport.as_ref(), "venue");
             let configured_symbols =
                 catalog_transport_string_list(source.transport.as_ref(), "symbols");
@@ -1843,6 +1848,7 @@ fn catalog_response(
                 name: source.name,
                 description: source.description,
                 feed_type: source.feed_type,
+                provider,
                 tags: source.tags,
                 source_name: feed_name.clone(),
                 enabled: feed.is_some_and(|feed| feed.enabled),
@@ -2627,12 +2633,28 @@ mod tests {
             binance["transport_template"]["provider"].as_str().unwrap(),
             "binance"
         );
+        assert_eq!(binance["provider"], "binance");
         assert_eq!(binance["venue"], "binance");
         assert_eq!(
             binance["configured_symbols"],
             serde_json::json!(["BTCUSDT", "ETHUSDT"])
         );
         assert_eq!(binance["configured_timeframes"], serde_json::json!(["1m"]));
+
+        let longbridge = entries
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|entry| entry["id"] == "longbridge-market-candles")
+            .unwrap();
+        assert_eq!(longbridge["provider"], "longbridge");
+        assert_eq!(longbridge["requires_configuration"], true);
+        assert_eq!(longbridge["feed_type"], "market_candle");
+        assert!(
+            longbridge["setup_hint"]
+                .as_str()
+                .is_some_and(|hint| hint.contains("Longbridge"))
+        );
     }
 
     #[tokio::test]

--- a/crates/extensions/rara-trading/src/feed/catalog.rs
+++ b/crates/extensions/rara-trading/src/feed/catalog.rs
@@ -26,6 +26,7 @@ pub struct DefaultFeedSource {
     pub name:                   String,
     pub description:            String,
     pub feed_type:              FeedType,
+    pub provider:               Option<String>,
     pub tags:                   Vec<String>,
     pub transport:              Option<serde_json::Value>,
     pub auth:                   Option<AuthConfig>,
@@ -122,6 +123,7 @@ fn rss_source(
         name:                   name.to_owned(),
         description:            description.to_owned(),
         feed_type:              FeedType::Rss,
+        provider:               None,
         tags:                   tags.into_iter().map(str::to_owned).collect(),
         transport:              Some(serde_json::json!({
             "url": url,
@@ -149,6 +151,7 @@ fn binance_market_candles_source(
         name:                   name.to_owned(),
         description:            description.to_owned(),
         feed_type:              FeedType::MarketCandle,
+        provider:               Some("binance".to_owned()),
         tags:                   tags.into_iter().map(str::to_owned).collect(),
         transport:              Some(serde_json::json!({
             "provider": "binance",
@@ -181,6 +184,7 @@ fn provider_preset(
         name:                   name.to_owned(),
         description:            description.to_owned(),
         feed_type:              FeedType::MarketCandle,
+        provider:               Some(venue.to_owned()),
         tags:                   tags.into_iter().map(str::to_owned).collect(),
         transport:              Some(serde_json::json!({
             "url": "",
@@ -294,7 +298,9 @@ mod tests {
         assert!(!source.can_enable());
         assert!(source.requires_configuration);
         assert!(source.setup_hint.is_some());
+        assert_eq!(source.provider.as_deref(), Some("longbridge"));
         let transport = source.transport.expect("transport template");
+        assert!(transport.get("provider").is_none());
         assert_eq!(transport["venue"], "longbridge");
         assert_eq!(
             transport["symbols"],

--- a/docs/guides/finance-subscriptions.md
+++ b/docs/guides/finance-subscriptions.md
@@ -149,12 +149,17 @@ checks:
 subscription changes. It combines the built-in source catalog, persisted feed
 runtime state, event watermarks (`event_count`, `last_event_type`,
 `last_event_at`, and `lag_seconds`), configured K-line selectors, and
-source-name subscription matches for the current user/session. Use
-`finance_list_feed_events` when the user asks what recent finance news or
-closed-candle notifications were actually received. It reads persisted events by
-`catalog_source_ids`, `source_names`, or `feed_ids`, can narrow mixed sources by
-`event_kinds` (`rss_article`, `market_candle_closed`), and returns per-source
-pages with `total`, `has_more`, `query_limit`, and `query_offset`.
+provider metadata. It also reports source-name subscription matches for the
+current user/session. Use `finance_list_feed_events` when the user asks what
+recent finance news or closed-candle notifications were actually received. It
+reads persisted events by `catalog_source_ids`, `source_names`, or `feed_ids`,
+can narrow mixed sources by `event_kinds` (`rss_article`,
+`market_candle_closed`), and returns per-source pages with `total`, `has_more`,
+`query_limit`, and `query_offset`.
+
+For built-in catalog entries, `provider` is catalog metadata used by the agent
+and UI to label fixed data sources such as Binance and Longbridge. It is
+separate from `transport.provider`, which selects a runtime transport driver.
 
 Stored closed candles are queryable through read-only market-data tools:
 


### PR DESCRIPTION
## Summary
- add catalog-level provider metadata for built-in finance feed sources
- expose provider through app finance feed source tools and admin feed catalog API
- document provider metadata as distinct from runtime transport.provider

## Verification
- cargo +nightly fmt --all -- --check
- cargo test -p rara-trading feed::catalog --lib
- cargo test -p rara-app tools::finance_feed --lib
- cargo test -p rara-backend-admin data_feeds::router --lib
- cargo check -p rara-app
- cargo check -p rara-backend-admin
- git diff --check
- pre-commit: cargo check/fmt/clippy/doc
