### PR TITLE
feat(trading): signal-accuracy backtest harness (#2437)

### DIFF
--- a/crates/extensions/rara-trading/AGENT.md
+++ b/crates/extensions/rara-trading/AGENT.md
@@ -7,7 +7,7 @@ and evaluates newly closed candles for market anomalies — emitting ordinary
 kernel `FeedEvent`s and, on the app side, enriched synthetic directives.
 
 ## Architecture
-Five modules, each a `mod.rs` (re-exports + `//!` docs only) over sub-files:
+Six modules, each a `mod.rs` (re-exports + `//!` docs only) over sub-files:
 
 - `dispatch/` — the **market-signal facade** (`pipeline.rs`). `on_feed_event`
   is the single entry point that runs the whole persist → upsert → evaluate →
@@ -57,6 +57,23 @@ Five modules, each a `mod.rs` (re-exports + `//!` docs only) over sub-files:
   volume, z-score, jump), so keep it stable. `evaluate_with` is the test seam
   (`registered_signal_participates_in_evaluation` injects an extra signal).
 
+- `backtest/` — signal-accuracy backtest harness (issue 2437), the first rung
+  of layer ② (decision support). It replays a single symbol/timeframe stream of
+  stored candles through `anomaly::evaluate` and, for every bar the evaluator
+  fires on, applies one **fixed naive rule** (enter long at the trigger bar's
+  close, exit `HOLD_BARS` bars later at that bar's close) to answer "is a signal
+  actually any good?". `runner.rs` holds `run_backtest(candles) ->
+  Result<BacktestReport>` (the **pure** deterministic core the unit tests bind
+  to) and the thin async `backtest(repo, query)` entry that fetches via
+  `MarketDataRepository::candles` and delegates to the core — the same
+  pure-core/async-entry seam as `anomaly::evaluate` / the dispatch adapter.
+  `report.rs` = `BacktestReport` (`bon::Builder`, the fixed metric set:
+  `trigger_count`, `evaluated_trade_count`, `win_count`, `win_rate`, signed
+  `mean`/`median_forward_return`, strategy `max_drawdown`); `error.rs` =
+  `BacktestError` (snafu; `Evaluate` wraps `AnomalyError`, `FetchCandles` wraps
+  the repository read). It only **consumes** `anomaly::evaluate` and
+  `market_data`; it changes neither.
+
 The write→read→enrich wiring lives in `dispatch/pipeline.rs` (`on_feed_event`):
 it upserts the closed candle, pulls the window via `recent_candles`, runs
 `anomaly::evaluate`, and enriches `finance_directive` when a signal is
@@ -83,6 +100,21 @@ dispatch loop (`crates/app/src/lib.rs`).
 - **Candle selectors are normalized before storage** (venue lowercase, symbol
   uppercase, timeframe canonical). `recent_candles`/`latest_closed_candle`
   match on the normalized form.
+- **`backtest` has no look-ahead** — the number-one backtest bug. Signal
+  evaluation for bar `i` sees only `candles[i.saturating_sub(EVAL_WINDOW)..i]`
+  plus `latest = candles[i]`, never a bar `> i` (the same invariant `dispatch`
+  enforces with `end = Some(latest.open_time)`); forward return reads only bars
+  strictly after `i`. A trigger with fewer than `HOLD_BARS` bars remaining is
+  counted in `trigger_count` but **excluded** from `evaluated_trade_count` and
+  every P&L metric — never zero-filled. Consequence of violation: fabricated
+  edge that would ship a future ③ execution gate on a lie.
+- **The backtest unit is the composite `AnomalySignal`, and forward returns are
+  signed.** A "trigger" is one bar where `evaluate` returns `Some` (what
+  `dispatch` acts on) — not per-signal attribution (a documented future
+  extension). A trade wins **iff** its forward return is strictly `> 0.0`;
+  because the detectors are tail/volatility signals, a low win rate with a
+  negative mean is a valid, informative result. Report the signed mean/median;
+  do not take absolute value. `HOLD_BARS` is a `const`, never YAML.
 
 ## What NOT To Do
 - Do NOT change delivery policy (cooldown / hourly budget / `Silent` downgrade)
@@ -115,6 +147,18 @@ dispatch loop (`crates/app/src/lib.rs`).
   scale and masks a fresh move; use median/MAD (`statistics::robust_zscore`).
 - Do NOT compute log-returns on non-positive prices — `evaluate` returns
   `AnomalyError::NonPositivePrice` instead of producing garbage.
+- Do NOT grow `backtest` into a quant platform — **why:** it self-evaluates
+  rara's own signals with one fixed rule and a fixed metric set over a single
+  stream (issue 2437 Boundaries). No strategy DSL / selectable-or-parameterized
+  rule / parameter search / multi-asset portfolio / Python sandbox /
+  `BacktestArtifact` / transaction-cost model / paper-live execution — several
+  would cross the "NOT a quant platform for others" line. The heavier
+  `trading_backtest` research-desk tool is a separate later issue.
+- Do NOT add a `BacktestReport` field nothing reads, or emit `NaN` on an
+  empty/trigger-less stream — **why:** hollow output is forbidden
+  (`docs/guides/anti-patterns.md`); the empty result is `Option::None` (win
+  rate / returns) and `0.0` (drawdown), and every reported field is asserted by
+  a `runner.rs` test.
 
 ## Dependencies
 - Upstream: `rara-kernel` (`FeedEvent`, `Subscription`, tool traits).

--- a/crates/extensions/rara-trading/src/backtest/error.rs
+++ b/crates/extensions/rara-trading/src/backtest/error.rs
@@ -1,0 +1,51 @@
+// Copyright 2026 Rararulab
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Errors surfaced by the signal-accuracy backtest harness.
+
+use snafu::Snafu;
+
+use crate::anomaly::AnomalyError;
+
+/// Failures the backtest harness raises.
+///
+/// The harness never fabricates a report from bad data: a candle the anomaly
+/// evaluator rejects (a non-positive close makes its log-returns undefined)
+/// surfaces as [`BacktestError::Evaluate`] carrying the underlying
+/// [`AnomalyError`], and a repository read that fails on the async entry
+/// surfaces as [`BacktestError::FetchCandles`]. Both stop the replay rather
+/// than returning a silently-empty report.
+#[derive(Debug, Snafu)]
+#[snafu(visibility(pub))]
+pub enum BacktestError {
+    /// The anomaly evaluator rejected a candle while replaying the stream, so
+    /// no trustworthy report can be produced from it.
+    #[snafu(display("anomaly evaluation failed while replaying the candle stream: {source}"))]
+    Evaluate {
+        /// The evaluator error (e.g. a non-positive close).
+        source: AnomalyError,
+    },
+
+    /// Fetching the candle stream from the market-data repository failed on the
+    /// async entry point.
+    #[snafu(display("failed to fetch candles for backtest: {source}"))]
+    FetchCandles {
+        /// The underlying repository error, boxed to keep the domain error
+        /// independent of the `anyhow` boundary the repository trait uses.
+        source: Box<dyn std::error::Error + Send + Sync>,
+    },
+}
+
+/// Convenience alias for backtest results.
+pub type Result<T, E = BacktestError> = std::result::Result<T, E>;

--- a/crates/extensions/rara-trading/src/backtest/mod.rs
+++ b/crates/extensions/rara-trading/src/backtest/mod.rs
@@ -1,0 +1,55 @@
+// Copyright 2026 Rararulab
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Signal-accuracy backtest harness: the first rung of layer ② (decision
+//! support).
+//!
+//! Layer ① (`anomaly` + `dispatch`) lets rara *see* the market — `evaluate`
+//! fires a composite `AnomalySignal` on each closed candle and `dispatch`
+//! delivers it. This module answers the next question: **is a signal actually
+//! any good?** It replays a single symbol/timeframe stream of stored candles in
+//! time order through the same `anomaly::evaluate` and, for every bar the
+//! evaluator fires on, applies one **fixed naive rule** — enter a long at the
+//! trigger bar's close, exit `HOLD_BARS` bars later at that bar's close — then
+//! reports a **fixed metric set** ([`BacktestReport`]): trigger count, win
+//! rate, signed mean/median forward return, and the naive strategy's max
+//! drawdown.
+//!
+//! Two seams, mirroring the `anomaly` module:
+//! - [`run_backtest`] — the **pure, deterministic core** over an ordered candle
+//!   slice (no clock, no I/O); the unit tests bind here.
+//! - [`backtest`] — the **thin async entry** that fetches the stream via
+//!   [`MarketDataRepository::candles`](crate::market_data::MarketDataRepository::candles)
+//!   and delegates to the core.
+//!
+//! **No look-ahead** is the number-one backtest bug and is enforced
+//! structurally: signal evaluation for bar `i` sees only the `EVAL_WINDOW` bars
+//! strictly before `i` plus `latest = candles[i]`, and forward return reads
+//! only bars strictly after `i`. A trigger without a full `HOLD_BARS` forward
+//! window is counted but excluded from the P&L denominator — never fabricated
+//! or zero-filled. Because the detectors are tail/volatility signals, a low win
+//! rate with a negative mean forward return is a valid, informative result; the
+//! signed returns are reported without taking absolute value.
+//!
+//! This is a deliberately narrow first cut: one fixed rule, one fixed metric
+//! set, a single stream. No strategy DSL, parameter search, multi-asset
+//! portfolio, cost model, or execution wiring — those stay out of scope.
+
+mod error;
+mod report;
+mod runner;
+
+pub use error::{BacktestError, Result};
+pub use report::BacktestReport;
+pub use runner::{HOLD_BARS, backtest, run_backtest};

--- a/crates/extensions/rara-trading/src/backtest/report.rs
+++ b/crates/extensions/rara-trading/src/backtest/report.rs
@@ -1,0 +1,57 @@
+// Copyright 2026 Rararulab
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! The fixed metric set the backtest harness reports.
+
+use bon::Builder;
+
+/// The result of replaying one candle stream through the naive-long rule.
+///
+/// Every field is stream-wide over the composite `AnomalySignal` triggers.
+/// Exposing both [`Self::trigger_count`] and [`Self::evaluated_trade_count`]
+/// keeps the end-of-stream exclusion inspectable rather than silently dropped:
+/// a trigger too close to the end of the stream to have a full `HOLD_BARS`
+/// forward window counts in `trigger_count` but not in `evaluated_trade_count`.
+///
+/// The forward-return metrics are **signed** — because rara's detectors are
+/// tail/volatility signals rather than directional buy signals, a low
+/// [`Self::win_rate`] paired with a negative [`Self::mean_forward_return`] is a
+/// valid, informative result (the signals lean bearish), not a broken harness.
+/// The `Option` fields are `None` — never `NaN` — when there are no evaluated
+/// trades to average over.
+#[derive(Debug, Clone, Copy, PartialEq, Builder)]
+pub struct BacktestReport {
+    /// Bars where `anomaly::evaluate` returned `Some` (the composite signal
+    /// fired).
+    pub trigger_count:         usize,
+    /// Triggers that have a full `HOLD_BARS` forward window — the denominator
+    /// for the win-rate and forward-return metrics.
+    pub evaluated_trade_count: usize,
+    /// Evaluated trades whose forward return is strictly positive.
+    pub win_count:             usize,
+    /// Fraction of evaluated trades that won (`win_count /
+    /// evaluated_trade_count`), or `None` when there are no evaluated
+    /// trades.
+    pub win_rate:              Option<f64>,
+    /// Signed arithmetic mean forward return across evaluated trades, or `None`
+    /// when there are no evaluated trades.
+    pub mean_forward_return:   Option<f64>,
+    /// Signed median forward return across evaluated trades, or `None` when
+    /// there are no evaluated trades.
+    pub median_forward_return: Option<f64>,
+    /// Deepest peak-to-trough fractional decline of the naive strategy's equity
+    /// curve — the cumulative product of `(1 + per-trade forward return)` over
+    /// evaluated trades in trigger-time order. `0.0` when there are no trades.
+    pub max_drawdown:          f64,
+}

