### PR TITLE
docs(goal): promote rara to autonomous trading agent (#2420)

### DIFF
--- a/goal.md
+++ b/goal.md
@@ -7,24 +7,58 @@ exemplified by [Hermes Agent](https://hermes-agent.nousresearch.com/):
 a long-running local process that represents one user, accumulates memory
 across years, and acts on its own initiative.
 
+rara also serves as this user's **autonomous trading agent.** It observes
+markets, forms its own decisions, and acts on the user's behalf to execute
+trades — always **within hard, user-set risk boundaries.** This is not a
+tool the user drives trade-by-trade; it is an agent the user delegates to,
+inside limits it may not cross.
+
 The bet: **Rust plus boring technology plus kernel discipline produces an
-agent that runs for years without rewriting.** We trade time-to-feature
-for time-to-decay.
+agent that runs for years without rewriting — and trades for years without
+blowing up or going out of control.** We trade time-to-feature for
+time-to-decay, and we trade raw returns for surviving the tail.
 
 ## What rara is NOT
 
 - **NOT a feature-parity race.** We will ship fewer integrations than Hermes
   if that is what the engineering bet costs. Single-surface depth comes
-  before multi-surface breadth.
+  before multi-surface breadth. In trading terms: one exchange, one asset
+  class, proven end-to-end before we add breadth.
 - **NOT a multi-user product.** rara learns one user's language, preferences,
   and rhythms. Multi-tenancy dilutes that signal to nothing.
 - **NOT a code agent.** Claude Code and Cursor represent the developer's
   intent inside an IDE. rara represents the user's intent in their life
   and work — and acts on its own initiative, not on call.
-- **NOT a black box.** Every decision rara makes must be inspectable through
-  native eval interfaces. No "trust me" agents.
-- **NOT a framework.** rara *is* one specific agent. We will not generalize
-  into a library for spawning agents.
+- **NOT a black box** — and for trading this is a **hard constraint**, not a
+  preference. Every decision rara makes must be inspectable through native
+  eval interfaces, and **every trade must be a replayable trace**: which
+  signals and factors drove it, what risk it took on, why it entered and why
+  it exited. No unexplained fills. No "trust me" agents.
+- **NOT a quant platform for others.** rara *is* one specific agent. Its
+  factor and signal library exists to serve *rara's own* trading decisions —
+  not as a third-party research or strategy-incubation framework. We will
+  not generalize into a library for spawning agents or strategies.
+
+## Safety invariants (trading)
+
+Autonomous execution earns a set of invariants that the personal-agent
+side does not need. These are specific to ③ (self-directed execution) and
+are **code-enforced, not advisory** — they live in the type system and the
+tests, not in a prompt or a README:
+
+1. **Hard risk boundaries are first-class.** Position caps, per-trade and
+   total exposure caps, and a max-drawdown kill-switch are user-set,
+   enforced in code, and covered by tests. They are not knobs rara may talk
+   itself past.
+2. **Simulation first.** Paper-trading and backtest precede live. Real-money
+   execution sits behind a switch the user must **explicitly arm**; the
+   default state is simulated.
+3. **Human-in-the-loop gate.** Any action beyond its pre-authorized
+   boundaries stops and waits for a human — it does not widen its own
+   mandate.
+4. **Fail safe.** On uncertainty, error, or disconnect, rara **stops
+   trading** — it holds and does nothing rather than guessing. Doing nothing
+   is always a valid, safe action.
 
 ## What working rara looks like
 
@@ -44,9 +78,37 @@ Observable signals that the engineering bet is paying off:
    why it did that."
 5. **Memory survives time.** Recall accuracy does not degrade as the corpus
    grows from weeks to months to years to decades.
+6. **It trades live for months inside its risk boundaries.** The account is
+   not blown, there are no runaway loops, and no single day wipes out a
+   season of gains. Survival first.
+7. **Every trade is inspectable.** The replayable-trace constraint is
+   observed in practice: for any fill, the driving signals, the risk taken,
+   and the entry/exit rationale can be pulled back out. No "I don't know why
+   it bought that."
+8. **It never crosses a user-set risk cap.** The position, exposure, and
+   drawdown limits hold under real conditions — enforced in code and covered
+   by tests, not merely intended.
 
 ## Current focus (2026-Q2 — will rot)
 
+Trading capability is built in three layers, and the ordering is
+load-bearing:
+
+- **① Market perception** — ingest feeds, detect anomalies and black-swan
+  conditions, and alert. rara *sees* the market.
+- **② Decision support** — backtest, evaluate, and advise. rara *forms and
+  defends a view*, but the human still acts.
+- **③ Autonomous execution** — rara places its own orders, real money,
+  inside its risk boundaries. rara *acts*.
+
+**③ is the end state, not the near term.** Live real-money execution is
+hard-gated behind ① and ② being solid **plus** a stretch of paper-trading
+track record — it does not ship until the safety invariants above are
+enforced and the simulated record earns the arm switch.
+
+The current focus (2026-Q2) is still **layer ① first**:
+
+- Market perception — black-swan / anomaly alerting (issues 2415 / 2416 / 2417)
 - Safety and stability hardening
 - Performance
 - Agent eval infrastructure


### PR DESCRIPTION
## Summary

Revises the repo-root north star `goal.md` so it **leads** the shipped trading substrate instead of lagging it. rara is now stated as this user's **autonomous trading agent** — it observes markets, forms its own decisions, and executes trades within hard, user-set risk boundaries — with the bet extended to "trades for years without blowing up or going out of control." This is an additive governance update (product-owner decision already made), not a reversal.

Substance:
- **"What rara is"**: adds the autonomous-trading-agent framing + extends the bet.
- **"What rara is NOT"**: `NOT a framework` → **"NOT a quant platform for others"** (factor/signal library serves rara's own decisions only); **hardens "NOT a black box"** into a hard constraint (every trade is a replayable trace, no unexplained fills); keeps `NOT a feature-parity race` (single exchange/asset class first), `NOT multi-user`, `NOT a code agent`.
- **New `## Safety invariants (trading)`** — code-enforced, not advisory: hard risk boundaries + max-drawdown kill-switch, simulation-first behind an explicitly-armed switch, human-in-the-loop gate, fail-safe on uncertainty/error/disconnect.
- **Working-rara signals ⑥⑦⑧**: months live inside risk boundaries, every trade inspectable, never crosses a user-set risk cap.
- **"Current focus"**: frames trading as ① market perception → ② decision support → ③ autonomous execution, with **③ (live, real money) hard-gated behind ①② solid + a paper-trading track record**; near term stays layer-① (issues 2415/2416/2417) + stability/eval.

Documentation-only. The only file changed is `goal.md`. A verification report commit accompanies it.

## Type of change

Documentation — label `documentation`.

## Component

`core` (repo-root governance doc).

## Closes

Closes #2420

## Verification

Verification: PASS — /Users/ryan/code/personal/rara/.worktrees/issue-2420-goal-trading-agent/verification/report.md

- Lane 2 (documentation); score authority: verifier.
- Issue `Verify:` rg commands all match; four load-bearing locks (code-enforced safety invariants / ①→②③ layering with ③ gated behind paper-trading / "NOT a black box" hardening / single-user + single-surface KEEP lines) all present, none softened.

## Test plan

- [x] Issue `Verify:` commands (rg keyword existence) all match.
- [x] `prek run --all-files`: Rust hooks (cargo check/fmt/clippy/doc) pass; path-scoped hooks correctly skip a repo-root markdown diff.
- [x] Docs-only change; no runtime surface to drive.