### PR TITLE
feat(finance): show feed providers in data feeds UI

### DIFF
--- a/web/e2e/harness/data-feeds.spec.ts
+++ b/web/e2e/harness/data-feeds.spec.ts
@@ -56,6 +56,7 @@ interface FeedCatalogEntry {
   name: string;
   description: string;
   feed_type: DataFeedConfig['feed_type'];
+  provider?: string | null;
   tags: string[];
   source_name?: string;
   enabled: boolean;
@@ -640,6 +641,7 @@ test.describe('Data Feeds Management', () => {
           name: 'Binance Market Candles',
           description: 'Public Binance spot OHLCV feed.',
           feed_type: 'market_candle',
+          provider: 'binance',
           tags: ['finance', 'market-data', 'crypto', 'binance'],
           enabled: false,
           feed_id: null,
@@ -666,6 +668,7 @@ test.describe('Data Feeds Management', () => {
     await expect(page.getByText('Federal Reserve Press Releases', { exact: true })).toBeVisible();
     await expect(page.getByText('Source finance-fed-press-releases')).toBeVisible();
     await expect(page.getByText('Subscribed')).toBeVisible();
+    await expect(page.getByText('Provider binance')).toBeVisible();
     await expect(page.getByText('binance · BTCUSDT, ETHUSDT · 1m')).toBeVisible();
 
     const fedEntry = page
@@ -689,6 +692,7 @@ test.describe('Data Feeds Management', () => {
           name: 'Longbridge Market Data',
           description: 'Preset for Longbridge equities market data.',
           feed_type: 'market_candle',
+          provider: 'longbridge',
           tags: ['finance', 'market-data', 'equities', 'longbridge'],
           enabled: false,
           feed_id: null,
@@ -710,6 +714,7 @@ test.describe('Data Feeds Management', () => {
 
     await expect(page.getByText(/^Provider presets$/)).toBeVisible({ timeout: 10_000 });
     await expect(page.getByText('Longbridge Market Data')).toBeVisible();
+    await expect(page.getByText('Provider longbridge')).toBeVisible();
 
     await page.getByRole('button', { name: 'Use template' }).click();
 

--- a/web/src/api/data-feeds.ts
+++ b/web/src/api/data-feeds.ts
@@ -152,6 +152,7 @@ export interface FeedCatalogEntry {
   name: string;
   description: string;
   feed_type: FeedType;
+  provider?: string | null;
   tags: string[];
   source_name?: string;
   enabled: boolean;

--- a/web/src/components/DataFeedsPanel.tsx
+++ b/web/src/components/DataFeedsPanel.tsx
@@ -163,6 +163,10 @@ function catalogVenue(entry: FeedCatalogEntry): string | null {
   return entry.venue?.trim() || transportString(entry, 'venue');
 }
 
+function catalogProvider(entry: FeedCatalogEntry): string | null {
+  return entry.provider?.trim() || null;
+}
+
 function catalogSymbols(entry: FeedCatalogEntry): string[] {
   return entry.configured_symbols?.length
     ? entry.configured_symbols
@@ -1461,6 +1465,7 @@ function FeedCatalogCard({
       (disableMutation.isPending && disableMutation.variables === entry.id) ||
       (unsubscribeMutation.isPending && unsubscribeMutation.variables === entry.id);
     const coverage = catalogCoverageLabel(entry);
+    const provider = catalogProvider(entry);
     const subscribed = entry.subscriptions?.user_subscribed === true;
     const unsubscribeButton = subscribed ? (
       <Button
@@ -1485,6 +1490,11 @@ function FeedCatalogCard({
             <Badge variant="outline" className="text-xs">
               {typeLabel(entry.feed_type)}
             </Badge>
+            {provider && (
+              <Badge variant="outline" className="text-xs text-muted-foreground">
+                Provider {provider}
+              </Badge>
+            )}
             {entry.enabled && (
               <Badge variant="secondary" className="text-xs text-foreground">
                 Enabled

--- a/web/src/components/__tests__/DataFeedsPanel.test.tsx
+++ b/web/src/components/__tests__/DataFeedsPanel.test.tsx
@@ -176,6 +176,68 @@ afterEach(() => {
 });
 
 describe('DataFeedsPanel', () => {
+  it('shows provider metadata for built-in finance catalog entries', async () => {
+    catalogMock.mockResolvedValue([
+      {
+        id: 'binance-market-candles',
+        name: 'Binance Market Candles',
+        description: 'Public Binance spot OHLCV feed.',
+        feed_type: 'market_candle',
+        provider: 'binance',
+        tags: ['finance', 'market-data', 'crypto', 'binance'],
+        source_name: 'finance-binance-market-candles',
+        enabled: false,
+        feed_id: null,
+        requires_configuration: false,
+        setup_hint: null,
+        transport_template: {
+          provider: 'binance',
+          base_url: 'https://api.binance.com',
+          interval_secs: 60,
+          headers: {},
+          venue: 'binance',
+          symbols: ['BTCUSDT', 'ETHUSDT'],
+          timeframes: ['1m'],
+          max_candles_per_poll: 1000,
+        },
+        venue: 'binance',
+        configured_symbols: ['BTCUSDT', 'ETHUSDT'],
+        configured_timeframes: ['1m'],
+      },
+      {
+        id: 'longbridge-market-candles',
+        name: 'Longbridge Market Data',
+        description: 'Preset for Longbridge equities market data.',
+        feed_type: 'market_candle',
+        provider: 'longbridge',
+        tags: ['finance', 'market-data', 'equities', 'longbridge'],
+        source_name: 'finance-longbridge-market-candles',
+        enabled: false,
+        feed_id: null,
+        requires_configuration: true,
+        setup_hint: 'Connect Longbridge credentials behind a normalized candle endpoint.',
+        transport_template: {
+          url: '',
+          interval_secs: 60,
+          headers: {},
+          venue: 'longbridge',
+          symbols: ['AAPL.US', 'NVDA.US'],
+          timeframes: ['1d'],
+          max_candles_per_poll: 1000,
+        },
+        venue: 'longbridge',
+        configured_symbols: ['AAPL.US', 'NVDA.US'],
+        configured_timeframes: ['1d'],
+      },
+    ] satisfies FeedCatalogEntry[]);
+
+    renderPanel();
+
+    expect(await screen.findByText('Default finance sources')).toBeInTheDocument();
+    expect(screen.getByText('Provider binance')).toBeInTheDocument();
+    expect(screen.getByText('Provider longbridge')).toBeInTheDocument();
+  });
+
   it('requests and displays stored K-line stream watermarks', async () => {
     listMock.mockResolvedValue([feed()]);
     candleStreamsMock.mockResolvedValue({


### PR DESCRIPTION
## Summary
- add provider metadata to the web feed catalog type
- show provider badges for built-in finance catalog entries in the Data Feeds panel
- cover Binance/Longbridge provider display with unit and harness e2e assertions

## Verification
- pnpm vitest run src/components/__tests__/DataFeedsPanel.test.tsx -t "shows provider metadata"
- pnpm vitest run src/components/__tests__/DataFeedsPanel.test.tsx
- pnpm build
- pnpm exec playwright test e2e/harness/data-feeds.spec.ts -g "shows default finance sources and enables one|provider preset opens a prefilled market candle form"
- pnpm typecheck
- pnpm lint
- pnpm format:check
- git diff --check
