### PR TITLE
feat: prepare rara for Flux deployment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,4 @@
-# Build context for docker/Dockerfile (server-only rara image).
+# Shared build context for the server and web images.
 #
 # Keep this a BLOCK-list: the Rust workspace has many build.rs scripts that
 # read files across the tree, so excluding by allow-list is fragile. We only
@@ -21,8 +21,7 @@ vendor/
 # Nested worktrees
 .worktrees/
 
-# Frontend / desktop — server-only image, no web build, no nginx
-web/
+# Non-web application surfaces
 desktop/
 extension/
 site/

--- a/.github/workflows/container-publish.yml
+++ b/.github/workflows/container-publish.yml
@@ -1,0 +1,96 @@
+name: container-publish
+
+# Publish immutable, amd64 production images. Deployment manifests consume the
+# resulting digest, never a mutable tag.
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - "v*"
+    paths:
+      - ".cargo/**"
+      - "api/**"
+      - "crates/**"
+      - "docker/**"
+      - "web/**"
+      - ".dockerignore"
+      - "Cargo.lock"
+      - "Cargo.toml"
+      - "rust-toolchain.toml"
+      - ".github/workflows/container-publish.yml"
+  workflow_dispatch:
+
+concurrency:
+  group: container-publish-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  publish:
+    name: publish ${{ matrix.image }}
+    if: github.repository == 'rararulab/rara'
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - image: rara-server
+            dockerfile: docker/Dockerfile
+          - image: rara-web
+            dockerfile: docker/web.Dockerfile
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+
+      - name: Log in to GHCR
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Compute immutable image reference
+        id: image
+        shell: bash
+        env:
+          IMAGE: ghcr.io/rararulab/${{ matrix.image }}
+        run: |
+          short_sha="${GITHUB_SHA::12}"
+          echo "ref=${IMAGE}:sha-${short_sha}" >> "${GITHUB_OUTPUT}"
+
+      - name: Build and publish linux/amd64 image
+        id: build
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: .
+          file: ${{ matrix.dockerfile }}
+          platforms: linux/amd64
+          push: true
+          tags: ${{ steps.image.outputs.ref }}
+          labels: |
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
+            org.opencontainers.image.revision=${{ github.sha }}
+          cache-from: type=gha,scope=publish-${{ matrix.image }}
+          cache-to: type=gha,mode=max,scope=publish-${{ matrix.image }}
+
+      - name: Record published digest
+        shell: bash
+        env:
+          IMAGE_REF: ${{ steps.image.outputs.ref }}
+          IMAGE_DIGEST: ${{ steps.build.outputs.digest }}
+        run: |
+          {
+            echo "### ${{ matrix.image }}"
+            echo
+            echo "- Reference: \`${IMAGE_REF}\`"
+            echo "- Digest: \`${IMAGE_DIGEST}\`"
+          } >> "${GITHUB_STEP_SUMMARY}"

--- a/.github/workflows/container-smoke.yml
+++ b/.github/workflows/container-smoke.yml
@@ -196,8 +196,16 @@ jobs:
             --read-only --tmpfs /tmp:rw,noexec,nosuid,size=64m \
             -p 18080:8080 rara-web:smoke
 
-          body="$(curl --retry 20 --retry-delay 1 --retry-connrefused \
-            -fsS http://127.0.0.1:18080/healthz)"
+          # Poll the health condition instead of relying on curl's retry
+          # classification. During startup nginx can accept TCP and reset the
+          # first request; curl exit 56 is not retried by --retry-connrefused.
+          body=""
+          for i in $(seq 1 20); do
+            if body="$(curl -fsS http://127.0.0.1:18080/healthz)"; then
+              break
+            fi
+            sleep 1
+          done
           test "${body}" = "ok"
           curl -fsS http://127.0.0.1:18080/ | grep -q '<div id="root"></div>'
 

--- a/.github/workflows/container-smoke.yml
+++ b/.github/workflows/container-smoke.yml
@@ -1,12 +1,8 @@
 name: container-smoke
 
