### PR TITLE
docs(harness): reasoning-first PR descriptions (#2460)

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,11 @@
-## Summary
+## What & why
 
-<!-- Brief description of the changes -->
+<!-- Explain your change as a story a reviewer can follow WITHOUT reading the diff first:
+  - What problem or goal prompted this? (the issue's Intent — don't just restate the title)
+  - What approach did you take, and *why this one*? Name the key design decision.
+  - What did you consider and reject, or what non-obvious constraint/tradeoff shaped it?
+  The diff shows WHAT changed. This section must explain WHY it looks like this.
+  If a reviewer would have to reverse-engineer your reasoning from the code, this section is too thin. -->
 
 ## Type of change
 
@@ -28,8 +33,9 @@
 
 Closes #
 
-## Test plan
+## How to verify
 
-- [ ] `just test` passes
+<!-- Commands you ran or steps a reviewer can repeat — evidence, not an exhaustive command dump. -->
+- [ ] `just test` / relevant `cargo test -p …` passes
 - [ ] `just lint` passes
-- [ ] Tested locally
+- [ ] Tested locally (say how)

--- a/harness/roles/implementer.md
+++ b/harness/roles/implementer.md
@@ -207,6 +207,15 @@ PR body uses `.github/pull_request_template.md`. Labels: pick one type
 component choice further (e.g. backend → `core`/`backend`; frontend →
 `ui`/`extension`).
 
+The PR body's job is to give the reviewer the mental model you had — the
+problem, the approach you chose, and *why that approach* over the
+alternatives you rejected. Write it as prose a reviewer can follow without
+opening the diff; the diff already shows *what* changed, so don't just list
+files touched. A bullet-list of changes plus a wall of verification
+commands is **not** an acceptable body — if the reviewer would have to
+reverse-engineer your reasoning from the code, the description has failed
+its job.
+
 If a CI check fails: read the failure log, diagnose root cause, fix in
 the worktree, push again. Do not mark tests `#[ignore]` to make CI green.
 If a failure looks transient, check `gh run list --branch main --limit 10`


### PR DESCRIPTION
## What & why

Our PR bodies carried no reasoning. `## Summary` became a bullet restatement of the diff ("edited X", "added Y") and `## Test plan` became a wall of `just test` / `just lint` checkboxes. Both duplicate what the diff and CI already show, so a reviewer reading the body learned *what* changed (which the diff shows better) but nothing about the *approach the agent took or why*. They had to reverse-engineer intent from the code — exactly the design-level signal review is supposed to catch cheaply.

**Approach:** reframe the two prose sections of the template and add a matching hard rule where the agent actually reads it.
- `.github/pull_request_template.md`: `## Summary` → `## What & why` (a guided prompt for problem → approach → why-this-approach-over-rejected-alternatives) and `## Test plan` → `## How to verify` (repeatable evidence, not an exhaustive command dump). `## Type of change` / `## Component` / `## Closes` are deliberately left untouched — the label structure was tuned by #417 and #1010 and is out of scope.
- `harness/roles/implementer.md` step 8: a paragraph stating the PR body's job is to give the reviewer the agent's mental model, with the explicit rule that a bullet-list of changes plus a command wall is **not** an acceptable body.

**Why the template alone isn't enough:** the implementer agent follows its role contract, not the template comments, so guidance that lived only in the template HTML comment would be invisible at authoring time. The two edits are coordinated — the contract sets the rule, the template scaffolds it.

**Why docs-only guidance, not tooling enforcement:** a linter that fails PRs with thin bodies was explicitly rejected (issue "Out of scope"). "Reasoning is present and non-thin" is a judgment call the reviewer already makes; a regex/word-count gate would produce false positives on genuinely small changes and false negatives on padded ones, adding a CI failure mode without adding real signal. The reviewer is the enforcement point.

This PR dogfoods its own change: this body is written in the `## What & why` + `## How to verify` framing it introduces.

## How to verify

- [x] `prek run --all-files` passes (cargo check / fmt / clippy / doc / AGENT.md / web lint-staged all green)
- [x] Template sections correct and Type/Component/Closes intact:
  `grep -n "What & why\|How to verify\|Type of change\|Component\|Closes" .github/pull_request_template.md`
- [x] Contract paragraph present:
  `grep -n "mental model\|reverse-engineer" harness/roles/implementer.md`

## Type of change

Documentation (`documentation`)

## Component

`ci`

## Closes

Closes #2460

---

**Verification (inline per workflow convention — no committed report file):**
- Verifier: **PASS** — re-ran the quality gate from clean state and confirmed both Verify greps against a fresh worktree.
- Reviewer: **APPROVE** — no change requests.