### PR TITLE
feat(finance): expose candle signal trace

### DIFF
--- a/crates/extensions/rara-trading/AGENT.md
+++ b/crates/extensions/rara-trading/AGENT.md
@@ -59,8 +59,10 @@ Six modules, each a `mod.rs` (re-exports + `//!` docs only) over sub-files:
   `finance_evaluate_candle_signal` agent tool. It pulls either the latest
   stored closed candle or one requested `open_time`, fetches the rolling window
   with `end = Some(latest.open_time)`, delegates to `evaluate`, and returns the
-  resolved candle, window status, and structured signal trace. It is an
-  inspection surface for "does this stream currently have a rara signal?", not a
+  resolved candle, window status, composite anomaly signal, and the per-builtin
+  signal trace (`signal_name`, computed `value`, `fired`, and the fired
+  `reason_fragment`). It is an inspection surface for "does this stream
+  currently have a rara signal?" and "which builtin signals contributed?", not a
   strategy/deployment/order tool.
 
   `volatility_regime` and `directional_run` are **orthogonal** tail-risk
@@ -80,7 +82,9 @@ Six modules, each a `mod.rs` (re-exports + `//!` docs only) over sub-files:
   new signal contributes to the reason (via its `fragment`) and the fired-count.
   `builtin_registry()` order **is** the reason-fragment order (drawdown, return,
   volume, z-score, jump, volatility regime, directional run), so append new
-  signals and keep the existing order stable. `evaluate_with` is the test seam
+  signals and keep the existing order stable. `evaluate_trace` is the
+  agent-facing pure seam for composite + per-builtin trace over the builtin
+  registry; `evaluate_with` is the explicit-registry test seam
   (`registered_signal_participates_in_evaluation` injects an extra signal).
 
 - `backtest/` — signal-accuracy backtest harness (issue 2437), the first rung

--- a/crates/extensions/rara-trading/src/anomaly/evaluator.rs
+++ b/crates/extensions/rara-trading/src/anomaly/evaluator.rs
@@ -53,15 +53,30 @@ const CRITICAL_DRAWDOWN: f64 = 0.06;
 
 /// Agent/research-facing snapshot of one builtin signal's evaluation.
 ///
-/// This deliberately exposes only the stable data currently needed by
-/// Layer-② backtests: the signal name and fired flag, not the [`Signal`] trait
-/// object itself.
+/// This deliberately exposes stable evaluation data — not the [`Signal`] trait
+/// object itself — so tools can explain which builtin signals fired and
+/// backtests can attribute composite anomalies without coupling to the registry
+/// implementation.
 #[derive(Debug, Clone, PartialEq)]
 pub(crate) struct SignalEvaluation {
     /// Stable signal identifier from [`Signal::name`].
-    pub(crate) name:  &'static str,
+    pub(crate) name:            &'static str,
+    /// The signal's computed value, or `None` when not evaluable.
+    pub(crate) value:           Option<f64>,
     /// Whether this signal crossed its trip threshold.
-    pub(crate) fired: bool,
+    pub(crate) fired:           bool,
+    /// Human-readable fragment, present only when [`Self::fired`] is true.
+    pub(crate) reason_fragment: Option<String>,
+}
+
+/// Composite anomaly result plus the per-builtin-signal trace for the same
+/// evaluation pass.
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct EvaluationTrace {
+    /// The composite signal [`evaluate`] would return.
+    pub(crate) signal:  Option<AnomalySignal>,
+    /// Builtin signal evaluations in stable registry order.
+    pub(crate) signals: Vec<SignalEvaluation>,
 }
 
 /// Evaluate the newly closed `latest` candle against its preceding `window`
@@ -79,6 +94,26 @@ pub(crate) struct SignalEvaluation {
 /// or the latest candle is not strictly positive.
 pub fn evaluate(window: &[MarketCandle], latest: &MarketCandle) -> Result<Option<AnomalySignal>> {
     evaluate_with(&builtin_registry(), window, latest)
+}
+
+/// Evaluate `latest` once and return both the composite anomaly and the
+/// per-builtin signal trace.
+///
+/// # Errors
+///
+/// Returns [`super::AnomalyError::NonPositivePrice`] if any close in the window
+/// or the latest candle is not strictly positive.
+pub(crate) fn evaluate_trace(
+    window: &[MarketCandle],
+    latest: &MarketCandle,
+) -> Result<EvaluationTrace> {
+    let registry = builtin_registry();
+    let evaluated = evaluate_registry_outputs(&registry, window, latest)?;
+    let metrics = metrics_from(&evaluated);
+    Ok(EvaluationTrace {
+        signal:  classify(&evaluated, metrics),
+        signals: signal_evaluations_from(&evaluated),
+    })
 }
 
 /// Return the builtin signal names in stable registry order.
@@ -177,8 +212,10 @@ fn signal_evaluations_from(evaluated: &[(&dyn Signal, SignalOutput)]) -> Vec<Sig
     evaluated
         .iter()
         .map(|(signal, output)| SignalEvaluation {
-            name:  signal.name(),
-            fired: output.fired,
+            name:            signal.name(),
+            value:           output.value,
+            fired:           output.fired,
+            reason_fragment: output.fired.then(|| signal.fragment(output)),
         })
         .collect()
 }