-# Build the server-only rara image (docker/Dockerfile) and prove it boots
-# and serves /api/health → healthy. This is the canonical, executable Verify
-# for the containerization work (issue #2239).
-#
-# It does NOT push to any registry — publishing is deliberately out of scope
-# (decision #9; it must not re-introduce the publish pipeline #443 removed).
-# The image is built and loaded locally, run, and probed.
+# Build both production images without publishing them. The backend must boot
+# and serve /api/health; the web image must run read-only as a non-root user,
+# serve the SPA, and expose its health endpoint.
 #
 # Gated behind a paths filter so it only runs on PRs touching the
 # container / deploy files. Not a required merge gate.
@@ -15,6 +11,7 @@ on:
   pull_request:
     paths:
       - "docker/**"
+      - "web/**"
       - ".dockerignore"
       - "deploy/k8s/**"
       - ".github/workflows/container-smoke.yml"
@@ -153,3 +150,63 @@ jobs:
       - name: Cleanup
         if: always()
         run: docker rm -f rara-smoke || true; docker volume rm rara-cfg || true
+
+  web-smoke:
+    name: web build + health
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+
+      - name: Build web image (linux/amd64, load locally — no push)
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: .
+          file: docker/web.Dockerfile
+          platforms: linux/amd64
+          load: true
+          push: false
+          tags: rara-web:smoke
+          cache-from: type=gha,scope=container-smoke-web
+          cache-to: type=gha,mode=max,scope=container-smoke-web
+
+      - name: Assert web image runs as non-root
+        run: |
+          user="$(docker inspect -f '{{.Config.User}}' rara-web:smoke)"
+          echo "image User = '${user}'"
+          if [ -z "${user}" ] || [ "${user}" = "root" ] || [ "${user}" = "0" ]; then
+            echo "FAIL: image must run as a non-root user"
+            exit 1
+          fi
+
+      - name: Boot web container and assert health + SPA
+        run: |
+          # nginx resolves its backend when it starts. The smoke only needs a
+          # live DNS entry; backend behavior is covered by the server job.
+          docker network create rara-web-smoke >/dev/null
+          docker run -d --rm --name rara-server --network rara-web-smoke \
+            alpine:3.23@sha256:fd791d74b68913cbb027c6546007b3f0d3bc45125f797758156952bc2d6daf40 \
+            tail -f /dev/null
+          docker run -d --rm --name rara-web-smoke --network rara-web-smoke \
+            --read-only --tmpfs /tmp:rw,noexec,nosuid,size=64m \
+            -p 18080:8080 rara-web:smoke
+
+          body="$(curl --retry 20 --retry-delay 1 --retry-connrefused \
+            -fsS http://127.0.0.1:18080/healthz)"
+          test "${body}" = "ok"
+          curl -fsS http://127.0.0.1:18080/ | grep -q '<div id="root"></div>'
+
+      - name: Web container logs (always)
+        if: always()
+        run: docker logs rara-web-smoke || true
+
+      - name: Web cleanup
+        if: always()
+        run: |
+          docker rm -f rara-web-smoke rara-server || true
+          docker network rm rara-web-smoke || true

--- a/crates/app/src/lib.rs
+++ b/crates/app/src/lib.rs
@@ -720,7 +720,9 @@ pub async fn start_with_options(
             rara_paths::data_dir().join("trading/finance-subscriptions.json"),
         ),
     );
-    let market_data_repo = init_market_data_repository().await;
+    let market_data_repo = init_market_data_repository()
+        .await
+        .whatever_context("Failed to initialize required market-data repository")?;
 
     // -- Data feed subsystem --------------------------------------------------
     // Create the event channel and registry before tool registration so
@@ -1509,31 +1511,26 @@ fn normalize_restored_data_feed_config(config: &mut DataFeedConfig) -> anyhow::R
     Ok(config.transport != before)
 }
 
