### PR TITLE
Add news subscribe result hints

### DIFF
--- a/crates/app/src/tools/finance_feed.rs
+++ b/crates/app/src/tools/finance_feed.rs
@@ -471,6 +471,8 @@ pub(super) struct FinanceSubscribeNewsParams {
 pub(super) struct FinanceSubscribeNewsResult {
     pub subscription_id:        Uuid,
     pub subscription_created:   bool,
+    pub unsubscribe_hint:       Option<FinanceSubscriptionUnsubscribeHint>,
+    pub events_hint:            Option<FinanceSubscriptionEventsHint>,
     pub sources:                Vec<SubscribedNewsSource>,
     pub source_names:           Vec<String>,
     pub category_tags:          Vec<String>,
@@ -1239,6 +1241,8 @@ impl ToolExecute for FinanceSubscribeNewsTool {
         Ok(FinanceSubscribeNewsResult {
             subscription_id,
             subscription_created,
+            unsubscribe_hint: Some(unsubscribe_hint_for_subscription(subscription_id)),
+            events_hint: events_hint_for_subscription(&persisted),
             sources,
             source_names: persisted.source_names,
             category_tags: persisted.category_tags,
@@ -3089,8 +3093,8 @@ mod tests {
         FinanceListSubscriptionsParams, FinanceListSubscriptionsTool,
         FinanceRestartFeedSourceParams, FinanceRestartFeedSourceTool,
         FinanceSubscribeInstrumentsParams, FinanceSubscribeInstrumentsResult,
-        FinanceSubscribeInstrumentsTool, FinanceSubscribeNewsParams, FinanceSubscribeNewsTool,
-        FinanceUnsubscribeParams, FinanceUnsubscribeTool,
+        FinanceSubscribeInstrumentsTool, FinanceSubscribeNewsParams, FinanceSubscribeNewsResult,
+        FinanceSubscribeNewsTool, FinanceUnsubscribeParams, FinanceUnsubscribeTool,
     };
 
     fn context() -> ToolContext {
@@ -3213,6 +3217,42 @@ mod tests {
         assert_eq!(query.default_params, single_stream_params_with_limit());
         assert_eq!(query.required_params, ["start", "end"]);
         assert_eq!(query.optional_params, ["limit"]);
+    }
+
+    fn assert_news_result_hints(result: &FinanceSubscribeNewsResult) {
+        let unsubscribe = result
+            .unsubscribe_hint
+            .as_ref()
+            .expect("news subscribe result should include unsubscribe hint");
+        assert_eq!(unsubscribe.tool, "finance_unsubscribe");
+        assert_eq!(
+            unsubscribe.default_params,
+            serde_json::json!({
+                "subscription_ids": [result.subscription_id],
+            })
+        );
+        assert!(unsubscribe.required_params.is_empty());
+        assert_eq!(unsubscribe.optional_params, ["dry_run"]);
+
+        let events = result
+            .events_hint
+            .as_ref()
+            .expect("news subscribe result should include events hint");
+        assert_eq!(events.tool, "finance_list_feed_events");
+        assert_eq!(
+            events.default_params,
+            serde_json::json!({
+                "source_names": [
+                    "finance-fed-press-releases",
+                    "finance-sec-press-releases"
+                ],
+                "event_kinds": ["rss_article"],
+                "since": "24h",
+                "limit": 20,
+            })
+        );
+        assert!(events.required_params.is_empty());
+        assert_eq!(events.optional_params, ["since", "limit", "offset"]);
     }
 
     fn single_stream_params() -> serde_json::Value {
@@ -4681,6 +4721,7 @@ mod tests {
         assert_eq!(result.delivery, FinanceDelivery::Immediate);
         assert_eq!(result.cooldown_secs, 120);
         assert_eq!(result.max_immediate_per_hour, 3);
+        assert_news_result_hints(&result);
         assert_eq!(result.sources.len(), 2);
         assert!(result.sources.iter().all(|source| {
             source.feed_change == FeedChange::Created && !source.started && !source.running

--- a/docs/guides/finance-subscriptions.md
+++ b/docs/guides/finance-subscriptions.md
@@ -158,6 +158,11 @@ operations. Market-candle sources expose `market_data_hint` for
 `finance_list_candle_streams` so rara can move from source status to stored
 TSDB stream discovery before querying latest or historical candles.
 
+`finance_subscribe_news` returns `unsubscribe_hint` and `events_hint`
+immediately after creating or updating an RSS article subscription, so rara can
+either list recent persisted articles for the subscribed sources or cancel the
+subscription without first calling `finance_list_subscriptions`.
+
 `finance_subscribe_instruments` returns the same market-data and single-stream
 candle hints immediately after creating or updating a subscription. For broad
 subscriptions, use the returned `market_data_hint` to discover stored streams.


### PR DESCRIPTION
## Summary

- return `unsubscribe_hint` and `events_hint` directly from `finance_subscribe_news`
- reuse the persisted subscription to generate hints, keeping semantics aligned with `finance_list_subscriptions`
- document that news subscriptions can immediately list recent persisted articles or unsubscribe without an extra list call

## TDD

RED:

```text
cargo test -p rara-app tools::finance_feed::tests::subscribe_news_enables_rss_catalog_and_creates_subscription --lib
error[E0609]: no field `unsubscribe_hint` on type `&FinanceSubscribeNewsResult`
error[E0609]: no field `events_hint` on type `&FinanceSubscribeNewsResult`
```

GREEN / verification:

```text
cargo test -p rara-app tools::finance_feed --lib
cargo check -p rara-app
cargo +nightly fmt --all -- --check
git diff --check
scripts/lint-ratchet.sh
```

Pre-commit also passed cargo check, fmt, clippy, and doc.
