### PR TITLE
fix(finance): guard unsafe candle watchlists

### DIFF
--- a/crates/app/src/tools/finance_feed.rs
+++ b/crates/app/src/tools/finance_feed.rs
@@ -1178,14 +1178,7 @@ impl ToolExecute for FinancePlanInstrumentWatchlistTool {
         let budget = params
             .max_requests_per_second
             .unwrap_or(DEFAULT_MARKET_CANDLE_REQUEST_BUDGET_PER_SECOND);
-        anyhow::ensure!(
-            budget.is_finite() && budget > 0.0,
-            "max_requests_per_second must be positive"
-        );
-        anyhow::ensure!(
-            budget <= MAX_MARKET_CANDLE_REQUEST_BUDGET_PER_SECOND,
-            "max_requests_per_second must be <= {MAX_MARKET_CANDLE_REQUEST_BUDGET_PER_SECOND}"
-        );
+        validate_market_candle_request_budget(budget)?;
 
         let transport = source.transport.as_ref().ok_or_else(|| {
             anyhow::anyhow!("finance feed source {catalog_source_id} has no transport template")
@@ -1197,28 +1190,13 @@ impl ToolExecute for FinancePlanInstrumentWatchlistTool {
             .ok_or_else(|| {
                 anyhow::anyhow!("market candle source {catalog_source_id} has no venue")
             })?;
-        let configured_interval_secs = transport
-            .get("interval_secs")
-            .and_then(serde_json::Value::as_u64)
-            .ok_or_else(|| {
-                anyhow::anyhow!("market candle source {catalog_source_id} has no interval_secs")
-            })?;
-        anyhow::ensure!(
-            configured_interval_secs > 0,
-            "market candle source {catalog_source_id} has invalid interval_secs"
-        );
-
-        let stream_count = symbols.len().saturating_mul(timeframes.len());
-        let poll_request_count = if source.provider.as_deref() == Some("binance") {
-            stream_count
-        } else {
-            1
-        };
-        let estimated_requests_per_second =
-            poll_request_count as f64 / configured_interval_secs as f64;
-        let minimum_safe_interval_secs =
-            MIN_MARKET_CANDLE_INTERVAL_SECS.max((poll_request_count as f64 / budget).ceil() as u64);
-        let safe_to_start = configured_interval_secs >= minimum_safe_interval_secs;
+        let safety = market_candle_fanout_safety(
+            source.provider.as_deref(),
+            transport,
+            &symbols,
+            &timeframes,
+            budget,
+        )?;
 
         Ok(FinancePlanInstrumentWatchlistResult {
             catalog_source_id: catalog_source_id.clone(),
@@ -1227,18 +1205,18 @@ impl ToolExecute for FinancePlanInstrumentWatchlistTool {
             venue: venue.clone(),
             symbols: symbols.clone(),
             timeframes: timeframes.clone(),
-            stream_count,
-            poll_request_count,
-            configured_interval_secs,
-            estimated_requests_per_second,
-            request_budget_per_second: budget,
-            minimum_safe_interval_secs,
-            safe_to_start,
+            stream_count: safety.stream_count,
+            poll_request_count: safety.poll_request_count,
+            configured_interval_secs: safety.configured_interval_secs,
+            estimated_requests_per_second: safety.estimated_requests_per_second,
+            request_budget_per_second: safety.request_budget_per_second,
+            minimum_safe_interval_secs: safety.minimum_safe_interval_secs,
+            safe_to_start: safety.safe_to_start,
             warning: watchlist_plan_warning(
-                safe_to_start,
-                poll_request_count,
-                configured_interval_secs,
-                minimum_safe_interval_secs,
+                safety.safe_to_start,
+                safety.poll_request_count,
+                safety.configured_interval_secs,
+                safety.minimum_safe_interval_secs,
             ),
             subscribe_hint: FinanceInstrumentWatchlistSubscribeHint {
                 tool:            "finance_subscribe_instruments".to_owned(),
@@ -1247,7 +1225,7 @@ impl ToolExecute for FinancePlanInstrumentWatchlistTool {
                     "venue": venue,
                     "symbols": symbols,
                     "timeframes": timeframes,
-                    "start_now": safe_to_start,
+                    "start_now": safety.safe_to_start,
                 }),
                 required_params: Vec::new(),
                 optional_params: [
@@ -1260,21 +1238,23 @@ impl ToolExecute for FinancePlanInstrumentWatchlistTool {
                 .map(str::to_owned)
                 .collect(),
             },
-            configure_hint: (!safe_to_start).then(|| FinanceInstrumentWatchlistConfigureHint {
-                action:          "open_settings".to_owned(),
-                section:         "data-feeds".to_owned(),
-                default_params:  serde_json::json!({
-                    "catalog_source_id": catalog_source_id,
-                    "dataFeedCatalogId": catalog_source_id,
-                    "transport": {
-                        "interval_secs": minimum_safe_interval_secs,
-                    },
-                }),
-                required_params: Vec::new(),
-                optional_params: ["transport.interval_secs"]
-                    .into_iter()
-                    .map(str::to_owned)
-                    .collect(),
+            configure_hint: (!safety.safe_to_start).then(|| {
+                FinanceInstrumentWatchlistConfigureHint {
+                    action:          "open_settings".to_owned(),
+                    section:         "data-feeds".to_owned(),
+                    default_params:  serde_json::json!({
+                        "catalog_source_id": catalog_source_id,
+                        "dataFeedCatalogId": catalog_source_id,
+                        "transport": {
+                            "interval_secs": safety.minimum_safe_interval_secs,
+                        },
+                    }),
+                    required_params: Vec::new(),
+                    optional_params: ["transport.interval_secs"]
+                        .into_iter()
+                        .map(str::to_owned)
+                        .collect(),
+                }
             }),
         })
     }
@@ -2573,16 +2553,14 @@ impl ToolExecute for FinanceSubscribeInstrumentsTool {
             &timeframes,
             replace_existing_instruments,
         )?;
-        config.enabled = true;
-        config.status = FeedStatus::Idle;
-        config.last_error = None;
-        config.updated_at = Timestamp::now();
+        let disabled_for_fanout_safety = apply_market_candle_fanout_guard(&mut config, start_now)?;
 
         let feed_updated = if created {
             self.data_feed_svc.create_feed(&config).await?;
             self.data_feed_registry.register(config.clone())?;
             true
-        } else if normalized_transport_changed || transport_changed || !was_enabled {
+        } else if normalized_transport_changed || transport_changed || config.enabled != was_enabled
+        {
             anyhow::ensure!(
                 self.data_feed_svc.update_feed(&config).await?,
                 "failed to update market candle feed source: {}",
@@ -2601,7 +2579,14 @@ impl ToolExecute for FinanceSubscribeInstrumentsTool {
             false
         };
 
-        let feed_restarted = start_now && (created || transport_changed || !was_running);
+        if disabled_for_fanout_safety && was_running {
+            self.data_feed_registry.remove(&config.name)?;
+            self.data_feed_registry.register(config.clone())?;
+        }
+
+        let feed_restarted = !disabled_for_fanout_safety
+            && start_now
+            && (created || transport_changed || !was_running);
         if feed_restarted {
             if self.data_feed_registry.get(&config.name).is_none() {
                 self.data_feed_registry.register(config.clone())?;
@@ -3203,6 +3188,103 @@ fn normalize_watchlist_timeframes(
         }
     }
     Ok(out)
+}
+
+#[derive(Debug, Clone)]
+struct MarketCandleFanoutSafety {
+    stream_count:                  usize,
+    poll_request_count:            usize,
+    configured_interval_secs:      u64,
+    estimated_requests_per_second: f64,
+    request_budget_per_second:     f64,
+    minimum_safe_interval_secs:    u64,
+    safe_to_start:                 bool,
+}
+
+fn validate_market_candle_request_budget(budget: f64) -> anyhow::Result<()> {
+    anyhow::ensure!(
+        budget.is_finite() && budget > 0.0,
+        "max_requests_per_second must be positive"
+    );
+    anyhow::ensure!(
+        budget <= MAX_MARKET_CANDLE_REQUEST_BUDGET_PER_SECOND,
+        "max_requests_per_second must be <= {MAX_MARKET_CANDLE_REQUEST_BUDGET_PER_SECOND}"
+    );
+    Ok(())
+}
+
+fn market_candle_fanout_safety(
+    provider: Option<&str>,
+    transport: &serde_json::Value,
+    symbols: &[String],
+    timeframes: &[String],
+    request_budget_per_second: f64,
+) -> anyhow::Result<MarketCandleFanoutSafety> {
+    validate_market_candle_request_budget(request_budget_per_second)?;
+    let configured_interval_secs = transport
+        .get("interval_secs")
+        .and_then(serde_json::Value::as_u64)
+        .ok_or_else(|| anyhow::anyhow!("market candle source has no interval_secs"))?;
+    anyhow::ensure!(
+        configured_interval_secs > 0,
+        "market candle source has invalid interval_secs"
+    );
+
+    let stream_count = symbols.len().saturating_mul(timeframes.len());
+    let poll_request_count = if provider == Some("binance") {
+        stream_count
+    } else {
+        1
+    };
+    let estimated_requests_per_second = poll_request_count as f64 / configured_interval_secs as f64;
+    let minimum_safe_interval_secs = MIN_MARKET_CANDLE_INTERVAL_SECS
+        .max((poll_request_count as f64 / request_budget_per_second).ceil() as u64);
+
+    Ok(MarketCandleFanoutSafety {
+        stream_count,
+        poll_request_count,
+        configured_interval_secs,
+        estimated_requests_per_second,
+        request_budget_per_second,
+        minimum_safe_interval_secs,
+        safe_to_start: configured_interval_secs >= minimum_safe_interval_secs,
+    })
+}
+
+fn apply_market_candle_fanout_guard(
+    config: &mut DataFeedConfig,
+    start_now: bool,
+) -> anyhow::Result<bool> {
+    let final_symbols = extract_normalized_string_array(&config.transport, "symbols", true);
+    let final_timeframes = extract_normalized_string_array(&config.transport, "timeframes", false);
+    let provider = config
+        .transport
+        .get("provider")
+        .and_then(serde_json::Value::as_str);
+    let safety = market_candle_fanout_safety(
+        provider,
+        &config.transport,
+        &final_symbols,
+        &final_timeframes,
+        DEFAULT_MARKET_CANDLE_REQUEST_BUDGET_PER_SECOND,
+    )?;
+    anyhow::ensure!(
+        safety.safe_to_start || !start_now,
+        "market candle watchlist fans out to {} requests per poll at interval_secs={}; configured \
+         interval is unsafe for the default request budget. Increase interval_secs to at least {} \
+         or call finance_plan_instrument_watchlist and retry with start_now=false after reviewing \
+         the plan.",
+        safety.poll_request_count,
+        safety.configured_interval_secs,
+        safety.minimum_safe_interval_secs
+    );
+
+    let disabled_for_fanout_safety = !safety.safe_to_start;
+    config.enabled = !disabled_for_fanout_safety;
+    config.status = FeedStatus::Idle;
+    config.last_error = None;
+    config.updated_at = Timestamp::now();
+    Ok(disabled_for_fanout_safety)
 }
 
 fn watchlist_plan_warning(
@@ -4723,7 +4805,7 @@ mod tests {
         FinanceSubscribeFeedBundleParams, FinanceSubscribeFeedBundleTool,
         FinanceSubscribeInstrumentsParams, FinanceSubscribeInstrumentsResult,
         FinanceSubscribeInstrumentsTool, FinanceSubscribeNewsParams, FinanceSubscribeNewsResult,
-        FinanceSubscribeNewsTool, FinanceUnsubscribeParams, FinanceUnsubscribeTool,
+        FinanceSubscribeNewsTool, FinanceUnsubscribeParams, FinanceUnsubscribeTool, MAX_SYMBOLS,
     };
 
     fn context() -> ToolContext {
@@ -5712,6 +5794,12 @@ mod tests {
             "timeframe": "1m",
             "limit": 20,
         })
+    }
+
+    fn large_binance_symbols() -> Vec<String> {
+        (0..MAX_SYMBOLS)
+            .map(|idx| format!("ALT{idx}USDT"))
+            .collect()
     }
 
     fn finance_subscription(
@@ -7898,6 +7986,148 @@ mod tests {
             .unwrap();
         assert_eq!(listed.count, 1);
         assert_single_stream_subscription_entry_hints(&listed.subscriptions[0]);
+    }
+
+    #[tokio::test]
+    async fn subscribe_instruments_rejects_unsafe_fanout_when_starting_now() {
+        let (_list, _enable, _disable, _restart, tool, _svc, _registry, _finance_registry) =
+            tool().await;
+
+        let err = tool
+            .run(
+                FinanceSubscribeInstrumentsParams {
+                    catalog_source_id:      Some("binance-market-candles".to_owned()),
+                    feed_id:                None,
+                    venue:                  None,
+                    symbols:                large_binance_symbols(),
+                    timeframes:             vec!["1m".to_owned(), "5m".to_owned()],
+                    start_now:              Some(true),
+                    delivery:               None,
+                    cooldown_secs:          None,
+                    max_immediate_per_hour: None,
+                },
+                &context(),
+            )
+            .await
+            .expect_err("unsafe fanout should require interval review");
+
+        assert!(
+            err.to_string()
+                .contains("fans out to 1000 requests per poll"),
+            "unexpected error: {err}"
+        );
+        assert!(
+            err.to_string().contains("at least 100"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn subscribe_instruments_persists_unsafe_fanout_disabled_when_not_starting() {
+        let (_list, _enable, _disable, _restart, tool, svc, registry, finance_registry) =
+            tool().await;
+        let ctx = context();
+
+        let result = tool
+            .run(
+                FinanceSubscribeInstrumentsParams {
+                    catalog_source_id:      Some("binance-market-candles".to_owned()),
+                    feed_id:                None,
+                    venue:                  None,
+                    symbols:                large_binance_symbols(),
+                    timeframes:             vec!["1m".to_owned(), "5m".to_owned()],
+                    start_now:              Some(false),
+                    delivery:               None,
+                    cooldown_secs:          None,
+                    max_immediate_per_hour: None,
+                },
+                &ctx,
+            )
+            .await
+            .expect("unsafe fanout can be staged disabled");
+
+        assert_eq!(result.feed_change, FeedChange::Created);
+        assert!(!result.feed_restarted);
+        assert!(!result.running);
+
+        let feeds = svc.list_feeds().await.unwrap();
+        assert_eq!(feeds.len(), 1);
+        assert!(!feeds[0].enabled);
+        assert_eq!(
+            feeds[0].transport["timeframes"],
+            serde_json::json!(["1m", "5m"])
+        );
+        assert_eq!(
+            feeds[0].transport["symbols"]
+                .as_array()
+                .expect("symbols should be an array")
+                .len(),
+            500
+        );
+        assert!(!registry.is_running("finance-binance-market-candles"));
+
+        let subs = finance_registry
+            .list_for_owner(&rara_kernel::identity::UserId(ctx.user_id))
+            .await;
+        assert_eq!(subs.len(), 1);
+        assert_eq!(subs[0].event_kinds, [FinanceEventKind::MarketCandleClosed]);
+        assert_eq!(subs[0].source_names, ["finance-binance-market-candles"]);
+        assert_eq!(subs[0].symbols.len(), 500);
+        assert_eq!(subs[0].timeframes, ["1m", "5m"]);
+    }
+
+    #[tokio::test]
+    async fn subscribe_instruments_cancels_running_feed_when_staging_unsafe_fanout() {
+        let (_list, _enable, _disable, _restart, tool, svc, registry, _finance_registry) =
+            tool().await;
+        let ctx = context();
+        let large_symbols = large_binance_symbols();
+
+        let first = tool
+            .run(
+                FinanceSubscribeInstrumentsParams {
+                    catalog_source_id:      Some("binance-market-candles".to_owned()),
+                    feed_id:                None,
+                    venue:                  None,
+                    symbols:                vec![large_symbols[0].clone()],
+                    timeframes:             vec!["1m".to_owned()],
+                    start_now:              Some(false),
+                    delivery:               None,
+                    cooldown_secs:          None,
+                    max_immediate_per_hour: None,
+                },
+                &ctx,
+            )
+            .await
+            .expect("initial safe subscribe");
+        let token = tokio_util::sync::CancellationToken::new();
+        let token_clone = token.clone();
+        registry.set_running(first.source_name.clone(), token);
+
+        let staged = tool
+            .run(
+                FinanceSubscribeInstrumentsParams {
+                    catalog_source_id:      Some("binance-market-candles".to_owned()),
+                    feed_id:                None,
+                    venue:                  None,
+                    symbols:                large_symbols,
+                    timeframes:             vec!["1m".to_owned(), "5m".to_owned()],
+                    start_now:              Some(false),
+                    delivery:               None,
+                    cooldown_secs:          None,
+                    max_immediate_per_hour: None,
+                },
+                &ctx,
+            )
+            .await
+            .expect("unsafe fanout can be staged disabled");
+
+        assert_eq!(staged.feed_change, FeedChange::Updated);
+        assert!(!staged.feed_restarted);
+        assert!(token_clone.is_cancelled());
+        assert!(!registry.is_running(&first.source_name));
+        assert!(!registry.get(&first.source_name).unwrap().enabled);
+        assert!(!svc.get_feed(&first.feed_id).await.unwrap().unwrap().enabled);
     }
 
     #[tokio::test]

--- a/crates/extensions/rara-trading/AGENT.md
+++ b/crates/extensions/rara-trading/AGENT.md
@@ -146,6 +146,12 @@ dispatch loop (`crates/app/src/lib.rs`).
 - **Candle selectors are normalized before storage** (venue lowercase, symbol
   uppercase, timeframe canonical). `recent_candles`/`latest_closed_candle`
   match on the normalized form.
+- **Binance watchlist fan-out is guarded before starting a feed.** The app-side
+  `finance_subscribe_instruments` path computes the final configured
+  `symbols × timeframes` request count and rejects unsafe `start_now=true`
+  subscriptions. Unsafe staged subscriptions keep the feed disabled until an
+  operator raises `transport.interval_secs`; do not silently persist an enabled
+  poller that will hit provider rate limits on app restart.
 - **`backtest` has no look-ahead** — the number-one backtest bug. Signal
   evaluation for bar `i` sees only `candles[i.saturating_sub(EVAL_WINDOW)..i]`
   plus `latest = candles[i]`, never a bar `> i` (the same invariant `dispatch`

--- a/docs/guides/finance-subscriptions.md
+++ b/docs/guides/finance-subscriptions.md
@@ -227,9 +227,13 @@ source's `interval_secs` against a conservative request-rate budget, and returns
 safe `finance_subscribe_instruments` parameters. If the configured polling
 interval is too aggressive for the watchlist size, the subscribe hint sets
 `start_now=false` and the result includes a Settings → Data Feeds configure hint
-for raising `transport.interval_secs` before the feed is started. This is the
-preferred path when tracking tens or hundreds of instruments because Binance
-polling fans out as `symbols × timeframes` requests per poll.
+for raising `transport.interval_secs` before the feed is started. The mutating
+subscription tool enforces the same guard: an unsafe watchlist with
+`start_now=true` is rejected, while `start_now=false` stages the requested
+selection and subscription with the feed persisted as disabled so app restart
+does not accidentally start an unsafe poller. This is the preferred path when
+tracking tens or hundreds of instruments because Binance polling fans out as
+`symbols × timeframes` requests per poll.
 
 The lower-level `finance_subscribe` tool remains available for callers that
 already know the exact selectors. Its result echoes the persisted normalized


### PR DESCRIPTION
## Summary
- reuse watchlist fan-out planning logic in the mutating instrument subscription path
- reject unsafe Binance candle watchlists when start_now=true
- persist unsafe staged watchlists as disabled and cancel any running runtime so app restart cannot accidentally start an unsafe poller
- document the guard and trading-agent invariant

## Verification
- cargo +nightly fmt -p rara-app -p rara-trading
- cargo check -p rara-app -p rara-trading
- cargo test -p rara-app unsafe_fanout -- --nocapture
- cargo test -p rara-app finance_feed -- --nocapture
- cargo clippy -p rara-app -p rara-trading --all-targets --quiet -- --force-warn clippy::too_many_lines
- scripts/lint-ratchet.sh
- git diff --check
- cargo test -p rara-trading (includes Timescale testcontainer)
