### PR TITLE
Expose finance feed bundles in watches UI

### DIFF
--- a/crates/extensions/backend-admin/src/data_feeds/router.rs
+++ b/crates/extensions/backend-admin/src/data_feeds/router.rs
@@ -25,6 +25,7 @@
 //! | GET    | `/api/v1/data-feeds/{id}/events`             | query feed events   |
 //! | GET    | `/api/v1/data-feeds/{id}/events/{event_id}` | get single event    |
 //! | POST   | `/api/v1/data-feeds/catalog/{id}/unsubscribe` | remove current user's catalog subscriptions |
+//! | GET    | `/api/v1/data-feeds/finance/bundles` | list curated finance feed bundles |
 //! | GET    | `/api/v1/data-feeds/finance/subscriptions` | list current user's finance subscriptions |
 //! | POST   | `/api/v1/data-feeds/finance/subscriptions` | create/update current user's finance subscription |
 //! | GET    | `/api/v1/data-feeds/market-data/candle-streams` | list stored market-data candle streams |
@@ -59,7 +60,10 @@ use rara_kernel::{
 };
 use rara_trading::{
     feed::{
-        catalog::{DefaultFeedSource, default_finance_feed_sources},
+        catalog::{
+            DefaultFeedBundle, DefaultFeedSource, default_finance_feed_bundles,
+            default_finance_feed_sources,
+        },
         market_candle::MarketCandleSource,
         rss::RssSource,
     },
@@ -126,6 +130,10 @@ pub fn data_feed_routes(state: DataFeedRouterState) -> Router {
         .route(
             "/api/v1/data-feeds/finance/subscriptions",
             get(list_finance_subscriptions).post(create_finance_subscription),
+        )
+        .route(
+            "/api/v1/data-feeds/finance/bundles",
+            get(list_finance_feed_bundles),
         )
         .route(
             "/api/v1/data-feeds/finance/subscriptions/{id}",
@@ -418,7 +426,7 @@ struct FeedSummaryResponse {
 }
 
 /// Built-in feed catalog entry plus current materialized state.
-#[derive(Debug, Serialize)]
+#[derive(Debug, Clone, Serialize)]
 struct FeedCatalogEntryResponse {
     id:                     String,
     name:                   String,
@@ -439,10 +447,34 @@ struct FeedCatalogEntryResponse {
 }
 
 /// Current user's finance subscription status for a built-in feed source.
-#[derive(Debug, Serialize)]
+#[derive(Debug, Clone, Serialize)]
 struct FeedCatalogSubscriptionResponse {
     user_subscribed:       bool,
     user_subscription_ids: Vec<Uuid>,
+}
+
+#[derive(Debug, Serialize)]
+struct FinanceFeedBundleListResponse {
+    bundles: Vec<FinanceFeedBundleResponse>,
+    count:   usize,
+}
+
+#[derive(Debug, Serialize)]
+struct FinanceFeedBundleResponse {
+    id:                     String,
+    name:                   String,
+    description:            String,
+    tags:                   Vec<String>,
+    catalog_source_ids:     Vec<String>,
+    feed_types:             Vec<FeedType>,
+    providers:              Vec<String>,
+    source_count:           usize,
+    enabled_source_count:   usize,
+    ready_source_count:     usize,
+    requires_configuration: bool,
+    can_enable:             bool,
+    sources:                Vec<FeedCatalogEntryResponse>,
+    subscriptions:          FeedCatalogSubscriptionResponse,
 }
 
 #[derive(Debug, Serialize)]
@@ -540,6 +572,31 @@ async fn list_feed_catalog(
     let owner = UserId(principal.user_id.0);
     let subscriptions = state.finance_registry.list_for_owner(&owner).await;
     Ok(Json(catalog_response(&feeds, &subscriptions)))
+}
+
+/// `GET /api/v1/data-feeds/finance/bundles` — list curated finance feed
+/// bundles expanded to catalog source entries plus current-user subscription
+/// status.
+async fn list_finance_feed_bundles(
+    State(state): State<DataFeedRouterState>,
+    axum::Extension(principal): axum::Extension<Principal<Resolved>>,
+) -> Result<Json<FinanceFeedBundleListResponse>, ProblemDetails> {
+    let feeds = state.svc.list_feeds().await?;
+    let owner = UserId(principal.user_id.0);
+    let subscriptions = state.finance_registry.list_for_owner(&owner).await;
+    let catalog = catalog_response(&feeds, &subscriptions)
+        .into_iter()
+        .map(|entry| (entry.id.clone(), entry))
+        .collect::<HashMap<_, _>>();
+    let bundles = default_finance_feed_bundles()
+        .into_iter()
+        .map(|bundle| finance_feed_bundle_response(bundle, &catalog, &subscriptions))
+        .collect::<Vec<_>>();
+
+    Ok(Json(FinanceFeedBundleListResponse {
+        count: bundles.len(),
+        bundles,
+    }))
 }
 
 /// `GET /api/v1/data-feeds/finance/subscriptions` — list current user's
@@ -1899,6 +1956,91 @@ fn catalog_subscription_response(
     }
 }
 
+fn finance_feed_bundle_response(
+    bundle: DefaultFeedBundle,
+    catalog: &HashMap<String, FeedCatalogEntryResponse>,
+    subscriptions: &[FinanceSubscription],
+) -> FinanceFeedBundleResponse {
+    let sources = bundle
+        .catalog_source_ids
+        .iter()
+        .filter_map(|source_id| catalog.get(source_id).cloned())
+        .collect::<Vec<_>>();
+    let feed_types =
+        sources
+            .iter()
+            .map(|source| source.feed_type)
+            .fold(Vec::new(), |mut values, feed_type| {
+                if !values.contains(&feed_type) {
+                    values.push(feed_type);
+                }
+                values
+            });
+    let providers = sources
+        .iter()
+        .filter_map(|source| source.provider.clone())
+        .fold(Vec::new(), |mut values, provider| {
+            if !values.contains(&provider) {
+                values.push(provider);
+            }
+            values
+        });
+    let enabled_source_count = sources.iter().filter(|source| source.enabled).count();
+    let ready_source_count = sources
+        .iter()
+        .filter(|source| !source.requires_configuration && source.transport_template.is_some())
+        .count();
+    let requires_configuration = sources.iter().any(|source| source.requires_configuration);
+    let can_enable = sources.len() == bundle.catalog_source_ids.len()
+        && sources.iter().all(|source| {
+            source.enabled
+                || (!source.requires_configuration && source.transport_template.is_some())
+        });
+    let source_names = sources
+        .iter()
+        .map(|source| source.source_name.as_str())
+        .collect::<Vec<_>>();
+
+    FinanceFeedBundleResponse {
+        id: bundle.id,
+        name: bundle.name,
+        description: bundle.description,
+        tags: bundle.tags,
+        catalog_source_ids: bundle.catalog_source_ids,
+        feed_types,
+        providers,
+        source_count: sources.len(),
+        enabled_source_count,
+        ready_source_count,
+        requires_configuration,
+        can_enable,
+        subscriptions: bundle_subscription_response(subscriptions, &source_names),
+        sources,
+    }
+}
+
+fn bundle_subscription_response(
+    subscriptions: &[FinanceSubscription],
+    source_names: &[&str],
+) -> FeedCatalogSubscriptionResponse {
+    let source_names = source_names.iter().copied().collect::<HashSet<_>>();
+    let user_subscription_ids = subscriptions
+        .iter()
+        .filter(|subscription| {
+            subscription
+                .source_names
+                .iter()
+                .any(|name| source_names.contains(name.as_str()))
+        })
+        .map(|subscription| subscription.id)
+        .collect::<Vec<_>>();
+
+    FeedCatalogSubscriptionResponse {
+        user_subscribed: !user_subscription_ids.is_empty(),
+        user_subscription_ids,
+    }
+}
+
 fn resolve_finance_subscription_source_names(
     catalog_source_ids: &[String],
     source_names: &[String],
@@ -2756,6 +2898,95 @@ mod tests {
             sec["subscriptions"]["user_subscription_ids"],
             serde_json::json!([])
         );
+    }
+
+    #[tokio::test]
+    async fn finance_feed_bundles_list_expands_sources_and_subscription_status() {
+        let finance_registry = test_finance_registry();
+        let subscription_id = Uuid::new_v4();
+        finance_registry
+            .upsert(FinanceSubscription {
+                id:                     subscription_id,
+                owner:                  UserId("admin".to_owned()),
+                session_key:            SessionKey::new(),
+                event_kinds:            vec![FinanceEventKind::MarketCandleClosed],
+                source_names:           vec!["finance-binance-major-crypto-15m".to_owned()],
+                category_tags:          Vec::new(),
+                watch_terms:            Vec::new(),
+                venues:                 vec!["binance".to_owned()],
+                symbols:                vec!["BTCUSDT".to_owned(), "ETHUSDT".to_owned()],
+                timeframes:             vec!["15m".to_owned()],
+                delivery:               FinanceDelivery::Silent,
+                cooldown_secs:          900,
+                max_immediate_per_hour: 6,
+            })
+            .await
+            .unwrap();
+
+        let app = app_with_user_and_finance_registry(user_of(Role::Admin), finance_registry).await;
+        let res = app
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri("/api/v1/data-feeds/finance/bundles")
+                    .header("Authorization", "Bearer s3cret")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(res.status(), StatusCode::OK);
+
+        let body = axum::body::to_bytes(res.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let result: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(result["count"], 4);
+
+        let bundles = result["bundles"].as_array().unwrap();
+        let macro_news = bundles
+            .iter()
+            .find(|bundle| bundle["id"] == "macro-news")
+            .unwrap();
+        assert_eq!(
+            macro_news["catalog_source_ids"],
+            serde_json::json!([
+                "fed-press-releases",
+                "fed-h15-announcements",
+                "fed-h10-announcements",
+                "sec-press-releases"
+            ])
+        );
+        assert_eq!(macro_news["feed_types"], serde_json::json!(["rss"]));
+        assert_eq!(macro_news["source_count"], 4);
+        assert_eq!(macro_news["ready_source_count"], 4);
+        assert_eq!(macro_news["requires_configuration"], false);
+        assert_eq!(macro_news["can_enable"], true);
+
+        let binance = bundles
+            .iter()
+            .find(|bundle| bundle["id"] == "binance-major-crypto-15m")
+            .unwrap();
+        assert_eq!(binance["providers"], serde_json::json!(["binance"]));
+        assert_eq!(binance["feed_types"], serde_json::json!(["market_candle"]));
+        assert_eq!(binance["source_count"], 1);
+        assert_eq!(
+            binance["sources"][0]["source_name"],
+            "finance-binance-major-crypto-15m"
+        );
+        assert_eq!(binance["subscriptions"]["user_subscribed"], true);
+        assert_eq!(
+            binance["subscriptions"]["user_subscription_ids"],
+            serde_json::json!([subscription_id])
+        );
+
+        let longbridge = bundles
+            .iter()
+            .find(|bundle| bundle["id"] == "longbridge-equities-daily")
+            .unwrap();
+        assert_eq!(longbridge["requires_configuration"], true);
+        assert_eq!(longbridge["can_enable"], false);
     }
 
     #[tokio::test]

--- a/web/e2e/harness/data-feeds.spec.ts
+++ b/web/e2e/harness/data-feeds.spec.ts
@@ -106,6 +106,31 @@ interface FinanceSubscriptionsResponse {
   count: number;
 }
 
+interface FinanceFeedBundle {
+  id: string;
+  name: string;
+  description: string;
+  tags: string[];
+  catalog_source_ids: string[];
+  feed_types: DataFeedConfig['feed_type'][];
+  providers: string[];
+  source_count: number;
+  enabled_source_count: number;
+  ready_source_count: number;
+  requires_configuration: boolean;
+  can_enable: boolean;
+  sources: FeedCatalogEntry[];
+  subscriptions: {
+    user_subscribed: boolean;
+    user_subscription_ids: string[];
+  };
+}
+
+interface FinanceFeedBundlesResponse {
+  bundles: FinanceFeedBundle[];
+  count: number;
+}
+
 interface ChatSession {
   key: string;
   title: string | null;
@@ -289,6 +314,7 @@ async function setupRoutes(
     events: FeedEvent[];
     summaries?: FeedSummary[];
     catalog?: FeedCatalogEntry[];
+    financeBundles?: FinanceFeedBundlesResponse;
     financeSubscriptions?: FinanceSubscriptionsResponse;
     sessions?: ChatSession[];
     lastCatalogEnableBody?: unknown;
@@ -364,6 +390,10 @@ async function setupRoutes(
   // Default feed source catalog.
   await page.route('**/api/v1/data-feeds/catalog', async (route) => {
     await route.fulfill({ json: state.catalog ?? [] });
+  });
+
+  await page.route('**/api/v1/data-feeds/finance/bundles', async (route) => {
+    await route.fulfill({ json: state.financeBundles ?? { bundles: [], count: 0 } });
   });
 
   await page.route('**/api/v1/data-feeds/summary', async (route) => {

--- a/web/src/api/data-feeds.ts
+++ b/web/src/api/data-feeds.ts
@@ -172,6 +172,28 @@ export interface FeedCatalogSubscriptions {
   user_subscription_ids: string[];
 }
 
+export interface FinanceFeedBundle {
+  id: string;
+  name: string;
+  description: string;
+  tags: string[];
+  catalog_source_ids: string[];
+  feed_types: FeedType[];
+  providers: string[];
+  source_count: number;
+  enabled_source_count: number;
+  ready_source_count: number;
+  requires_configuration: boolean;
+  can_enable: boolean;
+  sources: FeedCatalogEntry[];
+  subscriptions: FeedCatalogSubscriptions;
+}
+
+export interface FinanceFeedBundlesResponse {
+  bundles: FinanceFeedBundle[];
+  count: number;
+}
+
 export interface EnableCatalogEntryRequest {
   transport?: Record<string, unknown>;
   auth?: AuthConfig | null;
@@ -399,6 +421,8 @@ export const dataFeedsApi = {
 
   financeSubscriptions: () =>
     api.get<FinanceSubscriptionsResponse>('/api/v1/data-feeds/finance/subscriptions'),
+
+  financeBundles: () => api.get<FinanceFeedBundlesResponse>('/api/v1/data-feeds/finance/bundles'),
 
   createFinanceSubscription: (body: CreateFinanceSubscriptionRequest) =>
     api.post<CreateFinanceSubscriptionResponse>('/api/v1/data-feeds/finance/subscriptions', body),

--- a/web/src/components/topology/FinanceWatchesCard.tsx
+++ b/web/src/components/topology/FinanceWatchesCard.tsx
@@ -22,6 +22,7 @@ import {
   type CandleStream,
   type CreateFinanceSubscriptionRequest,
   type FeedCatalogEntry,
+  type FinanceFeedBundle,
   type FinanceEventKind,
   type FinanceSubscription,
 } from '@/api/data-feeds';
@@ -48,6 +49,11 @@ export function FinanceWatchesCard({ sessionKey }: FinanceWatchesCardProps) {
     queryFn: () => dataFeedsApi.financeSubscriptions(),
     staleTime: 30_000,
   });
+  const bundlesQuery = useQuery({
+    queryKey: ['finance-feed-bundles'],
+    queryFn: () => dataFeedsApi.financeBundles(),
+    staleTime: 30_000,
+  });
   const candleStreamsQuery = useQuery({
     queryKey: ['market-data-candle-streams'],
     queryFn: () => dataFeedsApi.candleStreams({ limit: CANDLE_STREAM_OVERVIEW_LIMIT }),
@@ -64,10 +70,36 @@ export function FinanceWatchesCard({ sessionKey }: FinanceWatchesCardProps) {
       void queryClient.invalidateQueries({ queryKey: ['market-data-candle-streams'] });
     },
   });
+  const subscribeBundleMutation = useMutation({
+    mutationFn: (bundle: FinanceFeedBundle) =>
+      dataFeedsApi.createFinanceSubscription(subscriptionRequestForBundle(bundle, sessionKey)),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ['finance-subscriptions'] });
+      void queryClient.invalidateQueries({ queryKey: ['data-feed-catalog'] });
+      void queryClient.invalidateQueries({ queryKey: ['finance-feed-bundles'] });
+      void queryClient.invalidateQueries({ queryKey: ['market-data-candle-streams'] });
+    },
+  });
   const enableMutation = useMutation({
     mutationFn: (entry: FeedCatalogEntry) => dataFeedsApi.enableCatalogEntry(entry.id),
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: ['data-feed-catalog'] });
+      void queryClient.invalidateQueries({ queryKey: ['finance-feed-bundles'] });
+      void queryClient.invalidateQueries({ queryKey: ['data-feeds'] });
+      void queryClient.invalidateQueries({ queryKey: ['data-feed-summaries'] });
+      void queryClient.invalidateQueries({ queryKey: ['market-data-candle-streams'] });
+    },
+  });
+  const enableBundleMutation = useMutation({
+    mutationFn: (bundle: FinanceFeedBundle) =>
+      Promise.all(
+        bundle.sources
+          .filter((source) => !source.enabled && !source.requires_configuration)
+          .map((source) => dataFeedsApi.enableCatalogEntry(source.id)),
+      ),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ['data-feed-catalog'] });
+      void queryClient.invalidateQueries({ queryKey: ['finance-feed-bundles'] });
       void queryClient.invalidateQueries({ queryKey: ['data-feeds'] });
       void queryClient.invalidateQueries({ queryKey: ['data-feed-summaries'] });
       void queryClient.invalidateQueries({ queryKey: ['market-data-candle-streams'] });
@@ -84,24 +116,44 @@ export function FinanceWatchesCard({ sessionKey }: FinanceWatchesCardProps) {
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: ['finance-subscriptions'] });
       void queryClient.invalidateQueries({ queryKey: ['data-feed-catalog'] });
+      void queryClient.invalidateQueries({ queryKey: ['finance-feed-bundles'] });
+      void queryClient.invalidateQueries({ queryKey: ['market-data-candle-streams'] });
+    },
+  });
+  const unsubscribeBundleMutation = useMutation({
+    mutationFn: (subscriptionIds: string[]) =>
+      Promise.all(
+        subscriptionIds.map((subscriptionId) =>
+          dataFeedsApi.deleteFinanceSubscription(subscriptionId),
+        ),
+      ),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ['finance-subscriptions'] });
+      void queryClient.invalidateQueries({ queryKey: ['data-feed-catalog'] });
+      void queryClient.invalidateQueries({ queryKey: ['finance-feed-bundles'] });
       void queryClient.invalidateQueries({ queryKey: ['market-data-candle-streams'] });
     },
   });
 
   const entries = (catalogQuery.data ?? []).filter(isFinanceWatchableEntry);
