### PR TITLE
fix(finance): harden Yahoo feed availability

### DIFF
--- a/crates/app/src/tools/finance_feed.rs
+++ b/crates/app/src/tools/finance_feed.rs
@@ -2013,6 +2013,7 @@ impl ToolExecute for FinanceEnableFeedSourceTool {
             Some(feed) => {
                 let config = config_from_source(&source, Some(feed))?;
                 ensure_market_candle_fanout_safe_to_enable(&config)?;
+                preflight_finance_feed_config(&config).await?;
                 anyhow::ensure!(
                     self.svc.update_feed(&config).await?,
                     "failed to update existing finance feed source: {source_name}"
@@ -2023,6 +2024,7 @@ impl ToolExecute for FinanceEnableFeedSourceTool {
             None => {
                 let config = config_from_source(&source, None)?;
                 ensure_market_candle_fanout_safe_to_enable(&config)?;
+                preflight_finance_feed_config(&config).await?;
                 self.svc.create_feed(&config).await?;
                 self.registry.register(config.clone())?;
                 (config, true)
@@ -2125,6 +2127,7 @@ impl ToolExecute for FinanceRestartFeedSourceTool {
 
         normalize_finance_feed_config(&mut config)?;
         ensure_market_candle_fanout_safe_to_enable(&config)?;
+        preflight_finance_feed_config(&config).await?;
         config.status = FeedStatus::Idle;
         config.last_error = None;
         config.updated_at = Timestamp::now();
@@ -2625,6 +2628,9 @@ impl ToolExecute for FinanceSubscribeInstrumentsTool {
             replace_existing_instruments,
         )?;
         let disabled_for_fanout_safety = apply_market_candle_fanout_guard(&mut config, start_now)?;
+        if config.enabled {
+            preflight_finance_feed_config(&config).await?;
+        }
 
         let feed_updated = if created {
             self.data_feed_svc.create_feed(&config).await?;
@@ -4897,6 +4903,17 @@ fn normalize_finance_feed_config(config: &mut DataFeedConfig) -> anyhow::Result<
         MarketCandleSource::normalize_config(config)?;
     }
     Ok(())
+}
+
+async fn preflight_finance_feed_config(config: &DataFeedConfig) -> anyhow::Result<()> {
+    if config.feed_type != FeedType::MarketCandle {
+        return Ok(());
+    }
+    let source = MarketCandleSource::from_config(config)?;
+    source
+        .preflight()
+        .await
+        .map_err(|failure| anyhow::anyhow!("market candle provider preflight failed: {failure}"))
 }
 
 fn merge_tags(mut tags: Vec<String>, existing: &[String]) -> Vec<String> {
@@ -7670,6 +7687,49 @@ mod tests {
             .unwrap_err();
 
         assert!(err.to_string().contains("requires configuration"));
+    }
+
+    #[tokio::test]
+    async fn enable_feed_source_preflights_yahoo_before_persisting_enabled_state() {
+        let (_list, tool, _disable, _restart, _subscribe, svc, _registry, _finance_registry) =
+            tool().await;
+        let now = jiff::Timestamp::now();
+        let existing = DataFeedConfig::builder()
+            .id("existing-yahoo".to_owned())
+            .name("finance-yahoo-market-candles".to_owned())
+            .feed_type(FeedType::MarketCandle)
+            .tags(vec!["finance".to_owned(), "experimental".to_owned()])
+            .transport(serde_json::json!({
+                "provider": "yahoo",
+                "base_url": "https://127.0.0.1:9",
+                "interval_secs": 900,
+                "headers": {},
+                "venue": "yahoo",
+                "symbols": ["AAPL"],
+                "timeframes": ["1d"],
+                "max_candles_per_poll": 5
+            }))
+            .enabled(false)
+            .status(FeedStatus::Idle)
+            .created_at(now)
+            .updated_at(now)
+            .build();
+        svc.create_feed(&existing).await.unwrap();
+
+        let err = tool
+            .run(
+                FinanceEnableFeedSourceParams {
+                    catalog_source_id: "yahoo-market-candles".to_owned(),
+                    start_now:         Some(false),
+                },
+                &context(),
+            )
+            .await
+            .unwrap_err();
+
+        assert!(err.to_string().contains("code=unavailable"));
+        let persisted = svc.get_feed("existing-yahoo").await.unwrap().unwrap();
+        assert!(!persisted.enabled);
     }
 
     #[tokio::test]

--- a/crates/app/src/tools/finance_feed.rs
+++ b/crates/app/src/tools/finance_feed.rs
@@ -2628,9 +2628,7 @@ impl ToolExecute for FinanceSubscribeInstrumentsTool {
             replace_existing_instruments,
         )?;
         let disabled_for_fanout_safety = apply_market_candle_fanout_guard(&mut config, start_now)?;
-        if config.enabled {
-            preflight_finance_feed_config(&config).await?;
-        }
+        preflight_finance_feed_config(&config).await?;
 
         let feed_updated = if created {
             self.data_feed_svc.create_feed(&config).await?;
@@ -4906,7 +4904,7 @@ fn normalize_finance_feed_config(config: &mut DataFeedConfig) -> anyhow::Result<
 }
 
 async fn preflight_finance_feed_config(config: &DataFeedConfig) -> anyhow::Result<()> {
-    if config.feed_type != FeedType::MarketCandle {
+    if !config.enabled || config.feed_type != FeedType::MarketCandle {
         return Ok(());
     }
     let source = MarketCandleSource::from_config(config)?;

--- a/crates/extensions/backend-admin/src/data_feeds/router.rs
+++ b/crates/extensions/backend-admin/src/data_feeds/router.rs
@@ -893,6 +893,7 @@ async fn enable_catalog_feed(
             .updated_at(now)
             .build();
         normalize_active_feed_config(&mut updated)?;
+        preflight_active_feed_config(&updated).await?;
         state.svc.update_feed(&updated).await?;
         (StatusCode::OK, updated)
     } else {
@@ -909,6 +910,7 @@ async fn enable_catalog_feed(
             .updated_at(now)
             .build();
         normalize_active_feed_config(&mut created)?;
+        preflight_active_feed_config(&created).await?;
         state.svc.create_feed(&created).await?;
         (StatusCode::CREATED, created)
     };
@@ -1071,6 +1073,7 @@ async fn create_feed(
         .updated_at(now)
         .build();
     normalize_active_feed_config(&mut config)?;
+    preflight_active_feed_config(&config).await?;
 
     // 1. Persist to database.
     state.svc.create_feed(&config).await?;
@@ -1156,6 +1159,9 @@ async fn update_feed(
         .updated_at(Timestamp::now())
         .build();
     normalize_active_feed_config(&mut updated)?;
+    if updated.enabled {
+        preflight_active_feed_config(&updated).await?;
+    }
 
     // 1. Persist to database.
     state.svc.update_feed(&updated).await?;
@@ -1245,6 +1251,7 @@ async fn toggle_feed(
 
     if feed.enabled {
         normalize_active_feed_config(&mut feed)?;
+        preflight_active_feed_config(&feed).await?;
     }
     if !state.svc.update_feed(&feed).await? {
         return Err(ProblemDetails::internal(format!(
@@ -2480,6 +2487,26 @@ fn normalize_active_feed_config(config: &mut DataFeedConfig) -> Result<(), Probl
     }
 }
 
+async fn preflight_active_feed_config(config: &DataFeedConfig) -> Result<(), ProblemDetails> {
+    if config.feed_type != FeedType::MarketCandle {
+        return Ok(());
+    }
+    let source = MarketCandleSource::from_config(config).map_err(|err| {
+        ProblemDetails::bad_request(format!("invalid market candle config: {err}"))
+    })?;
+    source.preflight().await.map_err(|failure| {
+        if failure.retryable {
+            ProblemDetails::service_unavailable(format!(
+                "market candle provider preflight failed: {failure}"
+            ))
+        } else {
+            ProblemDetails::bad_request(format!(
+                "market candle provider preflight failed: {failure}"
+            ))
+        }
+    })
+}
+
 fn sync_registry_and_maybe_start(config: &DataFeedConfig, registry: &Arc<DataFeedRegistry>) {
     let _ = registry.remove(&config.name);
     if let Err(e) = registry.register(config.clone()) {
@@ -2935,6 +2962,7 @@ mod tests {
         assert!(ids.contains(&"fed-press-releases"));
         assert!(ids.contains(&"sec-press-releases"));
         assert!(ids.contains(&"binance-market-candles"));
+        assert!(ids.contains(&"yahoo-market-candles"));
 
         let binance = entries
             .as_array()
@@ -2980,6 +3008,29 @@ mod tests {
                 - 2.0 / 60.0)
                 .abs()
                 < f64::EPSILON
+        );
+
+        let yahoo = entries
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|entry| entry["id"] == "yahoo-market-candles")
+            .unwrap();
+        assert_eq!(yahoo["provider"], "yahoo");
+        assert_eq!(yahoo["requires_configuration"], false);
+        assert!(
+            yahoo["tags"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .any(|tag| tag == "experimental")
+        );
+        assert!(
+            yahoo["tags"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .any(|tag| tag == "region-dependent")
         );
 
         let longbridge = entries
@@ -3110,7 +3161,7 @@ mod tests {
             .await
             .unwrap();
         let result: serde_json::Value = serde_json::from_slice(&body).unwrap();
-        assert_eq!(result["count"], 6);
+        assert_eq!(result["count"], 4);
 
         let bundles = result["bundles"].as_array().unwrap();
         let macro_news = bundles
@@ -3169,33 +3220,11 @@ mod tests {
         assert_eq!(longbridge["requires_configuration"], true);
         assert_eq!(longbridge["can_enable"], false);
 
-        let yahoo = bundles
-            .iter()
-            .find(|bundle| bundle["id"] == "yahoo-us-equities-daily")
-            .unwrap();
-        assert_eq!(yahoo["providers"], serde_json::json!(["yahoo"]));
-        assert_eq!(yahoo["requires_configuration"], false);
-        assert_eq!(yahoo["can_enable"], true);
-        assert_eq!(yahoo["sources"][0]["provider"], "yahoo");
-        assert_eq!(
-            yahoo["sources"][0]["configured_timeframes"],
-            serde_json::json!(["1d"])
-        );
-        assert_eq!(
-            yahoo["sources"][0]["load"]["configured_market_request_budget_per_second"],
-            0.2
-        );
-        assert_eq!(
-            yahoo["sources"][0]["load"]["configured_market_fanout_safe_to_start"],
-            true
-        );
-        assert!(
-            yahoo["sources"][0]["tags"]
+        assert!(bundles.iter().all(|bundle| {
+            bundle["providers"]
                 .as_array()
-                .unwrap()
-                .iter()
-                .any(|tag| tag == "best-effort")
-        );
+                .is_none_or(|providers| providers.iter().all(|provider| provider != "yahoo"))
+        }));
     }
 
     #[test]
@@ -3670,6 +3699,48 @@ mod tests {
         assert_eq!(feed.transport["venue"], "binance");
         assert_eq!(feed.transport["symbols"][0], "BTCUSDT");
         assert!(feed.enabled);
+    }
+
+    #[tokio::test]
+    async fn finance_catalog_enable_preflights_yahoo_before_persisting() {
+        let (app, pools) = app_with_user_and_pools(user_of(Role::Admin)).await;
+        let res = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/v1/data-feeds/catalog/yahoo-market-candles/enable")
+                    .header("Authorization", "Bearer s3cret")
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        serde_json::json!({
+                            "transport": {
+                                "base_url": "https://127.0.0.1:9",
+                                "symbols": ["AAPL"],
+                                "timeframes": ["1d"]
+                            }
+                        })
+                        .to_string(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(res.status(), StatusCode::SERVICE_UNAVAILABLE);
+        let body = axum::body::to_bytes(res.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let problem: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert!(
+            problem["detail"]
+                .as_str()
+                .unwrap()
+                .contains("code=unavailable"),
+            "unexpected preflight problem: {problem}"
+        );
+
+        let svc = DataFeedSvc::new(pools);
+        assert!(svc.list_feeds().await.unwrap().is_empty());
     }
 
     #[tokio::test]

--- a/crates/extensions/rara-trading/src/feed/catalog.rs
+++ b/crates/extensions/rara-trading/src/feed/catalog.rs
@@ -81,20 +81,6 @@ pub fn default_finance_feed_bundles() -> Vec<DefaultFeedBundle> {
             ["binance-major-crypto-15m"],
         ),
         feed_bundle(
-            "yahoo-us-equities-daily",
-            "Yahoo US Equities Daily",
-            "Keyless best-effort daily candles for a focused US equities research watchlist.",
-            ["finance", "market-data", "equities", "yahoo", "best-effort"],
-            ["yahoo-market-candles"],
-        ),
-        feed_bundle(
-            "yahoo-global-starter",
-            "Yahoo Global Starter",
-            "Keyless best-effort daily candles for a small cross-market research watchlist.",
-            ["finance", "market-data", "global", "yahoo", "best-effort"],
-            ["yahoo-global-market-candles"],
-        ),
-        feed_bundle(
             "longbridge-equities-daily",
             "Longbridge Equities Daily",
             "Longbridge equities daily candles preset for configured normalized endpoints.",
@@ -172,6 +158,8 @@ pub fn default_finance_feed_sources() -> Vec<DefaultFeedSource> {
                 "no-auth",
                 "best-effort",
                 "delayed",
+                "experimental",
+                "region-dependent",
                 "unofficial-api",
                 "redistribution-restricted",
             ],
@@ -191,6 +179,8 @@ pub fn default_finance_feed_sources() -> Vec<DefaultFeedSource> {
                 "no-auth",
                 "best-effort",
                 "delayed",
+                "experimental",
+                "region-dependent",
                 "unofficial-api",
                 "redistribution-restricted",
             ],
@@ -500,7 +490,7 @@ mod tests {
     }
 
     #[test]
-    fn yahoo_presets_are_keyless_best_effort_daily_sources() {
+    fn yahoo_presets_are_explicit_region_dependent_sources_not_quick_start_bundles() {
         let sources = default_finance_feed_sources();
         let yahoo = sources
             .iter()
@@ -514,6 +504,8 @@ mod tests {
             "no-auth",
             "best-effort",
             "delayed",
+            "experimental",
+            "region-dependent",
             "unofficial-api",
             "redistribution-restricted",
         ] {
@@ -526,15 +518,14 @@ mod tests {
         assert_eq!(transport["interval_secs"], 900);
 
         let bundles = default_finance_feed_bundles();
-        let us = bundles
-            .iter()
-            .find(|bundle| bundle.id == "yahoo-us-equities-daily")
-            .expect("missing Yahoo US equities bundle");
-        assert_eq!(us.catalog_source_ids, ["yahoo-market-candles"]);
-        let global = bundles
-            .iter()
-            .find(|bundle| bundle.id == "yahoo-global-starter")
-            .expect("missing Yahoo global starter bundle");
-        assert_eq!(global.catalog_source_ids, ["yahoo-global-market-candles"]);
+        assert!(
+            bundles.iter().all(|bundle| {
+                !bundle
+                    .catalog_source_ids
+                    .iter()
+                    .any(|source_id| source_id.starts_with("yahoo-"))
+            }),
+            "region-dependent Yahoo sources must not be advertised as quick-start bundles"
+        );
     }
 }

--- a/crates/extensions/rara-trading/src/feed/market_candle.rs
+++ b/crates/extensions/rara-trading/src/feed/market_candle.rs
@@ -22,10 +22,10 @@ use std::{
     collections::{HashMap, HashSet},
     str::FromStr,
     sync::{
-        Arc,
+        Arc, Mutex,
         atomic::{AtomicBool, Ordering},
     },
-    time::Duration,
+    time::{Duration, Instant},
 };
 
 use async_trait::async_trait;
@@ -35,8 +35,8 @@ use rara_kernel::data_feed::{
     StatusReporterRef, polling::apply_request_auth,
 };
 use reqwest::{
-    Url,
-    header::{HeaderName, HeaderValue},
+    StatusCode, Url,
+    header::{HeaderName, HeaderValue, RETRY_AFTER},
 };
 use rust_decimal::Decimal;
 use serde::{Deserialize, Serialize};
@@ -53,6 +53,9 @@ const MAX_MARKET_CANDLE_REQUEST_BUDGET_PER_SECOND: f64 = 100.0;
 const YAHOO_MARKET_CANDLE_REQUEST_BUDGET_PER_SECOND: f64 = 0.2;
 const YAHOO_MIN_INTERVAL_SECS: u64 = 60;
 const YAHOO_REQUEST_SPACING_SECS: u64 = 5;
+const YAHOO_ACCESS_BLOCK_COOLDOWN_SECS: u64 = 6 * 60 * 60;
+const YAHOO_RATE_LIMIT_COOLDOWN_SECS: u64 = 15 * 60;
+const YAHOO_MAX_COOLDOWN_SECS: u64 = 24 * 60 * 60;
 
 /// Minimum polling cadence for a market-candle feed, in seconds.
 ///
@@ -221,15 +224,188 @@ pub struct MarketCandleTransport {
 }
 
 pub struct MarketCandleSource {
-    name:       String,
-    tags:       Vec<String>,
-    transport:  MarketCandleTransport,
-    auth:       Option<AuthConfig>,
-    client:     reqwest::Client,
-    reporter:   Option<StatusReporterRef>,
-    in_error:   Arc<AtomicBool>,
-    symbols:    HashSet<String>,
-    timeframes: HashSet<String>,
+    name:          String,
+    tags:          Vec<String>,
+    transport:     MarketCandleTransport,
+    auth:          Option<AuthConfig>,
+    client:        reqwest::Client,
+    reporter:      Option<StatusReporterRef>,
+    in_error:      Arc<AtomicBool>,
+    yahoo_circuit: Mutex<YahooCircuitBreaker>,
+    symbols:       HashSet<String>,
+    timeframes:    HashSet<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MarketCandleProviderFailureKind {
+    RegionBlocked,
+    AccessBlocked,
+    RateLimited,
+    Unavailable,
+    InvalidResponse,
+}
+
+impl MarketCandleProviderFailureKind {
+    #[must_use]
+    pub fn code(self) -> &'static str {
+        match self {
+            Self::RegionBlocked => "region_blocked",
+            Self::AccessBlocked => "access_blocked",
+            Self::RateLimited => "rate_limited",
+            Self::Unavailable => "unavailable",
+            Self::InvalidResponse => "invalid_response",
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct MarketCandleProviderFailure {
+    pub provider:            String,
+    pub kind:                MarketCandleProviderFailureKind,
+    pub status:              Option<u16>,
+    pub retryable:           bool,
+    pub retry_after_seconds: Option<u64>,
+    message:                 String,
+}
+
+impl std::fmt::Display for MarketCandleProviderFailure {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            formatter,
+            "provider={} code={} retryable={}",
+            self.provider,
+            self.kind.code(),
+            self.retryable
+        )?;
+        if let Some(status) = self.status {
+            write!(formatter, " status={status}")?;
+        }
+        if let Some(seconds) = self.retry_after_seconds {
+            write!(formatter, " retry_after_secs={seconds}")?;
+        }
+        write!(formatter, ": {}", self.message)
+    }
+}
+
+impl std::error::Error for MarketCandleProviderFailure {}
+
+impl MarketCandleProviderFailure {
+    fn from_yahoo_response(status: StatusCode, retry_after: Option<u64>, body: &[u8]) -> Self {
+        let body = String::from_utf8_lossy(body).to_ascii_lowercase();
+        let (kind, retryable, retry_after_seconds, message) = match status {
+            StatusCode::FORBIDDEN if body.contains("mainland china") => (
+                MarketCandleProviderFailureKind::RegionBlocked,
+                false,
+                Some(YAHOO_ACCESS_BLOCK_COOLDOWN_SECS),
+                "Yahoo Finance is unavailable from this server's egress region; use a supported \
+                 equity provider or change the server egress region"
+                    .to_owned(),
+            ),
+            StatusCode::FORBIDDEN => (
+                MarketCandleProviderFailureKind::AccessBlocked,
+                false,
+                Some(YAHOO_ACCESS_BLOCK_COOLDOWN_SECS),
+                "Yahoo Finance rejected this server's egress; do not retry the same request per \
+                 symbol"
+                    .to_owned(),
+            ),
+            StatusCode::TOO_MANY_REQUESTS => {
+                let retry_after_seconds = retry_after
+                    .unwrap_or(YAHOO_RATE_LIMIT_COOLDOWN_SECS)
+                    .min(YAHOO_MAX_COOLDOWN_SECS);
+                (
+                    MarketCandleProviderFailureKind::RateLimited,
+                    true,
+                    Some(retry_after_seconds),
+                    "Yahoo Finance rate-limited this server; retry after the provider cooldown"
+                        .to_owned(),
+                )
+            }
+            status if status.is_server_error() => (
+                MarketCandleProviderFailureKind::Unavailable,
+                true,
+                None,
+                "Yahoo Finance is temporarily unavailable".to_owned(),
+            ),
+            _ => (
+                MarketCandleProviderFailureKind::InvalidResponse,
+                false,
+                None,
+                "Yahoo Finance rejected the chart request".to_owned(),
+            ),
+        };
+        Self {
+            provider: "yahoo".to_owned(),
+            kind,
+            status: Some(status.as_u16()),
+            retryable,
+            retry_after_seconds,
+            message,
+        }
+    }
+
+    fn yahoo_request(message: impl Into<String>) -> Self {
+        Self {
+            provider:            "yahoo".to_owned(),
+            kind:                MarketCandleProviderFailureKind::Unavailable,
+            status:              None,
+            retryable:           true,
+            retry_after_seconds: None,
+            message:             message.into(),
+        }
+    }
+
+    fn yahoo_invalid_response(message: impl Into<String>) -> Self {
+        Self {
+            provider:            "yahoo".to_owned(),
+            kind:                MarketCandleProviderFailureKind::InvalidResponse,
+            status:              None,
+            retryable:           false,
+            retry_after_seconds: None,
+            message:             message.into(),
+        }
+    }
+
+    fn opens_provider_circuit(&self) -> bool {
+        matches!(
+            self.kind,
+            MarketCandleProviderFailureKind::RegionBlocked
+                | MarketCandleProviderFailureKind::AccessBlocked
+                | MarketCandleProviderFailureKind::RateLimited
+                | MarketCandleProviderFailureKind::Unavailable
+        )
+    }
+
+    fn circuit_duration(&self) -> Duration {
+        Duration::from_secs(
+            self.retry_after_seconds
+                .unwrap_or(YAHOO_RATE_LIMIT_COOLDOWN_SECS),
+        )
+    }
+}
+
+#[derive(Debug, Default)]
+struct YahooCircuitBreaker {
+    open_until: Option<Instant>,
+}
+
+impl YahooCircuitBreaker {
+    fn remaining(&mut self) -> Option<Duration> {
+        let open_until = self.open_until?;
+        match open_until.checked_duration_since(Instant::now()) {
+            Some(remaining) => Some(remaining),
+            None => {
+                self.open_until = None;
+                None
+            }
+        }
+    }
+
+    fn open_for(&mut self, duration: Duration) {
+        self.open_until = Instant::now().checked_add(duration);
+    }
+
+    fn close(&mut self) { self.open_until = None; }
 }
 
 #[derive(Debug, Deserialize)]
@@ -325,6 +501,7 @@ impl MarketCandleSource {
             client,
             reporter: None,
             in_error: Arc::new(AtomicBool::new(false)),
+            yahoo_circuit: Mutex::new(YahooCircuitBreaker::default()),
             symbols,
             timeframes,
         })
@@ -383,6 +560,108 @@ impl MarketCandleSource {
             .append_pair("events", "history")
             .append_pair("includePrePost", "false");
         Ok(url)
+    }
+
+    async fn fetch_yahoo_chart_body(
+        &self,
+        symbol: &str,
+        timeframe: &str,
+    ) -> Result<Vec<u8>, MarketCandleProviderFailure> {
+        let url = self
+            .build_yahoo_chart_url(symbol, timeframe)
+            .map_err(|err| {
+                MarketCandleProviderFailure::yahoo_invalid_response(format!(
+                    "failed to build Yahoo chart URL: {err}"
+                ))
+            })?;
+        let mut request = self.client.get(url);
+        for (key, value) in &self.transport.headers {
+            request = request.header(key.as_str(), value.as_str());
+        }
+        request = apply_request_auth(request, &self.auth);
+
+        let response = request.send().await.map_err(|err| {
+            debug!(feed = %self.name, error = %err, "Yahoo chart request failed");
+            MarketCandleProviderFailure::yahoo_request("Yahoo chart request failed")
+        })?;
+        let status = response.status();
+        let retry_after = response
+            .headers()
+            .get(RETRY_AFTER)
+            .and_then(|value| value.to_str().ok())
+            .and_then(|value| value.trim().parse::<u64>().ok());
+        let body = response.bytes().await.map_err(|err| {
+            debug!(feed = %self.name, error = %err, "failed to read Yahoo chart response");
+            MarketCandleProviderFailure::yahoo_request("failed to read Yahoo chart response")
+        })?;
+        if body.len() > MAX_BODY_BYTES {
+            return Err(MarketCandleProviderFailure::yahoo_invalid_response(
+                format!("Yahoo chart response exceeded {MAX_BODY_BYTES} bytes"),
+            ));
+        }
+        if !status.is_success() {
+            return Err(MarketCandleProviderFailure::from_yahoo_response(
+                status,
+                retry_after,
+                &body,
+            ));
+        }
+        Ok(body.to_vec())
+    }
+
+    /// Probe the first configured stream before a provider-backed feed is
+    /// enabled.
+    ///
+    /// Normalized endpoints and providers with stable public contracts are
+    /// validated structurally at config load. Yahoo needs an actual request
+    /// because availability depends on the server's egress region and current
+    /// provider throttling state.
+    pub async fn preflight(&self) -> Result<(), MarketCandleProviderFailure> {
+        if self.transport.provider.as_deref() != Some("yahoo") {
+            return Ok(());
+        }
+        let symbol = self.transport.symbols.first().ok_or_else(|| {
+            MarketCandleProviderFailure::yahoo_invalid_response(
+                "Yahoo preflight requires at least one symbol",
+            )
+        })?;
+        let timeframe = self.transport.timeframes.first().ok_or_else(|| {
+            MarketCandleProviderFailure::yahoo_invalid_response(
+                "Yahoo preflight requires at least one timeframe",
+            )
+        })?;
+        let body = self.fetch_yahoo_chart_body(symbol, timeframe).await?;
+        self.parse_yahoo_candle_events(symbol, timeframe, &body)
+            .map_err(|err| {
+                MarketCandleProviderFailure::yahoo_invalid_response(format!(
+                    "failed to parse Yahoo chart response: {err}"
+                ))
+            })?;
+        Ok(())
+    }
+
+    fn yahoo_circuit_remaining(&self) -> Option<Duration> {
+        self.yahoo_circuit
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .remaining()
+    }
+
+    #[cfg(test)]
+    fn yahoo_circuit_is_open(&self) -> bool { self.yahoo_circuit_remaining().is_some() }
+
+    fn open_yahoo_circuit(&self, duration: Duration) {
+        self.yahoo_circuit
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .open_for(duration);
+    }
+
+    fn close_yahoo_circuit(&self) {
+        self.yahoo_circuit
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .close();
     }
 
     fn record_error(&self, message: String) {
@@ -756,57 +1035,38 @@ impl MarketCandleSource {
     }
 
     async fn poll_yahoo_once(&self, tx: &mpsc::Sender<FeedEvent>) -> bool {
+        if let Some(remaining) = self.yahoo_circuit_remaining() {
+            debug!(
+                feed = %self.name,
+                retry_after_secs = remaining.as_secs(),
+                "Yahoo provider circuit is open; skipping poll"
+            );
+            return true;
+        }
+
         let mut any_success = false;
         let mut request_count = 0_usize;
 
         for symbol in &self.transport.symbols {
             for timeframe in &self.transport.timeframes {
-                let url = match self.build_yahoo_chart_url(symbol, timeframe) {
-                    Ok(url) => url,
-                    Err(err) => {
-                        self.record_error(format!("failed to build Yahoo chart URL: {err}"));
-                        continue;
-                    }
-                };
-
                 if request_count > 0 {
                     tokio::time::sleep(Duration::from_secs(YAHOO_REQUEST_SPACING_SECS)).await;
                 }
                 request_count += 1;
 
-                let mut request = self.client.get(url);
-                for (key, value) in &self.transport.headers {
-                    request = request.header(key.as_str(), value.as_str());
-                }
-                request = apply_request_auth(request, &self.auth);
-
-                let response = match request.send().await {
-                    Ok(response) => response,
-                    Err(err) => {
-                        self.record_error(format!("Yahoo chart fetch failed: {err}"));
-                        continue;
-                    }
-                };
-                let status = response.status();
-                if !status.is_success() {
-                    self.record_error(format!(
-                        "Yahoo chart fetch received non-success status: {status}"
-                    ));
-                    continue;
-                }
-                let body = match response.bytes().await {
+                let body = match self.fetch_yahoo_chart_body(symbol, timeframe).await {
                     Ok(body) => body,
-                    Err(err) => {
-                        self.record_error(format!("failed to read Yahoo chart body: {err}"));
+                    Err(failure) => {
+                        let opens_provider_circuit = failure.opens_provider_circuit();
+                        let circuit_duration = failure.circuit_duration();
+                        self.record_error(failure.to_string());
+                        if opens_provider_circuit {
+                            self.open_yahoo_circuit(circuit_duration);
+                            return true;
+                        }
                         continue;
                     }
                 };
-                if body.len() > MAX_BODY_BYTES {
-                    self.record_error(format!(
-                        "Yahoo chart response exceeded {MAX_BODY_BYTES} bytes"
-                    ));
-                    continue;
-                }
                 let events = match self.parse_yahoo_candle_events(symbol, timeframe, &body) {
                     Ok(events) => events,
                     Err(err) => {
@@ -826,6 +1086,7 @@ impl MarketCandleSource {
         }
 
         if any_success {
+            self.close_yahoo_circuit();
             self.record_success();
         }
         true
@@ -861,7 +1122,12 @@ impl DataFeed for MarketCandleSource {
             "market candle feed started"
         );
 
-        let mut interval_timer = tokio::time::interval(interval);
+        let first_poll_at = if self.transport.provider.as_deref() == Some("yahoo") {
+            tokio::time::Instant::now() + Duration::from_secs(YAHOO_REQUEST_SPACING_SECS)
+        } else {
+            tokio::time::Instant::now()
+        };
+        let mut interval_timer = tokio::time::interval_at(first_poll_at, interval);
         interval_timer.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
 
         loop {
@@ -1078,13 +1344,16 @@ fn dedupe_sort(values: &mut Vec<String>) {
 
 #[cfg(test)]
 mod tests {
-    use rara_kernel::data_feed::{DataFeedConfig, FeedStatus, FeedType};
+    use std::time::Duration;
+
+    use rara_kernel::data_feed::{DataFeed, DataFeedConfig, FeedStatus, FeedType};
+    use tokio_util::sync::CancellationToken;
     use wiremock::{
         Mock, MockServer, ResponseTemplate,
         matchers::{method, path, query_param},
     };
 
-    use super::{MarketCandleSource, market_candle_fanout_safety};
+    use super::{MarketCandleProviderFailureKind, MarketCandleSource, market_candle_fanout_safety};
 
     fn candle_source() -> MarketCandleSource {
         let config = DataFeedConfig::builder()
@@ -1468,6 +1737,121 @@ mod tests {
         assert_eq!(event.payload["symbol"], "AAPL");
         assert_eq!(event.payload["close"], "175.04");
         assert!(rx.recv().await.is_none());
+    }
+
+    #[tokio::test]
+    async fn yahoo_run_delays_first_poll_after_activation_preflight() {
+        let server = MockServer::start().await;
+        let source = yahoo_source_with_base_url(&server.uri(), "AAPL");
+        let (tx, _rx) = tokio::sync::mpsc::channel(1);
+        let cancel = CancellationToken::new();
+        let run = source.run(tx, cancel.clone());
+        tokio::pin!(run);
+
+        tokio::select! {
+            result = &mut run => panic!("Yahoo feed stopped before cancellation: {result:?}"),
+            () = tokio::time::sleep(Duration::from_millis(50)) => cancel.cancel(),
+        }
+        run.await.expect("Yahoo feed should stop cleanly");
+
+        let requests = server
+            .received_requests()
+            .await
+            .expect("wiremock request history");
+        assert!(
+            requests.is_empty(),
+            "activation preflight must not be followed by an immediate runtime request"
+        );
+    }
+
+    #[tokio::test]
+    async fn yahoo_preflight_classifies_mainland_china_block() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/v8/finance/chart/AAPL"))
+            .respond_with(
+                ResponseTemplate::new(403).set_body_string(
+                    "Yahoo services are no longer accessible from mainland China.",
+                ),
+            )
+            .expect(1)
+            .mount(&server)
+            .await;
+        let source = yahoo_source_with_base_url(&server.uri(), "AAPL");
+
+        let failure = source
+            .preflight()
+            .await
+            .expect_err("region-blocked Yahoo must fail preflight");
+
+        assert_eq!(failure.kind, MarketCandleProviderFailureKind::RegionBlocked);
+        assert_eq!(failure.status, Some(403));
+        assert!(!failure.retryable);
+        assert!(failure.to_string().contains("code=region_blocked"));
+        assert!(failure.to_string().contains("egress region"));
+    }
+
+    #[tokio::test]
+    async fn yahoo_provider_block_stops_fanout_and_opens_circuit() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .respond_with(ResponseTemplate::new(403).set_body_string("Forbidden"))
+            .expect(1)
+            .mount(&server)
+            .await;
+        let mut source = yahoo_source_with_base_url(&server.uri(), "AAPL");
+        source.transport.symbols = vec!["AAPL".to_owned(), "MSFT".to_owned()];
+        let (tx, _rx) = tokio::sync::mpsc::channel(1);
+
+        assert!(source.poll_yahoo_once(&tx).await);
+        assert!(source.yahoo_circuit_is_open());
+        assert!(source.poll_yahoo_once(&tx).await);
+
+        let requests = server
+            .received_requests()
+            .await
+            .expect("wiremock request history");
+        assert_eq!(
+            requests.len(),
+            1,
+            "403 must stop fanout and suppress retries"
+        );
+    }
+
+    #[tokio::test]
+    async fn yahoo_rate_limit_stops_fanout_and_honors_retry_after() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .respond_with(
+                ResponseTemplate::new(429)
+                    .insert_header("Retry-After", "120")
+                    .set_body_string("Too Many Requests"),
+            )
+            .expect(1)
+            .mount(&server)
+            .await;
+        let mut source = yahoo_source_with_base_url(&server.uri(), "AAPL");
+        source.transport.symbols = vec!["AAPL".to_owned(), "MSFT".to_owned()];
+        let (tx, _rx) = tokio::sync::mpsc::channel(1);
+
+        assert!(source.poll_yahoo_once(&tx).await);
+
+        let remaining = source
+            .yahoo_circuit_remaining()
+            .expect("429 should open the provider circuit");
+        assert!(remaining.as_secs() >= 119);
+        assert!(remaining.as_secs() <= 120);
+        assert!(source.poll_yahoo_once(&tx).await);
+
+        let requests = server
+            .received_requests()
+            .await
+            .expect("wiremock request history");
+        assert_eq!(
+            requests.len(),
+            1,
+            "429 must stop fanout and suppress retries"
+        );
     }
 
     #[test]

--- a/docs/guides/finance-subscriptions.md
+++ b/docs/guides/finance-subscriptions.md
@@ -125,12 +125,24 @@ Ready Binance catalog entries use Binance's public spot kline API directly and
 do not require rara to hold exchange credentials. They still emit only
 `market_candle_closed` feed events.
 
-Yahoo catalog entries are also keyless, but they use Yahoo Finance's
-undocumented public chart endpoint and are deliberately marked `best-effort`,
-`delayed`, `unofficial-api`, and `redistribution-restricted`. They are research
-feeds, not execution-grade market data. The built-in US and global starters use
-daily candles, poll every 15 minutes, cap Yahoo traffic at 0.2 requests per
-second, and space requests by five seconds. Custom Yahoo transports may use
+Yahoo catalog entries are keyless, but they use Yahoo Finance's undocumented
+public chart endpoint and are deliberately marked `experimental`,
+`region-dependent`, `best-effort`, `delayed`, `unofficial-api`, and
+`redistribution-restricted`. They remain available as explicit research
+sources, but are not curated quick-start bundles or execution-grade market
+data. Enabling a Yahoo source first probes its first configured stream from the
+rara server. A region/access block fails with `code=region_blocked` or
+`code=access_blocked`; throttling fails with `code=rate_limited` and includes a
+retry interval. No new or updated enabled state is persisted when this
+preflight fails.
+
+At runtime, Yahoo feeds poll every 15 minutes by default, cap traffic at 0.2
+requests per second, and space requests by five seconds. The first runtime poll
+also waits five seconds after activation preflight, avoiding an immediate
+duplicate request. A provider-wide 403 or 429 stops the current symbol fan-out
+immediately and opens a source-local circuit for the classified cooldown, so a
+blocked egress does not turn a large watchlist into repeated failed requests.
+Custom Yahoo transports may use
 `1m`, `5m`, `15m`, `30m`, `1h`, or `1d`, but the fan-out guard enforces at
 least a 60-second polling cadence and raises the safe interval as the configured
 symbol/timeframe cross-product grows.
@@ -157,8 +169,9 @@ runtime control, subscription management, and inspection:
 `finance_list_feed_bundles` is the preferred discovery view when the user asks
 what default finance data feeding rara can provide. It groups built-in catalog
 sources into curated presets such as `macro-news`, `binance-spot-starter`,
-`binance-major-crypto-15m`, `yahoo-us-equities-daily`,
-`yahoo-global-starter`, and `longbridge-equities-daily`. Each bundle echoes
+`binance-major-crypto-15m`, and `longbridge-equities-daily`. Region-dependent
+Yahoo sources are discoverable through `finance_list_feed_sources` instead of
+the quick-start bundle list. Each bundle echoes
 its `catalog_source_ids`, providers, feed types, aggregate
 `enabled_source_count`, `ready_source_count`, persisted/running/subscribed
 counts, per-session subscription counts, setup hints for operator-only presets,

--- a/web/src/components/__tests__/DataFeedsPanel.test.tsx
+++ b/web/src/components/__tests__/DataFeedsPanel.test.tsx
@@ -433,6 +433,8 @@ describe('DataFeedsPanel', () => {
         'no-auth',
         'best-effort',
         'delayed',
+        'experimental',
+        'region-dependent',
         'unofficial-api',
       ],
       source_name: 'finance-yahoo-market-candles',
@@ -479,6 +481,7 @@ describe('DataFeedsPanel', () => {
     expect(await screen.findAllByText('No key required')).toHaveLength(2);
     expect(screen.getAllByText('Best effort')).toHaveLength(2);
     expect(screen.getAllByText('Delayed / unofficial')).toHaveLength(2);
+    expect(screen.getAllByText('Region dependent')).toHaveLength(2);
   });
 
   it('opens the catalog configure dialog from a requires-config finance bundle', async () => {

--- a/web/src/components/topology/__tests__/FinanceWatchesCard.test.tsx
+++ b/web/src/components/topology/__tests__/FinanceWatchesCard.test.tsx
@@ -343,6 +343,8 @@ describe('FinanceWatchesCard', () => {
         'no-auth',
         'best-effort',
         'delayed',
+        'experimental',
+        'region-dependent',
         'unofficial-api',
       ],
       enabled: false,
@@ -376,6 +378,7 @@ describe('FinanceWatchesCard', () => {
     expect(await screen.findByText('No key required')).toBeInTheDocument();
     expect(screen.getByText('Best effort')).toBeInTheDocument();
     expect(screen.getByText('Delayed / unofficial')).toBeInTheDocument();
+    expect(screen.getByText('Region dependent')).toBeInTheDocument();
   });
 
   it('uses_quick_start_configure_hint_for_bundle_settings_target', async () => {

--- a/web/src/lib/finance-feed-quality.ts
+++ b/web/src/lib/finance-feed-quality.ts
@@ -35,5 +35,8 @@ export function financeFeedQualityDisclosures(sources: TaggedFeedSource[]): stri
   ) {
     disclosures.push('Delayed / unofficial');
   }
+  if (sources.some((source) => source.tags.includes('region-dependent'))) {
+    disclosures.push('Region dependent');
+  }
   return disclosures;
 }


### PR DESCRIPTION
## Summary

- treat Yahoo Finance as an explicit experimental, region-dependent source instead of a quick-start bundle
- preflight Yahoo from rara's real egress before activation and return classified region, access, rate-limit, and availability failures without persisting enabled state
- stop Yahoo symbol fan-out on provider failures, honor Retry-After with a source-local circuit breaker, and preserve the five-second request spacing after preflight
- surface the region-dependent quality disclosure in the feed UI and document the operating behavior

## Test plan

- cargo test -p rara-trading -p rara-backend-admin --no-fail-fast
- cargo test -p rara-app tools::finance_feed::tests --no-fail-fast
- cargo test -p rara-trading --no-fail-fast
- cargo clippy --workspace --all-targets --no-deps -- -D warnings
- cargo deny check
- npm test
- npm run typecheck
- npm run lint
- npm run build
- pre-commit hooks: cargo check, fmt, clippy, doc, AGENT.md presence, web lint-staged