### PR TITLE
feat(trading): add volatility-regime + directional-run anomaly signals (#2436)

### DIFF
--- a/crates/extensions/rara-trading/AGENT.md
+++ b/crates/extensions/rara-trading/AGENT.md
@@ -32,29 +32,47 @@ Five modules, each a `mod.rs` (re-exports + `//!` docs only) over sub-files:
   `recent_candles(CandleRecentQuery)` returns the newest N candles ascending
   and is the rolling-window source for anomaly evaluation.
 - `anomaly/` — market-anomaly evaluation (issue 2415; generalized into a signal
-  registry in issue 2429). `evaluate(window, latest) ->
+  registry in issue 2429; tail-risk signals added in issue 2436).
+  `evaluate(window, latest) ->
   Result<Option<AnomalySignal>>` is a **pure** function of its candle inputs. It
   prepares the shared context once, walks a `SignalRegistry` collecting each
   signal's `SignalOutput`, projects those onto `AnomalyMetrics`, then classifies
   severity. `registry.rs` = the `Signal` trait (`name` / `evaluate` /
   `fragment`), `SignalOutput` (value / fired), `SignalContext` (shared
-  closes/returns/volumes), and `builtin_registry()`; the signal's stable name is
+  closes/returns/volumes), and `builtin_registry()` (**seven** builtin signals);
+  the signal's stable name is
   a static property of the `Signal` (used to route its value into
   `AnomalyMetrics`), not per-output data. `rules.rs` = L1 pure functions + their
   `Signal` adapters
-  (window return, rolling drawdown, volume surge); `statistics.rs` = L2 pure
+  (window return, rolling drawdown, volume surge, directional run — the signed
+  trailing same-sign return run that catches a persistent one-directional
+  grind); `statistics.rs` = L2 pure
   functions + adapters (MAD-based robust z-score, BNS realized-variance vs
-  bipower-variation jump test); `signal.rs` = `AnomalySignal` / `Severity` /
+  bipower-variation jump test, volatility regime — the recent-to-baseline
+  per-bar realized-variance ratio that catches a sustained dispersion
+  expansion); `signal.rs` = `AnomalySignal` / `Severity` /
   `AnomalyMetrics`; `error.rs` = `AnomalyError` (snafu). `evaluator.rs` holds the
   `evaluate` / `evaluate_with(&registry, …)` loop, the metrics projection, and
   `classify`.
 
+  `volatility_regime` and `directional_run` are **orthogonal** tail-risk
+  detectors: the first measures dispersion (magnitude), the second sign
+  persistence (direction). Both are structurally invisible to the first five —
+  a sustained variance regime is in-family for the single-bar MAD z-score and
+  diffusive for the BNS jump test; a slow grind crosses no magnitude threshold
+  and a monotonic path has no drawdown. Their trip thresholds are semantic
+  `const`s (`DIRECTIONAL_RUN_THRESHOLD = 6` bars, `VOLATILITY_REGIME_THRESHOLD =
+  4.0×`), **never** tuned to dodge a test fixture.
+
   **Extending the signal set** = implement `Signal` (a struct wrapping a pure
-  stat) + add one `Box::new(...)` line to `builtin_registry()`. The core loop in
-  `evaluate_with`, the metrics projection, and `classify` do not change — the
+  stat) + add one `Box::new(...)` line to `builtin_registry()` + (if the value
+  should reach the public trace) one `Option<f64>` `AnomalyMetrics` field and one
+  `.maybe_<field>(...)` line in `metrics_from`. The core loop in
+  `evaluate_with` and `classify` do not change — the
   new signal contributes to the reason (via its `fragment`) and the fired-count.
   `builtin_registry()` order **is** the reason-fragment order (drawdown, return,
-  volume, z-score, jump), so keep it stable. `evaluate_with` is the test seam
+  volume, z-score, jump, volatility regime, directional run), so append new
+  signals and keep the existing order stable. `evaluate_with` is the test seam
   (`registered_signal_participates_in_evaluation` injects an extra signal).
 
 The write→read→enrich wiring lives in `dispatch/pipeline.rs` (`on_feed_event`):

--- a/crates/extensions/rara-trading/src/anomaly/evaluator.rs
+++ b/crates/extensions/rara-trading/src/anomaly/evaluator.rs
@@ -36,9 +36,9 @@ use rust_decimal::prelude::ToPrimitive;
 use super::{
     error::{NonPositivePriceSnafu, Result},
     registry::{Signal, SignalContext, SignalOutput, SignalRegistry, builtin_registry},
-    rules::{MaxDrawdownSignal, VolumeSurgeSignal, WindowReturnSignal},
+    rules::{DirectionalRunSignal, MaxDrawdownSignal, VolumeSurgeSignal, WindowReturnSignal},
     signal::{AnomalyMetrics, AnomalySignal, Severity},
-    statistics::{self, JumpSignal, RobustZScoreSignal},
+    statistics::{self, JumpSignal, RobustZScoreSignal, VolatilityRegimeSignal},
 };
 use crate::market_data::MarketCandle;
 
@@ -121,11 +121,11 @@ pub(crate) fn evaluate_with(
 /// Project the collected signal outputs onto the public [`AnomalyMetrics`]
 /// trace, routing each builtin signal's value into its field by stable name.
 ///
-/// This preserves the fixed metrics struct byte-for-byte for the builtin five;
-/// a signal beyond them contributes to the reason and severity but not to this
-/// trace. `None` values stay `None` (never flattened to `0.0`) so "not
-/// evaluable" survives the projection; `window_return` / `max_drawdown` are
-/// always computed, so an absent output falls back to their neutral `0.0`.
+/// Each builtin signal projects onto its named field; a signal beyond the
+/// builtin set contributes to the reason and severity but not to this trace.
+/// `None` values stay `None` (never flattened to `0.0`) so "not evaluable"
+/// survives the projection; `window_return` / `max_drawdown` are always
+/// computed, so an absent output falls back to their neutral `0.0`.
 fn metrics_from(evaluated: &[(&dyn Signal, SignalOutput)]) -> AnomalyMetrics {
     let output = |name: &str| {
         evaluated
@@ -149,6 +149,8 @@ fn metrics_from(evaluated: &[(&dyn Signal, SignalOutput)]) -> AnomalyMetrics {
         .maybe_robust_zscore(output(RobustZScoreSignal::NAME).and_then(|out| out.value))
         .maybe_jump_ratio(jump.and_then(|out| out.value))
         .jump_flagged(jump.is_some_and(|out| out.fired))
+        .maybe_volatility_regime(output(VolatilityRegimeSignal::NAME).and_then(|out| out.value))
+        .maybe_directional_run(output(DirectionalRunSignal::NAME).and_then(|out| out.value))
         .build()
 }
 
@@ -290,6 +292,19 @@ mod tests {
             .collect()
     }
 
+    /// Build `(window, latest)` from a close series at steady volume: the last
+    /// close is the newly closed `latest` candle, the rest are the window.
+    fn steady_volume_window(closes: &[i64]) -> (Vec<MarketCandle>, MarketCandle) {
+        let (&last, history) = closes.split_last().expect("at least one close");
+        let window: Vec<MarketCandle> = history
+            .iter()
+            .enumerate()
+            .map(|(index, &close)| candle(index as i64, close, 120))
+            .collect();
+        let latest = candle(history.len() as i64, last, 120);
+        (window, latest)
+    }
+
     #[test]
     fn crash_window_produces_high_severity_anomaly_signal() {
         // Six flat bars, then a four-bar decline, all at steady volume.
@@ -398,20 +413,144 @@ mod tests {
 
     #[test]
     fn single_moderate_rule_produces_watch_severity() {
-        // A steady ~4% rise: only the window-return rule trips, no drawdown, no
-        // volume surge, no return-outlier.
-        let history: Vec<MarketCandle> = (0..12)
-            .map(|index| candle(index, 60_000 + 200 * index, 120))
-            .collect();
-        let latest = candle(12, 62_400, 120);
+        // A varied-magnitude rise that nets ~5% (tripping only the
+        // window-return rule), ending on a small in-family up-tick preceded by a
+        // shallow pullback so the trailing same-sign run is a single bar (below
+        // the directional-run threshold). The magnitudes vary, so the MAD scale
+        // stays healthy and no bar is a z-score outlier, and recent and baseline
+        // per-bar variance match (no regime shift). The old fixture — a 12-bar
+        // monotonic rise — is now a persistent grind the directional-run signal
+        // legitimately fires on, so it can no longer isolate a single rule; this
+        // window restores that isolation.
+        let steps = [
+            0.004, 0.005, 0.003, 0.006, 0.004, 0.005, 0.003, 0.005, 0.004, 0.006, 0.004, -0.0025,
+            0.002,
+        ];
+        let mut price = 60_000.0_f64;
+        let mut closes = vec![price.round() as i64];
+        for step in steps {
+            price *= 1.0 + step;
+            closes.push(price.round() as i64);
+        }
+        let (history, latest) = steady_volume_window(&closes);
 
         let signal = evaluate(&history, &latest)
             .expect("positive prices")
-            .expect("a 4% run trips the return rule");
+            .expect("a > 3% net move trips the return rule");
 
         assert_eq!(signal.severity, Severity::Watch);
         assert!(signal.metrics.window_return >= 0.03);
         assert!(signal.metrics.max_drawdown < 0.03);
+        // Only the window-return rule contributed to the fired count: no other
+        // signal's fragment appears in the reason.
+        assert!(
+            signal.reason.contains("window return"),
+            "reason should name the window return: {}",
+            signal.reason
+        );
+        for fragment in [
+            "drawdown",
+            "volume surge",
+            "robust z-score",
+            "jump",
+            "volatility regime",
+            "directional run",
+        ] {
+            assert!(
+                !signal.reason.contains(fragment),
+                "only the window-return rule should fire, found {fragment:?}: {}",
+                signal.reason
+            );
+        }
+    }
+
+    #[test]
+    fn volatility_regime_alone_enriches_unremarkable_tape() {
+        // A quiet ±0.15% baseline that shifts into a choppy ±0.8% cluster, with
+        // a small in-family newest bar. The dispersion expansion trips only the
+        // volatility-regime signal: the net move, drawdown, volume, z-score, and
+        // jump path all stay unremarkable, and the alternating cluster leaves no
+        // directional run.
+        let closes = [
+            60_000, 60_090, 60_000, 60_090, 60_000, 60_090, 60_000, 60_090, 60_000, 60_090, 60_480,
+            60_000, 60_480, 60_000, 60_090,
+        ];
+        let (history, latest) = steady_volume_window(&closes);
+
+        let signal = evaluate(&history, &latest)
+            .expect("positive prices")
+            .expect("the volatility-regime shift now yields a signal");
+
+        assert_eq!(signal.severity, Severity::Watch);
+        assert!(
+            signal.reason.contains("volatility regime"),
+            "reason should carry the volatility-regime fragment: {}",
+            signal.reason
+        );
+        assert!(
+            signal.metrics.volatility_regime.expect("ratio computed") >= 4.0,
+            "the projected metric carries the ratio: {:?}",
+            signal.metrics.volatility_regime
+        );
+        // None of the five existing signals' fragments, and no directional run.
+        for fragment in [
+            "window return",
+            "drawdown",
+            "volume surge",
+            "robust z-score",
+            "jump",
+            "directional run",
+        ] {
+            assert!(
+                !signal.reason.contains(fragment),
+                "only the volatility-regime signal should lift the tape, found {fragment:?}: {}",
+                signal.reason
+            );
+        }
+    }
+
+    #[test]
+    fn directional_run_alone_enriches_unremarkable_tape() {
+        // An alternating ±0.4% baseline (no persistent run, uniform variance)
+        // followed by six consecutive +0.4% bars. The trailing grind trips only
+        // the directional-run signal: the net move stays under 3%, the path has
+        // no meaningful drawdown, volume is steady, the newest bar is in-family
+        // for the z-score, and the recent variance matches the baseline.
+        let closes = [
+            60_000, 60_240, 60_000, 60_240, 60_000, 60_240, 60_000, 60_240, 60_000, 60_240, 60_480,
+            60_720, 60_960, 61_200, 61_440,
+        ];
+        let (history, latest) = steady_volume_window(&closes);
+
+        let signal = evaluate(&history, &latest)
+            .expect("positive prices")
+            .expect("the directional grind now yields a signal");
+
+        assert_eq!(signal.severity, Severity::Watch);
+        assert!(
+            signal.reason.contains("directional run"),
+            "reason should carry the directional-run fragment: {}",
+            signal.reason
+        );
+        assert_eq!(
+            signal.metrics.directional_run.expect("run computed"),
+            6.0,
+            "the projected metric carries the signed run length"
+        );
+        for fragment in [
+            "window return",
+            "drawdown",
+            "volume surge",
+            "robust z-score",
+            "jump",
+            "volatility regime",
+        ] {
+            assert!(
+                !signal.reason.contains(fragment),
+                "only the directional-run signal should lift the tape, found {fragment:?}: {}",
+                signal.reason
+            );
+        }
     }
 
     #[test]

--- a/crates/extensions/rara-trading/src/anomaly/registry.rs
+++ b/crates/extensions/rara-trading/src/anomaly/registry.rs
@@ -14,19 +14,19 @@
 
 //! The anomaly signal registry: a minimal [`Signal`] trait, the structured
 //! per-signal output, the shared per-evaluation context, and the builtin
-//! registry of the five signals the evaluator ships with.
+//! registry of the seven signals the evaluator ships with.
 //!
 //! This is the extensibility seam for layer-② decision support: a new signal
 //! is "implement [`Signal`] + add one line to [`builtin_registry`]", with no
-//! edit to the core evaluation loop in [`super::evaluator`]. The five builtin
+//! edit to the core evaluation loop in [`super::evaluator`]. The builtin
 //! signals are thin adapters over the pure functions in [`super::rules`] and
 //! [`super::statistics`]; those pure functions remain the computational core.
 
 use bon::Builder;
 
 use super::{
-    rules::{MaxDrawdownSignal, VolumeSurgeSignal, WindowReturnSignal},
-    statistics::{JumpSignal, RobustZScoreSignal},
+    rules::{DirectionalRunSignal, MaxDrawdownSignal, VolumeSurgeSignal, WindowReturnSignal},
+    statistics::{JumpSignal, RobustZScoreSignal, VolatilityRegimeSignal},
 };
 
 /// Shared inputs prepared once per evaluation and handed to every signal, so no
@@ -100,14 +100,20 @@ pub(crate) trait Signal {
 }
 
 /// An ordered set of signals the evaluator walks. The builtin order encodes the
-/// reason-fragment order (drawdown, return, volume, z-score, jump), so the
-/// `reason` string is byte-for-byte stable.
+/// reason-fragment order (drawdown, return, volume, z-score, jump, volatility
+/// regime, directional run), so the `reason` string is byte-for-byte stable.
 pub(crate) type SignalRegistry = Vec<Box<dyn Signal>>;
 
-/// The five signals the anomaly evaluator ships with, in reason-fragment order.
+/// The seven signals the anomaly evaluator ships with, in reason-fragment
+/// order.
 ///
-/// Adding a sixth signal is a one-line extension here plus its [`Signal`] impl;
-/// the core loop in [`super::evaluator::evaluate_with`] does not change.
+/// The first five are the magnitude/outlier detectors; `volatility_regime` and
+/// `directional_run` are appended tail-risk detectors that catch a sustained
+/// dispersion expansion and a persistent one-directional grind the first five
+/// structurally miss. Adding a further signal is a one-line extension here plus
+/// its [`Signal`] impl; the core loop in [`super::evaluator::evaluate_with`]
+/// does not change. New signals are **appended** so the existing
+/// reason-fragment order stays byte-for-byte stable.
 pub(crate) fn builtin_registry() -> SignalRegistry {
     vec![
         Box::new(MaxDrawdownSignal),
@@ -115,5 +121,7 @@ pub(crate) fn builtin_registry() -> SignalRegistry {
         Box::new(VolumeSurgeSignal),
         Box::new(RobustZScoreSignal),
         Box::new(JumpSignal),
+        Box::new(VolatilityRegimeSignal),
+        Box::new(DirectionalRunSignal),
     ]
 }

--- a/crates/extensions/rara-trading/src/anomaly/rules.rs
+++ b/crates/extensions/rara-trading/src/anomaly/rules.rs
@@ -26,6 +26,13 @@ const WINDOW_RETURN_THRESHOLD: f64 = 0.03;
 const DRAWDOWN_THRESHOLD: f64 = 0.03;
 /// Volume-vs-rolling-mean multiple that trips the volume-surge rule.
 const VOLUME_SURGE_THRESHOLD: f64 = 3.0;
+/// Trailing same-sign run length (bars) that trips the directional-run rule.
+///
+/// A domain-semantic constant: how many consecutive same-direction bars make a
+/// grind persistent enough to be anomalous. Deliberately **not** tuned to dodge
+/// any test fixture — a shorter run is ordinary drift, a run at or beyond this
+/// is a one-directional grind worth narrating.
+const DIRECTIONAL_RUN_THRESHOLD: f64 = 6.0;
 
 /// Signed cumulative return across `closes`, as a fraction of the first close.
 ///
@@ -66,6 +73,32 @@ pub(crate) fn volume_surge(history_volumes: &[f64], latest_volume: f64) -> Optio
         return None;
     }
     Some(latest_volume / mean)
+}
+
+/// Signed length of the trailing run of consecutive same-sign log-returns: `+N`
+/// for an up-run, `-N` for a down-run. A zero-magnitude return is neither up
+/// nor down and breaks the run.
+///
+/// This is the sign-persistence detector: a steady one-directional grind where
+/// no single bar is large enough to trip the magnitude rules, yet the
+/// persistence itself is the anomaly. `None` when the return series is empty
+/// (the window was too short to form even one return).
+pub(crate) fn directional_run(returns: &[f64]) -> Option<f64> {
+    let &last = returns.last()?;
+    let sign = if last > 0.0 {
+        1.0
+    } else if last < 0.0 {
+        -1.0
+    } else {
+        // A flat newest bar starts no run.
+        return Some(0.0);
+    };
+    let run = returns
+        .iter()
+        .rev()
+        .take_while(|&&value| value * sign > 0.0)
+        .count();
+    Some(sign * run as f64)
 }
 
 /// L1 signal: signed cumulative window return. Fires on a large move in either
@@ -152,9 +185,40 @@ impl Signal for VolumeSurgeSignal {
     }
 }
 
+/// L1 signal: signed length of the trailing same-sign return run. Fires on a
+/// sustained one-directional grind — the persistence itself, not any single
+/// bar's magnitude. Not evaluable (`None`) on an empty return series.
+pub(crate) struct DirectionalRunSignal;
+
+impl DirectionalRunSignal {
+    /// Stable trace identifier (matches the `AnomalyMetrics::directional_run`
+    /// field it projects onto).
+    pub(crate) const NAME: &'static str = "directional_run";
+}
+
+impl Signal for DirectionalRunSignal {
+    fn name(&self) -> &'static str { Self::NAME }
+
+    fn evaluate(&self, ctx: &SignalContext<'_>) -> SignalOutput {
+        let value = directional_run(ctx.returns());
+        SignalOutput {
+            value,
+            fired: value.is_some_and(|run| run.abs() >= DIRECTIONAL_RUN_THRESHOLD),
+        }
+    }
+
+    fn fragment(&self, output: &SignalOutput) -> String {
+        format!(
+            "directional run {:+.0} bars",
+            output.value.unwrap_or_default()
+        )
+    }
+}
+
 #[cfg(test)]
 mod tests {
-    use super::{max_drawdown, volume_surge, window_return};
+    use super::{DirectionalRunSignal, directional_run, max_drawdown, volume_surge, window_return};
+    use crate::anomaly::registry::{Signal, SignalContext};
 
     #[test]
     fn window_return_is_signed_fraction_of_first_close() {
@@ -177,5 +241,46 @@ mod tests {
         let surge = volume_surge(&[100.0, 100.0, 100.0], 400.0).expect("non-empty history");
         assert!((surge - 4.0).abs() < 1e-9);
         assert!(volume_surge(&[], 400.0).is_none());
+    }
+
+    /// A [`SignalContext`] over a bare return series; the directional-run
+    /// signal reads only `returns`, so the other inputs are inert.
+    fn ctx(returns: &[f64]) -> SignalContext<'_> {
+        SignalContext::builder()
+            .closes(&[])
+            .returns(returns)
+            .history_volumes(&[])
+            .latest_volume(0.0)
+            .build()
+    }
+
+    #[test]
+    fn directional_run_fires_on_sustained_directional_grind() {
+        // Six consecutive up-returns — a run at the threshold.
+        let returns = [0.003, 0.003, 0.003, 0.003, 0.003, 0.003];
+        let output = DirectionalRunSignal.evaluate(&ctx(&returns));
+
+        assert_eq!(
+            output.value.expect("a non-empty series is evaluable"),
+            6.0,
+            "the signed run length is the whole up-run"
+        );
+        assert!(output.fired, "a six-bar up-run crosses the threshold");
+        // The pure function and the signal agree on the value.
+        assert_eq!(directional_run(&returns), output.value);
+    }
+
+    #[test]
+    fn directional_run_silent_on_choppy_tape() {
+        // Alternating signs, so the trailing same-sign run is a single bar.
+        let returns = [0.003, -0.003, 0.003, -0.003, 0.003, -0.003];
+        let output = DirectionalRunSignal.evaluate(&ctx(&returns));
+
+        assert_eq!(
+            output.value.expect("a non-empty series is evaluable"),
+            -1.0,
+            "the trailing run is one down bar"
+        );
+        assert!(!output.fired, "a choppy tape has no persistent run");
     }
 }

--- a/crates/extensions/rara-trading/src/anomaly/signal.rs
+++ b/crates/extensions/rara-trading/src/anomaly/signal.rs
@@ -56,18 +56,24 @@ impl Severity {
 pub struct AnomalyMetrics {
     /// Signed cumulative return across the window, as a fraction (`0.05` =
     /// +5%).
-    pub window_return: f64,
+    pub window_return:     f64,
     /// Deepest peak-to-trough decline across the window, as a positive
     /// fraction.
-    pub max_drawdown:  f64,
+    pub max_drawdown:      f64,
     /// Newest volume divided by the rolling mean volume, when computable.
-    pub volume_surge:  Option<f64>,
+    pub volume_surge:      Option<f64>,
     /// MAD-based robust z-score of the newest log-return, when computable.
-    pub robust_zscore: Option<f64>,
+    pub robust_zscore:     Option<f64>,
     /// BNS jump ratio (realized variance / bipower variation), when computable.
-    pub jump_ratio:    Option<f64>,
+    pub jump_ratio:        Option<f64>,
     /// Whether the jump ratio crossed the discontinuity threshold.
-    pub jump_flagged:  bool,
+    pub jump_flagged:      bool,
+    /// Recent-to-baseline per-bar realized-variance ratio, when computable —
+    /// the volatility-regime signal's value.
+    pub volatility_regime: Option<f64>,
+    /// Signed trailing same-sign run length in bars (`+N` up-run, `-N`
+    /// down-run), when computable — the directional-run signal's value.
+    pub directional_run:   Option<f64>,
 }
 
 /// A detected market anomaly: a severity, a human-readable reason naming the

--- a/crates/extensions/rara-trading/src/anomaly/statistics.rs
+++ b/crates/extensions/rara-trading/src/anomaly/statistics.rs
@@ -32,6 +32,15 @@ use super::registry::{Signal, SignalContext, SignalOutput};
 const ZSCORE_THRESHOLD: f64 = 3.5;
 /// BNS jump ratio above which the path is flagged as containing a jump.
 const JUMP_RATIO_THRESHOLD: f64 = 1.5;
+/// Recent-to-baseline per-bar realized-variance ratio that trips the
+/// volatility-regime statistic (recent variance at least this multiple of the
+/// baseline).
+const VOLATILITY_REGIME_THRESHOLD: f64 = 4.0;
+
+/// Number of trailing returns forming the "recent" variance sample compared
+/// against the earlier baseline. Small enough to react to a fresh regime, large
+/// enough that a single bar does not dominate the recent per-bar average.
+const RECENT_VARIANCE_SAMPLES: usize = 5;
 
 /// Minimum number of returns required before a statistic is trusted. Below this
 /// the MAD scale and bipower variation are too noisy to separate signal from
@@ -107,6 +116,37 @@ pub(crate) fn robust_zscore(history: &[f64], newest: f64) -> Option<f64> {
 /// jump because each return enters squared.
 pub(crate) fn realized_variance(returns: &[f64]) -> f64 {
     returns.iter().map(|value| value * value).sum()
+}
+
+/// Ratio of the recent per-bar realized variance (the last
+/// [`RECENT_VARIANCE_SAMPLES`] returns) to the baseline per-bar realized
+/// variance (the preceding returns). Each side is normalized by its sample
+/// count, so a short recent window and a longer baseline compare on a per-bar
+/// basis rather than by raw sum.
+///
+/// This is the sustained-dispersion detector the single-bar statistics miss by
+/// construction: the MAD z-score reads a fresh return as in-family once its
+/// history is also elevated, and the BNS jump test reads a cluster of moderate
+/// bars as diffusive (ratio near one). A regime that shifts from quiet to
+/// choppy therefore trips neither, but drives this ratio up.
+///
+/// Returns `None` when the baseline holds fewer than [`MIN_SAMPLES`] returns
+/// (too few to trust as a baseline), the window is too short to spare
+/// [`RECENT_VARIANCE_SAMPLES`] recent returns, or the baseline variance
+/// collapses to ~zero (a flat baseline, where any recent motion is an undefined
+/// multiple).
+pub(crate) fn volatility_regime_ratio(returns: &[f64]) -> Option<f64> {
+    if returns.len() < RECENT_VARIANCE_SAMPLES + MIN_SAMPLES {
+        return None;
+    }
+    let split = returns.len() - RECENT_VARIANCE_SAMPLES;
+    let (baseline, recent) = returns.split_at(split);
+    let recent_per_bar = realized_variance(recent) / recent.len() as f64;
+    let baseline_per_bar = realized_variance(baseline) / baseline.len() as f64;
+    if baseline_per_bar <= EPSILON {
+        return None;
+    }
+    Some(recent_per_bar / baseline_per_bar)
 }
 
 /// Bipower variation: `μ₁⁻²` times the sum of products of adjacent absolute
@@ -195,9 +235,41 @@ impl Signal for JumpSignal {
     }
 }
 
+/// L2 signal: ratio of recent to baseline per-bar realized variance, catching a
+/// sustained volatility-regime expansion the single-bar statistics miss. Not
+/// evaluable (`None`) below [`RECENT_VARIANCE_SAMPLES`] + [`MIN_SAMPLES`]
+/// returns or on a ~flat baseline.
+pub(crate) struct VolatilityRegimeSignal;
+
+impl VolatilityRegimeSignal {
+    /// Stable trace identifier (matches the `AnomalyMetrics::volatility_regime`
+    /// field it projects onto).
+    pub(crate) const NAME: &'static str = "volatility_regime";
+}
+
+impl Signal for VolatilityRegimeSignal {
+    fn name(&self) -> &'static str { Self::NAME }
+
+    fn evaluate(&self, ctx: &SignalContext<'_>) -> SignalOutput {
+        let value = volatility_regime_ratio(ctx.returns());
+        SignalOutput {
+            value,
+            fired: value.is_some_and(|ratio| ratio >= VOLATILITY_REGIME_THRESHOLD),
+        }
+    }
+
+    fn fragment(&self, output: &SignalOutput) -> String {
+        format!("volatility regime {:.1}x", output.value.unwrap_or_default())
+    }
+}
+
 #[cfg(test)]
 mod tests {
-    use super::{jump_ratio, realized_variance, robust_zscore};
+    use super::{
+        VOLATILITY_REGIME_THRESHOLD, VolatilityRegimeSignal, jump_ratio, realized_variance,
+        robust_zscore, volatility_regime_ratio,
+    };
+    use crate::anomaly::registry::{Signal, SignalContext};
 
     /// Naive mean/standard-deviation z-score, used only to demonstrate the
     /// contrast the robust version is designed to beat.
@@ -278,6 +350,66 @@ mod tests {
         assert!(
             jump_ratio_value > JUMP_RATIO_THRESHOLD,
             "jump ratio {jump_ratio_value} should exceed {JUMP_RATIO_THRESHOLD}"
+        );
+    }
+
+    /// A [`SignalContext`] over a bare return series; the volatility-regime
+    /// signal reads only `returns`, so the other inputs are inert.
+    fn ctx(returns: &[f64]) -> SignalContext<'_> {
+        SignalContext::builder()
+            .closes(&[])
+            .returns(returns)
+            .history_volumes(&[])
+            .latest_volume(0.0)
+            .build()
+    }
+
+    #[test]
+    fn volatility_regime_fires_on_sustained_variance_expansion() {
+        // Eight quiet ±0.15% baseline bars, then five loud ±0.8% recent bars —
+        // a sustained dispersion expansion, not a single outlier.
+        let mut returns = vec![
+            0.0015, -0.0015, 0.0015, -0.0015, 0.0015, -0.0015, 0.0015, -0.0015,
+        ];
+        returns.extend_from_slice(&[0.008, -0.008, 0.008, -0.008, 0.008]);
+
+        let output = VolatilityRegimeSignal.evaluate(&ctx(&returns));
+        let ratio = output
+            .value
+            .expect("recent + baseline both exceed the minimum sample count");
+
+        assert!(
+            ratio >= VOLATILITY_REGIME_THRESHOLD,
+            "recent variance should be >= {VOLATILITY_REGIME_THRESHOLD}x baseline: {ratio}"
+        );
+        assert!(output.fired, "a sustained variance expansion should fire");
+        // The pure function and the signal agree on the value.
+        assert_eq!(volatility_regime_ratio(&returns), output.value);
+    }
+
+    #[test]
+    fn volatility_regime_silent_on_stable_variance() {
+        // Recent and baseline bars carry comparable per-bar variance.
+        let returns = [
+            0.0015, -0.0015, 0.0015, -0.0015, 0.0015, -0.0015, 0.0015, -0.0015, 0.0016, -0.0016,
+            0.0015, -0.0016, 0.0015,
+        ];
+        let output = VolatilityRegimeSignal.evaluate(&ctx(&returns));
+        assert!(
+            output.value.is_some(),
+            "a full-length window is evaluable: {:?}",
+            output.value
+        );
+        assert!(!output.fired, "a stable-variance tape should not fire");
+
+        // Too short to split into recent + baseline: not evaluable.
+        let short = [0.001, -0.001, 0.001];
+        assert!(
+            VolatilityRegimeSignal
+                .evaluate(&ctx(&short))
+                .value
+                .is_none(),
+            "a window shorter than recent + baseline reports no value"
         );
     }
 }

--- a/specs/issue-2436-anomaly-tail-risk-signals.spec.md
+++ b/specs/issue-2436-anomaly-tail-risk-signals.spec.md
@@ -1,0 +1,331 @@
+spec: task
+name: "issue-2436-anomaly-tail-risk-signals"
+inherits: project
+tags: [enhancement, backend, trading]
+---
+
+## Intent
+
+rara's trading extension evaluates market anomalies in
+`crates/extensions/rara-trading/src/anomaly/`. PR 2430 (issue 2429) generalized
+the five hardcoded signals into an extensible registry: a `Signal` trait
+(`name` / `evaluate(ctx)` / `fragment`), a structured `SignalOutput` (`value` /
+`fired`), a shared `SignalContext` (prepared `closes` / `returns` /
+`history_volumes` / `latest_volume`), and `builtin_registry()` returning the
+five builtin signals (window return, max drawdown, volume surge, MAD robust
+z-score, BNS jump). Adding a signal is now "implement `Signal` + add one
+`Box::new(...)` line to `builtin_registry()`" — the core loop `evaluate_with`
+and the `classify` severity logic do not change.
+
+That extensibility seam has exactly one production signal set today: the five it
+shipped with. This issue is the first layer-② signal expansion — it cashes the
+registry in by **adding two new single-instrument tail-risk signals** the
+existing five structurally cannot detect, so rara recognizes a broader class of
+anomalies and the "add a signal = trait impl + one line" claim is exercised by
+real signals, not just the `#[cfg(test)]` beacon:
+
+- **Volatility-regime shift** (`volatility_regime`): the ratio of recent
+  per-bar realized variance to a longer rolling baseline. It reuses
+  `statistics::realized_variance`. It fires on a *sustained* expansion of return
+  dispersion — many elevated-magnitude bars in a row — which the single-bar
+  outlier detectors miss by construction: the MAD z-score compares one fresh
+  return against its history (a whole cluster of elevated bars is not an
+  outlier once the history is also elevated), and the BNS jump test flags a
+  discontinuity against a diffusive path (a regime of many moderate bars is
+  diffusive, ratio near one). A quiet tape shifting into a choppy high-variance
+  regime therefore trips none of the five today.
+
+- **Directional run** (`directional_run`): the length of the trailing run of
+  consecutive same-sign log-returns (signed: `+N` for an up-run, `-N` for a
+  down-run). It fires on a sustained one-directional grind — a slow, steady
+  march where no single bar is large enough to trip the window-return,
+  drawdown, z-score, or jump thresholds, but the *persistence* itself is the
+  anomaly. A monotonic grind of small same-sign bars trips none of the five
+  today (net move stays under the 3% window-return floor, a monotonic rise has
+  zero drawdown, each identical small return is not a z-score outlier, and a
+  constant-magnitude path is diffusive).
+
+The two are deliberately orthogonal: `volatility_regime` measures dispersion
+(magnitude), `directional_run` measures sign persistence (direction), so a
+window crafted to trip one leaves the other silent. Each new signal is a clean
+`Signal` impl over a pure function plus one registry line. Because the existing
+metrics projection routes each builtin signal's value into a named
+`AnomalyMetrics` field, each new signal also adds one `Option<f64>` field to
+`AnomalyMetrics` and one `.maybe_<field>(...)` projection line in `metrics_from`
+so its value stays inspectable — the minimal coupling the registry design
+already anticipated (a signal beyond the builtin set still contributes to the
+reason and severity, but its value only reaches the public trace through a named
+field). The core `evaluate_with` loop and the `classify` severity logic are
+**not** touched; each new signal contributes to the reason via its `fragment`
+and to the generic `fired`-count, exactly like the five.
+
+If we do not do this, the following concrete gap appears. Reproducer:
+
+1. A user watches a symbol that drifts from a quiet regime into a choppy,
+   high-variance regime over ~5 bars — each bar ±0.8% where the prior baseline
+   was ±0.15%, alternating so the net move is ~0 — and separately grinds
+   steadily in one direction for six consecutive +0.3% bars.
+2. rara's anomaly evaluator runs `evaluate(window, latest)` over each window.
+3. Observed bad outcome: `evaluate` returns `None` for both. The variance
+   regime change is invisible because the MAD z-score sees the newest bar as
+   in-family with an already-elevated history and the BNS jump test sees a
+   diffusive (non-discontinuous) path; the directional grind is invisible
+   because no single bar crosses any threshold and the monotonic path has no
+   drawdown. Two genuine tail-risk shapes — a volatility regime change and a
+   persistent one-way trend — pass silently, so the finance directive is never
+   enriched and the user is never told. The registry built for exactly this
+   expansion sits with a single production signal set.
+
+This advances `goal.md` signal 3 (rara building its own market-analysis
+capability — a broader, still-inspectable anomaly vocabulary is the substrate
+the layer-② stock-analysis behavior grows on) and signal 4 ("Every action is
+inspectable" — each new signal carries a stable `name` and projects a named
+`AnomalyMetrics` value, so the evaluation stays a readable per-signal trace, not
+an opaque verdict). It crosses no "What rara is NOT" line: the signals are
+scoped to rara's own single-process anomaly evaluation, consumed only through
+the existing `dispatch` facade, and reinforce the "not a black box" line by
+naming and tracing every new detection. It builds directly on the PR 2430
+registry and is the layer-② signal-expansion block; backtest, trade
+suggestions, and cross-asset correlation are separate later issues, explicitly
+out of scope here.
+
+Prior-art search (2026-07-16) against `rararulab/rara` (the canonical repo; the
+local `origin` fork has issues disabled). `gh issue list` / `gh pr list` for
+`anomaly signal registry volatility`, `tail risk regime momentum gap`,
+`anomaly signal registry` returned only the existing anomaly lineage: issue
+2415 / PR 2418 (the anomaly engine that introduced the five hardcoded signals),
+issue 2416 (severity-graded delivery), issue 2425 / PR 2426 (the market-signal
+`dispatch` facade), and issue 2429 / PR 2430 (generalizing the five signals into
+the extensible registry this issue extends). `git log --all --grep "anomaly"
+--grep "volatility" --grep "regime" --grep "signal registry"` since 180 days
+shows the same commits and nothing that added or removed a volatility-regime or
+directional-run signal. `rg` for `volatility|regime|momentum|acceleration` in
+the trading crate found no existing signal implementation. No prior work added
+these signals and no prior decision is being reversed — this is the first
+forward extension of the registry PR 2430 landed.
+
+## Decisions
+
+- Work happens entirely inside `crates/extensions/rara-trading/src/anomaly/`
+  plus the crate `AGENT.md`. The public re-exports in `anomaly/mod.rs`
+  (`evaluate`, `EVAL_WINDOW`, `AnomalySignal`, `AnomalyMetrics`, `Severity`,
+  `AnomalyError`, `Result`) and the `evaluate(window, latest) ->
+  Result<Option<AnomalySignal>>` signature stay unchanged, so the `dispatch`
+  facade consumer needs no edit.
+- Add exactly two new `Signal` implementations, each a thin adapter over a new
+  pure function:
+  - `volatility_regime`: a pure function computing the ratio of recent per-bar
+    realized variance (over the last `RECENT_VARIANCE_SAMPLES` returns) to the
+    baseline per-bar realized variance (over the preceding returns), reusing
+    `statistics::realized_variance` and normalizing each side by its sample
+    count so windows of different lengths are comparable. Suggested home:
+    `statistics.rs` (L2, next to `realized_variance`). `None` (not evaluable)
+    when either side has too few samples (reuse the `MIN_SAMPLES` discipline) or
+    the baseline variance collapses to ~zero.
+  - `directional_run`: a pure function returning the signed length of the
+    trailing run of consecutive same-sign log-returns (`+N` up-run, `-N`
+    down-run; zero-magnitude returns break the run). Suggested home: `rules.rs`
+    or `statistics.rs` (a structural rule over the return series). `None` when
+    the return series is empty (window too short to form a return).
+- Each new signal owns its trip threshold as a Rust `const` next to it
+  (`docs/guides/anti-patterns.md` mechanism-tuning rule) — no YAML knob.
+  Suggested starting values (implementer finalizes against the acceptance
+  windows): `VOLATILITY_REGIME_THRESHOLD ≈ 4.0` (recent variance ≥ 4× baseline),
+  `RECENT_VARIANCE_SAMPLES ≈ 5`, `DIRECTIONAL_RUN_THRESHOLD ≈ 5–6` (bars). These
+  are mechanism constants, not deployment config.
+- `DIRECTIONAL_RUN_THRESHOLD` is set by **domain semantics** — how many
+  consecutive same-sign bars constitute a persistent, anomalous grind (~5–6) —
+  and MUST NOT be inflated to dodge an existing test fixture. In particular, do
+  **not** set it to ≥13 so it stays silent on the current
+  `single_moderate_rule_produces_watch_severity` window (a 12-bar monotonic
+  rise): that window *is* a persistent grind and `directional_run` **should**
+  fire on it, so the correct fix is to update that fixture (next decision), not
+  to couple the constant to the fixture. Coupling a mechanism constant to a test
+  fixture is the anti-pattern this const rule exists to prevent.
+- Register the two new signals by **appending** them to `builtin_registry()`
+  after the existing five (`jump`), so the reason-fragment order of the existing
+  five stays byte-for-byte unchanged (drawdown, return, volume, z-score, jump,
+  then volatility_regime, directional_run). Each new signal's `fragment` is a
+  human-readable phrase (e.g. `volatility regime {:.1}x`,
+  `directional run {:+.0} bars`) appended to the joined reason only when it
+  fires.
+- Give each new signal an inspectable trace: add one `Option<f64>` field to
+  `AnomalyMetrics` per new signal (`volatility_regime`, `directional_run`) and
+  one `.maybe_<field>(...)` projection line in `evaluator::metrics_from` routing
+  the signal's value into it by its stable `name`. `None` stays `None` (never
+  flattened to `0.0`). This is the only edit to `evaluator.rs` — the
+  `evaluate_with` loop and `classify` are not touched.
+- Severity stays exactly as it is: the generic `fired`-count plus the
+  drawdown-keyed `CRITICAL_DRAWDOWN && fired_count >= 2` escalation. The two new
+  signals contribute to the `fired`-count like any other signal — a single new
+  signal firing yields `Watch`; a new signal firing alongside another yields
+  `Elevated` (or `Critical` under the existing drawdown escalation). This issue
+  does **not** introduce weights, scores, per-signal severity contributions, or
+  any factor-combination framework.
+- Update the `single_moderate_rule_produces_watch_severity` evaluator fixture,
+  because `directional_run` makes its current window semantically obsolete. That
+  test's window is a 12-bar monotonic +0.33%/bar rise (13 rising closes = 12
+  consecutive up-returns); once `directional_run` is registered at a semantic
+  threshold (~5–6), it legitimately fires on that grind, so the window no longer
+  isolates a single rule and `fired_count` becomes 2 → the severity would move
+  `Watch → Elevated`. Preserve the test's **intent** ("a single moderate rule
+  trips → `Watch`") by replacing the window with one that trips only the
+  window-return rule (net move ≥ 3%) while the trailing same-sign run stays
+  **below** `DIRECTIONAL_RUN_THRESHOLD` and per-bar variance stays uniform (no
+  regime shift) — e.g. a rise whose final bars flatten or tick back so the
+  ongoing run is short, or an oscillating staircase that nets ≥ 3% without a
+  long trailing run. The assertions stay `severity == Watch`,
+  `window_return >= 0.03`, `max_drawdown < 0.03`; only the fixture data changes.
+  This is the **one** parity fixture this issue may edit.
+- Every field on the new `SignalOutput`s and every new `AnomalyMetrics` field
+  must have a consumer asserted by a test (`docs/guides/anti-patterns.md`
+  hollow-implementation rule): the fire tests assert the projected
+  `metrics.volatility_regime` / `metrics.directional_run` value and the reason
+  fragment; a production `Signal` that ignores its `SignalContext` and returns a
+  constant is forbidden.
+- Errors stay `snafu`; 3+-field structs use `#[derive(bon::Builder)]`; new
+  `pub` items (the new `AnomalyMetrics` fields) get `///` docs. Update
+  `crates/extensions/rara-trading/AGENT.md` to list the two new builtin signals
+  in the anomaly-module description and the count of builtin signals.
+
+## Boundaries
+
+### Allowed Changes
+- **/crates/extensions/rara-trading/src/anomaly/**
+- **/crates/extensions/rara-trading/AGENT.md
+- **/specs/issue-2436-anomaly-tail-risk-signals.spec.md
+
+### Forbidden
+- **/crates/extensions/rara-trading/src/dispatch/**
+- **/crates/extensions/rara-trading/src/finance/**
+- **/crates/extensions/rara-trading/src/feed/**
+- **/crates/extensions/rara-trading/src/market_data/**
+- **/crates/extensions/rara-trading/src/lib.rs
+- **/crates/app/**
+- **/config.example.yaml
+- **/web/**
+- **/extension/**
+- Do NOT change the `evaluate_with` core loop or the `classify` severity logic —
+  the two new signals must participate purely by implementing `Signal` and
+  appending one registry line each; the only `evaluator.rs` edit is the
+  `metrics_from` projection (one `.maybe_<field>(...)` line per new signal) plus
+  its imports.
+- Do NOT alter the fire condition, reason fragment, or severity contribution of
+  any of the five existing signals — their outputs must stay bit-for-bit
+  identical.
+- Do NOT change the parity **outcomes** of the crash (`→ Critical`), flat
+  (`→ None`), two-rules (`→ Elevated`), and non-positive-price (`→ error`)
+  evaluator/unit tests — these must stay bit-for-bit green (the two new signals
+  must not fire on those windows, or must not change their severity outcome;
+  the crash reason uses `contains`, so appended fragments are fine there).
+- You MAY (and must) update exactly one existing parity fixture — the
+  `single_moderate_rule_produces_watch_severity` window — because the new
+  `directional_run` signal makes its old 12-bar-grind window semantically
+  obsolete (see Decisions). Its Watch **intent** and assertions are preserved;
+  only the window data changes. No other existing test may be edited.
+- Do NOT reorder `builtin_registry()` — append the new signals after `jump` so
+  the existing reason-fragment order is preserved.
+- Do NOT add a YAML knob for any threshold or window size — mechanism tuning
+  stays a Rust `const` (`docs/guides/anti-patterns.md`).
+- Do NOT build a weight / scoring / factor-combination framework, per-signal
+  severity weights, or config-driven signal selection — severity stays the
+  concrete fired-count plus drawdown escalation.
+- Do NOT construct hollow outputs: a `SignalOutput` field or `AnomalyMetrics`
+  field nothing reads, or a `Signal` impl that returns a constant regardless of
+  its `SignalContext`, is forbidden.
+
+## Out of Scope
+
+- **Cross-asset / cross-symbol correlation-breakdown signals.** They require a
+  multi-instrument window, but the `dispatch` facade prepares and passes only a
+  single-symbol window today (`SignalContext` holds one symbol's
+  closes/returns/volumes). Adding them is an independent architecture change to
+  the window-preparation seam and is a separate later issue — this issue does
+  not touch it.
+- Backtest, trade suggestions, and any layer-③ trade-execution behavior.
+- Per-symbol sensitivity tuning or any deployment-config surface for signals.
+
+## Acceptance Criteria
+
+Scenario: The volatility-regime signal fires on a sustained variance expansion
+  Test:
+    Package: rara-trading
+    Filter: volatility_regime_fires_on_sustained_variance_expansion
+  Given a return series whose recent bars carry a much larger per-bar realized variance than the earlier baseline bars
+  When the volatility-regime signal evaluates the prepared context
+  Then it reports a computed ratio value
+    And it fires because the recent-to-baseline variance ratio crosses its threshold
+
+Scenario: The volatility-regime signal stays silent on a stable-variance tape
+  Test:
+    Package: rara-trading
+    Filter: volatility_regime_silent_on_stable_variance
+  Given a return series whose recent and baseline bars carry comparable per-bar variance
+  When the volatility-regime signal evaluates the prepared context
+  Then it does not fire
+    And on a window too short to split into recent and baseline it reports no value (not evaluable)
+
+Scenario: The directional-run signal fires on a sustained one-directional grind
+  Test:
+    Package: rara-trading
+    Filter: directional_run_fires_on_sustained_directional_grind
+  Given a return series ending in a run of consecutive same-sign returns at or above the run threshold
+  When the directional-run signal evaluates the prepared context
+  Then it reports the signed run length as its value
+    And it fires because the run length crosses its threshold
+
+Scenario: The directional-run signal stays silent on a choppy tape
+  Test:
+    Package: rara-trading
+    Filter: directional_run_silent_on_choppy_tape
+  Given a return series of alternating-sign returns so the trailing same-sign run is short
+  When the directional-run signal evaluates the prepared context
+  Then it does not fire
+
+Scenario: The volatility-regime signal alone enriches an otherwise unremarkable tape
+  Test:
+    Package: rara-trading
+    Filter: volatility_regime_alone_enriches_unremarkable_tape
+  Given a candle window that shifts into a high-variance regime the five existing signals leave unremarkable
+  When the registry-driven evaluator runs over the window and the newest closed candle
+  Then it now returns a signal because the volatility-regime signal fired
+    And the reason contains the volatility-regime fragment
+    And the projected metrics carry the volatility-regime ratio value
+    And none of the five existing signals' fragments appear (only the new signal lifted the tape)
+
+Scenario: The directional-run signal alone enriches an otherwise unremarkable tape
+  Test:
+    Package: rara-trading
+    Filter: directional_run_alone_enriches_unremarkable_tape
+  Given a grind of small same-sign bars whose trailing run reaches the run threshold while the net move stays below the window-return floor, so the five existing signals leave it unremarkable
+  When the registry-driven evaluator runs over the window and the newest closed candle
+  Then it now returns a signal because the directional-run signal fired
+    And the reason contains the directional-run fragment
+    And the projected metrics carry the signed directional-run value
+    And none of the five existing signals' fragments appear (only the new signal lifted the tape)
+
+Scenario: A single moderate rule still yields Watch severity on a window with no persistent grind
+  Test:
+    Package: rara-trading
+    Filter: single_moderate_rule_produces_watch_severity
+  Given a candle window that trips only the window-return rule — a net move of at least 3% whose trailing same-sign run stays below the directional-run threshold and whose per-bar variance is uniform
+  When the registry-driven evaluator runs over the window and the newest closed candle
+  Then it returns Watch severity, unchanged in intent by the two added signals
+    And only the window-return rule contributed to the fired count
+
+Scenario: A multi-bar crash on a volume spike still produces the same high-severity signal
+  Test:
+    Package: rara-trading
+    Filter: crash_window_produces_high_severity_anomaly_signal
+  Given an ordered candle window ending in a sharp multi-bar decline with a volume spike
+  When the registry-driven evaluator runs over the window and the newest closed candle
+  Then it returns the highest (bypass-eligible) severity, unchanged by the two added signals
+    And the reason still names the drawdown and window-return magnitudes
+
+Scenario: A flat, low-volatility tape still produces no anomaly signal
+  Test:
+    Package: rara-trading
+    Filter: flat_tape_produces_no_anomaly_signal
+  Given an ordered candle window of small alternating moves at steady volume
+  When the registry-driven evaluator runs over the window and the newest closed candle
+  Then it returns None, unchanged by the two added signals


### PR DESCRIPTION
## Summary

First layer-② expansion of the anomaly signal registry (built on #2429 / PR 2430): two new single-instrument tail-risk `Signal`s the existing five structurally miss, added purely through the registry's extension seam.

- **`volatility_regime`** (`statistics.rs`, reuses `realized_variance`): ratio of recent per-bar realized variance (last 5 returns) to the longer rolling baseline; fires on a *sustained dispersion expansion* the single-bar MAD z-score sees as in-family and the BNS jump test reads as diffusive. Semantic threshold `VOLATILITY_REGIME_THRESHOLD = 4.0×`.
- **`directional_run`** (`rules.rs`): signed length of the trailing same-sign log-return run; fires on a *persistent one-directional grind* no single bar's magnitude trips. Semantic threshold `DIRECTIONAL_RUN_THRESHOLD = 6` bars (set by domain semantics, not tuned to any fixture).

Each new signal = pure function + thin `Signal` impl + one appended `builtin_registry()` line + one `Option<f64>` `AnomalyMetrics` field + one `metrics_from` projection line. **The `evaluate_with` core loop and `classify` severity logic are untouched** — the extension point carries the new signals with zero core edits. No scoring/weight framework; severity stays fired-count + drawdown escalation.

The `single_moderate_rule_produces_watch_severity` fixture is updated (its old 12-bar monotonic rise is now a legitimate `directional_run` grind) — only the window data changes; the Watch intent and assertions are preserved and strengthened. The crash (→Critical), flat (→None), two-rules (→Elevated), and non-positive (→error) parity tests stay bit-for-bit unchanged.

## Type of change

New feature — `enhancement`

## Component

`backend`

## Closes

Closes #2436

## Test plan

- [x] `cargo test -p rara-trading -p rara-app` passes (rara-trading lib 99 tests incl. 18 anomaly + testcontainer integration; rara-app green)
- [x] Full Rust gate: `cargo check --all --all-targets`, `cargo +nightly fmt --check`, `cargo clippy --workspace --all-targets --all-features -D warnings`, `RUSTDOCFLAGS=-D warnings cargo +nightly doc`
- [x] `just spec-lifecycle specs/issue-2436-anomaly-tail-risk-signals.spec.md` — 8 scenarios + boundaries all PASS
- [x] Verification: PASS (independent verifier, cold-boot + hostile probes, no caveats)