### PR TITLE
feat(finance): add keyless Tencent candle feed

### DIFF
--- a/crates/extensions/rara-trading/src/feed/catalog.rs
+++ b/crates/extensions/rara-trading/src/feed/catalog.rs
@@ -81,6 +81,20 @@ pub fn default_finance_feed_bundles() -> Vec<DefaultFeedBundle> {
             ["binance-major-crypto-15m"],
         ),
         feed_bundle(
+            "tencent-cn-equities-daily",
+            "Tencent CN A-Shares Daily",
+            "Keyless forward-adjusted daily candles for a focused Shanghai and Shenzhen research \
+             watchlist.",
+            [
+                "finance",
+                "market-data",
+                "equities",
+                "cn-a-shares",
+                "tencent",
+            ],
+            ["tencent-cn-equities-daily"],
+        ),
+        feed_bundle(
             "yahoo-us-equities-daily",
             "Yahoo US Equities Daily",
             "Keyless best-effort daily candles for a focused US equities research watchlist.",
@@ -159,6 +173,14 @@ pub fn default_finance_feed_sources() -> Vec<DefaultFeedSource> {
             &["15m"],
             300,
         ),
+        tencent_market_candles_source(
+            "tencent-cn-equities-daily",
+            "Tencent CN A-Shares Daily",
+            "Keyless Tencent Finance forward-adjusted daily candles for A-share research. Best \
+             effort, sourced from a public web endpoint, and not intended for execution-grade \
+             decisions or redistribution.",
+            &["SH600519", "SZ000001", "SZ300750", "SH601318", "SH600036"],
+        ),
         yahoo_market_candles_source(
             "yahoo-market-candles",
             "Yahoo US Equities Daily",
@@ -207,6 +229,52 @@ pub fn default_finance_feed_sources() -> Vec<DefaultFeedSource> {
             &["1d"],
         ),
     ]
+}
+
+fn tencent_market_candles_source(
+    id: &str,
+    name: &str,
+    description: &str,
+    symbols: &[&str],
+) -> DefaultFeedSource {
+    DefaultFeedSource {
+        id:                     id.to_owned(),
+        name:                   name.to_owned(),
+        description:            description.to_owned(),
+        feed_type:              FeedType::MarketCandle,
+        provider:               Some("tencent".to_owned()),
+        tags:                   [
+            "finance",
+            "market-data",
+            "equities",
+            "cn-a-shares",
+            "tencent",
+            "no-auth",
+            "forward-adjusted",
+            "best-effort",
+            "unofficial-api",
+            "redistribution-restricted",
+        ]
+        .into_iter()
+        .map(str::to_owned)
+        .collect(),
+        transport:              Some(serde_json::json!({
+            "provider": "tencent",
+            "base_url": "https://web.ifzq.gtimg.cn",
+            "interval_secs": 3600,
+            "headers": {
+                "User-Agent": "Mozilla/5.0",
+                "Referer": "https://gu.qq.com/"
+            },
+            "venue": "tencent",
+            "symbols": symbols,
+            "timeframes": ["1d"],
+            "max_candles_per_poll": 5
+        })),
+        auth:                   None,
+        requires_configuration: false,
+        setup_hint:             None,
+    }
 }
 
 fn yahoo_market_candles_source(
@@ -536,5 +604,33 @@ mod tests {
             .find(|bundle| bundle.id == "yahoo-global-starter")
             .expect("missing Yahoo global starter bundle");
         assert_eq!(global.catalog_source_ids, ["yahoo-global-market-candles"]);
+    }
+
+    #[test]
+    fn tencent_preset_is_keyless_forward_adjusted_cn_equities() {
+        let sources = default_finance_feed_sources();
+        let tencent = sources
+            .iter()
+            .find(|source| source.id == "tencent-cn-equities-daily")
+            .expect("missing Tencent CN equities preset");
+
+        assert!(tencent.can_enable());
+        assert!(!tencent.requires_configuration);
+        assert_eq!(tencent.provider.as_deref(), Some("tencent"));
+        assert!(tencent.auth.is_none());
+        for tag in ["no-auth", "forward-adjusted", "cn-a-shares"] {
+            assert!(tencent.tags.iter().any(|candidate| candidate == tag));
+        }
+        let transport = tencent.transport.as_ref().expect("transport template");
+        assert_eq!(transport["provider"], "tencent");
+        assert_eq!(transport["base_url"], "https://web.ifzq.gtimg.cn");
+        assert_eq!(transport["venue"], "tencent");
+        assert_eq!(transport["timeframes"], serde_json::json!(["1d"]));
+
+        let bundle = default_finance_feed_bundles()
+            .into_iter()
+            .find(|bundle| bundle.id == "tencent-cn-equities-daily")
+            .expect("missing Tencent CN equities bundle");
+        assert_eq!(bundle.catalog_source_ids, ["tencent-cn-equities-daily"]);
     }
 }