--- a/crates/extensions/rara-trading/src/anomaly/mod.rs
+++ b/crates/extensions/rara-trading/src/anomaly/mod.rs
@@ -37,5 +37,7 @@ pub mod tools;
 
 pub use error::{AnomalyError, Result};
 pub use evaluator::{EVAL_WINDOW, evaluate};
-pub(crate) use evaluator::{builtin_signal_names, evaluate_builtin_signals};
+pub(crate) use evaluator::{
+    SignalEvaluation, builtin_signal_names, evaluate_builtin_signals, evaluate_trace,
+};
 pub use signal::{AnomalyMetrics, AnomalySignal, Severity};

--- a/crates/extensions/rara-trading/src/anomaly/tools.rs
+++ b/crates/extensions/rara-trading/src/anomaly/tools.rs
@@ -21,7 +21,7 @@ use rara_tool_macro::ToolDef;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
-use super::{AnomalyMetrics, AnomalySignal, EVAL_WINDOW, evaluate};
+use super::{AnomalyMetrics, AnomalySignal, EVAL_WINDOW, evaluate_trace};
 use crate::market_data::{
     CandleLatestQuery, CandleRangeQuery, CandleRecentQuery, MarketCandle, MarketDataRepositoryRef,
     Timeframe,
@@ -53,6 +53,7 @@ pub struct FinanceEvaluateCandleSignalResult {
     pub has_signal:          bool,
     pub status:              String,
     pub signal:              Option<FinanceEvaluatedAnomalySignal>,
+    pub signal_trace:        Vec<FinanceEvaluatedBuiltinSignal>,
     pub diagnostic_hint:     Option<FinanceEvaluateCandleSignalDiagnosticHint>,
 }
 
@@ -88,6 +89,14 @@ pub struct FinanceEvaluatedAnomalySignal {
     pub metrics:  FinanceEvaluatedAnomalyMetrics,
 }
 
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct FinanceEvaluatedBuiltinSignal {
+    pub signal_name:     String,
+    pub value:           Option<f64>,
+    pub fired:           bool,
+    pub reason_fragment: Option<String>,
+}
+
 #[derive(Debug, Clone, Copy, Serialize)]
 pub struct FinanceEvaluatedAnomalyMetrics {
     pub window_return:     f64,
@@ -113,8 +122,9 @@ pub struct FinanceEvaluateCandleSignalDiagnosticHint {
     name = "finance_evaluate_candle_signal",
     description = "Evaluate the latest or a specified stored closed OHLCV candle through rara's \
                    built-in market-anomaly signal evaluator. Use this after discovering a candle \
-                   stream when the user asks whether the current stream has an anomaly signal. \
-                   This is read-only and never places trades.",
+                   stream when the user asks whether the current stream has an anomaly signal or \
+                   which built-in signals contributed to it. This is read-only and never places \
+                   trades.",
     tier = "deferred",
     read_only,
     concurrency_safe
@@ -193,7 +203,13 @@ impl ToolExecute for FinanceEvaluateCandleSignalTool {
             })
             .await?;
         let window_candle_count = window.len();
-        let signal = evaluate(&window, &latest)?.map(FinanceEvaluatedAnomalySignal::from);
+        let evaluation = evaluate_trace(&window, &latest)?;
+        let signal_trace = evaluation
+            .signals
+            .into_iter()
+            .map(FinanceEvaluatedBuiltinSignal::from)
+            .collect();
+        let signal = evaluation.signal.map(FinanceEvaluatedAnomalySignal::from);
         let has_signal = signal.is_some();
         let status = if has_signal {
             "signal"
@@ -224,6 +240,7 @@ impl ToolExecute for FinanceEvaluateCandleSignalTool {
             has_signal,
             status: status.to_owned(),
             signal,
+            signal_trace,
             diagnostic_hint: None,
         })
     }
@@ -293,6 +310,7 @@ fn missing_result(
         has_signal: false,
         status: "missing".to_owned(),
         signal: None,
+        signal_trace: Vec::new(),
         diagnostic_hint: source_scoped_missing_candle_diagnostic_hint(source_name.as_deref()),
     }
 }
