### PR TITLE
Show feed event summaries

### DIFF
--- a/web/src/components/DataFeedsPanel.tsx
+++ b/web/src/components/DataFeedsPanel.tsx
@@ -113,6 +113,43 @@ function payloadSize(payload: unknown): string {
   return `${(bytes / 1024).toFixed(1)}K`;
 }
 
+function payloadRecord(payload: unknown): Record<string, unknown> | null {
+  if (!payload || typeof payload !== 'object' || Array.isArray(payload)) return null;
+  return payload as Record<string, unknown>;
+}
+
+function payloadString(payload: unknown, key: string): string | null {
+  const value = payloadRecord(payload)?.[key];
+  return typeof value === 'string' && value.trim() ? value.trim() : null;
+}
+
+function eventSummary(event: FeedEvent): { title: string; detail: string | null } | null {
+  if (event.event_type === 'market_candle_closed') {
+    const venue = payloadString(event.payload, 'venue')?.toUpperCase();
+    const symbol = payloadString(event.payload, 'symbol');
+    const timeframe = payloadString(event.payload, 'timeframe');
+    const close = payloadString(event.payload, 'close');
+    const title = [venue, symbol, timeframe].filter(Boolean).join(' · ');
+
+    if (!title) return null;
+    return {
+      title,
+      detail: close ? `close ${close}` : null,
+    };
+  }
+
+  if (event.event_type === 'rss_article') {
+    const title = payloadString(event.payload, 'title');
+    if (!title) return null;
+    return {
+      title,
+      detail: payloadString(event.payload, 'url') ?? payloadString(event.payload, 'summary'),
+    };
+  }
+
+  return null;
+}
+
 function eventCountLabel(count: number): string {
   return `${count} event${count === 1 ? '' : 's'}`;
 }
@@ -1240,36 +1277,55 @@ function EventHistoryView({ feed, onBack }: { feed: DataFeedConfig; onBack: () =
             <TableRow>
               <TableHead className="w-32">Time</TableHead>
               <TableHead>Type</TableHead>
+              <TableHead>Event</TableHead>
               <TableHead className="w-20 text-right">Size</TableHead>
               <TableHead className="w-8" />
             </TableRow>
           </TableHeader>
           <TableBody>
-            {events.map((evt) => (
-              <TableRow
-                key={evt.id}
-                className="cursor-pointer"
-                onClick={() => setSelectedEvent(evt)}
-              >
-                <TableCell
-                  className="font-mono text-xs"
-                  title={new Date(evt.received_at).toLocaleString()}
+            {events.map((evt) => {
+              const summary = eventSummary(evt);
+
+              return (
+                <TableRow
+                  key={evt.id}
+                  className="cursor-pointer"
+                  onClick={() => setSelectedEvent(evt)}
                 >
-                  {timeAgo(evt.received_at)}
-                </TableCell>
-                <TableCell>
-                  <Badge variant="outline" className="text-xs">
-                    {evt.event_type}
-                  </Badge>
-                </TableCell>
-                <TableCell className="text-right text-xs text-muted-foreground">
-                  {payloadSize(evt.payload)}
-                </TableCell>
-                <TableCell>
-                  <ChevronRight className="h-4 w-4 text-muted-foreground" />
-                </TableCell>
-              </TableRow>
-            ))}
+                  <TableCell
+                    className="font-mono text-xs"
+                    title={new Date(evt.received_at).toLocaleString()}
+                  >
+                    {timeAgo(evt.received_at)}
+                  </TableCell>
+                  <TableCell>
+                    <Badge variant="outline" className="text-xs">
+                      {evt.event_type}
+                    </Badge>
+                  </TableCell>
+                  <TableCell>
+                    {summary ? (
+                      <div className="min-w-0">
+                        <div className="truncate text-sm font-medium">{summary.title}</div>
+                        {summary.detail && (
+                          <div className="truncate font-mono text-xs text-muted-foreground">
+                            {summary.detail}
+                          </div>
+                        )}
+                      </div>
+                    ) : (
+                      <span className="text-xs text-muted-foreground">Raw event</span>
+                    )}
+                  </TableCell>
+                  <TableCell className="text-right text-xs text-muted-foreground">
+                    {payloadSize(evt.payload)}
+                  </TableCell>
+                  <TableCell>
+                    <ChevronRight className="h-4 w-4 text-muted-foreground" />
+                  </TableCell>
+                </TableRow>
+              );
+            })}
           </TableBody>
         </Table>
       )}

--- a/web/src/components/__tests__/DataFeedsPanel.test.tsx
+++ b/web/src/components/__tests__/DataFeedsPanel.test.tsx
@@ -432,6 +432,37 @@ describe('DataFeedsPanel', () => {
     });
   });
 
+  it('shows a compact K-line summary in feed history rows', async () => {
+    listMock.mockResolvedValue([feed()]);
+    eventsMock.mockResolvedValue({
+      events: [
+        {
+          id: 'event-1',
+          source_name: 'finance-binance-market-candles',
+          event_type: 'market_candle_closed',
+          tags: ['finance', 'market-data', 'venue:binance', 'symbol:BTCUSDT', 'timeframe:1m'],
+          payload: {
+            venue: 'binance',
+            symbol: 'BTCUSDT',
+            timeframe: '1m',
+            close_time: '2026-07-12T00:42:00Z',
+            close: '61610.30',
+          },
+          received_at: '2026-07-12T00:42:02Z',
+        },
+      ],
+      total: 1,
+      has_more: false,
+    } satisfies FeedEventsResponse);
+
+    renderPanel();
+
+    fireEvent.click(await screen.findByRole('button', { name: 'finance-binance-market-candles' }));
+
+    expect(await screen.findByText('BINANCE · BTCUSDT · 1m')).toBeInTheDocument();
+    expect(screen.getByText('close 61610.30')).toBeInTheDocument();
+  });
+
   it('shows fresh health for a K-line subscription with a matching stored stream', async () => {
     vi.spyOn(Date, 'now').mockReturnValue(Date.parse('2026-07-12T00:42:30Z'));
     financeSubscriptionsMock.mockResolvedValue({


### PR DESCRIPTION
## Summary
- Add compact event summaries to feed history rows so operators do not need to open raw JSON for every event.
- Summarize K-line close events as `VENUE · SYMBOL · timeframe` plus the close price, keeping price values as strings.
- Also support RSS article summaries from payload title/url/summary fields, with a safe event-id fallback for unknown payloads.

## Test Plan
- `git diff --check`
- `npm --prefix web run typecheck`
- `npm --prefix web run format:check`
- `npm --prefix web run test -- src/components/__tests__/DataFeedsPanel.test.tsx`
- `npm --prefix web run lint`