### PR TITLE
Summarize finance feed event pages

### DIFF
--- a/crates/app/src/tools/finance_feed.rs
+++ b/crates/app/src/tools/finance_feed.rs
@@ -253,8 +253,12 @@ pub(super) struct FinanceListFeedEventsParams {
 
 #[derive(Debug, Clone, Serialize)]
 pub(super) struct FinanceListFeedEventsResult {
-    pub sources: Vec<FinanceFeedEventPage>,
-    pub query:   FinanceListFeedEventsQuery,
+    pub sources:      Vec<FinanceFeedEventPage>,
+    pub query:        FinanceListFeedEventsQuery,
+    pub source_count: usize,
+    pub event_count:  usize,
+    pub total:        i64,
+    pub has_more:     bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
@@ -1034,7 +1038,19 @@ impl ToolExecute for FinanceListFeedEventsTool {
             });
         }
 
-        Ok(FinanceListFeedEventsResult { sources, query })
+        let source_count = sources.len();
+        let event_count = sources.iter().map(|page| page.events.len()).sum();
+        let total = sources.iter().map(|page| page.total).sum();
+        let has_more = sources.iter().any(|page| page.has_more);
+
+        Ok(FinanceListFeedEventsResult {
+            sources,
+            query,
+            source_count,
+            event_count,
+            total,
+            has_more,
+        })
     }
 }
 
@@ -4699,6 +4715,10 @@ mod tests {
             .await
             .unwrap();
 
+        assert_eq!(result.source_count, 1);
+        assert_eq!(result.event_count, 1);
+        assert_eq!(result.total, 2);
+        assert!(result.has_more);
         assert_eq!(result.sources.len(), 1);
         let page = &result.sources[0];
         assert_eq!(

--- a/docs/guides/finance-subscriptions.md
+++ b/docs/guides/finance-subscriptions.md
@@ -218,7 +218,8 @@ pages with `total`, `has_more`, `query_limit`, and `query_offset`. Pages with
 next `offset`. The result also echoes a normalized `query` with resolved unique
 sources, event-kind strings, `since`, `query_limit`, and `query_offset`, so rara
 can explain empty pages or paginated event lookups without reconstructing the
-request.
+request. Top-level `source_count`, `event_count`, `total`, and `has_more`
+summarize the returned pages across all selected sources.
 
 For built-in catalog entries, `provider` is catalog metadata used by the agent
 and UI to label fixed data sources such as Binance and Longbridge. It is


### PR DESCRIPTION
## Summary
- add top-level source_count, event_count, total, and has_more to finance_list_feed_events
- keep per-source pages unchanged while making event lookups easier to explain
- document the feed-event rollup fields

## Validation
- cargo test -p rara-app list_feed_events -- --nocapture
- cargo +nightly fmt --check -p rara-app
- git diff --check
- cargo check -p rara-app
- cargo clippy -p rara-app --lib --all-targets -- -D warnings
- pre-commit with BOXLITE_DEPS_STUB=1: cargo check/fmt/clippy/doc/check-agent-md
