### PR TITLE
feat(finance): show feed providers in watches

### DIFF
--- a/web/src/components/topology/FinanceWatchesCard.tsx
+++ b/web/src/components/topology/FinanceWatchesCard.tsx
@@ -159,6 +159,7 @@ export function FinanceWatchesCard({ sessionKey }: FinanceWatchesCardProps) {
                 (subscribeMutation.isPending && subscribeMutation.variables?.id === entry.id) ||
                 (unsubscribeMutation.isPending &&
                   unsubscribeMutation.variables?.entry.id === entry.id);
+              const provider = catalogProvider(entry);
               const actionLabel = financeWatchActionLabel({
                 pending,
                 canEnableInline,
@@ -174,6 +175,14 @@ export function FinanceWatchesCard({ sessionKey }: FinanceWatchesCardProps) {
                         <Badge variant="outline" className="px-1.5 py-0 text-[10px]">
                           {entry.feed_type === 'rss' ? 'News' : 'K-line'}
                         </Badge>
+                        {provider && (
+                          <Badge
+                            variant="outline"
+                            className="px-1.5 py-0 text-[10px] text-muted-foreground"
+                          >
+                            Provider {provider}
+                          </Badge>
+                        )}
                         {!entry.enabled && (
                           <Badge variant="secondary" className="px-1.5 py-0 text-[10px]">
                             {needsConfiguration ? 'needs config' : 'source off'}
@@ -307,6 +316,10 @@ function catalogSourceName(entry: FeedCatalogEntry): string {
 
 function catalogVenue(entry: FeedCatalogEntry): string | null {
   return entry.venue?.trim() || transportString(entry, 'venue');
+}
+
+function catalogProvider(entry: FeedCatalogEntry): string | null {
+  return entry.provider?.trim() || null;
 }
 
 function catalogSymbols(entry: FeedCatalogEntry): string[] {

--- a/web/src/components/topology/__tests__/FinanceWatchesCard.test.tsx
+++ b/web/src/components/topology/__tests__/FinanceWatchesCard.test.tsx
@@ -87,6 +87,7 @@ function catalogEntry(partial: Partial<FeedCatalogEntry> & { id: string }): Feed
     transport_template: partial.transport_template ?? null,
   };
   if (partial.source_name !== undefined) entry.source_name = partial.source_name;
+  if (partial.provider !== undefined) entry.provider = partial.provider;
   if (partial.venue !== undefined) entry.venue = partial.venue;
   if (partial.configured_symbols !== undefined)
     entry.configured_symbols = partial.configured_symbols;
@@ -138,6 +139,40 @@ afterEach(() => {
 });
 
 describe('FinanceWatchesCard', () => {
+  it('shows_provider_metadata_for_catalog_watch_sources', async () => {
+    catalogMock.mockResolvedValue([
+      catalogEntry({
+        id: 'binance-market-candles',
+        name: 'Binance Market Candles',
+        feed_type: 'market_candle',
+        provider: 'binance',
+        venue: 'binance',
+        configured_symbols: ['BTCUSDT', 'ETHUSDT'],
+        configured_timeframes: ['1m'],
+      }),
+      catalogEntry({
+        id: 'longbridge-market-candles',
+        name: 'Longbridge Market Data',
+        feed_type: 'market_candle',
+        provider: 'longbridge',
+        enabled: false,
+        requires_configuration: true,
+        venue: 'longbridge',
+        configured_symbols: ['AAPL.US', 'NVDA.US'],
+        configured_timeframes: ['1d'],
+      }),
+    ]);
+    financeSubscriptionsMock.mockResolvedValue({
+      subscriptions: [],
+      count: 0,
+    } satisfies FinanceSubscriptionsResponse);
+
+    renderCard('session-1');
+
+    expect(await screen.findByText('Provider binance')).toBeInTheDocument();
+    expect(screen.getByText('Provider longbridge')).toBeInTheDocument();
+  });
+
   it('creates_session_watch_from_catalog_kline_source_with_configured_selectors', async () => {
     const binance = catalogEntry({
       id: 'binance-market-candles',


### PR DESCRIPTION
## Summary
- show catalog provider badges in the Finance watches card
- cover Binance and Longbridge provider metadata in the watch source list

## Verification
- pnpm vitest run src/components/topology/__tests__/FinanceWatchesCard.test.tsx -t "shows_provider_metadata"
- pnpm vitest run src/components/topology/__tests__/FinanceWatchesCard.test.tsx
- pnpm typecheck
- pnpm lint
- pnpm format:check
- git diff --check
