### PR TITLE
feat(finance): surface bundle subscription hints

### DIFF
--- a/crates/app/src/tools/finance_feed.rs
+++ b/crates/app/src/tools/finance_feed.rs
@@ -720,6 +720,8 @@ pub(super) struct FinanceSubscribeFeedBundleResult {
     pub name:                    String,
     pub subscription_kind:       String,
     pub catalog_source_ids:      Vec<String>,
+    pub diagnostic_hint:         Option<FinanceSubscriptionDiagnosticHint>,
+    pub market_data_hint:        Option<FinanceSubscriptionMarketDataHint>,
     pub news_subscription:       Option<FinanceSubscribeNewsResult>,
     pub instrument_subscription: Option<FinanceSubscribeInstrumentsResult>,
 }
@@ -1929,6 +1931,8 @@ impl ToolExecute for FinanceSubscribeFeedBundleTool {
                 name:                    bundle.name,
                 subscription_kind:       "rss_article".to_owned(),
                 catalog_source_ids:      bundle.catalog_source_ids,
+                diagnostic_hint:         None,
+                market_data_hint:        None,
                 news_subscription:       Some(result),
                 instrument_subscription: None,
             });
@@ -1970,12 +1974,16 @@ impl ToolExecute for FinanceSubscribeFeedBundleTool {
                     context,
                 )
                 .await?;
+            let diagnostic_hint = result.diagnostic_hint.clone();
+            let market_data_hint = result.market_data_hint.clone();
             return Ok(FinanceSubscribeFeedBundleResult {
-                bundle_id:               bundle.id,
-                name:                    bundle.name,
-                subscription_kind:       "market_candle_closed".to_owned(),
-                catalog_source_ids:      bundle.catalog_source_ids,
-                news_subscription:       None,
+                bundle_id: bundle.id,
+                name: bundle.name,
+                subscription_kind: "market_candle_closed".to_owned(),
+                catalog_source_ids: bundle.catalog_source_ids,
+                diagnostic_hint,
+                market_data_hint,
+                news_subscription: None,
                 instrument_subscription: Some(result),
             });
         }
@@ -4541,6 +4549,14 @@ mod tests {
                 "sec-press-releases"
             ]
         );
+        assert!(
+            result.diagnostic_hint.is_none(),
+            "RSS bundle should not expose candle diagnostics"
+        );
+        assert!(
+            result.market_data_hint.is_none(),
+            "RSS bundle should not expose candle stream hints"
+        );
         let news = result
             .news_subscription
             .as_ref()
@@ -4613,6 +4629,25 @@ mod tests {
         assert_eq!(result.subscription_kind, "market_candle_closed");
         assert_eq!(result.catalog_source_ids, ["binance-major-crypto-15m"]);
         assert!(result.news_subscription.is_none());
+        let diagnostic = result
+            .diagnostic_hint
+            .as_ref()
+            .expect("market bundle should expose top-level diagnostic hint");
+        assert_eq!(diagnostic.tool, "finance_diagnose_candle_subscriptions");
+        let market_data = result
+            .market_data_hint
+            .as_ref()
+            .expect("market bundle should expose top-level market-data hint");
+        assert_eq!(market_data.tool, "finance_list_candle_streams");
+        assert_eq!(
+            market_data.default_params,
+            serde_json::json!({
+                "source_name": "finance-binance-major-crypto-15m",
+                "venue": "binance",
+                "timeframe": "15m",
+                "limit": 20
+            })
+        );
         let instruments = result
             .instrument_subscription
             .as_ref()

--- a/docs/guides/finance-subscriptions.md
+++ b/docs/guides/finance-subscriptions.md
@@ -145,8 +145,8 @@ runtime control, subscription management, and inspection:
 
 `finance_list_feed_bundles` is the preferred discovery view when the user asks
 what default finance data feeding rara can provide. It groups built-in catalog
-sources into curated presets such as `macro-news`, `binance-spot-starter`,
-`binance-major-crypto-15m`, and `longbridge-equities-daily`. Each bundle echoes
+sources into curated presets such as `macro-news`, `binance-major-crypto-15m`,
+and `longbridge-equities-daily`. Each bundle echoes
 its `catalog_source_ids`, feed types, aggregate persisted/running/subscribed
 counts, setup hints for operator-only presets, and action hints:
 `list_sources_hint` for drilling into per-source status, `enable_hints` for
@@ -155,11 +155,12 @@ direct bundle-level subscription tool, and `subscription_hint` when the caller
 needs the lower-level specialized tool. `finance_subscribe_feed_bundle` is the
 conversation-first entry point after bundle discovery: macro/news bundles
 subscribe multiple RSS `catalog_source_ids` at once, while single-source
-market-data bundles subscribe their preset symbols/timeframes. Bundles that
-require operator credentials or a custom endpoint do not expose
-`subscribe_bundle_hint`; use their setup hints first. Use the `bundle_ids`,
-`feed_types`, `can_enable`, and `requires_configuration` filters to narrow the
-recommendation list.
+market-data bundles subscribe their preset symbols/timeframes and return
+top-level `diagnostic_hint` / `market_data_hint` values for the next candle
+health or stream-overview step. Bundles that require operator credentials or a
+custom endpoint do not expose `subscribe_bundle_hint`; use their setup hints
+first. Use the `bundle_ids`, `feed_types`, `can_enable`, and
+`requires_configuration` filters to narrow the recommendation list.
 
 `finance_list_feed_sources` is the preferred status view before and after
 subscription changes. It combines the built-in source catalog, persisted feed


### PR DESCRIPTION
## Summary
- expose top-level diagnostic and market-data hints from finance_subscribe_feed_bundle results
- keep RSS bundles candle-hint-free while reusing existing instrument subscription hint rules for market bundles
- update the finance subscription guide to describe the direct bundle follow-up path

## Tests
- cargo test -p rara-app subscribe_feed_bundle_subscribes_binance_market_bundle -- --nocapture
- cargo test -p rara-app subscribe_feed_bundle_subscribes_macro_news_bundle -- --nocapture
- cargo test -p rara-app tools::finance_feed::tests -- --nocapture
- cargo +nightly fmt --check -p rara-app
- cargo clippy -p rara-app --all-targets -- -D warnings
- cargo test -p rara-app tools::tests -- --nocapture
