### PR TITLE
Add source filters to finance candle diagnostics

### DIFF
--- a/crates/app/src/tools/finance_diagnostics.rs
+++ b/crates/app/src/tools/finance_diagnostics.rs
@@ -12,7 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::{collections::HashMap, sync::Arc};
+use std::{
+    collections::{HashMap, HashSet},
+    sync::Arc,
+};
 
 use async_trait::async_trait;
 use jiff::Timestamp;
@@ -33,18 +36,29 @@ use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
 const MAX_STALE_AFTER_SECS: u64 = 31_536_000;
+const MAX_DIAGNOSTIC_SOURCE_REFS: usize = 32;
+const MAX_DIAGNOSTIC_SOURCE_REF_LEN: usize = 128;
 
 #[derive(Debug, Deserialize, JsonSchema)]
 pub(super) struct FinanceDiagnoseCandleSubscriptionsParams {
     /// Optional current-user subscription id filter.
     #[serde(default)]
-    pub subscription_id:  Option<Uuid>,
+    pub subscription_id:    Option<Uuid>,
+    /// Built-in market-candle source ids from finance_list_feed_sources.
+    #[serde(default)]
+    pub catalog_source_ids: Vec<String>,
+    /// Concrete finance market-candle source names.
+    #[serde(default)]
+    pub source_names:       Vec<String>,
+    /// Existing persisted finance DataFeedConfig ids.
+    #[serde(default)]
+    pub feed_ids:           Vec<String>,
     /// Comparison timestamp. Defaults to server now.
     #[serde(default)]
-    pub as_of:            Option<String>,
+    pub as_of:              Option<String>,
     /// Stale threshold in seconds. Defaults to 2x each timeframe step.
     #[serde(default)]
-    pub stale_after_secs: Option<u64>,
+    pub stale_after_secs:   Option<u64>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -147,6 +161,58 @@ struct FeedEventSummary {
     last_event_at:   Option<Timestamp>,
 }
 
+#[derive(Debug, Clone)]
+struct DiagnosticSourceFilter {
+    source_names: Option<HashSet<String>>,
+}
+
+impl DiagnosticSourceFilter {
+    fn from_params(
+        feeds_by_name: &HashMap<String, DataFeedConfig>,
+        catalog_source_ids: Vec<String>,
+        source_names: Vec<String>,
+        feed_ids: Vec<String>,
+    ) -> anyhow::Result<Self> {
+        let catalog_source_ids =
+            normalize_diagnostic_refs("catalog_source_ids", catalog_source_ids)?;
+        let source_names = normalize_diagnostic_refs("source_names", source_names)?;
+        let feed_ids = normalize_diagnostic_refs("feed_ids", feed_ids)?;
+        anyhow::ensure!(
+            catalog_source_ids.len() + source_names.len() + feed_ids.len()
+                <= MAX_DIAGNOSTIC_SOURCE_REFS,
+            "too many diagnostic source filters"
+        );
+
+        let mut selected_source_names = HashSet::new();
+        for catalog_source_id in catalog_source_ids {
+            selected_source_names.insert(find_catalog_source(&catalog_source_id)?.feed_name());
+        }
+        for source_name in source_names {
+            selected_source_names.insert(source_name);
+        }
+        for feed_id in feed_ids {
+            let feed = feeds_by_name
+                .values()
+                .find(|feed| feed.id == feed_id)
+                .ok_or_else(|| anyhow::anyhow!("unknown data feed id: {feed_id}"))?;
+            selected_source_names.insert(feed.name.clone());
+        }
+
+        Ok(Self {
+            source_names: (!selected_source_names.is_empty()).then_some(selected_source_names),
+        })
+    }
+
+    fn matches(&self, subscription: &FinanceSubscription) -> bool {
+        self.source_names.as_ref().is_none_or(|source_names| {
+            subscription
+                .source_names
+                .iter()
+                .any(|source_name| source_names.contains(source_name))
+        })
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub(super) enum CandleStreamStatus {
@@ -163,7 +229,9 @@ pub(super) enum CandleStreamStatus {
     description = "Diagnose current-user finance candle subscriptions by combining subscription \
                    selectors, feed config/runtime status, and latest stored candle freshness. Use \
                    this after finance_subscribe_instruments to verify that data is actually \
-                   flowing. This is read-only and never places trades.",
+                   flowing, or after an empty market-candle finance_list_feed_events result with \
+                   the same catalog_source_ids, source_names, or feed_ids selector. This is \
+                   read-only and never places trades.",
     tier = "deferred",
     read_only,
     concurrency_safe
@@ -210,6 +278,12 @@ impl ToolExecute for FinanceDiagnoseCandleSubscriptionsTool {
             .into_iter()
             .map(|feed| (feed.name.clone(), feed))
             .collect::<HashMap<_, _>>();
+        let source_filter = DiagnosticSourceFilter::from_params(
+            &feeds_by_name,
+            params.catalog_source_ids,
+            params.source_names,
+            params.feed_ids,
+        )?;
         let event_summaries = self
             .data_feed_svc
             .event_summaries()
@@ -238,6 +312,7 @@ impl ToolExecute for FinanceDiagnoseCandleSubscriptionsTool {
                     .subscription_id
                     .is_none_or(|id| id == subscription.id)
             })
+            .filter(|subscription| source_filter.matches(subscription))
             .collect::<Vec<_>>();
 
         let mut diagnostics = Vec::with_capacity(subscriptions.len());
@@ -479,6 +554,35 @@ fn catalog_by_source_name() -> HashMap<String, DefaultFeedSource> {
         .into_iter()
         .map(|source| (source.feed_name(), source))
         .collect()
+}
+
+fn find_catalog_source(catalog_source_id: &str) -> anyhow::Result<DefaultFeedSource> {
+    default_finance_feed_sources()
+        .into_iter()
+        .find(|source| source.id == catalog_source_id)
+        .ok_or_else(|| {
+            anyhow::anyhow!("unknown finance feed catalog source id: {catalog_source_id}")
+        })
+}
+
+fn normalize_diagnostic_refs(label: &str, values: Vec<String>) -> anyhow::Result<Vec<String>> {
+    anyhow::ensure!(
+        values.len() <= MAX_DIAGNOSTIC_SOURCE_REFS,
+        "too many {label}"
+    );
+    let mut normalized = Vec::new();
+    for value in values {
+        let value = value.trim();
+        anyhow::ensure!(!value.is_empty(), "{label} must not contain empty values");
+        anyhow::ensure!(
+            value.chars().count() <= MAX_DIAGNOSTIC_SOURCE_REF_LEN,
+            "{label} value is too long"
+        );
+        if !normalized.iter().any(|existing| existing == value) {
+            normalized.push(value.to_owned());
+        }
+    }
+    Ok(normalized)
 }
 
 fn transport_string(transport: &serde_json::Value, key: &str) -> Option<String> {
@@ -936,11 +1040,11 @@ fn feed_events_hint(
         tool:            "finance_list_feed_events".to_owned(),
         default_params:  serde_json::json!({
             "source_names": source_names,
-            "event_types": ["market_candle_closed"],
+            "event_kinds": ["market_candle_closed"],
             "limit": 20
         }),
         required_params: Vec::new(),
-        optional_params: ["after", "before", "offset"].map(str::to_owned).to_vec(),
+        optional_params: ["since", "limit", "offset"].map(str::to_owned).to_vec(),
     })
 }
 
@@ -1224,9 +1328,12 @@ mod tests {
         let result = tool
             .run(
                 FinanceDiagnoseCandleSubscriptionsParams {
-                    subscription_id:  None,
-                    as_of:            Some("2026-07-10T08:31:00Z".to_owned()),
-                    stale_after_secs: Some(120),
+                    subscription_id:    None,
+                    catalog_source_ids: Vec::new(),
+                    source_names:       Vec::new(),
+                    feed_ids:           Vec::new(),
+                    as_of:              Some("2026-07-10T08:31:00Z".to_owned()),
+                    stale_after_secs:   Some(120),
                 },
                 &ctx,
             )
@@ -1316,9 +1423,12 @@ mod tests {
         let result = tool
             .run(
                 FinanceDiagnoseCandleSubscriptionsParams {
-                    subscription_id:  Some(id),
-                    as_of:            Some("2026-07-10T08:31:00Z".to_owned()),
-                    stale_after_secs: Some(120),
+                    subscription_id:    Some(id),
+                    catalog_source_ids: Vec::new(),
+                    source_names:       Vec::new(),
+                    feed_ids:           Vec::new(),
+                    as_of:              Some("2026-07-10T08:31:00Z".to_owned()),
+                    stale_after_secs:   Some(120),
                 },
                 &ctx,
             )
@@ -1398,9 +1508,12 @@ mod tests {
         let result = tool
             .run(
                 FinanceDiagnoseCandleSubscriptionsParams {
-                    subscription_id:  None,
-                    as_of:            Some("2026-07-10T08:31:00Z".to_owned()),
-                    stale_after_secs: None,
+                    subscription_id:    None,
+                    catalog_source_ids: Vec::new(),
+                    source_names:       Vec::new(),
+                    feed_ids:           Vec::new(),
+                    as_of:              Some("2026-07-10T08:31:00Z".to_owned()),
+                    stale_after_secs:   None,
                 },
                 &ctx,
             )
@@ -1434,9 +1547,12 @@ mod tests {
         let result = tool
             .run(
                 FinanceDiagnoseCandleSubscriptionsParams {
-                    subscription_id:  None,
-                    as_of:            Some("2026-07-10T08:31:00Z".to_owned()),
-                    stale_after_secs: None,
+                    subscription_id:    None,
+                    catalog_source_ids: Vec::new(),
+                    source_names:       Vec::new(),
+                    feed_ids:           Vec::new(),
+                    as_of:              Some("2026-07-10T08:31:00Z".to_owned()),
+                    stale_after_secs:   None,
                 },
                 &ctx,
             )
@@ -1482,9 +1598,12 @@ mod tests {
         let result = tool
             .run(
                 FinanceDiagnoseCandleSubscriptionsParams {
-                    subscription_id:  None,
-                    as_of:            Some("2026-07-10T08:31:00Z".to_owned()),
-                    stale_after_secs: None,
+                    subscription_id:    None,
+                    catalog_source_ids: Vec::new(),
+                    source_names:       Vec::new(),
+                    feed_ids:           Vec::new(),
+                    as_of:              Some("2026-07-10T08:31:00Z".to_owned()),
+                    stale_after_secs:   None,
                 },
                 &ctx,
             )
@@ -1509,14 +1628,14 @@ mod tests {
             next_action.default_params,
             serde_json::json!({
                 "source_names": ["finance-binance-market-candles"],
-                "event_types": ["market_candle_closed"],
+                "event_kinds": ["market_candle_closed"],
                 "limit": 20
             })
         );
         assert_eq!(next_action.required_params, Vec::<String>::new());
         assert_eq!(
             next_action.optional_params,
-            ["after", "before", "offset"].map(str::to_owned)
+            ["since", "limit", "offset"].map(str::to_owned)
         );
         assert_eq!(sub.feed_sources[0].runtime_state, FeedRuntimeState::Running);
         assert_eq!(sub.streams[0].status, CandleStreamStatus::Missing);
@@ -1550,9 +1669,12 @@ mod tests {
         let result = tool
             .run(
                 FinanceDiagnoseCandleSubscriptionsParams {
-                    subscription_id:  Some(id),
-                    as_of:            Some("2026-07-10T08:31:00Z".to_owned()),
-                    stale_after_secs: None,
+                    subscription_id:    Some(id),
+                    catalog_source_ids: Vec::new(),
+                    source_names:       Vec::new(),
+                    feed_ids:           Vec::new(),
+                    as_of:              Some("2026-07-10T08:31:00Z".to_owned()),
+                    stale_after_secs:   None,
                 },
                 &ctx,
             )
@@ -1596,9 +1718,12 @@ mod tests {
         let result = tool
             .run(
                 FinanceDiagnoseCandleSubscriptionsParams {
-                    subscription_id:  None,
-                    as_of:            Some("2026-07-10T08:31:00Z".to_owned()),
-                    stale_after_secs: None,
+                    subscription_id:    None,
+                    catalog_source_ids: Vec::new(),
+                    source_names:       Vec::new(),
+                    feed_ids:           Vec::new(),
+                    as_of:              Some("2026-07-10T08:31:00Z".to_owned()),
+                    stale_after_secs:   None,
                 },
                 &ctx,
             )
@@ -1654,9 +1779,12 @@ mod tests {
         let result = tool
             .run(
                 FinanceDiagnoseCandleSubscriptionsParams {
-                    subscription_id:  None,
-                    as_of:            Some("2026-07-10T08:31:00Z".to_owned()),
-                    stale_after_secs: None,
+                    subscription_id:    None,
+                    catalog_source_ids: Vec::new(),
+                    source_names:       Vec::new(),
+                    feed_ids:           Vec::new(),
+                    as_of:              Some("2026-07-10T08:31:00Z".to_owned()),
+                    stale_after_secs:   None,
                 },
                 &ctx,
             )
@@ -1718,9 +1846,12 @@ mod tests {
         let result = tool
             .run(
                 FinanceDiagnoseCandleSubscriptionsParams {
-                    subscription_id:  Some(id),
-                    as_of:            Some("2026-07-10T08:31:00Z".to_owned()),
-                    stale_after_secs: None,
+                    subscription_id:    Some(id),
+                    catalog_source_ids: Vec::new(),
+                    source_names:       Vec::new(),
+                    feed_ids:           Vec::new(),
+                    as_of:              Some("2026-07-10T08:31:00Z".to_owned()),
+                    stale_after_secs:   None,
                 },
                 &ctx,
             )
@@ -1729,6 +1860,54 @@ mod tests {
 
         assert_eq!(result.count, 1);
         assert_eq!(result.subscriptions[0].subscription_id, id);
+    }
+
+    #[tokio::test]
+    async fn diagnose_filters_by_catalog_source_id_for_current_user() {
+        let (tool, finance_registry, _data_feed_registry, _market_repo, _feed_store, ctx) =
+            fixture().await;
+        let binance_id = insert_subscription(&finance_registry, &ctx).await;
+        let longbridge_id = uuid::Uuid::new_v4();
+        finance_registry
+            .upsert(FinanceSubscription {
+                id:                     longbridge_id,
+                owner:                  UserId(ctx.user_id.clone()),
+                session_key:            ctx.session_key,
+                event_kinds:            vec![FinanceEventKind::MarketCandleClosed],
+                source_names:           vec!["finance-longbridge-market-candles".to_owned()],
+                category_tags:          Vec::new(),
+                watch_terms:            Vec::new(),
+                venues:                 vec!["longbridge".to_owned()],
+                symbols:                vec!["AAPL.US".to_owned()],
+                timeframes:             vec!["1d".to_owned()],
+                delivery:               FinanceDelivery::Silent,
+                cooldown_secs:          900,
+                max_immediate_per_hour: 6,
+            })
+            .await
+            .unwrap();
+
+        let result = tool
+            .run(
+                FinanceDiagnoseCandleSubscriptionsParams {
+                    subscription_id:    None,
+                    catalog_source_ids: vec!["binance-market-candles".to_owned()],
+                    source_names:       Vec::new(),
+                    feed_ids:           Vec::new(),
+                    as_of:              Some("2026-07-10T08:31:00Z".to_owned()),
+                    stale_after_secs:   None,
+                },
+                &ctx,
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(result.count, 1);
+        assert_eq!(result.subscriptions[0].subscription_id, binance_id);
+        assert_eq!(
+            result.subscriptions[0].source_names,
+            ["finance-binance-market-candles"]
+        );
     }
 
     #[tokio::test]

--- a/crates/app/src/tools/finance_feed.rs
+++ b/crates/app/src/tools/finance_feed.rs
@@ -2278,14 +2278,36 @@ fn empty_candle_feed_events_diagnostic_hint(
         return None;
     }
 
+    let mut default_params = serde_json::Map::new();
+    if let Some(catalog_source_id) = &source_ref.catalog_source_id {
+        default_params.insert(
+            "catalog_source_ids".to_owned(),
+            serde_json::json!([catalog_source_id]),
+        );
+    } else if let Some(feed_id) = &source_ref.feed_id {
+        default_params.insert("feed_ids".to_owned(), serde_json::json!([feed_id]));
+    } else {
+        default_params.insert(
+            "source_names".to_owned(),
+            serde_json::json!([source_ref.source_name]),
+        );
+    }
+
     Some(FinanceFeedEventDiagnosticHint {
         tool:            "finance_diagnose_candle_subscriptions".to_owned(),
-        default_params:  serde_json::json!({}),
+        default_params:  serde_json::Value::Object(default_params),
         required_params: Vec::new(),
-        optional_params: ["subscription_id", "as_of", "stale_after_secs"]
-            .into_iter()
-            .map(str::to_owned)
-            .collect(),
+        optional_params: [
+            "subscription_id",
+            "catalog_source_ids",
+            "source_names",
+            "feed_ids",
+            "as_of",
+            "stale_after_secs",
+        ]
+        .into_iter()
+        .map(str::to_owned)
+        .collect(),
     })
 }
 
@@ -5148,11 +5170,23 @@ mod tests {
             diagnostic_hint.tool,
             "finance_diagnose_candle_subscriptions"
         );
-        assert_eq!(diagnostic_hint.default_params, serde_json::json!({}));
+        assert_eq!(
+            diagnostic_hint.default_params,
+            serde_json::json!({
+                "catalog_source_ids": ["binance-market-candles"]
+            })
+        );
         assert!(diagnostic_hint.required_params.is_empty());
         assert_eq!(
             diagnostic_hint.optional_params,
-            ["subscription_id", "as_of", "stale_after_secs"]
+            [
+                "subscription_id",
+                "catalog_source_ids",
+                "source_names",
+                "feed_ids",
+                "as_of",
+                "stale_after_secs"
+            ]
         );
     }
 

--- a/docs/guides/finance-subscriptions.md
+++ b/docs/guides/finance-subscriptions.md
@@ -218,9 +218,10 @@ pages with `total`, `has_more`, `query_limit`, and `query_offset`. Pages with
 `has_more=true` also include `next_page_hint`, which calls
 `finance_list_feed_events` with the same source selector and filters plus the
 next `offset`. Empty market-candle pages include a `diagnostic_hint` for
-`finance_diagnose_candle_subscriptions` so rara can move from "no raw closed
-candle events" to subscription/runtime diagnosis without inventing follow-up
-parameters. The result also echoes a normalized `query` with resolved unique
+`finance_diagnose_candle_subscriptions`, prefilled with the same
+`catalog_source_ids`, `source_names`, or `feed_ids` selector, so rara can move
+from "no raw closed candle events" to source-scoped subscription/runtime
+diagnosis. The result also echoes a normalized `query` with resolved unique
 sources, event-kind strings, `since`, `query_limit`, and `query_offset`, so rara
 can explain empty pages or paginated event lookups without reconstructing the
 request. Top-level `source_count`, `event_count`, `total`, and `has_more`
@@ -317,8 +318,10 @@ cooldown and hourly budget; events above the budget are appended to tape rather
 than waking the session.
 
 After subscribing to candle instruments, call
-`finance_diagnose_candle_subscriptions` to verify the path end to end. Each
-subscription diagnostic includes:
+`finance_diagnose_candle_subscriptions` to verify the path end to end. It can
+inspect all current-user candle subscriptions, one explicit `subscription_id`,
+or the subset whose source matches `catalog_source_ids`, `source_names`, or
+`feed_ids`. Each subscription diagnostic includes:
 
 - feed config/runtime state, including whether the source is registered and
   running, plus configured `venue`, `symbols`, and `timeframes`;


### PR DESCRIPTION
## Summary
- add catalog_source_ids/source_names/feed_ids filters to finance_diagnose_candle_subscriptions
- prefill empty market-candle finance_list_feed_events diagnostic hints with the same source selector
- fix the diagnose -> feed-events next_action_hint to use the actual finance_list_feed_events params (event_kinds/since/offset)
- document source-scoped candle diagnosis

## Verification
- cargo test -p rara-app diagnose_filters_by_catalog_source_id_for_current_user -- --nocapture
- cargo test -p rara-app list_feed_events_returns_candle_diagnostic_hint_when_empty -- --nocapture
- cargo test -p rara-app diagnose_reports_missing_data_when_feed_is_running_without_candles -- --nocapture
- cargo test -p rara-app diagnose_ -- --nocapture
- cargo test -p rara-app list_feed_events -- --nocapture
- cargo +nightly fmt --check -p rara-app
- git diff --check
- cargo check -p rara-app
- cargo clippy -p rara-app --lib --all-targets -- -D warnings
- BOXLITE_DEPS_STUB=1 scripts/lint-ratchet.sh
- pre-commit: cargo check, cargo fmt, cargo clippy, cargo doc, AGENT.md check