### PR TITLE
fix(web): keep backend requests on the page origin

### DIFF
--- a/web/src/api/__tests__/client.backendUrl.test.ts
+++ b/web/src/api/__tests__/client.backendUrl.test.ts
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2025 Rararulab
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { getBackendUrl } from '../client';
+
+function installLocalStorageStub() {
+  const store = new Map<string, string>();
+  const stub = {
+    getItem: (key: string) => store.get(key) ?? null,
+    setItem: (key: string, value: string) => store.set(key, String(value)),
+    removeItem: (key: string) => store.delete(key),
+    clear: () => store.clear(),
+    key: (index: number) => Array.from(store.keys())[index] ?? null,
+    get length() {
+      return store.size;
+    },
+  };
+  vi.stubGlobal('localStorage', stub);
+  Object.defineProperty(window, 'localStorage', { value: stub, configurable: true });
+}
+
+describe('getBackendUrl', () => {
+  beforeEach(() => {
+    installLocalStorageStub();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('defaults to the page origin when no explicit backend is configured', () => {
+    expect(getBackendUrl()).toBe(window.location.origin);
+  });
+
+  it('preserves an HTTPS production origin', () => {
+    vi.stubGlobal('window', { location: { origin: 'https://rara.crownni.com' } });
+
+    expect(getBackendUrl()).toBe('https://rara.crownni.com');
+  });
+});

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -29,10 +29,9 @@ export interface AuthUser {
   is_admin: boolean;
 }
 
-/** Derive a sensible default backend URL from the current page hostname. */
+/** Use the page origin by default so deployed reverse proxies remain in the request path. */
 function defaultBackendUrl(): string {
-  const host = typeof window !== 'undefined' ? window.location.hostname : 'localhost';
-  return `http://${host}:25555`;
+  return typeof window !== 'undefined' ? window.location.origin : 'http://localhost:25555';
 }
 
 /** Read the backend URL from localStorage, env, or fallback to default. */


### PR DESCRIPTION
## Summary
- default the backend URL to the browser page origin so HTTPS deployments stay behind their reverse proxy
- preserve the localhost:25555 fallback for non-browser runtimes and existing explicit overrides
- add regression coverage for same-origin and HTTPS behavior

## Root cause
The connection dialog derived http://<hostname>:25555 even when loaded from an HTTPS production origin. That bypassed Cloudflare and the nginx /api proxy, producing an unreachable mixed-content URL.

## Test plan
- bun run test (116 tests)
- bun run lint
- bun run format:check
- bun run typecheck
- bun run build