+  const bundles = bundlesQuery.data?.bundles ?? [];
   const candleStreams = candleStreamsQuery.data?.streams ?? [];
   const candleStreamHasMore = candleStreamsQuery.data?.has_more ?? false;
   const sessionSubscriptions = (subscriptionsQuery.data?.subscriptions ?? []).filter(
     (subscription) => subscription.session_key === sessionKey,
   );
-  const loading = catalogQuery.isLoading || subscriptionsQuery.isLoading;
+  const loading = catalogQuery.isLoading || subscriptionsQuery.isLoading || bundlesQuery.isLoading;
   const error =
     catalogQuery.error?.message ??
+    bundlesQuery.error?.message ??
     subscriptionsQuery.error?.message ??
     candleStreamsQuery.error?.message ??
     enableMutation.error?.message ??
+    enableBundleMutation.error?.message ??
     subscribeMutation.error?.message ??
+    subscribeBundleMutation.error?.message ??
     unsubscribeMutation.error?.message ??
+    unsubscribeBundleMutation.error?.message ??
     null;
 
   return (
@@ -126,7 +178,7 @@ export function FinanceWatchesCard({ sessionKey }: FinanceWatchesCardProps) {
           <div className="rounded-md border border-dashed px-3 py-2 text-[11px] text-muted-foreground">
             Loading finance sources…
           </div>
-        ) : entries.length === 0 ? (
+        ) : entries.length === 0 && bundles.length === 0 ? (
           <div className="rounded-md border border-dashed px-3 py-2 text-[11px] text-muted-foreground">
             No finance feed sources are configured.
           </div>
@@ -136,6 +188,101 @@ export function FinanceWatchesCard({ sessionKey }: FinanceWatchesCardProps) {
               <div className="rounded-md border border-dashed bg-muted/30 px-3 py-2 text-[11px] text-muted-foreground">
                 K-line stream overview is limited to {candleStreamsQuery.data.query_limit} streams;
                 a missing health check may need a narrower source, symbol, or timeframe query.
+              </div>
+            )}
+            {bundles.length > 0 && (
+              <div className="space-y-2">
+                <div className="text-[11px] font-medium text-muted-foreground">Curated bundles</div>
+                {bundles.map((bundle) => {
+                  const matchingSubscriptions = sessionSubscriptions.filter((subscription) =>
+                    subscriptionMatchesBundle(subscription, bundle),
+                  );
+                  const subscribed = matchingSubscriptions.length > 0;
+                  const canEnableInline =
+                    !subscribed &&
+                    bundle.can_enable &&
+                    bundle.sources.some((source) => !source.enabled);
+                  const configurationSource = bundle.sources.find(
+                    (source) => !source.enabled && source.requires_configuration,
+                  );
+                  const needsConfiguration = !subscribed && configurationSource != null;
+                  const pending =
+                    (enableBundleMutation.isPending &&
+                      enableBundleMutation.variables?.id === bundle.id) ||
+                    (subscribeBundleMutation.isPending &&
+                      subscribeBundleMutation.variables?.id === bundle.id) ||
+                    (unsubscribeBundleMutation.isPending &&
+                      matchingSubscriptions.some((subscription) =>
+                        unsubscribeBundleMutation.variables?.includes(subscription.subscription_id),
+                      ));
+                  const providers = summarizeList(bundle.providers, 2);
+                  return (
+                    <div key={bundle.id} className="rounded-md border bg-muted/20 px-3 py-2">
+                      <div className="flex items-start justify-between gap-2">
+                        <div className="min-w-0 space-y-1">
+                          <div className="flex flex-wrap items-center gap-1.5">
+                            <span className="truncate text-xs font-medium">{bundle.name}</span>
+                            <Badge variant="outline" className="px-1.5 py-0 text-[10px]">
+                              Bundle
+                            </Badge>
+                            {providers && (
+                              <Badge
+                                variant="outline"
+                                className="px-1.5 py-0 text-[10px] text-muted-foreground"
+                              >
+                                {providers}
+                              </Badge>
+                            )}
+                            <Badge variant="secondary" className="px-1.5 py-0 text-[10px]">
+                              {bundle.enabled_source_count}/{bundle.source_count} sources on
+                            </Badge>
+                            {subscribed && (
+                              <Badge variant="secondary" className="px-1.5 py-0 text-[10px]">
+                                watching
+                              </Badge>
+                            )}
+                          </div>
+                          <p className="line-clamp-2 text-[11px] text-muted-foreground">
+                            {bundle.description}
+                          </p>
+                          <p className="text-[11px] text-muted-foreground">
+                            {bundle.sources.map((source) => source.name).join(', ')}
+                          </p>
+                        </div>
+                        <Button
+                          size="sm"
+                          variant={subscribed ? 'outline' : 'default'}
+                          className="h-7 shrink-0 px-2 text-[11px]"
+                          disabled={pending}
+                          onClick={() => {
+                            if (canEnableInline) {
+                              enableBundleMutation.mutate(bundle);
+                            } else if (needsConfiguration && configurationSource) {
+                              openSettings('data-feeds', {
+                                dataFeedCatalogId: configurationSource.id,
+                              });
+                            } else if (subscribed) {
+                              unsubscribeBundleMutation.mutate(
+                                matchingSubscriptions.map(
+                                  (subscription) => subscription.subscription_id,
+                                ),
+                              );
+                            } else {
+                              subscribeBundleMutation.mutate(bundle);
+                            }
+                          }}
+                        >
+                          {financeBundleActionLabel({
+                            pending,
+                            canEnableInline,
+                            needsConfiguration,
+                            subscribed,
+                          })}
+                        </Button>
+                      </div>
+                    </div>
+                  );
+                })}
               </div>
             )}
             {entries.map((entry) => {
@@ -279,6 +426,26 @@ function financeWatchActionLabel({
   return subscribed ? 'Unwatch' : 'Watch';
 }
 
+function financeBundleActionLabel({
+  pending,
+  canEnableInline,
+  needsConfiguration,
+  subscribed,
+}: {
+  pending: boolean;
+  canEnableInline: boolean;
+  needsConfiguration: boolean;
+  subscribed: boolean;
+}): string {
+  if (pending) {
+    if (canEnableInline) return 'Enabling…';
+    return subscribed ? 'Removing…' : 'Adding…';
+  }
+  if (needsConfiguration) return 'Configure';
+  if (canEnableInline) return 'Enable bundle';
+  return subscribed ? 'Unwatch' : 'Watch bundle';
+}
+
 function subscriptionRequestForEntry(
   entry: FeedCatalogEntry,
   sessionKey: string,
@@ -296,6 +463,24 @@ function subscriptionRequestForEntry(
   return request;
 }
 
+function subscriptionRequestForBundle(
+  bundle: FinanceFeedBundle,
+  sessionKey: string,
+): CreateFinanceSubscriptionRequest {
+  const request: CreateFinanceSubscriptionRequest = {
+    session_key: sessionKey,
+    catalog_source_ids: bundle.catalog_source_ids,
+    delivery: 'silent',
+  };
+  const marketSources = bundle.sources.filter((source) => source.feed_type === 'market_candle');
+  if (marketSources.length > 0) {
+    request.venues = uniqueStrings(marketSources.map(catalogVenue).filter(isPresent));
+    request.symbols = uniqueStrings(marketSources.flatMap(catalogSymbols));
+    request.timeframes = uniqueStrings(marketSources.flatMap(catalogTimeframes));
+  }
+  return request;
+}
+
 function subscriptionMatchesEntry(
   subscription: FinanceSubscription,
   entry: FeedCatalogEntry,
@@ -303,6 +488,19 @@ function subscriptionMatchesEntry(
   return (
     subscription.source_names.includes(catalogSourceName(entry)) &&
     subscription.event_kinds.includes(eventKindForEntry(entry))
+  );
+}
+
+function subscriptionMatchesBundle(
+  subscription: FinanceSubscription,
+  bundle: FinanceFeedBundle,
+): boolean {
+  const sourceNames = bundle.sources.map(catalogSourceName);
+  const eventKinds = uniqueFinanceEventKinds(bundle.sources.map(eventKindForEntry));
+  return (
+    sourceNames.length > 0 &&
+    sourceNames.every((sourceName) => subscription.source_names.includes(sourceName)) &&
+    eventKinds.every((kind) => subscription.event_kinds.includes(kind))
   );
 }
 
@@ -395,6 +593,24 @@ function transportStringList(entry: FeedCatalogEntry, key: string): string[] {
 
 function optionalList(value: string | null): string[] {
   return value ? [value] : [];
+}
+
+function isPresent<T>(value: T | null | undefined): value is T {
+  return value !== null && value !== undefined;
+}
+
+function uniqueStrings(values: string[]): string[] {
+  return values.reduce<string[]>((acc, value) => {
+    if (!acc.includes(value)) acc.push(value);
+    return acc;
+  }, []);
+}
+
+function uniqueFinanceEventKinds(values: FinanceEventKind[]): FinanceEventKind[] {
+  return values.reduce<FinanceEventKind[]>((acc, value) => {
+    if (!acc.includes(value)) acc.push(value);
+    return acc;
+  }, []);
 }
 
 function summarizeList(values: string[], max = 3): string {

--- a/web/src/components/topology/__tests__/FinanceWatchesCard.test.tsx
+++ b/web/src/components/topology/__tests__/FinanceWatchesCard.test.tsx
@@ -23,27 +23,32 @@ import { FinanceWatchesCard } from '../FinanceWatchesCard';
 import type {
   CandleStreamsResponse,
   FeedCatalogEntry,
+  FinanceFeedBundle,
   FinanceSubscription,
   FinanceSubscriptionsResponse,
 } from '@/api/data-feeds';
 
 const catalogMock = vi.fn();
+const financeBundlesMock = vi.fn();
 const financeSubscriptionsMock = vi.fn();
 const candleStreamsMock = vi.fn();
 const enableCatalogEntryMock = vi.fn();
 const createFinanceSubscriptionMock = vi.fn();
 const unsubscribeCatalogEntryMock = vi.fn();
+const deleteFinanceSubscriptionMock = vi.fn();
 const openSettingsMock = vi.fn();
 
 vi.mock('@/api/data-feeds', () => ({
   CANDLE_STREAM_OVERVIEW_LIMIT: 500,
   dataFeedsApi: {
     catalog: (...args: unknown[]) => catalogMock(...args),
+    financeBundles: (...args: unknown[]) => financeBundlesMock(...args),
     financeSubscriptions: (...args: unknown[]) => financeSubscriptionsMock(...args),
     candleStreams: (...args: unknown[]) => candleStreamsMock(...args),
     enableCatalogEntry: (...args: unknown[]) => enableCatalogEntryMock(...args),
     createFinanceSubscription: (...args: unknown[]) => createFinanceSubscriptionMock(...args),
     unsubscribeCatalogEntry: (...args: unknown[]) => unsubscribeCatalogEntryMock(...args),
+    deleteFinanceSubscription: (...args: unknown[]) => deleteFinanceSubscriptionMock(...args),
   },
 }));
 
@@ -117,14 +122,61 @@ function financeSubscription(partial: Partial<FinanceSubscription> = {}): Financ
   };
 }
 
+function financeBundle(partial: Partial<FinanceFeedBundle> & { id: string }): FinanceFeedBundle {
+  const sources = partial.sources ?? [
+    catalogEntry({
+      id: 'fed-press-releases',
+      name: 'Federal Reserve Press Releases',
+      source_name: 'finance-fed-press-releases',
+      enabled: true,
+    }),
+    catalogEntry({
+      id: 'sec-press-releases',
+      name: 'SEC Press Releases',
+      source_name: 'finance-sec-press-releases',
+      enabled: true,
+    }),
+  ];
+  return {
+    id: partial.id,
+    name: partial.name ?? partial.id,
+    description: partial.description ?? 'bundle description',
+    tags: partial.tags ?? ['finance', 'news'],
+    catalog_source_ids: partial.catalog_source_ids ?? sources.map((source) => source.id),
+    feed_types: partial.feed_types ?? ['rss'],
+    providers: partial.providers ?? [],
+    source_count: partial.source_count ?? sources.length,
+    enabled_source_count:
+      partial.enabled_source_count ?? sources.filter((source) => source.enabled).length,
+    ready_source_count:
+      partial.ready_source_count ??
+      sources.filter(
+        (source) => !source.requires_configuration && source.transport_template != null,
+      ).length,
+    requires_configuration: partial.requires_configuration ?? false,
+    can_enable: partial.can_enable ?? true,
+    sources,
+    subscriptions: partial.subscriptions ?? {
+      user_subscribed: false,
+      user_subscription_ids: [],
+    },
+  };
+}
+
 beforeEach(() => {
   catalogMock.mockReset();
+  financeBundlesMock.mockReset();
   financeSubscriptionsMock.mockReset();
   candleStreamsMock.mockReset();
   enableCatalogEntryMock.mockReset();
   createFinanceSubscriptionMock.mockReset();
   unsubscribeCatalogEntryMock.mockReset();
+  deleteFinanceSubscriptionMock.mockReset();
   openSettingsMock.mockReset();
+  financeBundlesMock.mockResolvedValue({
+    bundles: [],
+    count: 0,
+  });
   candleStreamsMock.mockResolvedValue({
     streams: [],
     count: 0,
@@ -139,6 +191,115 @@ afterEach(() => {
 });
 
 describe('FinanceWatchesCard', () => {
+  it('creates_session_watch_from_curated_kline_bundle_with_configured_selectors', async () => {
+    const source = catalogEntry({
+      id: 'binance-major-crypto-15m',
+      name: 'Binance Major Crypto 15m',
+      feed_type: 'market_candle',
+      source_name: 'finance-binance-major-crypto-15m',
+      provider: 'binance',
+      venue: 'binance',
+      configured_symbols: ['BTCUSDT', 'ETHUSDT'],
+      configured_timeframes: ['15m'],
+      tags: ['finance', 'market-data', 'crypto', 'binance'],
+      transport_template: {
+        venue: 'binance',
+        symbols: ['BTCUSDT', 'ETHUSDT'],
+        timeframes: ['15m'],
+      },
+    });
+    catalogMock.mockResolvedValue([]);
+    financeBundlesMock.mockResolvedValue({
+      bundles: [
+        financeBundle({
+          id: 'binance-major-crypto-15m',
+          name: 'Binance Major Crypto 15m',
+          feed_types: ['market_candle'],
+          providers: ['binance'],
+          catalog_source_ids: ['binance-major-crypto-15m'],
+          sources: [source],
+        }),
+      ],
+      count: 1,
+    });
+    financeSubscriptionsMock.mockResolvedValue({
+      subscriptions: [],
+      count: 0,
+    } satisfies FinanceSubscriptionsResponse);
+    createFinanceSubscriptionMock.mockResolvedValue({
+      created: true,
+      subscription: financeSubscription({
+        subscription_id: 'sub-bundle',
+        source_names: ['finance-binance-major-crypto-15m'],
+        venues: ['binance'],
+        symbols: ['BTCUSDT', 'ETHUSDT'],
+        timeframes: ['15m'],
+      }),
+    });
+
+    renderCard('session-1');
+
+    expect(await screen.findByText('Curated bundles')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'Watch bundle' }));
+
+    await waitFor(() => {
+      expect(createFinanceSubscriptionMock).toHaveBeenCalledWith({
+        session_key: 'session-1',
+        catalog_source_ids: ['binance-major-crypto-15m'],
+        delivery: 'silent',
+        venues: ['binance'],
+        symbols: ['BTCUSDT', 'ETHUSDT'],
+        timeframes: ['15m'],
+      });
+    });
+  });
+
+  it('enables_all_ready_sources_in_a_curated_bundle_before_watch', async () => {
+    const fed = catalogEntry({
+      id: 'fed-press-releases',
+      name: 'Federal Reserve Press Releases',
+      source_name: 'finance-fed-press-releases',
+      enabled: false,
+      transport_template: { url: 'https://www.federalreserve.gov/feeds/press_all.xml' },
+    });
+    const sec = catalogEntry({
+      id: 'sec-press-releases',
+      name: 'SEC Press Releases',
+      source_name: 'finance-sec-press-releases',
+      enabled: false,
+      transport_template: { url: 'https://www.sec.gov/news/pressreleases.rss' },
+    });
+    catalogMock.mockResolvedValue([]);
+    financeBundlesMock.mockResolvedValue({
+      bundles: [
+        financeBundle({
+          id: 'macro-news',
+          name: 'Macro News',
+          sources: [fed, sec],
+          enabled_source_count: 0,
+          ready_source_count: 2,
+          catalog_source_ids: ['fed-press-releases', 'sec-press-releases'],
+        }),
+      ],
+      count: 1,
+    });
+    financeSubscriptionsMock.mockResolvedValue({
+      subscriptions: [],
+      count: 0,
+    } satisfies FinanceSubscriptionsResponse);
+    enableCatalogEntryMock.mockResolvedValue({});
+
+    renderCard('session-1');
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Enable bundle' }));
+
+    await waitFor(() => {
+      expect(enableCatalogEntryMock).toHaveBeenCalledWith('fed-press-releases');
+      expect(enableCatalogEntryMock).toHaveBeenCalledWith('sec-press-releases');
+    });
+    expect(createFinanceSubscriptionMock).not.toHaveBeenCalled();
+  });
+
   it('shows_provider_metadata_for_catalog_watch_sources', async () => {
     catalogMock.mockResolvedValue([
       catalogEntry({


### PR DESCRIPTION
## Summary
- add backend-admin finance bundle list endpoint expanding curated bundles to catalog sources
- add web API types/client for finance bundles
- show curated bundles in Chat finance watches, with enable-all/watch/unwatch flows
- update E2E harness route mocks for finance bundles

## Tests
- cargo test -p rara-backend-admin finance_feed_bundles_list_expands_sources_and_subscription_status -- --nocapture
- cargo test -p rara-backend-admin data_feeds::router::tests -- --nocapture
- cargo clippy -p rara-backend-admin --all-targets -- -D warnings
- cargo +nightly fmt -p rara-backend-admin --check
- npm --prefix web test -- FinanceWatchesCard.test.tsx
- npm --prefix web run typecheck
- npm --prefix web run lint
- npm --prefix web run format:check
- npm --prefix web run test:e2e -- e2e/harness/data-feeds.spec.ts
- commit hook: cargo check/fmt/clippy/doc, AGENT.md presence, web lint-staged
