### PR TITLE
refactor(trading): generalize anomaly signals into extensible signal registry (#2429)

### DIFF
--- a/crates/extensions/rara-trading/AGENT.md
+++ b/crates/extensions/rara-trading/AGENT.md
@@ -36,9 +36,12 @@ Five modules, each a `mod.rs` (re-exports + `//!` docs only) over sub-files:
   Result<Option<AnomalySignal>>` is a **pure** function of its candle inputs. It
   prepares the shared context once, walks a `SignalRegistry` collecting each
   signal's `SignalOutput`, projects those onto `AnomalyMetrics`, then classifies
-  severity. `registry.rs` = the `Signal` trait, `SignalOutput` (name / value /
-  fired), `SignalContext` (shared closes/returns/volumes), and
-  `builtin_registry()`; `rules.rs` = L1 pure functions + their `Signal` adapters
+  severity. `registry.rs` = the `Signal` trait (`name` / `evaluate` /
+  `fragment`), `SignalOutput` (value / fired), `SignalContext` (shared
+  closes/returns/volumes), and `builtin_registry()`; the signal's stable name is
+  a static property of the `Signal` (used to route its value into
+  `AnomalyMetrics`), not per-output data. `rules.rs` = L1 pure functions + their
+  `Signal` adapters
   (window return, rolling drawdown, volume surge); `statistics.rs` = L2 pure
   functions + adapters (MAD-based robust z-score, BNS realized-variance vs
   bipower-variation jump test); `signal.rs` = `AnomalySignal` / `Severity` /
@@ -97,8 +100,9 @@ dispatch loop (`crates/app/src/lib.rs`).
   reachable and asserted by a test. The same bar applies to a `Signal`: a
   production impl that ignores its `SignalContext` and returns a constant, or a
   `SignalOutput` field nothing consumes, is hollow. Every `SignalOutput` field
-  has a consumer — `name` routes into `AnomalyMetrics`, `value` populates the
-  trace and the fragment, `fired` drives the count / severity / reason.
+  has a consumer — `value` populates the `AnomalyMetrics` trace and the
+  fragment, `fired` drives the count / severity / reason; the routing name comes
+  from `Signal::name()`.
 - Do NOT turn severity into a weighted / scored / factor-combination framework
   when adding signals — **why:** `classify` stays concrete (fired-count plus the
   drawdown-keyed critical escalation); a scoring framework is speculative

--- a/crates/extensions/rara-trading/AGENT.md
+++ b/crates/extensions/rara-trading/AGENT.md
@@ -31,12 +31,28 @@ Five modules, each a `mod.rs` (re-exports + `//!` docs only) over sub-files:
   `timescale.rs` (TimescaleDB impl), `tools.rs` (agent-facing query tools).
   `recent_candles(CandleRecentQuery)` returns the newest N candles ascending
   and is the rolling-window source for anomaly evaluation.
-- `anomaly/` — market-anomaly evaluation (issue 2415). `evaluate(window,
-  latest) -> Result<Option<AnomalySignal>>` is a **pure** function of its
-  candle inputs. `rules.rs` = L1 (window return, rolling drawdown, volume
-  surge); `statistics.rs` = L2 (MAD-based robust z-score, BNS realized-variance
-  vs bipower-variation jump test); `signal.rs` = `AnomalySignal` / `Severity` /
-  `AnomalyMetrics`; `error.rs` = `AnomalyError` (snafu).
+- `anomaly/` — market-anomaly evaluation (issue 2415; generalized into a signal
+  registry in issue 2429). `evaluate(window, latest) ->
+  Result<Option<AnomalySignal>>` is a **pure** function of its candle inputs. It
+  prepares the shared context once, walks a `SignalRegistry` collecting each
+  signal's `SignalOutput`, projects those onto `AnomalyMetrics`, then classifies
+  severity. `registry.rs` = the `Signal` trait, `SignalOutput` (name / value /
+  fired), `SignalContext` (shared closes/returns/volumes), and
+  `builtin_registry()`; `rules.rs` = L1 pure functions + their `Signal` adapters
+  (window return, rolling drawdown, volume surge); `statistics.rs` = L2 pure
+  functions + adapters (MAD-based robust z-score, BNS realized-variance vs
+  bipower-variation jump test); `signal.rs` = `AnomalySignal` / `Severity` /
+  `AnomalyMetrics`; `error.rs` = `AnomalyError` (snafu). `evaluator.rs` holds the
+  `evaluate` / `evaluate_with(&registry, …)` loop, the metrics projection, and
+  `classify`.
+
+  **Extending the signal set** = implement `Signal` (a struct wrapping a pure
+  stat) + add one `Box::new(...)` line to `builtin_registry()`. The core loop in
+  `evaluate_with`, the metrics projection, and `classify` do not change — the
+  new signal contributes to the reason (via its `fragment`) and the fired-count.
+  `builtin_registry()` order **is** the reason-fragment order (drawdown, return,
+  volume, z-score, jump), so keep it stable. `evaluate_with` is the test seam
+  (`registered_signal_participates_in_evaluation` injects an extra signal).
 
 The write→read→enrich wiring lives in `dispatch/pipeline.rs` (`on_feed_event`):
 it upserts the closed candle, pulls the window via `recent_candles`, runs
@@ -78,7 +94,16 @@ dispatch loop (`crates/app/src/lib.rs`).
 - Do NOT return a fixed `Severity` regardless of input, or add an
   `AnomalyMetrics` field nothing reads — that is a hollow implementation
   (`docs/guides/anti-patterns.md`). Every severity level and metric must be
-  reachable and asserted by a test.
+  reachable and asserted by a test. The same bar applies to a `Signal`: a
+  production impl that ignores its `SignalContext` and returns a constant, or a
+  `SignalOutput` field nothing consumes, is hollow. Every `SignalOutput` field
+  has a consumer — `name` routes into `AnomalyMetrics`, `value` populates the
+  trace and the fragment, `fired` drives the count / severity / reason.
+- Do NOT turn severity into a weighted / scored / factor-combination framework
+  when adding signals — **why:** `classify` stays concrete (fired-count plus the
+  drawdown-keyed critical escalation); a scoring framework is speculative
+  machinery (issue 2429 Boundaries). Per-signal trip thresholds stay `const`
+  next to each signal, never YAML.
 - Do NOT feed the newest candle into `evaluate` twice: `window` is the history
   strictly before `latest`. `dispatch/pipeline.rs` queries `recent_candles`
   with `end = Some(latest.open_time)` to enforce this.

--- a/crates/extensions/rara-trading/src/anomaly/evaluator.rs
+++ b/crates/extensions/rara-trading/src/anomaly/evaluator.rs
@@ -15,25 +15,30 @@
 //! The anomaly-evaluation entry point.
 //!
 //! [`evaluate`] is a pure function of its candle inputs — no clock, no I/O — so
-//! every rule and statistic is reproducible from a fixture window. It composes
-//! the L1 rules ([`super::rules`]) and L2 statistics ([`super::statistics`])
-//! into a single [`AnomalySignal`], or `None` when the tape is unremarkable.
+//! every rule and statistic is reproducible from a fixture window. It prepares
+//! the shared per-evaluation context once, walks the builtin [`SignalRegistry`]
+//! collecting each signal's [`SignalOutput`], projects those onto the public
+//! [`AnomalyMetrics`], and classifies severity — producing a single
+//! [`AnomalySignal`], or `None` when the tape is unremarkable.
 //!
-//! The thresholds below are **mechanism constants**
+//! Adding a signal is "implement [`Signal`] + register one line" in
+//! [`super::registry`]; the loop below does not change. The seam that makes
+//! that testable is [`evaluate_with`], which takes an explicit registry.
+//!
+//! The drawdown escalation threshold below is a **mechanism constant**
 //! (`docs/guides/anti-patterns.md`): a deploy operator has no principled reason
-//! to retune the drawdown or volume-surge trip points, and a YAML knob would
-//! recreate the #1804→#1817 footgun where a default config silently disables
-//! the fix. The one value a deployment might legitimately tune (per-symbol
-//! sensitivity) is out of scope for this issue and would arrive via
-//! `config.example.yaml`, never as a hardcoded Rust default.
+//! to retune it, and a YAML knob would recreate the #1804→#1817 footgun where a
+//! default config silently disables the fix. Per-signal trip thresholds live as
+//! `const` next to each signal in [`super::rules`] / [`super::statistics`].
 
 use rust_decimal::prelude::ToPrimitive;
 
 use super::{
     error::{NonPositivePriceSnafu, Result},
-    rules,
+    registry::{Signal, SignalContext, SignalOutput, SignalRegistry, builtin_registry},
+    rules::{MaxDrawdownSignal, VolumeSurgeSignal, WindowReturnSignal},
     signal::{AnomalyMetrics, AnomalySignal, Severity},
-    statistics,
+    statistics::{self, JumpSignal, RobustZScoreSignal},
 };
 use crate::market_data::MarketCandle;
 
@@ -42,16 +47,6 @@ use crate::market_data::MarketCandle;
 /// enough to stay responsive to a regime change.
 pub const EVAL_WINDOW: usize = 30;
 
-/// Absolute cumulative window return (fraction) that trips the return rule.
-const WINDOW_RETURN_THRESHOLD: f64 = 0.03;
-/// Rolling max-drawdown magnitude (fraction) that trips the drawdown rule.
-const DRAWDOWN_THRESHOLD: f64 = 0.03;
-/// Volume-vs-rolling-mean multiple that trips the volume-surge rule.
-const VOLUME_SURGE_THRESHOLD: f64 = 3.0;
-/// Robust z-score magnitude that trips the return-anomaly statistic.
-const ZSCORE_THRESHOLD: f64 = 3.5;
-/// BNS jump ratio above which the path is flagged as containing a jump.
-const JUMP_RATIO_THRESHOLD: f64 = 1.5;
 /// Drawdown magnitude (fraction) that escalates a multi-rule anomaly to
 /// [`Severity::Critical`] — the flash-crash shape.
 const CRITICAL_DRAWDOWN: f64 = 0.06;
@@ -70,6 +65,25 @@ const CRITICAL_DRAWDOWN: f64 = 0.06;
 /// Returns [`super::AnomalyError::NonPositivePrice`] if any close in the window
 /// or the latest candle is not strictly positive.
 pub fn evaluate(window: &[MarketCandle], latest: &MarketCandle) -> Result<Option<AnomalySignal>> {
+    evaluate_with(&builtin_registry(), window, latest)
+}
+
+/// Evaluate `latest` against `window` using an explicit signal `registry`.
+///
+/// [`evaluate`] delegates here with [`builtin_registry`]; this is the seam a
+/// test uses to inject an extra signal and prove it participates without any
+/// edit to the walk below. The shared inputs (`closes`, log-`returns`,
+/// historical/latest volumes) are prepared once and handed to every signal.
+///
+/// # Errors
+///
+/// Returns [`super::AnomalyError::NonPositivePrice`] if any close in the window
+/// or the latest candle is not strictly positive.
+pub(crate) fn evaluate_with(
+    registry: &SignalRegistry,
+    window: &[MarketCandle],
+    latest: &MarketCandle,
+) -> Result<Option<AnomalySignal>> {
     let mut closes = Vec::with_capacity(window.len() + 1);
     for candle in window {
         closes.push(close_f64(candle)?);
@@ -83,23 +97,59 @@ pub fn evaluate(window: &[MarketCandle], latest: &MarketCandle) -> Result<Option
 
     let history_volumes: Vec<f64> = window.iter().map(volume_f64).collect();
     let latest_volume = volume_f64(latest);
-
     let returns = statistics::log_returns(&closes);
-    let (&newest_return, history_returns) = returns
-        .split_last()
-        .expect("returns is non-empty when closes has at least two entries");
 
-    let jump_ratio = statistics::jump_ratio(&returns);
-    let metrics = AnomalyMetrics::builder()
-        .window_return(rules::window_return(&closes))
-        .max_drawdown(rules::max_drawdown(&closes))
-        .maybe_volume_surge(rules::volume_surge(&history_volumes, latest_volume))
-        .maybe_robust_zscore(statistics::robust_zscore(history_returns, newest_return))
-        .maybe_jump_ratio(jump_ratio)
-        .jump_flagged(jump_ratio.is_some_and(|ratio| ratio >= JUMP_RATIO_THRESHOLD))
+    let ctx = SignalContext::builder()
+        .closes(&closes)
+        .returns(&returns)
+        .history_volumes(&history_volumes)
+        .latest_volume(latest_volume)
         .build();
 
-    Ok(classify(metrics))
+    let evaluated: Vec<(&dyn Signal, SignalOutput)> = registry
+        .iter()
+        .map(|signal| {
+            let output = signal.evaluate(&ctx);
+            (signal.as_ref(), output)
+        })
+        .collect();
+
+    let metrics = metrics_from(&evaluated);
+    Ok(classify(&evaluated, metrics))
+}
+
+/// Project the collected signal outputs onto the public [`AnomalyMetrics`]
+/// trace, routing each builtin signal's value into its field by stable name.
+///
+/// This preserves the fixed metrics struct byte-for-byte for the builtin five;
+/// a signal beyond them contributes to the reason and severity but not to this
+/// trace. `None` values stay `None` (never flattened to `0.0`) so "not
+/// evaluable" survives the projection; `window_return` / `max_drawdown` are
+/// always computed, so an absent output falls back to their neutral `0.0`.
+fn metrics_from(evaluated: &[(&dyn Signal, SignalOutput)]) -> AnomalyMetrics {
+    let output = |name: &str| {
+        evaluated
+            .iter()
+            .map(|(_, out)| out)
+            .find(|out| out.name == name)
+    };
+    let jump = output(JumpSignal::NAME);
+    AnomalyMetrics::builder()
+        .window_return(
+            output(WindowReturnSignal::NAME)
+                .and_then(|out| out.value)
+                .unwrap_or(0.0),
+        )
+        .max_drawdown(
+            output(MaxDrawdownSignal::NAME)
+                .and_then(|out| out.value)
+                .unwrap_or(0.0),
+        )
+        .maybe_volume_surge(output(VolumeSurgeSignal::NAME).and_then(|out| out.value))
+        .maybe_robust_zscore(output(RobustZScoreSignal::NAME).and_then(|out| out.value))
+        .maybe_jump_ratio(jump.and_then(|out| out.value))
+        .jump_flagged(jump.is_some_and(|out| out.fired))
+        .build()
 }
 
 /// Extract a strictly-positive `f64` close, or fail with a typed error.
@@ -129,28 +179,19 @@ fn volume_f64(candle: &MarketCandle) -> f64 {
         .unwrap_or(0.0)
 }
 
-/// Map computed metrics to a severity and reason, or `None` when no rule fired.
-fn classify(metrics: AnomalyMetrics) -> Option<AnomalySignal> {
-    let return_fired = metrics.window_return.abs() >= WINDOW_RETURN_THRESHOLD;
-    let drawdown_fired = metrics.max_drawdown >= DRAWDOWN_THRESHOLD;
-    let volume_fired = metrics
-        .volume_surge
-        .is_some_and(|value| value >= VOLUME_SURGE_THRESHOLD);
-    let zscore_fired = metrics
-        .robust_zscore
-        .is_some_and(|value| value >= ZSCORE_THRESHOLD);
-    let jump_fired = metrics.jump_flagged;
-
-    let fired_count = [
-        return_fired,
-        drawdown_fired,
-        volume_fired,
-        zscore_fired,
-        jump_fired,
-    ]
-    .into_iter()
-    .filter(|&fired| fired)
-    .count();
+/// Map the collected signal outputs and their projected metrics to a severity
+/// and reason, or `None` when no signal fired.
+///
+/// Severity is driven by the generic fired-count over the registry plus the
+/// concrete flash-crash escalation keyed on the drawdown value (domain logic
+/// that stays concrete — not a weighted/scored combination). The reason is the
+/// fired signals' own fragments joined in registry order, so a newly registered
+/// signal's fragment appears here with no edit to this function.
+fn classify(
+    evaluated: &[(&dyn Signal, SignalOutput)],
+    metrics: AnomalyMetrics,
+) -> Option<AnomalySignal> {
+    let fired_count = evaluated.iter().filter(|(_, out)| out.fired).count();
     if fired_count == 0 {
         return None;
     }
@@ -163,25 +204,11 @@ fn classify(metrics: AnomalyMetrics) -> Option<AnomalySignal> {
         Severity::Watch
     };
 
-    let mut parts = Vec::new();
-    if drawdown_fired {
-        parts.push(format!("drawdown {:.1}%", metrics.max_drawdown * 100.0));
-    }
-    if return_fired {
-        parts.push(format!(
-            "window return {:+.1}%",
-            metrics.window_return * 100.0
-        ));
-    }
-    if let Some(surge) = metrics.volume_surge.filter(|_| volume_fired) {
-        parts.push(format!("volume surge {surge:.1}x"));
-    }
-    if let Some(zscore) = metrics.robust_zscore.filter(|_| zscore_fired) {
-        parts.push(format!("robust z-score {zscore:.1}"));
-    }
-    if let Some(ratio) = metrics.jump_ratio.filter(|_| jump_fired) {
-        parts.push(format!("jump ratio {ratio:.1}"));
-    }
+    let parts: Vec<String> = evaluated
+        .iter()
+        .filter(|(_, out)| out.fired)
+        .map(|(signal, out)| signal.fragment(out))
+        .collect();
 
     let reason = format!("{} anomaly — {}", severity.label(), parts.join(", "));
     Some(
@@ -198,11 +225,39 @@ mod tests {
     use jiff::{SignedDuration, Timestamp};
     use rust_decimal::Decimal;
 
-    use super::evaluate;
+    use super::{evaluate, evaluate_with};
     use crate::{
-        anomaly::{error::AnomalyError, signal::Severity},
+        anomaly::{
+            error::AnomalyError,
+            registry::{Signal, SignalContext, SignalOutput, builtin_registry},
+            signal::Severity,
+        },
         market_data::{MarketCandle, Timeframe},
     };
+
+    /// A test-only signal that always fires with a recognizable fragment, used
+    /// to prove a newly registered signal participates in evaluation without
+    /// any edit to the core loop. It is `#[cfg(test)]` only — production code
+    /// never registers an input-independent signal.
+    struct BeaconSignal;
+
+    impl BeaconSignal {
+        const NAME: &'static str = "test_beacon";
+    }
+
+    impl Signal for BeaconSignal {
+        fn name(&self) -> &'static str { Self::NAME }
+
+        fn evaluate(&self, _ctx: &SignalContext<'_>) -> SignalOutput {
+            SignalOutput::builder()
+                .name(Self::NAME)
+                .value(1.0)
+                .fired(true)
+                .build()
+        }
+
+        fn fragment(&self, _output: &SignalOutput) -> String { "test beacon fired".to_owned() }
+    }
 
     /// Build a candle whose open/high/low/close all equal `close` (drawdown and
     /// returns read closes only) at a distinct, increasing open time.
@@ -289,6 +344,57 @@ mod tests {
 
         let signal = evaluate(&history, &latest).expect("positive prices");
         assert!(signal.is_none(), "flat tape should not enrich: {signal:?}");
+    }
+
+    #[test]
+    fn registered_signal_participates_in_evaluation() {
+        // A flat tape the five builtin signals leave unremarkable.
+        let history = window(&[
+            (61_500, 120),
+            (61_510, 120),
+            (61_500, 120),
+            (61_510, 120),
+            (61_500, 120),
+            (61_510, 120),
+            (61_500, 120),
+            (61_510, 120),
+            (61_500, 120),
+            (61_510, 120),
+            (61_500, 120),
+            (61_510, 120),
+        ]);
+        let latest = candle(12, 61_505, 122);
+
+        // Builtin-only registry: the tape is unremarkable, so no signal.
+        assert!(
+            evaluate(&history, &latest)
+                .expect("positive prices")
+                .is_none(),
+            "the builtin five should leave this flat tape unremarkable"
+        );
+
+        // Extend the registry with one always-firing signal — a one-line
+        // registration, no edit to the evaluation loop.
+        let mut registry = builtin_registry();
+        registry.push(Box::new(BeaconSignal));
+
+        let signal = evaluate_with(&registry, &history, &latest)
+            .expect("positive prices")
+            .expect("the added signal fires, so evaluation now yields a signal");
+        assert!(
+            signal.reason.contains("test beacon fired"),
+            "the added signal's fragment should appear in the collected output: {}",
+            signal.reason
+        );
+
+        // The same window through the builtin-only registry still returns None,
+        // confirming the added signal — not the window — caused the difference.
+        assert!(
+            evaluate_with(&builtin_registry(), &history, &latest)
+                .expect("positive prices")
+                .is_none(),
+            "the builtin-only registry must stay silent on this window"
+        );
     }
 
     #[test]

--- a/crates/extensions/rara-trading/src/anomaly/evaluator.rs
+++ b/crates/extensions/rara-trading/src/anomaly/evaluator.rs
@@ -130,8 +130,8 @@ fn metrics_from(evaluated: &[(&dyn Signal, SignalOutput)]) -> AnomalyMetrics {
     let output = |name: &str| {
         evaluated
             .iter()
+            .find(|(signal, _)| signal.name() == name)
             .map(|(_, out)| out)
-            .find(|out| out.name == name)
     };
     let jump = output(JumpSignal::NAME);
     AnomalyMetrics::builder()
@@ -249,11 +249,10 @@ mod tests {
         fn name(&self) -> &'static str { Self::NAME }
 
         fn evaluate(&self, _ctx: &SignalContext<'_>) -> SignalOutput {
-            SignalOutput::builder()
-                .name(Self::NAME)
-                .value(1.0)
-                .fired(true)
-                .build()
+            SignalOutput {
+                value: Some(1.0),
+                fired: true,
+            }
         }
 
         fn fragment(&self, _output: &SignalOutput) -> String { "test beacon fired".to_owned() }

--- a/crates/extensions/rara-trading/src/anomaly/mod.rs
+++ b/crates/extensions/rara-trading/src/anomaly/mod.rs
@@ -29,6 +29,7 @@
 
 mod error;
 mod evaluator;
+mod registry;
 mod rules;
 mod signal;
 mod statistics;

--- a/crates/extensions/rara-trading/src/anomaly/registry.rs
+++ b/crates/extensions/rara-trading/src/anomaly/registry.rs
@@ -67,15 +67,15 @@ impl SignalContext<'_> {
 
 /// The structured output of one [`Signal`] over a [`SignalContext`].
 ///
-/// Every field has a downstream consumer, so no field is a hollow placeholder
-/// (`docs/guides/anti-patterns.md`): [`Self::name`] routes the value into the
-/// public [`super::AnomalyMetrics`] trace, [`Self::value`] populates that trace
-/// and feeds [`Signal::fragment`], and [`Self::fired`] drives the fired-count,
-/// severity, and reason-fragment selection in the classifier.
-#[derive(Debug, Clone, Builder)]
+/// Both fields have a downstream consumer, so neither is a hollow placeholder
+/// (`docs/guides/anti-patterns.md`): [`Self::value`] populates the public
+/// [`super::AnomalyMetrics`] trace and feeds [`Signal::fragment`], and
+/// [`Self::fired`] drives the fired-count, severity, and reason-fragment
+/// selection in the classifier. The signal's identity is a static property of
+/// the [`Signal`] itself ([`Signal::name`]), not per-evaluation data, so it is
+/// not duplicated into every output.
+#[derive(Debug, Clone)]
 pub(crate) struct SignalOutput {
-    /// Stable identifier routing this signal's value into the metrics trace.
-    pub(crate) name:  &'static str,
     /// The signal's computed value, or `None` when the window was too short to
     /// compute it — mirrors the `Option<f64>` metrics so "not evaluable" is not
     /// flattened into a numeric `0.0`.

--- a/crates/extensions/rara-trading/src/anomaly/registry.rs
+++ b/crates/extensions/rara-trading/src/anomaly/registry.rs
@@ -1,0 +1,119 @@
+// Copyright 2026 Rararulab
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! The anomaly signal registry: a minimal [`Signal`] trait, the structured
+//! per-signal output, the shared per-evaluation context, and the builtin
+//! registry of the five signals the evaluator ships with.
+//!
+//! This is the extensibility seam for layer-② decision support: a new signal
+//! is "implement [`Signal`] + add one line to [`builtin_registry`]", with no
+//! edit to the core evaluation loop in [`super::evaluator`]. The five builtin
+//! signals are thin adapters over the pure functions in [`super::rules`] and
+//! [`super::statistics`]; those pure functions remain the computational core.
+
+use bon::Builder;
+
+use super::{
+    rules::{MaxDrawdownSignal, VolumeSurgeSignal, WindowReturnSignal},
+    statistics::{JumpSignal, RobustZScoreSignal},
+};
+
+/// Shared inputs prepared once per evaluation and handed to every signal, so no
+/// signal recomputes the close/return/volume series.
+#[derive(Builder)]
+pub(crate) struct SignalContext<'a> {
+    /// Ordered close series: window history followed by the latest close.
+    closes:          &'a [f64],
+    /// Log-returns of [`Self::closes`], newest last.
+    returns:         &'a [f64],
+    /// Rolling historical volumes (excluding the latest candle).
+    history_volumes: &'a [f64],
+    /// Volume of the latest (newly closed) candle.
+    latest_volume:   f64,
+}
+
+impl SignalContext<'_> {
+    /// Ordered close series (window history followed by the latest close).
+    pub(crate) fn closes(&self) -> &[f64] { self.closes }
+
+    /// Log-returns of [`Self::closes`], newest last.
+    pub(crate) fn returns(&self) -> &[f64] { self.returns }
+
+    /// Rolling historical volumes (excluding the latest candle).
+    pub(crate) fn history_volumes(&self) -> &[f64] { self.history_volumes }
+
+    /// Volume of the latest (newly closed) candle.
+    pub(crate) fn latest_volume(&self) -> f64 { self.latest_volume }
+
+    /// The newest return split from the preceding history, or `None` when the
+    /// return series is empty (window too short to form a single return).
+    pub(crate) fn newest_return(&self) -> Option<(f64, &[f64])> {
+        self.returns
+            .split_last()
+            .map(|(&newest, history)| (newest, history))
+    }
+}
+
+/// The structured output of one [`Signal`] over a [`SignalContext`].
+///
+/// Every field has a downstream consumer, so no field is a hollow placeholder
+/// (`docs/guides/anti-patterns.md`): [`Self::name`] routes the value into the
+/// public [`super::AnomalyMetrics`] trace, [`Self::value`] populates that trace
+/// and feeds [`Signal::fragment`], and [`Self::fired`] drives the fired-count,
+/// severity, and reason-fragment selection in the classifier.
+#[derive(Debug, Clone, Builder)]
+pub(crate) struct SignalOutput {
+    /// Stable identifier routing this signal's value into the metrics trace.
+    pub(crate) name:  &'static str,
+    /// The signal's computed value, or `None` when the window was too short to
+    /// compute it — mirrors the `Option<f64>` metrics so "not evaluable" is not
+    /// flattened into a numeric `0.0`.
+    pub(crate) value: Option<f64>,
+    /// Whether the signal crossed its trip threshold.
+    pub(crate) fired: bool,
+}
+
+/// One anomaly signal: it computes a structured output over the prepared
+/// context and formats its own reason fragment when it fires.
+pub(crate) trait Signal {
+    /// Stable identifier used to route this signal's value into the public
+    /// [`super::AnomalyMetrics`] trace. Not shown to users.
+    fn name(&self) -> &'static str;
+
+    /// Evaluate the prepared context into this signal's structured output.
+    fn evaluate(&self, ctx: &SignalContext<'_>) -> SignalOutput;
+
+    /// Human-readable reason fragment for a fired output (e.g. `drawdown
+    /// 6.1%`). Only called for outputs whose [`SignalOutput::fired`] is set.
+    fn fragment(&self, output: &SignalOutput) -> String;
+}
+
+/// An ordered set of signals the evaluator walks. The builtin order encodes the
+/// reason-fragment order (drawdown, return, volume, z-score, jump), so the
+/// `reason` string is byte-for-byte stable.
+pub(crate) type SignalRegistry = Vec<Box<dyn Signal>>;
+
+/// The five signals the anomaly evaluator ships with, in reason-fragment order.
+///
+/// Adding a sixth signal is a one-line extension here plus its [`Signal`] impl;
+/// the core loop in [`super::evaluator::evaluate_with`] does not change.
+pub(crate) fn builtin_registry() -> SignalRegistry {
+    vec![
+        Box::new(MaxDrawdownSignal),
+        Box::new(WindowReturnSignal),
+        Box::new(VolumeSurgeSignal),
+        Box::new(RobustZScoreSignal),
+        Box::new(JumpSignal),
+    ]
+}

--- a/crates/extensions/rara-trading/src/anomaly/rules.rs
+++ b/crates/extensions/rara-trading/src/anomaly/rules.rs
@@ -14,7 +14,18 @@
 
 //! L1 window rules: cumulative return, rolling drawdown, and volume surge.
 //! Each is a pure function over the ordered close/volume series so the
-//! evaluator can compose them and every branch stays unit-testable.
+//! evaluator can compose them and every branch stays unit-testable. Each pure
+//! function is wrapped by a thin [`Signal`] adapter that owns its trip
+//! threshold and reason wording, so the registry can walk them uniformly.
+
+use super::registry::{Signal, SignalContext, SignalOutput};
+
+/// Absolute cumulative window return (fraction) that trips the return rule.
+const WINDOW_RETURN_THRESHOLD: f64 = 0.03;
+/// Rolling max-drawdown magnitude (fraction) that trips the drawdown rule.
+const DRAWDOWN_THRESHOLD: f64 = 0.03;
+/// Volume-vs-rolling-mean multiple that trips the volume-surge rule.
+const VOLUME_SURGE_THRESHOLD: f64 = 3.0;
 
 /// Signed cumulative return across `closes`, as a fraction of the first close.
 ///
@@ -55,6 +66,93 @@ pub(crate) fn volume_surge(history_volumes: &[f64], latest_volume: f64) -> Optio
         return None;
     }
     Some(latest_volume / mean)
+}
+
+/// L1 signal: signed cumulative window return. Fires on a large move in either
+/// direction; the fragment keeps the sign so a rally and a slide read
+/// differently.
+pub(crate) struct WindowReturnSignal;
+
+impl WindowReturnSignal {
+    /// Stable trace identifier (matches the `AnomalyMetrics::window_return`
+    /// field it projects onto).
+    pub(crate) const NAME: &'static str = "window_return";
+}
+
+impl Signal for WindowReturnSignal {
+    fn name(&self) -> &'static str { Self::NAME }
+
+    fn evaluate(&self, ctx: &SignalContext<'_>) -> SignalOutput {
+        let value = window_return(ctx.closes());
+        SignalOutput::builder()
+            .name(Self::NAME)
+            .value(value)
+            .fired(value.abs() >= WINDOW_RETURN_THRESHOLD)
+            .build()
+    }
+
+    fn fragment(&self, output: &SignalOutput) -> String {
+        format!(
+            "window return {:+.1}%",
+            output.value.unwrap_or_default() * 100.0
+        )
+    }
+}
+
+/// L1 signal: deepest peak-to-trough decline across the window. Fires on a
+/// drawdown magnitude; the classifier also reads its value for the flash-crash
+/// escalation.
+pub(crate) struct MaxDrawdownSignal;
+
+impl MaxDrawdownSignal {
+    /// Stable trace identifier (matches the `AnomalyMetrics::max_drawdown`
+    /// field it projects onto).
+    pub(crate) const NAME: &'static str = "max_drawdown";
+}
+
+impl Signal for MaxDrawdownSignal {
+    fn name(&self) -> &'static str { Self::NAME }
+
+    fn evaluate(&self, ctx: &SignalContext<'_>) -> SignalOutput {
+        let value = max_drawdown(ctx.closes());
+        SignalOutput::builder()
+            .name(Self::NAME)
+            .value(value)
+            .fired(value >= DRAWDOWN_THRESHOLD)
+            .build()
+    }
+
+    fn fragment(&self, output: &SignalOutput) -> String {
+        format!("drawdown {:.1}%", output.value.unwrap_or_default() * 100.0)
+    }
+}
+
+/// L1 signal: newest volume relative to the rolling mean. Not evaluable
+/// (`None`) when there is no history or a ~zero mean, so it never fires on a
+/// dead tape.
+pub(crate) struct VolumeSurgeSignal;
+
+impl VolumeSurgeSignal {
+    /// Stable trace identifier (matches the `AnomalyMetrics::volume_surge`
+    /// field it projects onto).
+    pub(crate) const NAME: &'static str = "volume_surge";
+}
+
+impl Signal for VolumeSurgeSignal {
+    fn name(&self) -> &'static str { Self::NAME }
+
+    fn evaluate(&self, ctx: &SignalContext<'_>) -> SignalOutput {
+        let value = volume_surge(ctx.history_volumes(), ctx.latest_volume());
+        SignalOutput::builder()
+            .name(Self::NAME)
+            .maybe_value(value)
+            .fired(value.is_some_and(|surge| surge >= VOLUME_SURGE_THRESHOLD))
+            .build()
+    }
+
+    fn fragment(&self, output: &SignalOutput) -> String {
+        format!("volume surge {:.1}x", output.value.unwrap_or_default())
+    }
 }
 
 #[cfg(test)]

--- a/crates/extensions/rara-trading/src/anomaly/rules.rs
+++ b/crates/extensions/rara-trading/src/anomaly/rules.rs
@@ -84,11 +84,10 @@ impl Signal for WindowReturnSignal {
 
     fn evaluate(&self, ctx: &SignalContext<'_>) -> SignalOutput {
         let value = window_return(ctx.closes());
-        SignalOutput::builder()
-            .name(Self::NAME)
-            .value(value)
-            .fired(value.abs() >= WINDOW_RETURN_THRESHOLD)
-            .build()
+        SignalOutput {
+            value: Some(value),
+            fired: value.abs() >= WINDOW_RETURN_THRESHOLD,
+        }
     }
 
     fn fragment(&self, output: &SignalOutput) -> String {
@@ -115,11 +114,10 @@ impl Signal for MaxDrawdownSignal {
 
     fn evaluate(&self, ctx: &SignalContext<'_>) -> SignalOutput {
         let value = max_drawdown(ctx.closes());
-        SignalOutput::builder()
-            .name(Self::NAME)
-            .value(value)
-            .fired(value >= DRAWDOWN_THRESHOLD)
-            .build()
+        SignalOutput {
+            value: Some(value),
+            fired: value >= DRAWDOWN_THRESHOLD,
+        }
     }
 
     fn fragment(&self, output: &SignalOutput) -> String {
@@ -143,11 +141,10 @@ impl Signal for VolumeSurgeSignal {
 
     fn evaluate(&self, ctx: &SignalContext<'_>) -> SignalOutput {
         let value = volume_surge(ctx.history_volumes(), ctx.latest_volume());
-        SignalOutput::builder()
-            .name(Self::NAME)
-            .maybe_value(value)
-            .fired(value.is_some_and(|surge| surge >= VOLUME_SURGE_THRESHOLD))
-            .build()
+        SignalOutput {
+            value,
+            fired: value.is_some_and(|surge| surge >= VOLUME_SURGE_THRESHOLD),
+        }
     }
 
     fn fragment(&self, output: &SignalOutput) -> String {

--- a/crates/extensions/rara-trading/src/anomaly/statistics.rs
+++ b/crates/extensions/rara-trading/src/anomaly/statistics.rs
@@ -21,6 +21,17 @@
 //! reason to pick a different MAD-to-sigma factor or bipower coefficient, and a
 //! YAML knob would recreate the #1804→#1817 footgun where a default config
 //! silently disables the fix.
+//!
+//! Each pure statistic is wrapped by a thin [`Signal`] adapter that owns its
+//! trip threshold and reason wording, so the registry can walk L1 rules and L2
+//! statistics uniformly.
+
+use super::registry::{Signal, SignalContext, SignalOutput};
+
+/// Robust z-score magnitude that trips the return-anomaly statistic.
+const ZSCORE_THRESHOLD: f64 = 3.5;
+/// BNS jump ratio above which the path is flagged as containing a jump.
+const JUMP_RATIO_THRESHOLD: f64 = 1.5;
 
 /// Minimum number of returns required before a statistic is trusted. Below this
 /// the MAD scale and bipower variation are too noisy to separate signal from
@@ -125,6 +136,65 @@ pub(crate) fn jump_ratio(returns: &[f64]) -> Option<f64> {
         return None;
     }
     Some(realized_variance(returns) / bipower)
+}
+
+/// L2 signal: MAD-based robust z-score of the newest log-return against its
+/// history. Not evaluable (`None`) below [`MIN_SAMPLES`] history points or on a
+/// flat history where the MAD collapses.
+pub(crate) struct RobustZScoreSignal;
+
+impl RobustZScoreSignal {
+    /// Stable trace identifier (matches the `AnomalyMetrics::robust_zscore`
+    /// field it projects onto).
+    pub(crate) const NAME: &'static str = "robust_zscore";
+}
+
+impl Signal for RobustZScoreSignal {
+    fn name(&self) -> &'static str { Self::NAME }
+
+    fn evaluate(&self, ctx: &SignalContext<'_>) -> SignalOutput {
+        let value = ctx
+            .newest_return()
+            .and_then(|(newest, history)| robust_zscore(history, newest));
+        SignalOutput::builder()
+            .name(Self::NAME)
+            .maybe_value(value)
+            .fired(value.is_some_and(|zscore| zscore >= ZSCORE_THRESHOLD))
+            .build()
+    }
+
+    fn fragment(&self, output: &SignalOutput) -> String {
+        format!("robust z-score {:.1}", output.value.unwrap_or_default())
+    }
+}
+
+/// L2 signal: Barndorff-Nielsen–Shephard jump ratio (realized variance over
+/// bipower variation). Not evaluable (`None`) below [`MIN_SAMPLES`] returns or
+/// a ~zero bipower variation. Its `fired` flag is the
+/// `AnomalyMetrics::jump_flagged` bit.
+pub(crate) struct JumpSignal;
+
+impl JumpSignal {
+    /// Stable trace identifier (matches the `AnomalyMetrics::jump_ratio` field
+    /// it projects onto).
+    pub(crate) const NAME: &'static str = "jump_ratio";
+}
+
+impl Signal for JumpSignal {
+    fn name(&self) -> &'static str { Self::NAME }
+
+    fn evaluate(&self, ctx: &SignalContext<'_>) -> SignalOutput {
+        let value = jump_ratio(ctx.returns());
+        SignalOutput::builder()
+            .name(Self::NAME)
+            .maybe_value(value)
+            .fired(value.is_some_and(|ratio| ratio >= JUMP_RATIO_THRESHOLD))
+            .build()
+    }
+
+    fn fragment(&self, output: &SignalOutput) -> String {
+        format!("jump ratio {:.1}", output.value.unwrap_or_default())
+    }
 }
 
 #[cfg(test)]

--- a/crates/extensions/rara-trading/src/anomaly/statistics.rs
+++ b/crates/extensions/rara-trading/src/anomaly/statistics.rs
@@ -156,11 +156,10 @@ impl Signal for RobustZScoreSignal {
         let value = ctx
             .newest_return()
             .and_then(|(newest, history)| robust_zscore(history, newest));
-        SignalOutput::builder()
-            .name(Self::NAME)
-            .maybe_value(value)
-            .fired(value.is_some_and(|zscore| zscore >= ZSCORE_THRESHOLD))
-            .build()
+        SignalOutput {
+            value,
+            fired: value.is_some_and(|zscore| zscore >= ZSCORE_THRESHOLD),
+        }
     }
 
     fn fragment(&self, output: &SignalOutput) -> String {
@@ -185,11 +184,10 @@ impl Signal for JumpSignal {
 
     fn evaluate(&self, ctx: &SignalContext<'_>) -> SignalOutput {
         let value = jump_ratio(ctx.returns());
-        SignalOutput::builder()
-            .name(Self::NAME)
-            .maybe_value(value)
-            .fired(value.is_some_and(|ratio| ratio >= JUMP_RATIO_THRESHOLD))
-            .build()
+        SignalOutput {
+            value,
+            fired: value.is_some_and(|ratio| ratio >= JUMP_RATIO_THRESHOLD),
+        }
     }
 
     fn fragment(&self, output: &SignalOutput) -> String {

--- a/specs/issue-2429-anomaly-signal-registry.spec.md
+++ b/specs/issue-2429-anomaly-signal-registry.spec.md
@@ -1,0 +1,239 @@
+spec: task
+name: "issue-2429-anomaly-signal-registry"
+inherits: project
+tags: [refactor, backend, trading]
+---
+
+## Intent
+
+rara's trading extension evaluates market anomalies in
+`crates/extensions/rara-trading/src/anomaly/`. Today the five signals are
+hardcoded into the evaluator: `evaluator.rs::evaluate` builds an
+`AnomalyMetrics` by calling each signal function by name — `rules::window_return`,
+`rules::max_drawdown`, `rules::volume_surge` (L1) plus
+`statistics::robust_zscore` and `statistics::jump_ratio` (L2) — and then
+`classify` hardcodes, per signal, a `*_fired` boolean, the `fired_count` array,
+and a bespoke `parts.push(...)` reason fragment. Adding a sixth signal means
+editing three disjoint places (the builder call in `evaluate`, the fired-set and
+count in `classify`, and the reason-formatting block) plus threading a new field
+through the `AnomalyMetrics` struct. The signals are not an extensible set; they
+are welded into the core control flow.
+
+This issue is the foundation ("地基") for layer-② decision support: it
+generalizes the five hardcoded signals into an **extensible signal registry**.
+A minimal `Signal` trait describes one signal (evaluate over the prepared window
+context → a structured output carrying its stable name, its value, whether it
+fired, and its inspectable contribution). The five existing signals move behind
+that trait and register into a builtin registry; `evaluate` changes from a
+hand-composed builder call into a loop that walks the registry, collects each
+signal's output, and hands the collected set to the severity classifier. The
+observable win is the extensibility point: **adding a sixth signal becomes
+"implement the trait + register one line", with no edit to the core `evaluate`
+loop.** Behavior is preserved bit-for-bit for the existing five signals — same
+`AnomalyMetrics`, same `Severity` verdicts, same `reason` text, same enriched
+directive.
+
+If we do not do this, the following concrete maintenance bug appears when
+layer-② adds its next signal (e.g. a realized-volatility spike). Reproducer:
+
+1. An engineer implements the new statistic as a pure function.
+2. To make `evaluate` actually use it they must: add a field to
+   `AnomalyMetrics`, add a `.maybe_<x>(...)` call to the builder inside
+   `evaluate`, add an `<x>_fired` local plus a new entry in the `fired_count`
+   array inside `classify`, and add a `parts.push(...)` branch in the reason
+   block — four edits across two functions for one signal.
+3. Observed bad outcome: `evaluate`/`classify` grow monotonically and become a
+   merge-conflict magnet across the parallel signal-adding PRs the layer-②
+   roadmap requires (more signals, then backtest, then trade suggestions).
+   There is no isolated unit boundary for "signal N" — its threshold, its reason
+   wording, and its metric live in three files — so each new signal re-touches
+   shared control flow and risks perturbing the other four. This is precisely
+   the "别扭、不可扩展" the layer-② plan flags as the thing to fix before
+   growing the signal set.
+
+This advances `goal.md` signal 3 (rara building its own market-analysis
+capability — the extensible registry is the substrate the layer-② signals grow
+on) and signal 4 ("Every action is inspectable" — each signal's structured
+output carries a stable name and value, so the evaluation is a readable
+per-signal trace rather than an opaque verdict). It crosses no "What rara is
+NOT" line: the registry is scoped to rara's own anomaly evaluation and is
+consumed only through the existing single-process `dispatch` facade — it is
+**not** a general agent/plugin framework, and it exposes no new surface to any
+other user or product. It is the prerequisite for the later layer-② blocks
+(additional signals, backtest, trade suggestions), each of which is a separate
+issue and explicitly out of scope here.
+
+Prior-art search (2026-07-15) against `rararulab/rara` (the canonical repo; the
+local `origin` fork has issues disabled). `gh issue list` / `gh pr list` for
+`anomaly signal registry`, `trading signal extensible factor`, `signal registry
+trait` returned only the existing anomaly lineage: issue 2415 / PR 2418 (the
+anomaly engine that introduced these five hardcoded signals), issue 2416 / PR
+2424 (severity-graded delivery), issue 2425 / PR 2426 (consolidating market
+signal orchestration behind the `dispatch` facade), and issue 2417 / PR 2419
+(candle polling floor). `git log --all --grep "anomaly"` / `--grep "signal
+registry"` since 180 days shows the same three trading commits and nothing that
+introduced or removed a signal-registry abstraction. No prior work built a
+signal registry and no prior decision is being reversed — this is a forward
+generalization of what PR 2418 landed as hardcoded, built on top of the
+`dispatch` facade PR 2426 established.
+
+## Decisions
+
+- Work happens entirely inside `crates/extensions/rara-trading/src/anomaly/`.
+  The public re-exports in `anomaly/mod.rs` — `evaluate`, `EVAL_WINDOW`,
+  `AnomalySignal`, `AnomalyMetrics`, `Severity`, `AnomalyError`, `Result` — and
+  the `evaluate(window, latest) -> Result<Option<AnomalySignal>>` signature stay
+  unchanged so the `dispatch` facade consumer (`dispatch/pipeline.rs`,
+  `anomaly::evaluate`) needs no edit. This issue is invisible from outside the
+  module.
+- Introduce a minimal `Signal` trait. One signal computes, from a prepared
+  per-evaluation context, a structured `SignalOutput` carrying: a stable `name`
+  (the identifier used in the inspectable trace and as the reason-fragment
+  label), the signal's `value` (or `Option` when the window was too short to
+  compute it, mirroring today's `Option<f64>` metrics), a `fired` flag, and the
+  ability to format its own reason fragment. Prepare the shared inputs
+  (`closes`, log-`returns`, split history/newest return, historical volumes,
+  latest volume) **once** in `evaluate` and pass them to every signal — do not
+  recompute per signal, and do not change what each signal reads.
+- `evaluate` becomes: build the context, walk the builtin registry collecting
+  each signal's `SignalOutput`, assemble the existing `AnomalyMetrics` from the
+  collected outputs, then classify. The five signals move into trait impls (L1:
+  window return, max drawdown, volume surge; L2: robust MAD z-score, BNS jump)
+  that wrap the existing pure functions in `rules.rs` / `statistics.rs` — keep
+  those pure functions and their unit tests as the computational core; the trait
+  impls are thin adapters.
+- Reason text and severity classification are preserved **byte-for-byte**. The
+  `reason` string keeps the exact `"{severity_label} anomaly — {parts}"` shape
+  with the same per-signal fragments (`drawdown {:.1}%`, `window return
+  {:+.1}%`, `volume surge {:.1}x`, `robust z-score {:.1}`, `jump ratio {:.1}`)
+  in the same order (drawdown, return, volume, z-score, jump — encoded as the
+  registry's builtin order). Each fragment still appears only when that signal
+  fired. Severity stays the current rule: `fired_count`, with the
+  `CRITICAL_DRAWDOWN && fired_count >= 2` escalation keyed on the drawdown value.
+- Severity classification stays concrete. This issue does **not** turn severity
+  into a weighted / scored / factor-combination framework — the drawdown-aware
+  critical escalation is domain logic that stays where it is. Generalizing
+  severity into weights is explicitly a later layer-② concern, not this one.
+- Keep the module minimal (dtolnay's "least surface" anchor): the trait carries
+  only what the five signals plus "a sixth signal can plug in" genuinely need.
+  Do **not** add speculative machinery — no factor metadata catalog, no
+  per-signal weights, no config-driven signal selection, no signal-dependency
+  graph. Every field on `SignalOutput` must be read by `evaluate`, the metrics
+  assembly, the reason builder, or the classifier — a field nothing consumes is
+  a hollow field (`docs/guides/anti-patterns.md`) and must be dropped. In
+  particular, only add a signal `category` (L1/L2) tag if some behavior-
+  preserving output actually reads it; otherwise omit it.
+- Provide a seam so a signal registered into the registry demonstrably
+  participates without editing the core loop: `evaluate` delegates to an internal
+  evaluation over a passed-in registry (e.g. `evaluate_with(&registry, window,
+  latest)`), and the public `evaluate` calls it with the builtin registry. This
+  is the seam the extensibility acceptance test exercises; it is internal to the
+  module (may be `pub(crate)` / `#[cfg(test)]`), not new public API.
+- Thresholds and statistical constants remain Rust `const` next to their
+  mechanism (`docs/guides/anti-patterns.md` mechanism-tuning rule). No new YAML
+  knob. Errors stay `snafu`; 3+-field structs use `#[derive(bon::Builder)]`.
+- Update `crates/extensions/rara-trading/AGENT.md` to document the signal
+  registry (the `Signal` trait, the builtin registry, and the "implement + one
+  line to register" extension path) since this changes how the anomaly module is
+  structured and extended.
+
+## Boundaries
+
+### Allowed Changes
+- **/crates/extensions/rara-trading/src/anomaly/**
+- **/crates/extensions/rara-trading/AGENT.md
+- **/specs/issue-2429-anomaly-signal-registry.spec.md
+
+### Forbidden
+- **/crates/extensions/rara-trading/src/dispatch/**
+- **/crates/extensions/rara-trading/src/finance/registry.rs
+- **/crates/extensions/rara-trading/src/lib.rs
+- **/config.example.yaml
+- **/web/**
+- **/extension/**
+- Do NOT change the public re-exports or the `evaluate` signature — the
+  `dispatch` facade consumer must compile and behave identically with no edit.
+- Do NOT alter the `AnomalyMetrics` fields, the `reason` string wording/order,
+  or the `Severity` classification outcome for the existing five signals. This
+  is a behavior-preserving generalization; the existing anomaly unit tests and
+  the delivery/directive tests are the parity gate and must stay green
+  unchanged.
+- Do NOT add a new signal in this issue — the registry ships with exactly the
+  five existing signals. The sixth signal is a later issue.
+- Do NOT build a weight / scoring / factor-metadata / combination framework, a
+  signal-dependency graph, or config-driven signal selection — that is
+  speculative machinery this issue must not introduce.
+- Do NOT add a YAML knob for any signal, threshold, or window size — mechanism
+  tuning stays a Rust `const` (`docs/guides/anti-patterns.md`).
+- Do NOT construct hollow outputs: a `SignalOutput` field nothing reads, or a
+  trait impl that returns a constant regardless of input, is a hollow
+  implementation and is forbidden.
+
+## Acceptance Criteria
+
+Scenario: A signal registered into the registry participates in evaluation without editing the core loop
+  Test:
+    Package: rara-trading
+    Filter: registered_signal_participates_in_evaluation
+  Given a registry of the five builtin signals plus one additional test signal that fires with a recognizable name
+  And a candle window that the five builtin signals alone would leave unremarkable (evaluate returns None)
+  When the evaluator runs over that window using the extended registry
+  Then it now returns a signal because the added signal fired
+    And the added signal's name/fragment appears in the collected output
+    And running the same window through the builtin-only registry still returns None
+
+Scenario: A multi-bar crash on a volume spike still produces the same high-severity signal
+  Test:
+    Package: rara-trading
+    Filter: crash_window_produces_high_severity_anomaly_signal
+  Given an ordered candle window ending in a sharp multi-bar decline with a volume spike
+  When the registry-driven evaluator runs over the window and the newest closed candle
+  Then it returns the highest (bypass-eligible) severity as before
+    And the reason still names the drawdown and window-return magnitudes
+
+Scenario: A flat, low-volatility tape still produces no anomaly signal
+  Test:
+    Package: rara-trading
+    Filter: flat_tape_produces_no_anomaly_signal
+  Given an ordered candle window of small alternating moves at steady volume
+  When the registry-driven evaluator runs over the window and the newest closed candle
+  Then it returns None, unchanged from before the registry migration
+
+Scenario: Multiple signals firing without a deep drawdown still classify as elevated
+  Test:
+    Package: rara-trading
+    Filter: two_rules_without_deep_drawdown_produce_elevated_severity
+  Given a single-bar drop on a volume surge where several signals fire but the drawdown stays under the critical floor
+  When the registry-driven evaluator collects the fired signals and classifies severity
+  Then the severity is the middle (elevated) level, identical to the pre-registry classifier
+
+Scenario: A produced signal still enriches the injected directive with its narrative
+  Test:
+    Package: rara-trading
+    Filter: anomaly_signal_enriches_finance_directive
+  Given a matched immediate BTCUSDT candle whose rolling window is crash-shaped
+  When the dispatch facade evaluates the window and injects the synthetic directive
+  Then the directive text contains the same anomaly severity and reason as before
+    And a matched candle whose window is flat still yields the unchanged factual wording
+
+Scenario: A non-positive candle close still fails with the typed error
+  Test:
+    Package: rara-trading
+    Filter: non_positive_close_is_a_typed_error
+  Given a candle window where the newest close is not strictly positive
+  When the registry-driven evaluator prepares the shared context before walking the registry
+  Then it returns the same NonPositivePrice typed error, unchanged by the migration
+
+## Out of Scope
+
+- Adding any new signal (realized-volatility spike, RSI divergence, etc.) — a
+  later layer-② issue; the registry ships with the existing five only.
+- Backtesting / historical replay of signals — later layer-② block.
+- Trade suggestions / actionable recommendations — later layer-② block.
+- Turning severity into a weighted or scored combination of signals, or any
+  factor-metadata / signal-weighting framework.
+- Per-signal or per-symbol operator-tunable config (YAML) — only if ever needed,
+  in a later issue, through `config.example.yaml`.
+- Any change to the delivery policy (cooldown / budget / severity bypass) in
+  `finance/registry.rs` or to the `dispatch` facade.
+- Any web / extension UI surface for signals.


### PR DESCRIPTION
## Summary

Foundation ("地基") for layer-② decision support: generalizes the five
**hardcoded** anomaly signals in `crates/extensions/rara-trading/src/anomaly/`
into an **extensible signal registry**, preserving behavior bit-for-bit.

A minimal `Signal` trait describes one signal; `evaluate` prepares the shared
context once, walks the builtin registry collecting each `SignalOutput`,
projects those onto the existing `AnomalyMetrics` by stable name, then
classifies severity. Adding a signal is now "implement `Signal` + register one
line" with no edit to the core `evaluate` loop, the metrics projection, or
`classify` — the `evaluate_with(&registry, …)` seam lets a test inject an extra
signal to prove participation. This is the substrate the later layer-② signals
(additional signals, backtest, trade suggestions) grow on — not a general
agent/plugin framework and no new outward surface.

Behavior preserved for the five builtins: public re-exports and the
`evaluate(window, latest)` signature are unchanged (the `dispatch` facade needs
no edit), `AnomalyMetrics` fields, the `reason` fragment wording and order
(drawdown, return, volume, z-score, jump — encoded as the registry's builtin
order), and the `Severity` rules (fired-count plus the drawdown-keyed critical
escalation) are byte-for-byte. `None` metrics survive the projection (never
flattened to `0.0`). Per-signal trip thresholds stay `const` next to each
signal; no scoring/weighting framework, no YAML knob.

## Type of change

Refactor — label `refactor`

## Component

`backend`

## Closes

Closes #2429

## Test plan

- [x] `cargo test -p rara-trading` — 93 passed, 0 failed (5 behavior-parity scenarios + the extensibility acceptance test)
- [x] `cargo test -p rara-app` — 176 passed, 0 failed
- [x] `cargo check` / `cargo +nightly fmt --check` / `clippy -D warnings` / `cargo doc` — all pass
- [x] `just spec-lifecycle specs/issue-2429-anomaly-signal-registry.spec.md` — stage complete, 6/6 scenarios PASS + boundaries PASS

Verification: PASS (行为逐位不变,6/6 spec,数值核心零删除).