### PR TITLE
feat(trading): enforce sub-minute market-candle polling floor (#2417)

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -262,6 +262,16 @@ agents:
 #   symbols: ["BTCUSDT", "ETHUSDT"]
 #   timeframes: ["15m", "1h"]
 #   max_candles_per_poll: 1000
+#
+# interval_secs is the polling cadence. Sub-minute monitoring (5–10s) is
+# supported so a flash crash is observed within seconds; 5s is the hard floor
+# (interval_secs below it is rejected at load). The floor is a fixed property
+# of Binance's per-IP request-weight limit, not a tunable — do not try to
+# override it. Note the effective request rate is symbols × timeframes /
+# interval_secs per second, not 1 / interval_secs: each tick fans out to one
+# /api/v3/klines request per symbol × timeframe. So even at interval_secs >= 5,
+# a large symbols × timeframes set can approach the venue's rate limit — keep
+# the monitored set focused rather than pushing the interval to the floor.
 
 # ---------------------------------------------------------------------------
 # Optional integrations — remove or leave commented out if unused

--- a/crates/extensions/rara-trading/src/feed/catalog.rs
+++ b/crates/extensions/rara-trading/src/feed/catalog.rs
@@ -201,6 +201,14 @@ fn rss_source(
     }
 }
 
+/// Builds a public Binance spot OHLCV preset polling `/api/v3/klines`.
+///
+/// `interval_secs` is the polling cadence. Sub-minute monitoring (5–10s) is
+/// supported for timely flash-crash detection; the transport rejects any
+/// cadence below the `MIN_INTERVAL_SECS` floor at load. The effective request
+/// rate is `symbols × timeframes / interval_secs` per second, so keep the
+/// monitored set focused when polling near the floor to stay within Binance's
+/// per-IP request-weight budget.
 fn binance_market_candles_source(
     id: &str,
     name: &str,

--- a/crates/extensions/rara-trading/src/feed/market_candle.rs
+++ b/crates/extensions/rara-trading/src/feed/market_candle.rs
@@ -49,6 +49,27 @@ use crate::market_data::Timeframe;
 const MAX_CANDLES_PER_POLL: usize = 10_000;
 const MAX_BODY_BYTES: usize = 4 * 1024 * 1024;
 
+/// Minimum polling cadence for a market-candle feed, in seconds.
+///
+/// Sub-minute polling (5–10s) is the intended operating point: a flash crash
+/// must be observed within seconds, not up to a minute late. But the Binance
+/// public REST API enforces a per-IP request-weight budget, and each poll tick
+/// fans out to `symbols × timeframes` `/api/v3/klines` requests — so the true
+/// request rate is `symbols × timeframes / interval_secs` per second, not
+/// `1 / interval_secs`. A cadence below this floor multiplies that fan-out into
+/// a request burst that trips the venue's rate limit (HTTP 429/418) and gets
+/// the deployment IP temporarily banned, flipping every symbol to `Error` at
+/// once. Five seconds is the fastest cadence that keeps the intended monitoring
+/// fan-out within the venue's budget while still catching a sub-minute crash in
+/// time.
+///
+/// This encodes a fixed property of the venue API's rate limit — no deploy
+/// operator has a principled reason to poll faster than the venue allows — so
+/// it lives as a mechanism `const` rather than a YAML knob
+/// (`docs/guides/anti-patterns.md`). `interval_secs` itself stays a per-feed
+/// config value: a genuine deploy-relevant choice *within* the allowed range.
+const MIN_INTERVAL_SECS: u64 = 5;
+
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct MarketCandleTransport {
     #[serde(default)]
@@ -617,6 +638,12 @@ fn validate_transport(transport: &MarketCandleTransport) -> anyhow::Result<()> {
         "market candle interval_secs must be greater than zero"
     );
     anyhow::ensure!(
+        transport.interval_secs >= MIN_INTERVAL_SECS,
+        "market candle interval_secs must be at least {MIN_INTERVAL_SECS} seconds: each poll tick \
+         fans out to symbols × timeframes /api/v3/klines requests, so polling faster trips \
+         Binance's per-IP request-weight rate limit and gets the deployment IP-banned"
+    );
+    anyhow::ensure!(
         !transport.venue.is_empty(),
         "market candle venue is required"
     );
@@ -987,5 +1014,56 @@ mod tests {
         assert_eq!(event.payload["low"], "61480.50");
         assert_eq!(event.payload["close"], "61610.30");
         assert_eq!(event.payload["volume"], "124.551");
+    }
+
+    fn candle_config_with_interval(interval_secs: u64) -> DataFeedConfig {
+        DataFeedConfig::builder()
+            .id("candles-cadence-test".to_owned())
+            .name("binance-cadence".to_owned())
+            .feed_type(FeedType::MarketCandle)
+            .tags(vec!["finance".to_owned(), "crypto".to_owned()])
+            .transport(serde_json::json!({
+                "provider": "binance",
+                "base_url": "https://api.binance.com",
+                "interval_secs": interval_secs,
+                "venue": "binance",
+                "symbols": ["BTCUSDT"],
+                "timeframes": ["1m"],
+                "max_candles_per_poll": 2
+            }))
+            .enabled(true)
+            .status(FeedStatus::Idle)
+            .created_at(jiff::Timestamp::UNIX_EPOCH)
+            .updated_at(jiff::Timestamp::UNIX_EPOCH)
+            .build()
+    }
+
+    #[test]
+    fn subminute_interval_within_floor_is_accepted() {
+        let config = candle_config_with_interval(super::MIN_INTERVAL_SECS);
+
+        MarketCandleSource::from_config(&config)
+            .expect("a 5s monitoring cadence at the floor should pass transport validation");
+    }
+
+    #[test]
+    fn interval_below_rate_limit_floor_is_rejected() {
+        let config = candle_config_with_interval(super::MIN_INTERVAL_SECS - 1);
+
+        // `MarketCandleSource` is not `Debug`, so match rather than `expect_err`.
+        let error = match MarketCandleSource::from_config(&config) {
+            Ok(_) => panic!("an interval below the rate-limit floor must be rejected at load"),
+            Err(error) => error,
+        };
+        let message = error.to_string();
+
+        assert!(
+            message.contains(&super::MIN_INTERVAL_SECS.to_string()),
+            "error must name the minimum interval, got: {message}"
+        );
+        assert!(
+            message.contains("request-weight") && message.contains("rate limit"),
+            "error must explain the rate-limit rationale, got: {message}"
+        );
     }
 }

--- a/specs/issue-2417-subminute-candle-polling.spec.md
+++ b/specs/issue-2417-subminute-candle-polling.spec.md
@@ -1,0 +1,125 @@
+spec: task
+name: "issue-2417-subminute-candle-polling"
+inherits: project
+tags: [enhancement, backend, trading]
+---
+
+## Intent
+
+The built-in Binance `market_candle` source polls `/api/v3/klines` on a fixed
+cadence driven by `MarketCandleTransport.interval_secs`
+(`crates/extensions/rara-trading/src/feed/market_candle.rs`). For real-time
+black-swan detection the monitored streams need a sub-minute cadence (5–10s)
+so a crash is observed within seconds, not up to a minute late. Reusing the
+existing REST polling loop is the intended path — WebSocket ingestion is a
+later phase and explicitly out of scope here.
+
+`interval_secs` is already a free per-feed field, but `validate_transport`
+only enforces `interval_secs > 0`. That is the wrong guard for two reasons:
+(1) nothing documents or blesses the 5–10s operating point the MVP needs, and
+(2) there is no floor stopping a config from polling at, say, 1s across many
+`symbols × timeframes`, which fans out to a burst of klines calls per tick and
+will trip Binance's per-IP request-weight limit and get the deployment
+temporarily banned. The MVP needs sub-minute polling to be *enabled and safe*,
+not merely *not rejected*.
+
+If we do not do this, one of two concrete bugs appears. Reproducer A
+(latency): the operator leaves `interval_secs: 60`; a flash crash that starts
+and bottoms within 40s is only observed on the next minute boundary, after the
+worst of the move — the anomaly engine (issue 2415) evaluates a candle that
+already reflects a recovered or fully-collapsed price, defeating "timely
+feedback". Reproducer B (ban): the operator, wanting speed, sets
+`interval_secs: 1` with 15 symbols × 2 timeframes; each tick issues 30 klines
+requests, ~1800/min, exceeding Binance's request-weight budget; the venue
+returns HTTP 429/418 and the feed flips to `Error` (via the existing
+`record_error` path) — rara goes blind on every symbol at once, the opposite of
+resilient monitoring.
+
+This advances `goal.md` signal 2 (surfacing the right thing *at the right
+time* — timeliness is half of "the right time") and signal 1 ("runs for months
+without intervention" — a rate-limit-aware floor keeps the feed from
+self-inflicting a ban). It crosses no "What rara is NOT" line: single-surface
+depth on the existing crypto feed, reusing the existing transport.
+
+Prior-art search (2026-07-14): the market-candle transport and its
+`validate_transport` guards came from the finance-feed lineage (PRs 2223, 2243,
+2250 default presets, 2270 config normalization, 2276 timestamp validation).
+No prior PR added or removed an interval floor / rate-limit guard, and none
+set a minimum cadence that this issue would be reversing. `git log --all
+--grep "interval|poll"` since 180 days shows no removed minimum-interval logic.
+So this is a first-time guard, not a regression-decision reversal.
+
+## Decisions
+
+- Keep the existing REST polling loop and `interval_secs` field. This issue
+  does not add a new transport or a WebSocket path.
+- Add a minimum-interval floor to `validate_transport`: reject an
+  `interval_secs` below the floor with a clear `snafu`/`anyhow` boundary error
+  message, so a reckless sub-floor config fails fast at load instead of getting
+  the deployment IP-banned at runtime. The floor is chosen to keep the
+  worst-case fan-out (`symbols × timeframes` requests per tick) within Binance's
+  documented per-IP request-weight budget at the intended 5–10s operating point.
+- The floor value is a **mechanism constant** (Rust `const` next to the
+  transport validation), NOT a YAML knob — it encodes a fixed property of the
+  Binance public API's rate limit, which no deploy operator has a principled
+  reason to raise past what the venue allows
+  (`docs/guides/anti-patterns.md`). `interval_secs` itself stays a per-feed
+  config value in `config.example.yaml` (a genuine deploy-relevant choice
+  *within* the allowed range).
+- Update `config.example.yaml`'s commented market-candle example and any
+  built-in preset in `crates/extensions/rara-trading/src/feed/catalog.rs` to
+  document the supported 5–10s monitoring cadence and the floor, so operators
+  see the safe operating point instead of guessing.
+- No change to event shape, dedupe, or downstream matching — only cadence and
+  its validation.
+
+## Boundaries
+
+### Allowed Changes
+- **/crates/extensions/rara-trading/src/feed/market_candle.rs
+- **/crates/extensions/rara-trading/src/feed/catalog.rs
+- **/config.example.yaml
+- **/specs/issue-2417-subminute-candle-polling.spec.md
+
+### Forbidden
+- **/crates/extensions/rara-trading/src/anomaly/**
+- **/crates/extensions/rara-trading/src/finance/registry.rs
+- **/crates/app/src/finance_event.rs
+- **/web/**
+- **/extension/**
+- Do NOT introduce WebSocket ingestion or a new transport type — reuse the
+  existing REST poll loop.
+- Do NOT expose the rate-limit floor as a YAML knob — it is a fixed property of
+  the venue API, a mechanism const (`docs/guides/anti-patterns.md`).
+- Do NOT change candle event shape, tags, dedupe, or the anomaly / delivery
+  paths (issues 2415 / 2416).
+- Do NOT remove the existing `interval_secs > 0` and other transport
+  validations — the floor is added alongside them.
+
+## Acceptance Criteria
+
+Scenario: A 5-second monitoring interval is accepted by transport validation
+  Test:
+    Package: rara-trading
+    Filter: subminute_interval_within_floor_is_accepted
+  Given a Binance market-candle transport config with interval_secs at the intended monitoring cadence (e.g. 5s) and a small symbol set
+  When the transport is normalized and validated
+  Then validation succeeds
+
+Scenario: An interval below the rate-limit floor is rejected at load
+  Test:
+    Package: rara-trading
+    Filter: interval_below_rate_limit_floor_is_rejected
+  Given a Binance market-candle transport config whose interval_secs is below the floor
+  When the transport is validated
+  Then validation fails with an error naming the minimum interval
+    And the message explains the rate-limit rationale
+
+## Out of Scope
+
+- WebSocket ingestion (a later phase).
+- The anomaly evaluation engine — issue 2415.
+- Severity-graded delivery — issue 2416.
+- Per-symbol adaptive cadence or dynamic backoff on 429s beyond the existing
+  `record_error` reporting.
+- Non-Binance venues and non-crypto assets.

--- a/verification/report.md
+++ b/verification/report.md
@@ -1,51 +1,75 @@
-# Verification report — issue #2224 — VERDICT: PASS
+# Verification report — issue #2417 (sub-minute market-candle polling floor)
 
-chore(site): honor prefers-reduced-motion + motion polish on landing page
+- base_sha: `911eab9fab1ba0ce08fb08baccaa35190cc80857`
+- head_sha: `f5c0a8405ad6043f1f358dde56b90e68a744401a`
+- lane: 1
+- score_authority: verifier
+- implementer_evidence: self_check_only (not read)
 
-- **base_sha:** `682da7b47da16e1fb86b8fdde2e1c674f92c7b07`
-- **head_sha:** `b1aaead8c522a83a5f2a9f05f5c2b44469bd130b`
-- **lane:** 2 (chore)
-- **score_authority:** verifier
-- **implementer_evidence:** self_check_only (not read)
+## Scope verified
+A rate-limit floor (`MIN_INTERVAL_SECS = 5`) added to `validate_transport` in
+`crates/extensions/rara-trading/src/feed/market_candle.rs`, so a Binance
+market-candle feed with `interval_secs >= 5` is accepted and one below the floor
+is rejected at config-load with a message naming the minimum interval and the
+per-IP request-weight rationale. Doc updates in `catalog.rs` +
+`config.example.yaml`. Existing `interval_secs > 0` guard preserved.
 
-## Scope check
-`git diff --stat origin/main..HEAD`: 3 files, +95/−129 — `site/src/pages/index.astro` (+103/−8), deleted `site/src/components/Features.astro` (−75) + `Typewriter.astro` (−46).
-- Touches ONLY `site/` — no `web/**`, no `crates/**`. PASS.
-- `site/package-lock.json` unchanged; no `site/bun.lock` committed. PASS.
-- `grep -rn "Features\|Typewriter" site/src` → NO REFS. PASS.
+## (a) Quality gate — clean state
+- `git status --short` → empty (committed work only).
+- `cargo +nightly fmt --all -- --check` → exit 0.
+- `cargo check --all --all-targets` → exit 0.
+- `cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings` → exit 0.
+- `RUSTDOCFLAGS="-D warnings" cargo +nightly doc --workspace --no-deps --document-private-items` → exit 0.
+- `cargo test -p rara-trading` → exit 0:
+  - `interval_below_rate_limit_floor_is_rejected ... ok`
+  - `subminute_interval_within_floor_is_accepted ... ok`
+  - `test result: ok. 68 passed; 0 failed` (+ doctests `ok. 1 passed`)
 
-## (a) Quality gate from clean state
-- `cd site && bun install` → no changes
-- `cd site && bun run build` → astro build: 1 page built, "Complete!" (exit 0)
-- `prek run --all-files` → all hooks Passed
-Only build warning is an upstream `@astrojs/internal-helpers` node_modules notice — unrelated.
+Note: `prek` not installed on this host; ran the four hook commands directly per
+the equivalent-command allowance.
 
-## (b) Lane-2 Verify command
-`cd site && bun run build` → SUCCESS (orphan deletions did not break the static build).
+## (b) Spec lifecycle
+`just spec-lifecycle specs/issue-2417-subminute-candle-polling.spec.md` → exit 0:
+```
+Spec: issue-2417-subminute-candle-polling  stage: complete  passed: true
+  [PASS] A 5-second monitoring interval is accepted by transport validation
+  [PASS] An interval below the rate-limit floor is rejected at load
+spec-lifecycle-guard: OK — every Test selector executed >=1 test
+```
 
-## (c)/(d) Cold-boot + real-browser drive
-Cold-booted `bun run preview` (http://localhost:4321/rara). Playwright headless Chromium, `emulateMedia({ reducedMotion })`, viewport 1280×800. "Animating" = differing `canvas.toDataURL()` SHA-256 frame hashes; "static" = identical hashes.
+## (c) End-to-end drive of the runtime config-load surface
+Guard reached at runtime via `POST /api/v1/data-feeds` → `create_feed` →
+`normalize_active_feed_config` → `MarketCandleSource::normalize_config` →
+`validate_transport`, error mapped to `ProblemDetails::bad_request`. Also on
+activation via `start_feed_task` → `MarketCandleSource::from_config` →
+`validate_transport`. Built-in catalog presets (60s/300s) stay above the floor.
 
-| Surface | Mode | Metric | Observed | Expected | Result |
-|---|---|---|---|---|---|
-| Hero `c0` | normal | distinct/5 (mouse-move) | 5 | >1 | PASS |
-| Kernel `c1` | normal | distinct/5 | 5 | >1 | PASS |
-| `.scroll-hint` | normal | `animation-name` | `bob` | `bob` | PASS |
-| Hero `c0` | reduce | distinct/6 | 1 | 1 | PASS |
-| Kernel `c1` | reduce | distinct/5 | 1 | 1 | PASS |
-| Kernel `c1` | reduce | non-BG ink px | 347 | >0 | PASS |
-| Kernel `c1` | reduce | screenshot | dashed kernel ring + 6 labeled agents at rest on evenly-spaced orbits — deliberate arrangement, not frozen mid-explosion | deliberate + legible | PASS |
-| `.scroll-hint` | reduce | `animation-name` | `none` | `none` | PASS |
-| All 4 panels text | reduce | screenshot | fully legible | legible | PASS |
-
-### Probes
-1. **Live toggle → reduce, NO reload:** `c1` distinct 4→1 (identical to fresh-reduced static frame); hero also went static. PASS.
-2. **Live toggle back → no-preference, NO reload:** `c1` distinct=5, motion resumed (bi-directional). PASS.
-3. **Orphan deletion + narrow viewport under reduce:** build succeeds, no references remain, copy legible at 420×720. PASS.
+Drove the real HTTP surface using the crate's in-tree axum router harness
+(`app_with_user(Role::Admin)` + `tower::ServiceExt::oneshot`, in-memory diesel
+pool, real `Principal`, bearer) via a throwaway probe test, run then removed
+(tree confirmed clean, HEAD unchanged). Observed (verbatim `detail`):
+- interval=5 → `201 Created`, feed persisted.
+- interval=4 → `400 Bad Request`: names the minimum (5) AND the per-IP
+  request-weight rate-limit rationale.
+- interval=0 → `400 Bad Request`: existing "greater than zero" guard preserved.
 
 ## Transition matrix
-- **fail_to_pass:** at base_sha the page ignored `prefers-reduced-motion` entirely; at head_sha the hero physics/lens, kernel orbit, scroll-slide, and `bob` are all suppressed under reduce and content stays legible.
-- **pass_to_fail:** 0. Normal-motion behavior fully preserved.
+- fail_to_pass: `subminute_interval_within_floor_is_accepted` (5s accepted),
+  `interval_below_rate_limit_floor_is_rejected` (4s rejected w/ min+rationale).
+  At base_sha the floor does not exist (only `> 0`), so 4s would be accepted.
+- pass_to_fail: 0 — full `rara-trading` suite 68/68; existing validations intact.
+
+## Probes (all via real HTTP `POST /api/v1/data-feeds`)
+| # | Input | Expected | Observed | Verdict |
+|---|---|---|---|---|
+| 1 | interval_secs=5 | 201, persisted | 201 Created, stored | PASS |
+| 2 | interval_secs=4 | 400, names min + rationale | 400, names 5 + rate limit | PASS |
+| 3 | interval_secs=0 | 400 | 400 "greater than zero" | PASS |
+| 4 | missing `interval_secs` | 400 | 400 "missing field" | PASS |
+| 5 | CJK name + interval=4 | 400, floor message | 400, correct message | PASS |
+| 6 | concurrent 5 and 4 | 201 / 400 independently | ok=201, bad=400 | PASS |
 
 ## Verdict
-PASS — build + prek green from clean state; scope confined to `site/`, no stray lockfiles, no orphan imports; real-browser cold-boot proves normal motion animates, reduced motion is static + legible across all four panels, and the live `matchMedia` `change` listener stops and resumes motion bi-directionally without reload. No repair round needed.
+**PASS** — gate green from clean state, both BDD scenarios pass, config-load
+acceptance/rejection drives correctly end-to-end through the real HTTP surface
+(incl. CJK, empty/boundary, concurrent probes), `pass_to_fail = 0`.


### PR DESCRIPTION
## Summary

Support the intended 5–10s sub-minute monitoring cadence for the built-in Binance `market_candle` feed, while preventing a reckless sub-floor `interval_secs` from tripping Binance's per-IP request-weight limit and getting the deployment IP-banned.

- Add a `MIN_INTERVAL_SECS = 5` **mechanism const** and enforce it in `validate_transport` alongside the existing `interval_secs > 0` guard. An interval below the floor now fails fast at config load with an error that names the minimum interval and explains the rate-limit rationale.
- Keep `interval_secs` a per-feed YAML value; the floor is a fixed property of the venue API (not a deploy-tunable), so it lives as a `const`, not YAML (`docs/guides/anti-patterns.md` mechanism-vs-config rule).
- Document the supported cadence, the floor, and the `symbols × timeframes / interval` request fan-out in `config.example.yaml` and the catalog preset helper — so operators see that effective request rate scales with the monitored set, not just the interval.

No change to event shape, dedupe, tags, or the anomaly / delivery paths (issues 2415 / 2416). Reuses the existing REST poll loop — no WebSocket, no new transport.

## Type of change

New feature — `enhancement`

## Component

`backend`

## Closes

Closes #2417

## Test plan

- [x] `cargo test -p rara-trading` — `68 passed; 0 failed` (+ integration suite `1 passed`)
- [x] `cargo check --all --all-targets` / `cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings` / `RUSTDOCFLAGS="-D warnings" cargo +nightly doc --workspace --no-deps --document-private-items` — all clean
- [x] `cargo +nightly fmt --all -- --check` — clean
- [x] Lane-1 `just spec-lifecycle specs/issue-2417-subminute-candle-polling.spec.md` — both scenarios PASS, boundaries PASS, zero-match guard OK

### Spec scenarios (bound to real tests)

- `subminute_interval_within_floor_is_accepted` — a 5s cadence at the floor passes validation
- `interval_below_rate_limit_floor_is_rejected` — a sub-floor interval is rejected at load with an error naming the minimum and the rate-limit rationale

Verification: PASS — /Users/ryan/code/personal/rara/.worktrees/issue-2417-subminute-candle-polling/verification/report.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)