--- a/crates/extensions/rara-trading/src/feed/market_candle.rs
+++ b/crates/extensions/rara-trading/src/feed/market_candle.rs
@@ -53,6 +53,11 @@ const MAX_MARKET_CANDLE_REQUEST_BUDGET_PER_SECOND: f64 = 100.0;
 const YAHOO_MARKET_CANDLE_REQUEST_BUDGET_PER_SECOND: f64 = 0.2;
 const YAHOO_MIN_INTERVAL_SECS: u64 = 60;
 const YAHOO_REQUEST_SPACING_SECS: u64 = 5;
+const TENCENT_MARKET_CANDLE_REQUEST_BUDGET_PER_SECOND: f64 = 1.0;
+const TENCENT_MIN_INTERVAL_SECS: u64 = 60;
+const TENCENT_REQUEST_SPACING_SECS: u64 = 1;
+const TENCENT_MAX_CANDLES_PER_REQUEST: usize = 640;
+const TENCENT_A_SHARE_LOT_SIZE: u32 = 100;
 
 /// Minimum polling cadence for a market-candle feed, in seconds.
 ///
@@ -116,21 +121,25 @@ pub fn market_candle_fanout_safety(
     );
 
     let stream_count = symbols.len().saturating_mul(timeframes.len());
-    let poll_request_count = if matches!(provider, Some("binance" | "yahoo")) {
+    let poll_request_count = if matches!(provider, Some("binance" | "tencent" | "yahoo")) {
         stream_count
     } else {
         1
     };
-    let request_budget_per_second = if provider == Some("yahoo") {
-        request_budget_per_second.min(YAHOO_MARKET_CANDLE_REQUEST_BUDGET_PER_SECOND)
-    } else {
-        request_budget_per_second
+    let request_budget_per_second = match provider {
+        Some("tencent") => {
+            request_budget_per_second.min(TENCENT_MARKET_CANDLE_REQUEST_BUDGET_PER_SECOND)
+        }
+        Some("yahoo") => {
+            request_budget_per_second.min(YAHOO_MARKET_CANDLE_REQUEST_BUDGET_PER_SECOND)
+        }
+        _ => request_budget_per_second,
     };
     let estimated_requests_per_second = poll_request_count as f64 / configured_interval_secs as f64;
-    let provider_minimum_interval_secs = if provider == Some("yahoo") {
-        YAHOO_MIN_INTERVAL_SECS
-    } else {
-        MIN_INTERVAL_SECS
+    let provider_minimum_interval_secs = match provider {
+        Some("tencent") => TENCENT_MIN_INTERVAL_SECS,
+        Some("yahoo") => YAHOO_MIN_INTERVAL_SECS,
+        _ => MIN_INTERVAL_SECS,
     };
     let minimum_safe_interval_secs = provider_minimum_interval_secs
         .max((poll_request_count as f64 / request_budget_per_second).ceil() as u64);
@@ -270,6 +279,20 @@ struct YahooQuote {
 }
 
 #[derive(Debug, Deserialize)]
+struct TencentKlineResponse {
+    code: i64,
+    #[serde(default)]
+    msg:  String,
+    data: Option<HashMap<String, TencentKlineData>>,
+}
+
+#[derive(Debug, Deserialize)]
+struct TencentKlineData {
+    #[serde(default)]
+    qfqday: Vec<Vec<String>>,
+}
+
+#[derive(Debug, Deserialize)]
 struct RawCandle {
     venue:      String,
     symbol:     String,
@@ -364,6 +387,28 @@ impl MarketCandleSource {
             .append_pair("symbol", symbol)
             .append_pair("interval", timeframe)
             .append_pair("limit", "2");
+        Ok(url)
+    }
+
+    fn build_tencent_kline_url(&self, symbol: &str, timeframe: &str) -> anyhow::Result<Url> {
+        anyhow::ensure!(
+            timeframe == "1d",
+            "Tencent market candle timeframe {timeframe:?} is unsupported; use 1d"
+        );
+        let base_url = self
+            .transport
+            .base_url
+            .as_deref()
+            .unwrap_or("https://web.ifzq.gtimg.cn");
+        let wire_symbol = tencent_wire_symbol(symbol)?;
+        let limit = self
+            .transport
+            .max_candles_per_poll
+            .saturating_add(1)
+            .min(TENCENT_MAX_CANDLES_PER_REQUEST);
+        let param = format!("{wire_symbol},day,,,{limit},qfq");
+        let mut url = Url::parse(base_url)?.join("/appstock/app/fqkline/get")?;
+        url.query_pairs_mut().append_pair("param", &param);
         Ok(url)
     }
 
@@ -515,6 +560,44 @@ impl MarketCandleSource {
         }
 
         Ok(events)
+    }
+
+    fn parse_tencent_candle_events(
+        &self,
+        symbol: &str,
+        timeframe: &str,
+        body: &[u8],
+    ) -> anyhow::Result<Vec<FeedEvent>> {
+        let response: TencentKlineResponse = serde_json::from_slice(body)?;
+        anyhow::ensure!(
+            response.code == 0,
+            "Tencent K-line returned code {}: {}",
+            response.code,
+            response.msg
+        );
+        let wire_symbol = tencent_wire_symbol(symbol)?;
+        let rows = response
+            .data
+            .and_then(|mut data| data.remove(&wire_symbol))
+            .map(|data| data.qfqday)
+            .unwrap_or_default();
+        let received_at = Timestamp::now();
+        let mut candles = rows
+            .into_iter()
+            .filter_map(|row| {
+                tencent_daily_candle(row, &self.transport.venue, symbol, timeframe, received_at)
+            })
+            .collect::<Vec<_>>();
+        candles.sort_by(|left, right| left.open_time.cmp(&right.open_time));
+        let keep_from = candles
+            .len()
+            .saturating_sub(self.transport.max_candles_per_poll);
+
+        Ok(candles
+            .into_iter()
+            .skip(keep_from)
+            .map(|candle| self.event_from_candle(candle, received_at))
+            .collect())
     }
 
     fn event_from_candle(&self, candle: ParsedCandle, received_at: Timestamp) -> FeedEvent {
@@ -755,6 +838,84 @@ impl MarketCandleSource {
         true
     }
 
+    async fn poll_tencent_once(&self, tx: &mpsc::Sender<FeedEvent>) -> bool {
+        let mut any_success = false;
+        let mut request_count = 0_usize;
+
+        for symbol in &self.transport.symbols {
+            for timeframe in &self.transport.timeframes {
+                let url = match self.build_tencent_kline_url(symbol, timeframe) {
+                    Ok(url) => url,
+                    Err(err) => {
+                        self.record_error(format!("failed to build Tencent K-line URL: {err}"));
+                        continue;
+                    }
+                };
+
+                if request_count > 0 {
+                    tokio::time::sleep(Duration::from_secs(TENCENT_REQUEST_SPACING_SECS)).await;
+                }
+                request_count += 1;
+
+                let mut request = self.client.get(url);
+                for (key, value) in &self.transport.headers {
+                    request = request.header(key.as_str(), value.as_str());
+                }
+                request = apply_request_auth(request, &self.auth);
+
+                let response = match request.send().await {
+                    Ok(response) => response,
+                    Err(err) => {
+                        self.record_error(format!("Tencent K-line fetch failed: {err}"));
+                        continue;
+                    }
+                };
+                let status = response.status();
+                if !status.is_success() {
+                    self.record_error(format!(
+                        "Tencent K-line fetch received non-success status: {status}"
+                    ));
+                    continue;
+                }
+                let body = match response.bytes().await {
+                    Ok(body) => body,
+                    Err(err) => {
+                        self.record_error(format!("failed to read Tencent K-line body: {err}"));
+                        continue;
+                    }
+                };
+                if body.len() > MAX_BODY_BYTES {
+                    self.record_error(format!(
+                        "Tencent K-line response exceeded {MAX_BODY_BYTES} bytes"
+                    ));
+                    continue;
+                }
+                let events = match self.parse_tencent_candle_events(symbol, timeframe, &body) {
+                    Ok(events) => events,
+                    Err(err) => {
+                        self.record_error(format!(
+                            "failed to parse Tencent K-line response: {err}"
+                        ));
+                        continue;
+                    }
+                };
+
+                any_success = true;
+                for event in events {
+                    if tx.send(event).await.is_err() {
+                        tracing::info!("event channel closed, stopping market candle loop");
+                        return false;
+                    }
+                }
+            }
+        }
+
+        if any_success {
+            self.record_success();
+        }
+        true
+    }
+
     async fn poll_yahoo_once(&self, tx: &mpsc::Sender<FeedEvent>) -> bool {
         let mut any_success = false;
         let mut request_count = 0_usize;
@@ -834,6 +995,7 @@ impl MarketCandleSource {
     async fn poll_once(&self, tx: &mpsc::Sender<FeedEvent>) -> bool {
         match self.transport.provider.as_deref() {
             Some("binance") => self.poll_binance_once(tx).await,
+            Some("tencent") => self.poll_tencent_once(tx).await,
             Some("yahoo") => self.poll_yahoo_once(tx).await,
             _ => self.poll_normalized_once(tx).await,
         }
@@ -953,6 +1115,33 @@ fn validate_transport(transport: &MarketCandleTransport) -> anyhow::Result<()> {
                 "Binance market candle base_url must use HTTPS"
             );
         }
+        "tencent" => {
+            let base_url = transport
+                .base_url
+                .as_deref()
+                .unwrap_or("https://web.ifzq.gtimg.cn");
+            let url = Url::parse(base_url)?;
+            let test_loopback = cfg!(test)
+                && url.scheme() == "http"
+                && matches!(url.host_str(), Some("127.0.0.1" | "localhost" | "::1"));
+            anyhow::ensure!(
+                url.scheme() == "https" || test_loopback,
+                "Tencent market candle base_url must use HTTPS"
+            );
+            for symbol in &transport.symbols {
+                tencent_wire_symbol(symbol)?;
+            }
+            for timeframe in &transport.timeframes {
+                anyhow::ensure!(
+                    timeframe == "1d",
+                    "Tencent market candle timeframe {timeframe:?} is unsupported; use 1d"
+                );
+            }
+            anyhow::ensure!(
+                transport.max_candles_per_poll < TENCENT_MAX_CANDLES_PER_REQUEST,
+                "Tencent max_candles_per_poll must be < {TENCENT_MAX_CANDLES_PER_REQUEST}"
+            );
+        }
         "yahoo" => {
             let base_url = transport
                 .base_url
@@ -976,10 +1165,10 @@ fn validate_transport(transport: &MarketCandleTransport) -> anyhow::Result<()> {
         transport.interval_secs > 0,
         "market candle interval_secs must be greater than zero"
     );
-    let minimum_interval_secs = if transport.provider.as_deref() == Some("yahoo") {
-        YAHOO_MIN_INTERVAL_SECS
-    } else {
-        MIN_INTERVAL_SECS
+    let minimum_interval_secs = match transport.provider.as_deref() {
+        Some("tencent") => TENCENT_MIN_INTERVAL_SECS,
+        Some("yahoo") => YAHOO_MIN_INTERVAL_SECS,
+        _ => MIN_INTERVAL_SECS,
     };
     anyhow::ensure!(
         transport.interval_secs >= minimum_interval_secs,
@@ -1030,6 +1219,52 @@ fn yahoo_interval(timeframe: &str) -> anyhow::Result<&'static str> {
     }
 }
 
+fn tencent_wire_symbol(symbol: &str) -> anyhow::Result<String> {
+    let code = symbol
+        .strip_prefix("SH")
+        .or_else(|| symbol.strip_prefix("SZ"));
+    anyhow::ensure!(
+        code.is_some_and(|code| code.len() == 6 && code.bytes().all(|byte| byte.is_ascii_digit())),
+        "Tencent market candle symbol {symbol:?} is unsupported; use an exchange-prefixed symbol \
+         such as SH600519 or SZ000001"
+    );
+    Ok(symbol.to_ascii_lowercase())
+}
+
+fn tencent_daily_candle(
+    row: Vec<String>,
+    venue: &str,
+    symbol: &str,
+    timeframe: &str,
+    received_at: Timestamp,
+) -> Option<ParsedCandle> {
+    let [date, open, close, high, low, volume, ..] = row.as_slice() else {
+        return None;
+    };
+    let open_time = format!("{date}T09:30:00+08:00").parse::<Timestamp>().ok()?;
+    let close_time = format!("{date}T15:00:00+08:00").parse::<Timestamp>().ok()?;
+    if close_time > received_at {
+        return None;
+    }
+
+    Some(ParsedCandle {
+        venue:      venue.to_owned(),
+        symbol:     symbol.to_owned(),
+        timeframe:  timeframe.to_owned(),
+        open_time:  open_time.to_string(),
+        close_time: close_time.to_string(),
+        open:       Decimal::from_str(open).ok()?,
+        high:       Decimal::from_str(high).ok()?,
+        low:        Decimal::from_str(low).ok()?,
+        close:      Decimal::from_str(close).ok()?,
+        // Tencent reports A-share volume in board lots (手); normalize to shares so
+        // the stored OHLCV stream matches Yahoo/FMP equity volume semantics.
+        volume:     Decimal::from_str(volume)
+            .ok()?
+            .checked_mul(Decimal::from(TENCENT_A_SHARE_LOT_SIZE))?,
+    })
+}
+
 fn yahoo_timeframe_millis(timeframe: &str) -> anyhow::Result<i64> {
     let timeframe = Timeframe::parse(timeframe)?;
     let seconds = timeframe.step()?.as_secs();
@@ -1078,10 +1313,13 @@ fn dedupe_sort(values: &mut Vec<String>) {
 
 #[cfg(test)]
 mod tests {
+    use std::str::FromStr;
+
     use rara_kernel::data_feed::{DataFeedConfig, FeedStatus, FeedType};
+    use rust_decimal::Decimal;
     use wiremock::{
         Mock, MockServer, ResponseTemplate,
-        matchers::{method, path, query_param},
+        matchers::{header, method, path, query_param},
     };
 
     use super::{MarketCandleSource, market_candle_fanout_safety};
@@ -1159,6 +1397,141 @@ mod tests {
             .build();
 
         MarketCandleSource::from_config(&config).expect("Yahoo config should parse")
+    }
+
+    fn tencent_config(base_url: &str, symbols: &[&str]) -> DataFeedConfig {
+        DataFeedConfig::builder()
+            .id("tencent-candles-test".to_owned())
+            .name("tencent-cn-equities".to_owned())
+            .feed_type(FeedType::MarketCandle)
+            .tags(vec!["finance".to_owned(), "cn-a-shares".to_owned()])
+            .transport(serde_json::json!({
+                "provider": "tencent",
+                "base_url": base_url,
+                "interval_secs": 900,
+                "headers": {
+                    "User-Agent": "Mozilla/5.0",
+                    "Referer": "https://gu.qq.com/"
+                },
+                "venue": "tencent",
+                "symbols": symbols,
+                "timeframes": ["1d"],
+                "max_candles_per_poll": 5
+            }))
+            .enabled(true)
+            .status(FeedStatus::Idle)
+            .created_at(jiff::Timestamp::UNIX_EPOCH)
+            .updated_at(jiff::Timestamp::UNIX_EPOCH)
+            .build()
+    }
+
+    #[test]
+    fn tencent_provider_rejects_noncanonical_cn_symbol() {
+        let error = match MarketCandleSource::from_config(&tencent_config(
+            "https://web.ifzq.gtimg.cn",
+            &["600519"],
+        )) {
+            Ok(_) => panic!("Tencent must reject a symbol without its exchange prefix"),
+            Err(error) => error,
+        };
+
+        assert!(
+            error.to_string().contains("SH600519"),
+            "error should explain the Tencent symbol namespace: {error}"
+        );
+    }
+
+    #[test]
+    fn tencent_fanout_uses_one_request_per_symbol() {
+        let safety = market_candle_fanout_safety(
+            Some("tencent"),
+            &serde_json::json!({"interval_secs": 900}),
+            &[
+                "SH600519".to_owned(),
+                "SZ000001".to_owned(),
+                "SZ300750".to_owned(),
+            ],
+            &["1d".to_owned()],
+            super::DEFAULT_MARKET_CANDLE_REQUEST_BUDGET_PER_SECOND,
+        )
+        .expect("fan-out should calculate");
+
+        assert_eq!(safety.stream_count, 3);
+        assert_eq!(safety.poll_request_count, 3);
+    }
+
+    #[tokio::test]
+    async fn tencent_poll_fetches_keyless_qfq_daily_candles() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/appstock/app/fqkline/get"))
+            .and(query_param("param", "sh600519,day,,,6,qfq"))
+            .and(header("User-Agent", "Mozilla/5.0"))
+            .and(header("Referer", "https://gu.qq.com/"))
+            .respond_with(ResponseTemplate::new(200).set_body_raw(
+                r#"{
+  "code": 0,
+  "msg": "",
+  "data": {
+    "sh600519": {
+      "qfqday": [
+        ["2026-07-17", "1269.010", "1253.000", "1269.330", "1238.980", "58417.000"],
+        ["2100-01-01", "1300.000", "1310.000", "1320.000", "1290.000", "1000.000"]
+      ]
+    }
+  }
+}"#,
+                "application/json",
+            ))
+            .expect(1)
+            .mount(&server)
+            .await;
+        let source =
+            MarketCandleSource::from_config(&tencent_config(&server.uri(), &[" sh600519 "]))
+                .expect("Tencent config should parse");
+        let (tx, mut rx) = tokio::sync::mpsc::channel(2);
+
+        assert!(source.poll_once(&tx).await);
+        drop(tx);
+
+        let event = rx.recv().await.expect("closed Tencent candle event");
+        assert_eq!(event.source_name, "tencent-cn-equities");
+        assert_eq!(event.payload["venue"], "tencent");
+        assert_eq!(event.payload["symbol"], "SH600519");
+        assert_eq!(event.payload["timeframe"], "1d");
+        assert_eq!(event.payload["open_time"], "2026-07-17T01:30:00Z");
+        assert_eq!(event.payload["close_time"], "2026-07-17T07:00:00Z");
+        assert_eq!(event.payload["open"], "1269.010");
+        assert_eq!(event.payload["high"], "1269.330");
+        assert_eq!(event.payload["low"], "1238.980");
+        assert_eq!(event.payload["close"], "1253.000");
+        assert_eq!(event.payload["volume"], "5841700.000");
+        assert!(
+            rx.recv().await.is_none(),
+            "future daily bar must be skipped"
+        );
+    }
+
+    #[tokio::test]
+    #[ignore = "requires live access to the public Tencent Finance endpoint"]
+    async fn tencent_live_endpoint_returns_a_closed_daily_candle_without_auth() {
+        let source = MarketCandleSource::from_config(&tencent_config(
+            "https://web.ifzq.gtimg.cn",
+            &["SH600519"],
+        ))
+        .expect("live Tencent config should parse");
+        let (tx, mut rx) = tokio::sync::mpsc::channel(8);
+
+        assert!(source.poll_once(&tx).await);
+        drop(tx);
+
+        let event = rx.recv().await.expect("live Tencent candle event");
+        assert_eq!(event.payload["venue"], "tencent");
+        assert_eq!(event.payload["symbol"], "SH600519");
+        assert_eq!(event.payload["timeframe"], "1d");
+        assert!(event.payload["close"].as_str().is_some_and(|value| {
+            Decimal::from_str(value).is_ok_and(|close| close > Decimal::ZERO)
+        }));
     }
 
     #[test]


### PR DESCRIPTION
## Summary\n\n- add a ready-to-enable, keyless Tencent Finance catalog bundle for forward-adjusted Shanghai and Shenzhen daily candles\n- implement native Tencent qfq K-line polling with canonical SH/SZ symbols, HTTPS validation, conservative one-request-per-second fan-out, and closed-session filtering\n- normalize Tencent OHLC field order, Asia/Shanghai session timestamps, and A-share volume from board lots to shares\n- label the source as best-effort, unofficial, and redistribution-restricted so research-grade semantics are explicit\n\n## Provider choice\n\nOpenAlice's Eastmoney source was evaluated first. Its search endpoint worked, but the historical K-line endpoint returned empty replies from the current egress both through and outside the configured proxy. Tencent's public K-line endpoint returned real data through the configured HTTPS proxy, so this PR adds the provider that is verifiably usable instead of a nominal integration with no working data path.\n\nThere is no silent fallback between providers: users explicitly enable the Tencent catalog source.\n\n## Test plan\n\n- 
running 124 tests
test anomaly::rules::tests::volume_surge_is_ratio_to_rolling_mean ... ok
test anomaly::rules::tests::max_drawdown_tracks_peak_to_trough ... ok
test anomaly::rules::tests::window_return_is_signed_fraction_of_first_close ... ok
test anomaly::statistics::tests::bns_jump_test_flags_jump_over_diffusion ... ok
test anomaly::rules::tests::directional_run_silent_on_choppy_tape ... ok
test anomaly::statistics::tests::volatility_regime_silent_on_stable_variance ... ok
test anomaly::rules::tests::directional_run_fires_on_sustained_directional_grind ... ok
test anomaly::statistics::tests::volatility_regime_fires_on_sustained_variance_expansion ... ok
test anomaly::statistics::tests::robust_zscore_uses_mad_not_stddev ... ok
test anomaly::tools::tests::evaluate_candle_signal_tool_is_read_only ... ok
test anomaly::evaluator::tests::flat_tape_produces_no_anomaly_signal ... ok
test anomaly::evaluator::tests::non_positive_close_is_a_typed_error ... ok
test backtest::runner::tests::flat_tape_yields_zero_triggers_and_empty_report ... ok
test backtest::runner::tests::non_positive_close_fails_backtest_with_typed_error ... ok
test backtest::tools::tests::backtest_signal_tool_rejects_ranges_over_limit ... ok
test anomaly::tools::tests::evaluate_candle_signal_tool_does_not_look_past_requested_open_time ... ok
test anomaly::evaluator::tests::directional_run_alone_enriches_unremarkable_tape ... ok
test anomaly::evaluator::tests::single_moderate_rule_produces_watch_severity ... ok
test anomaly::evaluator::tests::registered_signal_participates_in_evaluation ... ok
test anomaly::evaluator::tests::volatility_regime_alone_enriches_unremarkable_tape ... ok
test backtest::runner::tests::naive_long_backtest_reports_deterministic_metrics_on_fixture ... ok
test backtest::runner::tests::forward_return_excludes_triggers_without_full_hold_window ... ok
test backtest::runner::tests::signal_evaluation_never_reads_bars_after_the_trigger ... ok
test backtest::runner::tests::signal_attribution_reports_deterministic_metrics_per_builtin_signal ... ok
test backtest::tools::tests::backtest_signal_tool_reports_existing_harness_metrics ... ok
test backtest::runner::tests::backtest_pulls_stream_via_repository_candles_and_matches_pure_core ... ok
test anomaly::evaluator::tests::two_rules_without_deep_drawdown_produce_elevated_severity ... ok
test anomaly::evaluator::tests::crash_window_produces_high_severity_anomaly_signal ... ok
test anomaly::tools::tests::evaluate_candle_signal_tool_reports_latest_signal ... ok
test backtest::tools::tests::empty_source_scoped_backtest_points_to_diagnostics ... ok
test anomaly::tools::tests::empty_source_scoped_signal_evaluation_points_to_diagnostics ... ok
test feed::catalog::tests::catalog_contains_public_binance_15m_major_crypto_preset ... ok
test feed::catalog::tests::catalog_ids_and_feed_names_are_unique ... ok
test feed::catalog::tests::longbridge_preset_is_prefilled_but_requires_operator_endpoint ... ok
test feed::catalog::tests::bundle_ids_are_unique_and_reference_existing_sources ... ok
test feed::catalog::tests::tencent_preset_is_keyless_forward_adjusted_cn_equities ... ok
test feed::catalog::tests::yahoo_presets_are_keyless_best_effort_daily_sources ... ok
test dispatch::tests::unmatched_finance_event_does_not_wake_a_session ... ok
test feed::market_candle::tests::interval_below_rate_limit_floor_is_rejected ... ok
test dispatch::tests::matched_immediate_candle_creates_compact_market_update_turn ... ok
test dispatch::tests::duplicate_immediate_finance_event_does_not_wake_session_twice ... ok
test dispatch::tests::closed_candle_event_selectors_are_normalized_before_upsert ... ok
test dispatch::tests::matched_immediate_finance_article_creates_one_synthetic_turn ... ok
test dispatch::tests::closed_candle_dispatch_is_queryable_through_latest_candle_tool ... ok
test dispatch::tests::closed_candle_is_upserted_before_subscription_delivery ... ok
test dispatch::tests::silent_finance_event_appends_to_tape_without_turn ... ok
test feed::market_candle::tests::tencent_live_endpoint_returns_a_closed_daily_candle_without_auth ... ignored, requires live access to the public Tencent Finance endpoint
test feed::market_candle::tests::tencent_fanout_uses_one_request_per_symbol ... ok
test feed::market_candle::tests::tencent_provider_rejects_noncanonical_cn_symbol ... ok
test dispatch::tests::anomaly_signal_enriches_finance_directive ... ok
test feed::market_candle::tests::yahoo_fanout_uses_one_request_per_stream_and_conservative_budget ... ok
test dispatch::tests::default_immediate_budget_silences_seventh_finance_event ... ok
test dispatch::tests::critical_candle_burst_wakes_session_every_bar ... ok
test feed::market_candle::tests::binance_provider_builds_public_klines_url ... ok
test feed::market_candle::tests::yahoo_provider_builds_public_chart_url ... ok
test feed::market_candle::tests::subminute_interval_within_floor_is_accepted ... ok
test feed::market_candle::tests::binance_provider_normalizes_config_selectors ... ok
test feed::market_candle::tests::binance_klines_become_closed_candle_events ... ok
test feed::market_candle::tests::open_or_invalid_decimal_candles_are_not_emitted ... ok
test feed::market_candle::tests::yahoo_chart_normalizes_missing_volume_to_zero ... ok
test feed::market_candle::tests::invalid_timestamp_candles_are_not_emitted ... ok
test feed::market_candle::tests::normalized_endpoint_candles_are_matched_and_emitted_with_canonical_selectors ... ok
test feed::market_candle::tests::yahoo_chart_becomes_closed_candle_events_and_skips_open_or_null_bars ... ok
test feed::market_candle::tests::closed_candles_for_many_symbols_become_batched_events ... ok
test feed::market_candle::tests::same_candle_has_same_event_id_across_polls ... ok
test finance::registry::tests::article_source_and_watch_terms_are_anded ... ok
test finance::registry::tests::candle_symbol_and_timeframe_are_anded ... ok
test finance::registry::tests::candle_selectors_are_normalized_before_matching ... ok
test finance::registry::tests::candle_event_payload_selectors_are_normalized_before_matching ... ok
test finance::registry::tests::duplicate_event_is_delivered_once_after_reload ... ok
test finance::registry::tests::low_severity_still_downgrades_under_budget ... ok
test finance::registry::tests::high_severity_bypasses_hourly_budget ... ok
test finance::tools::tests::list_feed_sources_exposes_subscription_source_names ... ok
test finance::registry::tests::immediate_budget_downgrades_excess_events_to_silent ... ok
test feed::rss::tests::same_guid_has_same_event_id_across_polls ... ok
test finance::registry::tests::high_severity_bypasses_cooldown ... ok
test finance::tools::tests::list_schema_has_no_identity_or_session_parameter ... ok
test feed::market_candle::tests::yahoo_poll_fetches_chart_and_emits_closed_candle ... ok
test feed::market_candle::tests::tencent_poll_fetches_keyless_qfq_daily_candles ... ok
test feed::rss::tests::missing_guid_uses_link_then_content_fallback ... ok
test finance::tools::tests::list_subscriptions_omits_owner_and_session_from_output ... ok
test finance::tools::tests::subscribe_expands_catalog_source_ids_to_source_names ... ok
test finance::tools::tests::subscribe_rejects_invalid_timeframe_selectors ... ok
test finance::tools::tests::subscribe_rejects_mismatched_event_specific_selectors ... ok
test finance::registry::tests::values_inside_filter_groups_are_ored ... ok
test finance::tools::tests::subscribe_infers_candle_event_kind_for_market_selectors ... ok
test finance::tools::tests::subscribe_infers_rss_event_kind_for_watch_terms ... ok
test finance::tools::tests::subscribe_instruments_rejects_catalog_venue_mismatch ... ok
test market_data::repository::tests::corrected_candle_updates_current_row_and_records_audit ... ok
test finance::registry::tests::default_immediate_budget_allows_sixth_and_silences_seventh ... ok
test market_data::repository::tests::gap_detection_reports_missing_open_times ... ok
test market_data::repository::tests::candle_streams_returns_latest_watermarks_per_stream ... ok
test finance::tools::tests::subscribe_instruments_rejects_news_catalog_sources ... ok
test market_data::repository::tests::query_range_returns_ordered_candles_for_symbol_timeframe ... ok
test market_data::repository::tests::gap_detection_ignores_range_query_limit ... ok
test market_data::repository::tests::latest_closed_candle_returns_newest_matching_stream ... ok
test finance::tools::tests::subscribe_persists_normalized_market_selectors ... ok
test market_data::repository::tests::upsert_candle_is_idempotent_for_same_primary_key ... ok
test market_data::tools::tests::candle_query_tools_are_read_only ... ok
test market_data::repository::tests::recent_candles_returns_latest_n_in_ascending_order ... ok
test feed::catalog::tests::ready_catalog_sources_have_valid_transport_templates ... ok
test finance::tools::tests::subscribe_uses_context_owner_and_session_not_llm_fields ... ok
test market_data::tools::tests::list_candle_streams_tool_echoes_filters_when_no_streams_match ... ok
test market_data::tools::tests::latest_candle_tool_returns_diagnostic_hint_when_source_scoped_stream_is_empty ... ok
test finance::tools::tests::subscribe_news_sets_rss_event_kind_and_rejects_market_catalog_sources ... ok
test market_data::tools::tests::list_candle_streams_tool_rejects_unprobeable_limit ... ok
test finance::tools::tests::subscribe_instruments_sets_candle_event_kind_and_derives_catalog_venue ... ok
test market_data::tools::tests::find_candle_gaps_tool_reports_missing_open_times ... ok
test market_data::tools::tests::freshness_tool_reports_fresh_and_stale_status ... ok
test market_data::tools::tests::list_candle_streams_tool_filters_by_symbol ... ok
test market_data::tools::tests::list_candle_streams_tool_normalizes_user_selectors ... ok
test market_data::tools::tests::latest_candle_tool_returns_newest_candle_as_strings ... ok
test market_data::tools::tests::list_candle_streams_tool_reports_when_more_streams_match ... ok
test market_data::tools::tests::latest_candle_tool_normalizes_user_selectors ... ok
test finance::tools::tests::unsubscribe_cannot_remove_another_users_subscription ... ok
test market_data::tools::tests::candle_quality_tools_normalize_user_selectors ... ok
test market_data::tools::tests::query_candles_tool_rejects_invalid_ranges ... ok
test market_data::tools::tests::query_candles_tool_rejects_unprobeable_limit ... ok
test market_data::tools::tests::query_candles_tool_reports_when_more_candles_match ... ok
test market_data::tools::tests::query_candles_tool_returns_ordered_range ... ok
test market_data::tools::tests::list_candle_streams_tool_returns_available_stream_watermarks ... ok
test market_data::tools::tests::recent_candles_tool_returns_latest_candles_in_order ... ok
test market_data::tools::tests::single_stream_candle_tools_echo_selector_when_no_rows_match ... ok
test feed::rss::tests::rss_item_becomes_one_normalized_article_event ... ok

test result: ok. 123 passed; 0 failed; 1 ignored; 0 measured; 0 filtered out; finished in 0.06s


running 1 test
test timescale_repository_contract_runs_against_testcontainer ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 4.35s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s\n- 
running 1 test
test feed::market_candle::tests::tencent_live_endpoint_returns_a_closed_daily_candle_without_auth ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 123 filtered out; finished in 0.16s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 1 filtered out; finished in 0.00s\n- \n- \n- advisories ok, bans ok, licenses ok, sources ok\n- repository pre-commit hooks: cargo check, fmt, clippy, doc, AGENT.md presence