### PR TITLE
feat(trading): severity-graded finance delivery — high-severity anomalies bypass cooldown/budget (#2416)

### DIFF
--- a/crates/app/src/finance_event.rs
+++ b/crates/app/src/finance_event.rs
@@ -112,7 +112,13 @@ pub(crate) async fn dispatch_feed_event(
     };
 
     let event_json = serde_json::to_value(event).unwrap_or_default();
-    let decisions = finance_registry.match_event(event).await;
+    // Feed the evaluated severity into the delivery decision so an alert-grade
+    // anomaly bypasses the routine cooldown / hourly-budget throttle. The
+    // registry stays the single home of that policy; the app only supplies the
+    // severity it already computed above.
+    let decisions = finance_registry
+        .match_event(event, anomaly.as_ref().map(|signal| signal.severity))
+        .await;
     for decision in &decisions {
         dispatch_finance_decision(event, &event_json, decision, anomaly.as_ref(), sink).await;
     }
@@ -344,6 +350,7 @@ mod tests {
     use rara_trading::{
         finance::registry::{
             FinanceDelivery, FinanceEventKind, FinanceSubscription, FinanceSubscriptionRegistry,
+            ManualFinanceClock,
         },
         market_data::{
             CandleLatestQuery, InMemoryMarketDataRepository, MarketCandle, MarketDataRepository,
@@ -873,5 +880,112 @@ mod tests {
             "flat window must not be enriched: {}",
             flat_turns[0]
         );
+    }
+
+    #[tokio::test]
+    async fn critical_candle_burst_wakes_session_every_bar() {
+        // A crash burst: 30 flat bars of history, then eight consecutive bars
+        // each dropping well past the 6% critical-drawdown floor, so every
+        // burst bar evaluates to Severity::Critical.
+        let crash_prices = [
+            57_000, 55_000, 53_000, 51_000, 49_000, 47_000, 45_000, 43_000,
+        ];
+
+        let session = SessionKey::new();
+        let market_repo = InMemoryMarketDataRepository::default();
+        let sink = TestFeedDispatchSink::new([session]);
+        let clock = Arc::new(ManualFinanceClock::new(ts("2026-07-10T08:00:00Z")));
+
+        // Default budget (6); cooldown disabled so the hourly budget is the sole
+        // routine throttle — the lane the scenario names ("after the budget is
+        // spent"). A high-severity anomaly must bypass it on every bar.
+        let tmp = tempfile::tempdir().expect("tempdir should be created");
+        let registry = FinanceSubscriptionRegistry::load_with_clock(
+            tmp.path().join("subs.json"),
+            clock.clone(),
+        );
+        let mut subscription = candle_sub(session, FinanceDelivery::Immediate);
+        subscription.cooldown_secs = 0;
+        registry.upsert(subscription).await.unwrap();
+
+        for index in 0..30 {
+            market_repo
+                .upsert_closed_candle(mk_candle(index, 61_500, 120))
+                .await
+                .unwrap();
+        }
+
+        // Dispatch the eight-bar crash burst (indices 30..38), advancing 60s per
+        // bar so every delivery falls inside one hourly-budget window.
+        for (offset, &close) in crash_prices.iter().enumerate() {
+            let crash = mk_candle(30 + offset as i64, close, 600);
+            dispatch_feed_event(
+                &candle_event_from(&crash),
+                &InMemoryFeedStore::default(),
+                &market_repo,
+                &registry,
+                &sink,
+            )
+            .await
+            .unwrap();
+            clock.advance(jiff::SignedDuration::from_secs(60));
+        }
+
+        let turns = sink.synthetic_turns().await;
+        assert_eq!(
+            turns.len(),
+            8,
+            "each critical bar must wake the session, not be throttled"
+        );
+        assert!(sink.silent_appends().await.is_empty());
+        assert!(
+            turns
+                .iter()
+                .all(|turn| turn.contains("[Anomaly severity=critical")),
+            "every burst turn should carry the critical anomaly directive: {turns:?}"
+        );
+
+        // Contrast: a flat burst carries no anomaly (severity None), so the
+        // routine budget applies — the first six wake the session, the rest are
+        // silenced. Same stream, same budget, only the severity differs.
+        let flat_session = SessionKey::new();
+        let flat_repo = InMemoryMarketDataRepository::default();
+        let flat_sink = TestFeedDispatchSink::new([flat_session]);
+        let flat_clock = Arc::new(ManualFinanceClock::new(ts("2026-07-10T08:00:00Z")));
+        let flat_tmp = tempfile::tempdir().expect("tempdir should be created");
+        let flat_registry = FinanceSubscriptionRegistry::load_with_clock(
+            flat_tmp.path().join("subs.json"),
+            flat_clock.clone(),
+        );
+        let mut flat_sub = candle_sub(flat_session, FinanceDelivery::Immediate);
+        flat_sub.cooldown_secs = 0;
+        flat_registry.upsert(flat_sub).await.unwrap();
+
+        for index in 0..30 {
+            flat_repo
+                .upsert_closed_candle(mk_candle(index, 61_500, 120))
+                .await
+                .unwrap();
+        }
+        for offset in 0..8 {
+            let flat = mk_candle(30 + offset, 61_500, 120);
+            dispatch_feed_event(
+                &candle_event_from(&flat),
+                &InMemoryFeedStore::default(),
+                &flat_repo,
+                &flat_registry,
+                &flat_sink,
+            )
+            .await
+            .unwrap();
+            flat_clock.advance(jiff::SignedDuration::from_secs(60));
+        }
+
+        assert_eq!(
+            flat_sink.synthetic_turns().await.len(),
+            6,
+            "the routine budget still caps a low-severity burst at six turns"
+        );
+        assert_eq!(flat_sink.silent_appends().await.len(), 2);
     }
 }

--- a/crates/extensions/rara-trading/src/finance/registry.rs
+++ b/crates/extensions/rara-trading/src/finance/registry.rs
@@ -33,7 +33,7 @@ use tokio::sync::RwLock;
 use tracing::warn;
 use uuid::Uuid;
 
-use crate::market_data::Timeframe;
+use crate::{anomaly::Severity, market_data::Timeframe};
 
 /// Finance event kinds supported by the MVP.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, JsonSchema)]
@@ -95,7 +95,13 @@ pub struct FinanceDeliveryDecision {
     pub session_key:       SessionKey,
     pub event_id:          FeedEventId,
     pub action:            FinanceDeliveryAction,
+    /// Set when the routine lane silenced a low-severity event, naming the
+    /// throttle that fired (`cooldown` / `hourly_budget`).
     pub downgraded_reason: Option<String>,
+    /// Set when a bypass-eligible severity overrode a throttle that would
+    /// otherwise have silenced the event, naming the bypassed constraint. Keeps
+    /// the alert-bypass decision inspectable rather than a silent control path.
+    pub bypass_reason:     Option<String>,
 }
 
 /// Clock abstraction for deterministic budget tests.
@@ -235,7 +241,17 @@ impl FinanceSubscriptionRegistry {
     }
 
     /// Match an incoming feed event and record delivery decisions.
-    pub async fn match_event(&self, event: &FeedEvent) -> Vec<FinanceDeliveryDecision> {
+    ///
+    /// `severity` is the anomaly severity the app evaluated for this event (see
+    /// `crates/app/src/finance_event.rs`), or `None` when the event carried no
+    /// anomaly. A severity at or above the private `BYPASS_SEVERITY` threshold
+    /// overrides the routine cooldown / hourly-budget throttle so a genuine
+    /// alert is never the thing that gets silenced.
+    pub async fn match_event(
+        &self,
+        event: &FeedEvent,
+        severity: Option<Severity>,
+    ) -> Vec<FinanceDeliveryDecision> {
         if !event.tags.iter().any(|tag| tag == "finance") {
             return Vec::new();
         }
@@ -257,20 +273,21 @@ impl FinanceSubscriptionRegistry {
                 continue;
             }
 
-            let (action, downgraded_reason) = delivery_action(subscription, &inner.ledger, now);
+            let verdict = delivery_action(subscription, &inner.ledger, now, severity);
             decisions.push(FinanceDeliveryDecision {
-                subscription_id: subscription.id,
-                owner: subscription.owner.clone(),
-                session_key: subscription.session_key,
-                event_id: event.id.clone(),
-                action,
-                downgraded_reason: downgraded_reason.clone(),
+                subscription_id:   subscription.id,
+                owner:             subscription.owner.clone(),
+                session_key:       subscription.session_key,
+                event_id:          event.id.clone(),
+                action:            verdict.action,
+                downgraded_reason: verdict.downgraded_reason,
+                bypass_reason:     verdict.bypass_reason,
             });
             new_ledger_entries.push(DeliveryLedgerEntry {
                 subscription_id: subscription.id,
-                event_id: event_id.clone(),
-                delivered_at: now,
-                action,
+                event_id:        event_id.clone(),
+                delivered_at:    now,
+                action:          verdict.action,
             });
         }
 
@@ -307,15 +324,79 @@ fn already_delivered(
         .any(|entry| entry.subscription_id == subscription_id && entry.event_id == event_id)
 }
 
+/// Severity at or above which an anomaly bypasses the routine throttle.
+///
+/// This is a mechanism constant, not a per-deployment knob: "which severity
+/// counts as an alert" is a property of the alerting design, and a deploy
+/// operator has no principled reason to retune it. A YAML knob here would
+/// recreate the config-silently-disables-the-fix footgun
+/// (`docs/guides/anti-patterns.md`). The per-subscription `cooldown_secs` /
+/// `max_immediate_per_hour` remain genuine user preferences.
+const BYPASS_SEVERITY: Severity = Severity::Critical;
+
+/// Outcome of the budget / cooldown / bypass rule for one matched event.
+struct DeliveryVerdict {
+    action:            FinanceDeliveryAction,
+    /// Set when the routine lane silenced a low-severity event (`cooldown` /
+    /// `hourly_budget`).
+    downgraded_reason: Option<String>,
+    /// Set when a bypass-eligible severity overrode a throttle that would
+    /// otherwise have silenced the event, naming the bypassed constraint.
+    bypass_reason:     Option<String>,
+}
+
 fn delivery_action(
     subscription: &FinanceSubscription,
     ledger: &[DeliveryLedgerEntry],
     now: Timestamp,
-) -> (FinanceDeliveryAction, Option<String>) {
+    severity: Option<Severity>,
+) -> DeliveryVerdict {
     if subscription.delivery == FinanceDelivery::Silent {
-        return (FinanceDeliveryAction::Silent, None);
+        return DeliveryVerdict {
+            action:            FinanceDeliveryAction::Silent,
+            downgraded_reason: None,
+            bypass_reason:     None,
+        };
     }
 
+    // What the budget / cooldown rule would do on its own, ignoring severity:
+    // `Some(reason)` means the routine throttle would silence this event.
+    let throttle_reason = routine_throttle_reason(subscription, ledger, now);
+    let is_alert = severity.is_some_and(|level| level >= BYPASS_SEVERITY);
+
+    match throttle_reason {
+        // An alert-grade severity overrides a throttle that would have silenced
+        // the event: deliver immediately and record which constraint it bypassed.
+        Some(reason) if is_alert => DeliveryVerdict {
+            action:            FinanceDeliveryAction::Immediate,
+            downgraded_reason: None,
+            bypass_reason:     Some(reason),
+        },
+        // Routine lane unchanged: a below-threshold event stays silenced.
+        Some(reason) => DeliveryVerdict {
+            action:            FinanceDeliveryAction::Silent,
+            downgraded_reason: Some(reason),
+            bypass_reason:     None,
+        },
+        // No throttle fired; deliver immediately regardless of severity.
+        None => DeliveryVerdict {
+            action:            FinanceDeliveryAction::Immediate,
+            downgraded_reason: None,
+            bypass_reason:     None,
+        },
+    }
+}
+
+/// Return the routine-throttle disposition for an `Immediate` subscription.
+///
+/// `Some(reason)` when the trailing-hour cooldown / hourly-budget rule would
+/// downgrade this event to `Silent` (naming the throttle that fired), `None`
+/// when the event may be delivered immediately.
+fn routine_throttle_reason(
+    subscription: &FinanceSubscription,
+    ledger: &[DeliveryLedgerEntry],
+    now: Timestamp,
+) -> Option<String> {
     let immediate_entries: Vec<&DeliveryLedgerEntry> = ledger
         .iter()
         .filter(|entry| {
@@ -331,17 +412,14 @@ fn delivery_action(
                 < SignedDuration::from_secs(subscription.cooldown_secs as i64)
         })
     {
-        return (FinanceDeliveryAction::Silent, Some("cooldown".to_owned()));
+        return Some("cooldown".to_owned());
     }
 
     if immediate_entries.len() >= usize::from(subscription.max_immediate_per_hour) {
-        return (
-            FinanceDeliveryAction::Silent,
-            Some("hourly_budget".to_owned()),
-        );
+        return Some("hourly_budget".to_owned());
     }
 
-    (FinanceDeliveryAction::Immediate, None)
+    None
 }
 
 fn matches_subscription(
@@ -544,7 +622,7 @@ mod tests {
 
     use super::{
         FinanceDelivery, FinanceDeliveryAction, FinanceEventKind, FinanceSubscription,
-        FinanceSubscriptionRegistry, ManualFinanceClock,
+        FinanceSubscriptionRegistry, ManualFinanceClock, Severity,
     };
 
     fn ts(value: &str) -> Timestamp { value.parse().expect("timestamp fixture should parse") }
@@ -662,20 +740,20 @@ mod tests {
 
         assert_eq!(
             registry
-                .match_event(&article("fed-news", "Fed mentions BTC liquidity", ""))
+                .match_event(&article("fed-news", "Fed mentions BTC liquidity", ""), None)
                 .await
                 .len(),
             1
         );
         assert!(
             registry
-                .match_event(&article("fed-news", "Fed holds rates", ""))
+                .match_event(&article("fed-news", "Fed holds rates", ""), None)
                 .await
                 .is_empty()
         );
         assert!(
             registry
-                .match_event(&article("other-news", "BTC headline", ""))
+                .match_event(&article("other-news", "BTC headline", ""), None)
                 .await
                 .is_empty()
         );
@@ -705,18 +783,21 @@ mod tests {
             .unwrap();
 
         assert_eq!(
-            registry.match_event(&candle("BTCUSDT", "15m")).await.len(),
+            registry
+                .match_event(&candle("BTCUSDT", "15m"), None)
+                .await
+                .len(),
             1
         );
         assert!(
             registry
-                .match_event(&candle("ETHUSDT", "15m"))
+                .match_event(&candle("ETHUSDT", "15m"), None)
                 .await
                 .is_empty()
         );
         assert!(
             registry
-                .match_event(&candle("BTCUSDT", "1h"))
+                .match_event(&candle("BTCUSDT", "1h"), None)
                 .await
                 .is_empty()
         );
@@ -746,7 +827,10 @@ mod tests {
             .unwrap();
 
         assert_eq!(
-            registry.match_event(&candle("BTCUSDT", "15m")).await.len(),
+            registry
+                .match_event(&candle("BTCUSDT", "15m"), None)
+                .await
+                .len(),
             1
         );
     }
@@ -776,7 +860,10 @@ mod tests {
 
         assert_eq!(
             registry
-                .match_event(&candle_with_payload(" Binance ", " btcusdt ", " 15M "))
+                .match_event(
+                    &candle_with_payload(" Binance ", " btcusdt ", " 15M "),
+                    None
+                )
                 .await
                 .len(),
             1
@@ -808,7 +895,7 @@ mod tests {
 
         assert_eq!(
             registry
-                .match_event(&article("sec-news", "NVDA filing update", ""))
+                .match_event(&article("sec-news", "NVDA filing update", ""), None)
                 .await
                 .len(),
             1
@@ -825,10 +912,10 @@ mod tests {
         registry.upsert(sub(session)).await.unwrap();
 
         let event = article("fed-news", "BTC first notice", "");
-        assert_eq!(registry.match_event(&event).await.len(), 1);
+        assert_eq!(registry.match_event(&event, None).await.len(), 1);
 
         let reloaded = FinanceSubscriptionRegistry::load_with_clock(path, clock);
-        assert!(reloaded.match_event(&event).await.is_empty());
+        assert!(reloaded.match_event(&event, None).await.is_empty());
     }
 
     #[tokio::test]
@@ -841,13 +928,13 @@ mod tests {
         registry.upsert(subscription).await.unwrap();
 
         let first = registry
-            .match_event(&article("fed-news", "BTC first", ""))
+            .match_event(&article("fed-news", "BTC first", ""), None)
             .await;
         assert_eq!(first[0].action, FinanceDeliveryAction::Immediate);
 
         clock.advance(SignedDuration::from_secs(60));
         let second = registry
-            .match_event(&article("fed-news", "BTC second", ""))
+            .match_event(&article("fed-news", "BTC second", ""), None)
             .await;
         assert_eq!(second[0].action, FinanceDeliveryAction::Silent);
         assert_eq!(
@@ -866,7 +953,10 @@ mod tests {
 
         for index in 1..=6 {
             let matched = registry
-                .match_event(&article("fed-news", &format!("BTC notice {index}"), ""))
+                .match_event(
+                    &article("fed-news", &format!("BTC notice {index}"), ""),
+                    None,
+                )
                 .await;
             assert_eq!(matched.len(), 1);
             assert_eq!(
@@ -879,7 +969,7 @@ mod tests {
         }
 
         let seventh = registry
-            .match_event(&article("fed-news", "BTC notice 7", ""))
+            .match_event(&article("fed-news", "BTC notice 7", ""), None)
             .await;
         assert_eq!(seventh.len(), 1);
         assert_eq!(seventh[0].action, FinanceDeliveryAction::Silent);
@@ -887,5 +977,90 @@ mod tests {
             seventh[0].downgraded_reason.as_deref(),
             Some("hourly_budget")
         );
+    }
+
+    #[tokio::test]
+    async fn high_severity_bypasses_cooldown() {
+        let (registry, clock, _tmp) = registry(ts("2026-07-10T08:00:00Z"));
+        let session = SessionKey::new();
+        // Default sub: cooldown 900s, budget 6.
+        registry.upsert(sub(session)).await.unwrap();
+
+        // First immediate delivery seeds the cooldown window.
+        let first = registry
+            .match_event(&article("fed-news", "BTC first", ""), None)
+            .await;
+        assert_eq!(first[0].action, FinanceDeliveryAction::Immediate);
+
+        // A second matched event 60s later sits well inside the 900s cooldown,
+        // but a critical severity must override it.
+        clock.advance(SignedDuration::from_secs(60));
+        let bypass = registry
+            .match_event(
+                &article("fed-news", "BTC crash", ""),
+                Some(Severity::Critical),
+            )
+            .await;
+        assert_eq!(bypass[0].action, FinanceDeliveryAction::Immediate);
+        assert_eq!(bypass[0].bypass_reason.as_deref(), Some("cooldown"));
+        assert_eq!(bypass[0].downgraded_reason, None);
+    }
+
+    #[tokio::test]
+    async fn high_severity_bypasses_hourly_budget() {
+        let (registry, clock, _tmp) = registry(ts("2026-07-10T08:00:00Z"));
+        let session = SessionKey::new();
+        let mut subscription = sub(session);
+        subscription.max_immediate_per_hour = 1;
+        subscription.cooldown_secs = 0;
+        registry.upsert(subscription).await.unwrap();
+
+        // Spend the single-event budget.
+        let first = registry
+            .match_event(&article("fed-news", "BTC first", ""), None)
+            .await;
+        assert_eq!(first[0].action, FinanceDeliveryAction::Immediate);
+
+        // The budget is now exhausted, but a critical severity bypasses it
+        // instead of taking the hourly_budget downgrade.
+        clock.advance(SignedDuration::from_secs(60));
+        let bypass = registry
+            .match_event(
+                &article("fed-news", "BTC crash", ""),
+                Some(Severity::Critical),
+            )
+            .await;
+        assert_eq!(bypass[0].action, FinanceDeliveryAction::Immediate);
+        assert_eq!(bypass[0].bypass_reason.as_deref(), Some("hourly_budget"));
+        assert_eq!(bypass[0].downgraded_reason, None);
+    }
+
+    #[tokio::test]
+    async fn low_severity_still_downgrades_under_budget() {
+        let (registry, clock, _tmp) = registry(ts("2026-07-10T08:00:00Z"));
+        let session = SessionKey::new();
+        let mut subscription = sub(session);
+        subscription.max_immediate_per_hour = 1;
+        subscription.cooldown_secs = 0;
+        registry.upsert(subscription).await.unwrap();
+
+        // Spend the single-event budget.
+        let first = registry
+            .match_event(&article("fed-news", "BTC first", ""), None)
+            .await;
+        assert_eq!(first[0].action, FinanceDeliveryAction::Immediate);
+
+        // A below-threshold severity stays on the routine lane: silenced with
+        // the unchanged hourly_budget reason, no bypass.
+        clock.advance(SignedDuration::from_secs(60));
+        let routine = registry
+            .match_event(&article("fed-news", "BTC drift", ""), Some(Severity::Watch))
+            .await;
+        assert_eq!(routine[0].action, FinanceDeliveryAction::Silent);
+        assert_eq!(
+            routine[0].downgraded_reason.as_deref(),
+            Some("hourly_budget")
+        );
+        assert_eq!(routine[0].bypass_reason, None);
     }
 }

--- a/specs/issue-2416-severity-graded-delivery.spec.md
+++ b/specs/issue-2416-severity-graded-delivery.spec.md
@@ -1,0 +1,155 @@
+spec: task
+name: "issue-2416-severity-graded-delivery"
+inherits: project
+tags: [enhancement, backend, trading]
+---
+
+## Intent
+
+The finance delivery layer has a reverse-design defect that directly defeats
+black-swan alerting. `crates/extensions/rara-trading/src/finance/registry.rs::delivery_action`
+downgrades an `Immediate` subscription to `Silent` whenever, within the trailing
+hour, the subscription has either delivered inside its `cooldown_secs` window
+(default 900s) or already spent its `max_immediate_per_hour` budget (default 6).
+That policy is metadata-blind: it cannot tell a routine drift bar from a crash.
+The consequence is exactly backwards — when a market event is *most* dense and
+*most* severe (a crash prints many bars fast), the subscription hits its budget
+/ cooldown and rara falls **silent** precisely when it should be shouting.
+
+Issue 2415 introduced the anomaly-evaluation layer that produces an
+`AnomalySignal { severity, reason, metrics }` for each matched candle and
+enriches the injected directive. This issue consumes that severity to make
+delivery severity-aware: a high-severity anomaly (an actual alert-grade event)
+**bypasses** the cooldown and hourly budget and is delivered immediately, while
+low-severity / routine events remain budget-constrained (the "digest" lane).
+This splits one undifferentiated stream into two intents — routine digest vs
+anomaly alert — so a burst of critical bars wakes the session every time
+instead of being throttled into silence.
+
+If we do not do this, the following concrete bug appears. Reproducer:
+
+1. A session subscribes to `binance / BTCUSDT / 1m`, `delivery: immediate`,
+   `cooldown_secs: 900`, `max_immediate_per_hour: 6` (the defaults).
+2. BTCUSDT flash-crashes: eight consecutive 1m bars each fire a high-severity
+   anomaly signal from the 2415 evaluator.
+3. `delivery_action` delivers bars 1–6 immediately, then downgrades bars 7 and
+   8 to `Silent` on `hourly_budget` (and, with the default 900s cooldown, would
+   in fact silence everything after bar 1 on `cooldown`). The observed bad
+   outcome: during the single most dangerous window of the day, the alerts that
+   matter most are appended silently to the tape and never wake the agent —
+   the throttle designed for routine chatter muzzles the crash.
+
+This advances `goal.md` signal 2 ("surface the right thing at the right time,
+unprompted") — the whole point of the throttle-bypass is that a genuine alert
+is never the thing that gets throttled. It also keeps signal 4 intact: the
+`downgraded_reason` / bypass decision stays an inspectable field on the delivery
+decision. It crosses no "What rara is NOT" line.
+
+Prior-art search (2026-07-14): the budget / cooldown logic was introduced with
+the finance-subscription feature (PR 2223) and refined by PR 2278
+(selector-scope) and PR 2270 (config normalization). No PR reversed or
+reconsidered the "downgrade to Silent under budget" behavior — this issue is
+the first to make it severity-aware, not a re-introduction of something a prior
+PR removed. `git log --all --grep "cooldown|delivery_action"` since 180 days
+shows no removal of a severity-aware path. So this is a first-time fix, not a
+regression-decision reversal.
+
+## Decisions
+
+- Thread the `AnomalySignal.severity` produced in issue 2415 into the delivery
+  decision. High-severity (at or above a bypass threshold, expressed against the
+  ordered `Severity` enum) forces `FinanceDeliveryAction::Immediate` regardless
+  of `cooldown_secs` and `max_immediate_per_hour`. Below the threshold, the
+  existing budget / cooldown logic is preserved unchanged (routine digest lane).
+- The bypass threshold is a **mechanism constant** (Rust `const` next to the
+  delivery logic), not YAML — a deploy operator has no principled reason to
+  retune "which severity counts as an alert" per deployment, and a YAML knob
+  would recreate the config-silently-disables-the-fix footgun
+  (`docs/guides/anti-patterns.md`). `cooldown_secs` and `max_immediate_per_hour`
+  remain per-subscription fields as today (they are genuine per-user
+  preferences, already persisted).
+- Bypass must remain **observable**: when a high-severity event bypasses the
+  throttle, the delivery decision records that it was an alert bypass (e.g. a
+  populated reason/flag), so the choice is inspectable per `goal.md` signal 4.
+  Do NOT silently drop the `downgraded_reason` bookkeeping for the routine lane.
+- Idempotency is unchanged: the existing `already_delivered` ledger guard still
+  prevents a re-observed event id from being delivered twice; bypass changes
+  *whether* a first delivery is Immediate vs Silent, not the dedupe.
+- The seam: severity is computed in `crates/app/src/finance_event.rs`
+  (issue 2415 already evaluates the window there). This issue passes that
+  severity into the registry decision — `registry.rs` gains a severity-aware
+  delivery path (e.g. `delivery_action` / `match_event` take an optional
+  severity), and `finance_event.rs` supplies it. The registry stays the single
+  home of the budget/cooldown/bypass rule; the app does not fork a parallel
+  policy.
+- Directive wording differentiates the two lanes so the agent knows whether it
+  was woken for an alert or a routine update (building on the 2415 enrichment).
+
+## Boundaries
+
+### Allowed Changes
+- **/crates/extensions/rara-trading/src/finance/registry.rs
+- **/crates/app/src/finance_event.rs
+- **/specs/issue-2416-severity-graded-delivery.spec.md
+
+### Forbidden
+- **/crates/extensions/rara-trading/src/anomaly/**
+- **/config.example.yaml
+- **/web/**
+- **/extension/**
+- Do NOT change the anomaly evaluator or its constants — this issue consumes
+  the `Severity` from issue 2415, it does not redefine it.
+- Do NOT add a YAML knob for the bypass threshold — mechanism const
+  (`docs/guides/anti-patterns.md`).
+- Do NOT remove or weaken the routine-lane budget / cooldown for low-severity
+  events — the throttle still exists for chatter; only alerts bypass it.
+- Do NOT remove the `already_delivered` idempotency guard.
+- Do NOT let bypass become a silent path: the bypass decision must stay a
+  recorded, inspectable field (no hollow / undocumented control flow).
+
+## Acceptance Criteria
+
+Scenario: A high-severity anomaly bypasses an active cooldown
+  Test:
+    Package: rara-trading
+    Filter: high_severity_bypasses_cooldown
+  Given an immediate subscription with a non-zero cooldown that has just delivered
+    And a subsequent matched event carrying a high (bypass-eligible) severity
+  When the delivery action is computed inside the cooldown window
+  Then the action is Immediate
+    And the decision records that it was an alert bypass
+
+Scenario: A high-severity anomaly bypasses an exhausted hourly budget
+  Test:
+    Package: rara-trading
+    Filter: high_severity_bypasses_hourly_budget
+  Given an immediate subscription whose max_immediate_per_hour is already spent
+    And a subsequent matched event carrying a high (bypass-eligible) severity
+  When the delivery action is computed
+  Then the action is Immediate rather than a hourly_budget downgrade
+
+Scenario: A low-severity event still obeys the routine budget
+  Test:
+    Package: rara-trading
+    Filter: low_severity_still_downgrades_under_budget
+  Given an immediate subscription whose hourly budget is already spent
+    And a subsequent matched event carrying a low (below-threshold) severity
+  When the delivery action is computed
+  Then the action is Silent with a hourly_budget reason (routine lane unchanged)
+
+Scenario: A burst of critical candles wakes the session on every bar
+  Test:
+    Package: rara-app
+    Filter: critical_candle_burst_wakes_session_every_bar
+  Given an active session subscribed immediate to a crypto stream with default cooldown and budget
+  When a burst of consecutive candles each evaluates to a high-severity anomaly
+  Then every bar in the burst produces a synthetic turn (none is silenced by throttle)
+    And the same burst at low severity is throttled after the budget is spent
+
+## Out of Scope
+
+- Defining or computing the anomaly severity — issue 2415.
+- Sub-minute poll latency — issue 2417.
+- Changing the persisted per-subscription `cooldown_secs` /
+  `max_immediate_per_hour` schema or defaults.
+- WebSocket ingestion, non-crypto assets, and any web / extension UI.


### PR DESCRIPTION
## Summary

Fixes a reverse-design defect in finance delivery: the metadata-blind cooldown / hourly-budget throttle silenced a subscription exactly when events were densest and most severe (a crash prints many bars fast), muzzling the alerts that matter most.

This threads the `AnomalySignal.severity` from #2415 into the delivery decision:

- A **high-severity anomaly** (`>= Severity::Critical`) **bypasses** the routine `cooldown_secs` / `max_immediate_per_hour` throttle and is delivered `Immediate`, so a crash burst wakes the session on every bar.
- **Low-severity / routine events** stay budget-constrained (the digest lane) — the throttle for chatter is preserved byte-for-byte.
- The override is recorded in a new inspectable `bypass_reason: Option<String>` field on `FinanceDeliveryDecision` (naming the bypassed `cooldown` / `hourly_budget` constraint) — no alert is silently promoted.

Wiring: `crates/app/src/finance_event.rs` supplies the severity it already evaluates to `registry.match_event(event, severity)`; the registry stays the single home of the budget/cooldown/bypass rule. The bypass threshold is a mechanism `const` (`BYPASS_SEVERITY = Severity::Critical`), **not** YAML — a deploy operator has no principled reason to retune "which severity counts as an alert", and a YAML knob would recreate the config-silently-disables-the-fix footgun. `cooldown_secs` / `max_immediate_per_hour` remain per-subscription prefs.

## Type of change

New feature — label `enhancement`.

## Component

`backend` (and `core` cross-crate: `rara-trading` + `rara-app`).

## Closes

Closes #2416

## Test plan

Lane 1 (BDD-bound). All scenarios pass via `just spec-lifecycle specs/issue-2416-severity-graded-delivery.spec.md`:

- `rara-trading`: `high_severity_bypasses_cooldown`, `high_severity_bypasses_hourly_budget`, `low_severity_still_downgrades_under_budget` — assert `bypass_reason` is populated on bypass and `None` on the routine lane.
- `rara-app` (lane-1 no-LLM e2e, `finance_event`): `critical_candle_burst_wakes_session_every_bar` — an 8-bar crash burst yields 8 synthetic turns / 0 silenced; the identical flat burst yields 6 turns + 2 budget-silenced.

- [x] `cargo test -p rara-trading -p rara-app` passes (11 + 11 tests)
- [x] `cargo check` / `cargo +nightly fmt` / `cargo clippy` / `cargo +nightly doc` pass
- [x] `just spec-lifecycle` — all 4 scenarios + boundaries `[PASS]`

Verification: **PASS** (independent verifier — full gate re-run from clean state, cold-boot drive, 3 hostile probes, zero regressions). The `verification/report.md` is no longer tracked (gitignored via #2422), so only the verdict is recorded here.