### PR TITLE
Improve finance tool discovery

### DIFF
--- a/crates/app/src/tools/discover.rs
+++ b/crates/app/src/tools/discover.rs
@@ -74,6 +74,7 @@ impl ToolExecute for DiscoverToolsTool {
             .query
             .trim_matches(|c: char| !c.is_alphanumeric() && c != '-' && c != '_')
             .to_lowercase();
+        let query_terms: Vec<&str> = query.split_whitespace().collect();
 
         // --- Search deferred tools ---
         // TODO: pass actual activation state so already-activated tools are excluded.
@@ -88,9 +89,7 @@ impl ToolExecute for DiscoverToolsTool {
 
         let tool_matches: Vec<DiscoveredToolEntry> = catalog
             .iter()
-            .filter(|(name, desc)| {
-                name.to_lowercase().contains(&query) || desc.to_lowercase().contains(&query)
-            })
+            .filter(|(name, desc)| matches_discovery_query(name, desc, &query, &query_terms))
             .map(|(name, desc)| {
                 let parameters = context
                     .tool_registry
@@ -111,10 +110,7 @@ impl ToolExecute for DiscoverToolsTool {
             .skill_registry
             .list_all()
             .into_iter()
-            .filter(|s| {
-                s.name.to_lowercase().contains(&query)
-                    || s.description.to_lowercase().contains(&query)
-            })
+            .filter(|s| matches_discovery_query(&s.name, &s.description, &query, &query_terms))
             .map(|s| DiscoveredSkillEntry {
                 name:        s.name,
                 description: s.description,
@@ -167,4 +163,17 @@ impl ToolExecute for DiscoverToolsTool {
         };
         serde_json::to_value(&result).map_err(Into::into)
     }
+}
+
+fn matches_discovery_query(
+    name: &str,
+    description: &str,
+    query: &str,
+    query_terms: &[&str],
+) -> bool {
+    let haystack = format!("{name} {description}").to_lowercase();
+    if query_terms.len() <= 1 {
+        return haystack.contains(query);
+    }
+    query_terms.iter().all(|term| haystack.contains(term))
 }

--- a/crates/app/src/tools/finance_feed.rs
+++ b/crates/app/src/tools/finance_feed.rs
@@ -566,9 +566,9 @@ pub(super) enum FeedChange {
 #[tool(
     name = "finance_list_feed_sources",
     description = "List built-in finance data feed source catalog entries with current persisted \
-                   config and runtime status. Use this before enabling or subscribing to default \
-                   feeds such as Fed, SEC, Binance, or Longbridge. This is read-only and never \
-                   places trades.",
+                   config and runtime status. Use this before enable or subscribe operations for \
+                   default feeds such as Fed, SEC, Binance, or Longbridge. This is read-only and \
+                   never places trades.",
     tier = "deferred",
     read_only,
     concurrency_safe

--- a/crates/app/src/tools/mod.rs
+++ b/crates/app/src/tools/mod.rs
@@ -564,6 +564,66 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn discover_tools_finds_finance_feed_subscription_tools() {
+        let pools = rara_kernel::testing::build_memory_diesel_pools().await;
+        let data_feed_svc = rara_backend_admin::data_feeds::DataFeedSvc::new(pools);
+        let (event_tx, _event_rx) = tokio::sync::mpsc::channel(16);
+        let data_feed_registry = Arc::new(rara_kernel::data_feed::DataFeedRegistry::new(event_tx));
+        let tmp = tempfile::tempdir().expect("tempdir should be created");
+        let finance_registry = Arc::new(
+            rara_trading::finance::registry::FinanceSubscriptionRegistry::load(
+                tmp.path().join("finance-subscriptions.json"),
+            ),
+        );
+
+        let mut registry = ToolRegistry::new();
+        for tool in [
+            Arc::new(FinanceListFeedSourcesTool::new(
+                data_feed_svc.clone(),
+                data_feed_registry.clone(),
+                finance_registry.clone(),
+            )) as AgentToolRef,
+            Arc::new(FinanceSubscribeNewsTool::new(
+                data_feed_svc.clone(),
+                data_feed_registry.clone(),
+                finance_registry.clone(),
+            )),
+            Arc::new(FinanceSubscribeInstrumentsTool::new(
+                data_feed_svc,
+                data_feed_registry,
+                finance_registry,
+            )),
+        ] {
+            registry.register(tool);
+        }
+        let context = context_with_registry(registry);
+        let discover = DiscoverToolsTool::new(rara_skills::registry::InMemoryRegistry::new());
+
+        let output = discover
+            .execute(
+                serde_json::json!({"query": "finance feed subscribe"}),
+                &context,
+            )
+            .await
+            .expect("discover finance feed subscription tools");
+        let result: DiscoverToolsResult =
+            serde_json::from_value(output.json).expect("discover result");
+
+        assert_eq!(result.status, DiscoverToolsStatus::Activated);
+        let names: Vec<&str> = result.tools.iter().map(|tool| tool.name.as_str()).collect();
+        for expected in [
+            "finance_list_feed_sources",
+            "finance_subscribe_news",
+            "finance_subscribe_instruments",
+        ] {
+            assert!(
+                names.contains(&expected),
+                "discover-tools did not return finance feed tool: {expected}"
+            );
+        }
+    }
+
+    #[tokio::test]
     async fn finance_agent_tools_do_not_accept_provider_configuration_fields() {
         let pools = rara_kernel::testing::build_memory_diesel_pools().await;
         let data_feed_svc = rara_backend_admin::data_feeds::DataFeedSvc::new(pools);

--- a/docs/guides/finance-subscriptions.md
+++ b/docs/guides/finance-subscriptions.md
@@ -159,16 +159,20 @@ operations. Market-candle sources expose `market_data_hint` for
 TSDB stream discovery before querying latest or historical candles.
 
 `finance_subscribe_news` is the specialized RSS/article entry point. It fixes
-`event_kinds` to `rss_article`, rejects non-RSS catalog source IDs, and returns
-the persisted normalized selectors and delivery policy.
+`event_kinds` to `rss_article`, rejects non-RSS feed sources, ensures selected
+catalog or existing RSS feeds are enabled, starts them by default, creates or
+updates the subscription for the current ToolContext identity/session, and
+returns unsubscribe and event-query hints.
 
 `finance_subscribe_instruments` is the specialized closed-candle entry point.
 It fixes `event_kinds` to `market_candle_closed`, rejects non-`market_candle`
-catalog source IDs, derives `venue` from a selected market-candle catalog
-source when omitted, and returns the persisted normalized selectors and delivery
-policy. Use `finance_list_candle_streams` after subscription creation to
-discover stored TSDB streams, then call the single-stream candle tools for
-latest, recent, freshness, gaps, or bounded ranges.
+feed sources, derives `venue` from a selected market-candle source when omitted,
+persists requested `symbols` and `timeframes` into the feed transport, starts or
+restarts the runtime feed by default when needed, and returns market-data,
+diagnostic, and single-stream candle-query hints. Use
+`finance_list_candle_streams` after subscription creation to discover stored
+TSDB streams, then call the single-stream candle tools for latest, recent,
+freshness, gaps, or bounded ranges.
 
 The lower-level `finance_subscribe` tool remains available for callers that
 already know the exact selectors. Its result echoes the persisted normalized
@@ -256,8 +260,8 @@ Example article subscription:
 
 For built-in RSS sources, `finance_subscribe_news` is the preferred
 conversation entry point because it narrows the call surface to article
-subscriptions and expands selected RSS catalog IDs into subscription source
-names:
+subscriptions, materializes the selected RSS catalog feeds when needed, and
+expands catalog IDs into subscription source names:
 
 ```json
 {
@@ -280,9 +284,11 @@ Example candle subscription:
 ```
 
 `finance_subscribe_instruments` derives `venue` from the selected
-`market_candle` feed when omitted. If a caller supplies `venue`, it must match
-the feed transport venue; mismatches are rejected before subscription creation
-because the feed cannot emit candles for another venue.
+`market_candle` feed when omitted. It also persists requested `symbols` and
+`timeframes` into the feed transport before creating the subscription. If a
+caller supplies `venue`, it must match the feed transport venue; mismatches are
+rejected before subscription creation because the feed cannot emit candles for
+another venue.
 
 Default delivery is `silent`. Immediate delivery is bounded by per-subscription
 cooldown and hourly budget; events above the budget are appended to tape rather


### PR DESCRIPTION
## Summary
- make discover-tools match multi-word queries by requiring every query term to appear in the tool or skill name/description
- make finance_list_feed_sources discoverable for finance feed subscribe queries
- add a regression test that discovers finance feed subscription tools from a natural multi-word query
- align finance subscription guide with the app-level specialized subscribe behavior

## Verification
- cargo test -p rara-app tools::tests::discover_tools_finds_finance --lib
- cargo +nightly fmt --all -- --check
- git diff --check
- cargo check -p rara-app
- cargo check -p rara-trading
- scripts/lint-ratchet.sh
- pre-commit run --all-files