### PR TITLE
feat(finance): attribute backtest signal outcomes

### DIFF
--- a/crates/extensions/rara-trading/AGENT.md
+++ b/crates/extensions/rara-trading/AGENT.md
@@ -89,22 +89,27 @@ Six modules, each a `mod.rs` (re-exports + `//!` docs only) over sub-files:
   fires on, applies one **fixed naive rule** (enter long at the trigger bar's
   close, exit `HOLD_BARS` bars later at that bar's close) to answer "is a signal
   actually any good?". `runner.rs` holds `run_backtest(candles) ->
-  Result<BacktestReport>` (the **pure** deterministic core the unit tests bind
-  to) and the thin async `backtest(repo, query)` entry that fetches via
-  `MarketDataRepository::candles` and delegates to the core — the same
+  Result<BacktestReport>` (the **pure** deterministic composite core the unit
+  tests bind to), `run_signal_attribution(candles) ->
+  Result<SignalAttributionReport>` (the same no-look-ahead replay grouped by
+  builtin signal name), and the thin async `backtest(repo, query)` entry that
+  fetches via `MarketDataRepository::candles` and delegates to the core — the same
   pure-core/async-entry seam as `anomaly::evaluate` / the dispatch adapter.
   `report.rs` = `BacktestReport` (`bon::Builder`, the fixed metric set:
   `trigger_count`, `evaluated_trade_count`, `win_count`, `win_rate`, signed
-  `mean`/`median_forward_return`, strategy `max_drawdown`); `error.rs` =
+  `mean`/`median_forward_return`, strategy `max_drawdown`) plus
+  `SignalAttributionReport` / `SignalAttribution` (the same fixed metrics per
+  builtin signal row; a bar can count in multiple rows when multiple signals
+  fire); `error.rs` =
   `BacktestError` (snafu; `Evaluate` wraps `AnomalyError`, `FetchCandles` wraps
   the repository read). It only **consumes** `anomaly::evaluate` and
   `market_data`; it changes neither. `tools.rs` exposes the same narrow harness
   as the deferred, read-only `finance_backtest_signal` agent tool: the tool
   validates a single candle range, fetches from the shared market-data
   repository, rejects over-limit ranges instead of paginating a non-additive
-  replay, delegates to `run_backtest`, and returns the fixed report plus
-  diagnostic hints. It is not the heavier research-desk `trading_backtest`
-  surface.
+  replay, delegates to `run_backtest` and `run_signal_attribution`, and returns
+  the fixed composite report, per-signal attribution rows, and diagnostic hints.
+  It is not the heavier research-desk `trading_backtest` surface.
 
 The write→read→enrich wiring lives in `dispatch/pipeline.rs` (`on_feed_event`):
 it upserts the closed candle, pulls the window via `recent_candles`, runs
@@ -140,10 +145,11 @@ dispatch loop (`crates/app/src/lib.rs`).
   counted in `trigger_count` but **excluded** from `evaluated_trade_count` and
   every P&L metric — never zero-filled. Consequence of violation: fabricated
   edge that would ship a future ③ execution gate on a lie.
-- **The backtest unit is the composite `AnomalySignal`, and forward returns are
-  signed.** A "trigger" is one bar where `evaluate` returns `Some` (what
-  `dispatch` acts on) — not per-signal attribution (a documented future
-  extension). A trade wins **iff** its forward return is strictly `> 0.0`;
+- **The primary backtest unit is the composite `AnomalySignal`, and forward
+  returns are signed.** A composite "trigger" is one bar where `evaluate`
+  returns `Some` (what `dispatch` acts on). Per-signal attribution is a secondary
+  grouped view over the same replay, not a separate strategy definition. A trade
+  wins **iff** its forward return is strictly `> 0.0`;
   because the detectors are tail/volatility signals, a low win rate with a
   negative mean is a valid, informative result. Report the signed mean/median;
   do not take absolute value. `HOLD_BARS` is a `const`, never YAML.

