### PR TITLE
Add recent candle end pagination

### DIFF
--- a/crates/app/src/tools/finance_feed.rs
+++ b/crates/app/src/tools/finance_feed.rs
@@ -2863,7 +2863,7 @@ fn recent_candles_hint_for_subscription(
             "limit": DEFAULT_FEED_EVENT_LIMIT,
         }),
         required_params: Vec::new(),
-        optional_params: ["limit"].into_iter().map(str::to_owned).collect(),
+        optional_params: ["end", "limit"].into_iter().map(str::to_owned).collect(),
     })
 }
 
@@ -5208,7 +5208,7 @@ mod tests {
             })
         );
         assert!(recent_candles_hint.required_params.is_empty());
-        assert_eq!(recent_candles_hint.optional_params, ["limit"]);
+        assert_eq!(recent_candles_hint.optional_params, ["end", "limit"]);
         let freshness_hint = listed.subscriptions[0]
             .freshness_hint
             .as_ref()

--- a/crates/extensions/backend-admin/src/data_feeds/router.rs
+++ b/crates/extensions/backend-admin/src/data_feeds/router.rs
@@ -303,6 +303,7 @@ struct CandleRecentQueryParams {
     symbol:      String,
     timeframe:   String,
     limit:       Option<usize>,
+    end:         Option<String>,
 }
 
 /// Query parameters for a bounded stored closed-candle range.