--- a/crates/extensions/rara-trading/src/backtest/runner.rs
+++ b/crates/extensions/rara-trading/src/backtest/runner.rs
@@ -1,0 +1,442 @@
+// Copyright 2026 Rararulab
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! The replay loop: the pure, deterministic core and the thin async entry.
+//!
+//! [`run_backtest`] walks an ordered single-stream candle slice, replays each
+//! bar through `anomaly::evaluate` under a strict no-look-ahead window, applies
+//! one fixed naive-long rule, and computes the [`BacktestReport`]. It is pure
+//! (no clock, no I/O), so the whole report is reproducible from a fixture —
+//! this is the seam the unit tests bind to. [`backtest`] is the thin async
+//! entry that fetches the stream via [`MarketDataRepository::candles`] and
+//! delegates to the same core.
+
+use rust_decimal::prelude::ToPrimitive;
+use snafu::ResultExt;
+
+use super::{
+    error::{BacktestError, EvaluateSnafu, Result},
+    report::BacktestReport,
+};
+use crate::{
+    anomaly::{self, EVAL_WINDOW},
+    market_data::{CandleRangeQuery, MarketCandle, MarketDataRepository},
+};
+
+/// Bars held between the naive rule's entry and exit: enter at a trigger bar's
+/// close, exit `HOLD_BARS` bars later at that bar's close.
+///
+/// This is a **mechanism constant** (`docs/guides/anti-patterns.md`): the hold
+/// horizon tunes the single fixed rule, and a deploy operator has no principled
+/// reason to retune it — a YAML knob would recreate the #1804→#1817 footgun. A
+/// selectable/parameterized horizon is explicitly out of scope (that is the
+/// heavier research-desk tool, a separate later issue).
+pub const HOLD_BARS: usize = 3;
+
+/// Replay `candles` (an ordered single-stream slice) through
+/// `anomaly::evaluate` and the fixed naive-long rule, returning the
+/// deterministic report.
+///
+/// For the bar at index `i`, signal evaluation sees only the
+/// up-to-`EVAL_WINDOW` bars strictly before `i`
+/// (`candles[i.saturating_sub(EVAL_WINDOW)..i]`) plus `latest = candles[i]` —
+/// never a bar at index `> i`. This mirrors the production invariant
+/// (`dispatch` queries `recent_candles` with `end = Some(latest.open_time)`),
+/// so the same trigger set the live pipeline would have produced is reproduced
+/// here. On a trigger, forward return reads only bars strictly after `i` (up to
+/// `candles[i + HOLD_BARS]`); a trigger with fewer than `HOLD_BARS` bars
+/// remaining is counted in `trigger_count` but excluded from every P&L metric —
+/// never zero-filled.
+///
+/// # Errors
+///
+/// Returns [`BacktestError::Evaluate`] if `anomaly::evaluate` rejects a candle
+/// (e.g. a non-positive close) — the replay stops rather than producing a
+/// report from invalid data.
+pub fn run_backtest(candles: &[MarketCandle]) -> Result<BacktestReport> {
+    // Pass 1: collect the trigger set under the strict no-look-ahead window.
+    let mut trigger_indices = Vec::new();
+    for index in 0..candles.len() {
+        let window = &candles[index.saturating_sub(EVAL_WINDOW)..index];
+        let latest = &candles[index];
+        if anomaly::evaluate(window, latest)
+            .context(EvaluateSnafu)?
+            .is_some()
+        {
+            trigger_indices.push(index);
+        }
+    }
+    let trigger_count = trigger_indices.len();
+
+    // Pass 2: the naive-long forward return for every trigger that has a full
+    // HOLD_BARS forward window, in trigger-time order. A trigger without one is
+    // silently skipped here (never fabricated) yet still counted above.
+    let forward_returns: Vec<f64> = trigger_indices
+        .iter()
+        .filter_map(|&index| {
+            let exit = index + HOLD_BARS;
+            (exit < candles.len()).then(|| {
+                let entry_close = close_f64(&candles[index]);
+                let exit_close = close_f64(&candles[exit]);
+                (exit_close - entry_close) / entry_close
+            })
+        })
+        .collect();
+
+    let evaluated_trade_count = forward_returns.len();
+    let win_count = forward_returns.iter().filter(|value| **value > 0.0).count();
+
+    let (win_rate, mean_forward_return, median_forward_return) = if evaluated_trade_count == 0 {
+        // Well-defined empty result: None, never a NaN from a zero divisor.
+        (None, None, None)
+    } else {
+        let mean = forward_returns.iter().sum::<f64>() / evaluated_trade_count as f64;
+        (
+            Some(win_count as f64 / evaluated_trade_count as f64),
+            Some(mean),
+            median(&forward_returns),
+        )
+    };
+
+    Ok(BacktestReport::builder()
+        .trigger_count(trigger_count)
+        .evaluated_trade_count(evaluated_trade_count)
+        .win_count(win_count)
+        .maybe_win_rate(win_rate)
+        .maybe_mean_forward_return(mean_forward_return)
+        .maybe_median_forward_return(median_forward_return)
+        .max_drawdown(strategy_max_drawdown(&forward_returns))
+        .build())
+}
+
+/// Fetch the single-stream candle history for `query` and delegate to
+/// [`run_backtest`].
+///
+/// This is the `evaluate` / `evaluate_with` seam pattern the crate already
+/// uses: the I/O (one repository read) lives here, the deterministic
+/// computation lives in the pure core. It reads a single
+/// source/venue/symbol/timeframe/range and changes neither the repository nor
+/// the evaluator.
+///
+/// # Errors
+///
+/// Returns [`BacktestError::FetchCandles`] if the repository read fails, or
+/// [`BacktestError::Evaluate`] if the pure core rejects a candle.
+pub async fn backtest(
+    repo: &dyn MarketDataRepository,
+    query: CandleRangeQuery,
+) -> Result<BacktestReport> {
+    let candles = repo
+        .candles(query)
+        .await
+        .map_err(|source| BacktestError::FetchCandles {
+            source: source.into(),
+        })?;
+    run_backtest(&candles)
+}
+
+/// Strictly-positive `f64` close of a candle already validated by
+/// `anomaly::evaluate`.
+///
+/// `run_backtest` calls `evaluate` for every bar as `latest` before this runs,
+/// and `evaluate` rejects any non-positive or non-finite close; so by the time
+/// forward return reads an entry/exit close it is known valid. The `expect`
+/// documents that invariant rather than hiding a fabricated fallback.
+fn close_f64(candle: &MarketCandle) -> f64 {
+    candle
+        .close
+        .to_f64()
+        .filter(|value| value.is_finite() && *value > 0.0)
+        .expect("close validated as strictly positive and finite by anomaly::evaluate")
+}
+
+/// Median of `values`, or `None` when empty. Copies into a scratch buffer so
+/// the caller's order (trigger-time order) is preserved. Signed — the median of
+/// a bearish tail of returns is negative and reported as such.
+fn median(values: &[f64]) -> Option<f64> {
+    if values.is_empty() {
+        return None;
+    }
+    let mut sorted = values.to_vec();
+    sorted.sort_by(|left, right| left.total_cmp(right));
+    let mid = sorted.len() / 2;
+    let value = if sorted.len() % 2 == 0 {
+        f64::midpoint(sorted[mid - 1], sorted[mid])
+    } else {
+        sorted[mid]
+    };
+    Some(value)
+}
+
+/// Deepest peak-to-trough fractional decline of the naive strategy's equity
+/// curve — the cumulative product of `(1 + forward_return)` over evaluated
+/// trades in trigger-time order. `0.0` when there are no trades. This is a
+/// whole-strategy drawdown, not the worst single trade.
+fn strategy_max_drawdown(forward_returns: &[f64]) -> f64 {
+    let mut equity = 1.0_f64;
+    let mut peak = 1.0_f64;
+    let mut worst = 0.0_f64;
+    for &forward_return in forward_returns {
+        equity *= 1.0 + forward_return;
+        peak = peak.max(equity);
+        if peak > 0.0 {
+            worst = worst.max((peak - equity) / peak);
+        }
+    }
+    worst
+}
+
+#[cfg(test)]
+mod tests {
+    use jiff::{SignedDuration, Timestamp};
+    use rust_decimal::Decimal;
+
+    use super::{HOLD_BARS, backtest, run_backtest};
+    use crate::{
+        anomaly::AnomalyError,
+        backtest::BacktestError,
+        market_data::{
+            CandleRangeQuery, InMemoryMarketDataRepository, MarketCandle, MarketDataRepository,
+            Timeframe,
+        },
+    };
+
+    /// Tolerance for signed forward-return / drawdown comparisons.
+    const APPROX: f64 = 1e-12;
+    /// Fixed 15m step used to space fixture candles (seconds).
+    const STEP_SECS: i64 = 900;
+
+    /// Build a candle whose OHLC all equal `close` (signals read closes only)
+    /// at a distinct, increasing open time, mirroring the anomaly
+    /// evaluator's own fixture helper.
+    fn candle(index: i64, close: i64, volume: i64) -> MarketCandle {
+        let base: Timestamp = "2026-07-10T00:00:00Z"
+            .parse()
+            .expect("base timestamp parses");
+        let open_time = base + SignedDuration::from_secs(index * STEP_SECS);
+        MarketCandle {
+            source_name: "binance-spot".to_owned(),
+            venue: "binance".to_owned(),
+            symbol: "BTCUSDT".to_owned(),
+            timeframe: Timeframe::parse("15m").expect("timeframe parses"),
+            open_time,
+            close_time: open_time + SignedDuration::from_secs(STEP_SECS),
+            open: Decimal::from(close),
+            high: Decimal::from(close),
+            low: Decimal::from(close),
+            close: Decimal::from(close),
+            volume: Decimal::from(volume),
+            ingested_at: open_time,
+            provider_sequence: None,
+        }
+    }
+
+    /// Assemble an ordered single-stream fixture from parallel price/volume
+    /// rows.
+    fn stream(prices: &[i64], volumes: &[i64]) -> Vec<MarketCandle> {
+        assert_eq!(prices.len(), volumes.len(), "price/volume rows must align");
+        prices
+            .iter()
+            .zip(volumes)
+            .enumerate()
+            .map(|(index, (&price, &volume))| candle(index as i64, price, volume))
+            .collect()
+    }
+
+    /// The scenario-1 fixture: two volume-surge triggers (bars 5 and 9), each
+    /// with a full `HOLD_BARS` forward window, over a gentle price path that
+    /// trips no price-based signal. Trade 1 (5→8) rises +1%, trade 2 (9→12)
+    /// falls back, so one trade wins and one loses.
+    fn winning_and_losing_fixture() -> Vec<MarketCandle> {
+        stream(
+            &[
+                60000, 60000, 60000, 60000, 60000, 60000, 60200, 60400, 60600, 60600, 60400, 60200,
+                60000, 60000, 60000, 60000,
+            ],
+            &[
+                100, 100, 100, 100, 100, 400, 100, 100, 100, 400, 100, 100, 100, 100, 100, 100,
+            ],
+        )
+    }
+
+    #[test]
+    fn naive_long_backtest_reports_deterministic_metrics_on_fixture() {
+        let candles = winning_and_losing_fixture();
+        let report = run_backtest(&candles).expect("positive prices");
+
+        // Hand-computed from the fixture: enter at the trigger close, exit
+        // HOLD_BARS (=3) bars later at that close.
+        let win_return = (60600.0 - 60000.0) / 60000.0; // bar 5 → bar 8: +1%
+        let loss_return = (60000.0 - 60600.0) / 60600.0; // bar 9 → bar 12: <0
+
+        assert_eq!(report.trigger_count, 2);
+        assert_eq!(report.evaluated_trade_count, 2);
+        // A trade wins exactly when its forward return is strictly positive: the
+        // +1% trade counts, the negative one does not.
+        assert!(win_return > 0.0 && loss_return < 0.0);
+        assert_eq!(report.win_count, 1);
+        assert!((report.win_rate.expect("evaluated trades") - 0.5).abs() < APPROX);
+
+        let expected_mean = f64::midpoint(win_return, loss_return);
+        assert!((report.mean_forward_return.expect("mean") - expected_mean).abs() < APPROX);
+        // Two evaluated trades → the median is the midpoint of the two returns.
+        assert!((report.median_forward_return.expect("median") - expected_mean).abs() < APPROX);
+
+        // Equity: 1.0 → ×1.01 (peak 1.01) → back to 1.0. Deepest decline is
+        // (1.01 − 1.0) / 1.01.
+        let expected_drawdown = 0.01 / 1.01;
+        assert!((report.max_drawdown - expected_drawdown).abs() < APPROX);
+    }
+
+    #[test]
+    fn signal_evaluation_never_reads_bars_after_the_trigger() {
+        // Both fixtures are byte-identical up to and including the single trigger
+        // bar (5); they differ only in the post-trigger forward bars, moved
+        // within a band that fires no new signal.
+        let flat_tail = stream(
+            &[
+                60000, 60000, 60000, 60000, 60000, 60000, 60000, 60000, 60000,
+            ],
+            &[100, 100, 100, 100, 100, 400, 100, 100, 100],
+        );
+        let moved_tail = stream(
+            &[
+                60000, 60000, 60000, 60000, 60000, 60000, 60200, 60400, 60600,
+            ],
+            &[100, 100, 100, 100, 100, 400, 100, 100, 100],
+        );
+
+        let flat = run_backtest(&flat_tail).expect("positive prices");
+        let moved = run_backtest(&moved_tail).expect("positive prices");
+
+        // The trigger set is identical — one trigger at bar 5 in both. Had
+        // evaluation peeked at a future bar, the moved forward bars would have
+        // shifted the trigger set between the two runs.
+        assert_eq!(flat.trigger_count, moved.trigger_count);
+        assert_eq!(flat.trigger_count, 1);
+        assert_eq!(flat.evaluated_trade_count, moved.evaluated_trade_count);
+        assert_eq!(flat.evaluated_trade_count, 1);
+
+        // The forward-return metrics differ — proving forward return actually
+        // reads the post-trigger window, so the trigger-set assertion is not
+        // vacuous. Flat tail → 0% (no win); moved tail → +1% (a win).
+        assert_eq!(flat.win_count, 0);
+        assert_eq!(moved.win_count, 1);
+        assert!((flat.mean_forward_return.expect("flat mean")).abs() < APPROX);
+        assert!(
+            (moved.mean_forward_return.expect("moved mean") - 0.01).abs() < APPROX,
+            "moved tail forward return should be +1%"
+        );
+        assert_ne!(flat.mean_forward_return, moved.mean_forward_return);
+    }
+
+    #[test]
+    fn forward_return_excludes_triggers_without_full_hold_window() {
+        // The lone trigger is at bar 6 of an 8-bar stream: exit bar 6+HOLD_BARS
+        // (=9) is past the end, so the trade has no full forward window.
+        let candles = stream(
+            &[60000, 60000, 60000, 60000, 60000, 60000, 60000, 60000],
+            &[100, 100, 100, 100, 100, 100, 400, 100],
+        );
+        assert!(
+            6 + HOLD_BARS >= candles.len(),
+            "trigger must lack a full window"
+        );
+
+        let report = run_backtest(&candles).expect("positive prices");
+
+        // Counted as a trigger, but excluded from the P&L denominator — never
+        // fabricated or zero-filled.
+        assert_eq!(report.trigger_count, 1);
+        assert_eq!(report.evaluated_trade_count, 0);
+        assert_eq!(report.win_count, 0);
+        assert_eq!(report.win_rate, None);
+        assert_eq!(report.mean_forward_return, None);
+        assert_eq!(report.median_forward_return, None);
+        assert_eq!(report.max_drawdown, 0.0);
+    }
+
+    #[test]
+    fn flat_tape_yields_zero_triggers_and_empty_report() {
+        // Tiny alternating moves at steady volume: no signal ever fires.
+        let candles = stream(
+            &[
+                60000, 60010, 60000, 60010, 60000, 60010, 60000, 60010, 60000, 60010, 60000, 60010,
+                60000, 60010,
+            ],
+            &[100; 14],
+        );
+
+        let report = run_backtest(&candles).expect("positive prices");
+
+        assert_eq!(report.trigger_count, 0);
+        assert_eq!(report.evaluated_trade_count, 0);
+        assert_eq!(report.win_rate, None);
+        assert_eq!(report.mean_forward_return, None);
+        assert_eq!(report.median_forward_return, None);
+        assert_eq!(report.max_drawdown, 0.0);
+        // The empty result is well-defined, never a NaN.
+        assert!(!report.max_drawdown.is_nan());
+    }
+
+    #[tokio::test]
+    async fn backtest_pulls_stream_via_repository_candles_and_matches_pure_core() {
+        let candles = winning_and_losing_fixture();
+
+        let repo = InMemoryMarketDataRepository::default();
+        for candle in &candles {
+            repo.upsert_closed_candle(candle.clone())
+                .await
+                .expect("seed candle");
+        }
+
+        let last_open = candles.last().expect("non-empty fixture").open_time;
+        let query = CandleRangeQuery {
+            source_name: Some("binance-spot".to_owned()),
+            venue:       "binance".to_owned(),
+            symbol:      "BTCUSDT".to_owned(),
+            timeframe:   Timeframe::parse("15m").expect("timeframe parses"),
+            start:       candles.first().expect("non-empty fixture").open_time,
+            // Exclusive end one step past the last bar so the full stream is in
+            // range.
+            end:         last_open + SignedDuration::from_secs(STEP_SECS),
+            limit:       1_000,
+        };
+
+        let via_repo = backtest(&repo, query).await.expect("repository backtest");
+        let via_core = run_backtest(&candles).expect("pure-core backtest");
+
+        // The repository→core wiring produces exactly the pure-core report.
+        assert_eq!(via_repo, via_core);
+        // Non-vacuous: the fixture actually exercises trades.
+        assert_eq!(via_core.evaluated_trade_count, 2);
+    }
+
+    #[test]
+    fn non_positive_close_fails_backtest_with_typed_error() {
+        // Bar 2 carries a zero close; the anomaly evaluator rejects it.
+        let candles = stream(&[60000, 60000, 0, 60000, 60000], &[100, 100, 100, 100, 100]);
+
+        let error = run_backtest(&candles).expect_err("non-positive close is invalid");
+
+        // A typed BacktestError propagating the NonPositivePrice cause — not a
+        // report computed from the invalid data.
+        assert!(matches!(
+            error,
+            BacktestError::Evaluate {
+                source: AnomalyError::NonPositivePrice { .. },
+            }
+        ));
+    }
+}