--- a/crates/extensions/rara-trading/src/anomaly/evaluator.rs
+++ b/crates/extensions/rara-trading/src/anomaly/evaluator.rs
@@ -51,6 +51,19 @@ pub const EVAL_WINDOW: usize = 30;
 /// [`Severity::Critical`] — the flash-crash shape.
 const CRITICAL_DRAWDOWN: f64 = 0.06;
 
+/// Agent/research-facing snapshot of one builtin signal's evaluation.
+///
+/// This deliberately exposes only the stable data currently needed by
+/// Layer-② backtests: the signal name and fired flag, not the [`Signal`] trait
+/// object itself.
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct SignalEvaluation {
+    /// Stable signal identifier from [`Signal::name`].
+    pub(crate) name:  &'static str,
+    /// Whether this signal crossed its trip threshold.
+    pub(crate) fired: bool,
+}
+
 /// Evaluate the newly closed `latest` candle against its preceding `window`
 /// (ordered oldest-to-newest, excluding `latest`).
 ///
@@ -66,6 +79,30 @@ const CRITICAL_DRAWDOWN: f64 = 0.06;
 /// or the latest candle is not strictly positive.
 pub fn evaluate(window: &[MarketCandle], latest: &MarketCandle) -> Result<Option<AnomalySignal>> {
     evaluate_with(&builtin_registry(), window, latest)
+}
+
+/// Return the builtin signal names in stable registry order.
+pub(crate) fn builtin_signal_names() -> Vec<&'static str> {
+    builtin_registry()
+        .iter()
+        .map(|signal| signal.name())
+        .collect()
+}
+
+/// Evaluate every builtin signal against `latest` and return the per-signal
+/// outputs in stable registry order.
+///
+/// This is the read-side attribution seam for backtests. It uses the exact same
+/// context preparation and signal order as [`evaluate`], so a fired output here
+/// corresponds to one contribution to the composite [`AnomalySignal`] on the
+/// same bar.
+pub(crate) fn evaluate_builtin_signals(
+    window: &[MarketCandle],
+    latest: &MarketCandle,
+) -> Result<Vec<SignalEvaluation>> {
+    let registry = builtin_registry();
+    let evaluated = evaluate_registry_outputs(&registry, window, latest)?;
+    Ok(signal_evaluations_from(&evaluated))
 }
 
 /// Evaluate `latest` against `window` using an explicit signal `registry`.
