### PR TITLE
feat(finance): expose subscription source providers

### DIFF
--- a/crates/app/src/tools/finance_feed.rs
+++ b/crates/app/src/tools/finance_feed.rs
@@ -242,6 +242,7 @@ pub(super) struct FinanceSubscriptionSource {
     pub source_name:       String,
     pub catalog_source_id: Option<String>,
     pub catalog_name:      Option<String>,
+    pub provider:          Option<String>,
     pub feed_id:           Option<String>,
     pub feed_type:         Option<String>,
     pub persisted:         bool,
@@ -2235,6 +2236,7 @@ fn subscription_source_entry(
         source_name:       source_name.to_owned(),
         catalog_source_id: catalog_source.map(|source| source.id.clone()),
         catalog_name:      catalog_source.map(|source| source.name.clone()),
+        provider:          subscription_source_provider(catalog_source, feed),
         feed_id:           feed.map(|feed| feed.id.clone()),
         feed_type:         feed.map(|feed| feed.feed_type.to_string()),
         persisted:         feed.is_some(),
@@ -2243,6 +2245,22 @@ fn subscription_source_entry(
         status:            feed.map(|feed| feed.status.to_string()),
         last_error:        feed.and_then(|feed| feed.last_error.clone()),
     }
+}
+
+fn subscription_source_provider(
+    catalog_source: Option<&DefaultFeedSource>,
+    feed: Option<&DataFeedConfig>,
+) -> Option<String> {
+    catalog_source
+        .and_then(|source| source.provider.clone())
+        .or_else(|| {
+            feed.and_then(|feed| {
+                feed.transport
+                    .get("provider")
+                    .and_then(serde_json::Value::as_str)
+                    .map(str::to_owned)
+            })
+        })
 }
 
 fn source_subscription_summary(
@@ -2700,6 +2718,7 @@ mod tests {
         assert_eq!(source.enabled, Some(true));
         assert!(!source.running);
         assert_eq!(source.status.as_deref(), Some("idle"));
+        assert_eq!(source.provider, None);
         assert_eq!(source.last_error, None);
     }
 
@@ -3838,6 +3857,11 @@ mod tests {
     async fn subscribe_instruments_creates_market_feed_and_finance_subscription() {
         let (_list, _enable, _disable, _restart, tool, svc, registry, finance_registry) =
             tool().await;
+        let list = FinanceListSubscriptionsTool::new(
+            svc.clone(),
+            registry.clone(),
+            finance_registry.clone(),
+        );
         let ctx = context();
 
         let result = tool
@@ -3884,6 +3908,21 @@ mod tests {
         assert_eq!(subs[0].venues, ["binance"]);
         assert_eq!(subs[0].symbols, ["BTCUSDT", "SOLUSDT"]);
         assert_eq!(subs[0].timeframes, ["1m", "5m"]);
+
+        let listed = list
+            .run(
+                FinanceListSubscriptionsParams {
+                    current_session_only: Some(true),
+                },
+                &ctx,
+            )
+            .await
+            .unwrap();
+        assert_eq!(listed.count, 1);
+        assert_eq!(
+            listed.subscriptions[0].sources[0].provider.as_deref(),
+            Some("binance")
+        );
     }
 
     #[tokio::test]

--- a/crates/extensions/backend-admin/src/data_feeds/router.rs
+++ b/crates/extensions/backend-admin/src/data_feeds/router.rs
@@ -503,6 +503,7 @@ struct FinanceSubscriptionSourceResponse {
     source_name:       String,
     catalog_source_id: Option<String>,
     catalog_name:      Option<String>,
+    provider:          Option<String>,
     feed_id:           Option<String>,
     feed_type:         Option<FeedType>,
     enabled:           Option<bool>,
@@ -2054,11 +2055,28 @@ fn finance_subscription_source_response(
         source_name:       source_name.to_owned(),
         catalog_source_id: catalog_source.map(|source| source.id.clone()),
         catalog_name:      catalog_source.map(|source| source.name.clone()),
+        provider:          finance_subscription_source_provider(catalog_source, feed),
         feed_id:           feed.map(|feed| feed.id.clone()),
         feed_type:         feed.map(|feed| feed.feed_type.clone()),
         enabled:           feed.map(|feed| feed.enabled),
         status:            feed.map(|feed| feed.status),
     }
+}
+
+fn finance_subscription_source_provider(
+    catalog_source: Option<&DefaultFeedSource>,
+    feed: Option<&DataFeedConfig>,
+) -> Option<String> {
+    catalog_source
+        .and_then(|source| source.provider.clone())
+        .or_else(|| {
+            feed.and_then(|feed| {
+                feed.transport
+                    .get("provider")
+                    .and_then(serde_json::Value::as_str)
+                    .map(str::to_owned)
+            })
+        })
 }
 
 fn catalog_by_source_name() -> HashMap<String, DefaultFeedSource> {
@@ -2883,6 +2901,7 @@ mod tests {
             subscription["sources"][0]["catalog_source_id"],
             "binance-market-candles"
         );
+        assert_eq!(subscription["sources"][0]["provider"], "binance");
         assert_eq!(subscription["venues"], serde_json::json!(["binance"]));
         assert_eq!(subscription["symbols"], serde_json::json!(["BTCUSDT"]));
         assert_eq!(subscription["timeframes"], serde_json::json!(["1m"]));
@@ -2938,6 +2957,7 @@ mod tests {
             created["subscription"]["sources"][0]["catalog_source_id"],
             "binance-market-candles"
         );
+        assert_eq!(created["subscription"]["sources"][0]["provider"], "binance");
         assert_eq!(created["subscription"]["delivery"], "immediate");
 
         let update_body = serde_json::json!({

--- a/web/e2e/harness/data-feeds.spec.ts
+++ b/web/e2e/harness/data-feeds.spec.ts
@@ -77,6 +77,7 @@ interface FinanceSubscriptionSource {
   source_name: string;
   catalog_source_id: string | null;
   catalog_name: string | null;
+  provider: string | null;
   feed_id: string | null;
   feed_type: DataFeedConfig['feed_type'] | null;
   enabled: boolean | null;

--- a/web/src/api/data-feeds.ts
+++ b/web/src/api/data-feeds.ts
@@ -195,6 +195,7 @@ export interface FinanceSubscriptionSource {
   source_name: string;
   catalog_source_id: string | null;
   catalog_name: string | null;
+  provider: string | null;
   feed_id: string | null;
   feed_type: FeedType | null;
   enabled: boolean | null;


### PR DESCRIPTION
## Summary
- add provider metadata to finance subscription source read models in rara-app tools and backend admin API
- derive provider from catalog source metadata with persisted feed transport fallback
- sync web API and e2e harness types

## Verification
- cargo test -p rara-app tools::finance_feed --lib
- cargo test -p rara-backend-admin data_feeds::router::tests --lib
- cargo check -p rara-app
- cargo check -p rara-backend-admin
- cargo +nightly fmt --all -- --check
- pnpm --dir web typecheck
- pnpm --dir web lint
- pnpm --dir web test -- src/components/__tests__/DataFeedsPanel.test.tsx src/components/topology/__tests__/FinanceWatchesCard.test.tsx
- pnpm --dir web format:check
- cargo deny check