### PR TITLE
feat(finance): configure bundle sources from settings

### DIFF
--- a/web/e2e/harness/data-feeds.spec.ts
+++ b/web/e2e/harness/data-feeds.spec.ts
@@ -830,6 +830,90 @@ test.describe('Data Feeds Management', () => {
     ]);
   });
 
+  test('configures a requires-config source from a curated bundle', async ({ page }) => {
+    const longbridge: FeedCatalogEntry = {
+      id: 'longbridge-market-candles',
+      name: 'Longbridge Market Data',
+      description: 'Preset for Longbridge equities market data.',
+      feed_type: 'market_candle',
+      provider: 'longbridge',
+      tags: ['finance', 'market-data', 'equities', 'longbridge'],
+      source_name: 'finance-longbridge-market-candles',
+      enabled: false,
+      feed_id: null,
+      requires_configuration: true,
+      setup_hint: 'Connect Longbridge credentials behind a normalized candle endpoint.',
+      transport_template: {
+        url: '',
+        interval_secs: 60,
+        headers: {},
+        venue: 'longbridge',
+        symbols: [],
+        timeframes: [],
+        max_candles_per_poll: 1000,
+      },
+    };
+    const state = {
+      feeds: [] as DataFeedConfig[],
+      events: [] as FeedEvent[],
+      lastCatalogEnableBody: null as unknown,
+      catalog: [longbridge],
+      financeBundles: {
+        count: 1,
+        bundles: [
+          {
+            id: 'longbridge-equities-daily',
+            name: 'Longbridge Equities Daily',
+            description: 'Longbridge equities daily candles preset.',
+            tags: ['finance', 'market-data', 'equities', 'longbridge'],
+            catalog_source_ids: ['longbridge-market-candles'],
+            feed_types: ['market_candle'],
+            providers: ['longbridge'],
+            source_count: 1,
+            enabled_source_count: 0,
+            ready_source_count: 0,
+            requires_configuration: true,
+            can_enable: false,
+            sources: [longbridge],
+            subscriptions: {
+              user_subscribed: false,
+              user_subscription_ids: [],
+            },
+          },
+        ],
+      },
+    };
+    await setupRoutes(page, state);
+    await goToDataFeeds(page);
+
+    await expect(page.getByText('Longbridge Equities Daily', { exact: true })).toBeVisible({
+      timeout: 10_000,
+    });
+    await page.getByRole('button', { name: 'Configure source' }).click();
+
+    await expect(page.getByText('Configure Longbridge Market Data')).toBeVisible({
+      timeout: 5_000,
+    });
+    await page
+      .locator('input[placeholder="https://market-data.example/candles/latest"]')
+      .fill('https://market-data.local/longbridge/candles/latest');
+    await page.locator('input[placeholder="BTCUSDT, ETHUSDT"]').fill('AAPL.US, NVDA.US');
+    await page.locator('input[placeholder="1m, 15m, 1h"]').fill('1d');
+    await page.getByRole('button', { name: 'Enable source' }).click();
+
+    await expect(
+      page.getByRole('button', { name: 'finance-longbridge-market-candles' }),
+    ).toBeVisible({ timeout: 5_000 });
+    expect(state.lastCatalogEnableBody).toMatchObject({
+      transport: {
+        url: 'https://market-data.local/longbridge/candles/latest',
+        venue: 'longbridge',
+        symbols: ['AAPL.US', 'NVDA.US'],
+        timeframes: ['1d'],
+      },
+    });
+  });
+
   test('provider preset opens a prefilled market candle form', async ({ page }) => {
     await setupRoutes(page, {
       feeds: [],

--- a/web/src/components/DataFeedsPanel.tsx
+++ b/web/src/components/DataFeedsPanel.tsx
@@ -1732,6 +1732,7 @@ function FeedCatalogCard({
 
 function FinanceFeedBundlesCard({ bundles }: { bundles: FinanceFeedBundle[] }) {
   const queryClient = useQueryClient();
+  const [configureEntry, setConfigureEntry] = useState<FeedCatalogEntry | null>(null);
 
   const refresh = () => {
     void queryClient.invalidateQueries({ queryKey: ['data-feeds'] });
@@ -1755,82 +1756,132 @@ function FinanceFeedBundlesCard({ bundles }: { bundles: FinanceFeedBundle[] }) {
     onSuccess: refresh,
   });
 
+  const configureSourceMutation = useMutation({
+    mutationFn: ({ id, body }: { id: string; body: EnableCatalogEntryRequest }) =>
+      dataFeedsApi.enableCatalogEntry(id, body),
+    onSuccess: refresh,
+  });
+
   if (bundles.length === 0) return null;
 
   return (
-    <div className="rounded-lg border bg-card">
-      <div className="border-b px-4 py-3">
-        <h3 className="text-sm font-semibold">Curated feed bundles</h3>
-        <p className="text-xs text-muted-foreground">
-          Operator-owned defaults for common finance ingestion paths. Enable ready sources here;
-          configure credentialed providers from the catalog below.
-        </p>
-      </div>
-      <div className="divide-y">
-        {bundles.map((bundle) => {
-          const readyDisabledSources = bundle.sources.filter(
-            (source) => !source.enabled && !source.requires_configuration,
-          );
-          const configuredSources = bundle.sources.filter((source) => source.enabled);
-          const configuredLabel = `${bundle.enabled_source_count}/${bundle.source_count} sources on`;
-          const pending =
-            enableBundleMutation.isPending && enableBundleMutation.variables?.id === bundle.id;
-          const providerLabel =
-            bundle.providers.length > 0 ? summarizeList(bundle.providers) : 'Mixed sources';
-          const feedTypeLabel = bundle.feed_types.map(typeLabel).join(' + ');
-          const sourceNames = bundle.sources.map((source) => catalogSourceName(source));
-          const canEnable = bundle.can_enable && readyDisabledSources.length > 0;
+    <>
+      <div className="rounded-lg border bg-card">
+        <div className="border-b px-4 py-3">
+          <h3 className="text-sm font-semibold">Curated feed bundles</h3>
+          <p className="text-xs text-muted-foreground">
+            Operator-owned defaults for common finance ingestion paths. Enable ready sources here;
+            configure credentialed providers from the catalog below.
+          </p>
+        </div>
+        <div className="divide-y">
+          {bundles.map((bundle) => {
+            const readyDisabledSources = bundle.sources.filter(
+              (source) => !source.enabled && !source.requires_configuration,
+            );
+            const configurableSources = bundle.sources.filter(
+              (source) => !source.enabled && source.requires_configuration,
+            );
+            const configuredSources = bundle.sources.filter((source) => source.enabled);
+            const configuredLabel = `${bundle.enabled_source_count}/${bundle.source_count} sources on`;
+            const pending =
+              enableBundleMutation.isPending && enableBundleMutation.variables?.id === bundle.id;
+            const providerLabel =
+              bundle.providers.length > 0 ? summarizeList(bundle.providers) : 'Mixed sources';
+            const feedTypeLabel = bundle.feed_types.map(typeLabel).join(' + ');
+            const sourceNames = bundle.sources.map((source) => catalogSourceName(source));
+            const canEnable = bundle.can_enable && readyDisabledSources.length > 0;
+            const singleConfigurableSource =
+              configurableSources.length === 1 ? (configurableSources[0] ?? null) : null;
 
-          return (
-            <div key={bundle.id} className="flex flex-col gap-3 px-4 py-3">
-              <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
-                <div className="min-w-0 space-y-1">
-                  <div className="flex flex-wrap items-center gap-2">
-                    <span className="text-sm font-medium">{bundle.name}</span>
-                    <Badge variant="outline" className="text-xs">
-                      {configuredLabel}
-                    </Badge>
-                    {configuredSources.length === bundle.source_count && (
-                      <Badge variant="secondary" className="text-xs text-foreground">
-                        Enabled
+            return (
+              <div key={bundle.id} className="flex flex-col gap-3 px-4 py-3">
+                <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+                  <div className="min-w-0 space-y-1">
+                    <div className="flex flex-wrap items-center gap-2">
+                      <span className="text-sm font-medium">{bundle.name}</span>
+                      <Badge variant="outline" className="text-xs">
+                        {configuredLabel}
                       </Badge>
-                    )}
-                    {bundle.requires_configuration && (
-                      <Badge variant="secondary" className="text-xs text-muted-foreground">
-                        Requires config
-                      </Badge>
+                      {configuredSources.length === bundle.source_count && (
+                        <Badge variant="secondary" className="text-xs text-foreground">
+                          Enabled
+                        </Badge>
+                      )}
+                      {bundle.requires_configuration && (
+                        <Badge variant="secondary" className="text-xs text-muted-foreground">
+                          Requires config
+                        </Badge>
+                      )}
+                    </div>
+                    <p className="text-xs text-muted-foreground">{bundle.description}</p>
+                    <p className="text-[11px] text-muted-foreground">
+                      {feedTypeLabel} · {providerLabel}
+                    </p>
+                    {sourceNames.length > 0 && (
+                      <p className="font-mono text-[11px] text-muted-foreground">
+                        Sources {summarizeList(sourceNames, 5)}
+                      </p>
                     )}
                   </div>
-                  <p className="text-xs text-muted-foreground">{bundle.description}</p>
-                  <p className="text-[11px] text-muted-foreground">
-                    {feedTypeLabel} · {providerLabel}
-                  </p>
-                  {sourceNames.length > 0 && (
-                    <p className="font-mono text-[11px] text-muted-foreground">
-                      Sources {summarizeList(sourceNames, 5)}
-                    </p>
-                  )}
+                  <div className="flex shrink-0 flex-wrap gap-2 sm:justify-end">
+                    {canEnable && (
+                      <Button
+                        size="sm"
+                        className="h-8"
+                        onClick={() => enableBundleMutation.mutate(bundle)}
+                        disabled={pending}
+                      >
+                        {pending ? 'Enabling...' : 'Enable bundle'}
+                      </Button>
+                    )}
+                    {singleConfigurableSource ? (
+                      <Button
+                        size="sm"
+                        className="h-8"
+                        variant={canEnable ? 'outline' : 'default'}
+                        onClick={() => setConfigureEntry(singleConfigurableSource)}
+                      >
+                        Configure source
+                      </Button>
+                    ) : bundle.requires_configuration ? (
+                      <p className="text-xs text-muted-foreground sm:max-w-40 sm:text-right">
+                        Configure required sources below.
+                      </p>
+                    ) : null}
+                  </div>
                 </div>
-                {canEnable ? (
-                  <Button
-                    size="sm"
-                    className="h-8 shrink-0"
-                    onClick={() => enableBundleMutation.mutate(bundle)}
-                    disabled={pending}
-                  >
-                    {pending ? 'Enabling...' : 'Enable bundle'}
-                  </Button>
-                ) : bundle.requires_configuration ? (
-                  <p className="text-xs text-muted-foreground sm:max-w-40 sm:text-right">
-                    Configure required sources below.
-                  </p>
-                ) : null}
               </div>
-            </div>
-          );
-        })}
+            );
+          })}
+        </div>
       </div>
-    </div>
+      <CatalogConfigureDialog
+        entry={configureEntry}
+        onOpenChange={(open) => {
+          if (!open) setConfigureEntry(null);
+        }}
+        onSubmit={(body) => {
+          if (!configureEntry) return;
+          configureSourceMutation.mutate(
+            { id: configureEntry.id, body },
+            {
+              onSuccess: () => setConfigureEntry(null),
+            },
+          );
+        }}
+        saving={
+          configureSourceMutation.isPending &&
+          configureSourceMutation.variables?.id === configureEntry?.id
+        }
+        serverError={
+          configureSourceMutation.isError &&
+          configureSourceMutation.variables?.id === configureEntry?.id
+            ? configureSourceMutation.error.message
+            : null
+        }
+      />
+    </>
   );
 }
 

--- a/web/src/components/__tests__/DataFeedsPanel.test.tsx
+++ b/web/src/components/__tests__/DataFeedsPanel.test.tsx
@@ -352,6 +352,86 @@ describe('DataFeedsPanel', () => {
     });
   });
 
+  it('opens the catalog configure dialog from a requires-config finance bundle', async () => {
+    const longbridge: FeedCatalogEntry = {
+      id: 'longbridge-market-candles',
+      name: 'Longbridge Market Data',
+      description: 'Preset for Longbridge equities market data.',
+      feed_type: 'market_candle',
+      provider: 'longbridge',
+      tags: ['finance', 'market-data', 'equities', 'longbridge'],
+      source_name: 'finance-longbridge-market-candles',
+      enabled: false,
+      feed_id: null,
+      requires_configuration: true,
+      setup_hint: 'Connect Longbridge credentials behind a normalized candle endpoint.',
+      transport_template: {
+        url: '',
+        interval_secs: 60,
+        headers: {},
+        venue: 'longbridge',
+        symbols: [],
+        timeframes: [],
+        max_candles_per_poll: 1000,
+      },
+    };
+
+    catalogMock.mockResolvedValue([longbridge] satisfies FeedCatalogEntry[]);
+    financeBundlesMock.mockResolvedValue({
+      count: 1,
+      bundles: [
+        {
+          id: 'longbridge-equities-daily',
+          name: 'Longbridge Equities Daily',
+          description: 'Longbridge equities daily candles preset.',
+          tags: ['finance', 'market-data', 'equities', 'longbridge'],
+          catalog_source_ids: ['longbridge-market-candles'],
+          feed_types: ['market_candle'],
+          providers: ['longbridge'],
+          source_count: 1,
+          enabled_source_count: 0,
+          ready_source_count: 0,
+          requires_configuration: true,
+          can_enable: false,
+          sources: [longbridge],
+          subscriptions: {
+            user_subscribed: false,
+            user_subscription_ids: [],
+          },
+        },
+      ],
+    } satisfies FinanceFeedBundlesResponse);
+
+    renderPanel();
+
+    expect(await screen.findByText('Longbridge Equities Daily')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'Configure source' }));
+
+    expect(await screen.findByText('Configure Longbridge Market Data')).toBeInTheDocument();
+    fireEvent.change(screen.getByPlaceholderText('https://market-data.example/candles/latest'), {
+      target: { value: 'https://market-data.local/longbridge/candles/latest' },
+    });
+    fireEvent.change(screen.getByPlaceholderText('BTCUSDT, ETHUSDT'), {
+      target: { value: 'AAPL.US, NVDA.US' },
+    });
+    fireEvent.change(screen.getByPlaceholderText('1m, 15m, 1h'), {
+      target: { value: '1d' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Enable source' }));
+
+    await waitFor(() => {
+      expect(enableCatalogEntryMock).toHaveBeenCalledWith('longbridge-market-candles', {
+        transport: expect.objectContaining({
+          url: 'https://market-data.local/longbridge/candles/latest',
+          venue: 'longbridge',
+          symbols: ['AAPL.US', 'NVDA.US'],
+          timeframes: ['1d'],
+        }),
+        auth: null,
+      });
+    });
+  });
+
   it('requests and displays stored K-line stream watermarks', async () => {
     listMock.mockResolvedValue([feed()]);
     candleStreamsMock.mockResolvedValue({


### PR DESCRIPTION
## Summary
- add a Configure source action for single-source requires-config finance bundles
- reuse the existing catalog configuration dialog and catalog enable API from the bundle card
- cover the Longbridge bundle configure path with component and Playwright harness tests

## Tests
- npm --prefix web run typecheck
- npm --prefix web run test -- DataFeedsPanel.test.tsx
- npm --prefix web run build
- npm --prefix web run test:e2e -- e2e/harness/data-feeds.spec.ts -g "requires-config source from a curated bundle"
- npm --prefix web run test:e2e -- e2e/harness/data-feeds.spec.ts
- npm --prefix web run lint
- npm --prefix web run format:check
- git diff --check

Note: one local lint attempt raced with Playwright removing web/test-results while the full E2E suite was running; rerunning lint after E2E completed passed.