### PR TITLE
Show last feed event type

### DIFF
--- a/web/src/api/data-feeds.ts
+++ b/web/src/api/data-feeds.ts
@@ -64,6 +64,7 @@ export interface FeedSummary {
   feed_id: string;
   source_name: string;
   event_count: number;
+  last_event_type: string | null;
   last_event_at: string | null;
   lag_seconds: number | null;
 }

--- a/web/src/components/DataFeedsPanel.tsx
+++ b/web/src/components/DataFeedsPanel.tsx
@@ -130,6 +130,10 @@ function lagLabel(summary: FeedSummary | undefined): string {
   return `${Math.floor(hours / 24)}d lag`;
 }
 
+function lastEventTypeLabel(summary: FeedSummary | undefined): string | null {
+  return summary?.last_event_type?.trim() || null;
+}
+
 /** Format type badge label. */
 function typeLabel(t: DataFeedConfig['feed_type']): string {
   switch (t) {
@@ -2405,7 +2409,14 @@ function FeedListView({
                         : undefined
                     }
                   >
-                    {lagLabel(summary)}
+                    <div className="flex flex-col items-end gap-1">
+                      {lastEventTypeLabel(summary) && (
+                        <Badge variant="outline" className="max-w-40 font-mono text-[10px]">
+                          {lastEventTypeLabel(summary)}
+                        </Badge>
+                      )}
+                      <span>{lagLabel(summary)}</span>
+                    </div>
                   </TableCell>
                   <TableCell
                     className="text-right text-xs text-muted-foreground"

--- a/web/src/components/__tests__/DataFeedsPanel.test.tsx
+++ b/web/src/components/__tests__/DataFeedsPanel.test.tsx
@@ -290,6 +290,25 @@ describe('DataFeedsPanel', () => {
     });
   });
 
+  it('shows the last feed event type from summary data', async () => {
+    listMock.mockResolvedValue([feed()]);
+    summariesMock.mockResolvedValue([
+      {
+        feed_id: 'feed-1',
+        source_name: 'finance-binance-market-candles',
+        event_count: 12,
+        last_event_type: 'market_candle_closed',
+        last_event_at: '2026-07-12T00:42:02Z',
+        lag_seconds: 30,
+      },
+    ]);
+
+    renderPanel();
+
+    expect(await screen.findByText('market_candle_closed')).toBeInTheDocument();
+    expect(screen.getByText('30s lag')).toBeInTheDocument();
+  });
+
   it('shows an empty state before the first persisted candle', async () => {
     renderPanel();
 


### PR DESCRIPTION
## Summary
- Add `last_event_type` to the frontend `FeedSummary` API model.
- Show the latest feed event kind in the Data Feeds list next to lag, so operators can distinguish RSS articles from market candle closes.
- Cover the UI behavior with a DataFeedsPanel regression test.

## Test Plan
- `git diff --check`
- `npm --prefix web run typecheck`
- `npm --prefix web run format:check`
- `npm --prefix web run test -- src/components/__tests__/DataFeedsPanel.test.tsx`
- `npm --prefix web run lint`