### PR TITLE
Index feed event queries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7336,6 +7336,8 @@ name = "rara-model"
 version = "0.0.1"
 dependencies = [
  "diesel",
+ "diesel_migrations",
+ "tempfile",
 ]
 
 [[package]]

--- a/crates/app/src/tools/finance_feed.rs
+++ b/crates/app/src/tools/finance_feed.rs
@@ -3496,6 +3496,10 @@ mod tests {
             )",
             "CREATE INDEX idx_data_feed_events_source ON data_feed_events(source_name)",
             "CREATE INDEX idx_data_feed_events_received ON data_feed_events(received_at)",
+            "CREATE INDEX idx_data_feed_events_source_received_created_id ON \
+             data_feed_events(source_name, received_at DESC, created_at DESC, id DESC)",
+            "CREATE INDEX idx_data_feed_events_source_type_received_created_id ON \
+             data_feed_events(source_name, event_type, received_at DESC, created_at DESC, id DESC)",
         ] {
             diesel::sql_query(ddl)
                 .execute(&mut *conn)

--- a/crates/extensions/backend-admin/src/data_feeds/router.rs
+++ b/crates/extensions/backend-admin/src/data_feeds/router.rs
@@ -2419,6 +2419,10 @@ mod tests {
             )",
             "CREATE INDEX idx_data_feed_events_source ON data_feed_events(source_name)",
             "CREATE INDEX idx_data_feed_events_received ON data_feed_events(received_at)",
+            "CREATE INDEX idx_data_feed_events_source_received_created_id ON \
+             data_feed_events(source_name, received_at DESC, created_at DESC, id DESC)",
+            "CREATE INDEX idx_data_feed_events_source_type_received_created_id ON \
+             data_feed_events(source_name, event_type, received_at DESC, created_at DESC, id DESC)",
         ] {
             diesel::sql_query(ddl)
                 .execute(&mut *conn)

--- a/crates/rara-model/Cargo.toml
+++ b/crates/rara-model/Cargo.toml
@@ -14,5 +14,9 @@ description = "Database-layer models and SQL migrations shared across domains"
 [dependencies]
 diesel = { workspace = true }
 
+[dev-dependencies]
+diesel_migrations = { workspace = true }
+tempfile = { workspace = true }
+
 [lints]
 workspace = true

--- a/crates/rara-model/migrations/20260713000000_datafeed_event_query_index/down.sql
+++ b/crates/rara-model/migrations/20260713000000_datafeed_event_query_index/down.sql
@@ -1,0 +1,2 @@
+DROP INDEX IF EXISTS idx_data_feed_events_source_type_received_created_id;
+DROP INDEX IF EXISTS idx_data_feed_events_source_received_created_id;

--- a/crates/rara-model/migrations/20260713000000_datafeed_event_query_index/up.sql
+++ b/crates/rara-model/migrations/20260713000000_datafeed_event_query_index/up.sql
@@ -1,0 +1,9 @@
+-- Optimize feed-event pages used by finance source diagnostics and event
+-- inspection. These queries filter by source_name, optionally by event_type,
+-- then return the latest events in a deterministic order.
+
+CREATE INDEX idx_data_feed_events_source_received_created_id
+ON data_feed_events(source_name, received_at DESC, created_at DESC, id DESC);
+
+CREATE INDEX idx_data_feed_events_source_type_received_created_id
+ON data_feed_events(source_name, event_type, received_at DESC, created_at DESC, id DESC);

--- a/crates/rara-model/tests/data_feed_indexes.rs
+++ b/crates/rara-model/tests/data_feed_indexes.rs
@@ -1,0 +1,44 @@
+// Copyright 2026 Rararulab
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use diesel::{Connection, QueryableByName, RunQueryDsl, sql_types::Text, sqlite::SqliteConnection};
+use diesel_migrations::{EmbeddedMigrations, MigrationHarness, embed_migrations};
+
+const MIGRATIONS: EmbeddedMigrations = embed_migrations!("migrations");
+
+#[derive(Debug, QueryableByName)]
+struct IndexRow {
+    #[diesel(sql_type = Text)]
+    name: String,
+}
+
+#[test]
+fn data_feed_event_query_indexes_are_migrated() {
+    let db = tempfile::NamedTempFile::new().expect("temp sqlite db");
+    let url = db.path().to_string_lossy();
+    let mut conn = SqliteConnection::establish(&url).expect("open sqlite db");
+    conn.run_pending_migrations(MIGRATIONS)
+        .expect("run rara-model migrations");
+
+    let indexes: Vec<IndexRow> = diesel::sql_query("PRAGMA index_list(data_feed_events)")
+        .load(&mut conn)
+        .expect("list data_feed_events indexes");
+    let names = indexes
+        .into_iter()
+        .map(|index| index.name)
+        .collect::<std::collections::HashSet<_>>();
+
+    assert!(names.contains("idx_data_feed_events_source_received_created_id"));
+    assert!(names.contains("idx_data_feed_events_source_type_received_created_id"));
+}


### PR DESCRIPTION
## Summary
- add composite SQLite indexes for data_feed_events source/time and source/type/time query patterns
- mirror the indexes in data-feed test bootstrap schemas
- add a migration test that applies embedded rara-model migrations and verifies the feed-event query indexes exist

## Verification
- cargo test -p rara-model data_feed_event_query_indexes_are_migrated
- cargo test -p rara-app finance_feed::tests::list_feed_events --lib
- cargo +nightly fmt --all -- --check
- git diff --check
- cargo check -p rara-app
- scripts/lint-ratchet.sh
- pre-commit run --all-files