### PR TITLE
Echo finance subscribe selectors

### DIFF
--- a/crates/extensions/rara-trading/src/finance/tools.rs
+++ b/crates/extensions/rara-trading/src/finance/tools.rs
@@ -66,8 +66,14 @@ pub struct FinanceSubscribeParams {
 #[derive(Debug, Clone, Serialize)]
 pub struct FinanceSubscribeResult {
     pub subscription_id:        Uuid,
+    pub event_kinds:            Vec<FinanceEventKind>,
     pub source_names:           Vec<String>,
     pub catalog_source_ids:     Vec<String>,
+    pub category_tags:          Vec<String>,
+    pub watch_terms:            Vec<String>,
+    pub venues:                 Vec<String>,
+    pub symbols:                Vec<String>,
+    pub timeframes:             Vec<String>,
     pub delivery:               FinanceDelivery,
     pub cooldown_secs:          u64,
     pub max_immediate_per_hour: u16,
@@ -202,21 +208,29 @@ impl ToolExecute for FinanceSubscribeTool {
             max_immediate_per_hour,
         };
         let subscription_id = self.registry.upsert(subscription).await?;
-        let source_names = self
+        let saved_subscription = self
             .registry
             .list_for_owner(&owner)
             .await
             .into_iter()
             .find(|subscription| subscription.id == subscription_id)
-            .map_or_else(Vec::new, |subscription| subscription.source_names);
+            .ok_or_else(|| {
+                anyhow::anyhow!("created finance subscription {subscription_id} was not persisted")
+            })?;
 
         Ok(FinanceSubscribeResult {
             subscription_id,
-            source_names,
+            event_kinds: saved_subscription.event_kinds,
+            source_names: saved_subscription.source_names,
             catalog_source_ids,
-            delivery,
-            cooldown_secs,
-            max_immediate_per_hour,
+            category_tags: saved_subscription.category_tags,
+            watch_terms: saved_subscription.watch_terms,
+            venues: saved_subscription.venues,
+            symbols: saved_subscription.symbols,
+            timeframes: saved_subscription.timeframes,
+            delivery: saved_subscription.delivery,
+            cooldown_secs: saved_subscription.cooldown_secs,
+            max_immediate_per_hour: saved_subscription.max_immediate_per_hour,
         })
     }
 }
@@ -664,7 +678,13 @@ mod tests {
             .unwrap();
 
         assert_eq!(result.catalog_source_ids, ["fed-press-releases"]);
+        assert_eq!(result.event_kinds, [FinanceEventKind::RssArticle]);
         assert_eq!(result.source_names, ["finance-fed-press-releases"]);
+        assert_eq!(result.watch_terms, ["rate cut"]);
+        assert!(result.category_tags.is_empty());
+        assert!(result.venues.is_empty());
+        assert!(result.symbols.is_empty());
+        assert!(result.timeframes.is_empty());
 
         let subs = registry
             .list_for_owner(&rara_kernel::identity::UserId("alice".to_owned()))
@@ -702,7 +722,13 @@ mod tests {
             )
             .await
             .unwrap();
+        assert_eq!(result.event_kinds, [FinanceEventKind::MarketCandleClosed]);
         assert_eq!(result.source_names, ["finance-binance-market-candles"]);
+        assert_eq!(result.category_tags, ["category:market-data"]);
+        assert!(result.watch_terms.is_empty());
+        assert_eq!(result.venues, ["binance"]);
+        assert_eq!(result.symbols, ["BTCUSDT"]);
+        assert_eq!(result.timeframes, ["15m"]);
 
         let subs = registry
             .list_for_owner(&rara_kernel::identity::UserId("alice".to_owned()))

--- a/docs/guides/finance-subscriptions.md
+++ b/docs/guides/finance-subscriptions.md
@@ -170,6 +170,13 @@ For a single `(source_name, venue, symbol, timeframe)` subscription, the result
 also includes direct hints for latest, recent, freshness, gap, and bounded range
 candle tools.
 
+The lower-level `finance_subscribe` tool remains available for callers that
+already know the exact selectors. Its result echoes the persisted normalized
+subscription selectors (`event_kinds`, `source_names`, `category_tags`,
+`watch_terms`, `venues`, `symbols`, and `timeframes`) plus the delivery policy,
+so rara can explain the created subscription without an immediate follow-up list
+call.
+
 `finance_list_subscriptions` is the preferred status view after a subscription
 exists. Each subscription includes source/runtime details, an
 `unsubscribe_hint` for `finance_unsubscribe`, and an `events_hint` for


### PR DESCRIPTION
## Summary
- Return persisted normalized selectors from finance_subscribe results
- Read back the created subscription from the registry so the response reflects authoritative stored state
- Document the lower-level subscribe result contract

## Verification
- cargo test -p rara-trading finance::tools --lib
- cargo +nightly fmt --all -- --check
- git diff --check
- cargo check -p rara-trading
- cargo check -p rara-app
- scripts/lint-ratchet.sh
- pre-commit: cargo check, cargo fmt, cargo clippy, cargo doc