@@ -84,6 +121,16 @@ pub(crate) fn evaluate_with(
     window: &[MarketCandle],
     latest: &MarketCandle,
 ) -> Result<Option<AnomalySignal>> {
+    let evaluated = evaluate_registry_outputs(registry, window, latest)?;
+    let metrics = metrics_from(&evaluated);
+    Ok(classify(&evaluated, metrics))
+}
+
+fn evaluate_registry_outputs<'a>(
+    registry: &'a SignalRegistry,
+    window: &[MarketCandle],
+    latest: &MarketCandle,
+) -> Result<Vec<(&'a dyn Signal, SignalOutput)>> {
     let mut closes = Vec::with_capacity(window.len() + 1);
     for candle in window {
         closes.push(close_f64(candle)?);
@@ -92,7 +139,18 @@ pub(crate) fn evaluate_with(
 
     // One prior close is the minimum needed to form a single return.
     if closes.len() < 2 {
-        return Ok(None);
+        return Ok(registry
+            .iter()
+            .map(|signal| {
+                (
+                    signal.as_ref(),
+                    SignalOutput {
+                        value: None,
+                        fired: false,
+                    },
+                )
+            })
+            .collect());
     }
 
     let history_volumes: Vec<f64> = window.iter().map(volume_f64).collect();
@@ -106,16 +164,23 @@ pub(crate) fn evaluate_with(
         .latest_volume(latest_volume)
         .build();
 
-    let evaluated: Vec<(&dyn Signal, SignalOutput)> = registry
+    Ok(registry
         .iter()
         .map(|signal| {
             let output = signal.evaluate(&ctx);
             (signal.as_ref(), output)
         })
-        .collect();
+        .collect())
+}
 
-    let metrics = metrics_from(&evaluated);
-    Ok(classify(&evaluated, metrics))
+fn signal_evaluations_from(evaluated: &[(&dyn Signal, SignalOutput)]) -> Vec<SignalEvaluation> {
+    evaluated
+        .iter()
+        .map(|(signal, output)| SignalEvaluation {
+            name:  signal.name(),
+            fired: output.fired,
+        })
+        .collect()
 }
 
 /// Project the collected signal outputs onto the public [`AnomalyMetrics`]

--- a/crates/extensions/rara-trading/src/anomaly/mod.rs
+++ b/crates/extensions/rara-trading/src/anomaly/mod.rs
@@ -37,4 +37,5 @@ pub mod tools;
 
 pub use error::{AnomalyError, Result};
 pub use evaluator::{EVAL_WINDOW, evaluate};
+pub(crate) use evaluator::{builtin_signal_names, evaluate_builtin_signals};
 pub use signal::{AnomalyMetrics, AnomalySignal, Severity};

--- a/crates/extensions/rara-trading/src/backtest/mod.rs
+++ b/crates/extensions/rara-trading/src/backtest/mod.rs
@@ -24,7 +24,9 @@
 //! trigger bar's close, exit `HOLD_BARS` bars later at that bar's close — then
 //! reports a **fixed metric set** ([`BacktestReport`]): trigger count, win
 //! rate, signed mean/median forward return, and the naive strategy's max
-//! drawdown.
+//! drawdown. It also reports [`SignalAttributionReport`], the same fixed
+//! forward-return metrics grouped by each builtin signal that contributed to
+//! composite anomalies.
 //!
 //! Two seams, mirroring the `anomaly` module:
 //! - [`run_backtest`] — the **pure, deterministic core** over an ordered candle
@@ -52,5 +54,5 @@ mod runner;
 pub mod tools;
 
 pub use error::{BacktestError, Result};
-pub use report::BacktestReport;
-pub use runner::{HOLD_BARS, backtest, run_backtest};
+pub use report::{BacktestReport, SignalAttribution, SignalAttributionReport};
+pub use runner::{HOLD_BARS, backtest, run_backtest, run_signal_attribution};

--- a/crates/extensions/rara-trading/src/backtest/report.rs
+++ b/crates/extensions/rara-trading/src/backtest/report.rs
@@ -56,3 +56,46 @@ pub struct BacktestReport {
     /// evaluated trades in trigger-time order. `0.0` when there are no trades.
     pub max_drawdown:          f64,
 }
+
+/// Per-signal attribution for the same replay and naive-long rule.
+///
+/// The composite [`BacktestReport`] answers "when rara would have emitted an
+/// anomaly, what happened next?". This report answers the next research
+/// question: "which builtin signals contributed to those anomalies, and what
+/// happened after each signal fired?". A bar can contribute to multiple rows
+/// when multiple signals fire on the same candle, so per-signal
+/// [`SignalAttribution::trigger_count`] values intentionally do not sum to the
+/// composite trigger count.
+#[derive(Debug, Clone, PartialEq, Serialize, Builder)]
+pub struct SignalAttributionReport {
+    /// Composite anomaly triggers from the same replay, for context.
+    pub composite_trigger_count: usize,
+    /// Builtin signals in stable registry order, including zero-count rows so
+    /// absence is explicit.
+    pub signals:                 Vec<SignalAttribution>,
+}
+
+/// One builtin signal's trigger and naive-long forward-return metrics.
+#[derive(Debug, Clone, PartialEq, Serialize, Builder)]
+pub struct SignalAttribution {
+    /// Stable signal identifier such as `volume_surge` or `directional_run`.
+    pub signal_name:           String,
+    /// Bars where this individual signal fired.
+    pub trigger_count:         usize,
+    /// Triggers that have a full `HOLD_BARS` forward window.
+    pub evaluated_trade_count: usize,
+    /// Evaluated trades whose forward return is strictly positive.
+    pub win_count:             usize,
+    /// Fraction of evaluated trades that won, or `None` when no full forward
+    /// window exists.
+    pub win_rate:              Option<f64>,
+    /// Signed arithmetic mean forward return, or `None` when no full forward
+    /// window exists.
+    pub mean_forward_return:   Option<f64>,
+    /// Signed median forward return, or `None` when no full forward window
+    /// exists.
+    pub median_forward_return: Option<f64>,
+    /// Deepest peak-to-trough fractional decline of this signal's naive
+    /// strategy equity curve. `0.0` when there are no evaluated trades.
+    pub max_drawdown:          f64,
+}

--- a/crates/extensions/rara-trading/src/backtest/runner.rs
+++ b/crates/extensions/rara-trading/src/backtest/runner.rs
@@ -27,7 +27,7 @@ use snafu::ResultExt;
 
 use super::{
     error::{BacktestError, EvaluateSnafu, Result},
-    report::BacktestReport,
+    report::{BacktestReport, SignalAttribution, SignalAttributionReport},
 };
 use crate::{
     anomaly::{self, EVAL_WINDOW},
@@ -120,6 +120,62 @@ pub fn run_backtest(candles: &[MarketCandle]) -> Result<BacktestReport> {
         .build())
 }
 
+/// Replay `candles` and attribute naive-long outcomes to each builtin signal.
+///
+/// This uses the same no-look-ahead evaluation window as [`run_backtest`], but
+/// keeps one row per builtin signal instead of collapsing all fired signals
+/// into a single composite `AnomalySignal`. A bar that fires multiple signals
+/// is counted once in [`SignalAttributionReport::composite_trigger_count`] and
+/// once in each fired signal's row.
+///
+/// # Errors
+///
+/// Returns [`BacktestError::Evaluate`] if the anomaly evaluator rejects any
+/// candle. The replay validates all bars before computing forward returns, so
+/// the later P&L pass never reads an invalid exit close.
+pub fn run_signal_attribution(candles: &[MarketCandle]) -> Result<SignalAttributionReport> {
+    let mut rows: Vec<SignalAttributionAccumulator> = anomaly::builtin_signal_names()
+        .into_iter()
+        .map(SignalAttributionAccumulator::new)
+        .collect();
+    let mut composite_trigger_count = 0;
+
+    // Pass 1: collect per-signal trigger indices. This validates every candle
+    // through the evaluator before any forward-return pass reads future exits.
+    for index in 0..candles.len() {
+        let window = &candles[index.saturating_sub(EVAL_WINDOW)..index];
+        let latest = &candles[index];
+        let outputs = anomaly::evaluate_builtin_signals(window, latest).context(EvaluateSnafu)?;
+        debug_assert_eq!(
+            rows.len(),
+            outputs.len(),
+            "builtin signal name and output registries should stay aligned"
+        );
+
+        let mut composite_fired = false;
+        for (row, output) in rows.iter_mut().zip(outputs) {
+            debug_assert_eq!(row.signal_name, output.name);
+            if output.fired {
+                composite_fired = true;
+                row.trigger_indices.push(index);
+            }
+        }
+        if composite_fired {
+            composite_trigger_count += 1;
+        }
+    }
+
+    // Pass 2: the same fixed naive-long forward return, now grouped by signal.
+    Ok(SignalAttributionReport::builder()
+        .composite_trigger_count(composite_trigger_count)
+        .signals(
+            rows.into_iter()
+                .map(|row| row.into_report_row(candles))
+                .collect(),
+        )
+        .build())
+}
+
 /// Fetch the single-stream candle history for `query` and delegate to
 /// [`run_backtest`].
 ///
@@ -149,16 +205,71 @@ pub async fn backtest(
 /// Strictly-positive `f64` close of a candle already validated by
 /// `anomaly::evaluate`.
 ///
-/// `run_backtest` calls `evaluate` for every bar as `latest` before this runs,
-/// and `evaluate` rejects any non-positive or non-finite close; so by the time
-/// forward return reads an entry/exit close it is known valid. The `expect`
-/// documents that invariant rather than hiding a fabricated fallback.
+/// `run_backtest` and `run_signal_attribution` validate every bar as `latest`
+/// before their forward-return pass runs, and the evaluator rejects any
+/// non-positive or non-finite close; so by the time forward return reads an
+/// entry/exit close it is known valid. The `expect` documents that invariant
+/// rather than hiding a fabricated fallback.
 fn close_f64(candle: &MarketCandle) -> f64 {
     candle
         .close
         .to_f64()
         .filter(|value| value.is_finite() && *value > 0.0)
         .expect("close validated as strictly positive and finite by anomaly::evaluate")
+}
+
+struct SignalAttributionAccumulator {
+    signal_name:     &'static str,
+    trigger_indices: Vec<usize>,
+}
+
+impl SignalAttributionAccumulator {
+    fn new(signal_name: &'static str) -> Self {
+        Self {
+            signal_name,
+            trigger_indices: Vec::new(),
+        }
+    }
+
+    fn into_report_row(self, candles: &[MarketCandle]) -> SignalAttribution {
+        let forward_returns: Vec<f64> = self
+            .trigger_indices
+            .iter()
+            .filter_map(|&index| forward_return(candles, index))
+            .collect();
+        let evaluated_trade_count = forward_returns.len();
+        let win_count = forward_returns.iter().filter(|value| **value > 0.0).count();
+        let (win_rate, mean_forward_return, median_forward_return) = if evaluated_trade_count == 0 {
+            (None, None, None)
+        } else {
+            let mean = forward_returns.iter().sum::<f64>() / evaluated_trade_count as f64;
+            (
+                Some(win_count as f64 / evaluated_trade_count as f64),
+                Some(mean),
+                median(&forward_returns),
+            )
+        };
+
+        SignalAttribution::builder()
+            .signal_name(self.signal_name.to_owned())
+            .trigger_count(self.trigger_indices.len())
+            .evaluated_trade_count(evaluated_trade_count)
+            .win_count(win_count)
+            .maybe_win_rate(win_rate)
+            .maybe_mean_forward_return(mean_forward_return)
+            .maybe_median_forward_return(median_forward_return)
+            .max_drawdown(strategy_max_drawdown(&forward_returns))
+            .build()
+    }
+}
+
+fn forward_return(candles: &[MarketCandle], index: usize) -> Option<f64> {
+    let exit = index + HOLD_BARS;
+    (exit < candles.len()).then(|| {
+        let entry_close = close_f64(&candles[index]);
+        let exit_close = close_f64(&candles[exit]);
+        (exit_close - entry_close) / entry_close
+    })
 }
 
 /// Median of `values`, or `None` when empty. Copies into a scratch buffer so
@@ -202,7 +313,7 @@ mod tests {
     use jiff::{SignedDuration, Timestamp};
     use rust_decimal::Decimal;
 
-    use super::{HOLD_BARS, backtest, run_backtest};
+    use super::{HOLD_BARS, backtest, run_backtest, run_signal_attribution};
     use crate::{
         anomaly::AnomalyError,
         backtest::BacktestError,
@@ -297,6 +408,63 @@ mod tests {
         // (1.01 − 1.0) / 1.01.
         let expected_drawdown = 0.01 / 1.01;
         assert!((report.max_drawdown - expected_drawdown).abs() < APPROX);
+    }
+
+    #[test]
+    fn signal_attribution_reports_deterministic_metrics_per_builtin_signal() {
+        let candles = winning_and_losing_fixture();
+        let composite = run_backtest(&candles).expect("positive prices");
+        let attribution = run_signal_attribution(&candles).expect("positive prices");
+
+        assert_eq!(
+            attribution.composite_trigger_count, composite.trigger_count,
+            "composite context should match the normal report"
+        );
+        assert_eq!(
+            attribution
+                .signals
+                .iter()
+                .map(|signal| signal.signal_name.as_str())
+                .collect::<Vec<_>>(),
+            [
+                "max_drawdown",
+                "window_return",
+                "volume_surge",
+                "robust_zscore",
+                "jump_ratio",
+                "volatility_regime",
+                "directional_run",
+            ]
+        );
+
+        let volume = attribution
+            .signals
+            .iter()
+            .find(|signal| signal.signal_name == "volume_surge")
+            .expect("volume surge attribution row");
+        assert_eq!(volume.trigger_count, 2);
+        assert_eq!(volume.evaluated_trade_count, 2);
+        assert_eq!(volume.win_count, 1);
+        assert_eq!(volume.win_rate, Some(0.5));
+
+        let expected_mean =
+            f64::midpoint((60600.0 - 60000.0) / 60000.0, (60000.0 - 60600.0) / 60600.0);
+        assert!((volume.mean_forward_return.expect("mean") - expected_mean).abs() < APPROX);
+        assert!((volume.median_forward_return.expect("median") - expected_mean).abs() < APPROX);
+        assert!((volume.max_drawdown - (0.01 / 1.01)).abs() < APPROX);
+
+        for signal in attribution
+            .signals
+            .iter()
+            .filter(|signal| signal.signal_name != "volume_surge")
+        {
+            assert_eq!(signal.trigger_count, 0, "unexpected trigger in {signal:?}");
+            assert_eq!(signal.evaluated_trade_count, 0);
+            assert_eq!(signal.win_rate, None);
+            assert_eq!(signal.mean_forward_return, None);
+            assert_eq!(signal.median_forward_return, None);
+            assert_eq!(signal.max_drawdown, 0.0);
+        }
     }
 
     #[test]
@@ -434,6 +602,15 @@ mod tests {
         // report computed from the invalid data.
         assert!(matches!(
             error,
+            BacktestError::Evaluate {
+                source: AnomalyError::NonPositivePrice { .. },
+            }
+        ));
+
+        let attribution_error =
+            run_signal_attribution(&candles).expect_err("non-positive close is invalid");
+        assert!(matches!(
+            attribution_error,
             BacktestError::Evaluate {
                 source: AnomalyError::NonPositivePrice { .. },
             }

--- a/crates/extensions/rara-trading/src/backtest/tools.rs
+++ b/crates/extensions/rara-trading/src/backtest/tools.rs
@@ -21,7 +21,9 @@ use rara_tool_macro::ToolDef;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
-use super::{BacktestReport, HOLD_BARS, run_backtest};
+use super::{
+    BacktestReport, HOLD_BARS, SignalAttributionReport, run_backtest, run_signal_attribution,
+};
 use crate::market_data::{CandleRangeQuery, MarketDataRepositoryRef, Timeframe};
 
 const DEFAULT_BACKTEST_LIMIT: usize = 10_000;
@@ -46,14 +48,15 @@ pub struct FinanceBacktestSignalParams {
 
 #[derive(Debug, Clone, Serialize)]
 pub struct FinanceBacktestSignalResult {
-    pub selector:        FinanceBacktestSignalSelector,
-    pub start:           String,
-    pub end:             String,
-    pub candle_count:    usize,
-    pub query_limit:     usize,
-    pub hold_bars:       usize,
-    pub report:          BacktestReport,
-    pub diagnostic_hint: Option<FinanceBacktestSignalDiagnosticHint>,
+    pub selector:           FinanceBacktestSignalSelector,
+    pub start:              String,
+    pub end:                String,
+    pub candle_count:       usize,
+    pub query_limit:        usize,
+    pub hold_bars:          usize,
+    pub report:             BacktestReport,
+    pub signal_attribution: SignalAttributionReport,
+    pub diagnostic_hint:    Option<FinanceBacktestSignalDiagnosticHint>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
@@ -135,6 +138,7 @@ impl ToolExecute for FinanceBacktestSignalTool {
 
         let candle_count = candles.len();
         let report = run_backtest(&candles)?;
+        let signal_attribution = run_signal_attribution(&candles)?;
         let diagnostic_hint =
             source_scoped_empty_candles_diagnostic_hint(source_name.as_deref(), candle_count == 0);
 
@@ -146,6 +150,7 @@ impl ToolExecute for FinanceBacktestSignalTool {
             query_limit: limit,
             hold_bars: HOLD_BARS,
             report,
+            signal_attribution,
             diagnostic_hint,
         })
     }
@@ -373,6 +378,26 @@ mod tests {
         assert_eq!(result.report.evaluated_trade_count, 2);
         assert_eq!(result.report.win_count, 1);
         assert_eq!(result.report.win_rate, Some(0.5));
+        assert_eq!(result.signal_attribution.composite_trigger_count, 2);
+        let volume_surge = result
+            .signal_attribution
+            .signals
+            .iter()
+            .find(|signal| signal.signal_name == "volume_surge")
+            .expect("volume surge row");
+        assert_eq!(volume_surge.trigger_count, 2);
+        assert_eq!(volume_surge.evaluated_trade_count, 2);
+        assert_eq!(volume_surge.win_count, 1);
+        assert_eq!(volume_surge.win_rate, Some(0.5));
+        let directional_run = result
+            .signal_attribution
+            .signals
+            .iter()
+            .find(|signal| signal.signal_name == "directional_run")
+            .expect("directional run row");
+        assert_eq!(directional_run.trigger_count, 0);
+        assert_eq!(directional_run.evaluated_trade_count, 0);
+        assert_eq!(directional_run.win_rate, None);
         assert!(result.diagnostic_hint.is_none());
     }
 
@@ -404,6 +429,14 @@ mod tests {
 
         assert_eq!(result.candle_count, 0);
         assert_eq!(result.report.trigger_count, 0);
+        assert_eq!(result.signal_attribution.composite_trigger_count, 0);
+        assert!(
+            result
+                .signal_attribution
+                .signals
+                .iter()
+                .all(|signal| signal.trigger_count == 0)
+        );
         let hint = result.diagnostic_hint.expect("diagnostic hint");
         assert_eq!(hint.tool, "finance_diagnose_candle_subscriptions");
         assert_eq!(

--- a/docs/guides/finance-subscriptions.md
+++ b/docs/guides/finance-subscriptions.md
@@ -315,9 +315,14 @@ severity/reason/metrics shape used by proactive candle directives. It is
 read-only and never places trades or gives trade advice.
 `finance_backtest_signal` uses the same range semantics over one stored stream,
 replays rara's built-in market-anomaly evaluator, and returns the fixed
-signal-accuracy report; it is read-only and never places trades. It rejects
-over-limit ranges instead of paginating the replay, because a paged backtest
-would lose the prior evaluation window and produce non-additive reports.
+signal-accuracy report plus `signal_attribution`, a per-builtin-signal breakdown
+of trigger count, evaluated forward trades, win-rate, signed mean/median forward
+return, and max drawdown under the same fixed naive-long rule. A single candle
+can count in multiple attribution rows when multiple signals fire; the
+top-level composite report remains the dispatch-equivalent view. The tool is
+read-only and never places trades. It rejects over-limit ranges instead of
+paginating the replay, because a paged backtest would lose the prior evaluation
+window and produce non-additive reports.
 
 Identity and session routing are always taken from `ToolContext`. Finance tool
 schemas do not accept `owner`, `user_id`, `session`, or `session_key` identity
@@ -418,7 +423,8 @@ returned by `finance_list_candle_streams` includes ready-to-call hints for
 `finance_query_candles`, plus `finance_evaluate_candle_signal` for checking the
 latest stored candle against the live anomaly evaluator and
 `finance_backtest_signal` for replaying the same stream through rara's built-in
-anomaly signal harness; range tools still require explicit `start`/`end`.
+anomaly signal harness and inspecting per-signal attribution; range tools still
+require explicit `start`/`end`.
 `finance_list_candle_streams`, `finance_get_recent_candles`, and
 `finance_query_candles` return `has_more` when additional rows match the
 selectors beyond the returned `query_limit`; narrow by `source_name`, `venue`,


### PR DESCRIPTION
## Summary
- add per-builtin-signal attribution alongside the existing composite anomaly backtest report
- expose attribution from finance_backtest_signal so agents can compare which built-in signals fired and how their forward returns behaved
- document the new attribution semantics and keep the existing composite report as the dispatch-equivalent metric

## Verification
- cargo +nightly fmt -p rara-trading -p rara-app
- cargo test -p rara-trading backtest::runner
- cargo test -p rara-trading backtest::tools
- cargo check -p rara-trading -p rara-app
- git diff --check
- cargo clippy -p rara-trading -p rara-app --all-targets --quiet -- --force-warn clippy::too_many_lines
- cargo test -p rara-trading
- pre-commit: cargo check / fmt / clippy / doc