@@ -1311,12 +1312,18 @@ async fn get_recent_market_data_candles(
 ) -> Result<Json<CandleRecentResponse>, ProblemDetails> {
     let limit = validate_market_data_candle_range_limit(params.limit)?;
     let probe_limit = limit.saturating_add(1);
+    let end = params
+        .end
+        .as_deref()
+        .map(|value| parse_market_data_timestamp("end", value.to_owned()))
+        .transpose()?;
     let query = CandleRecentQuery {
         source_name: normalize_optional_market_data_selector("source_name", params.source_name)?,
-        venue:       normalize_required_market_data_venue(params.venue)?,
-        symbol:      normalize_required_market_data_symbol(params.symbol)?,
-        timeframe:   normalize_required_market_data_timeframe(params.timeframe)?,
-        limit:       probe_limit,
+        venue: normalize_required_market_data_venue(params.venue)?,
+        symbol: normalize_required_market_data_symbol(params.symbol)?,
+        timeframe: normalize_required_market_data_timeframe(params.timeframe)?,
+        limit: probe_limit,
+        end,
     };
 
     let mut candles = state
@@ -3819,6 +3826,7 @@ mod tests {
 
         let app = app_with_user_and_market_data_repo(user_of(Role::Admin), market_data_repo).await;
         let res = app
+            .clone()
             .oneshot(
                 Request::builder()
                     .method("GET")
@@ -3847,6 +3855,32 @@ mod tests {
         assert_eq!(result["candles"][0]["close"], "1006.25");
         assert_eq!(result["candles"][1]["open_time"], "2026-07-10T08:02:00Z");
         assert_eq!(result["candles"][1]["close"], "1007.75");
+
+        let res = app
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri(
+                        "/api/v1/data-feeds/market-data/candles/recent?venue=binance&\
+                         symbol=BTCUSDT&timeframe=1m&limit=2&end=2026-07-10T08:01:00Z",
+                    )
+                    .header("Authorization", "Bearer s3cret")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(res.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(res.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let result: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(result["count"], 1);
+        assert_eq!(result["query_limit"], 2);
+        assert_eq!(result["has_more"], false);
+        assert_eq!(result["next_end"], serde_json::Value::Null);
+        assert_eq!(result["candles"][0]["open_time"], "2026-07-10T08:00:00Z");
     }
 
     #[tokio::test]

--- a/crates/extensions/rara-trading/src/market_data/model.rs
+++ b/crates/extensions/rara-trading/src/market_data/model.rs
@@ -150,6 +150,7 @@ pub struct CandleRecentQuery {
     pub symbol:      String,
     pub timeframe:   Timeframe,
     pub limit:       usize,
+    pub end:         Option<Timestamp>,
 }
 
 /// Stream inventory query for stored candle data.

--- a/crates/extensions/rara-trading/src/market_data/repository.rs
+++ b/crates/extensions/rara-trading/src/market_data/repository.rs
@@ -317,6 +317,7 @@ fn matches_recent_query(candle: &MarketCandle, query: &CandleRecentQuery) -> boo
         && candle.venue == query.venue
         && candle.symbol == query.symbol
         && candle.timeframe == query.timeframe
+        && query.end.is_none_or(|end| candle.open_time < end)
 }
 
 fn matches_stream_query(candle: &MarketCandle, query: &CandleStreamListQuery) -> bool {
@@ -536,6 +537,7 @@ mod tests {
                 symbol:      "BTCUSDT".to_owned(),
                 timeframe:   Timeframe::parse("15m").unwrap(),
                 limit:       2,
+                end:         None,
             })
             .await
             .unwrap();

--- a/crates/extensions/rara-trading/src/market_data/timescale.rs
+++ b/crates/extensions/rara-trading/src/market_data/timescale.rs
@@ -204,8 +204,9 @@ impl MarketDataRepository for TimescaleMarketDataRepository {
                 AND venue = $2
                 AND symbol = $3
                 AND timeframe = $4
+                AND ($5::timestamptz IS NULL OR open_time < $5::timestamptz)
               ORDER BY open_time DESC
-              LIMIT $5
+              LIMIT $6
             ) recent
             ORDER BY open_time ASC
             "#,
@@ -214,6 +215,7 @@ impl MarketDataRepository for TimescaleMarketDataRepository {
         .bind(&query.venue)
         .bind(&query.symbol)
         .bind(query.timeframe.as_str())
+        .bind(query.end.map(|end| end.to_string()))
         .bind(limit)
         .fetch_all(&self.pool)
         .await?;

--- a/crates/extensions/rara-trading/src/market_data/tools.rs
+++ b/crates/extensions/rara-trading/src/market_data/tools.rs
@@ -56,6 +56,9 @@ pub struct FinanceGetRecentCandlesParams {
     pub timeframe:   String,
     #[serde(default)]
     pub limit:       Option<usize>,
+    /// Exclusive candle open-time upper bound for paging older candles.
+    #[serde(default)]
+    pub end:         Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -368,12 +371,18 @@ impl ToolExecute for FinanceGetRecentCandlesTool {
         let venue = normalize_required_venue_selector(params.venue)?;
         let symbol = normalize_required_symbol_selector(params.symbol)?;
         let timeframe = normalize_required_timeframe_selector(params.timeframe)?;
+        let end = params
+            .end
+            .as_deref()
+            .map(|value| parse_timestamp("end", value))
+            .transpose()?;
         let query = CandleRecentQuery {
             source_name: source_name.clone(),
-            venue:       venue.clone(),
-            symbol:      symbol.clone(),
-            timeframe:   timeframe.clone(),
-            limit:       probe_limit,
+            venue: venue.clone(),
+            symbol: symbol.clone(),
+            timeframe: timeframe.clone(),
+            limit: probe_limit,
+            end,
         };
         let mut candles = self.repository.recent_candles(query).await?;
         let has_more = candles.len() > limit;
@@ -687,7 +696,7 @@ fn recent_candles_hint_for_stream(
         tool:            "finance_get_recent_candles".to_owned(),
         default_params:  serde_json::Value::Object(default_params),
         required_params: Vec::new(),
-        optional_params: vec!["limit".to_owned()],
+        optional_params: ["end", "limit"].into_iter().map(str::to_owned).collect(),
     }
 }
 
@@ -821,9 +830,9 @@ fn recent_candles_next_page_hint(
     default_params.insert("limit".to_owned(), serde_json::json!(limit));
 
     Some(FinanceCandleNextPageHint {
-        tool:            "finance_query_candles".to_owned(),
+        tool:            "finance_get_recent_candles".to_owned(),
         default_params:  serde_json::Value::Object(default_params),
-        required_params: vec!["start".to_owned()],
+        required_params: Vec::new(),
         optional_params: ["end", "limit"].into_iter().map(str::to_owned).collect(),
     })
 }
@@ -1193,6 +1202,10 @@ mod tests {
             })
         );
         assert_eq!(
+            result.streams[0].recent_candles_hint.optional_params,
+            ["end", "limit"]
+        );
+        assert_eq!(
             result.streams[0].freshness_hint.default_params,
             serde_json::json!({
                 "source_name": "binance-spot",
@@ -1436,6 +1449,7 @@ mod tests {
                     symbol:      "BTCUSDT".to_owned(),
                     timeframe:   "1m".to_owned(),
                     limit:       Some(1),
+                    end:         None,
                 },
                 &context(),
             )
@@ -1450,7 +1464,7 @@ mod tests {
             .next_page_hint
             .as_ref()
             .expect("paginated recent-candle result should include next-page hint");
-        assert_eq!(next_page_hint.tool, "finance_query_candles");
+        assert_eq!(next_page_hint.tool, "finance_get_recent_candles");
         assert_eq!(
             next_page_hint.default_params,
             serde_json::json!({
@@ -1462,10 +1476,31 @@ mod tests {
                 "limit": 1,
             })
         );
-        assert_eq!(next_page_hint.required_params, ["start"]);
+        assert!(next_page_hint.required_params.is_empty());
         assert_eq!(next_page_hint.optional_params, ["end", "limit"]);
         assert_eq!(result.candles[0].open_time, "2026-07-10T08:01:00Z");
         assert_eq!(result.candles[0].close, "61520.00");
+
+        let older_page = tool
+            .run(
+                FinanceGetRecentCandlesParams {
+                    source_name: Some("binance-spot".to_owned()),
+                    venue:       "binance".to_owned(),
+                    symbol:      "BTCUSDT".to_owned(),
+                    timeframe:   "1m".to_owned(),
+                    limit:       Some(1),
+                    end:         Some("2026-07-10T08:01:00Z".to_owned()),
+                },
+                &context(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(older_page.count, 1);
+        assert_eq!(older_page.query_limit, 1);
+        assert!(!older_page.has_more);
+        assert_eq!(older_page.next_end, None);
+        assert!(older_page.next_page_hint.is_none());
+        assert_eq!(older_page.candles[0].open_time, "2026-07-10T08:00:00Z");
     }
 
     #[tokio::test]

--- a/crates/extensions/rara-trading/tests/timescale_container.rs
+++ b/crates/extensions/rara-trading/tests/timescale_container.rs
@@ -95,11 +95,25 @@ async fn timescale_repository_contract_runs_against_testcontainer() -> anyhow::R
             symbol:      "BTCUSDT".to_owned(),
             timeframe:   Timeframe::parse("15m")?,
             limit:       1,
+            end:         None,
         })
         .await?;
     assert_eq!(recent.len(), 1);
     assert_eq!(recent[0].open_time, ts("2026-07-10T08:30:00Z"));
     assert_eq!(recent[0].close, dec("61700.00"));
+
+    let older_recent = repo
+        .recent_candles(CandleRecentQuery {
+            source_name: Some("timescale-container-contract".to_owned()),
+            venue:       "binance".to_owned(),
+            symbol:      "BTCUSDT".to_owned(),
+            timeframe:   Timeframe::parse("15m")?,
+            limit:       1,
+            end:         Some(ts("2026-07-10T08:30:00Z")),
+        })
+        .await?;
+    assert_eq!(older_recent.len(), 1);
+    assert_eq!(older_recent[0].open_time, ts("2026-07-10T08:15:00Z"));
 
     assert_eq!(
         repo.upsert_closed_candle(MarketCandle {

--- a/docs/guides/finance-subscriptions.md
+++ b/docs/guides/finance-subscriptions.md
@@ -317,8 +317,8 @@ inclusive `start`, and `next_page_hint` calls `finance_query_candles` with that
 `start`, the same selectors, the same exclusive `end`, and the same limit.
 When `finance_get_recent_candles.has_more` is true, `next_end` contains the
 oldest returned candle open time to use as an exclusive `end` when paging older
-history via `finance_query_candles`; its `next_page_hint` pre-fills that
-exclusive `end` and keeps `start` as the only required parameter. The
+history via another `finance_get_recent_candles` call; its `next_page_hint`
+pre-fills that exclusive `end`. The
 stream-list, recent-candle, and candle-range limits are capped at 9,999 so the
 tools can probe one extra row and report pagination state accurately.
 


### PR DESCRIPTION
## Summary
- add an exclusive end cursor to finance_get_recent_candles
- make recent-candle next-page hints call finance_get_recent_candles directly instead of requiring finance_query_candles plus manual start
- expose the same end cursor through the backend-admin recent candles endpoint and Timescale repository contract

## Verification
- cargo test -p rara-trading --lib
- cargo test -p rara-trading --test timescale_container
- cargo test -p rara-backend-admin data_feeds::router::tests::market_data_recent_candles_endpoint_returns_latest_candles --lib
- cargo test -p rara-backend-admin data_feeds::router::tests::market_data_candle_streams_endpoint_reports_has_more --lib
- cargo test -p rara-app tools::finance_feed --lib
- cargo check -p rara-app
- cargo +nightly fmt --all -- --check
- git diff --check
- scripts/lint-ratchet.sh
- commit hook: cargo check, fmt, clippy, doc