--- a/crates/extensions/rara-trading/src/lib.rs
+++ b/crates/extensions/rara-trading/src/lib.rs
@@ -20,6 +20,7 @@
 //! [`FeedEvent`](rara_kernel::data_feed::FeedEvent) values.
 
 pub mod anomaly;
+pub mod backtest;
 pub mod dispatch;
 pub mod feed;
 pub mod finance;

--- a/specs/issue-2437-signal-backtest-harness.spec.md
+++ b/specs/issue-2437-signal-backtest-harness.spec.md
@@ -1,0 +1,280 @@
+spec: task
+name: "issue-2437-signal-backtest-harness"
+inherits: project
+tags: [enhancement, backend, trading]
+---
+
+## Intent
+
+rara's trading extension now *sees* the market: `anomaly::evaluate(window,
+latest) -> Result<Option<AnomalySignal>>` fires a composite `AnomalySignal`
+(severity `Watch` / `Elevated` / `Critical`) on each newly closed candle, the
+`dispatch` facade delivers it, and issue 2429 / PR 2430 turned the five
+detectors into an extensible signal registry. That is layer ① (market
+perception). What is missing is the first rung of layer ② (decision support):
+**a way to ask "is a signal actually any good?"** by replaying stored history
+through the same evaluator and measuring what happened next.
+
+This issue builds a **signal-accuracy backtest harness**: replay a single
+symbol/timeframe stream of stored candles in time order through
+`anomaly::evaluate`, and for every bar where the evaluator fires, apply one
+**fixed naive rule** — enter a long at the trigger bar's close, exit `N` bars
+later at that bar's close — then report a fixed metric set over those trades:
+trigger count, win rate, mean and median forward return (signed), and the
+naive strategy's max drawdown. It answers "when this signal fires, what does
+price do next, and would the dumbest possible rule have made or lost money?"
+
+This is the concrete predecessor the `goal.md` ③ gate requires. `goal.md`
+("Current focus", "Safety invariants (trading)") hard-gates live real-money
+execution behind "① and ② being solid **plus** a stretch of paper-trading
+track record", and "Simulation first" makes backtest precede live. A
+deterministic, replayable signal-accuracy report is the first measurable
+predecessor of that track record and the first artifact that makes a signal's
+edge inspectable rather than asserted.
+
+If we do not do this, the following concrete bug appears the moment layer ②
+tries to advance to ③. Reproducer:
+
+1. The anomaly evaluator fires a `Critical` signal on a historical BTCUSDT 15m
+   crash window; the directive is delivered and the user sees it.
+2. The user (or spec-author gating a future "rara should act on this signal"
+   ③ issue) asks: "when a signal fires on this stream, what is the hit rate
+   and the average move over the next few bars — does acting on it make or
+   lose money?"
+3. Observed bad outcome: there is no way to answer except by eyeballing
+   charts. The signal's edge is unfalsifiable, so the ③ gate ("a stretch of
+   paper-trading track record") has no measurable predecessor. ③ then either
+   ships on faith — crossing the hard "NOT a black box / every trade a
+   replayable trace" line — or deadlocks forever under the default-deny
+   tiebreak. The ②→③ ladder is missing its bottom rung.
+
+This advances `goal.md` "What working rara looks like" signal 4 (**Every
+action is inspectable** — the backtest is a deterministic, replayable trace:
+same stored candles in → same trigger set and metrics out, reproducible from a
+fixture) and is the direct precursor of signal 7 (every trade a replayable
+trace) and the ② layer of Current focus ("backtest, evaluate, and advise").
+It crosses no "What rara is NOT" line — and the Boundaries below are what keep
+it on the right side of **"NOT a quant platform for others"**: it evaluates
+*rara's own* signals with **one fixed rule** and a **fixed metric set** over a
+single stream. There is no strategy DSL, no parameter/grid search, no
+multi-asset portfolio, no third-party research surface. It is a self-evaluation
+of rara's own perception, not a framework for spawning strategies.
+
+**Design divergence to record (not a reversal):** the trading design plan
+(`docs/plans/2026-07-10-rara-trading-design.md`, "第二阶段：研究台 MVP")
+sketches a much heavier ② backtest — a native `trading_backtest` tool taking
+`BacktestSpec + StrategyRef + DatasetRef`, a per-run Python/vectorbt sandbox,
+and a hash-manifested `BacktestArtifact`. This issue is a deliberately narrower
+first cut: a Rust-native, in-process, single-rule signal-accuracy harness with
+**no** Python sandbox, DSL, or dataset-export machinery. Nothing in the plan is
+built yet, so this is not reversing a prior decision; it is the minimal rung
+that earns "does the signal have edge" before any of that heavier research desk
+is justified. The heavier `trading_backtest` tool remains a separate, later
+issue and is explicitly out of scope here.
+
+Prior-art search (2026-07-16) against `rararulab/rara` (the canonical repo; the
+local `origin` is a behind fork). `gh issue list` / `gh pr list --search` for
+`backtest`, `backtest replay pnl`, `signal replay historical`,
+`anomaly signal registry` and `git log --all --grep backtest --since=180.days`
+return **no** prior backtest issue, PR, or code — the only `rg backtest` hits
+are this design doc's "第二阶段" section and passing mentions in the 2429 / 2436
+spec Out-of-Scope lists ("Backtesting / historical replay of signals — later
+layer-② block"). The adjacent trading work this builds on: issue 2415 / PR 2418
+(the anomaly `evaluate` engine), issue 2429 / PR 2430 (the signal registry this
+replays through), issue 2425 / PR 2426 (the `dispatch` facade), and the
+`market_data` `MarketDataRepository` (`candles(CandleRangeQuery)`) that stores
+the history. Sibling OPEN issue 2436 (`volatility_regime` + `directional_run`
+signals) *adds* signals; this issue *measures* signals — orthogonal and
+complementary, no overlap. No prior decision is being reversed.
+
+## Decisions
+
+- **Minimal backtest unit = the composite `AnomalySignal`, not per-signal.**
+  A "trigger" is one bar where `anomaly::evaluate(window, latest)` returns
+  `Some(signal)`. The composite `AnomalySignal` is exactly what `dispatch`
+  delivers and what rara acts on, so measuring it measures the real act-unit.
+  Per-signal attribution would require reaching into the `pub(crate)`
+  `SignalRegistry` / `SignalOutput` internals or re-walking the registry; that
+  is a documented **future extension**, out of scope here. The public
+  `AnomalySignal::severity` is recorded on each trade so the report *may*
+  expose a severity slice, but the required metric set below is stream-wide.
+- **New module `crates/extensions/rara-trading/src/backtest/`** — `mod.rs`
+  (re-exports + `//!` docs only) over sub-files (e.g. `runner.rs` the replay
+  loop, `report.rs` the `BacktestReport`, `error.rs` the `snafu` error).
+  Structure it around the same purity seam the anomaly module uses:
+  - A **pure, deterministic core** `run_backtest(candles: &[MarketCandle]) ->
+    Result<BacktestReport>` (no clock, no I/O) that walks an ordered
+    single-stream slice, calls `anomaly::evaluate` per bar, applies the naive
+    rule, and computes the report. This is the unit tests bind to.
+  - A **thin async entry** `backtest(repo, query) -> Result<BacktestReport>`
+    that fetches the stream via `MarketDataRepository::candles(CandleRangeQuery)`
+    (single source/venue/symbol/timeframe/range) and delegates to the pure
+    core. This is the `evaluate`/`evaluate_with` seam pattern the crate already
+    uses.
+- **Naive rule = a fixed long.** On a trigger bar, enter at that bar's `close`;
+  exit `HOLD_BARS` bars later at that bar's `close`. Per-trade forward return =
+  `(exit_close - entry_close) / entry_close`. There is exactly one rule; it is
+  not selectable. `HOLD_BARS` is a Rust `const` next to the runner (mechanism
+  tuning, `docs/guides/anti-patterns.md`) — never YAML.
+- **Win-rate definition (unambiguous, testable): a trade wins iff its forward
+  return is strictly positive** (`> 0.0`). Win rate = wins / trades-with-a-full-
+  forward-window. Because rara's anomaly detectors are *tail/volatility*
+  signals rather than directional buy signals, a **low win rate together with a
+  negative mean forward return is a valid, informative result** — it says the
+  signals are bearish and a future rule should short, not that the harness is
+  broken. The signed mean/median forward return is reported precisely so
+  direction is visible without being baked into "win". Report the signed
+  numbers; do not take absolute value.
+- **Fixed metric set** on `BacktestReport` (`#[derive(bon::Builder)]`, 3+
+  fields):
+  - `trigger_count: usize` — bars where `evaluate` returned `Some`.
+  - `evaluated_trade_count: usize` — triggers that have a full `HOLD_BARS`
+    forward window (the win-rate / return denominator).
+  - `win_count: usize`.
+  - `win_rate: Option<f64>` — `None` when `evaluated_trade_count == 0`
+    (never a `NaN`).
+  - `mean_forward_return: Option<f64>`, `median_forward_return: Option<f64>` —
+    signed, `None` when there are no evaluated trades.
+  - `max_drawdown: f64` — deepest peak-to-trough fractional decline of the
+    naive strategy's equity curve, where the equity curve is the cumulative
+    product of `(1 + per-trade forward return)` over trades ordered by trigger
+    time; `0.0` when there are no trades.
+  Exposing both `trigger_count` and `evaluated_trade_count` makes the
+  end-of-stream exclusion inspectable (the `goal.md` inspectability signal),
+  not silently dropped.
+- **No look-ahead — the number-one backtest bug — is enforced structurally and
+  falsified by a test:**
+  - Signal evaluation for the bar at index `i` sees only `window` (the
+    `EVAL_WINDOW` bars strictly before `i`) and `latest = candles[i]` — never
+    any bar at index `> i`. This mirrors the production invariant already in
+    the crate AGENT.md ("`window` is the history strictly before `latest`";
+    `dispatch` queries `recent_candles` with `end = Some(latest.open_time)`).
+  - Forward return for a trigger at `i` reads only bars strictly after `i`
+    (up to `candles[i + HOLD_BARS]`). A trigger with fewer than `HOLD_BARS`
+    bars remaining is **excluded from `evaluated_trade_count` and all P&L
+    metrics** — it is never zero-filled or fabricated, though it still counts
+    in `trigger_count`.
+- Mechanism constants (`HOLD_BARS`, any win epsilon, the reused `EVAL_WINDOW`)
+  are Rust `const`; symbol / venue / timeframe / time range are call inputs
+  (`CandleRangeQuery`), not YAML. Errors are `snafu` (`BacktestError`,
+  propagating `AnomalyError::NonPositivePrice` from `evaluate`); no `unwrap` in
+  non-test code.
+- Update `crates/extensions/rara-trading/AGENT.md` with a `backtest/` section
+  (purpose, the pure-core/async-entry seam, the no-look-ahead invariant, the
+  composite-unit and win-rate decisions) since this adds a module to the crate.
+
+## Boundaries
+
+### Allowed Changes
+- **/crates/extensions/rara-trading/src/backtest/**
+- **/crates/extensions/rara-trading/src/lib.rs
+- **/crates/extensions/rara-trading/AGENT.md
+- **/specs/issue-2437-signal-backtest-harness.spec.md
+
+### Forbidden
+- **/crates/extensions/rara-trading/src/anomaly/**
+- **/crates/extensions/rara-trading/src/dispatch/**
+- **/crates/extensions/rara-trading/src/finance/registry.rs
+- **/crates/extensions/rara-trading/src/market_data/**
+- **/config.example.yaml
+- **/web/**
+- **/extension/**
+- Do NOT modify the anomaly evaluator, the signal registry, the `dispatch`
+  facade, the delivery policy in `finance/registry.rs`, or the `market_data`
+  repository. This issue only *consumes* `anomaly::evaluate` and
+  `MarketDataRepository::candles`; it changes neither. The single edit outside
+  `backtest/` is registering the new `pub mod backtest;` in `lib.rs`.
+- Do NOT introduce a strategy DSL, a selectable/parameterized rule, parameter
+  or grid search, walk-forward optimization, multi-asset or portfolio backtest,
+  a Python/vectorbt sandbox, a `BacktestArtifact` manifest, transaction-cost /
+  slippage modeling, or paper/live execution wiring — all are out of scope
+  (see Out of Scope) and several would cross "NOT a quant platform for others".
+- Do NOT let forward-return computation read any bar at or before the trigger
+  bar, and do NOT let signal evaluation read any bar after the bar under
+  evaluation — that is the look-ahead bug this issue exists to prevent.
+- Do NOT fabricate, zero-fill, or extrapolate forward returns for triggers
+  without a full `HOLD_BARS` window; exclude them from the P&L denominator.
+- Do NOT emit `NaN` metrics for an empty/trigger-less stream — `Option::None`
+  (win rate / returns) and `0.0` (drawdown) are the well-defined empty result.
+- Do NOT add a YAML knob for `HOLD_BARS` or any threshold — mechanism tuning
+  stays a Rust `const` (`docs/guides/anti-patterns.md`).
+- Do NOT add a `BacktestReport` field nothing reads, or a code path that
+  silently returns an empty report on a real error — hollow output is forbidden
+  (`docs/guides/anti-patterns.md`).
+
+## Acceptance Criteria
+
+Scenario: Replaying a fixed candle fixture through the naive-long rule yields deterministic metrics
+  Test:
+    Package: rara-trading
+    Filter: naive_long_backtest_reports_deterministic_metrics_on_fixture
+  Given an ordered single-stream candle fixture containing at least one bar the anomaly evaluator fires on, each with a full forward window
+  When run_backtest replays the fixture through anomaly::evaluate and applies the fixed enter-at-close / exit-N-bars-later long rule
+  Then the report's trigger_count, evaluated_trade_count, win_count, win_rate, mean_forward_return, median_forward_return, and max_drawdown equal the exact values hand-computed from the fixture
+    And a trade wins exactly when its forward return is strictly positive
+
+Scenario: Perturbing only bars after each trigger changes P&L but never the trigger set (no look-ahead)
+  Test:
+    Package: rara-trading
+    Filter: signal_evaluation_never_reads_bars_after_the_trigger
+  Given a fixture that produces a known trigger set with a flat post-trigger tail, and a second fixture identical up to and including every trigger bar but with the forward bars moved within the no-new-trigger band
+  When run_backtest replays both fixtures
+  Then the trigger set (which bars fired) is identical across the two runs, proving signal evaluation never read a future bar
+    And the forward-return metrics differ across the two runs, proving forward return actually reads the post-trigger window and the assertion is non-vacuous
+
+Scenario: A trigger without a full forward window is counted but excluded from P&L
+  Test:
+    Package: rara-trading
+    Filter: forward_return_excludes_triggers_without_full_hold_window
+  Given a fixture whose only anomaly trigger occurs fewer than HOLD_BARS bars before the end of the stream
+  When run_backtest replays the fixture
+  Then trigger_count includes that trigger
+    And evaluated_trade_count excludes it, and win_rate and the forward-return metrics are None rather than a fabricated or zero-filled value
+
+Scenario: A flat, trigger-less stream yields a well-defined empty report
+  Test:
+    Package: rara-trading
+    Filter: flat_tape_yields_zero_triggers_and_empty_report
+  Given an ordered candle stream of small alternating moves at steady volume that the anomaly evaluator never fires on
+  When run_backtest replays the stream
+  Then trigger_count and evaluated_trade_count are zero
+    And win_rate, mean_forward_return, and median_forward_return are None and max_drawdown is 0.0, with no NaN
+
+Scenario: The async entry fetches the stream from the repository and produces the same report as the pure core
+  Test:
+    Package: rara-trading
+    Filter: backtest_pulls_stream_via_repository_candles_and_matches_pure_core
+  Given an InMemoryMarketDataRepository seeded with the same single-stream candle fixture used by the pure-core test
+  When backtest(repo, query) fetches the stream via MarketDataRepository::candles and delegates to run_backtest
+  Then the returned report equals the report the pure core produces from the same candles, verifying the repository→core wiring end to end
+
+Scenario: A non-positive candle close fails the backtest with a typed error rather than a garbage report
+  Test:
+    Package: rara-trading
+    Filter: non_positive_close_fails_backtest_with_typed_error
+  Given a candle fixture containing a bar whose close is not strictly positive
+  When run_backtest replays the fixture and anomaly::evaluate rejects the invalid close
+  Then run_backtest returns a typed BacktestError propagating the NonPositivePrice cause
+    And it does not return a report computed from the invalid data
+
+## Out of Scope
+
+- Any strategy DSL, selectable or parameterized rule, parameter/grid search,
+  walk-forward or hyper-parameter optimization — the rule is one fixed long.
+- Multi-asset, multi-stream, or portfolio backtesting; cross-symbol or
+  cross-timeframe aggregation — one symbol/timeframe/range per run.
+- Per-signal attribution (which of the five/N registry signals drove a
+  trigger) — a documented future extension; v1 measures the composite
+  `AnomalySignal`.
+- Transaction-cost, fee, slippage, or fill modeling; position sizing, capital
+  constraints, or netting of overlapping trades — each trigger is one
+  independent unit-notional trade (future work).
+- The heavier `trading_backtest` tool from the design plan: `BacktestSpec /
+  StrategyRef / DatasetRef` inputs, Python/vectorbt sandbox, `BacktestArtifact`
+  hash manifest, TSDB→Parquet dataset export — a separate later issue.
+- Paper-trading or live/testnet execution wiring, order management, or any
+  ③-layer autonomous-execution mechanism.
+- Any web / extension UI surface for backtest results; exposing backtest as an
+  agent tool.
+- Operator-tunable config (YAML) for `HOLD_BARS` or thresholds — mechanism
+  constants stay Rust `const`.


### PR DESCRIPTION
## Summary

First rung of layer ② (decision support): a **signal-accuracy backtest harness**. Layer ① lets rara *see* the market (`anomaly::evaluate` fires a composite `AnomalySignal` per closed candle; `dispatch` delivers it). This block answers **"is a signal actually any good?"** by replaying a single symbol/timeframe candle stream in time order through the same `anomaly::evaluate` and, for every bar it fires on, applying one **fixed naive-long rule** (enter at the trigger bar's close, exit `HOLD_BARS` bars later at that bar's close), then reporting a **fixed metric set**: trigger count, win rate, signed mean/median forward return, and the naive strategy's max drawdown.

New module `crates/extensions/rara-trading/src/backtest/`:
- `run_backtest(&[MarketCandle]) -> Result<BacktestReport>` — the pure, deterministic core the unit tests bind to.
- thin async `backtest(repo, query)` fetching via `MarketDataRepository::candles` and delegating to the core.
- `BacktestReport` (`bon::Builder`), `BacktestError` (`snafu`, wrapping `AnomalyError` / the repository read).

The only edit outside `backtest/` is `pub mod backtest;` in `lib.rs`, plus the crate `AGENT.md`.

**No look-ahead (structural):** signal eval for bar `i` sees only `candles[i.saturating_sub(EVAL_WINDOW)..i]` + `latest = candles[i]` — never a bar `> i` (mirrors the production `end = Some(latest.open_time)` invariant); forward return reads only bars strictly after `i`. A trigger with fewer than `HOLD_BARS` bars remaining is counted in `trigger_count` but **excluded** from the P&L denominator — never zero-filled. Returns are **signed** (a low win rate with a negative mean is a valid, informative bearish result). `HOLD_BARS` is a `const`, not YAML. Deliberately narrow: one fixed rule, one fixed metric set, single stream — no strategy DSL / param search / multi-asset / cost model / execution wiring.

## Type of change

New feature — `enhancement`

## Component

`backend`

## Closes

Closes #2437

## Test plan

- [x] `cargo test -p rara-trading` passes (99 lib + 1 integration; 6 new backtest tests, one per BDD scenario)
- [x] `just spec-lifecycle specs/issue-2437-signal-backtest-harness.spec.md` — all 6 scenarios + boundaries PASS
- [x] Full Rust gate green: `cargo +nightly fmt --check`, `cargo clippy … -D warnings`, `RUSTDOCFLAGS=-D warnings cargo +nightly doc`
- [x] Tested locally

Verification: PASS (look-ahead independently confirmed absent; metrics independently recomputed and matched).

Note: no `crates/{app,kernel,channels,acp,sandbox}/src/` touched, so no driver-stack e2e added — the module is pure + repo-backed and fully covered by the 6 fixture unit tests (lane 1, no LLM).
