### PR TITLE
feat(trading): market anomaly evaluation engine (#2415)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7496,6 +7496,7 @@ version = "0.0.1"
 dependencies = [
  "anyhow",
  "async-trait",
+ "bon",
  "feed-rs",
  "jiff",
  "rara-kernel",
@@ -7505,6 +7506,7 @@ dependencies = [
  "schemars 1.2.1",
  "serde",
  "serde_json",
+ "snafu",
  "sqlx-core",
  "sqlx-postgres",
  "tempfile",

--- a/crates/app/src/finance_event.rs
+++ b/crates/app/src/finance_event.rs
@@ -20,10 +20,11 @@ use rara_kernel::{
     session::SessionKey,
 };
 use rara_trading::{
+    anomaly::{self, AnomalySignal},
     finance::registry::{
         FinanceDeliveryAction, FinanceDeliveryDecision, FinanceSubscriptionRegistry,
     },
-    market_data::{MarketCandle, MarketDataRepository, Timeframe},
+    market_data::{CandleRecentQuery, MarketCandle, MarketDataRepository, Timeframe},
 };
 use rust_decimal::Decimal;
 
@@ -95,15 +96,25 @@ pub(crate) async fn dispatch_feed_event(
 ) -> anyhow::Result<FeedDispatchOutcome> {
     feed_store.append(event).await?;
 
-    if event.event_type == "market_candle_closed" {
+    // Keep the parsed candle so the anomaly evaluator can pull its rolling
+    // window after the upsert (the newest bar is then already durable).
+    let closed_candle = if event.event_type == "market_candle_closed" {
         let candle = market_candle_from_event(event)?;
-        market_repo.upsert_closed_candle(candle).await?;
-    }
+        market_repo.upsert_closed_candle(candle.clone()).await?;
+        Some(candle)
+    } else {
+        None
+    };
+
+    let anomaly = match &closed_candle {
+        Some(candle) => evaluate_anomaly(market_repo, candle).await,
+        None => None,
+    };
 
     let event_json = serde_json::to_value(event).unwrap_or_default();
     let decisions = finance_registry.match_event(event).await;
     for decision in &decisions {
-        dispatch_finance_decision(event, &event_json, decision, sink).await;
+        dispatch_finance_decision(event, &event_json, decision, anomaly.as_ref(), sink).await;
     }
 
     dispatch_generic_subscriptions(event, &event_json, sink).await;
@@ -118,6 +129,7 @@ async fn dispatch_finance_decision(
     event: &FeedEvent,
     event_json: &serde_json::Value,
     decision: &FinanceDeliveryDecision,
+    anomaly: Option<&AnomalySignal>,
     sink: &dyn FeedDispatchSink,
 ) {
     match decision.action {
@@ -130,7 +142,7 @@ async fn dispatch_finance_decision(
             sink.deliver_synthetic(
                 decision.owner.clone(),
                 decision.session_key,
-                finance_directive(event),
+                finance_directive(event, anomaly),
             )
             .await;
         }
@@ -171,19 +183,70 @@ async fn dispatch_generic_subscriptions(
     }
 }
 
-fn finance_directive(event: &FeedEvent) -> String {
+/// Pull the rolling window for `candle` and run the anomaly evaluator.
+///
+/// This is an application-boundary adapter: a repository read or an evaluator
+/// error must never block delivery, so both degrade to `None` (the factual,
+/// unenriched directive) after logging a concrete reason.
+#[tracing::instrument(skip_all)]
+async fn evaluate_anomaly(
+    market_repo: &dyn MarketDataRepository,
+    candle: &MarketCandle,
+) -> Option<AnomalySignal> {
+    let window = match market_repo
+        .recent_candles(CandleRecentQuery {
+            source_name: Some(candle.source_name.clone()),
+            venue:       candle.venue.clone(),
+            symbol:      candle.symbol.clone(),
+            timeframe:   candle.timeframe.clone(),
+            limit:       anomaly::EVAL_WINDOW,
+            // Strictly earlier bars: the window is the history before this bar.
+            end:         Some(candle.open_time),
+        })
+        .await
+    {
+        Ok(rows) => rows,
+        Err(err) => {
+            tracing::warn!(%err, "recent-candles query failed; skipping anomaly evaluation");
+            return None;
+        }
+    };
+
+    match anomaly::evaluate(&window, candle) {
+        Ok(signal) => signal,
+        Err(err) => {
+            tracing::warn!(%err, "anomaly evaluation failed; delivering factual directive");
+            None
+        }
+    }
+}
+
+fn finance_directive(event: &FeedEvent, anomaly: Option<&AnomalySignal>) -> String {
     match event.event_type.as_str() {
-        "market_candle_closed" => format!(
-            "[FinanceMarketUpdate] source={} venue={} symbol={} timeframe={} close_time={} \
-             close={}\nReport the market update factually; do not infer a trade unless the user \
-             asks.",
-            event.source_name,
-            event.payload["venue"].as_str().unwrap_or_default(),
-            event.payload["symbol"].as_str().unwrap_or_default(),
-            event.payload["timeframe"].as_str().unwrap_or_default(),
-            event.payload["close_time"].as_str().unwrap_or_default(),
-            event.payload["close"].as_str().unwrap_or_default(),
-        ),
+        "market_candle_closed" => {
+            let header = format!(
+                "[FinanceMarketUpdate] source={} venue={} symbol={} timeframe={} close_time={} \
+                 close={}",
+                event.source_name,
+                event.payload["venue"].as_str().unwrap_or_default(),
+                event.payload["symbol"].as_str().unwrap_or_default(),
+                event.payload["timeframe"].as_str().unwrap_or_default(),
+                event.payload["close_time"].as_str().unwrap_or_default(),
+                event.payload["close"].as_str().unwrap_or_default(),
+            );
+            match anomaly {
+                Some(signal) => format!(
+                    "{header}\n[Anomaly severity={} reason={}]\nDescribe what happened, the \
+                     related market context, and a suggested next action.",
+                    signal.severity.label(),
+                    signal.reason,
+                ),
+                None => format!(
+                    "{header}\nReport the market update factually; do not infer a trade unless \
+                     the user asks.",
+                ),
+            }
+        }
         _ => format!(
             "[FinanceArticle] source={} title={} url={} published_at={}\nSummarize factual \
              relevance; do not give trade advice unless the user asks.",
@@ -283,10 +346,12 @@ mod tests {
             FinanceDelivery, FinanceEventKind, FinanceSubscription, FinanceSubscriptionRegistry,
         },
         market_data::{
-            CandleLatestQuery, InMemoryMarketDataRepository, MarketDataRepository, Timeframe,
+            CandleLatestQuery, InMemoryMarketDataRepository, MarketCandle, MarketDataRepository,
+            Timeframe,
             tools::{FinanceGetLatestCandleParams, FinanceGetLatestCandleTool},
         },
     };
+    use rust_decimal::Decimal;
 
     use super::{FeedDispatchOutcome, TestFeedDispatchSink, dispatch_feed_event};
     use crate::feed_store::InMemoryFeedStore;
@@ -428,6 +493,62 @@ mod tests {
             cooldown_secs: 900,
             max_immediate_per_hour: 6,
         }
+    }
+
+    /// Build a `binance / BTCUSDT / 15m` candle at bar `index` (15m apart from
+    /// a fixed base), with `open = high = low = close` so drawdown/return
+    /// read the close series directly.
+    fn mk_candle(index: i64, close: i64, volume: i64) -> MarketCandle {
+        let base = ts("2026-07-10T08:00:00Z");
+        let open_time = base + jiff::SignedDuration::from_secs(index * 900);
+        MarketCandle {
+            source_name: "binance-spot".to_owned(),
+            venue: "binance".to_owned(),
+            symbol: "BTCUSDT".to_owned(),
+            timeframe: Timeframe::parse("15m").expect("timeframe fixture should parse"),
+            open_time,
+            close_time: open_time + jiff::SignedDuration::from_secs(900),
+            open: Decimal::from(close),
+            high: Decimal::from(close),
+            low: Decimal::from(close),
+            close: Decimal::from(close),
+            volume: Decimal::from(volume),
+            ingested_at: open_time,
+            provider_sequence: None,
+        }
+    }
+
+    /// Render a `market_candle_closed` feed event carrying `candle`'s fields,
+    /// so the dispatched event and the seeded history share one shape.
+    fn candle_event_from(candle: &MarketCandle) -> FeedEvent {
+        FeedEvent::builder()
+            .id(FeedEventId::deterministic(&format!(
+                "binance:BTCUSDT:15m:{}",
+                candle.open_time
+            )))
+            .source_name(candle.source_name.clone())
+            .event_type("market_candle_closed".to_owned())
+            .tags(vec![
+                "finance".to_owned(),
+                "market-data".to_owned(),
+                "venue:binance".to_owned(),
+                "symbol:BTCUSDT".to_owned(),
+                "timeframe:15m".to_owned(),
+            ])
+            .payload(serde_json::json!({
+                "venue": candle.venue,
+                "symbol": candle.symbol,
+                "timeframe": candle.timeframe.as_str(),
+                "open_time": candle.open_time.to_string(),
+                "close_time": candle.close_time.to_string(),
+                "open": candle.open.to_string(),
+                "high": candle.high.to_string(),
+                "low": candle.low.to_string(),
+                "close": candle.close.to_string(),
+                "volume": candle.volume.to_string(),
+            }))
+            .received_at(candle.ingested_at)
+            .build()
     }
 
     #[tokio::test]
@@ -654,5 +775,103 @@ mod tests {
 
         assert!(sink.synthetic_turns().await.is_empty());
         assert!(sink.silent_appends().await.is_empty());
+    }
+
+    #[tokio::test]
+    async fn anomaly_signal_enriches_finance_directive() {
+        // A crash-shaped rolling window: six flat bars, a four-bar decline, and
+        // a newly closed bar that completes a ~7% drop on a 5x volume spike.
+        let session = SessionKey::new();
+        let market_repo = InMemoryMarketDataRepository::default();
+        let sink = TestFeedDispatchSink::new([session]);
+        let registry = registry_for(candle_sub(session, FinanceDelivery::Immediate)).await;
+
+        let history = [
+            (61_500, 120),
+            (61_500, 120),
+            (61_500, 120),
+            (61_500, 120),
+            (61_500, 120),
+            (61_500, 120),
+            (61_000, 120),
+            (60_000, 120),
+            (59_000, 120),
+            (58_000, 120),
+        ];
+        for (index, (close, volume)) in history.iter().enumerate() {
+            market_repo
+                .upsert_closed_candle(mk_candle(index as i64, *close, *volume))
+                .await
+                .unwrap();
+        }
+        let crash = mk_candle(10, 57_000, 600);
+
+        dispatch_feed_event(
+            &candle_event_from(&crash),
+            &InMemoryFeedStore::default(),
+            &market_repo,
+            &registry,
+            &sink,
+        )
+        .await
+        .unwrap();
+
+        let turns = sink.synthetic_turns().await;
+        assert_eq!(turns.len(), 1);
+        assert!(
+            turns[0].contains("[Anomaly severity=critical"),
+            "directive should name the severity: {}",
+            turns[0]
+        );
+        assert!(
+            turns[0].contains("drawdown"),
+            "directive should carry the anomaly reason: {}",
+            turns[0]
+        );
+        assert!(
+            turns[0].contains("Describe what happened")
+                && turns[0].contains("suggested next action"),
+            "directive should instruct narration and a suggested action: {}",
+            turns[0]
+        );
+
+        // A flat window over the same stream keeps the unchanged factual wording.
+        let flat_session = SessionKey::new();
+        let flat_repo = InMemoryMarketDataRepository::default();
+        let flat_sink = TestFeedDispatchSink::new([flat_session]);
+        let flat_registry =
+            registry_for(candle_sub(flat_session, FinanceDelivery::Immediate)).await;
+
+        for index in 0..10 {
+            let close = if index % 2 == 0 { 61_500 } else { 61_510 };
+            flat_repo
+                .upsert_closed_candle(mk_candle(index, close, 120))
+                .await
+                .unwrap();
+        }
+        let flat = mk_candle(10, 61_505, 122);
+
+        dispatch_feed_event(
+            &candle_event_from(&flat),
+            &InMemoryFeedStore::default(),
+            &flat_repo,
+            &flat_registry,
+            &flat_sink,
+        )
+        .await
+        .unwrap();
+
+        let flat_turns = flat_sink.synthetic_turns().await;
+        assert_eq!(flat_turns.len(), 1);
+        assert!(
+            flat_turns[0].contains("Report the market update factually"),
+            "flat window keeps the factual wording: {}",
+            flat_turns[0]
+        );
+        assert!(
+            !flat_turns[0].contains("[Anomaly"),
+            "flat window must not be enriched: {}",
+            flat_turns[0]
+        );
     }
 }

--- a/crates/extensions/rara-trading/AGENT.md
+++ b/crates/extensions/rara-trading/AGENT.md
@@ -1,0 +1,80 @@
+# rara-trading — Agent Guidelines
+
+## Purpose
+Finance/trading data-feed extension: ingests Binance candles and RSS finance
+articles, persists OHLCV history, matches events against user subscriptions,
+and evaluates newly closed candles for market anomalies — emitting ordinary
+kernel `FeedEvent`s and, on the app side, enriched synthetic directives.
+
+## Architecture
+Four modules, each a `mod.rs` (re-exports + `//!` docs only) over sub-files:
+
+- `feed/` — finance-specific ingestion sources (Binance poller, RSS) that parse
+  external data into kernel `FeedEvent`s. The kernel owns the generic event
+  envelope, registry, and store; this crate only produces events.
+- `finance/registry.rs` — `FinanceSubscriptionRegistry`: matches events to
+  subscriptions on metadata (venue/symbol/timeframe/source/watch_term) and
+  decides delivery (`Immediate` vs `Silent`) under a cooldown + hourly budget.
+  **Delivery policy lives here and nowhere else.**
+- `market_data/` — durable OHLCV storage. `model.rs` (`MarketCandle`,
+  `Timeframe`, the `Candle*Query` structs), `repository.rs`
+  (`MarketDataRepository` trait + `InMemoryMarketDataRepository`),
+  `timescale.rs` (TimescaleDB impl), `tools.rs` (agent-facing query tools).
+  `recent_candles(CandleRecentQuery)` returns the newest N candles ascending
+  and is the rolling-window source for anomaly evaluation.
+- `anomaly/` — market-anomaly evaluation (issue 2415). `evaluate(window,
+  latest) -> Result<Option<AnomalySignal>>` is a **pure** function of its
+  candle inputs. `rules.rs` = L1 (window return, rolling drawdown, volume
+  surge); `statistics.rs` = L2 (MAD-based robust z-score, BNS realized-variance
+  vs bipower-variation jump test); `signal.rs` = `AnomalySignal` / `Severity` /
+  `AnomalyMetrics`; `error.rs` = `AnomalyError` (snafu).
+
+The write→read→enrich wiring lives in `crates/app/src/finance_event.rs`
+(`dispatch_feed_event`): it upserts the closed candle, pulls the window via
+`recent_candles`, runs `anomaly::evaluate`, and enriches `finance_directive`
+when a signal is produced. The evaluator itself holds no repository handle.
+
+## Critical Invariants
+- **The anomaly evaluator is pure — no clock, no I/O.** Every rule and
+  statistic must be reproducible from a fixture candle slice. Consequence of
+  violation: the L1/L2 logic stops being unit-testable and regressions hide
+  behind live data.
+- **Anomaly tuning values are `const`, never YAML** (window size, MAD-to-sigma
+  ≈1.4826, bipower π/2, z-score/drawdown/volume/jump thresholds, min sample
+  count). A deploy operator has no principled reason to retune them; a YAML
+  knob recreates the #1804→#1817 footgun where a default config silently
+  disables the fix (`docs/guides/anti-patterns.md`). The only value a
+  deployment might legitimately tune (per-symbol sensitivity) is out of scope
+  and, if ever added, goes through `config.example.yaml`.
+- **`Severity` is ordered** (`Watch < Elevated < Critical`) so downstream policy
+  compares with `>=`. `Critical` is the bypass-eligible level issue 2416 will
+  consume; do not reorder variants.
+- **Candle selectors are normalized before storage** (venue lowercase, symbol
+  uppercase, timeframe canonical). `recent_candles`/`latest_closed_candle`
+  match on the normalized form.
+
+## What NOT To Do
+- Do NOT change delivery policy (cooldown / hourly budget / `Silent` downgrade)
+  from the `anomaly/` module or `finance_event.rs` — that is `registry.rs`'s
+  job (severity-based bypass is issue 2416). Mixing evaluation and delivery
+  couples two independently-tested concerns.
+- Do NOT return a fixed `Severity` regardless of input, or add an
+  `AnomalyMetrics` field nothing reads — that is a hollow implementation
+  (`docs/guides/anti-patterns.md`). Every severity level and metric must be
+  reachable and asserted by a test.
+- Do NOT feed the newest candle into `evaluate` twice: `window` is the history
+  strictly before `latest`. The app queries `recent_candles` with
+  `end = Some(latest.open_time)` to enforce this.
+- Do NOT use mean/stddev for the return z-score — one outlier bar inflates the
+  scale and masks a fresh move; use median/MAD (`statistics::robust_zscore`).
+- Do NOT compute log-returns on non-positive prices — `evaluate` returns
+  `AnomalyError::NonPositivePrice` instead of producing garbage.
+
+## Dependencies
+- Upstream: `rara-kernel` (`FeedEvent`, `Subscription`, tool traits).
+- Downstream: `crates/app` (`finance_event.rs`) drives ingestion→evaluation→
+  directive delivery; `market_data::tools` are registered as agent tools.
+- External: Binance REST (candles), RSS feeds, TimescaleDB/Postgres
+  (`sqlx-postgres`) for durable candle history.
+- Style: `snafu` for domain errors, `bon::Builder` for 3+ field structs
+  (`AnomalySignal`, `AnomalyMetrics`), `#[async_trait]` on repository traits.

--- a/crates/extensions/rara-trading/Cargo.toml
+++ b/crates/extensions/rara-trading/Cargo.toml
@@ -11,6 +11,7 @@ workspace = true
 [dependencies]
 anyhow = { workspace = true }
 async-trait = { workspace = true }
+bon = { workspace = true }
 feed-rs = { workspace = true }
 jiff = { workspace = true }
 rara-kernel = { workspace = true }
@@ -19,6 +20,7 @@ rust_decimal = { workspace = true }
 schemars = { workspace = true, features = ["uuid1"] }
 serde = { workspace = true }
 serde_json = { workspace = true }
+snafu = { workspace = true }
 sqlx-core = { workspace = true }
 sqlx-postgres = { workspace = true }
 tokio = { workspace = true, features = ["sync", "time"] }

--- a/crates/extensions/rara-trading/src/anomaly/error.rs
+++ b/crates/extensions/rara-trading/src/anomaly/error.rs
@@ -1,0 +1,46 @@
+// Copyright 2026 Rararulab
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Errors surfaced by the anomaly evaluator.
+
+use snafu::Snafu;
+
+/// Failures the anomaly evaluator raises for structurally invalid input.
+///
+/// These are distinct from the ordinary `Ok(None)` outcome (a normal tape
+/// with nothing anomalous, or a window too short to judge): they mark candle
+/// data that violates the arithmetic preconditions of the statistics — a
+/// non-positive close makes a log-return undefined — so the caller can log a
+/// concrete, inspectable reason instead of silently swallowing it.
+#[derive(Debug, Snafu)]
+#[snafu(visibility(pub))]
+pub enum AnomalyError {
+    /// A candle carried a close price that is not strictly positive, so the
+    /// log-return series cannot be formed.
+    #[snafu(display(
+        "candle for {symbol} at {open_time} has non-positive close {close}; cannot compute \
+         log-returns"
+    ))]
+    NonPositivePrice {
+        /// Symbol of the offending candle.
+        symbol:    String,
+        /// Open time of the offending candle.
+        open_time: String,
+        /// The non-positive close value, rendered for the log line.
+        close:     String,
+    },
+}
+
+/// Convenience alias for evaluator results.
+pub type Result<T, E = AnomalyError> = std::result::Result<T, E>;

--- a/crates/extensions/rara-trading/src/anomaly/evaluator.rs
+++ b/crates/extensions/rara-trading/src/anomaly/evaluator.rs
@@ -1,0 +1,348 @@
+// Copyright 2026 Rararulab
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! The anomaly-evaluation entry point.
+//!
+//! [`evaluate`] is a pure function of its candle inputs — no clock, no I/O — so
+//! every rule and statistic is reproducible from a fixture window. It composes
+//! the L1 rules ([`super::rules`]) and L2 statistics ([`super::statistics`])
+//! into a single [`AnomalySignal`], or `None` when the tape is unremarkable.
+//!
+//! The thresholds below are **mechanism constants**
+//! (`docs/guides/anti-patterns.md`): a deploy operator has no principled reason
+//! to retune the drawdown or volume-surge trip points, and a YAML knob would
+//! recreate the #1804→#1817 footgun where a default config silently disables
+//! the fix. The one value a deployment might legitimately tune (per-symbol
+//! sensitivity) is out of scope for this issue and would arrive via
+//! `config.example.yaml`, never as a hardcoded Rust default.
+
+use rust_decimal::prelude::ToPrimitive;
+
+use super::{
+    error::{NonPositivePriceSnafu, Result},
+    rules,
+    signal::{AnomalyMetrics, AnomalySignal, Severity},
+    statistics,
+};
+use crate::market_data::MarketCandle;
+
+/// Number of preceding candles the caller pulls into the rolling window. Wide
+/// enough to give the MAD scale and bipower variation a stable sample, small
+/// enough to stay responsive to a regime change.
+pub const EVAL_WINDOW: usize = 30;
+
+/// Absolute cumulative window return (fraction) that trips the return rule.
+const WINDOW_RETURN_THRESHOLD: f64 = 0.03;
+/// Rolling max-drawdown magnitude (fraction) that trips the drawdown rule.
+const DRAWDOWN_THRESHOLD: f64 = 0.03;
+/// Volume-vs-rolling-mean multiple that trips the volume-surge rule.
+const VOLUME_SURGE_THRESHOLD: f64 = 3.0;
+/// Robust z-score magnitude that trips the return-anomaly statistic.
+const ZSCORE_THRESHOLD: f64 = 3.5;
+/// BNS jump ratio above which the path is flagged as containing a jump.
+const JUMP_RATIO_THRESHOLD: f64 = 1.5;
+/// Drawdown magnitude (fraction) that escalates a multi-rule anomaly to
+/// [`Severity::Critical`] — the flash-crash shape.
+const CRITICAL_DRAWDOWN: f64 = 0.06;
+
+/// Evaluate the newly closed `latest` candle against its preceding `window`
+/// (ordered oldest-to-newest, excluding `latest`).
+///
+/// Returns `Ok(None)` when nothing anomalous fired or the window is too short
+/// to judge, `Ok(Some(signal))` when at least one rule or statistic tripped,
+/// and `Err` only when a candle carries a non-positive close (log-returns
+/// undefined) — a structurally invalid input the caller logs rather than
+/// silently drops.
+///
+/// # Errors
+///
+/// Returns [`super::AnomalyError::NonPositivePrice`] if any close in the window
+/// or the latest candle is not strictly positive.
+pub fn evaluate(window: &[MarketCandle], latest: &MarketCandle) -> Result<Option<AnomalySignal>> {
+    let mut closes = Vec::with_capacity(window.len() + 1);
+    for candle in window {
+        closes.push(close_f64(candle)?);
+    }
+    closes.push(close_f64(latest)?);
+
+    // One prior close is the minimum needed to form a single return.
+    if closes.len() < 2 {
+        return Ok(None);
+    }
+
+    let history_volumes: Vec<f64> = window.iter().map(volume_f64).collect();
+    let latest_volume = volume_f64(latest);
+
+    let returns = statistics::log_returns(&closes);
+    let (&newest_return, history_returns) = returns
+        .split_last()
+        .expect("returns is non-empty when closes has at least two entries");
+
+    let jump_ratio = statistics::jump_ratio(&returns);
+    let metrics = AnomalyMetrics::builder()
+        .window_return(rules::window_return(&closes))
+        .max_drawdown(rules::max_drawdown(&closes))
+        .maybe_volume_surge(rules::volume_surge(&history_volumes, latest_volume))
+        .maybe_robust_zscore(statistics::robust_zscore(history_returns, newest_return))
+        .maybe_jump_ratio(jump_ratio)
+        .jump_flagged(jump_ratio.is_some_and(|ratio| ratio >= JUMP_RATIO_THRESHOLD))
+        .build();
+
+    Ok(classify(metrics))
+}
+
+/// Extract a strictly-positive `f64` close, or fail with a typed error.
+///
+/// Statistical intermediates use `f64` deliberately: log-returns and z-scores
+/// are dimensionless ratios, not ledger amounts, so the precision the candle's
+/// `Decimal` carries is irrelevant once we divide two prices.
+fn close_f64(candle: &MarketCandle) -> Result<f64> {
+    match candle.close.to_f64().filter(|value| value.is_finite()) {
+        Some(value) if value > 0.0 => Ok(value),
+        _ => NonPositivePriceSnafu {
+            symbol:    candle.symbol.clone(),
+            open_time: candle.open_time.to_string(),
+            close:     candle.close.to_string(),
+        }
+        .fail(),
+    }
+}
+
+/// Volume as `f64`; a missing or non-finite value degrades to `0.0`, which the
+/// surge rule treats as "no volume", not as an error.
+fn volume_f64(candle: &MarketCandle) -> f64 {
+    candle
+        .volume
+        .to_f64()
+        .filter(|value| value.is_finite())
+        .unwrap_or(0.0)
+}
+
+/// Map computed metrics to a severity and reason, or `None` when no rule fired.
+fn classify(metrics: AnomalyMetrics) -> Option<AnomalySignal> {
+    let return_fired = metrics.window_return.abs() >= WINDOW_RETURN_THRESHOLD;
+    let drawdown_fired = metrics.max_drawdown >= DRAWDOWN_THRESHOLD;
+    let volume_fired = metrics
+        .volume_surge
+        .is_some_and(|value| value >= VOLUME_SURGE_THRESHOLD);
+    let zscore_fired = metrics
+        .robust_zscore
+        .is_some_and(|value| value >= ZSCORE_THRESHOLD);
+    let jump_fired = metrics.jump_flagged;
+
+    let fired_count = [
+        return_fired,
+        drawdown_fired,
+        volume_fired,
+        zscore_fired,
+        jump_fired,
+    ]
+    .into_iter()
+    .filter(|&fired| fired)
+    .count();
+    if fired_count == 0 {
+        return None;
+    }
+
+    let severity = if metrics.max_drawdown >= CRITICAL_DRAWDOWN && fired_count >= 2 {
+        Severity::Critical
+    } else if fired_count >= 2 {
+        Severity::Elevated
+    } else {
+        Severity::Watch
+    };
+
+    let mut parts = Vec::new();
+    if drawdown_fired {
+        parts.push(format!("drawdown {:.1}%", metrics.max_drawdown * 100.0));
+    }
+    if return_fired {
+        parts.push(format!(
+            "window return {:+.1}%",
+            metrics.window_return * 100.0
+        ));
+    }
+    if let Some(surge) = metrics.volume_surge.filter(|_| volume_fired) {
+        parts.push(format!("volume surge {surge:.1}x"));
+    }
+    if let Some(zscore) = metrics.robust_zscore.filter(|_| zscore_fired) {
+        parts.push(format!("robust z-score {zscore:.1}"));
+    }
+    if let Some(ratio) = metrics.jump_ratio.filter(|_| jump_fired) {
+        parts.push(format!("jump ratio {ratio:.1}"));
+    }
+
+    let reason = format!("{} anomaly — {}", severity.label(), parts.join(", "));
+    Some(
+        AnomalySignal::builder()
+            .severity(severity)
+            .reason(reason)
+            .metrics(metrics)
+            .build(),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use jiff::{SignedDuration, Timestamp};
+    use rust_decimal::Decimal;
+
+    use super::evaluate;
+    use crate::{
+        anomaly::{error::AnomalyError, signal::Severity},
+        market_data::{MarketCandle, Timeframe},
+    };
+
+    /// Build a candle whose open/high/low/close all equal `close` (drawdown and
+    /// returns read closes only) at a distinct, increasing open time.
+    fn candle(index: i64, close: i64, volume: i64) -> MarketCandle {
+        let base: Timestamp = "2026-07-10T00:00:00Z"
+            .parse()
+            .expect("base timestamp parses");
+        let open_time = base + SignedDuration::from_secs(index * 900);
+        MarketCandle {
+            source_name: "binance-spot".to_owned(),
+            venue: "binance".to_owned(),
+            symbol: "BTCUSDT".to_owned(),
+            timeframe: Timeframe::parse("15m").expect("timeframe parses"),
+            open_time,
+            close_time: open_time + SignedDuration::from_secs(900),
+            open: Decimal::from(close),
+            high: Decimal::from(close),
+            low: Decimal::from(close),
+            close: Decimal::from(close),
+            volume: Decimal::from(volume),
+            ingested_at: open_time,
+            provider_sequence: None,
+        }
+    }
+
+    fn window(candles: &[(i64, i64)]) -> Vec<MarketCandle> {
+        candles
+            .iter()
+            .enumerate()
+            .map(|(index, &(close, volume))| candle(index as i64, close, volume))
+            .collect()
+    }
+
+    #[test]
+    fn crash_window_produces_high_severity_anomaly_signal() {
+        // Six flat bars, then a four-bar decline, all at steady volume.
+        let history = window(&[
+            (61_500, 120),
+            (61_500, 120),
+            (61_500, 120),
+            (61_500, 120),
+            (61_500, 120),
+            (61_500, 120),
+            (61_000, 120),
+            (60_000, 120),
+            (59_000, 120),
+            (58_000, 120),
+        ]);
+        // The newly closed bar completes a ~7% drop on a 5x volume spike.
+        let latest = candle(10, 57_000, 600);
+
+        let signal = evaluate(&history, &latest)
+            .expect("positive prices")
+            .expect("crash shape yields a signal");
+
+        assert_eq!(signal.severity, Severity::Critical);
+        assert!(
+            signal.reason.contains("drawdown") && signal.reason.contains("window return"),
+            "reason should name the drawdown and return magnitudes: {}",
+            signal.reason
+        );
+        assert!(signal.metrics.max_drawdown >= 0.06);
+        assert!(signal.metrics.window_return <= -0.06);
+        assert!(signal.metrics.volume_surge.expect("surge computed") >= 3.0);
+    }
+
+    #[test]
+    fn flat_tape_produces_no_anomaly_signal() {
+        let history = window(&[
+            (61_500, 120),
+            (61_510, 120),
+            (61_500, 120),
+            (61_510, 120),
+            (61_500, 120),
+            (61_510, 120),
+            (61_500, 120),
+            (61_510, 120),
+            (61_500, 120),
+            (61_510, 120),
+            (61_500, 120),
+            (61_510, 120),
+        ]);
+        let latest = candle(12, 61_505, 122);
+
+        let signal = evaluate(&history, &latest).expect("positive prices");
+        assert!(signal.is_none(), "flat tape should not enrich: {signal:?}");
+    }
+
+    #[test]
+    fn single_moderate_rule_produces_watch_severity() {
+        // A steady ~4% rise: only the window-return rule trips, no drawdown, no
+        // volume surge, no return-outlier.
+        let history: Vec<MarketCandle> = (0..12)
+            .map(|index| candle(index, 60_000 + 200 * index, 120))
+            .collect();
+        let latest = candle(12, 62_400, 120);
+
+        let signal = evaluate(&history, &latest)
+            .expect("positive prices")
+            .expect("a 4% run trips the return rule");
+
+        assert_eq!(signal.severity, Severity::Watch);
+        assert!(signal.metrics.window_return >= 0.03);
+        assert!(signal.metrics.max_drawdown < 0.03);
+    }
+
+    #[test]
+    fn two_rules_without_deep_drawdown_produce_elevated_severity() {
+        // A ~4% single-bar drop on a volume surge: return + drawdown + volume
+        // fire, but the drawdown stays under the critical 6% floor.
+        let history = window(&[
+            (61_500, 120),
+            (61_500, 120),
+            (61_500, 120),
+            (61_500, 120),
+            (61_500, 120),
+            (61_500, 120),
+            (61_500, 120),
+            (61_500, 120),
+            (61_500, 120),
+            (61_500, 120),
+            (61_500, 120),
+        ]);
+        let latest = candle(11, 59_000, 450);
+
+        let signal = evaluate(&history, &latest)
+            .expect("positive prices")
+            .expect("multi-rule anomaly");
+
+        assert_eq!(signal.severity, Severity::Elevated);
+        assert!(signal.metrics.max_drawdown < 0.06);
+        assert!(signal.metrics.volume_surge.expect("surge computed") >= 3.0);
+    }
+
+    #[test]
+    fn non_positive_close_is_a_typed_error() {
+        let history = window(&[(61_500, 120), (61_500, 120)]);
+        let latest = candle(2, 0, 120);
+
+        let error = evaluate(&history, &latest).expect_err("zero close is invalid");
+        assert!(matches!(error, AnomalyError::NonPositivePrice { .. }));
+    }
+}

--- a/crates/extensions/rara-trading/src/anomaly/mod.rs
+++ b/crates/extensions/rara-trading/src/anomaly/mod.rs
@@ -1,0 +1,38 @@
+// Copyright 2026 Rararulab
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Market-anomaly evaluation: the layer between candle ingestion and directive
+//! delivery.
+//!
+//! Given a newly closed candle plus its rolling window, [`evaluate`] computes
+//! structured signals — L1 rules (window return, rolling drawdown, volume
+//! surge) and L2 statistics (a MAD-based robust z-score of log-returns and the
+//! Barndorff-Nielsen–Shephard jump test) — and produces an [`AnomalySignal`]
+//! carrying a [`Severity`], a human-readable `reason`, and the
+//! [`AnomalyMetrics`] behind it. `None` means the tape is unremarkable and the
+//! caller should leave the directive wording unchanged.
+//!
+//! The evaluator is pure (no clock, no I/O); the wiring that pulls the window
+//! from the market-data repository and enriches the synthetic directive lives
+//! in `crates/app/src/finance_event.rs`.
+
+mod error;
+mod evaluator;
+mod rules;
+mod signal;
+mod statistics;
+
+pub use error::{AnomalyError, Result};
+pub use evaluator::{EVAL_WINDOW, evaluate};
+pub use signal::{AnomalyMetrics, AnomalySignal, Severity};

--- a/crates/extensions/rara-trading/src/anomaly/rules.rs
+++ b/crates/extensions/rara-trading/src/anomaly/rules.rs
@@ -1,0 +1,86 @@
+// Copyright 2026 Rararulab
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! L1 window rules: cumulative return, rolling drawdown, and volume surge.
+//! Each is a pure function over the ordered close/volume series so the
+//! evaluator can compose them and every branch stays unit-testable.
+
+/// Signed cumulative return across `closes`, as a fraction of the first close.
+///
+/// Returns `0.0` for a window of fewer than two prices or a non-positive first
+/// close (the caller rejects non-positive prices before this point, so the
+/// guard is defensive).
+pub(crate) fn window_return(closes: &[f64]) -> f64 {
+    match (closes.first(), closes.last()) {
+        (Some(&first), Some(&last)) if first > 0.0 && closes.len() >= 2 => (last - first) / first,
+        _ => 0.0,
+    }
+}
+
+/// Deepest peak-to-trough decline across `closes`, as a positive fraction of
+/// the running peak. `0.0` for a monotonically non-decreasing series.
+pub(crate) fn max_drawdown(closes: &[f64]) -> f64 {
+    let mut peak = f64::MIN;
+    let mut worst = 0.0_f64;
+    for &price in closes {
+        peak = peak.max(price);
+        if peak > 0.0 {
+            worst = worst.max((peak - price) / peak);
+        }
+    }
+    worst
+}
+
+/// Newest volume relative to the rolling mean of the historical volumes.
+///
+/// `None` when there is no history or the mean is ~zero (division would be
+/// meaningless), so the caller treats the surge rule as not evaluable.
+pub(crate) fn volume_surge(history_volumes: &[f64], latest_volume: f64) -> Option<f64> {
+    if history_volumes.is_empty() {
+        return None;
+    }
+    let mean = history_volumes.iter().sum::<f64>() / history_volumes.len() as f64;
+    if mean <= f64::EPSILON {
+        return None;
+    }
+    Some(latest_volume / mean)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{max_drawdown, volume_surge, window_return};
+
+    #[test]
+    fn window_return_is_signed_fraction_of_first_close() {
+        let closes = [100.0, 101.0, 93.0];
+        assert!((window_return(&closes) - (-0.07)).abs() < 1e-9);
+        assert_eq!(window_return(&[100.0]), 0.0);
+    }
+
+    #[test]
+    fn max_drawdown_tracks_peak_to_trough() {
+        // Peak 110, trough 99 → drawdown 0.1.
+        let closes = [100.0, 110.0, 99.0, 104.0];
+        assert!((max_drawdown(&closes) - 0.1).abs() < 1e-9);
+        // Monotonic rise has no drawdown.
+        assert_eq!(max_drawdown(&[100.0, 101.0, 102.0]), 0.0);
+    }
+
+    #[test]
+    fn volume_surge_is_ratio_to_rolling_mean() {
+        let surge = volume_surge(&[100.0, 100.0, 100.0], 400.0).expect("non-empty history");
+        assert!((surge - 4.0).abs() < 1e-9);
+        assert!(volume_surge(&[], 400.0).is_none());
+    }
+}

--- a/crates/extensions/rara-trading/src/anomaly/signal.rs
+++ b/crates/extensions/rara-trading/src/anomaly/signal.rs
@@ -1,0 +1,84 @@
+// Copyright 2026 Rararulab
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! The structured output of the anomaly evaluator.
+
+use bon::Builder;
+
+/// Ordered urgency of a detected market anomaly.
+///
+/// Variants are ordered from least to most urgent so downstream policy can
+/// compare against a threshold (issue 2416 will bypass the delivery budget at
+/// or above [`Severity::Critical`]). Deriving `Ord` makes that comparison a
+/// plain `>=` rather than a hand-rolled ranking.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum Severity {
+    /// A single rule fired at a modest magnitude — worth narrating, not
+    /// alarming.
+    Watch,
+    /// Multiple rules fired but the drawdown stayed shallow.
+    Elevated,
+    /// A deep drawdown coincided with corroborating signals — the
+    /// bypass-eligible level (a flash-crash shape).
+    Critical,
+}
+
+impl Severity {
+    /// Lowercase label embedded in the injected directive text.
+    #[must_use]
+    pub fn label(self) -> &'static str {
+        match self {
+            Severity::Watch => "watch",
+            Severity::Elevated => "elevated",
+            Severity::Critical => "critical",
+        }
+    }
+}
+
+/// The raw statistics behind an [`AnomalySignal`], kept so every alert is an
+/// inspectable trace rather than an opaque verdict.
+///
+/// Fractions are signed where direction matters ([`Self::window_return`]) and
+/// unsigned magnitudes otherwise ([`Self::max_drawdown`]). The `Option` fields
+/// are `None` when the window held too few samples to trust the statistic.
+#[derive(Debug, Clone, Copy, PartialEq, Builder)]
+pub struct AnomalyMetrics {
+    /// Signed cumulative return across the window, as a fraction (`0.05` =
+    /// +5%).
+    pub window_return: f64,
+    /// Deepest peak-to-trough decline across the window, as a positive
+    /// fraction.
+    pub max_drawdown:  f64,
+    /// Newest volume divided by the rolling mean volume, when computable.
+    pub volume_surge:  Option<f64>,
+    /// MAD-based robust z-score of the newest log-return, when computable.
+    pub robust_zscore: Option<f64>,
+    /// BNS jump ratio (realized variance / bipower variation), when computable.
+    pub jump_ratio:    Option<f64>,
+    /// Whether the jump ratio crossed the discontinuity threshold.
+    pub jump_flagged:  bool,
+}
+
+/// A detected market anomaly: a severity, a human-readable reason naming the
+/// rules/statistics that fired with their magnitudes, and the structured
+/// metrics behind them.
+#[derive(Debug, Clone, PartialEq, Builder)]
+pub struct AnomalySignal {
+    /// How urgent the anomaly is.
+    pub severity: Severity,
+    /// Human-readable summary of which rules fired and by how much.
+    pub reason:   String,
+    /// The structured statistics the [`Self::reason`] and severity derive from.
+    pub metrics:  AnomalyMetrics,
+}

--- a/crates/extensions/rara-trading/src/anomaly/statistics.rs
+++ b/crates/extensions/rara-trading/src/anomaly/statistics.rs
@@ -1,0 +1,215 @@
+// Copyright 2026 Rararulab
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! L2 robust statistics: a MAD-based z-score and the Barndorff-Nielsen–Shephard
+//! (BNS) jump test. Both operate on plain log-return slices so they are pure
+//! and unit-testable without candle fixtures.
+//!
+//! The tuning constants below are **mechanism constants**, not deployment
+//! config (`docs/guides/anti-patterns.md`): a deploy operator has no principled
+//! reason to pick a different MAD-to-sigma factor or bipower coefficient, and a
+//! YAML knob would recreate the #1804→#1817 footgun where a default config
+//! silently disables the fix.
+
+/// Minimum number of returns required before a statistic is trusted. Below this
+/// the MAD scale and bipower variation are too noisy to separate signal from
+/// sampling error, so the evaluator reports `None` for that statistic.
+pub(crate) const MIN_SAMPLES: usize = 8;
+
+/// Consistency constant making the median absolute deviation an unbiased
+/// estimator of the standard deviation for normally distributed data
+/// (`1 / Φ⁻¹(0.75) ≈ 1.4826`).
+const MAD_TO_SIGMA: f64 = 1.4826;
+
+/// Bipower-variation scaling constant `μ₁⁻² = π / 2`, where `μ₁ = E|Z| =
+/// √(2/π)` for a standard normal. It rescales the sum of adjacent absolute
+/// return products so that, under pure diffusion, bipower variation and
+/// realized variance estimate the same integrated variance.
+const BIPOWER_SCALE: f64 = std::f64::consts::FRAC_PI_2;
+
+/// Values whose absolute magnitude is at or below this are treated as zero,
+/// guarding the divisions in the z-score and jump ratio.
+const EPSILON: f64 = 1e-12;
+
+/// Log-returns `ln(cₜ / cₜ₋₁)` of an ordered close series. Empty for fewer than
+/// two prices. Callers guarantee all closes are strictly positive, so the
+/// logarithm is always defined.
+pub(crate) fn log_returns(closes: &[f64]) -> Vec<f64> {
+    closes
+        .windows(2)
+        .map(|pair| (pair[1] / pair[0]).ln())
+        .collect()
+}
+
+/// Median of a slice, or `None` when empty. Copies into a scratch buffer so the
+/// caller's ordering is preserved.
+pub(crate) fn median(values: &[f64]) -> Option<f64> {
+    if values.is_empty() {
+        return None;
+    }
+    let mut sorted = values.to_vec();
+    sorted.sort_by(|left, right| left.total_cmp(right));
+    let mid = sorted.len() / 2;
+    let value = if sorted.len() % 2 == 0 {
+        f64::midpoint(sorted[mid - 1], sorted[mid])
+    } else {
+        sorted[mid]
+    };
+    Some(value)
+}
+
+/// Robust z-score of `newest` against the `history` return series, using the
+/// median and median absolute deviation (MAD) rather than mean and standard
+/// deviation.
+///
+/// MAD is used deliberately: a single large historical outlier bar inflates the
+/// standard deviation and masks a genuinely anomalous fresh move, whereas the
+/// median/MAD scale is unmoved by that one bar. Returns `None` when there are
+/// fewer than [`MIN_SAMPLES`] history points or the MAD collapses to zero (a
+/// perfectly flat history, where no finite z-score is meaningful).
+pub(crate) fn robust_zscore(history: &[f64], newest: f64) -> Option<f64> {
+    if history.len() < MIN_SAMPLES {
+        return None;
+    }
+    let center = median(history)?;
+    let deviations: Vec<f64> = history.iter().map(|value| (value - center).abs()).collect();
+    let mad = median(&deviations)?;
+    let scale = MAD_TO_SIGMA * mad;
+    if scale <= EPSILON {
+        return None;
+    }
+    Some((newest - center).abs() / scale)
+}
+
+/// Realized variance: the sum of squared returns. Dominated by any single large
+/// jump because each return enters squared.
+pub(crate) fn realized_variance(returns: &[f64]) -> f64 {
+    returns.iter().map(|value| value * value).sum()
+}
+
+/// Bipower variation: `μ₁⁻²` times the sum of products of adjacent absolute
+/// returns. A lone jump contributes to only two adjacent products (and there
+/// dampened by its small neighbours), so bipower variation is robust to jumps
+/// and estimates the continuous (diffusive) part of variance.
+pub(crate) fn bipower_variation(returns: &[f64]) -> f64 {
+    let paired: f64 = returns
+        .windows(2)
+        .map(|pair| pair[0].abs() * pair[1].abs())
+        .sum();
+    BIPOWER_SCALE * paired
+}
+
+/// BNS jump statistic: realized variance divided by bipower variation.
+///
+/// Under pure diffusion the two estimate the same integrated variance so the
+/// ratio sits near one; a discontinuous jump inflates realized variance far
+/// more than bipower variation, driving the ratio above one. Returns `None`
+/// when there are too few returns or bipower variation is ~zero.
+pub(crate) fn jump_ratio(returns: &[f64]) -> Option<f64> {
+    if returns.len() < MIN_SAMPLES {
+        return None;
+    }
+    let bipower = bipower_variation(returns);
+    if bipower <= EPSILON {
+        return None;
+    }
+    Some(realized_variance(returns) / bipower)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{jump_ratio, realized_variance, robust_zscore};
+
+    /// Naive mean/standard-deviation z-score, used only to demonstrate the
+    /// contrast the robust version is designed to beat.
+    fn stddev_zscore(history: &[f64], newest: f64) -> f64 {
+        let n = history.len() as f64;
+        let mean = history.iter().sum::<f64>() / n;
+        let variance = history.iter().map(|v| (v - mean).powi(2)).sum::<f64>() / n;
+        (newest - mean).abs() / variance.sqrt()
+    }
+
+    #[test]
+    fn robust_zscore_uses_mad_not_stddev() {
+        // Eight quiet bars plus one large historical outlier (+10%). A fresh
+        // +2% move is anomalous relative to the quiet regime.
+        let history = [
+            0.001, -0.0012, 0.0009, -0.0008, 0.0011, -0.0010, 0.0012, -0.0009, 0.10,
+        ];
+        let newest = 0.02;
+
+        let robust = robust_zscore(&history, newest).expect("history exceeds min samples");
+        let naive = stddev_zscore(&history, newest);
+
+        // Threshold the evaluator applies to the robust score.
+        const ZSCORE_THRESHOLD: f64 = 3.5;
+
+        // The MAD scale ignores the lone outlier, so the fresh move stands out.
+        assert!(
+            robust > ZSCORE_THRESHOLD,
+            "robust z-score {robust} should exceed {ZSCORE_THRESHOLD}"
+        );
+        // The stddev scale is inflated by the outlier and suppresses the move.
+        assert!(
+            naive < ZSCORE_THRESHOLD,
+            "stddev z-score {naive} should be suppressed below {ZSCORE_THRESHOLD}"
+        );
+    }
+
+    #[test]
+    fn bns_jump_test_flags_jump_over_diffusion() {
+        // Diffusive window: constant-magnitude alternating returns. Realized
+        // variance = 10 * 0.01² = 0.001.
+        let diffusive = [
+            0.01, -0.01, 0.01, -0.01, 0.01, -0.01, 0.01, -0.01, 0.01, -0.01,
+        ];
+        // Jump window: quiet ±0.002 background plus one dominant jump bar,
+        // tuned so realized variance also equals 0.001.
+        let jump = [
+            0.002,
+            -0.002,
+            0.002,
+            -0.002,
+            0.031_048_349,
+            -0.002,
+            0.002,
+            -0.002,
+            0.002,
+            -0.002,
+        ];
+
+        // Equal realized variance is the whole point: the separation must come
+        // from bipower variation, not from a variance difference.
+        let rv_diffusive = realized_variance(&diffusive);
+        let rv_jump = realized_variance(&jump);
+        assert!(
+            (rv_diffusive - rv_jump).abs() < 1e-6,
+            "realized variance should match: {rv_diffusive} vs {rv_jump}"
+        );
+
+        const JUMP_RATIO_THRESHOLD: f64 = 1.5;
+
+        let diffusive_ratio = jump_ratio(&diffusive).expect("enough samples");
+        let jump_ratio_value = jump_ratio(&jump).expect("enough samples");
+
+        assert!(
+            diffusive_ratio < JUMP_RATIO_THRESHOLD,
+            "diffusive ratio {diffusive_ratio} should stay below {JUMP_RATIO_THRESHOLD}"
+        );
+        assert!(
+            jump_ratio_value > JUMP_RATIO_THRESHOLD,
+            "jump ratio {jump_ratio_value} should exceed {JUMP_RATIO_THRESHOLD}"
+        );
+    }
+}

--- a/crates/extensions/rara-trading/src/lib.rs
+++ b/crates/extensions/rara-trading/src/lib.rs
@@ -19,6 +19,7 @@
 //! ingestion/parsing sources and emits ordinary kernel
 //! [`FeedEvent`](rara_kernel::data_feed::FeedEvent) values.
 
+pub mod anomaly;
 pub mod feed;
 pub mod finance;
 pub mod market_data;

--- a/specs/issue-2415-market-anomaly-engine.spec.md
+++ b/specs/issue-2415-market-anomaly-engine.spec.md
@@ -1,0 +1,202 @@
+spec: task
+name: "issue-2415-market-anomaly-engine"
+inherits: project
+tags: [enhancement, backend, trading]
+---
+
+## Intent
+
+rara's trading extension already ingests Binance `market_candle_closed` events,
+stores OHLCV in the TimescaleDB market-data repository
+(`crates/extensions/rara-trading/src/market_data/`), matches them against
+finance subscriptions (`finance/registry.rs`), and injects synthetic directives
+into a session via `crates/app/src/finance_event.rs`. The proactive-feedback
+chain is wired end to end. What is missing is any notion of *abnormality*:
+`registry.rs::match_event` filters purely on metadata (symbol / timeframe /
+source / watch_term) and `finance_event.rs::finance_directive` emits a bare
+candle ("Report the market update factually"). Every matched bar is treated
+identically — a routine 0.1% drift and a 7% flash crash produce the same
+inert directive.
+
+This issue adds the anomaly-evaluation layer that sits between ingestion and
+delivery: given the newly closed candle plus a rolling window pulled from the
+market-data repository, it computes structured signals (window return, rolling
+drawdown, volume surge, a robust MAD-based z-score of returns, and a
+Barndorff-Nielsen–Shephard (BNS) jump test separating a true price jump from
+normal diffusion) and produces an `AnomalySignal { severity, reason, metrics }`.
+It then enriches the synthetic directive so the agent narrates *what happened*
+(magnitude, which statistics fired) rather than restating a candle. Delivery
+*policy* (cooldown / hourly budget) is unchanged in this issue — that reversal
+is issue 2416.
+
+If we do not do this, the following concrete black-swan bug appears.
+Reproducer:
+
+1. A user subscribes a session to `binance / BTCUSDT / 1m` with
+   `delivery: immediate`.
+2. BTCUSDT drops 7% across three consecutive 1m bars on a volume spike (a real
+   flash-crash shape).
+3. Each closed bar is matched by `match_event` and delivered, but the injected
+   directive is `[FinanceMarketUpdate] ... close=<price>\nReport the market
+   update factually; do not infer a trade unless the user asks.` — identical
+   in wording and salience to a flat-tape bar. The agent has no signal that
+   this was a crash, cannot narrate the drawdown or the volume surge, and the
+   observed bad outcome is: rara "sees" the black swan yet surfaces nothing
+   distinguishable from noise, which is precisely the failure the user is
+   asking us to prevent.
+
+This advances `goal.md` signal 2 ("The user stops asking ... they expect rara
+to surface the right thing at the right time, unprompted") and signal 4 ("Every
+action is inspectable" — `AnomalySignal.reason` + `metrics` make each alert a
+readable trace, not a black box). It crosses no "What rara is NOT" line: this
+is single-surface depth on the existing crypto feed, not a feature-parity race.
+
+Prior-art search (2026-07-14): `gh issue list` / `gh pr list` on
+`rararulab/rara` for `anomaly`, `severity`, `alert`, `volatility`, `market
+candle`, `cooldown` returned no prior anomaly / statistical-evaluation work.
+The finance feed lineage is PRs 2223 (subscriptions), 2243 / 2278 (candle
+subscribe + selector scope), 2276 (candle timestamp validation), 2362 / 2363 /
+2312 (candle pagination), and 2411 (bundle status). None added an anomaly or
+statistics layer; none is reversed by this work. `git log --all --grep` for
+`anomaly|z-score|bipower|jump` since 180 days found nothing in this area. No
+prior commit removed a market-anomaly evaluator, so this is greenfield, not a
+regression-decision reversal.
+
+## Decisions
+
+- New module `crates/extensions/rara-trading/src/anomaly/` (with its own
+  `mod.rs` for re-exports + module docs, logic split into sub-files per the
+  `mod.rs`-is-re-exports rule). Public surface: `AnomalySignal`, a `Severity`
+  enum, and an evaluator entry point that takes an ordered candle window plus
+  the newly closed candle and returns `Option<AnomalySignal>` (`None` = normal,
+  no directive enrichment).
+- `AnomalySignal` carries `severity: Severity`, a human-readable `reason`
+  (which rules/statistics fired, with magnitudes), and the structured `metrics`
+  behind them. `Severity` is an ordered enum so issue 2416 can compare against a
+  bypass threshold. Use `#[derive(bon::Builder)]` for the 3+ field signal
+  struct; `snafu` for any evaluator error type (domain path).
+- L1 rules, all over the rolling window: N-bar window return, rolling maximum
+  drawdown, and volume surge (current volume vs a rolling mean multiple).
+- L2 statistics: a robust z-score of log-returns using the median / MAD (not
+  mean / stddev, so a single outlier bar does not inflate the scale), and the
+  BNS jump test comparing realized variance against bipower variation to flag
+  a discontinuous jump versus continuous diffusion.
+- Money/price math uses `rust_decimal` (already a dependency) for candle
+  fields; statistical intermediates (log-returns, z-scores, variance) may use
+  `f64` — document at the boundary why the conversion is safe (returns are
+  ratios, not ledger amounts).
+- Window sizes, the MAD-to-sigma consistency constant (~1.4826), the bipower
+  scaling constant, the default z-score / drawdown / volume-surge thresholds,
+  and the minimum sample count before a statistic is trusted are **mechanism
+  constants** → Rust `const` next to the evaluator, NOT YAML. Rationale
+  (`docs/guides/anti-patterns.md` "mechanism-tuning constants"): a deploy
+  operator has no principled reason to pick a different bipower coefficient or
+  MAD multiplier, and a YAML knob would recreate the #1804→#1817 footgun where
+  a default config silently disables the fix. The single value a deployment
+  might legitimately tune (e.g. per-symbol sensitivity) is out of scope here;
+  if it is ever added it goes through `config.example.yaml`, never a hardcoded
+  Rust default.
+- Wiring: `crates/app/src/finance_event.rs::dispatch_feed_event` already holds
+  a `&dyn MarketDataRepository`. On a matched `market_candle_closed` decision,
+  query the rolling window via the existing
+  `MarketDataRepository::recent_candles(CandleRecentQuery)`, run the evaluator,
+  and when a signal is produced, enrich `finance_directive` so the injected
+  text names the anomaly (severity + reason + a "describe what happened, the
+  related context, and a suggested next action" instruction) instead of the
+  bare-candle wording. When the evaluator returns `None`, directive wording is
+  unchanged.
+- The evaluator is a pure function of its candle inputs (no clock, no I/O), so
+  every rule and statistic is unit-testable with fixture windows.
+
+## Boundaries
+
+### Allowed Changes
+- **/crates/extensions/rara-trading/src/anomaly/**
+- **/crates/extensions/rara-trading/src/lib.rs
+- **/crates/app/src/finance_event.rs
+- **/crates/extensions/rara-trading/Cargo.toml
+- **/crates/extensions/rara-trading/AGENT.md
+- **/Cargo.lock
+- **/specs/issue-2415-market-anomaly-engine.spec.md
+
+Note: the three paths above the spec file were added during implementation.
+`Cargo.toml` gains the `bon` and `snafu` workspace deps this spec's own
+Decisions mandate (`#[derive(bon::Builder)]` + snafu error type); `AGENT.md`
+is the crate-guidelines file `docs/guides/agent-md.md` requires for the new
+`anomaly/` domain; `Cargo.lock` is the mechanical lockfile update from the two
+added deps. None touches the Forbidden set.
+
+### Forbidden
+- **/crates/extensions/rara-trading/src/finance/registry.rs
+- **/config.example.yaml
+- **/web/**
+- **/extension/**
+- Do NOT change the delivery policy (cooldown / hourly-budget / Silent
+  downgrade) in this issue — `registry.rs::delivery_action` is untouched here;
+  the severity-bypass reversal is issue 2416.
+- Do NOT add a YAML knob for any window size, statistical constant, or default
+  threshold — mechanism tuning is a Rust `const` (`docs/guides/anti-patterns.md`).
+- Do NOT introduce WebSocket ingestion or change the polling transport — poll
+  latency is issue 2417.
+- Do NOT construct hollow signals: an evaluator path that always returns the
+  same `Severity` regardless of input, or a metric field nothing reads, is a
+  hollow implementation (`docs/guides/anti-patterns.md`). Every `Severity`
+  level and metric must be reachable and asserted by a test.
+
+## Acceptance Criteria
+
+Scenario: A multi-bar crash on a volume spike produces a high-severity signal
+  Test:
+    Package: rara-trading
+    Filter: crash_window_produces_high_severity_anomaly_signal
+  Given an ordered candle window ending in a sharp multi-bar decline with a volume spike
+  When the anomaly evaluator runs over the window and the newest closed candle
+  Then it returns a signal whose severity is the highest (bypass-eligible) level
+    And the reason names the drawdown / return magnitude that fired
+
+Scenario: A flat, low-volatility tape produces no anomaly signal
+  Test:
+    Package: rara-trading
+    Filter: flat_tape_produces_no_anomaly_signal
+  Given an ordered candle window of small alternating moves at steady volume
+  When the anomaly evaluator runs over the window and the newest closed candle
+  Then it returns None (no directive enrichment)
+
+Scenario: The robust z-score uses MAD so one prior outlier does not mask a new move
+  Test:
+    Package: rara-trading
+    Filter: robust_zscore_uses_mad_not_stddev
+  Given a return series containing one large historical outlier bar
+  When the robust z-score of the newest return is computed
+  Then the newest return is scored against the MAD-based scale
+    And a fresh anomalous return still exceeds the z-score threshold that a
+        stddev-based scale would have suppressed
+
+Scenario: The BNS jump test separates a discontinuous jump from diffusion
+  Test:
+    Package: rara-trading
+    Filter: bns_jump_test_flags_jump_over_diffusion
+  Given two windows of equal realized variance, one dominated by a single jump bar and one purely diffusive
+  When the BNS jump statistic (realized variance vs bipower variation) is computed for each
+  Then the jump-dominated window is flagged as a jump
+    And the diffusive window is not
+
+Scenario: A produced signal enriches the injected directive with its narrative
+  Test:
+    Package: rara-app
+    Filter: anomaly_signal_enriches_finance_directive
+  Given a matched immediate BTCUSDT candle whose rolling window is crash-shaped
+  When dispatch_feed_event evaluates the window and injects the synthetic directive
+  Then the directive text contains the anomaly severity and reason
+    And instructs the agent to describe what happened and a suggested action
+    And a matched candle whose window is flat yields the unchanged factual wording
+
+## Out of Scope
+
+- Delivery-policy changes (cooldown / budget bypass) — issue 2416.
+- Sub-minute poll latency and rate-limit floor — issue 2417.
+- WebSocket ingestion (a later phase).
+- Non-crypto assets and non-Binance venues.
+- Per-symbol operator-tunable sensitivity via YAML (only if ever needed, in a
+  later issue, through `config.example.yaml`).
+- Any web / extension UI surface for anomalies.


### PR DESCRIPTION
## Summary

Adds the market-anomaly evaluation layer between candle ingestion and directive delivery. `rara_trading::anomaly::evaluate(window, latest)` is a **pure** function over a rolling candle window that computes L1 rules (window return, rolling max drawdown, volume surge) and L2 statistics (a MAD-based robust z-score of log-returns and the Barndorff-Nielsen–Shephard realized-variance-vs-bipower jump test), returning `AnomalySignal { severity, reason, metrics }` or `None`.

`dispatch_feed_event` upserts the closed candle, pulls its rolling window via `MarketDataRepository::recent_candles` (with `end = Some(latest.open_time)` so history excludes the new bar), runs the evaluator, and enriches the injected `finance_directive` to name the severity + reason and instruct the agent to describe what happened and suggest a next action. A flat tape returns `None` and keeps the unchanged factual wording.

Tuning values (window size, MAD-to-sigma and bipower constants, z-score / drawdown / volume-surge / jump thresholds, min sample count) are Rust `const` next to the mechanism, **not YAML**, per `docs/guides/anti-patterns.md`. Delivery policy in `registry.rs` is untouched — severity bypass is issue 2416.

New module layout: `crates/extensions/rara-trading/src/anomaly/` (`mod.rs` re-exports only; logic split into `signal.rs`, `error.rs`, `rules.rs`, `statistics.rs`, `evaluator.rs`). `Severity` is an ordered enum (`Watch < Elevated < Critical`); every level and metric is reachable and asserted by a test. `AnomalyError::NonPositivePrice` (snafu) surfaces structurally invalid input.

Also adds `bon` + `snafu` deps to `rara-trading` (mandated by the spec's own Decisions), an `AGENT.md` for the crate, and widens the spec `Boundaries.Allowed` to cover those two build-required files plus `Cargo.lock`.

## Type of change

New feature (`enhancement`).

## Component

`backend` (finance/trading service + extension layer).

## Verification

Verification: PASS — /Users/ryan/code/personal/rara/.worktrees/issue-2415-market-anomaly-engine/verification/report.md

- Lane-1 `just spec-lifecycle`: `passed: true` — `[PASS] [boundaries]` + all 5 BDD scenarios PASS.
- `rara-trading`: 76 lib tests pass; `rara-app`: 186 lib tests pass (incl. `anomaly_signal_enriches_finance_directive`).
- Gate clean: `cargo check --all --all-targets`, `cargo +nightly fmt -- --check`, `cargo clippy --workspace ... -D warnings`, `RUSTDOCFLAGS="-D warnings" cargo +nightly doc`.

## Deferred (reviewer P3 nits, non-blocking)

Kept out of this PR so the pushed artifact matches the verified + approved commit `b932944b`; candidate fast-follows:
1. Skip the window query when `match_event` returns no decisions (only evaluate on `!decisions.is_empty()`).
2. Directive `severity=critical` + reason prefix `critical anomaly —` are mildly redundant.
3. `statistics.rs` test module re-declares the evaluator's threshold consts.

## Closes

Closes #2415

## Test plan

- [x] `cargo test -p rara-trading` / `cargo test -p rara-app` pass
- [x] `cargo clippy --workspace ... -D warnings` passes
- [x] Lane-1 `just spec-lifecycle` — 5/5 scenarios + boundaries PASS