### PR TITLE
Add candle stream pagination hints

### DIFF
--- a/crates/app/src/tools/finance_feed.rs
+++ b/crates/app/src/tools/finance_feed.rs
@@ -2525,7 +2525,7 @@ fn market_data_hint_for_source(
         tool:            "finance_list_candle_streams".to_owned(),
         default_params:  serde_json::Value::Object(default_params),
         required_params: Vec::new(),
-        optional_params: ["symbol", "timeframe", "limit"]
+        optional_params: ["symbol", "timeframe", "limit", "offset"]
             .into_iter()
             .map(str::to_owned)
             .collect(),
@@ -2802,10 +2802,17 @@ fn market_data_hint_for_subscription(
         tool:            "finance_list_candle_streams".to_owned(),
         default_params:  serde_json::Value::Object(default_params),
         required_params: Vec::new(),
-        optional_params: ["source_name", "venue", "symbol", "timeframe", "limit"]
-            .into_iter()
-            .map(str::to_owned)
-            .collect(),
+        optional_params: [
+            "source_name",
+            "venue",
+            "symbol",
+            "timeframe",
+            "limit",
+            "offset",
+        ]
+        .into_iter()
+        .map(str::to_owned)
+        .collect(),
     })
 }
 
@@ -3472,7 +3479,7 @@ mod tests {
         assert!(market_data_hint.required_params.is_empty());
         assert_eq!(
             market_data_hint.optional_params,
-            ["symbol", "timeframe", "limit"]
+            ["symbol", "timeframe", "limit", "offset"]
         );
     }
 
@@ -5072,7 +5079,14 @@ mod tests {
         assert!(market_data_hint.required_params.is_empty());
         assert_eq!(
             market_data_hint.optional_params,
-            ["source_name", "venue", "symbol", "timeframe", "limit"]
+            [
+                "source_name",
+                "venue",
+                "symbol",
+                "timeframe",
+                "limit",
+                "offset"
+            ]
         );
         assert!(
             listed.subscriptions[0].latest_candle_hint.is_none(),

--- a/crates/extensions/backend-admin/src/data_feeds/router.rs
+++ b/crates/extensions/backend-admin/src/data_feeds/router.rs
@@ -260,15 +260,17 @@ struct CandleStreamQueryParams {
     symbol:      Option<String>,
     timeframe:   Option<String>,
     limit:       Option<usize>,
+    offset:      Option<usize>,
 }
 
 /// Stored market-data candle stream inventory response.
 #[derive(Debug, Serialize)]
 struct CandleStreamListResponse {
-    streams:     Vec<CandleStreamResponse>,
-    count:       usize,
-    query_limit: usize,
-    has_more:    bool,
+    streams:      Vec<CandleStreamResponse>,
+    count:        usize,
+    query_limit:  usize,
+    query_offset: usize,
+    has_more:     bool,
 }
 
 #[derive(Debug, Serialize)]
@@ -1245,13 +1247,15 @@ async fn list_market_data_candle_streams(
     Query(params): Query<CandleStreamQueryParams>,
 ) -> Result<Json<CandleStreamListResponse>, ProblemDetails> {
     let limit = validate_market_data_stream_limit(params.limit)?;
+    let offset = params.offset.unwrap_or(0);
     let probe_limit = limit.saturating_add(1);
     let query = CandleStreamListQuery {
         source_name: normalize_optional_market_data_selector("source_name", params.source_name)?,
-        venue:       normalize_optional_market_data_venue(params.venue)?,
-        symbol:      normalize_optional_market_data_symbol(params.symbol)?,
-        timeframe:   normalize_optional_market_data_timeframe(params.timeframe)?,
-        limit:       probe_limit,
+        venue: normalize_optional_market_data_venue(params.venue)?,
+        symbol: normalize_optional_market_data_symbol(params.symbol)?,
+        timeframe: normalize_optional_market_data_timeframe(params.timeframe)?,
+        limit: probe_limit,
+        offset,
     };
 
     let mut streams = state
@@ -1270,6 +1274,7 @@ async fn list_market_data_candle_streams(
             .collect(),
         count,
         query_limit: limit,
+        query_offset: offset,
         has_more,
     }))
 }
