### PR TITLE
fix(finance): suppress unsafe feed diagnostics actions

### DIFF
--- a/crates/app/src/tools/finance_candle_fanout.rs
+++ b/crates/app/src/tools/finance_candle_fanout.rs
@@ -1,0 +1,137 @@
+// Copyright 2026 Rararulab
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use rara_kernel::data_feed::{DataFeedConfig, FeedType};
+
+pub(super) const DEFAULT_MARKET_CANDLE_REQUEST_BUDGET_PER_SECOND: f64 = 10.0;
+const MAX_MARKET_CANDLE_REQUEST_BUDGET_PER_SECOND: f64 = 100.0;
+const MIN_MARKET_CANDLE_INTERVAL_SECS: u64 = 5;
+
+#[derive(Debug, Clone)]
+pub(super) struct MarketCandleFanoutSafety {
+    pub(super) stream_count:                  usize,
+    pub(super) poll_request_count:            usize,
+    pub(super) configured_interval_secs:      u64,
+    pub(super) estimated_requests_per_second: f64,
+    pub(super) request_budget_per_second:     f64,
+    pub(super) minimum_safe_interval_secs:    u64,
+    pub(super) safe_to_start:                 bool,
+}
+
+pub(super) fn validate_market_candle_request_budget(budget: f64) -> anyhow::Result<()> {
+    anyhow::ensure!(
+        budget.is_finite() && budget > 0.0,
+        "max_requests_per_second must be positive"
+    );
+    anyhow::ensure!(
+        budget <= MAX_MARKET_CANDLE_REQUEST_BUDGET_PER_SECOND,
+        "max_requests_per_second must be <= {MAX_MARKET_CANDLE_REQUEST_BUDGET_PER_SECOND}"
+    );
+    Ok(())
+}
+
+pub(super) fn market_candle_fanout_safety(
+    provider: Option<&str>,
+    transport: &serde_json::Value,
+    symbols: &[String],
+    timeframes: &[String],
+    request_budget_per_second: f64,
+) -> anyhow::Result<MarketCandleFanoutSafety> {
+    validate_market_candle_request_budget(request_budget_per_second)?;
+    let configured_interval_secs = transport
+        .get("interval_secs")
+        .and_then(serde_json::Value::as_u64)
+        .ok_or_else(|| anyhow::anyhow!("market candle source has no interval_secs"))?;
+    anyhow::ensure!(
+        configured_interval_secs > 0,
+        "market candle source has invalid interval_secs"
+    );
+
+    let stream_count = symbols.len().saturating_mul(timeframes.len());
+    let poll_request_count = if provider == Some("binance") {
+        stream_count
+    } else {
+        1
+    };
+    let estimated_requests_per_second = poll_request_count as f64 / configured_interval_secs as f64;
+    let minimum_safe_interval_secs = MIN_MARKET_CANDLE_INTERVAL_SECS
+        .max((poll_request_count as f64 / request_budget_per_second).ceil() as u64);
+
+    Ok(MarketCandleFanoutSafety {
+        stream_count,
+        poll_request_count,
+        configured_interval_secs,
+        estimated_requests_per_second,
+        request_budget_per_second,
+        minimum_safe_interval_secs,
+        safe_to_start: configured_interval_secs >= minimum_safe_interval_secs,
+    })
+}
+
+pub(super) fn market_candle_config_fanout_safety(
+    config: &DataFeedConfig,
+) -> anyhow::Result<MarketCandleFanoutSafety> {
+    anyhow::ensure!(
+        config.feed_type == FeedType::MarketCandle,
+        "feed type {} is not market_candle",
+        config.feed_type
+    );
+    let final_symbols = transport_string_array(&config.transport, "symbols", true);
+    let final_timeframes = transport_string_array(&config.transport, "timeframes", false);
+    let provider = config
+        .transport
+        .get("provider")
+        .and_then(serde_json::Value::as_str);
+    market_candle_fanout_safety(
+        provider,
+        &config.transport,
+        &final_symbols,
+        &final_timeframes,
+        DEFAULT_MARKET_CANDLE_REQUEST_BUDGET_PER_SECOND,
+    )
+}
+
+pub(super) fn unsafe_market_candle_fanout_message(safety: &MarketCandleFanoutSafety) -> String {
+    format!(
+        "market candle watchlist fans out to {} requests per poll at interval_secs={}; configured \
+         interval is unsafe for the default request budget. Increase interval_secs to at least {} \
+         or call finance_plan_instrument_watchlist and retry after reviewing the plan.",
+        safety.poll_request_count,
+        safety.configured_interval_secs,
+        safety.minimum_safe_interval_secs
+    )
+}
+
+fn transport_string_array(
+    transport: &serde_json::Value,
+    key: &str,
+    uppercase: bool,
+) -> Vec<String> {
+    transport
+        .get(key)
+        .and_then(serde_json::Value::as_array)
+        .into_iter()
+        .flatten()
+        .filter_map(serde_json::Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(|value| {
+            if uppercase {
+                value.to_ascii_uppercase()
+            } else {
+                value.to_ascii_lowercase()
+            }
+        })
+        .collect()
+}

--- a/crates/app/src/tools/finance_diagnostics.rs
+++ b/crates/app/src/tools/finance_diagnostics.rs
@@ -35,6 +35,10 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
+use super::finance_candle_fanout::{
+    market_candle_config_fanout_safety, unsafe_market_candle_fanout_message,
+};
+
 const MAX_STALE_AFTER_SECS: u64 = 31_536_000;
 const MAX_DIAGNOSTIC_SOURCE_REFS: usize = 32;
 const MAX_DIAGNOSTIC_SOURCE_REF_LEN: usize = 128;
@@ -129,6 +133,8 @@ pub(super) struct FeedSourceDiagnostic {
     pub configured_timeframes: Vec<String>,
     pub selector_coverage:     FeedSelectorCoverage,
     pub selector_diagnostic:   Option<String>,
+    pub fanout_safe_to_start:  Option<bool>,
+    pub fanout_diagnostic:     Option<String>,
     pub enabled:               Option<bool>,
     pub configured_status:     Option<String>,
     pub runtime_state:         FeedRuntimeState,
@@ -457,6 +463,7 @@ impl FinanceDiagnoseCandleSubscriptionsTool {
                     &configured_timeframes,
                     subscription,
                 );
+                let (fanout_safe_to_start, fanout_diagnostic) = market_candle_start_safety(feed);
                 FeedSourceDiagnostic {
                     source_name: source_name.clone(),
                     catalog_source_id: catalog_source.map(|source| source.id.clone()),
@@ -469,6 +476,8 @@ impl FinanceDiagnoseCandleSubscriptionsTool {
                     configured_timeframes,
                     selector_coverage,
                     selector_diagnostic,
+                    fanout_safe_to_start,
+                    fanout_diagnostic,
                     enabled: feed.map(|feed| feed.enabled),
                     configured_status: feed.map(|feed| feed.status.to_string()),
                     runtime_state: runtime_state(
@@ -589,6 +598,23 @@ fn runtime_state(feed: Option<&DataFeedConfig>, running: bool) -> FeedRuntimeSta
         (Some(feed), _) if !feed.enabled => FeedRuntimeState::Disabled,
         (Some(_), true) => FeedRuntimeState::Running,
         (Some(_), false) => FeedRuntimeState::Stopped,
+    }
+}
+
+fn market_candle_start_safety(feed: Option<&DataFeedConfig>) -> (Option<bool>, Option<String>) {
+    let Some(feed) = feed else {
+        return (None, None);
+    };
+    if feed.feed_type != FeedType::MarketCandle {
+        return (None, None);
+    }
+
+    match market_candle_config_fanout_safety(feed) {
+        Ok(safety) => (
+            Some(safety.safe_to_start),
+            (!safety.safe_to_start).then(|| unsafe_market_candle_fanout_message(&safety)),
+        ),
+        Err(err) => (Some(false), Some(err.to_string())),
     }
 }
 
@@ -1130,6 +1156,10 @@ fn subscribe_instruments_hint(
 }
 
 fn enable_feed_source_hint(feed: &FeedSourceDiagnostic) -> Option<FinanceDiagnosticNextActionHint> {
+    if feed.fanout_safe_to_start == Some(false) {
+        return None;
+    }
+
     let catalog_source_id = feed.catalog_source_id.as_ref()?;
     Some(FinanceDiagnosticNextActionHint {
         tool:            "finance_enable_feed_source".to_owned(),
@@ -1145,6 +1175,10 @@ fn enable_feed_source_hint(feed: &FeedSourceDiagnostic) -> Option<FinanceDiagnos
 fn restart_feed_source_hint(
     feed: &FeedSourceDiagnostic,
 ) -> Option<FinanceDiagnosticNextActionHint> {
+    if feed.fanout_safe_to_start == Some(false) {
+        return None;
+    }
+
     if let Some(catalog_source_id) = &feed.catalog_source_id {
         return Some(FinanceDiagnosticNextActionHint {
             tool:            "finance_restart_feed_source".to_owned(),
@@ -1375,6 +1409,12 @@ mod tests {
             .created_at(now)
             .updated_at(now)
             .build()
+    }
+
+    fn large_binance_symbols() -> Vec<String> {
+        std::iter::once("BTCUSDT".to_owned())
+            .chain((1..500).map(|index| format!("ASSET{index:03}USDT")))
+            .collect()
     }
 
     async fn fixture() -> (
@@ -1810,6 +1850,55 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn diagnose_suppresses_restart_hint_when_stopped_feed_fanout_is_unsafe() {
+        let (tool, finance_registry, _data_feed_registry, _market_repo, _feed_store, ctx) =
+            fixture().await;
+        insert_subscription(&finance_registry, &ctx).await;
+        let mut unsafe_feed = feed_config();
+        unsafe_feed.transport["symbols"] = serde_json::json!(large_binance_symbols());
+        unsafe_feed.transport["timeframes"] = serde_json::json!(["1m", "5m"]);
+        unsafe_feed.updated_at = ts("2026-07-10T08:31:00Z");
+        assert!(
+            tool.data_feed_svc
+                .update_feed(&unsafe_feed)
+                .await
+                .expect("unsafe feed update should succeed")
+        );
+
+        let result = tool
+            .run(
+                FinanceDiagnoseCandleSubscriptionsParams {
+                    subscription_id:    None,
+                    catalog_source_ids: Vec::new(),
+                    source_names:       Vec::new(),
+                    feed_ids:           Vec::new(),
+                    as_of:              Some("2026-07-10T08:31:00Z".to_owned()),
+                    stale_after_secs:   None,
+                },
+                &ctx,
+            )
+            .await
+            .unwrap();
+
+        let sub = &result.subscriptions[0];
+        assert_eq!(sub.status, SubscriptionHealth::NeedsRuntime);
+        assert_eq!(sub.feed_sources[0].runtime_state, FeedRuntimeState::Stopped);
+        assert_eq!(sub.feed_sources[0].fanout_safe_to_start, Some(false));
+        assert!(
+            sub.feed_sources[0]
+                .fanout_diagnostic
+                .as_deref()
+                .is_some_and(|diagnostic| diagnostic.contains("at least 100")),
+            "unexpected fanout diagnostic: {:?}",
+            sub.feed_sources[0].fanout_diagnostic
+        );
+        assert!(
+            sub.next_action_hint.is_none(),
+            "unsafe stopped feed should not expose a restart hint that will be rejected"
+        );
+    }
+
+    #[tokio::test]
     async fn diagnose_reports_missing_data_when_feed_is_running_without_candles() {
         let (tool, finance_registry, data_feed_registry, _market_repo, _feed_store, ctx) =
             fixture().await;
@@ -2040,6 +2129,60 @@ mod tests {
         );
         assert_eq!(next_action.required_params, Vec::<String>::new());
         assert_eq!(next_action.optional_params, ["start_now".to_owned()]);
+    }
+
+    #[tokio::test]
+    async fn diagnose_suppresses_enable_hint_when_disabled_feed_fanout_is_unsafe() {
+        let (tool, finance_registry, _data_feed_registry, _market_repo, _feed_store, ctx) =
+            fixture().await;
+        insert_subscription(&finance_registry, &ctx).await;
+        let mut disabled = feed_config();
+        disabled.enabled = false;
+        disabled.status = FeedStatus::Idle;
+        disabled.transport["symbols"] = serde_json::json!(large_binance_symbols());
+        disabled.transport["timeframes"] = serde_json::json!(["1m", "5m"]);
+        disabled.updated_at = ts("2026-07-10T08:31:00Z");
+        assert!(
+            tool.data_feed_svc
+                .update_feed(&disabled)
+                .await
+                .expect("disabled feed update should succeed")
+        );
+
+        let result = tool
+            .run(
+                FinanceDiagnoseCandleSubscriptionsParams {
+                    subscription_id:    None,
+                    catalog_source_ids: Vec::new(),
+                    source_names:       Vec::new(),
+                    feed_ids:           Vec::new(),
+                    as_of:              Some("2026-07-10T08:31:00Z".to_owned()),
+                    stale_after_secs:   None,
+                },
+                &ctx,
+            )
+            .await
+            .unwrap();
+
+        let sub = &result.subscriptions[0];
+        assert_eq!(sub.status, SubscriptionHealth::Unconfigured);
+        assert_eq!(
+            sub.feed_sources[0].runtime_state,
+            FeedRuntimeState::Disabled
+        );
+        assert_eq!(sub.feed_sources[0].fanout_safe_to_start, Some(false));
+        assert!(
+            sub.feed_sources[0]
+                .fanout_diagnostic
+                .as_deref()
+                .is_some_and(|diagnostic| diagnostic.contains("fans out to 1000 requests")),
+            "unexpected fanout diagnostic: {:?}",
+            sub.feed_sources[0].fanout_diagnostic
+        );
+        assert!(
+            sub.next_action_hint.is_none(),
+            "unsafe disabled feed should not expose an enable hint that will be rejected"
+        );
     }
 
     #[tokio::test]

--- a/crates/app/src/tools/finance_feed.rs
+++ b/crates/app/src/tools/finance_feed.rs
@@ -45,6 +45,12 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
+use super::finance_candle_fanout::{
+    DEFAULT_MARKET_CANDLE_REQUEST_BUDGET_PER_SECOND, market_candle_config_fanout_safety,
+    market_candle_fanout_safety, unsafe_market_candle_fanout_message,
+    validate_market_candle_request_budget,
+};
+
 const MAX_CATALOG_SOURCE_ID_LEN: usize = 128;
 const MAX_FEED_ID_LEN: usize = 128;
 const MAX_SOURCE_NAME_LEN: usize = 128;
@@ -64,9 +70,6 @@ const DEFAULT_MAX_IMMEDIATE_PER_HOUR: u16 = 6;
 const DEFAULT_FEED_EVENT_LIMIT: i64 = 20;
 const MAX_FEED_EVENT_LIMIT: i64 = 200;
 const DEFAULT_MARKET_CANDLE_CATALOG_SOURCE_ID: &str = "binance-market-candles";
-const DEFAULT_MARKET_CANDLE_REQUEST_BUDGET_PER_SECOND: f64 = 10.0;
-const MAX_MARKET_CANDLE_REQUEST_BUDGET_PER_SECOND: f64 = 100.0;
-const MIN_MARKET_CANDLE_INTERVAL_SECS: u64 = 5;
 
 #[derive(Debug, Default, Deserialize, JsonSchema)]
 pub(super) struct FinanceListFeedBundlesParams {
@@ -3197,67 +3200,6 @@ fn normalize_watchlist_timeframes(
     Ok(out)
 }
 
-#[derive(Debug, Clone)]
-struct MarketCandleFanoutSafety {
-    stream_count:                  usize,
-    poll_request_count:            usize,
-    configured_interval_secs:      u64,
-    estimated_requests_per_second: f64,
-    request_budget_per_second:     f64,
-    minimum_safe_interval_secs:    u64,
-    safe_to_start:                 bool,
-}
-
-fn validate_market_candle_request_budget(budget: f64) -> anyhow::Result<()> {
-    anyhow::ensure!(
-        budget.is_finite() && budget > 0.0,
-        "max_requests_per_second must be positive"
-    );
-    anyhow::ensure!(
-        budget <= MAX_MARKET_CANDLE_REQUEST_BUDGET_PER_SECOND,
-        "max_requests_per_second must be <= {MAX_MARKET_CANDLE_REQUEST_BUDGET_PER_SECOND}"
-    );
-    Ok(())
-}
-
-fn market_candle_fanout_safety(
-    provider: Option<&str>,
-    transport: &serde_json::Value,
-    symbols: &[String],
-    timeframes: &[String],
-    request_budget_per_second: f64,
-) -> anyhow::Result<MarketCandleFanoutSafety> {
-    validate_market_candle_request_budget(request_budget_per_second)?;
-    let configured_interval_secs = transport
-        .get("interval_secs")
-        .and_then(serde_json::Value::as_u64)
-        .ok_or_else(|| anyhow::anyhow!("market candle source has no interval_secs"))?;
-    anyhow::ensure!(
-        configured_interval_secs > 0,
-        "market candle source has invalid interval_secs"
-    );
-
-    let stream_count = symbols.len().saturating_mul(timeframes.len());
-    let poll_request_count = if provider == Some("binance") {
-        stream_count
-    } else {
-        1
-    };
-    let estimated_requests_per_second = poll_request_count as f64 / configured_interval_secs as f64;
-    let minimum_safe_interval_secs = MIN_MARKET_CANDLE_INTERVAL_SECS
-        .max((poll_request_count as f64 / request_budget_per_second).ceil() as u64);
-
-    Ok(MarketCandleFanoutSafety {
-        stream_count,
-        poll_request_count,
-        configured_interval_secs,
-        estimated_requests_per_second,
-        request_budget_per_second,
-        minimum_safe_interval_secs,
-        safe_to_start: configured_interval_secs >= minimum_safe_interval_secs,
-    })
-}
-
 fn apply_market_candle_fanout_guard(
     config: &mut DataFeedConfig,
     start_now: bool,
@@ -3288,35 +3230,6 @@ fn ensure_market_candle_fanout_safe_to_enable(config: &DataFeedConfig) -> anyhow
         unsafe_market_candle_fanout_message(&safety)
     );
     Ok(())
-}
-
-fn market_candle_config_fanout_safety(
-    config: &DataFeedConfig,
-) -> anyhow::Result<MarketCandleFanoutSafety> {
-    let final_symbols = extract_normalized_string_array(&config.transport, "symbols", true);
-    let final_timeframes = extract_normalized_string_array(&config.transport, "timeframes", false);
-    let provider = config
-        .transport
-        .get("provider")
-        .and_then(serde_json::Value::as_str);
-    market_candle_fanout_safety(
-        provider,
-        &config.transport,
-        &final_symbols,
-        &final_timeframes,
-        DEFAULT_MARKET_CANDLE_REQUEST_BUDGET_PER_SECOND,
-    )
-}
-
-fn unsafe_market_candle_fanout_message(safety: &MarketCandleFanoutSafety) -> String {
-    format!(
-        "market candle watchlist fans out to {} requests per poll at interval_secs={}; configured \
-         interval is unsafe for the default request budget. Increase interval_secs to at least {} \
-         or call finance_plan_instrument_watchlist and retry after reviewing the plan.",
-        safety.poll_request_count,
-        safety.configured_interval_secs,
-        safety.minimum_safe_interval_secs
-    )
 }
 
 fn watchlist_plan_warning(

--- a/crates/app/src/tools/mod.rs
+++ b/crates/app/src/tools/mod.rs
@@ -31,6 +31,7 @@ mod edit_file;
 mod fff_find;
 mod fff_grep;
 mod file_stats;
+mod finance_candle_fanout;
 mod finance_diagnostics;
 mod finance_feed;
 mod find_files;

--- a/crates/extensions/rara-trading/AGENT.md
+++ b/crates/extensions/rara-trading/AGENT.md
@@ -153,8 +153,10 @@ dispatch loop (`crates/app/src/lib.rs`).
   operator raises `transport.interval_secs`. The app-side
   `finance_enable_feed_source` and `finance_restart_feed_source` controls must
   enforce the same guard, because enabling a persisted disabled feed can start
-  it on app restart even when `start_now=false`. Do not silently persist or
-  start an enabled poller that will hit provider rate limits.
+  it on app restart even when `start_now=false`. Candle diagnostics must reuse
+  the same fan-out calculation and avoid enable/restart `next_action_hint`
+  values for unsafe feeds. Do not silently persist, start, or recommend starting
+  an enabled poller that will hit provider rate limits.
 - **`backtest` has no look-ahead** — the number-one backtest bug. Signal
   evaluation for bar `i` sees only `candles[i.saturating_sub(EVAL_WINDOW)..i]`
   plus `latest = candles[i]`, never a bar `> i` (the same invariant `dispatch`

--- a/docs/guides/finance-subscriptions.md
+++ b/docs/guides/finance-subscriptions.md
@@ -237,6 +237,10 @@ enforce the same safety invariant: `finance_enable_feed_source` and
 turning a staged disabled watchlist into an enabled/running poller. This is the
 preferred path when tracking tens or hundreds of instruments because Binance
 polling fans out as `symbols × timeframes` requests per poll.
+`finance_diagnose_candle_subscriptions` reports the same fan-out safety on each
+feed source through `fanout_safe_to_start` and `fanout_diagnostic`; when a
+disabled or stopped feed is unsafe, diagnostics omit the enable/restart
+`next_action_hint` rather than suggesting an operation the guard will reject.
 
 The lower-level `finance_subscribe` tool remains available for callers that
 already know the exact selectors. Its result echoes the persisted normalized


### PR DESCRIPTION
## Summary
- extract market-candle fan-out safety into a shared app tools helper
- report fan-out safety in candle subscription diagnostics
- omit enable/restart next_action hints when a disabled or stopped candle feed would be rejected by the fan-out guard

## Verification
- cargo +nightly fmt -p rara-app -p rara-trading
- cargo test -p rara-app finance_feed -- --nocapture
- cargo test -p rara-app finance_diagnostics -- --nocapture
- cargo check -p rara-app -p rara-trading
- cargo clippy -p rara-app -p rara-trading --all-targets --quiet -- --force-warn clippy::too_many_lines
- scripts/lint-ratchet.sh
- git diff --check
- cargo test -p rara-trading