### PR TITLE
Filter feed events by kind in UI

### DIFF
--- a/web/src/api/__tests__/data-feeds.test.ts
+++ b/web/src/api/__tests__/data-feeds.test.ts
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2026 Rararulab
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { dataFeedsApi } from '../data-feeds';
+
+function installLocalStorageStub() {
+  const store = new Map<string, string>();
+  const stub = {
+    getItem: (k: string) => (store.has(k) ? store.get(k)! : null),
+    setItem: (k: string, v: string) => {
+      store.set(k, String(v));
+    },
+    removeItem: (k: string) => {
+      store.delete(k);
+    },
+    clear: () => store.clear(),
+    key: (i: number) => Array.from(store.keys())[i] ?? null,
+    get length() {
+      return store.size;
+    },
+  };
+  vi.stubGlobal('localStorage', stub);
+  Object.defineProperty(window, 'localStorage', { value: stub, configurable: true });
+}
+
+describe('dataFeedsApi.events URL shape', () => {
+  const originalFetch = globalThis.fetch;
+  const calls: string[] = [];
+
+  beforeEach(() => {
+    installLocalStorageStub();
+    calls.length = 0;
+    globalThis.fetch = vi.fn(async (input: RequestInfo | URL) => {
+      calls.push(typeof input === 'string' ? input : input.toString());
+      return new Response(JSON.stringify({ events: [], total: 0, has_more: false }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    });
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.unstubAllGlobals();
+  });
+
+  it('emits backend event_kinds filter while preserving pagination parameters', async () => {
+    await dataFeedsApi.events('feed-1', {
+      since: '24h',
+      event_kinds: ['market_candle_closed', 'rss_article'],
+      limit: 25,
+      offset: 50,
+    });
+
+    expect(calls).toHaveLength(1);
+    const url = calls[0]!;
+    expect(url).toContain('/api/v1/data-feeds/feed-1/events');
+    expect(url).toContain('since=24h');
+    expect(url).toContain('event_kinds=market_candle_closed%2Crss_article');
+    expect(url).toContain('limit=25');
+    expect(url).toContain('offset=50');
+  });
+});

--- a/web/src/api/data-feeds.ts
+++ b/web/src/api/data-feeds.ts
@@ -408,9 +408,18 @@ export const dataFeedsApi = {
   deleteFinanceSubscription: (id: string) =>
     api.del<DeleteFinanceSubscriptionResponse>(`/api/v1/data-feeds/finance/subscriptions/${id}`),
 
-  events: (id: string, params?: { since?: string; limit?: number; offset?: number }) => {
+  events: (
+    id: string,
+    params?: {
+      since?: string;
+      event_kinds?: FinanceEventKind[];
+      limit?: number;
+      offset?: number;
+    },
+  ) => {
     const query = new URLSearchParams();
     if (params?.since) query.set('since', params.since);
+    if (params?.event_kinds?.length) query.set('event_kinds', params.event_kinds.join(','));
     if (params?.limit) query.set('limit', String(params.limit));
     if (params?.offset) query.set('offset', String(params.offset));
     const qs = query.toString();

--- a/web/src/components/DataFeedsPanel.tsx
+++ b/web/src/components/DataFeedsPanel.tsx
@@ -37,6 +37,7 @@ import {
   type FeedCatalogEntry,
   type FeedEvent,
   type FeedSummary,
+  type FinanceEventKind,
   type FinanceSubscription,
   type FinanceSubscriptionsResponse,
   type CreateFeedRequest,
@@ -436,6 +437,15 @@ const TIME_FILTERS = [
   { value: '7d', label: 'Last 7 days' },
   { value: '30d', label: 'Last 30 days' },
 ] as const;
+
+const EVENT_KIND_FILTERS: ReadonlyArray<{
+  value: 'all' | FinanceEventKind;
+  label: string;
+}> = [
+  { value: 'all', label: 'All event types' },
+  { value: 'rss_article', label: 'RSS articles' },
+  { value: 'market_candle_closed', label: 'K-line closed' },
+];
 
 // ---------------------------------------------------------------------------
 // Empty auth/transport helpers
@@ -1102,15 +1112,23 @@ function EventDetailSheet({
 
 function EventHistoryView({ feed, onBack }: { feed: DataFeedConfig; onBack: () => void }) {
   const [timeFilter, setTimeFilter] = useState('24h');
+  const [eventKindFilter, setEventKindFilter] = useState<'all' | FinanceEventKind>('all');
   const [selectedEvent, setSelectedEvent] = useState<FeedEvent | null>(null);
   const [offset, setOffset] = useState(0);
   const limit = 50;
 
   const since = timeFilter;
+  const eventKinds = eventKindFilter === 'all' ? undefined : [eventKindFilter];
+  const eventQueryParams = {
+    since,
+    ...(eventKinds ? { event_kinds: eventKinds } : {}),
+    limit,
+    offset,
+  };
 
   const eventsQuery = useQuery({
-    queryKey: ['data-feed-events', feed.id, since, offset],
-    queryFn: () => dataFeedsApi.events(feed.id, { since, limit, offset }),
+    queryKey: ['data-feed-events', feed.id, since, eventKindFilter, offset],
+    queryFn: () => dataFeedsApi.events(feed.id, eventQueryParams),
   });
 
   const events = eventsQuery.data?.events ?? [];
@@ -1173,6 +1191,25 @@ function EventHistoryView({ feed, onBack }: { feed: DataFeedConfig; onBack: () =
           </SelectTrigger>
           <SelectContent>
             {TIME_FILTERS.map((f) => (
+              <SelectItem key={f.value} value={f.value}>
+                {f.label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+        <Select
+          value={eventKindFilter}
+          onValueChange={(v) => {
+            setEventKindFilter(v as 'all' | FinanceEventKind);
+            setOffset(0);
+          }}
+        >
+          <SelectTrigger aria-label="Event type" className="h-8 w-44 text-xs">
+            <Radio className="mr-1.5 h-3.5 w-3.5" />
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {EVENT_KIND_FILTERS.map((f) => (
               <SelectItem key={f.value} value={f.value}>
                 {f.label}
               </SelectItem>

--- a/web/src/components/__tests__/DataFeedsPanel.test.tsx
+++ b/web/src/components/__tests__/DataFeedsPanel.test.tsx
@@ -24,6 +24,7 @@ import type {
   CandleStreamsResponse,
   DataFeedConfig,
   FeedCatalogEntry,
+  FeedEventsResponse,
   FinanceSubscription,
   FinanceSubscriptionsResponse,
   MarketCandleFreshnessResponse,
@@ -34,6 +35,7 @@ import type {
 const listMock = vi.fn();
 const summariesMock = vi.fn();
 const catalogMock = vi.fn();
+const eventsMock = vi.fn();
 const financeSubscriptionsMock = vi.fn();
 const candleStreamsMock = vi.fn();
 const candlesMock = vi.fn();
@@ -47,6 +49,7 @@ vi.mock('@/api/data-feeds', () => ({
     list: (...args: unknown[]) => listMock(...args),
     summaries: (...args: unknown[]) => summariesMock(...args),
     catalog: (...args: unknown[]) => catalogMock(...args),
+    events: (...args: unknown[]) => eventsMock(...args),
     financeSubscriptions: (...args: unknown[]) => financeSubscriptionsMock(...args),
     candleStreams: (...args: unknown[]) => candleStreamsMock(...args),
     candles: (...args: unknown[]) => candlesMock(...args),
@@ -117,9 +120,20 @@ function candleSubscription(partial: Partial<FinanceSubscription> = {}): Finance
 }
 
 beforeEach(() => {
+  if (!Element.prototype.hasPointerCapture) {
+    Element.prototype.hasPointerCapture = () => false;
+  }
+  if (!Element.prototype.setPointerCapture) {
+    Element.prototype.setPointerCapture = () => {};
+  }
+  if (!Element.prototype.releasePointerCapture) {
+    Element.prototype.releasePointerCapture = () => {};
+  }
+
   listMock.mockReset();
   summariesMock.mockReset();
   catalogMock.mockReset();
+  eventsMock.mockReset();
   financeSubscriptionsMock.mockReset();
   candleStreamsMock.mockReset();
   candlesMock.mockReset();
@@ -130,6 +144,11 @@ beforeEach(() => {
   listMock.mockResolvedValue([]);
   summariesMock.mockResolvedValue([]);
   catalogMock.mockResolvedValue([] satisfies FeedCatalogEntry[]);
+  eventsMock.mockResolvedValue({
+    events: [],
+    total: 0,
+    has_more: false,
+  } satisfies FeedEventsResponse);
   financeSubscriptionsMock.mockResolvedValue({
     subscriptions: [],
     count: 0,
@@ -360,6 +379,37 @@ describe('DataFeedsPanel', () => {
 
     await waitFor(() => {
       expect(candleStreamsMock).toHaveBeenLastCalledWith({ limit: 500 });
+    });
+  });
+
+  it('filters feed history by backend event kind', async () => {
+    listMock.mockResolvedValue([feed()]);
+
+    renderPanel();
+
+    fireEvent.click(await screen.findByRole('button', { name: 'finance-binance-market-candles' }));
+    await waitFor(() => {
+      expect(eventsMock).toHaveBeenLastCalledWith('feed-1', {
+        since: '24h',
+        limit: 50,
+        offset: 0,
+      });
+    });
+
+    fireEvent.pointerDown(screen.getByRole('combobox', { name: 'Event type' }), {
+      button: 0,
+      ctrlKey: false,
+      pointerType: 'mouse',
+    });
+    fireEvent.click(await screen.findByRole('option', { name: 'K-line closed' }));
+
+    await waitFor(() => {
+      expect(eventsMock).toHaveBeenLastCalledWith('feed-1', {
+        since: '24h',
+        event_kinds: ['market_candle_closed'],
+        limit: 50,
+        offset: 0,
+      });
     });
   });
 


### PR DESCRIPTION
## Summary
- Add frontend API support for the backend `event_kinds` feed-event query parameter.
- Add an event type filter to the data feed event history view.
- Cover the API URL shape and DataFeedsPanel event-kind filter behavior.

## Test Plan
- npm --prefix web run typecheck
- npm --prefix web run format:check
- npm --prefix web run test -- src/api/__tests__/data-feeds.test.ts src/components/__tests__/DataFeedsPanel.test.tsx
- npm --prefix web run lint