-async fn init_market_data_repository() -> rara_trading::market_data::MarketDataRepositoryRef {
+async fn init_market_data_repository()
+-> anyhow::Result<rara_trading::market_data::MarketDataRepositoryRef> {
     let database_url = std::env::var("RARA_MARKET_DATA_DATABASE_URL").ok();
     init_market_data_repository_from_database_url(database_url.as_deref()).await
 }
 
 async fn init_market_data_repository_from_database_url(
     database_url: Option<&str>,
-) -> rara_trading::market_data::MarketDataRepositoryRef {
+) -> anyhow::Result<rara_trading::market_data::MarketDataRepositoryRef> {
     match database_url
         .map(str::trim)
         .filter(|value| !value.is_empty())
     {
-        Some(database_url) => match connect_timescale_market_data_repository(database_url).await {
-            Ok(repo) => Arc::new(repo),
-            Err(e) => {
-                warn!(
-                    error = %e,
-                    "market-data Timescale initialization failed; using in-memory repository"
-                );
-                in_memory_market_data_repository()
-            }
-        },
+        Some(database_url) => {
+            let repo = connect_timescale_market_data_repository(database_url).await?;
+            Ok(Arc::new(repo))
+        }
         _ => {
             warn!("RARA_MARKET_DATA_DATABASE_URL not set; using in-memory market-data repository");
-            in_memory_market_data_repository()
+            Ok(in_memory_market_data_repository())
         }
     }
 }
@@ -1711,8 +1708,6 @@ mod tests {
 
     use jiff::Timestamp;
     use rara_kernel::data_feed::{DataFeedConfig, FeedStatus, FeedType};
-    use rara_trading::market_data::{MarketCandle, Timeframe};
-    use rust_decimal::Decimal;
 
     use super::AppConfig;
 
@@ -1823,28 +1818,11 @@ mita:
     }
 
     #[tokio::test]
-    async fn market_data_repository_falls_back_when_timescale_initialization_fails() {
-        let repo =
+    async fn configured_market_data_database_failure_blocks_startup() {
+        let result =
             super::init_market_data_repository_from_database_url(Some("not-a-postgres-url")).await;
-        let candle = MarketCandle {
-            source_name:       "fallback-test".to_owned(),
-            venue:             "binance".to_owned(),
-            symbol:            "BTCUSDT".to_owned(),
-            timeframe:         Timeframe::parse("1m").unwrap(),
-            open_time:         "2026-07-10T08:00:00Z".parse().unwrap(),
-            close_time:        "2026-07-10T08:01:00Z".parse().unwrap(),
-            open:              Decimal::from_str_exact("61500.12").unwrap(),
-            high:              Decimal::from_str_exact("61640.00").unwrap(),
-            low:               Decimal::from_str_exact("61480.50").unwrap(),
-            close:             Decimal::from_str_exact("61610.30").unwrap(),
-            volume:            Decimal::from_str_exact("124.551").unwrap(),
-            ingested_at:       Timestamp::now(),
-            provider_sequence: None,
-        };
 
-        repo.upsert_closed_candle(candle)
-            .await
-            .expect("fallback repository should accept candles");
+        assert!(result.is_err());
     }
 
     #[test]

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -1,0 +1,41 @@
+server {
+    listen 8080;
+    server_name _;
+    server_tokens off;
+
+    root /usr/share/nginx/html;
+    index index.html;
+    charset utf-8;
+    client_max_body_size 50m;
+
+    location = /healthz {
+        access_log off;
+        default_type text/plain;
+        return 200 "ok\n";
+    }
+
+    location /api/ {
+        proxy_pass http://rara-server:25555;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_buffering off;
+        proxy_request_buffering off;
+        proxy_read_timeout 3600s;
+        proxy_send_timeout 3600s;
+    }
+
+    location /assets/ {
+        try_files $uri =404;
+        expires 1y;
+        add_header Cache-Control "public, immutable";
+    }
+
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+}

--- a/docker/web.Dockerfile
+++ b/docker/web.Dockerfile
@@ -1,0 +1,35 @@
+# syntax=docker/dockerfile:1
+
+# Build the Vite application with the Bun version used by CI at the time this
+# image was introduced. The manifest digest prevents a mutable base tag from
+# changing the build underneath an unchanged rara commit.
+FROM --platform=linux/amd64 oven/bun:1.3.14@sha256:e10577f0db68676a7024391c6e5cb4b879ebd17188ab750cf10024a6d700e5c4 AS builder
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        ca-certificates \
+        git \
+    && rm -rf /var/lib/apt/lists/*
+
+# bun.lock records the public style package with a git+ssh URL. Container
+# builds do not carry developer SSH credentials, so fetch public GitHub
+# dependencies over HTTPS instead.
+RUN git config --global url."https://github.com/".insteadOf "ssh://git@github.com/"
+
+WORKDIR /build/web
+COPY web/package.json web/bun.lock ./
+RUN --mount=type=cache,target=/root/.bun/install/cache \
+    bun install --frozen-lockfile
+
+COPY web/ ./
+RUN bun run build
+
+# The unprivileged image listens above the privileged-port range and writes
+# its pid and temporary files below /tmp, so it can run with a read-only root
+# filesystem plus a writable /tmp emptyDir in Kubernetes.
+FROM --platform=linux/amd64 nginxinc/nginx-unprivileged:1.29.4-alpine@sha256:a6c4f61f456b85b8fdf7ec7ab28cc3e299440e6fb4a9dea520e5fd8fd440025e AS runtime
+
+COPY --from=builder --chown=101:101 /build/web/dist/ /usr/share/nginx/html/
+COPY --chown=101:101 docker/nginx.conf /etc/nginx/conf.d/default.conf
+
+USER 101:101
+EXPOSE 8080

--- a/docs/guides/finance-subscriptions.md
+++ b/docs/guides/finance-subscriptions.md
@@ -43,9 +43,10 @@ export RARA_MARKET_DATA_DATABASE_URL='postgres://user:pass@host:5432/rara'
 On startup, rara applies the market-candle migration from
 `crates/extensions/rara-trading/migrations/0001_market_candles.sql`. The
 TimescaleDB extension must be installed in the target database. If the variable
-is missing, or if the connection or schema migration fails, rara falls back to
-an in-memory repository, which is suitable only for local development because
-candle history is not durable.
+is missing, rara uses an in-memory repository suitable only for local
+development because candle history is not durable. If the variable is present,
+the connection and schema migration are required: either failure blocks rara
+startup instead of silently losing production candle history.
 
 Local Timescale contract tests use testcontainers and do not require a manually
 managed database:


### PR DESCRIPTION
## Summary

- require an explicit TimescaleDB URL for finance feed startup instead of silently falling back to SQLite
- add a production, non-root, read-only-compatible web image with nginx health and SPA routing
- publish backend and web images to GHCR using immutable commit tags and expose their registry digests
- smoke both production images on pull requests, including real backend health and web health/SPA probes

## Verification

- `cargo test -p rara-trading --test timescale_container -- --nocapture` — passed against a real TimescaleDB testcontainer
- `docker buildx build --load --file docker/Dockerfile --tag rara-server:smoke .` — passed (cold release build)
- backend image runs as user `rara`; `/api/health` returned `status: healthy` after 6 seconds
- `docker buildx build --load --file docker/web.Dockerfile --tag rara-web:smoke .` — passed
- web image runs non-root with a read-only root filesystem; `/healthz` returned `ok` and `/` served the SPA
- `actionlint .github/workflows/container-smoke.yml .github/workflows/container-publish.yml` — passed
- `git diff --check` / `git show --check` — passed

## Deployment contract

The publish workflow creates only `sha-<12-char>` tags. Flux manifests will consume `ghcr.io/rararulab/{rara-server,rara-web}@sha256:...`; no deployment will depend on `latest` or another mutable tag.
