### PR TITLE
feat(finance): show feed load in watch card

### DIFF
--- a/web/src/components/topology/FinanceWatchesCard.tsx
+++ b/web/src/components/topology/FinanceWatchesCard.tsx
@@ -216,6 +216,8 @@ export function FinanceWatchesCard({ sessionKey }: FinanceWatchesCardProps) {
                         unsubscribeBundleMutation.variables?.includes(subscription.subscription_id),
                       ));
                   const providers = summarizeList(bundle.providers, 2);
+                  const load = bundleLoadLabel(bundle);
+                  const fanoutDiagnostic = bundleFanoutDiagnostic(bundle);
                   return (
                     <div key={bundle.id} className="rounded-md border bg-muted/20 px-3 py-2">
                       <div className="flex items-start justify-between gap-2">
@@ -241,6 +243,14 @@ export function FinanceWatchesCard({ sessionKey }: FinanceWatchesCardProps) {
                                 watching
                               </Badge>
                             )}
+                            {fanoutDiagnostic && (
+                              <Badge
+                                variant="outline"
+                                className="border-destructive/40 px-1.5 py-0 text-[10px] text-destructive"
+                              >
+                                unsafe fan-out
+                              </Badge>
+                            )}
                           </div>
                           <p className="line-clamp-2 text-[11px] text-muted-foreground">
                             {bundle.description}
@@ -248,6 +258,10 @@ export function FinanceWatchesCard({ sessionKey }: FinanceWatchesCardProps) {
                           <p className="text-[11px] text-muted-foreground">
                             {bundle.sources.map((source) => source.name).join(', ')}
                           </p>
+                          {load && <p className="text-[11px] text-muted-foreground">{load}</p>}
+                          {fanoutDiagnostic && (
+                            <p className="text-[11px] text-destructive">{fanoutDiagnostic}</p>
+                          )}
                         </div>
                         <Button
                           size="sm"
@@ -313,6 +327,8 @@ export function FinanceWatchesCard({ sessionKey }: FinanceWatchesCardProps) {
                 needsConfiguration,
                 subscribed,
               });
+              const load = catalogLoadLabel(entry);
+              const fanoutDiagnostic = catalogFanoutDiagnostic(entry);
               return (
                 <div key={entry.id} className="rounded-md border bg-background/60 px-3 py-2">
                   <div className="flex items-start justify-between gap-2">
@@ -340,10 +356,22 @@ export function FinanceWatchesCard({ sessionKey }: FinanceWatchesCardProps) {
                             watching
                           </Badge>
                         )}
+                        {fanoutDiagnostic && (
+                          <Badge
+                            variant="outline"
+                            className="border-destructive/40 px-1.5 py-0 text-[10px] text-destructive"
+                          >
+                            unsafe fan-out
+                          </Badge>
+                        )}
                       </div>
                       <p className="line-clamp-2 text-[11px] text-muted-foreground">
                         {coverageLabel(entry)}
                       </p>