@@ -3648,6 +3653,7 @@ mod tests {
 
         let app = app_with_user_and_market_data_repo(user_of(Role::Admin), market_data_repo).await;
         let res = app
+            .clone()
             .oneshot(
                 Request::builder()
                     .method("GET")
@@ -3667,8 +3673,32 @@ mod tests {
 
         assert_eq!(result["count"], 1);
         assert_eq!(result["query_limit"], 1);
+        assert_eq!(result["query_offset"], 0);
         assert_eq!(result["has_more"], true);
         assert_eq!(result["streams"].as_array().unwrap().len(), 1);
+
+        let res = app
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri("/api/v1/data-feeds/market-data/candle-streams?limit=1&offset=1")
+                    .header("Authorization", "Bearer s3cret")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(res.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(res.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let result: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(result["count"], 1);
+        assert_eq!(result["query_limit"], 1);
+        assert_eq!(result["query_offset"], 1);
+        assert_eq!(result["has_more"], false);
+        assert_eq!(result["streams"][0]["symbol"], "BTCUSDT");
     }
 
     #[tokio::test]

--- a/crates/extensions/rara-trading/src/market_data/model.rs
+++ b/crates/extensions/rara-trading/src/market_data/model.rs
@@ -160,6 +160,7 @@ pub struct CandleStreamListQuery {
     pub symbol:      Option<String>,
     pub timeframe:   Option<Timeframe>,
     pub limit:       usize,
+    pub offset:      usize,
 }
 
 /// Aggregated summary for one `(source, venue, symbol, timeframe)` candle

--- a/crates/extensions/rara-trading/src/market_data/repository.rs
+++ b/crates/extensions/rara-trading/src/market_data/repository.rs
@@ -223,7 +223,11 @@ impl MarketDataRepository for InMemoryMarketDataRepository {
                 .then_with(|| left.timeframe.cmp(&right.timeframe))
                 .then_with(|| left.source_name.cmp(&right.source_name))
         });
-        rows.truncate(query.limit.min(10_000));
+        rows = rows
+            .into_iter()
+            .skip(query.offset.min(10_000))
+            .take(query.limit.min(10_000))
+            .collect();
         Ok(rows)
     }
 
@@ -570,6 +574,7 @@ mod tests {
                 symbol:      None,
                 timeframe:   Some(Timeframe::parse("15m").unwrap()),
                 limit:       10,
+                offset:      0,
             })
             .await
             .unwrap();

--- a/crates/extensions/rara-trading/src/market_data/timescale.rs
+++ b/crates/extensions/rara-trading/src/market_data/timescale.rs
@@ -226,6 +226,7 @@ impl MarketDataRepository for TimescaleMarketDataRepository {
         query: CandleStreamListQuery,
     ) -> anyhow::Result<Vec<CandleStreamSummary>> {
         let limit = i64::try_from(query.limit.min(10_000))?;
+        let offset = i64::try_from(query.offset.min(10_000))?;
         let rows = sqlx_core::query::query(
             r#"
             WITH grouped AS (
@@ -267,6 +268,7 @@ impl MarketDataRepository for TimescaleMarketDataRepository {
                      grouped.timeframe ASC,
                      grouped.source_name ASC
             LIMIT $5
+            OFFSET $6
             "#,
         )
         .bind(query.source_name.as_deref())
@@ -274,6 +276,7 @@ impl MarketDataRepository for TimescaleMarketDataRepository {
         .bind(query.symbol.as_deref())
         .bind(query.timeframe.as_ref().map(Timeframe::as_str))
         .bind(limit)
+        .bind(offset)
         .fetch_all(&self.pool)
         .await?;
 

--- a/crates/extensions/rara-trading/src/market_data/tools.rs
+++ b/crates/extensions/rara-trading/src/market_data/tools.rs
@@ -159,14 +159,18 @@ pub struct FinanceListCandleStreamsParams {
     pub timeframe:   Option<String>,
     #[serde(default)]
     pub limit:       Option<usize>,
+    #[serde(default)]
+    pub offset:      Option<usize>,
 }
 
 #[derive(Debug, Clone, Serialize)]
 pub struct FinanceListCandleStreamsResult {
-    pub streams:     Vec<FinanceCandleStream>,
-    pub count:       usize,
-    pub query_limit: usize,
-    pub has_more:    bool,
+    pub streams:        Vec<FinanceCandleStream>,
+    pub count:          usize,
+    pub query_limit:    usize,
+    pub query_offset:   usize,
+    pub has_more:       bool,
+    pub next_page_hint: Option<FinanceCandleStreamNextPageHint>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -189,6 +193,14 @@ pub struct FinanceCandleStream {
 
 #[derive(Debug, Clone, Serialize)]
 pub struct FinanceCandleStreamToolHint {
+    pub tool:            String,
+    pub default_params:  serde_json::Value,
+    pub required_params: Vec<String>,
+    pub optional_params: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct FinanceCandleStreamNextPageHint {
     pub tool:            String,
     pub default_params:  serde_json::Value,
     pub required_params: Vec<String>,
@@ -242,23 +254,40 @@ impl ToolExecute for FinanceListCandleStreamsTool {
         _context: &ToolContext,
     ) -> anyhow::Result<FinanceListCandleStreamsResult> {
         let limit = validate_stream_limit(params.limit)?;
+        let offset = params.offset.unwrap_or(0);
         let query_limit = limit.saturating_add(1);
+        let source_name = normalize_optional_source_name_selector(params.source_name)?;
+        let venue = normalize_optional_venue_selector(params.venue)?;
+        let symbol = normalize_optional_symbol_selector(params.symbol)?;
+        let timeframe = normalize_optional_timeframe_selector(params.timeframe)?;
         let query = CandleStreamListQuery {
-            source_name: normalize_optional_source_name_selector(params.source_name)?,
-            venue:       normalize_optional_venue_selector(params.venue)?,
-            symbol:      normalize_optional_symbol_selector(params.symbol)?,
-            timeframe:   normalize_optional_timeframe_selector(params.timeframe)?,
-            limit:       query_limit,
+            source_name: source_name.clone(),
+            venue: venue.clone(),
+            symbol: symbol.clone(),
+            timeframe: timeframe.clone(),
+            limit: query_limit,
+            offset,
         };
         let mut streams = self.repository.candle_streams(query).await?;
         let has_more = streams.len() > limit;
         streams.truncate(limit);
         let count = streams.len();
+        let next_page_hint = stream_list_next_page_hint(
+            source_name.as_deref(),
+            venue.as_deref(),
+            symbol.as_deref(),
+            timeframe.as_ref(),
+            limit,
+            offset,
+            has_more,
+        );
         Ok(FinanceListCandleStreamsResult {
             streams: streams.into_iter().map(FinanceCandleStream::from).collect(),
             count,
             query_limit: limit,
+            query_offset: offset,
             has_more,
+            next_page_hint,
         })
     }
 }
@@ -713,6 +742,68 @@ fn query_candles_hint_for_stream(
     }
 }
 
+fn stream_list_next_page_hint(
+    source_name: Option<&str>,
+    venue: Option<&str>,
+    symbol: Option<&str>,
+    timeframe: Option<&Timeframe>,
+    limit: usize,
+    offset: usize,
+    has_more: bool,
+) -> Option<FinanceCandleStreamNextPageHint> {
+    if !has_more {
+        return None;
+    }
+
+    let mut default_params = serde_json::Map::new();
+    if let Some(source_name) = source_name {
+        default_params.insert(
+            "source_name".to_owned(),
+            serde_json::Value::String(source_name.to_owned()),
+        );
+    }
+    if let Some(venue) = venue {
+        default_params.insert(
+            "venue".to_owned(),
+            serde_json::Value::String(venue.to_owned()),
+        );
+    }
+    if let Some(symbol) = symbol {
+        default_params.insert(
+            "symbol".to_owned(),
+            serde_json::Value::String(symbol.to_owned()),
+        );
+    }
+    if let Some(timeframe) = timeframe {
+        default_params.insert(
+            "timeframe".to_owned(),
+            serde_json::Value::String(timeframe.to_string()),
+        );
+    }
+    default_params.insert("limit".to_owned(), serde_json::json!(limit));
+    default_params.insert(
+        "offset".to_owned(),
+        serde_json::json!(offset.saturating_add(limit)),
+    );
+
+    Some(FinanceCandleStreamNextPageHint {
+        tool:            "finance_list_candle_streams".to_owned(),
+        default_params:  serde_json::Value::Object(default_params),
+        required_params: Vec::new(),
+        optional_params: [
+            "source_name",
+            "venue",
+            "symbol",
+            "timeframe",
+            "limit",
+            "offset",
+        ]
+        .into_iter()
+        .map(str::to_owned)
+        .collect(),
+    })
+}
+
 fn recent_candles_next_page_hint(
     source_name: Option<&str>,
     venue: &str,
@@ -1070,6 +1161,7 @@ mod tests {
                     symbol:      None,
                     timeframe:   Some("1m".to_owned()),
                     limit:       Some(10),
+                    offset:      None,
                 },
                 &context(),
             )
@@ -1148,6 +1240,7 @@ mod tests {
                     symbol:      Some("BTCUSDT".to_owned()),
                     timeframe:   Some("1m".to_owned()),
                     limit:       None,
+                    offset:      None,
                 },
                 &context(),
             )
@@ -1171,6 +1264,7 @@ mod tests {
                     symbol:      None,
                     timeframe:   Some("1m".to_owned()),
                     limit:       Some(1),
+                    offset:      None,
                 },
                 &context(),
             )
@@ -1181,6 +1275,55 @@ mod tests {
         assert_eq!(result.query_limit, 1);
         assert!(result.has_more);
         assert_eq!(result.streams[0].symbol, "ETHUSDT");
+        assert_eq!(result.query_offset, 0);
+        let next_page_hint = result
+            .next_page_hint
+            .as_ref()
+            .expect("paginated stream list should include next-page hint");
+        assert_eq!(next_page_hint.tool, "finance_list_candle_streams");
+        assert_eq!(
+            next_page_hint.default_params,
+            serde_json::json!({
+                "source_name": "binance-spot",
+                "venue": "binance",
+                "timeframe": "1m",
+                "limit": 1,
+                "offset": 1,
+            })
+        );
+        assert!(next_page_hint.required_params.is_empty());
+        assert_eq!(
+            next_page_hint.optional_params,
+            [
+                "source_name",
+                "venue",
+                "symbol",
+                "timeframe",
+                "limit",
+                "offset"
+            ]
+        );
+
+        let second_page = tool
+            .run(
+                FinanceListCandleStreamsParams {
+                    source_name: Some("binance-spot".to_owned()),
+                    venue:       Some("binance".to_owned()),
+                    symbol:      None,
+                    timeframe:   Some("1m".to_owned()),
+                    limit:       Some(1),
+                    offset:      Some(1),
+                },
+                &context(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(second_page.count, 1);
+        assert_eq!(second_page.query_limit, 1);
+        assert_eq!(second_page.query_offset, 1);
+        assert!(!second_page.has_more);
+        assert!(second_page.next_page_hint.is_none());
+        assert_eq!(second_page.streams[0].symbol, "BTCUSDT");
     }
 
     #[tokio::test]
@@ -1195,6 +1338,7 @@ mod tests {
                     symbol:      None,
                     timeframe:   None,
                     limit:       Some(10_000),
+                    offset:      None,
                 },
                 &context(),
             )
@@ -1219,6 +1363,7 @@ mod tests {
                     symbol:      Some(" btcusdt ".to_owned()),
                     timeframe:   Some(" 1M ".to_owned()),
                     limit:       None,
+                    offset:      None,
                 },
                 &context(),
             )

--- a/crates/extensions/rara-trading/tests/timescale_container.rs
+++ b/crates/extensions/rara-trading/tests/timescale_container.rs
@@ -119,6 +119,7 @@ async fn timescale_repository_contract_runs_against_testcontainer() -> anyhow::R
             symbol:      None,
             timeframe:   Some(Timeframe::parse("15m")?),
             limit:       10,
+            offset:      0,
         })
         .await?;
     assert_eq!(streams.len(), 2);
@@ -130,6 +131,19 @@ async fn timescale_repository_contract_runs_against_testcontainer() -> anyhow::R
     assert_eq!(streams[1].candle_count, 2);
     assert_eq!(streams[1].first_open_time, ts("2026-07-10T08:15:00Z"));
     assert_eq!(streams[1].latest_open_time, ts("2026-07-10T08:30:00Z"));
+
+    let second_stream_page = repo
+        .candle_streams(CandleStreamListQuery {
+            source_name: Some("timescale-container-contract".to_owned()),
+            venue:       Some("binance".to_owned()),
+            symbol:      None,
+            timeframe:   Some(Timeframe::parse("15m")?),
+            limit:       1,
+            offset:      1,
+        })
+        .await?;
+    assert_eq!(second_stream_page.len(), 1);
+    assert_eq!(second_stream_page[0].symbol, "BTCUSDT");
 
     let missing = repo
         .missing_open_times(CandleRangeQuery {

--- a/docs/guides/finance-subscriptions.md
+++ b/docs/guides/finance-subscriptions.md
@@ -309,10 +309,12 @@ as strings to preserve decimal precision. Each stream returned by
 `finance_query_candles` return `has_more` when additional rows match the
 selectors beyond the returned `query_limit`; narrow by `source_name`, `venue`,
 `symbol`, `timeframe`, or time range before assuming a broad query is
-exhaustive. When `finance_query_candles.has_more` is true, `next_start` contains
-the next candle open time to use as the following query's inclusive `start`,
-and `next_page_hint` calls `finance_query_candles` with that `start`, the same
-selectors, the same exclusive `end`, and the same limit.
+exhaustive. `finance_list_candle_streams` also returns `query_offset`; when
+`has_more` is true, `next_page_hint` calls the same tool with the same filters
+and the next `offset`. When `finance_query_candles.has_more` is true,
+`next_start` contains the next candle open time to use as the following query's
+inclusive `start`, and `next_page_hint` calls `finance_query_candles` with that
+`start`, the same selectors, the same exclusive `end`, and the same limit.
 When `finance_get_recent_candles.has_more` is true, `next_end` contains the
 oldest returned candle open time to use as an exclusive `end` when paging older
 history via `finance_query_candles`; its `next_page_hint` pre-fills that


### PR DESCRIPTION
## Summary
- add offset pagination to finance_list_candle_streams and repository stream-list queries
- return query_offset and next_page_hint for paginated stream discovery
- expose offset in finance market-data hints and backend-admin candle-stream endpoint
- document stream-list pagination behavior

## Verification
- cargo test -p rara-trading market_data::tools::tests::list_candle_streams_tool_reports_when_more_streams_match --lib
- cargo test -p rara-trading --lib
- cargo test -p rara-backend-admin data_feeds::router::tests::market_data_candle_streams_endpoint --lib
- cargo test -p rara-app tools::finance_feed --lib
- cargo check -p rara-trading
- cargo check -p rara-backend-admin
- cargo check -p rara-app
- cargo +nightly fmt --all -- --check
- git diff --check
- scripts/lint-ratchet.sh
- pre-commit: cargo check, cargo fmt, cargo clippy, cargo doc

## Notes
- Attempted local testcontainer verification with cargo test -p rara-trading --test timescale_container; local Docker socket was unavailable at /Users/ryan/.orbstack/run/docker.sock, so CI should provide the authoritative container run.