### PR TITLE
feat(finance): surface feed bundles in settings

### DIFF
--- a/web/e2e/harness/data-feeds.spec.ts
+++ b/web/e2e/harness/data-feeds.spec.ts
@@ -742,6 +742,94 @@ test.describe('Data Feeds Management', () => {
     await expect(page.getByRole('button', { name: 'Disable' })).toBeVisible();
   });
 
+  test('shows curated finance bundles in settings and enables ready sources', async ({ page }) => {
+    const fed: FeedCatalogEntry = {
+      id: 'fed-press-releases',
+      name: 'Federal Reserve Press Releases',
+      description: 'Official Federal Reserve press releases.',
+      feed_type: 'rss',
+      provider: null,
+      tags: ['finance', 'news', 'fed', 'macro'],
+      source_name: 'finance-fed-press-releases',
+      enabled: false,
+      feed_id: null,
+      requires_configuration: false,
+      setup_hint: null,
+      transport_template: {
+        url: 'https://www.federalreserve.gov/feeds/press_all.xml',
+        interval_secs: 300,
+        headers: {},
+        max_entries_per_poll: 50,
+      },
+    };
+    const sec: FeedCatalogEntry = {
+      id: 'sec-press-releases',
+      name: 'SEC Press Releases',
+      description: 'SEC press releases RSS feed.',
+      feed_type: 'rss',
+      provider: null,
+      tags: ['finance', 'news', 'sec', 'regulatory'],
+      source_name: 'finance-sec-press-releases',
+      enabled: false,
+      feed_id: null,
+      requires_configuration: false,
+      setup_hint: null,
+      transport_template: {
+        url: 'https://www.sec.gov/news/pressreleases.rss',
+        interval_secs: 300,
+        headers: {},
+        max_entries_per_poll: 50,
+      },
+    };
+    const state = {
+      feeds: [] as DataFeedConfig[],
+      events: [] as FeedEvent[],
+      catalog: [fed, sec],
+      financeSubscriptions: { subscriptions: [], count: 0 },
+      financeBundles: {
+        count: 1,
+        bundles: [
+          {
+            id: 'macro-news',
+            name: 'Macro News',
+            description: 'Federal Reserve and SEC official RSS feeds.',
+            tags: ['finance', 'news', 'macro', 'regulatory'],
+            catalog_source_ids: ['fed-press-releases', 'sec-press-releases'],
+            feed_types: ['rss'],
+            providers: [],
+            source_count: 2,
+            enabled_source_count: 0,
+            ready_source_count: 2,
+            requires_configuration: false,
+            can_enable: true,
+            sources: [fed, sec],
+            subscriptions: {
+              user_subscribed: false,
+              user_subscription_ids: [],
+            },
+          },
+        ],
+      },
+    };
+    await setupRoutes(page, state);
+    await goToDataFeeds(page);
+
+    await expect(page.getByText('Curated feed bundles')).toBeVisible({ timeout: 10_000 });
+    await expect(page.getByText('Macro News', { exact: true })).toBeVisible();
+    await expect(page.getByText('0/2 sources on')).toBeVisible();
+    await expect(
+      page.getByText('Sources finance-fed-press-releases, finance-sec-press-releases'),
+    ).toBeVisible();
+
+    await page.getByRole('button', { name: 'Enable bundle' }).click();
+
+    await expect(page.getByText('2/2 sources on')).toBeVisible({ timeout: 10_000 });
+    expect(state.feeds.map((feed) => feed.name).sort()).toEqual([
+      'finance-fed-press-releases',
+      'finance-sec-press-releases',
+    ]);
+  });
+
   test('provider preset opens a prefilled market candle form', async ({ page }) => {
     await setupRoutes(page, {
       feeds: [],

--- a/web/src/components/DataFeedsPanel.tsx
+++ b/web/src/components/DataFeedsPanel.tsx
@@ -37,6 +37,7 @@ import {
   type FeedCatalogEntry,
   type FeedEvent,
   type FeedSummary,
+  type FinanceFeedBundle,
   type FinanceEventKind,
   type FinanceSubscription,
   type FinanceSubscriptionsResponse,
@@ -882,6 +883,7 @@ function FeedFormDialog({
       void queryClient.invalidateQueries({ queryKey: ['data-feeds'] });
       void queryClient.invalidateQueries({ queryKey: ['data-feed-catalog'] });
       void queryClient.invalidateQueries({ queryKey: ['data-feed-summaries'] });
+      void queryClient.invalidateQueries({ queryKey: ['finance-feed-bundles'] });
       onOpenChange(false);
     },
     onError: (err: Error) => setError(err.message),
@@ -893,6 +895,7 @@ function FeedFormDialog({
       void queryClient.invalidateQueries({ queryKey: ['data-feeds'] });
       void queryClient.invalidateQueries({ queryKey: ['data-feed-catalog'] });
       void queryClient.invalidateQueries({ queryKey: ['data-feed-summaries'] });
+      void queryClient.invalidateQueries({ queryKey: ['finance-feed-bundles'] });
       onOpenChange(false);
     },
     onError: (err: Error) => setError(err.message),
@@ -1529,7 +1532,9 @@ function FeedCatalogCard({
     void queryClient.invalidateQueries({ queryKey: ['data-feeds'] });
     void queryClient.invalidateQueries({ queryKey: ['data-feed-catalog'] });
     void queryClient.invalidateQueries({ queryKey: ['data-feed-summaries'] });
+    void queryClient.invalidateQueries({ queryKey: ['finance-feed-bundles'] });
     void queryClient.invalidateQueries({ queryKey: ['finance-subscriptions'] });
+    void queryClient.invalidateQueries({ queryKey: ['market-data-candle-streams'] });
   };
 
   const enableMutation = useMutation({
@@ -1725,6 +1730,110 @@ function FeedCatalogCard({
   );
 }
 
+function FinanceFeedBundlesCard({ bundles }: { bundles: FinanceFeedBundle[] }) {
+  const queryClient = useQueryClient();
+
+  const refresh = () => {
+    void queryClient.invalidateQueries({ queryKey: ['data-feeds'] });
+    void queryClient.invalidateQueries({ queryKey: ['data-feed-catalog'] });
+    void queryClient.invalidateQueries({ queryKey: ['data-feed-summaries'] });
+    void queryClient.invalidateQueries({ queryKey: ['finance-feed-bundles'] });
+    void queryClient.invalidateQueries({ queryKey: ['finance-subscriptions'] });
+    void queryClient.invalidateQueries({ queryKey: ['market-data-candle-streams'] });
+  };
+
+  const enableBundleMutation = useMutation({
+    mutationFn: async (bundle: FinanceFeedBundle) => {
+      const sources = bundle.sources.filter(
+        (source) => !source.enabled && !source.requires_configuration,
+      );
+      for (const source of sources) {
+        await dataFeedsApi.enableCatalogEntry(source.id);
+      }
+      return sources.length;
+    },
+    onSuccess: refresh,
+  });
+
+  if (bundles.length === 0) return null;
+
+  return (
+    <div className="rounded-lg border bg-card">
+      <div className="border-b px-4 py-3">
+        <h3 className="text-sm font-semibold">Curated feed bundles</h3>
+        <p className="text-xs text-muted-foreground">
+          Operator-owned defaults for common finance ingestion paths. Enable ready sources here;
+          configure credentialed providers from the catalog below.
+        </p>
+      </div>
+      <div className="divide-y">
+        {bundles.map((bundle) => {
+          const readyDisabledSources = bundle.sources.filter(
+            (source) => !source.enabled && !source.requires_configuration,
+          );
+          const configuredSources = bundle.sources.filter((source) => source.enabled);
+          const configuredLabel = `${bundle.enabled_source_count}/${bundle.source_count} sources on`;
+          const pending =
+            enableBundleMutation.isPending && enableBundleMutation.variables?.id === bundle.id;
+          const providerLabel =
+            bundle.providers.length > 0 ? summarizeList(bundle.providers) : 'Mixed sources';
+          const feedTypeLabel = bundle.feed_types.map(typeLabel).join(' + ');
+          const sourceNames = bundle.sources.map((source) => catalogSourceName(source));
+          const canEnable = bundle.can_enable && readyDisabledSources.length > 0;
+
+          return (
+            <div key={bundle.id} className="flex flex-col gap-3 px-4 py-3">
+              <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+                <div className="min-w-0 space-y-1">
+                  <div className="flex flex-wrap items-center gap-2">
+                    <span className="text-sm font-medium">{bundle.name}</span>
+                    <Badge variant="outline" className="text-xs">
+                      {configuredLabel}
+                    </Badge>
+                    {configuredSources.length === bundle.source_count && (
+                      <Badge variant="secondary" className="text-xs text-foreground">
+                        Enabled
+                      </Badge>
+                    )}
+                    {bundle.requires_configuration && (
+                      <Badge variant="secondary" className="text-xs text-muted-foreground">
+                        Requires config
+                      </Badge>
+                    )}
+                  </div>
+                  <p className="text-xs text-muted-foreground">{bundle.description}</p>
+                  <p className="text-[11px] text-muted-foreground">
+                    {feedTypeLabel} · {providerLabel}
+                  </p>
+                  {sourceNames.length > 0 && (
+                    <p className="font-mono text-[11px] text-muted-foreground">
+                      Sources {summarizeList(sourceNames, 5)}
+                    </p>
+                  )}
+                </div>
+                {canEnable ? (
+                  <Button
+                    size="sm"
+                    className="h-8 shrink-0"
+                    onClick={() => enableBundleMutation.mutate(bundle)}
+                    disabled={pending}
+                  >
+                    {pending ? 'Enabling...' : 'Enable bundle'}
+                  </Button>
+                ) : bundle.requires_configuration ? (
+                  <p className="text-xs text-muted-foreground sm:max-w-40 sm:text-right">
+                    Configure required sources below.
+                  </p>
+                ) : null}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
 function FinanceSubscriptionsCard({
   result,
   candleStreams,
@@ -1738,6 +1847,7 @@ function FinanceSubscriptionsCard({
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: ['finance-subscriptions'] });
       void queryClient.invalidateQueries({ queryKey: ['data-feed-catalog'] });
+      void queryClient.invalidateQueries({ queryKey: ['finance-feed-bundles'] });
     },
   });
 
@@ -2300,6 +2410,10 @@ function FeedListView({
     queryKey: ['data-feed-catalog'],
     queryFn: () => dataFeedsApi.catalog(),
   });
+  const financeBundlesQuery = useQuery({
+    queryKey: ['finance-feed-bundles'],
+    queryFn: () => dataFeedsApi.financeBundles(),
+  });
   const financeSubscriptionsQuery = useQuery({
     queryKey: ['finance-subscriptions'],
     queryFn: () => dataFeedsApi.financeSubscriptions(),
@@ -2310,6 +2424,7 @@ function FeedListView({
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: ['data-feeds'] });
       void queryClient.invalidateQueries({ queryKey: ['data-feed-catalog'] });
+      void queryClient.invalidateQueries({ queryKey: ['finance-feed-bundles'] });
       void queryClient.invalidateQueries({ queryKey: ['finance-subscriptions'] });
     },
   });
@@ -2320,6 +2435,7 @@ function FeedListView({
       void queryClient.invalidateQueries({ queryKey: ['data-feeds'] });
       void queryClient.invalidateQueries({ queryKey: ['data-feed-catalog'] });
       void queryClient.invalidateQueries({ queryKey: ['data-feed-summaries'] });
+      void queryClient.invalidateQueries({ queryKey: ['finance-feed-bundles'] });
       void queryClient.invalidateQueries({ queryKey: ['finance-subscriptions'] });
       setDeleteId(null);
     },
@@ -2368,6 +2484,9 @@ function FeedListView({
         </Button>
       </div>
 
+      {financeBundlesQuery.data && financeBundlesQuery.data.bundles.length > 0 && (
+        <FinanceFeedBundlesCard bundles={financeBundlesQuery.data.bundles} />
+      )}
       {catalogQuery.data && (
         <FeedCatalogCard
           entries={catalogQuery.data}

--- a/web/src/components/__tests__/DataFeedsPanel.test.tsx
+++ b/web/src/components/__tests__/DataFeedsPanel.test.tsx
@@ -25,6 +25,7 @@ import type {
   DataFeedConfig,
   FeedCatalogEntry,
   FeedEventsResponse,
+  FinanceFeedBundlesResponse,
   FinanceSubscription,
   FinanceSubscriptionsResponse,
   MarketCandleFreshnessResponse,
@@ -36,12 +37,14 @@ const listMock = vi.fn();
 const summariesMock = vi.fn();
 const catalogMock = vi.fn();
 const eventsMock = vi.fn();
+const financeBundlesMock = vi.fn();
 const financeSubscriptionsMock = vi.fn();
 const candleStreamsMock = vi.fn();
 const candlesMock = vi.fn();
 const recentCandlesMock = vi.fn();
 const candleFreshnessMock = vi.fn();
 const candleGapsMock = vi.fn();
+const enableCatalogEntryMock = vi.fn();
 
 vi.mock('@/api/data-feeds', () => ({
   CANDLE_STREAM_OVERVIEW_LIMIT: 500,
@@ -50,6 +53,7 @@ vi.mock('@/api/data-feeds', () => ({
     summaries: (...args: unknown[]) => summariesMock(...args),
     catalog: (...args: unknown[]) => catalogMock(...args),
     events: (...args: unknown[]) => eventsMock(...args),
+    financeBundles: (...args: unknown[]) => financeBundlesMock(...args),
     financeSubscriptions: (...args: unknown[]) => financeSubscriptionsMock(...args),
     candleStreams: (...args: unknown[]) => candleStreamsMock(...args),
     candles: (...args: unknown[]) => candlesMock(...args),
@@ -58,7 +62,7 @@ vi.mock('@/api/data-feeds', () => ({
     candleGaps: (...args: unknown[]) => candleGapsMock(...args),
     toggle: vi.fn(),
     delete: vi.fn(),
-    enableCatalogEntry: vi.fn(),
+    enableCatalogEntry: (...args: unknown[]) => enableCatalogEntryMock(...args),
     disableCatalogEntry: vi.fn(),
     unsubscribeCatalogEntry: vi.fn(),
     deleteFinanceSubscription: vi.fn(),
@@ -134,16 +138,22 @@ beforeEach(() => {
   summariesMock.mockReset();
   catalogMock.mockReset();
   eventsMock.mockReset();
+  financeBundlesMock.mockReset();
   financeSubscriptionsMock.mockReset();
   candleStreamsMock.mockReset();
   candlesMock.mockReset();
   recentCandlesMock.mockReset();
   candleFreshnessMock.mockReset();
   candleGapsMock.mockReset();
+  enableCatalogEntryMock.mockReset();
 
   listMock.mockResolvedValue([]);
   summariesMock.mockResolvedValue([]);
   catalogMock.mockResolvedValue([] satisfies FeedCatalogEntry[]);
+  financeBundlesMock.mockResolvedValue({
+    bundles: [],
+    count: 0,
+  } satisfies FinanceFeedBundlesResponse);
   eventsMock.mockResolvedValue({
     events: [],
     total: 0,
@@ -187,6 +197,7 @@ beforeEach(() => {
     expected_count: 50,
     complete: true,
   } satisfies MarketCandleGapsResponse);
+  enableCatalogEntryMock.mockResolvedValue(feed());
 });
 
 afterEach(() => {
@@ -255,6 +266,90 @@ describe('DataFeedsPanel', () => {
     expect(await screen.findByText('Default finance sources')).toBeInTheDocument();
     expect(screen.getByText('Provider binance')).toBeInTheDocument();
     expect(screen.getByText('Provider longbridge')).toBeInTheDocument();
+  });
+
+  it('shows curated finance bundles and enables all ready sources', async () => {
+    const fed: FeedCatalogEntry = {
+      id: 'fed-press-releases',
+      name: 'Federal Reserve Press Releases',
+      description: 'Official Federal Reserve press releases.',
+      feed_type: 'rss',
+      provider: null,
+      tags: ['finance', 'news', 'fed', 'macro'],
+      source_name: 'finance-fed-press-releases',
+      enabled: false,
+      feed_id: null,
+      requires_configuration: false,
+      setup_hint: null,
+      transport_template: {
+        url: 'https://www.federalreserve.gov/feeds/press_all.xml',
+        interval_secs: 300,
+        headers: {},
+        max_entries_per_poll: 50,
+      },
+    };
+    const sec: FeedCatalogEntry = {
+      id: 'sec-press-releases',
+      name: 'SEC Press Releases',
+      description: 'SEC press releases RSS feed.',
+      feed_type: 'rss',
+      provider: null,
+      tags: ['finance', 'news', 'sec', 'regulatory'],
+      source_name: 'finance-sec-press-releases',
+      enabled: false,
+      feed_id: null,
+      requires_configuration: false,
+      setup_hint: null,
+      transport_template: {
+        url: 'https://www.sec.gov/news/pressreleases.rss',
+        interval_secs: 300,
+        headers: {},
+        max_entries_per_poll: 50,
+      },
+    };
+
+    catalogMock.mockResolvedValue([fed, sec] satisfies FeedCatalogEntry[]);
+    financeBundlesMock.mockResolvedValue({
+      count: 1,
+      bundles: [
+        {
+          id: 'macro-news',
+          name: 'Macro News',
+          description: 'Federal Reserve and SEC official RSS feeds.',
+          tags: ['finance', 'news', 'macro', 'regulatory'],
+          catalog_source_ids: ['fed-press-releases', 'sec-press-releases'],
+          feed_types: ['rss'],
+          providers: [],
+          source_count: 2,
+          enabled_source_count: 0,
+          ready_source_count: 2,
+          requires_configuration: false,
+          can_enable: true,
+          sources: [fed, sec],
+          subscriptions: {
+            user_subscribed: false,
+            user_subscription_ids: [],
+          },
+        },
+      ],
+    } satisfies FinanceFeedBundlesResponse);
+
+    renderPanel();
+
+    expect(await screen.findByText('Curated feed bundles')).toBeInTheDocument();
+    expect(screen.getByText('Macro News')).toBeInTheDocument();
+    expect(screen.getByText('0/2 sources on')).toBeInTheDocument();
+    expect(screen.getByText('RSS · Mixed sources')).toBeInTheDocument();
+    expect(
+      screen.getByText('Sources finance-fed-press-releases, finance-sec-press-releases'),
+    ).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Enable bundle' }));
+
+    await waitFor(() => {
+      expect(enableCatalogEntryMock).toHaveBeenNthCalledWith(1, 'fed-press-releases');
+      expect(enableCatalogEntryMock).toHaveBeenNthCalledWith(2, 'sec-press-releases');
+    });
   });
 
   it('requests and displays stored K-line stream watermarks', async () => {


### PR DESCRIPTION
## Summary
- add a curated finance feed bundles card to Data Feeds settings
- enable all ready, non-configured sources in a bundle via existing catalog enable APIs
- invalidate catalog, bundle, subscription, feed, summary, and K-line stream queries after feed state changes
- cover the settings bundle path with component and Playwright harness tests

## Tests
- npm --prefix web run test -- DataFeedsPanel.test.tsx
- npm --prefix web run typecheck
- npm --prefix web run build
- npm --prefix web run test:e2e -- e2e/harness/data-feeds.spec.ts -g "curated finance bundles"
- npm --prefix web run test:e2e -- e2e/harness/data-feeds.spec.ts
- npm --prefix web run lint
- npm --prefix web run format:check
- git diff --check