### PR TITLE
feat(web): surface finance bundle quick starts

### DIFF
--- a/web/src/api/data-feeds.ts
+++ b/web/src/api/data-feeds.ts
@@ -202,9 +202,37 @@ export interface FinanceFeedBundle {
   subscriptions: FeedCatalogSubscriptions;
 }
 
+export interface FinanceToolHint {
+  tool: string;
+  default_params: Record<string, unknown>;
+  required_params: string[];
+  optional_params: string[];
+}
+
+export interface FinanceFeedSourceConfigureHint {
+  action: string;
+  section: string;
+  default_params: Record<string, unknown>;
+  required_params: string[];
+  optional_params: string[];
+}
+
+export interface FinanceFeedBundleQuickStartHint {
+  bundle_id: string;
+  name: string;
+  feed_types: FeedType[];
+  providers: string[];
+  can_start_now: boolean;
+  requires_configuration: boolean;
+  subscribe_bundle_hint: FinanceToolHint | null;
+  configure_hints: FinanceFeedSourceConfigureHint[];
+  list_sources_hint: FinanceToolHint;
+}
+
 export interface FinanceFeedBundlesResponse {
   bundles: FinanceFeedBundle[];
   count: number;
+  quick_start_hints?: FinanceFeedBundleQuickStartHint[];
 }
 
 export interface EnableCatalogEntryRequest {

--- a/web/src/components/topology/FinanceWatchesCard.tsx
+++ b/web/src/components/topology/FinanceWatchesCard.tsx
@@ -23,6 +23,7 @@ import {
   type CreateFinanceSubscriptionRequest,
   type FeedCatalogEntry,
   type FinanceFeedBundle,
+  type FinanceFeedBundleQuickStartHint,
   type FinanceEventKind,
   type FinanceSubscription,
 } from '@/api/data-feeds';
@@ -137,6 +138,9 @@ export function FinanceWatchesCard({ sessionKey }: FinanceWatchesCardProps) {
 
   const entries = (catalogQuery.data ?? []).filter(isFinanceWatchableEntry);
   const bundles = bundlesQuery.data?.bundles ?? [];
+  const bundleQuickStartHints = new Map(
+    (bundlesQuery.data?.quick_start_hints ?? []).map((hint) => [hint.bundle_id, hint]),
+  );
   const candleStreams = candleStreamsQuery.data?.streams ?? [];
   const candleStreamHasMore = candleStreamsQuery.data?.has_more ?? false;
   const sessionSubscriptions = (subscriptionsQuery.data?.subscriptions ?? []).filter(
@@ -195,6 +199,7 @@ export function FinanceWatchesCard({ sessionKey }: FinanceWatchesCardProps) {
               <div className="space-y-2">
                 <div className="text-[11px] font-medium text-muted-foreground">Curated bundles</div>
                 {bundles.map((bundle) => {
+                  const quickStartHint = bundleQuickStartHints.get(bundle.id);
                   const matchingSubscriptions = sessionSubscriptions.filter((subscription) =>
                     subscriptionMatchesBundle(subscription, bundle),
                   );
@@ -206,7 +211,12 @@ export function FinanceWatchesCard({ sessionKey }: FinanceWatchesCardProps) {
                   const configurationSource = bundle.sources.find(
                     (source) => !source.enabled && source.requires_configuration,
                   );
-                  const needsConfiguration = !subscribed && configurationSource != null;
+                  const configurationSourceId =
+                    quickStartConfigureSourceId(quickStartHint) ?? configurationSource?.id ?? null;
+                  const needsConfiguration = !subscribed && configurationSourceId != null;
+                  const quickStartAvailable = !subscribed && quickStartHint?.can_start_now === true;
+                  const quickStartNeedsConfiguration =
+                    !subscribed && quickStartHint?.requires_configuration === true;
                   const pending =
                     (enableBundleMutation.isPending &&
                       enableBundleMutation.variables?.id === bundle.id) ||
@@ -244,6 +254,16 @@ export function FinanceWatchesCard({ sessionKey }: FinanceWatchesCardProps) {
                                 watching
                               </Badge>
                             )}
+                            {quickStartAvailable && (
+                              <Badge variant="outline" className="px-1.5 py-0 text-[10px]">
+                                Rara quick start
+                              </Badge>
+                            )}
+                            {quickStartNeedsConfiguration && (
+                              <Badge variant="secondary" className="px-1.5 py-0 text-[10px]">
+                                setup required
+                              </Badge>
+                            )}
                             {fanoutDiagnostic && (
                               <Badge
                                 variant="outline"
@@ -264,6 +284,7 @@ export function FinanceWatchesCard({ sessionKey }: FinanceWatchesCardProps) {
                               bundle,
                               canEnableInline,
                               needsConfiguration,
+                              quickStartAvailable,
                               subscribed,
                             })}
                           </p>
@@ -280,9 +301,9 @@ export function FinanceWatchesCard({ sessionKey }: FinanceWatchesCardProps) {
                           onClick={() => {
                             if (canEnableInline) {
                               enableBundleMutation.mutate(bundle);
-                            } else if (needsConfiguration && configurationSource) {
+                            } else if (needsConfiguration && configurationSourceId) {
                               openSettings('data-feeds', {
-                                dataFeedCatalogId: configurationSource.id,
+                                dataFeedCatalogId: configurationSourceId,
                               });
                             } else if (subscribed) {
                               unsubscribeBundleMutation.mutate(
@@ -513,11 +534,13 @@ function bundleLifecycleLabel({
   bundle,
   canEnableInline,
   needsConfiguration,
+  quickStartAvailable,
   subscribed,
 }: {
   bundle: FinanceFeedBundle;
   canEnableInline: boolean;
   needsConfiguration: boolean;
+  quickStartAvailable: boolean;
   subscribed: boolean;
 }): string {
   if (subscribed) return 'This session is watching this bundle.';
@@ -525,10 +548,21 @@ function bundleLifecycleLabel({
   if (canEnableInline) {
     return 'Enable bundle starts ingestion; Watch subscribes this session after sources are on.';
   }
+  if (quickStartAvailable) return 'Rara can quick-start this bundle from chat.';
   if (bundle.enabled_source_count < bundle.source_count) {
     return 'Some sources are off; enable or configure them before watching.';
   }
   return 'Sources are on; Watch subscribes this session without changing ingestion.';
+}
+
+function quickStartConfigureSourceId(
+  hint: FinanceFeedBundleQuickStartHint | undefined,
+): string | null {
+  const defaultParams = hint?.configure_hints[0]?.default_params;
+  const catalogSourceId = defaultParams?.dataFeedCatalogId ?? defaultParams?.catalog_source_id;
+  return typeof catalogSourceId === 'string' && catalogSourceId.trim()
+    ? catalogSourceId.trim()
+    : null;
 }
 
 function subscriptionRequestForEntry(

--- a/web/src/components/topology/__tests__/FinanceWatchesCard.test.tsx
+++ b/web/src/components/topology/__tests__/FinanceWatchesCard.test.tsx
@@ -24,6 +24,7 @@ import type {
   CandleStreamsResponse,
   FeedCatalogEntry,
   FinanceFeedBundle,
+  FinanceFeedBundleQuickStartHint,
   FinanceSubscription,
   FinanceSubscriptionsResponse,
 } from '@/api/data-feeds';
@@ -164,6 +165,37 @@ function financeBundle(partial: Partial<FinanceFeedBundle> & { id: string }): Fi
   };
 }
 
+function bundleQuickStartHint(
+  partial: Partial<FinanceFeedBundleQuickStartHint> & { bundle_id: string },
+): FinanceFeedBundleQuickStartHint {
+  return {
+    bundle_id: partial.bundle_id,
+    name: partial.name ?? partial.bundle_id,
+    feed_types: partial.feed_types ?? ['rss'],
+    providers: partial.providers ?? [],
+    can_start_now: partial.can_start_now ?? true,
+    requires_configuration: partial.requires_configuration ?? false,
+    subscribe_bundle_hint: partial.subscribe_bundle_hint ?? {
+      tool: 'finance_subscribe_feed_bundle',
+      default_params: {
+        bundle_id: partial.bundle_id,
+        start_now: true,
+      },
+      required_params: [],
+      optional_params: ['delivery', 'start_now'],
+    },
+    configure_hints: partial.configure_hints ?? [],
+    list_sources_hint: partial.list_sources_hint ?? {
+      tool: 'finance_list_feed_sources',
+      default_params: {
+        bundle_ids: [partial.bundle_id],
+      },
+      required_params: [],
+      optional_params: ['feed_types'],
+    },
+  };
+}
+
 beforeEach(() => {
   catalogMock.mockReset();
   financeBundlesMock.mockReset();
@@ -257,6 +289,109 @@ describe('FinanceWatchesCard', () => {
         timeframes: ['15m'],
       });
     });
+  });
+
+  it('surfaces_quick_start_hints_for_curated_bundles', async () => {
+    const source = catalogEntry({
+      id: 'macro-news',
+      name: 'Macro News',
+      source_name: 'finance-macro-news',
+      enabled: true,
+      transport_template: { url: 'https://example.com/macro.xml' },
+    });
+    catalogMock.mockResolvedValue([]);
+    financeBundlesMock.mockResolvedValue({
+      bundles: [
+        financeBundle({
+          id: 'macro-news',
+          name: 'Macro News',
+          catalog_source_ids: ['macro-news'],
+          sources: [source],
+        }),
+      ],
+      count: 1,
+      quick_start_hints: [
+        bundleQuickStartHint({
+          bundle_id: 'macro-news',
+          name: 'Macro News',
+          can_start_now: true,
+        }),
+      ],
+    });
+    financeSubscriptionsMock.mockResolvedValue({
+      subscriptions: [],
+      count: 0,
+    } satisfies FinanceSubscriptionsResponse);
+
+    renderCard('session-1');
+
+    expect(await screen.findByText('Rara quick start')).toBeInTheDocument();
+    expect(screen.getByText('Rara can quick-start this bundle from chat.')).toBeInTheDocument();
+  });
+
+  it('uses_quick_start_configure_hint_for_bundle_settings_target', async () => {
+    const source = catalogEntry({
+      id: 'longbridge-default-candles',
+      name: 'LongBridge Market Candles',
+      feed_type: 'market_candle',
+      provider: 'longbridge',
+      enabled: false,
+      requires_configuration: true,
+      setup_hint: 'Configure LongBridge credentials and selectors before enabling.',
+    });
+    catalogMock.mockResolvedValue([]);
+    financeBundlesMock.mockResolvedValue({
+      bundles: [
+        financeBundle({
+          id: 'longbridge-market-data',
+          name: 'LongBridge Market Data',
+          feed_types: ['market_candle'],
+          providers: ['longbridge'],
+          catalog_source_ids: ['longbridge-default-candles'],
+          sources: [source],
+          requires_configuration: true,
+          can_enable: false,
+        }),
+      ],
+      count: 1,
+      quick_start_hints: [
+        bundleQuickStartHint({
+          bundle_id: 'longbridge-market-data',
+          name: 'LongBridge Market Data',
+          feed_types: ['market_candle'],
+          providers: ['longbridge'],
+          can_start_now: false,
+          requires_configuration: true,
+          subscribe_bundle_hint: null,
+          configure_hints: [
+            {
+              action: 'open_settings',
+              section: 'data-feeds',
+              default_params: {
+                dataFeedCatalogId: 'longbridge-market-candles',
+              },
+              required_params: [],
+              optional_params: ['dataFeedCatalogId'],
+            },
+          ],
+        }),
+      ],
+    });
+    financeSubscriptionsMock.mockResolvedValue({
+      subscriptions: [],
+      count: 0,
+    } satisfies FinanceSubscriptionsResponse);
+
+    renderCard('session-1');
+
+    expect(await screen.findByText('setup required')).toBeInTheDocument();
+    fireEvent.click(await screen.findByRole('button', { name: 'Configure' }));
+
+    expect(openSettingsMock).toHaveBeenCalledWith('data-feeds', {
+      dataFeedCatalogId: 'longbridge-market-candles',
+    });
+    expect(createFinanceSubscriptionMock).not.toHaveBeenCalled();
+    expect(enableCatalogEntryMock).not.toHaveBeenCalled();
   });
 
   it('enables_all_ready_sources_in_a_curated_bundle_before_watch', async () => {


### PR DESCRIPTION
## Summary
- add frontend API types for finance feed bundle quick-start hints
- surface quick-start/setup badges in FinanceWatchesCard curated bundles
- use configure hints to open the intended data-feed settings target

## Verification
- npm run test -- src/components/topology/__tests__/FinanceWatchesCard.test.tsx
- npm run typecheck
- npm run lint