@@ -361,6 +379,17 @@ impl From<AnomalySignal> for FinanceEvaluatedAnomalySignal {
             severity: signal.severity.label().to_owned(),
             reason:   signal.reason,
             metrics:  FinanceEvaluatedAnomalyMetrics::from(signal.metrics),
+        }
+    }
+}
+
+impl From<super::SignalEvaluation> for FinanceEvaluatedBuiltinSignal {
+    fn from(signal: super::SignalEvaluation) -> Self {
+        Self {
+            signal_name:     signal.name.to_owned(),
+            value:           signal.value,
+            fired:           signal.fired,
+            reason_fragment: signal.reason_fragment,
         }
     }
 }
@@ -545,6 +574,41 @@ mod tests {
         );
         assert_eq!(signal.metrics.directional_run, Some(6.0));
         assert_eq!(
+            result
+                .signal_trace
+                .iter()
+                .map(|signal| signal.signal_name.as_str())
+                .collect::<Vec<_>>(),
+            [
+                "max_drawdown",
+                "window_return",
+                "volume_surge",
+                "robust_zscore",
+                "jump_ratio",
+                "volatility_regime",
+                "directional_run",
+            ]
+        );
+        let directional_run = result
+            .signal_trace
+            .iter()
+            .find(|signal| signal.signal_name == "directional_run")
+            .expect("directional-run trace row");
+        assert_eq!(directional_run.value, Some(6.0));
+        assert!(directional_run.fired);
+        assert_eq!(
+            directional_run.reason_fragment.as_deref(),
+            Some("directional run +6 bars")
+        );
+        let max_drawdown = result
+            .signal_trace
+            .iter()
+            .find(|signal| signal.signal_name == "max_drawdown")
+            .expect("drawdown trace row");
+        assert_eq!(max_drawdown.value, Some(0.0));
+        assert!(!max_drawdown.fired);
+        assert!(max_drawdown.reason_fragment.is_none());
+        assert_eq!(
             result.evaluated_candle.expect("evaluated candle").open_time,
             "2026-07-10T00:06:00Z"
         );
@@ -572,6 +636,8 @@ mod tests {
         assert_eq!(result.status, "normal");
         assert!(!result.has_signal);
         assert!(result.signal.is_none());
+        assert_eq!(result.signal_trace.len(), 7);
+        assert!(result.signal_trace.iter().all(|signal| !signal.fired));
         assert_eq!(result.window_candle_count, 1);
         assert_eq!(
             result.evaluated_candle.expect("evaluated candle").open_time,
@@ -592,6 +658,7 @@ mod tests {
         assert_eq!(result.window_status, "missing");
         assert!(!result.has_signal);
         assert!(result.evaluated_candle.is_none());
+        assert!(result.signal_trace.is_empty());
         let hint = result.diagnostic_hint.expect("diagnostic hint");
         assert_eq!(hint.tool, "finance_diagnose_candle_subscriptions");
         assert_eq!(

--- a/docs/guides/finance-subscriptions.md
+++ b/docs/guides/finance-subscriptions.md
@@ -311,8 +311,12 @@ stream, or one explicit `open_time`, through rara's built-in market-anomaly
 evaluator. The evaluation window is pulled strictly before the evaluated
 candle, matching the dispatch path and avoiding look-ahead. The result reports
 the evaluated candle, window size/status, whether a signal fired, and the same
-severity/reason/metrics shape used by proactive candle directives. It is
-read-only and never places trades or gives trade advice.
+severity/reason/metrics shape used by proactive candle directives. It also
+returns `signal_trace`, one row per builtin signal in registry order, with the
+signal name, computed value when evaluable, fired flag, and reason fragment when
+that signal fired. Use this trace when rara needs to explain which detector
+contributed to the current composite anomaly. It is read-only and never places
+trades or gives trade advice.
 `finance_backtest_signal` uses the same range semantics over one stored stream,
 replays rara's built-in market-anomaly evaluator, and returns the fixed
 signal-accuracy report plus `signal_attribution`, a per-builtin-signal breakdown


### PR DESCRIPTION
## Summary
- add a pure evaluator trace seam that returns the composite anomaly plus per-builtin signal evaluations from one pass
- expose signal_trace from finance_evaluate_candle_signal with signal name, computed value, fired flag, and fired reason fragment
- document the trace semantics so rara can explain which detector contributed to a current candle anomaly

## Verification
- cargo +nightly fmt -p rara-trading -p rara-app
- cargo test -p rara-trading anomaly::tools
- git diff --check
- cargo check -p rara-trading -p rara-app
- cargo test -p rara-trading
- cargo clippy -p rara-trading -p rara-app --all-targets --quiet -- --force-warn clippy::too_many_lines
- pre-commit: cargo check / fmt / clippy / doc