### PR TITLE
Add candle gap hints to finance subscriptions

### DIFF
--- a/crates/app/src/tools/finance_feed.rs
+++ b/crates/app/src/tools/finance_feed.rs
@@ -281,6 +281,7 @@ pub(super) struct FinanceSubscriptionEntry {
     pub latest_candle_hint:         Option<FinanceSubscriptionLatestCandleHint>,
     pub recent_candles_hint:        Option<FinanceSubscriptionRecentCandlesHint>,
     pub freshness_hint:             Option<FinanceSubscriptionFreshnessHint>,
+    pub gaps_hint:                  Option<FinanceSubscriptionGapsHint>,
     pub source_names:               Vec<String>,
     pub matches_all_sources:        bool,
     pub sources:                    Vec<FinanceSubscriptionSource>,
@@ -336,6 +337,14 @@ pub(super) struct FinanceSubscriptionRecentCandlesHint {
 
 #[derive(Debug, Clone, Serialize)]
 pub(super) struct FinanceSubscriptionFreshnessHint {
+    pub tool:            String,
+    pub default_params:  serde_json::Value,
+    pub required_params: Vec<String>,
+    pub optional_params: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub(super) struct FinanceSubscriptionGapsHint {
     pub tool:            String,
     pub default_params:  serde_json::Value,
     pub required_params: Vec<String>,
@@ -2542,6 +2551,7 @@ fn subscription_entry(
     let latest_candle_hint = latest_candle_hint_for_subscription(&subscription);
     let recent_candles_hint = recent_candles_hint_for_subscription(&subscription);
     let freshness_hint = freshness_hint_for_subscription(&subscription);
+    let gaps_hint = gaps_hint_for_subscription(&subscription);
 
     FinanceSubscriptionEntry {
         subscription_id: subscription.id,
@@ -2556,6 +2566,7 @@ fn subscription_entry(
         latest_candle_hint,
         recent_candles_hint,
         freshness_hint,
+        gaps_hint,
         source_names: subscription.source_names,
         matches_all_sources,
         sources,
@@ -2722,6 +2733,31 @@ fn freshness_hint_for_subscription(
             .into_iter()
             .map(str::to_owned)
             .collect(),
+    })
+}
+
+fn gaps_hint_for_subscription(
+    subscription: &FinanceSubscription,
+) -> Option<FinanceSubscriptionGapsHint> {
+    if !subscription_is_market_candle(subscription) {
+        return None;
+    }
+
+    let source_name = single_selector_value(&subscription.source_names)?;
+    let venue = single_selector_value(&subscription.venues)?;
+    let symbol = single_selector_value(&subscription.symbols)?;
+    let timeframe = single_selector_value(&subscription.timeframes)?;
+
+    Some(FinanceSubscriptionGapsHint {
+        tool:            "finance_find_candle_gaps".to_owned(),
+        default_params:  serde_json::json!({
+            "source_name": source_name,
+            "venue": venue,
+            "symbol": symbol,
+            "timeframe": timeframe,
+        }),
+        required_params: ["start", "end"].into_iter().map(str::to_owned).collect(),
+        optional_params: Vec::new(),
     })
 }
 
@@ -4732,6 +4768,10 @@ mod tests {
             listed.subscriptions[0].freshness_hint.is_none(),
             "multi-symbol/timeframe subscriptions should not expose a direct freshness hint"
         );
+        assert!(
+            listed.subscriptions[0].gaps_hint.is_none(),
+            "multi-symbol/timeframe subscriptions should not expose a direct gaps hint"
+        );
         assert_eq!(
             listed.subscriptions[0].sources[0].provider.as_deref(),
             Some("binance")
@@ -4851,6 +4891,22 @@ mod tests {
             freshness_hint.optional_params,
             ["as_of", "stale_after_secs"]
         );
+        let gaps_hint = listed.subscriptions[0]
+            .gaps_hint
+            .as_ref()
+            .expect("single-stream market subscription should include gaps hint");
+        assert_eq!(gaps_hint.tool, "finance_find_candle_gaps");
+        assert_eq!(
+            gaps_hint.default_params,
+            serde_json::json!({
+                "source_name": "finance-binance-market-candles",
+                "venue": "binance",
+                "symbol": "BTCUSDT",
+                "timeframe": "1m",
+            })
+        );
+        assert_eq!(gaps_hint.required_params, ["start", "end"]);
+        assert!(gaps_hint.optional_params.is_empty());
     }
 
     #[tokio::test]

--- a/docs/guides/finance-subscriptions.md
+++ b/docs/guides/finance-subscriptions.md
@@ -169,11 +169,13 @@ single-stream market-candle subscriptions also include `latest_candle_hint` for
 the latest stored bar without first discovering streams, `recent_candles_hint`
 for `finance_get_recent_candles`, and `freshness_hint` for
 `finance_get_candle_freshness`, so rara can check recent bars and whether that
-stream is fresh or stale with the same exact selectors. Use the events hint when
-the user asks what recent finance news or closed-candle notifications were
-actually received; use the market-data hint when the user asks what closed
-candle streams are stored in the TSDB before drilling into gap queries. Event
-queries read persisted events by
+stream is fresh or stale with the same exact selectors. They also include
+`gaps_hint` for `finance_find_candle_gaps`; this pre-fills the stream selectors
+but still requires the user or agent to supply the `start` and `end` range. Use
+the events hint when the user asks what recent finance news or closed-candle
+notifications were actually received; use the market-data hint when the user
+asks what closed candle streams are stored in the TSDB before picking a stream.
+Event queries read persisted events by
 `catalog_source_ids`, `source_names`, or `feed_ids`, can narrow mixed sources by
 `event_kinds` (`rss_article`, `market_candle_closed`), and return per-source
 pages with `total`, `has_more`, `query_limit`, and `query_offset`.


### PR DESCRIPTION
## Summary
- add subscription-level gaps_hint for fully specified market-candle subscriptions
- keep multi-symbol/timeframe subscriptions on stream discovery only to avoid ambiguous gap defaults
- document that gaps_hint pre-fills stream selectors but requires start/end range parameters

## Test plan
- RED: cargo test -p rara-app tools::finance_feed::tests::subscribe_instruments_defaults_to_binance_market_feed --lib failed before implementation with missing gaps_hint field
- cargo test -p rara-app tools::finance_feed::tests::subscribe_instruments_defaults_to_binance_market_feed --lib
- cargo test -p rara-app tools::finance_feed --lib
- cargo check -p rara-app
- cargo +nightly fmt --all -- --check
- git diff --check
- scripts/lint-ratchet.sh
- pre-commit: cargo check, cargo fmt, cargo clippy, cargo doc