+                      {load && <p className="text-[11px] text-muted-foreground">{load}</p>}
+                      {fanoutDiagnostic && (
+                        <p className="text-[11px] text-destructive">{fanoutDiagnostic}</p>
+                      )}
                       {streamHealth && (
                         <div className="flex flex-wrap items-center gap-1.5 text-[11px] text-muted-foreground">
                           <Badge
@@ -545,6 +573,90 @@ function coverageLabel(entry: FeedCatalogEntry): string {
 
   const tags = entry.tags.filter((tag) => tag !== 'finance' && tag !== 'news');
   return tags.length > 0 ? tags.join(' · ') : entry.description;
+}
+
+function formatRate(value: number): string {
+  if (Number.isInteger(value)) return value.toString();
+  return value.toFixed(2).replace(/\.?0+$/, '');
+}
+
+function catalogLoadLabel(entry: FeedCatalogEntry): string | null {
+  if (entry.feed_type !== 'market_candle' || !entry.load) return null;
+
+  const parts: string[] = [];
+  if (entry.load.configured_market_stream_count != null) {
+    parts.push(`${entry.load.configured_market_stream_count} configured streams`);
+  }
+  if (entry.load.configured_market_poll_request_count != null) {
+    parts.push(`${entry.load.configured_market_poll_request_count} req/poll`);
+  }
+  if (entry.load.configured_market_requests_per_second != null) {
+    parts.push(`${formatRate(entry.load.configured_market_requests_per_second)} req/s`);
+  }
+  if (entry.load.subscribed_market_stream_count > 0) {
+    parts.push(`${entry.load.subscribed_market_stream_count} subscribed streams`);
+  }
+
+  return parts.length > 0 ? parts.join(' · ') : null;
+}
+
+function catalogFanoutDiagnostic(entry: FeedCatalogEntry): string | null {
+  if (entry.feed_type !== 'market_candle') return null;
+  if (entry.load?.configured_market_fanout_safe_to_start !== false) return null;
+  return (
+    entry.load.configured_market_fanout_diagnostic ?? 'K-line fan-out exceeds safe polling load.'
+  );
+}
+
+function bundleLoadLabel(bundle: FinanceFeedBundle): string | null {
+  const marketSources = bundle.sources.filter(
+    (source) => source.feed_type === 'market_candle' && source.load != null,
+  );
+  if (marketSources.length === 0) return null;
+
+  const configuredStreams = sumOptional(
+    marketSources.map((source) => source.load?.configured_market_stream_count),
+  );
+  const pollRequests = sumOptional(
+    marketSources.map((source) => source.load?.configured_market_poll_request_count),
+  );
+  const requestsPerSecond = sumOptional(
+    marketSources.map((source) => source.load?.configured_market_requests_per_second),
+  );
+  const subscribedStreams = marketSources.reduce(
+    (sum, source) => sum + (source.load?.subscribed_market_stream_count ?? 0),
+    0,
+  );
+
+  const parts: string[] = [];
+  if (configuredStreams != null) parts.push(`${configuredStreams} configured streams`);
+  if (pollRequests != null) parts.push(`${pollRequests} req/poll`);
+  if (requestsPerSecond != null) parts.push(`${formatRate(requestsPerSecond)} req/s`);
+  if (subscribedStreams > 0) parts.push(`${subscribedStreams} subscribed streams`);
+
+  return parts.length > 0 ? parts.join(' · ') : null;
+}
+
+function bundleFanoutDiagnostic(bundle: FinanceFeedBundle): string | null {
+  const source = bundle.sources.find(
+    (candidate) =>
+      candidate.feed_type === 'market_candle' &&
+      candidate.load?.configured_market_fanout_safe_to_start === false,
+  );
+  if (!source) return null;
+  const diagnostic = catalogFanoutDiagnostic(source);
+  return diagnostic ? `${source.name}: ${diagnostic}` : null;
+}
+
+function sumOptional(values: Array<number | null | undefined>): number | null {
+  let hasValue = false;
+  let sum = 0;
+  for (const value of values) {
+    if (value == null) continue;
+    hasValue = true;
+    sum += value;
+  }
+  return hasValue ? sum : null;
 }
 
 function marketCandleEntryStreamHealth(

--- a/web/src/components/topology/__tests__/FinanceWatchesCard.test.tsx
+++ b/web/src/components/topology/__tests__/FinanceWatchesCard.test.tsx
@@ -100,6 +100,7 @@ function catalogEntry(partial: Partial<FeedCatalogEntry> & { id: string }): Feed
     entry.configured_timeframes = partial.configured_timeframes;
   }
   if (partial.subscriptions !== undefined) entry.subscriptions = partial.subscriptions;
+  if (partial.load !== undefined) entry.load = partial.load;
   return entry;
 }
 
@@ -332,6 +333,131 @@ describe('FinanceWatchesCard', () => {
 
     expect(await screen.findByText('Provider binance')).toBeInTheDocument();
     expect(screen.getByText('Provider longbridge')).toBeInTheDocument();
+  });
+
+  it('shows_catalog_kline_load_before_watch', async () => {
+    catalogMock.mockResolvedValue([
+      catalogEntry({
+        id: 'binance-market-candles',
+        name: 'Binance Market Candles',
+        feed_type: 'market_candle',
+        provider: 'binance',
+        venue: 'binance',
+        configured_symbols: ['BTCUSDT', 'ETHUSDT'],
+        configured_timeframes: ['1m'],
+        load: {
+          user_subscription_count: 0,
+          subscribed_market_stream_count: 0,
+          configured_market_stream_count: 2,
+          configured_market_poll_request_count: 2,
+          configured_market_requests_per_second: 2 / 60,
+          configured_market_request_budget_per_second: 10,
+          configured_market_minimum_safe_interval_secs: 5,
+          configured_market_fanout_safe_to_start: true,
+          configured_market_fanout_diagnostic: null,
+        },
+      }),
+    ]);
+    financeSubscriptionsMock.mockResolvedValue({
+      subscriptions: [],
+      count: 0,
+    } satisfies FinanceSubscriptionsResponse);
+
+    renderCard('session-1');
+
+    expect(
+      await screen.findByText('2 configured streams · 2 req/poll · 0.03 req/s'),
+    ).toBeInTheDocument();
+  });
+
+  it('warns_when_catalog_kline_source_fanout_is_unsafe_before_watch', async () => {
+    catalogMock.mockResolvedValue([
+      catalogEntry({
+        id: 'binance-market-candles',
+        name: 'Binance Market Candles',
+        feed_type: 'market_candle',
+        provider: 'binance',
+        venue: 'binance',
+        configured_symbols: ['BTCUSDT'],
+        configured_timeframes: ['1m'],
+        load: {
+          user_subscription_count: 1,
+          subscribed_market_stream_count: 100,
+          configured_market_stream_count: 200,
+          configured_market_poll_request_count: 200,
+          configured_market_requests_per_second: 40,
+          configured_market_request_budget_per_second: 10,
+          configured_market_minimum_safe_interval_secs: 20,
+          configured_market_fanout_safe_to_start: false,
+          configured_market_fanout_diagnostic:
+            'market candle watchlist fans out to 200 requests per poll at interval_secs=5; increase interval_secs to at least 20.',
+        },
+      }),
+    ]);
+    financeSubscriptionsMock.mockResolvedValue({
+      subscriptions: [],
+      count: 0,
+    } satisfies FinanceSubscriptionsResponse);
+
+    renderCard('session-1');
+
+    expect(await screen.findByText('unsafe fan-out')).toBeInTheDocument();
+    expect(
+      screen.getByText('200 configured streams · 200 req/poll · 40 req/s · 100 subscribed streams'),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        'market candle watchlist fans out to 200 requests per poll at interval_secs=5; increase interval_secs to at least 20.',
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it('shows_curated_kline_bundle_load_before_watch', async () => {
+    const source = catalogEntry({
+      id: 'binance-major-crypto-15m',
+      name: 'Binance Major Crypto 15m',
+      feed_type: 'market_candle',
+      source_name: 'finance-binance-major-crypto-15m',
+      provider: 'binance',
+      venue: 'binance',
+      configured_symbols: ['BTCUSDT', 'ETHUSDT', 'SOLUSDT', 'BNBUSDT', 'XRPUSDT'],
+      configured_timeframes: ['15m'],
+      load: {
+        user_subscription_count: 0,
+        subscribed_market_stream_count: 0,
+        configured_market_stream_count: 5,
+        configured_market_poll_request_count: 5,
+        configured_market_requests_per_second: 5 / 300,
+        configured_market_request_budget_per_second: 10,
+        configured_market_minimum_safe_interval_secs: 5,
+        configured_market_fanout_safe_to_start: true,
+        configured_market_fanout_diagnostic: null,
+      },
+    });
+    catalogMock.mockResolvedValue([]);
+    financeBundlesMock.mockResolvedValue({
+      bundles: [
+        financeBundle({
+          id: 'binance-major-crypto-15m',
+          name: 'Binance Major Crypto 15m',
+          feed_types: ['market_candle'],
+          providers: ['binance'],
+          catalog_source_ids: ['binance-major-crypto-15m'],
+          sources: [source],
+        }),
+      ],
+      count: 1,
+    });
+    financeSubscriptionsMock.mockResolvedValue({
+      subscriptions: [],
+      count: 0,
+    } satisfies FinanceSubscriptionsResponse);
+
+    renderCard('session-1');
+
+    expect(
+      await screen.findByText('5 configured streams · 5 req/poll · 0.02 req/s'),
+    ).toBeInTheDocument();
   });
 
   it('creates_session_watch_from_catalog_kline_source_with_configured_selectors', async () => {


### PR DESCRIPTION
## Summary
- show configured K-line stream/request load in the Chat finance watch card
- surface unsafe fan-out badges and diagnostics before users start a source or bundle
- add coverage for catalog and curated bundle load rendering

## Verification
- npm test -- src/components/topology/__tests__/FinanceWatchesCard.test.tsx
- npm run typecheck
- git diff --check