### PR TITLE
feat(finance): add keyless Yahoo candle feeds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7515,6 +7515,7 @@ dependencies = [
  "tokio-util",
  "tracing",
  "uuid",
+ "wiremock",
 ]
 
 [[package]]

--- a/crates/extensions/backend-admin/src/data_feeds/router.rs
+++ b/crates/extensions/backend-admin/src/data_feeds/router.rs
@@ -3110,7 +3110,7 @@ mod tests {
             .await
             .unwrap();
         let result: serde_json::Value = serde_json::from_slice(&body).unwrap();
-        assert_eq!(result["count"], 4);
+        assert_eq!(result["count"], 6);
 
         let bundles = result["bundles"].as_array().unwrap();
         let macro_news = bundles
@@ -3168,6 +3168,34 @@ mod tests {
             .unwrap();
         assert_eq!(longbridge["requires_configuration"], true);
         assert_eq!(longbridge["can_enable"], false);
+
+        let yahoo = bundles
+            .iter()
+            .find(|bundle| bundle["id"] == "yahoo-us-equities-daily")
+            .unwrap();
+        assert_eq!(yahoo["providers"], serde_json::json!(["yahoo"]));
+        assert_eq!(yahoo["requires_configuration"], false);
+        assert_eq!(yahoo["can_enable"], true);
+        assert_eq!(yahoo["sources"][0]["provider"], "yahoo");
+        assert_eq!(
+            yahoo["sources"][0]["configured_timeframes"],
+            serde_json::json!(["1d"])
+        );
+        assert_eq!(
+            yahoo["sources"][0]["load"]["configured_market_request_budget_per_second"],
+            0.2
+        );
+        assert_eq!(
+            yahoo["sources"][0]["load"]["configured_market_fanout_safe_to_start"],
+            true
+        );
+        assert!(
+            yahoo["sources"][0]["tags"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .any(|tag| tag == "best-effort")
+        );
     }
 
     #[test]

--- a/crates/extensions/rara-trading/Cargo.toml
+++ b/crates/extensions/rara-trading/Cargo.toml
@@ -32,3 +32,4 @@ rara-tool-macro = { workspace = true }
 [dev-dependencies]
 tempfile = { workspace = true }
 testcontainers = { workspace = true }
+wiremock = "0.6"

--- a/crates/extensions/rara-trading/src/feed/catalog.rs
+++ b/crates/extensions/rara-trading/src/feed/catalog.rs
@@ -81,6 +81,20 @@ pub fn default_finance_feed_bundles() -> Vec<DefaultFeedBundle> {
             ["binance-major-crypto-15m"],
         ),
         feed_bundle(
+            "yahoo-us-equities-daily",
+            "Yahoo US Equities Daily",
+            "Keyless best-effort daily candles for a focused US equities research watchlist.",
+            ["finance", "market-data", "equities", "yahoo", "best-effort"],
+            ["yahoo-market-candles"],
+        ),
+        feed_bundle(
+            "yahoo-global-starter",
+            "Yahoo Global Starter",
+            "Keyless best-effort daily candles for a small cross-market research watchlist.",
+            ["finance", "market-data", "global", "yahoo", "best-effort"],
+            ["yahoo-global-market-candles"],
+        ),
+        feed_bundle(
             "longbridge-equities-daily",
             "Longbridge Equities Daily",
             "Longbridge equities daily candles preset for configured normalized endpoints.",
@@ -145,6 +159,43 @@ pub fn default_finance_feed_sources() -> Vec<DefaultFeedSource> {
             &["15m"],
             300,
         ),
+        yahoo_market_candles_source(
+            "yahoo-market-candles",
+            "Yahoo US Equities Daily",
+            "Keyless Yahoo Finance daily candles for research. Best effort, potentially delayed, \
+             unofficial, and not intended for execution-grade decisions or redistribution.",
+            [
+                "finance",
+                "market-data",
+                "equities",
+                "yahoo",
+                "no-auth",
+                "best-effort",
+                "delayed",
+                "unofficial-api",
+                "redistribution-restricted",
+            ],
+            &["AAPL", "MSFT", "NVDA", "SPY", "QQQ"],
+        ),
+        yahoo_market_candles_source(
+            "yahoo-global-market-candles",
+            "Yahoo Global Market Daily",
+            "Keyless Yahoo Finance daily candles for cross-market research. Best effort, \
+             potentially delayed, unofficial, and not intended for execution-grade decisions or \
+             redistribution.",
+            [
+                "finance",
+                "market-data",
+                "global",
+                "yahoo",
+                "no-auth",
+                "best-effort",
+                "delayed",
+                "unofficial-api",
+                "redistribution-restricted",
+            ],
+            &["^GSPC", "^N225", "000001.SS", "BTC-USD", "EURUSD=X"],
+        ),
         provider_preset(
             "longbridge-market-candles",
             "Longbridge Market Data",
@@ -156,6 +207,36 @@ pub fn default_finance_feed_sources() -> Vec<DefaultFeedSource> {
             &["1d"],
         ),
     ]
+}
+
+fn yahoo_market_candles_source(
+    id: &str,
+    name: &str,
+    description: &str,
+    tags: impl IntoIterator<Item = &'static str>,
+    symbols: &[&str],
+) -> DefaultFeedSource {
+    DefaultFeedSource {
+        id:                     id.to_owned(),
+        name:                   name.to_owned(),
+        description:            description.to_owned(),
+        feed_type:              FeedType::MarketCandle,
+        provider:               Some("yahoo".to_owned()),
+        tags:                   tags.into_iter().map(str::to_owned).collect(),
+        transport:              Some(serde_json::json!({
+            "provider": "yahoo",
+            "base_url": "https://query1.finance.yahoo.com",
+            "interval_secs": 900,
+            "headers": {},
+            "venue": "yahoo",
+            "symbols": symbols,
+            "timeframes": ["1d"],
+            "max_candles_per_poll": 5
+        })),
+        auth:                   None,
+        requires_configuration: false,
+        setup_hint:             None,
+    }
 }
 
 fn feed_bundle(
@@ -416,5 +497,44 @@ mod tests {
         );
         assert_eq!(transport["timeframes"], serde_json::json!(["1d"]));
         assert_eq!(transport["url"], "");
+    }
+
+    #[test]
+    fn yahoo_presets_are_keyless_best_effort_daily_sources() {
+        let sources = default_finance_feed_sources();
+        let yahoo = sources
+            .iter()
+            .find(|source| source.id == "yahoo-market-candles")
+            .expect("missing Yahoo market candle preset");
+
+        assert!(yahoo.can_enable());
+        assert_eq!(yahoo.provider.as_deref(), Some("yahoo"));
+        assert!(yahoo.auth.is_none());
+        for tag in [
+            "no-auth",
+            "best-effort",
+            "delayed",
+            "unofficial-api",
+            "redistribution-restricted",
+        ] {
+            assert!(yahoo.tags.iter().any(|candidate| candidate == tag));
+        }
+        let transport = yahoo.transport.as_ref().expect("transport template");
+        assert_eq!(transport["provider"], "yahoo");
+        assert_eq!(transport["venue"], "yahoo");
+        assert_eq!(transport["timeframes"], serde_json::json!(["1d"]));
+        assert_eq!(transport["interval_secs"], 900);
+
+        let bundles = default_finance_feed_bundles();
+        let us = bundles
+            .iter()
+            .find(|bundle| bundle.id == "yahoo-us-equities-daily")
+            .expect("missing Yahoo US equities bundle");
+        assert_eq!(us.catalog_source_ids, ["yahoo-market-candles"]);
+        let global = bundles
+            .iter()
+            .find(|bundle| bundle.id == "yahoo-global-starter")
+            .expect("missing Yahoo global starter bundle");
+        assert_eq!(global.catalog_source_ids, ["yahoo-global-market-candles"]);
     }
 }

--- a/crates/extensions/rara-trading/src/feed/market_candle.rs
+++ b/crates/extensions/rara-trading/src/feed/market_candle.rs
@@ -15,7 +15,7 @@
 //! Config-driven latest market candle data feed.
 //!
 //! This transport fetches either an operator-managed normalized candle endpoint
-//! or a built-in public provider such as Binance, then emits one
+//! or a built-in public provider such as Binance or Yahoo, then emits one
 //! `market_candle_closed` event per closed bar.
 
 use std::{
@@ -50,6 +50,9 @@ const MAX_CANDLES_PER_POLL: usize = 10_000;
 const MAX_BODY_BYTES: usize = 4 * 1024 * 1024;
 pub const DEFAULT_MARKET_CANDLE_REQUEST_BUDGET_PER_SECOND: f64 = 10.0;
 const MAX_MARKET_CANDLE_REQUEST_BUDGET_PER_SECOND: f64 = 100.0;
+const YAHOO_MARKET_CANDLE_REQUEST_BUDGET_PER_SECOND: f64 = 0.2;
+const YAHOO_MIN_INTERVAL_SECS: u64 = 60;
+const YAHOO_REQUEST_SPACING_SECS: u64 = 5;
 
 /// Minimum polling cadence for a market-candle feed, in seconds.
 ///
@@ -113,13 +116,23 @@ pub fn market_candle_fanout_safety(
     );
 
     let stream_count = symbols.len().saturating_mul(timeframes.len());
-    let poll_request_count = if provider == Some("binance") {
+    let poll_request_count = if matches!(provider, Some("binance" | "yahoo")) {
         stream_count
     } else {
         1
     };
+    let request_budget_per_second = if provider == Some("yahoo") {
+        request_budget_per_second.min(YAHOO_MARKET_CANDLE_REQUEST_BUDGET_PER_SECOND)
+    } else {
+        request_budget_per_second
+    };
     let estimated_requests_per_second = poll_request_count as f64 / configured_interval_secs as f64;
-    let minimum_safe_interval_secs = MIN_INTERVAL_SECS
+    let provider_minimum_interval_secs = if provider == Some("yahoo") {
+        YAHOO_MIN_INTERVAL_SECS
+    } else {
+        MIN_INTERVAL_SECS
+    };
+    let minimum_safe_interval_secs = provider_minimum_interval_secs
         .max((poll_request_count as f64 / request_budget_per_second).ceil() as u64);
 
     Ok(MarketCandleFanoutSafety {
@@ -225,6 +238,38 @@ struct CandleBatch {
 }
 
 #[derive(Debug, Deserialize)]
+struct YahooChartResponse {
+    chart: YahooChart,
+}
+
+#[derive(Debug, Deserialize)]
+struct YahooChart {
+    result: Option<Vec<YahooChartResult>>,
+    error:  Option<serde_json::Value>,
+}
+
+#[derive(Debug, Deserialize)]
+struct YahooChartResult {
+    timestamp:  Option<Vec<i64>>,
+    indicators: YahooIndicators,
+}
+
+#[derive(Debug, Deserialize)]
+struct YahooIndicators {
+    quote: Vec<YahooQuote>,
+}
+
+#[derive(Debug, Deserialize)]
+struct YahooQuote {
+    open:   Vec<Option<serde_json::Number>>,
+    high:   Vec<Option<serde_json::Number>>,
+    low:    Vec<Option<serde_json::Number>>,
+    close:  Vec<Option<serde_json::Number>>,
+    #[serde(default)]
+    volume: Vec<Option<serde_json::Number>>,
+}
+
+#[derive(Debug, Deserialize)]
 struct RawCandle {
     venue:      String,
     symbol:     String,
@@ -322,6 +367,24 @@ impl MarketCandleSource {
         Ok(url)
     }
 
+    fn build_yahoo_chart_url(&self, symbol: &str, timeframe: &str) -> anyhow::Result<Url> {
+        let base_url = self
+            .transport
+            .base_url
+            .as_deref()
+            .unwrap_or("https://query1.finance.yahoo.com");
+        let mut url = Url::parse(base_url)?.join("/v8/finance/chart")?;
+        url.path_segments_mut()
+            .map_err(|()| anyhow::anyhow!("Yahoo market candle base_url cannot be a base URL"))?
+            .push(symbol);
+        url.query_pairs_mut()
+            .append_pair("interval", yahoo_interval(timeframe)?)
+            .append_pair("range", "5d")
+            .append_pair("events", "history")
+            .append_pair("includePrePost", "false");
+        Ok(url)
+    }
+
     fn record_error(&self, message: String) {
         let was_in_error = self.in_error.swap(true, Ordering::SeqCst);
         if was_in_error {
@@ -383,6 +446,69 @@ impl MarketCandleSource {
 
         for row in rows.into_iter().take(self.transport.max_candles_per_poll) {
             let Some(candle) = self.parse_binance_row(symbol, timeframe, row, now_ms) else {
+                continue;
+            };
+            events.push(self.event_from_candle(candle, received_at));
+        }
+
+        Ok(events)
+    }
+
+    fn parse_yahoo_candle_events(
+        &self,
+        symbol: &str,
+        timeframe: &str,
+        body: &[u8],
+    ) -> anyhow::Result<Vec<FeedEvent>> {
+        let response: YahooChartResponse = serde_json::from_slice(body)?;
+        if let Some(error) = response.chart.error {
+            anyhow::bail!("Yahoo chart returned an error: {error}");
+        }
+        let result = response
+            .chart
+            .result
+            .and_then(|results| results.into_iter().next())
+            .ok_or_else(|| anyhow::anyhow!("Yahoo chart response contained no result"))?;
+        let timestamps = result
+            .timestamp
+            .ok_or_else(|| anyhow::anyhow!("Yahoo chart response contained no timestamps"))?;
+        let quote = result
+            .indicators
+            .quote
+            .into_iter()
+            .next()
+            .ok_or_else(|| anyhow::anyhow!("Yahoo chart response contained no quote"))?;
+        let received_at = Timestamp::now();
+        let now_ms = received_at.as_millisecond();
+        let step_ms = yahoo_timeframe_millis(timeframe)?;
+        let mut events = Vec::new();
+
+        for (index, open_time_seconds) in timestamps
+            .into_iter()
+            .enumerate()
+            .take(self.transport.max_candles_per_poll)
+        {
+            let Some(open_time_ms) = open_time_seconds.checked_mul(1000) else {
+                continue;
+            };
+            let Some(close_time_ms) = open_time_ms
+                .checked_add(step_ms)
+                .and_then(|value| value.checked_sub(1))
+            else {
+                continue;
+            };
+            if close_time_ms > now_ms {
+                continue;
+            }
+            let Some(candle) = yahoo_candle_at(
+                &quote,
+                index,
+                &self.transport.venue,
+                symbol,
+                timeframe,
+                open_time_ms,
+                close_time_ms,
+            ) else {
                 continue;
             };
             events.push(self.event_from_candle(candle, received_at));
@@ -629,11 +755,87 @@ impl MarketCandleSource {
         true
     }
 
+    async fn poll_yahoo_once(&self, tx: &mpsc::Sender<FeedEvent>) -> bool {
+        let mut any_success = false;
+        let mut request_count = 0_usize;
+
+        for symbol in &self.transport.symbols {
+            for timeframe in &self.transport.timeframes {
+                let url = match self.build_yahoo_chart_url(symbol, timeframe) {
+                    Ok(url) => url,
+                    Err(err) => {
+                        self.record_error(format!("failed to build Yahoo chart URL: {err}"));
+                        continue;
+                    }
+                };
+
+                if request_count > 0 {
+                    tokio::time::sleep(Duration::from_secs(YAHOO_REQUEST_SPACING_SECS)).await;
+                }
+                request_count += 1;
+
+                let mut request = self.client.get(url);
+                for (key, value) in &self.transport.headers {
+                    request = request.header(key.as_str(), value.as_str());
+                }
+                request = apply_request_auth(request, &self.auth);
+
+                let response = match request.send().await {
+                    Ok(response) => response,
+                    Err(err) => {
+                        self.record_error(format!("Yahoo chart fetch failed: {err}"));
+                        continue;
+                    }
+                };
+                let status = response.status();
+                if !status.is_success() {
+                    self.record_error(format!(
+                        "Yahoo chart fetch received non-success status: {status}"
+                    ));
+                    continue;
+                }
+                let body = match response.bytes().await {
+                    Ok(body) => body,
+                    Err(err) => {
+                        self.record_error(format!("failed to read Yahoo chart body: {err}"));
+                        continue;
+                    }
+                };
+                if body.len() > MAX_BODY_BYTES {
+                    self.record_error(format!(
+                        "Yahoo chart response exceeded {MAX_BODY_BYTES} bytes"
+                    ));
+                    continue;
+                }
+                let events = match self.parse_yahoo_candle_events(symbol, timeframe, &body) {
+                    Ok(events) => events,
+                    Err(err) => {
+                        self.record_error(format!("failed to parse Yahoo chart response: {err}"));
+                        continue;
+                    }
+                };
+
+                any_success = true;
+                for event in events {
+                    if tx.send(event).await.is_err() {
+                        tracing::info!("event channel closed, stopping market candle loop");
+                        return false;
+                    }
+                }
+            }
+        }
+
+        if any_success {
+            self.record_success();
+        }
+        true
+    }
+
     async fn poll_once(&self, tx: &mpsc::Sender<FeedEvent>) -> bool {
-        if self.transport.provider.as_deref() == Some("binance") {
-            self.poll_binance_once(tx).await
-        } else {
-            self.poll_normalized_once(tx).await
+        match self.transport.provider.as_deref() {
+            Some("binance") => self.poll_binance_once(tx).await,
+            Some("yahoo") => self.poll_yahoo_once(tx).await,
+            _ => self.poll_normalized_once(tx).await,
         }
     }
 }
@@ -751,17 +953,40 @@ fn validate_transport(transport: &MarketCandleTransport) -> anyhow::Result<()> {
                 "Binance market candle base_url must use HTTPS"
             );
         }
+        "yahoo" => {
+            let base_url = transport
+                .base_url
+                .as_deref()
+                .unwrap_or("https://query1.finance.yahoo.com");
+            let url = Url::parse(base_url)?;
+            let test_loopback = cfg!(test)
+                && url.scheme() == "http"
+                && matches!(url.host_str(), Some("127.0.0.1" | "localhost" | "::1"));
+            anyhow::ensure!(
+                url.scheme() == "https" || test_loopback,
+                "Yahoo market candle base_url must use HTTPS"
+            );
+            for timeframe in &transport.timeframes {
+                yahoo_interval(timeframe)?;
+            }
+        }
         provider => anyhow::bail!("unsupported market candle provider: {provider}"),
     }
     anyhow::ensure!(
         transport.interval_secs > 0,
         "market candle interval_secs must be greater than zero"
     );
+    let minimum_interval_secs = if transport.provider.as_deref() == Some("yahoo") {
+        YAHOO_MIN_INTERVAL_SECS
+    } else {
+        MIN_INTERVAL_SECS
+    };
     anyhow::ensure!(
-        transport.interval_secs >= MIN_INTERVAL_SECS,
-        "market candle interval_secs must be at least {MIN_INTERVAL_SECS} seconds: each poll tick \
-         fans out to symbols × timeframes /api/v3/klines requests, so polling faster trips \
-         Binance's per-IP request-weight rate limit and gets the deployment IP-banned"
+        transport.interval_secs >= minimum_interval_secs,
+        "market candle interval_secs must be at least {minimum_interval_secs} seconds for \
+         provider {:?}; each poll may fan out to symbols × timeframes requests, so faster polling \
+         can trip provider request-weight and rate limit policies",
+        transport.provider.as_deref().unwrap_or("normalized")
     );
     anyhow::ensure!(
         !transport.venue.is_empty(),
@@ -790,6 +1015,61 @@ fn validate_transport(transport: &MarketCandleTransport) -> anyhow::Result<()> {
     Ok(())
 }
 
+fn yahoo_interval(timeframe: &str) -> anyhow::Result<&'static str> {
+    match timeframe {
+        "1m" => Ok("1m"),
+        "5m" => Ok("5m"),
+        "15m" => Ok("15m"),
+        "30m" => Ok("30m"),
+        "1h" => Ok("1h"),
+        "1d" => Ok("1d"),
+        _ => anyhow::bail!(
+            "Yahoo market candle timeframe {timeframe:?} is unsupported; use one of 1m, 5m, 15m, \
+             30m, 1h, or 1d"
+        ),
+    }
+}
+
+fn yahoo_timeframe_millis(timeframe: &str) -> anyhow::Result<i64> {
+    let timeframe = Timeframe::parse(timeframe)?;
+    let seconds = timeframe.step()?.as_secs();
+    seconds
+        .checked_mul(1000)
+        .ok_or_else(|| anyhow::anyhow!("Yahoo timeframe is too large"))
+}
+
+fn yahoo_candle_at(
+    quote: &YahooQuote,
+    index: usize,
+    venue: &str,
+    symbol: &str,
+    timeframe: &str,
+    open_time_ms: i64,
+    close_time_ms: i64,
+) -> Option<ParsedCandle> {
+    fn decimal_at(values: &[Option<serde_json::Number>], index: usize) -> Option<Decimal> {
+        Decimal::from_str(&values.get(index)?.as_ref()?.to_string()).ok()
+    }
+
+    Some(ParsedCandle {
+        venue:      venue.to_owned(),
+        symbol:     symbol.to_owned(),
+        timeframe:  timeframe.to_owned(),
+        open_time:  Timestamp::from_millisecond(open_time_ms).ok()?.to_string(),
+        close_time: Timestamp::from_millisecond(close_time_ms).ok()?.to_string(),
+        open:       decimal_at(&quote.open, index)?,
+        high:       decimal_at(&quote.high, index)?,
+        low:        decimal_at(&quote.low, index)?,
+        close:      decimal_at(&quote.close, index)?,
+        volume:     quote
+            .volume
+            .get(index)
+            .and_then(Option::as_ref)
+            .and_then(|value| Decimal::from_str(&value.to_string()).ok())
+            .unwrap_or(Decimal::ZERO),
+    })
+}
+
 fn dedupe_sort(values: &mut Vec<String>) {
     let mut seen = HashSet::new();
     values.retain(|value| seen.insert(value.clone()));
@@ -799,8 +1079,12 @@ fn dedupe_sort(values: &mut Vec<String>) {
 #[cfg(test)]
 mod tests {
     use rara_kernel::data_feed::{DataFeedConfig, FeedStatus, FeedType};
+    use wiremock::{
+        Mock, MockServer, ResponseTemplate,
+        matchers::{method, path, query_param},
+    };
 
-    use super::MarketCandleSource;
+    use super::{MarketCandleSource, market_candle_fanout_safety};
 
     fn candle_source() -> MarketCandleSource {
         let config = DataFeedConfig::builder()
@@ -847,6 +1131,34 @@ mod tests {
             .build();
 
         MarketCandleSource::from_config(&config).expect("Binance config should parse")
+    }
+
+    fn yahoo_source() -> MarketCandleSource {
+        yahoo_source_with_base_url("https://query1.finance.yahoo.com", "AAPL")
+    }
+
+    fn yahoo_source_with_base_url(base_url: &str, symbol: &str) -> MarketCandleSource {
+        let config = DataFeedConfig::builder()
+            .id("yahoo-candles-test".to_owned())
+            .name("yahoo-public".to_owned())
+            .feed_type(FeedType::MarketCandle)
+            .tags(vec!["finance".to_owned(), "best-effort".to_owned()])
+            .transport(serde_json::json!({
+                "provider": "yahoo",
+                "base_url": base_url,
+                "interval_secs": 900,
+                "venue": "yahoo",
+                "symbols": [symbol],
+                "timeframes": ["1d"],
+                "max_candles_per_poll": 5
+            }))
+            .enabled(true)
+            .status(FeedStatus::Idle)
+            .created_at(jiff::Timestamp::UNIX_EPOCH)
+            .updated_at(jiff::Timestamp::UNIX_EPOCH)
+            .build();
+
+        MarketCandleSource::from_config(&config).expect("Yahoo config should parse")
     }
 
     #[test]
@@ -1026,6 +1338,170 @@ mod tests {
             url.as_str(),
             "https://api.binance.com/api/v3/klines?symbol=BTCUSDT&interval=1m&limit=2"
         );
+    }
+
+    #[test]
+    fn yahoo_provider_builds_public_chart_url() {
+        let source = yahoo_source();
+        let url = source
+            .build_yahoo_chart_url("^GSPC", "1d")
+            .expect("URL should build");
+
+        assert_eq!(
+            url.as_str(),
+            "https://query1.finance.yahoo.com/v8/finance/chart/^GSPC?interval=1d&range=5d&events=history&includePrePost=false"
+        );
+    }
+
+    #[test]
+    fn yahoo_chart_becomes_closed_candle_events_and_skips_open_or_null_bars() {
+        let source = yahoo_source();
+        let events = source
+            .parse_yahoo_candle_events(
+                "AAPL",
+                "1d",
+                br#"{
+  "chart": {
+    "result": [{
+      "meta": {"symbol": "AAPL"},
+      "timestamp": [1713139200, 4102444800, 1713312000],
+      "indicators": {
+        "quote": [{
+          "open": [172.50, 190.00, null],
+          "high": [176.63, 192.00, 180.00],
+          "low": [172.45, 189.50, 175.00],
+          "close": [175.04, 191.25, 179.00],
+          "volume": [73531800, 1000, 2000]
+        }]
+      }
+    }],
+    "error": null
+  }
+}"#,
+            )
+            .expect("Yahoo chart should parse");
+
+        assert_eq!(events.len(), 1);
+        let event = &events[0];
+        assert_eq!(event.source_name, "yahoo-public");
+        assert_eq!(event.event_type, "market_candle_closed");
+        assert!(event.tags.contains(&"venue:yahoo".to_owned()));
+        assert!(event.tags.contains(&"symbol:AAPL".to_owned()));
+        assert!(event.tags.contains(&"timeframe:1d".to_owned()));
+        assert_eq!(event.payload["open"], "172.5");
+        assert_eq!(event.payload["high"], "176.63");
+        assert_eq!(event.payload["low"], "172.45");
+        assert_eq!(event.payload["close"], "175.04");
+        assert_eq!(event.payload["volume"], "73531800");
+    }
+
+    #[test]
+    fn yahoo_chart_normalizes_missing_volume_to_zero() {
+        let source = yahoo_source();
+        let events = source
+            .parse_yahoo_candle_events(
+                "AAPL",
+                "1d",
+                br#"{
+  "chart": {
+    "result": [{
+      "timestamp": [1713139200],
+      "indicators": {
+        "quote": [{
+          "open": [172.50],
+          "high": [176.63],
+          "low": [172.45],
+          "close": [175.04],
+          "volume": [null]
+        }]
+      }
+    }],
+    "error": null
+  }
+}"#,
+            )
+            .expect("Yahoo chart should parse");
+
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].payload["volume"], "0");
+    }
+
+    #[tokio::test]
+    async fn yahoo_poll_fetches_chart_and_emits_closed_candle() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/v8/finance/chart/AAPL"))
+            .and(query_param("interval", "1d"))
+            .and(query_param("range", "5d"))
+            .and(query_param("events", "history"))
+            .and(query_param("includePrePost", "false"))
+            .respond_with(ResponseTemplate::new(200).set_body_raw(
+                r#"{
+  "chart": {
+    "result": [{
+      "timestamp": [1713139200],
+      "indicators": {
+        "quote": [{
+          "open": [172.50],
+          "high": [176.63],
+          "low": [172.45],
+          "close": [175.04],
+          "volume": [73531800]
+        }]
+      }
+    }],
+    "error": null
+  }
+}"#,
+                "application/json",
+            ))
+            .expect(1)
+            .mount(&server)
+            .await;
+        let source = yahoo_source_with_base_url(&server.uri(), "AAPL");
+        let (tx, mut rx) = tokio::sync::mpsc::channel(1);
+
+        assert!(source.poll_yahoo_once(&tx).await);
+        drop(tx);
+
+        let event = rx.recv().await.expect("closed candle event");
+        assert_eq!(event.payload["symbol"], "AAPL");
+        assert_eq!(event.payload["close"], "175.04");
+        assert!(rx.recv().await.is_none());
+    }
+
+    #[test]
+    fn yahoo_fanout_uses_one_request_per_stream_and_conservative_budget() {
+        let transport = serde_json::json!({"interval_secs": 60});
+        let symbols = (0..100)
+            .map(|index| format!("SYM{index}"))
+            .collect::<Vec<_>>();
+        let timeframes = vec!["1d".to_owned()];
+
+        let safety = market_candle_fanout_safety(
+            Some("yahoo"),
+            &transport,
+            &symbols,
+            &timeframes,
+            super::DEFAULT_MARKET_CANDLE_REQUEST_BUDGET_PER_SECOND,
+        )
+        .expect("fan-out should calculate");
+
+        assert_eq!(safety.poll_request_count, 100);
+        assert_eq!(safety.request_budget_per_second, 0.2);
+        assert_eq!(safety.minimum_safe_interval_secs, 500);
+        assert!(!safety.safe_to_start);
+
+        let one_symbol = market_candle_fanout_safety(
+            Some("yahoo"),
+            &serde_json::json!({"interval_secs": 5}),
+            &["AAPL".to_owned()],
+            &timeframes,
+            super::DEFAULT_MARKET_CANDLE_REQUEST_BUDGET_PER_SECOND,
+        )
+        .expect("fan-out should calculate");
+        assert_eq!(one_symbol.minimum_safe_interval_secs, 60);
+        assert!(!one_symbol.safe_to_start);
     }
 
     #[test]

--- a/docs/guides/finance-subscriptions.md
+++ b/docs/guides/finance-subscriptions.md
@@ -125,6 +125,16 @@ Ready Binance catalog entries use Binance's public spot kline API directly and
 do not require rara to hold exchange credentials. They still emit only
 `market_candle_closed` feed events.
 
+Yahoo catalog entries are also keyless, but they use Yahoo Finance's
+undocumented public chart endpoint and are deliberately marked `best-effort`,
+`delayed`, `unofficial-api`, and `redistribution-restricted`. They are research
+feeds, not execution-grade market data. The built-in US and global starters use
+daily candles, poll every 15 minutes, cap Yahoo traffic at 0.2 requests per
+second, and space requests by five seconds. Custom Yahoo transports may use
+`1m`, `5m`, `15m`, `30m`, `1h`, or `1d`, but the fan-out guard enforces at
+least a 60-second polling cadence and raises the safe interval as the configured
+symbol/timeframe cross-product grows.
+
 ## Conversation tools
 
 The app registers feed-oriented tools for finance data source discovery,
@@ -147,7 +157,8 @@ runtime control, subscription management, and inspection:
 `finance_list_feed_bundles` is the preferred discovery view when the user asks
 what default finance data feeding rara can provide. It groups built-in catalog
 sources into curated presets such as `macro-news`, `binance-spot-starter`,
-`binance-major-crypto-15m`, and `longbridge-equities-daily`. Each bundle echoes
+`binance-major-crypto-15m`, `yahoo-us-equities-daily`,
+`yahoo-global-starter`, and `longbridge-equities-daily`. Each bundle echoes
 its `catalog_source_ids`, providers, feed types, aggregate
 `enabled_source_count`, `ready_source_count`, persisted/running/subscribed
 counts, per-session subscription counts, setup hints for operator-only presets,
@@ -429,7 +440,7 @@ or the subset whose source matches `catalog_source_ids`, `source_names`, or
   running, plus configured `venue`, `symbols`, and `timeframes`;
 - selector coverage (`covered`, `missing_selectors`, or `unavailable`) with a
   deterministic diagnostic such as `missing symbols: ETHUSDT; missing
-  timeframes: 5m`, so a fresh-runtime/no-data case can be separated from a
+timeframes: 5m`, so a fresh-runtime/no-data case can be separated from a
   feed configuration that cannot emit the subscribed stream;
 - persisted feed-event summary (`event_count`, `last_event_type`,
   `last_event_at`, and `lag_seconds`) to confirm the source is emitting the
@@ -517,23 +528,23 @@ Use this checklist before considering a deployment ready:
    recent persisted events for the subscribed source, including filtered views
    by `event_kinds`.
 10. Confirm `finance_diagnose_candle_subscriptions` reports a running feed, a
-   recent feed event, `selector_coverage = covered`, and a fresh latest candle
-   for the subscribed stream.
+    recent feed event, `selector_coverage = covered`, and a fresh latest candle
+    for the subscribed stream.
 11. Confirm `finance_get_latest_candle` returns the latest stored closed candle
-   for the subscribed `(venue, symbol, timeframe)`.
+    for the subscribed `(venue, symbol, timeframe)`.
 12. Confirm
-   `GET /api/v1/data-feeds/market-data/candle-streams?venue=...&symbol=...`
-   returns the stored stream watermark.
-11. Confirm `finance_get_recent_candles`,
-   `GET /api/v1/data-feeds/market-data/candles/recent?venue=...&symbol=...&timeframe=...`,
-   `finance_query_candles`, and
-   `GET /api/v1/data-feeds/market-data/candles?venue=...&symbol=...&timeframe=...&start=...&end=...`
-   return ordered candles with decimal values encoded as strings.
-12. Confirm one matching item wakes the same session at most once.
-13. Confirm a seventh matching item in an hour is tape-only under the default
-   immediate-delivery budget.
-14. Confirm no feed URL, ticker provider URL, credentials, order, deployment, or
-   account tool is agent-callable.
+    `GET /api/v1/data-feeds/market-data/candle-streams?venue=...&symbol=...`
+    returns the stored stream watermark.
+13. Confirm `finance_get_recent_candles`,
+    `GET /api/v1/data-feeds/market-data/candles/recent?venue=...&symbol=...&timeframe=...`,
+    `finance_query_candles`, and
+    `GET /api/v1/data-feeds/market-data/candles?venue=...&symbol=...&timeframe=...&start=...&end=...`
+    return ordered candles with decimal values encoded as strings.
+14. Confirm one matching item wakes the same session at most once.
+15. Confirm a seventh matching item in an hour is tape-only under the default
+    immediate-delivery budget.
+16. Confirm no feed URL, ticker provider URL, credentials, order, deployment, or
+    account tool is agent-callable.
 
 ## Non-goals
 

--- a/web/src/components/DataFeedsPanel.tsx
+++ b/web/src/components/DataFeedsPanel.tsx
@@ -83,6 +83,7 @@ import {
   TableRow,
 } from '@/components/ui/table';
 import { candleSubscriptionStreamHealth } from '@/lib/finance-candle-health';
+import { financeFeedQualityDisclosures } from '@/lib/finance-feed-quality';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -1603,6 +1604,7 @@ function FeedCatalogCard({
     const load = catalogLoadLabel(entry);
     const fanoutDiagnostic = catalogFanoutDiagnostic(entry);
     const provider = catalogProvider(entry);
+    const qualityDisclosures = financeFeedQualityDisclosures([entry]);
     const subscribed = entry.subscriptions?.user_subscribed === true;
     const unsubscribeButton = subscribed ? (
       <Button
@@ -1632,6 +1634,11 @@ function FeedCatalogCard({
                 Provider {provider}
               </Badge>
             )}
+            {qualityDisclosures.map((disclosure) => (
+              <Badge key={disclosure} variant="outline" className="text-xs text-muted-foreground">
+                {disclosure}
+              </Badge>
+            ))}
             {entry.enabled && (
               <Badge variant="secondary" className="text-xs text-foreground">
                 Enabled
@@ -1832,6 +1839,7 @@ function FinanceFeedBundlesCard({ bundles }: { bundles: FinanceFeedBundle[] }) {
               bundle.providers.length > 0 ? summarizeList(bundle.providers) : 'Mixed sources';
             const feedTypeLabel = bundle.feed_types.map(typeLabel).join(' + ');
             const sourceNames = bundle.sources.map((source) => catalogSourceName(source));
+            const qualityDisclosures = financeFeedQualityDisclosures(bundle.sources);
             const canEnable = bundle.can_enable && readyDisabledSources.length > 0;
             const singleConfigurableSource =
               configurableSources.length === 1 ? (configurableSources[0] ?? null) : null;
@@ -1845,6 +1853,15 @@ function FinanceFeedBundlesCard({ bundles }: { bundles: FinanceFeedBundle[] }) {
                       <Badge variant="outline" className="text-xs">
                         {configuredLabel}
                       </Badge>
+                      {qualityDisclosures.map((disclosure) => (
+                        <Badge
+                          key={disclosure}
+                          variant="outline"
+                          className="text-xs text-muted-foreground"
+                        >
+                          {disclosure}
+                        </Badge>
+                      ))}
                       {configuredSources.length === bundle.source_count && (
                         <Badge variant="secondary" className="text-xs text-foreground">
                           Enabled

--- a/web/src/components/__tests__/DataFeedsPanel.test.tsx
+++ b/web/src/components/__tests__/DataFeedsPanel.test.tsx
@@ -419,6 +419,68 @@ describe('DataFeedsPanel', () => {
     });
   });
 
+  it('discloses keyless best-effort Yahoo bundle quality', async () => {
+    const yahoo: FeedCatalogEntry = {
+      id: 'yahoo-market-candles',
+      name: 'Yahoo US Equities Daily',
+      description: 'Best-effort Yahoo Finance daily candles for research.',
+      feed_type: 'market_candle',
+      provider: 'yahoo',
+      tags: [
+        'finance',
+        'market-data',
+        'yahoo',
+        'no-auth',
+        'best-effort',
+        'delayed',
+        'unofficial-api',
+      ],
+      source_name: 'finance-yahoo-market-candles',
+      enabled: false,
+      feed_id: null,
+      requires_configuration: false,
+      setup_hint: null,
+      transport_template: {
+        provider: 'yahoo',
+        venue: 'yahoo',
+        symbols: ['AAPL'],
+        timeframes: ['1d'],
+      },
+    };
+
+    catalogMock.mockResolvedValue([yahoo] satisfies FeedCatalogEntry[]);
+    financeBundlesMock.mockResolvedValue({
+      count: 1,
+      bundles: [
+        {
+          id: 'yahoo-us-equities-daily',
+          name: 'Yahoo US Equities Daily',
+          description: 'Keyless best-effort daily candles.',
+          tags: ['finance', 'market-data', 'equities', 'yahoo', 'best-effort'],
+          catalog_source_ids: ['yahoo-market-candles'],
+          feed_types: ['market_candle'],
+          providers: ['yahoo'],
+          source_count: 1,
+          enabled_source_count: 0,
+          ready_source_count: 1,
+          requires_configuration: false,
+          can_enable: true,
+          sources: [yahoo],
+          subscriptions: {
+            user_subscribed: false,
+            user_subscription_ids: [],
+          },
+        },
+      ],
+    } satisfies FinanceFeedBundlesResponse);
+
+    renderPanel();
+
+    expect(await screen.findAllByText('No key required')).toHaveLength(2);
+    expect(screen.getAllByText('Best effort')).toHaveLength(2);
+    expect(screen.getAllByText('Delayed / unofficial')).toHaveLength(2);
+  });
+
   it('opens the catalog configure dialog from a requires-config finance bundle', async () => {
     const longbridge: FeedCatalogEntry = {
       id: 'longbridge-market-candles',

--- a/web/src/components/topology/FinanceWatchesCard.tsx
+++ b/web/src/components/topology/FinanceWatchesCard.tsx
@@ -32,6 +32,7 @@ import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { expectedCandleStreamHealthForGroups } from '@/lib/finance-candle-health';
+import { financeFeedQualityDisclosures } from '@/lib/finance-feed-quality';
 
 interface FinanceWatchesCardProps {
   sessionKey: string;
@@ -229,6 +230,7 @@ export function FinanceWatchesCard({ sessionKey }: FinanceWatchesCardProps) {
                   const providers = summarizeList(bundle.providers, 2);
                   const load = bundleLoadLabel(bundle);
                   const fanoutDiagnostic = bundleFanoutDiagnostic(bundle);
+                  const qualityDisclosures = financeFeedQualityDisclosures(bundle.sources);
                   return (
                     <div key={bundle.id} className="rounded-md border bg-muted/20 px-3 py-2">
                       <div className="flex items-start justify-between gap-2">
@@ -249,6 +251,15 @@ export function FinanceWatchesCard({ sessionKey }: FinanceWatchesCardProps) {
                             <Badge variant="secondary" className="px-1.5 py-0 text-[10px]">
                               {bundle.enabled_source_count}/{bundle.source_count} sources on
                             </Badge>
+                            {qualityDisclosures.map((disclosure) => (
+                              <Badge
+                                key={disclosure}
+                                variant="outline"
+                                className="px-1.5 py-0 text-[10px] text-muted-foreground"
+                              >
+                                {disclosure}
+                              </Badge>
+                            ))}
                             {subscribed && (
                               <Badge variant="secondary" className="px-1.5 py-0 text-[10px]">
                                 watching
@@ -359,6 +370,7 @@ export function FinanceWatchesCard({ sessionKey }: FinanceWatchesCardProps) {
               });
               const load = catalogLoadLabel(entry);
               const fanoutDiagnostic = catalogFanoutDiagnostic(entry);
+              const qualityDisclosures = financeFeedQualityDisclosures([entry]);
               return (
                 <div key={entry.id} className="rounded-md border bg-background/60 px-3 py-2">
                   <div className="flex items-start justify-between gap-2">
@@ -379,6 +391,15 @@ export function FinanceWatchesCard({ sessionKey }: FinanceWatchesCardProps) {
                             Provider {provider}
                           </Badge>
                         )}
+                        {qualityDisclosures.map((disclosure) => (
+                          <Badge
+                            key={disclosure}
+                            variant="outline"
+                            className="px-1.5 py-0 text-[10px] text-muted-foreground"
+                          >
+                            {disclosure}
+                          </Badge>
+                        ))}
                         {!entry.enabled && (
                           <Badge variant="secondary" className="px-1.5 py-0 text-[10px]">
                             {needsConfiguration ? 'needs config' : 'source off'}

--- a/web/src/components/topology/__tests__/FinanceWatchesCard.test.tsx
+++ b/web/src/components/topology/__tests__/FinanceWatchesCard.test.tsx
@@ -329,6 +329,55 @@ describe('FinanceWatchesCard', () => {
     expect(screen.getByText('Rara can quick-start this bundle from chat.')).toBeInTheDocument();
   });
 
+  it('discloses_keyless_best_effort_yahoo_bundle_quality', async () => {
+    const source = catalogEntry({
+      id: 'yahoo-market-candles',
+      name: 'Yahoo US Equities Daily',
+      source_name: 'finance-yahoo-market-candles',
+      feed_type: 'market_candle',
+      provider: 'yahoo',
+      tags: [
+        'finance',
+        'market-data',
+        'yahoo',
+        'no-auth',
+        'best-effort',
+        'delayed',
+        'unofficial-api',
+      ],
+      enabled: false,
+      transport_template: {
+        provider: 'yahoo',
+        venue: 'yahoo',
+        symbols: ['AAPL'],
+        timeframes: ['1d'],
+      },
+    });
+    catalogMock.mockResolvedValue([]);
+    financeBundlesMock.mockResolvedValue({
+      bundles: [
+        financeBundle({
+          id: 'yahoo-us-equities-daily',
+          name: 'Yahoo US Equities Daily',
+          feed_types: ['market_candle'],
+          providers: ['yahoo'],
+          sources: [source],
+        }),
+      ],
+      count: 1,
+    });
+    financeSubscriptionsMock.mockResolvedValue({
+      subscriptions: [],
+      count: 0,
+    } satisfies FinanceSubscriptionsResponse);
+
+    renderCard('session-1');
+
+    expect(await screen.findByText('No key required')).toBeInTheDocument();
+    expect(screen.getByText('Best effort')).toBeInTheDocument();
+    expect(screen.getByText('Delayed / unofficial')).toBeInTheDocument();
+  });
+
   it('uses_quick_start_configure_hint_for_bundle_settings_target', async () => {
     const source = catalogEntry({
       id: 'longbridge-default-candles',

--- a/web/src/lib/finance-feed-quality.ts
+++ b/web/src/lib/finance-feed-quality.ts
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2026 Rararulab
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+interface TaggedFeedSource {
+  tags: string[];
+}
+
+export function financeFeedQualityDisclosures(sources: TaggedFeedSource[]): string[] {
+  if (sources.length === 0) return [];
+
+  const disclosures: string[] = [];
+  if (sources.every((source) => source.tags.includes('no-auth'))) {
+    disclosures.push('No key required');
+  }
+  if (sources.some((source) => source.tags.includes('best-effort'))) {
+    disclosures.push('Best effort');
+  }
+  if (
+    sources.some(
+      (source) => source.tags.includes('delayed') && source.tags.includes('unofficial-api'),
+    )
+  ) {
+    disclosures.push('Delayed / unofficial');
+  }
+  return disclosures;
+}


### PR DESCRIPTION
## Summary

- add a no-key Yahoo chart polling provider for closed market candles
- ship US-equity and global starter bundles with explicit best-effort/delayed/unofficial disclosures
- surface feed-quality badges in both finance subscription views
- document supported intervals, conservative throttling, and research-only constraints

## Safety and behavior

- routes Yahoo candles through the existing market_candle_closed event and TimescaleDB ingestion path
- caps Yahoo polling at 0.2 requests/second and validates fanout safety
- skips incomplete/future and null-OHLC bars; treats missing volume as zero
- does not present Yahoo as an execution-grade or redistribution-safe source

## Validation

- cargo test -p rara-trading -p rara-app -p rara-backend-admin
- TimescaleDB testcontainer integration test
- cargo clippy -p rara-trading -p rara-app -p rara-backend-admin --all-targets -- -D warnings
- cargo deny check
- npm run test (114 tests)
- npm run typecheck
- npm run lint
- npm run format:check
- npm run build
- pre-commit full-workspace check, clippy, and docs hooks

## Live-provider note

Yahoo returned HTTP 403/429 from the current CI/development egress, so the end-to-end request contract is covered with a real local HTTP mock. The source remains explicitly labeled best-effort and unofficial.