### PR TITLE
Guard finance tool identity schema

### DIFF
--- a/crates/app/src/tools/mod.rs
+++ b/crates/app/src/tools/mod.rs
@@ -624,7 +624,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn finance_agent_tools_do_not_accept_provider_configuration_fields() {
+    async fn finance_agent_tools_do_not_accept_provider_configuration_or_identity_fields() {
         let pools = rara_kernel::testing::build_memory_diesel_pools().await;
         let data_feed_svc = rara_backend_admin::data_feeds::DataFeedSvc::new(pools);
         let (event_tx, _event_rx) = tokio::sync::mpsc::channel(16);
@@ -696,10 +696,14 @@ mod tests {
             "headers",
             "order",
             "orders",
+            "owner",
             "provider_url",
+            "session",
+            "session_key",
             "transport",
             "url",
             "urls",
+            "user_id",
         ];
 
         for tool in tools {
@@ -713,8 +717,8 @@ mod tests {
             for field in forbidden_fields {
                 assert!(
                     !fields.iter().any(|candidate| candidate == field),
-                    "finance tool {} exposes provider/configuration field `{field}` in schema \
-                     properties {fields:?}",
+                    "finance tool {} exposes provider/configuration/identity field `{field}` in \
+                     schema properties {fields:?}",
                     tool.name()
                 );
             }

--- a/docs/guides/finance-subscriptions.md
+++ b/docs/guides/finance-subscriptions.md
@@ -241,11 +241,14 @@ as an exclusive open-time upper bound. Freshness defaults its stale threshold to
 2x the timeframe step. Gap checks use the same inclusive/exclusive range
 semantics and are capped at 10,000 expected candles.
 
-Identity and session routing are always taken from `ToolContext`. The tool
-schema has no `owner` or `session` parameter, so an agent cannot subscribe or
-unsubscribe on behalf of another user by passing forged IDs. Subscription list
-results also omit internal `owner` and `session_key` routing fields; they expose
-only the subscription ID, normalized selectors, and delivery policy.
+Identity and session routing are always taken from `ToolContext`. Finance tool
+schemas do not accept `owner`, `user_id`, `session`, or `session_key` identity
+parameters, so an agent cannot subscribe or unsubscribe on behalf of another
+user or conversation by passing forged IDs. `current_session_only` is only a
+scope flag for listing/removing the current user's subscriptions; it does not
+select an arbitrary session. Subscription list results also omit internal
+`owner` and `session_key` routing fields; they expose only the subscription ID,
+normalized selectors, source/runtime context, hints, and delivery policy.
 
 Example article subscription:
 


### PR DESCRIPTION
## Summary
- extend finance tool schema guardrails to reject identity/routing fields like owner, user_id, session, and session_key
- clarify that current_session_only is a scope flag, not a forged session selector
- update the finance subscription guide to match the public tool contract

## Tests
- cargo test -p rara-app finance_agent_tools_do_not_accept_provider_configuration_or_identity_fields --lib
- cargo +nightly fmt --all -- --check
- git diff --check
- cargo check -p rara-app
- scripts/lint-ratchet.sh
- pre-commit run --all-files